### PR TITLE
Refactor sitemap CSV import around a canonical resolved plan (#767)

### DIFF
--- a/client/src/protoFleet/features/fleetManagement/components/SiteMapCsvImportModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/SiteMapCsvImportModal.tsx
@@ -217,11 +217,11 @@ const SiteMapCsvImportModal = ({ open, onDismiss, onImported }: SiteMapCsvImport
         {preview?.omissionChoiceRequired && omissionCounts ? (
           <div className="flex flex-col gap-3 rounded-lg border border-border-5 p-4">
             <div>
-              <div className="text-emphasis-300 text-text-primary">Choose how omitted rows are handled</div>
+              <div className="text-emphasis-300 text-text-primary">Confirm removal of omitted rows</div>
               <div className="text-200 text-text-primary-70">
                 The CSV omits {omissionCounts.sites} sites, {omissionCounts.buildings} buildings,
-                {` ${omissionCounts.racks} racks, and ${omissionCounts.miners} miners.`} Choose whether missing rows
-                stay untouched or are removed from the fleet topology.
+                {` ${omissionCounts.racks} racks, and ${omissionCounts.miners} miners.`} Confirm to remove them from the
+                fleet topology.
               </div>
             </div>
             <div className="flex flex-col gap-3">
@@ -237,21 +237,6 @@ const SiteMapCsvImportModal = ({ open, onDismiss, onImported }: SiteMapCsvImport
                   <div className="text-300 text-text-primary">Remove omitted rows</div>
                   <div className="text-200 text-text-primary-70">
                     Delete omitted sites, buildings, and racks. Omitted miners are unassigned, not deleted.
-                  </div>
-                </div>
-              </label>
-              <label className="flex cursor-pointer gap-3 rounded-lg border border-border-5 p-3">
-                <Radio
-                  name="site-map-omission-mode"
-                  value={OmissionMode.LEAVE_IN_PLACE}
-                  selected={selectedOmissionMode === OmissionMode.LEAVE_IN_PLACE}
-                  disabled={isImportingSiteMapCsv}
-                  onChange={() => handleSelectOmissionMode(OmissionMode.LEAVE_IN_PLACE)}
-                />
-                <div>
-                  <div className="text-300 text-text-primary">Leave omitted rows in place</div>
-                  <div className="text-200 text-text-primary-70">
-                    Keep existing entities that are missing from the CSV.
                   </div>
                 </div>
               </label>

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentAutomations.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentAutomations.test.tsx
@@ -144,6 +144,9 @@ describe("CurtailmentAutomationsContent", () => {
 
     await waitFor(() => expect(screen.queryByTestId("curtailment-automation-modal")).not.toBeInTheDocument());
 
+    // The row list re-renders with the new rule a tick after the modal closes;
+    // wait for it before the synchronous row lookup to avoid a load-dependent race.
+    await screen.findByText("High LMP spike");
     const row = getAutomationRow("High LMP spike");
     expect(within(row).getByText("Site Alpha MaestroOS grid signal changes to 0")).toBeVisible();
     expect(within(row).getByText("Standard shed")).toBeVisible();

--- a/docs/plans/2026-07-22-767-sitemap-canonical-plan-tdd.md
+++ b/docs/plans/2026-07-22-767-sitemap-canonical-plan-tdd.md
@@ -8,6 +8,29 @@ tracker: https://github.com/block/proto-fleet/issues/767
 
 # Refactor sitemap import around a canonical resolved plan
 
+## Update 2026-07-23 — single reference-cell model adopted
+
+Superseding the `(*_id, name)` column-pair design below: each parent relationship
+is now **one reference cell**. Grammar: blank = unassigned; a bare integer =
+existing entity by id; `NAME:x` = a same-import create whose own name/label is x;
+anything else = validation error. `resolveReferences` (replacing
+`normalizeIDReferences` + `normalizeInferredPlacement`) canonicalizes every cell
+in place to a canonical name with implied ancestors filled (a building reference
+also fills its site), so resolve/validate/apply read names exclusively. This
+deleted the id/name-mismatch errors, `ambiguousBuildingLabels`, the
+`desired*ByID` family, and the building name-lookup fork. Export writes the
+parent id into the single cell; change-detection comparable rows hold canonical
+names.
+
+**Known interim limitation (accepted, to restore in step 7):** because a
+building reference canonicalizes to its `(site, name)` pair, two buildings
+identical in both `(site, name)` — e.g. two site-less buildings sharing a name,
+which the DB permits — are not independently addressable in the name-keyed
+interim, and the grid/collision/capacity/miner-move validators would false-positive
+on them. Step 7 restores id-precision by keying those validators on
+`building_id` via the resolved-plan graph, and re-adds the four id-disambiguation
+tests dropped here (see git history of `service_test.go` for the deleted cases).
+
 ## Context
 
 The sitemap CSV import planner lives in a single 4,738-line file,

--- a/docs/plans/2026-07-22-767-sitemap-canonical-plan-tdd.md
+++ b/docs/plans/2026-07-22-767-sitemap-canonical-plan-tdd.md
@@ -1,0 +1,350 @@
+---
+title: "Refactor sitemap import around a canonical resolved plan"
+date: 2026-07-22
+status: draft
+type: tdd
+tracker: https://github.com/block/proto-fleet/issues/767
+---
+
+# Refactor sitemap import around a canonical resolved plan
+
+## Context
+
+The sitemap CSV import planner lives in a single 4,738-line file,
+`server/internal/domain/sitemap/service.go`. It grew organically through PR #752
+and its review rounds. The recurring class of bug — found repeatedly in review —
+is **representation drift**: there is no canonical resolved model, so preview,
+validation, commit-token generation, and apply each recompute the "desired"
+topology independently from raw parsed rows, and those recomputations disagree.
+
+### Current data flow (the problem)
+
+```
+CSV bytes
+  → parseSiteMapCSV       → parsedCSV{ sections map[string][]map[string]string }
+  → loadSnapshot          → snapshot{ sites, buildings, racks, miners, hiddenRackMembers }
+  → buildPlan(parsed, snap, mode):
+        normalizeIDReferences(parsed, snap)          // MUTATES rows in place
+        normalizeInferredPlacement(parsed, target)   // MUTATES rows in place
+        ~30 validate*() calls, each reading parsed.sections[...] + snap
+        ~15 desired*() helpers, each REBUILDING the desired graph from rows
+        count*() helpers for the preview summary (yet another recompute)
+  → commitToken(parsed, mode, plan, snap)            // hashes rows again
+  → applyImportPlan(parsed, snap, mode):
+        applySiteRows / applyBuildingRows / applyRackRows / applyMinerRows
+        each re-deriving desired parents from rows during the write tx
+```
+
+Every consumer starts from `[]map[string]string` and re-resolves. The
+"desired graph" is recomputed at least six times, by six sets of rules:
+`desiredSitesByID`, `desiredBuildingsByID`, `desiredRacksByID`,
+`desiredBuildingMap`, `desiredBuildingNameLookup`, `desiredRackMap`,
+`desiredBuildingCapacityMap`, `desiredRackGridBuilding`,
+`desiredMinerSiteBuilding`, `desiredSiteBuildingIDs`, and the `count*` family.
+
+### Bug classes this has produced (from #752 review + #767 comments)
+
+1. **Row-representation divergence.** Raw DB snapshot rows, exported CSV rows
+   with blank inferred columns, parsed rows after escape cleanup, rows after
+   ID/name normalization, desired maps for preview, and commit-time resolution
+   are six representations that can diverge. Concrete: rack preview counts
+   compared raw rack rows instead of export/parse-normalized rows.
+2. **Premature authority.** `rack_id` miner rows skipped supplied-parent-ID
+   consistency checks because the rack was treated as authoritative too early.
+3. **Snapshot-vs-edited-rows divergence.** Rack validators built desired
+   building lookups from the pre-import snapshot in some paths and from edited
+   BUILDING rows in others (`validateRackGridPositions`,
+   capacity/grid validators for renamed/moved buildings).
+4. **Mutable-population drift.** Snapshots filtered out UNPAIRED/PENDING/FAILED
+   miners, but remove-omitted cascades still mutate those devices. Exported
+   rows, omission counts, hidden-resource checks, validation, and apply must
+   share one scoped population.
+5. **Ordering-sensitive uniqueness collisions.** `UpdateSite` → `uk_site_org_name`
+   on name swaps/rotations; `moveBuildingsToSite` + `UpdateBuilding` →
+   `uk_building_site_name`; `UpdateCollection` → `uk_device_collection_org_type_label`
+   on rack label swaps. Currently rejected in preview per entity type; the
+   canonical plan should generate collision-safe two-phase ops or explicitly
+   model unsupported cases once.
+6. **Preflight/lock TOCTOU race.** Remove-omitted site deletion does hidden-resource
+   preflight (`validateOmittedSiteDeleteImpacts`) *before* `deleteOmittedSites`
+   acquires delete locks. A concurrent curtailment-profile or infrastructure-device
+   create can land in the window and be silently cascade-deleted.
+
+## Goals
+
+- One **canonical resolved plan** built exactly once from `(parsed, snapshot, mode)`.
+- Preview counts, all validation, commit-token, and apply consume **that same
+  plan** — no consumer re-resolves from raw rows.
+- Names are create/reference sugar; **stable IDs are primary identity** for
+  existing entities, resolved once during graph construction.
+- One explicitly-scoped mutable population, shared by export, omission counts,
+  hidden-resource checks, validation, and apply.
+- Identity swaps/rotations become **collision-safe two-phase operations**
+  (rename via reserved temp name) within the existing single transaction.
+- Hidden-resource safety re-checked **after** acquiring delete locks, inside the
+  commit transaction, before destructive deletes.
+- **No behavior change** for the happy path and all currently-covered error
+  cases — the existing 2,885-line test suite must stay green.
+
+## Non-goals
+
+- No proto/API surface change (`ImportSiteMapCsvRequest/Response`, error shapes,
+  change-summary operations stay identical).
+- No CSV format change (headers, section markers, escape rules unchanged).
+- No new supported operations beyond making today's rejected transient-collision
+  cases succeed via two-phase. Anything `ensureSupportedCommitPlan` rejects today
+  stays rejected unless explicitly listed below.
+- Not fixing #778 (interactive "Manage racks" reparent over-capacity ordering
+  bug). It shares a bug *class* and the building-capacity invariant with this
+  work (see below) but its fix is a client-side commit-staging decision on a live
+  RPC flow, not a planner change.
+
+## Design: the canonical resolved plan
+
+### Core types (new file: `resolved.go`)
+
+```go
+// nodeAction is the resolved verb for one entity, derived once.
+type nodeAction int
+const (
+    actionNone nodeAction = iota // present, unchanged
+    actionCreate
+    actionUpdate                 // field-only change, no identity collision
+    actionRename                 // identity (name/label) change — may need two-phase
+    actionMove                   // parent change (buildings→site, miners→placement)
+    actionUnassign               // miner detached (remove-omitted)
+    actionDelete                 // site/building/rack removed (remove-omitted)
+)
+
+type resolvedSite struct {
+    id       *int64            // nil ⇒ create
+    name     string            // desired final name
+    action   nodeAction
+    prevName string            // for rename collision detection
+    rowNum   int               // provenance for error messages
+    // ...remaining site fields
+}
+
+type resolvedBuilding struct {
+    id       *int64
+    site     *resolvedSite     // resolved parent pointer, never a re-lookup
+    name     string
+    action   nodeAction
+    // layout: aisles, racksPerAisle, etc.
+    rowNum   int
+}
+
+type resolvedRack struct {
+    id       *int64
+    building *resolvedBuilding // nil ⇒ rack sits directly under site (see memory: miner placement model)
+    site     *resolvedSite
+    label    string
+    action   nodeAction
+    // zone, rows, cols, cooling, orderIndex, aisleIndex, positionInAisle
+    rowNum   int
+}
+
+type resolvedMiner struct {
+    deviceID string            // stable identity, always present
+    name     string
+    rack     *resolvedRack     // resolved placement, pointers not names
+    building *resolvedBuilding
+    site     *resolvedSite
+    rackRow, rackCol string
+    action   nodeAction
+    rowNum   int
+}
+
+// resolvedPlan is the single source of truth.
+type resolvedPlan struct {
+    mode       pb.OmissionMode
+    sites      []*resolvedSite
+    buildings  []*resolvedBuilding
+    racks      []*resolvedRack
+    miners     []*resolvedMiner
+    population minerPopulation // the one scoped mutable set (goal 4)
+
+    // derived, all consumed downstream — never recomputed:
+    omissions  *pb.OmissionCounts
+    errors     []*pb.ImportValidationError
+    warnings   []string
+    changes    []*pb.ImportChangeSummary
+}
+```
+
+Nodes hold **resolved parent pointers**, not names or repeated ID lookups. Once
+`resolvePlan` links `resolvedRack.building → *resolvedBuilding`, every validator
+and the applier follow the pointer instead of re-deriving from
+`row[fieldBuilding]` against a freshly-built map. This structurally eliminates
+bug classes 1–3.
+
+### Resolution pipeline (`resolvePlan`)
+
+```
+resolvePlan(parsed, snapshot, mode) → *resolvedPlan
+  1. scopePopulation(snapshot, mode)      // one mutable-miner set (goal 4)
+  2. resolveSites(parsed.SITE, snapshot)  // ID-first identity, name is sugar
+  3. resolveBuildings(...) linking → sites
+  4. resolveRacks(...)     linking → buildings/sites
+  5. resolveMiners(...)    linking → racks/buildings/sites
+       - fold normalizeIDReferences + normalizeInferredPlacement into resolution
+         so ID/name consistency errors are produced here, once, against the
+         resolved parent pointer (fixes bug class 2: no premature rack authority)
+  6. classifyActions()                    // sets nodeAction per node from id/prev
+  7. validate(plan)                       // all validators read resolved nodes
+  8. computeOmissions(plan)               // from population + node presence
+  9. computeChanges(plan)                 // preview counts from nodeAction, not count*()
+```
+
+Steps 7–9 replace ~30 `validate*` + ~15 `desired*` + ~12 `count*` functions.
+Validators are rewritten to take typed nodes; the *rules* (constraint messages,
+row numbers, ordering) are preserved verbatim — this is a representation change,
+not a policy change.
+
+### Two-phase identity operations (goal 5, answers "is it still safe?")
+
+Apply already runs in one `transactor.RunInTx`. Identity changes that would trip
+a unique constraint mid-transaction (name swaps/rotations across sites,
+building move+rename, rack label swaps) are emitted by the resolved plan as an
+ordered op sequence:
+
+```
+Phase A: rename each colliding entity to a reserved temp label
+Phase B: apply the real renames/moves (target names now free)
+Phase C: (temp labels already consumed by B)
+```
+
+**Safety invariant:** all three phases run inside the *same* transaction. Unique
+constraints are non-deferred and checked per statement — that is exactly why the
+transient collision exists today — but a failure at any statement rolls the
+whole transaction back. The temp label is only ever visible inside the
+uncommitted tx and is never observable by another connection. So two-phase
+removes the false collision **without weakening atomicity**: either the full
+final topology commits or nothing does. Requirements:
+
+- Temp labels must be provably unique and outside the valid user namespace
+  (e.g. a reserved prefix + node id) so Phase A cannot itself collide.
+- The plan orders phases deterministically (sorted by node id) so the commit
+  token and apply agree.
+- Cases genuinely unsupportable in one tx are modeled as explicit plan errors
+  **before token generation** (replacing today's scattered per-entity rejects in
+  `validateSiteRenameTargets` / `validateBuildingMoveRenameTargets` /
+  `validateRackRenameTargets`).
+
+### Locked hidden-resource re-validation (goal 6)
+
+Keep the preview-time `validateOmittedSiteDeleteImpacts` check (fast feedback),
+but move the **authoritative** check inside `deleteOmittedSites`, *after*
+`LockSiteForWrite` / `LockBuildingsBySiteForWrite` /
+`LockInfrastructureDevicesBySiteForWrite`, before the destructive cascade. If a
+concurrent create landed in the preview→lock window, the locked re-check fails
+the transaction (rolls back) instead of silently deleting hidden resources. This
+is the "commit-time apply rehydrates and locks live state before writes"
+requirement from the issue.
+
+### Shared building-capacity invariant (issue bullet 5, coupling to #778)
+
+Sitemap import currently maintains its **own copy** of the building rack-capacity
+invariant (`validateBuildingRackCapacity`, `service.go:3540`, backed by
+`desiredBuildingCapacityMap`) — separate from the authoritative guard in the
+buildings domain (`buildings/service.go:600-611`, in `AssignRacksToBuilding`).
+Both enforce the same rule: `existing + net-new members ≤ aisles × racks_per_aisle`.
+Two independent copies of one invariant is exactly the duplication the issue's
+"reuse or extract domain validation helpers" bullet targets.
+
+As part of routing validation through the resolved plan (step 3), extract a
+single capacity helper — e.g. `buildings.RackCapacityFits(building, resultingCount)`
+or a small `gridCapacity`/net-membership function in the buildings domain — and
+have the sitemap capacity validator call it against the resolved final graph
+instead of reimplementing the arithmetic. The resolved plan already knows each
+building's final rack membership (via `resolvedRack.building` pointers), so it
+passes the *net-final* count, not an intermediate one.
+
+**Coupling to #778 (informational, out of scope here):** #778 is a false
+over-capacity rejection in the interactive "Manage racks" reparent flow, caused
+by the buildings guard being evaluated at commit time against *intermediate*
+membership (removals staged to Save, reparents committed on Continue). Its fix is
+a client commit-staging decision, not part of this refactor. But it enforces the
+*same* invariant this plan extracts. Extracting one canonical
+net-final-membership helper here gives #778 a single correct implementation to
+reuse rather than maintaining a third copy — so keep the helper's signature
+capacity-agnostic about *how* the resulting count was derived (import graph vs.
+live reparent working set), taking only `(building, resultingRackCount)`.
+
+### Commit token
+
+`commitToken` hashes the resolved plan (scoped population fingerprint + resolved
+node set + mode) instead of raw rows. Same dry-run/commit token contract; token
+is now derived from the same structure that apply will execute, so a token can
+never validate a topology that apply resolves differently.
+
+## Work breakdown (incremental, each step compiles + tests green)
+
+Even though the end state is a full rewrite, land it in reviewable steps on this
+branch (`issue-767`), each independently green:
+
+1. **Introduce `resolved.go` types + `resolvePlan`** producing the graph, with
+   `classifyActions`. Not yet wired — pure addition. Unit-test resolution
+   directly (ID-first identity, name sugar, inferred placement, scoped
+   population).
+2. **Route preview counts** (`computeChanges`) through the plan; delete the
+   `count*` family. Assert change summaries byte-identical on the existing corpus.
+3. **Route validation** through the plan node-by-node; delete `desired*` helpers
+   and per-row validators as each is replaced. This is the largest step — do it
+   validator-group by validator-group (uniqueness, placement targets, capacity/
+   grid, slot collisions) so each sub-commit stays green.
+4. **Route apply** through the resolved op list, including two-phase identity
+   ops. Replace `applySiteRows/applyBuildingRows/applyRackRows/applyMinerRows`
+   row-walkers with plan-driven appliers.
+5. **Locked hidden-resource re-validation** in `deleteOmittedSites` /
+   building / rack delete paths.
+6. **Commit token from plan**; verify token stability against current tokens for
+   unchanged inputs (may intentionally change — see Risks).
+7. **Delete dead code** (`normalizeIDReferences`, `normalizeInferredPlacement`,
+   `snapshotForOmissionMode`, the `desired*`/`count*` families, row-identity
+   helpers). Target: `service.go` shrinks substantially; new `resolved.go`
+   carries the model.
+
+## Testing strategy
+
+- **Characterization first.** Before refactoring, capture current behavior as a
+  golden corpus: for a matrix of CSV inputs × omission modes, snapshot the full
+  `ImportSiteMapCsvResponse` (errors, warnings, changes, omission counts,
+  commit token). Re-run after each step; diffs must be explained (only the token
+  may change, and only in step 6).
+- **Regression tests for every #752/#767 bug** listed in Context, asserted
+  against the resolved plan so they cannot silently regress:
+  - rack preview count uses normalized rows,
+  - rack_id parent consistency enforced,
+  - renamed/moved building visible to rack grid/capacity validators,
+  - UNPAIRED/PENDING/FAILED miners in scoped population under remove-omitted.
+- **New two-phase tests:** site name rotation (A→B→C→A), building move+rename
+  into occupied target name, rack label swap — each now *commits* and produces
+  the correct final topology; assert no temp label leaks post-commit.
+- **New race test:** concurrent curtailment-profile/infra-device create between
+  preflight and lock is rejected by the locked re-check (rolls back, nothing
+  deleted).
+- Keep `go test -race -count=1 ./internal/domain/sitemap`. DB-backed integration
+  tests for the two-phase/lock paths where a real transaction is needed.
+
+## Risks & mitigations
+
+- **Behavior drift during rewrite.** Mitigated by the golden corpus gate on every
+  step and by preserving validator messages/row numbers verbatim.
+- **Commit-token churn.** Changing the token derivation invalidates in-flight
+  dry-run tokens at deploy time; acceptable (users re-run dry-run) but call it out
+  in the PR and land token change as its own commit.
+- **Two-phase temp-label collisions.** Mitigated by reserved out-of-namespace
+  prefix + node id; add a validator asserting no user label uses the reserved
+  prefix.
+- **Big diff review fatigue.** Mitigated by the 7-step breakdown; each step is
+  independently reviewable and green. Consider stacking as separate PRs off this
+  branch if the single diff is too large.
+
+## Open questions
+
+- Should step 6 (token from plan) ship in this PR or defer, given it forces
+  in-flight dry-run tokens to invalidate on deploy?
+- Are there operations currently rejected by `ensureSupportedCommitPlan` that we
+  should opportunistically support now that the plan models them cleanly, or hold
+  the line on non-goals?

--- a/server/internal/domain/buildings/models/models.go
+++ b/server/internal/domain/buildings/models/models.go
@@ -23,6 +23,23 @@ func (r RackOrderIndex) Valid() bool {
 	return r >= RackOrderIndexUnspecified && r <= RackOrderIndexTopRight
 }
 
+// GridCapacity is the number of racks a building's grid holds
+// (aisles × racks_per_aisle). Zero means the layout is unconfigured and
+// imposes no rack limit.
+func GridCapacity(aisles, racksPerAisle int32) int64 {
+	return int64(aisles) * int64(racksPerAisle)
+}
+
+// RackCapacityExceeded reports whether resultingCount racks would exceed a
+// building's configured grid. An unconfigured grid (capacity 0) is never
+// exceeded. resultingCount is the net final membership the caller intends,
+// leaving the caller free to derive it from an import graph or a live
+// reassignment.
+func RackCapacityExceeded(aisles, racksPerAisle int32, resultingCount int64) bool {
+	capacity := GridCapacity(aisles, racksPerAisle)
+	return capacity > 0 && resultingCount > capacity
+}
+
 // Building is the canonical domain shape for a building row.
 type Building struct {
 	ID                    int64

--- a/server/internal/domain/buildings/models/models_test.go
+++ b/server/internal/domain/buildings/models/models_test.go
@@ -1,0 +1,39 @@
+package models
+
+import "testing"
+
+func TestGridCapacity(t *testing.T) {
+	cases := []struct {
+		aisles, racksPerAisle int32
+		want                  int64
+	}{
+		{0, 0, 0},
+		{3, 0, 0},
+		{0, 4, 0},
+		{3, 4, 12},
+	}
+	for _, c := range cases {
+		if got := GridCapacity(c.aisles, c.racksPerAisle); got != c.want {
+			t.Errorf("GridCapacity(%d,%d) = %d, want %d", c.aisles, c.racksPerAisle, got, c.want)
+		}
+	}
+}
+
+func TestRackCapacityExceeded(t *testing.T) {
+	cases := []struct {
+		name                  string
+		aisles, racksPerAisle int32
+		resulting             int64
+		want                  bool
+	}{
+		{"unconfigured grid is never exceeded", 0, 0, 100, false},
+		{"at capacity fits", 3, 4, 12, false},
+		{"over capacity exceeds", 3, 4, 13, true},
+		{"under capacity fits", 3, 4, 5, false},
+	}
+	for _, c := range cases {
+		if got := RackCapacityExceeded(c.aisles, c.racksPerAisle, c.resulting); got != c.want {
+			t.Errorf("%s: RackCapacityExceeded(%d,%d,%d) = %v, want %v", c.name, c.aisles, c.racksPerAisle, c.resulting, got, c.want)
+		}
+	}
+}

--- a/server/internal/domain/buildings/service.go
+++ b/server/internal/domain/buildings/service.go
@@ -604,7 +604,7 @@ func (s *Service) AssignRacksToBuilding(ctx context.Context, params models.Assig
 					return nil, err
 				}
 				resulting := existing + int64(netNewBuildingMembers)
-				if models.RackCapacityExceeded(targetBuilding.Aisles, targetBuilding.RacksPerAisle, resulting) {
+				if resulting > capacity {
 					return nil, fleeterror.NewInvalidArgumentErrorf(
 						"cannot assign racks: building has %d positions (%d aisles × %d racks per aisle) but %d racks would be assigned",
 						capacity, targetBuilding.Aisles, targetBuilding.RacksPerAisle, resulting,

--- a/server/internal/domain/buildings/service.go
+++ b/server/internal/domain/buildings/service.go
@@ -257,7 +257,7 @@ func (s *Service) UpdateBuilding(ctx context.Context, params models.UpdateParams
 		// — that the grid can't hold. Bound total members against the new grid
 		// here so that path can't persist an over-capacity building. Skipped
 		// when the new grid is still unconfigured (capacity 0).
-		if capacity := gridCapacity(params.Aisles, params.RacksPerAisle); capacity > 0 {
+		if capacity := models.GridCapacity(params.Aisles, params.RacksPerAisle); capacity > 0 {
 			members, err := s.store.CountRacksInBuilding(txCtx, params.OrgID, params.ID)
 			if err != nil {
 				return err
@@ -598,12 +598,13 @@ func (s *Service) AssignRacksToBuilding(ctx context.Context, params models.Assig
 		// max_items, and the per-cell check above still rejects placement
 		// into a 0-cell grid.
 		if targetBuilding != nil {
-			if capacity := gridCapacity(targetBuilding.Aisles, targetBuilding.RacksPerAisle); capacity > 0 {
+			if capacity := models.GridCapacity(targetBuilding.Aisles, targetBuilding.RacksPerAisle); capacity > 0 {
 				existing, err := s.store.CountRacksInBuilding(txCtx, params.OrgID, *params.TargetBuildingID)
 				if err != nil {
 					return nil, err
 				}
-				if resulting := existing + int64(netNewBuildingMembers); resulting > capacity {
+				resulting := existing + int64(netNewBuildingMembers)
+				if models.RackCapacityExceeded(targetBuilding.Aisles, targetBuilding.RacksPerAisle, resulting) {
 					return nil, fleeterror.NewInvalidArgumentErrorf(
 						"cannot assign racks: building has %d positions (%d aisles × %d racks per aisle) but %d racks would be assigned",
 						capacity, targetBuilding.Aisles, targetBuilding.RacksPerAisle, resulting,
@@ -789,17 +790,6 @@ func validateLayoutBounds(aisles, racksPerAisle int32) error {
 		return fleeterror.NewInvalidArgumentErrorf("racks_per_aisle must be ≤ %d (got %d)", layoutDimensionMax, racksPerAisle)
 	}
 	return nil
-}
-
-// gridCapacity is the number of rack positions a building's grid holds.
-// 0 means the layout is unconfigured (aisles or racks_per_aisle still 0):
-// there is no geometric limit to enforce yet, so callers treat 0 as
-// "unbounded" and skip the membership cap. A building has no "floating
-// beyond capacity" state once a grid exists — every write path that grows
-// membership (AssignRacksToBuilding, the SaveRack placement path, and a
-// shrinking UpdateBuilding) bounds total members against this.
-func gridCapacity(aisles, racksPerAisle int32) int64 {
-	return int64(aisles) * int64(racksPerAisle)
 }
 
 func int64PtrEqual(a, b *int64) bool {

--- a/server/internal/domain/sitemap/resolved.go
+++ b/server/internal/domain/sitemap/resolved.go
@@ -59,8 +59,12 @@ type resolvedRack struct {
 	siteLabel     string
 	// siteRef / buildingRef are the canonical site and building names the row
 	// references, filled in by resolveReferences.
-	siteRef         string
-	buildingRef     string
+	siteRef     string
+	buildingRef string
+	// buildingID is the id of the existing building the rack references, when the
+	// reference resolved to one; nil for a same-import create or an unlinked rack.
+	// It disambiguates two buildings that share a (site, name) pair.
+	buildingID      *int64
 	label           string
 	prevLabel       string
 	zone            string
@@ -89,12 +93,16 @@ type resolvedMiner struct {
 	rackLabel    string
 	siteLabel    string
 	buildLabel   string
-	rackRow      string
-	rackCol      string
-	renamed      bool
-	moved        bool
-	unassigned   bool
-	rowNum       int
+	// buildingID is the id of the existing building the miner's placement targets
+	// (via its building or rack reference), when it resolved to one; nil
+	// otherwise. It disambiguates two buildings that share a (site, name) pair.
+	buildingID *int64
+	rackRow    string
+	rackCol    string
+	renamed    bool
+	moved      bool
+	unassigned bool
+	rowNum     int
 }
 
 // minerPopulation is the scoped mutable-miner set shared by omission counts,
@@ -271,6 +279,7 @@ func resolveRacks(
 			siteLabel:       row[fieldSite],
 			siteRef:         row[fieldSite],
 			buildingRef:     row[fieldBuilding],
+			buildingID:      refID(row, refBuildingIDCell),
 			rowNum:          rn,
 		}
 		if id, ok := rowID(row); ok {
@@ -298,6 +307,7 @@ func resolveMiners(rows []map[string]string, existingByID map[string]minerSnapsh
 			rackLabel:    row[fieldRack],
 			siteLabel:    row[fieldSite],
 			buildLabel:   row[fieldBuilding],
+			buildingID:   refID(row, refBuildingIDCell),
 			rackRow:      row["rack_row"],
 			rackCol:      row["rack_col"],
 			rowNum:       rowNumber(row, i+1),
@@ -320,8 +330,13 @@ func classifyMinerMoves(miners []*resolvedMiner, tv *topologyView) {
 			continue
 		}
 		desiredSite, desiredBuilding := minerDesiredSiteBuilding(m, tv)
-		if desiredSite != m.existing.Site ||
-			desiredBuilding != m.existing.Building ||
+		buildingChanged := desiredSite != m.existing.Site || desiredBuilding != m.existing.Building
+		// Two buildings can share a (site, name) pair, so a move between them shows
+		// no name change; the resolved building id disambiguates them.
+		if m.buildingID != nil && m.existing.BuildingID != nil && *m.buildingID != *m.existing.BuildingID {
+			buildingChanged = true
+		}
+		if buildingChanged ||
 			m.rackLabel != m.existing.Rack ||
 			m.rackRow != m.existing.RackRow ||
 			m.rackCol != m.existing.RackCol {
@@ -513,6 +528,13 @@ func validateRackGridPositions(racks []*resolvedRack, tv *topologyView) []*pb.Im
 }
 
 func rackGridBuilding(r *resolvedRack, tv *topologyView) (buildingmodels.Building, bool) {
+	// Prefer the resolved building id so two buildings sharing a (site, name) pair
+	// keep independent grids; fall back to the (site, name) key for creates.
+	if r.buildingID != nil {
+		if building, ok := tv.buildingsByLayoutID[*r.buildingID]; ok {
+			return building, true
+		}
+	}
 	building, ok := tv.buildingsByKey[r.siteRef+"\x00"+r.buildingRef]
 	return building, ok
 }

--- a/server/internal/domain/sitemap/resolved.go
+++ b/server/internal/domain/sitemap/resolved.go
@@ -80,25 +80,30 @@ type resolvedRack struct {
 // mutable facets. existing is the matched live miner, or nil when the device is
 // unknown.
 type resolvedMiner struct {
-	deviceID      string
-	name          string
-	serialNumber  string
-	ipAddress     string
-	macAddress    string
-	existing      *minerSnapshot
-	rack          *resolvedRack
-	building      *resolvedBuilding
-	site          *resolvedSite
-	rackLabel     string
-	siteLabel     string
-	buildLabel    string
-	rackRow       string
-	rackCol       string
-	hasBuildingID bool
-	renamed       bool
-	moved         bool
-	unassigned    bool
-	rowNum        int
+	deviceID     string
+	name         string
+	serialNumber string
+	ipAddress    string
+	macAddress   string
+	existing     *minerSnapshot
+	rack         *resolvedRack
+	building     *resolvedBuilding
+	site         *resolvedSite
+	rackLabel    string
+	siteLabel    string
+	buildLabel   string
+	rackRow      string
+	rackCol      string
+	// siteIDCell / buildingIDCell / rackIDCell are the raw *_id row cells, used to
+	// detect placement identity changes against the existing miner.
+	siteIDCell     string
+	buildingIDCell string
+	rackIDCell     string
+	hasBuildingID  bool
+	renamed        bool
+	moved          bool
+	unassigned     bool
+	rowNum         int
 }
 
 // minerPopulation is the scoped mutable-miner set shared by omission counts,
@@ -178,6 +183,7 @@ func resolvePlan(parsed *parsedCSV, snap *snapshot, mode pb.OmissionMode) *resol
 	plan.errors = append(plan.errors, rackErrs...)
 
 	plan.miners = resolveMiners(parsed.sections["MINER"], minerMap(snap.miners))
+	classifyMinerMoves(plan.miners, plan.topology)
 
 	classifyTopologyActions(plan, snap, mode)
 	plan.omissions = computeOmissions(parsed, snap, mode)
@@ -324,18 +330,21 @@ func resolveMiners(rows []map[string]string, existingByID map[string]minerSnapsh
 	out := make([]*resolvedMiner, 0, len(rows))
 	for i, row := range rows {
 		node := &resolvedMiner{
-			deviceID:      row["device_identifier"],
-			name:          row[fieldName],
-			serialNumber:  row["serial_number"],
-			ipAddress:     row["ip_address"],
-			macAddress:    row["mac_address"],
-			rackLabel:     row[fieldRack],
-			siteLabel:     row[fieldSite],
-			buildLabel:    row[fieldBuilding],
-			rackRow:       row["rack_row"],
-			rackCol:       row["rack_col"],
-			hasBuildingID: row[fieldBuildingID] != "",
-			rowNum:        rowNumber(row, i+1),
+			deviceID:       row["device_identifier"],
+			name:           row[fieldName],
+			serialNumber:   row["serial_number"],
+			ipAddress:      row["ip_address"],
+			macAddress:     row["mac_address"],
+			rackLabel:      row[fieldRack],
+			siteLabel:      row[fieldSite],
+			buildLabel:     row[fieldBuilding],
+			rackRow:        row["rack_row"],
+			rackCol:        row["rack_col"],
+			siteIDCell:     row[fieldSiteID],
+			buildingIDCell: row[fieldBuildingID],
+			rackIDCell:     row[fieldRackID],
+			hasBuildingID:  row[fieldBuildingID] != "",
+			rowNum:         rowNumber(row, i+1),
 		}
 		if existing, ok := existingByID[node.deviceID]; ok {
 			e := existing
@@ -345,6 +354,84 @@ func resolveMiners(rows []map[string]string, existingByID map[string]minerSnapsh
 		out = append(out, node)
 	}
 	return out
+}
+
+// classifyMinerMoves flags existing miners whose desired placement (site,
+// building, rack, slot, or placement identity) differs from their live state.
+func classifyMinerMoves(miners []*resolvedMiner, tv *topologyView) {
+	for _, m := range miners {
+		if m.existing == nil {
+			continue
+		}
+		desiredSite, desiredBuilding := minerDesiredSiteBuilding(m, tv)
+		if !minerPlacementIDsMatchNode(m) ||
+			desiredSite != m.existing.Site ||
+			desiredBuilding != m.existing.Building ||
+			m.rackLabel != m.existing.Rack ||
+			m.rackRow != m.existing.RackRow ||
+			m.rackCol != m.existing.RackCol {
+			m.moved = true
+		}
+	}
+}
+
+// minerDesiredSiteBuilding resolves the site and building a miner row targets,
+// following rack, then building_id, then unambiguous building name.
+func minerDesiredSiteBuilding(m *resolvedMiner, tv *topologyView) (string, string) {
+	if m.rackLabel != "" {
+		rack := tv.racksByLabel[m.rackLabel]
+		return rack.Site, rack.Building
+	}
+	if id, ok := idFromCell(m.buildingIDCell); ok {
+		if building, ok := tv.buildingsByLayoutID[id]; ok {
+			return building.SiteLabel, building.Name
+		}
+	}
+	if m.siteLabel == "" && m.buildLabel != "" && !tv.buildingAmbig[m.buildLabel] {
+		if building, ok := tv.buildingsByName[m.buildLabel]; ok {
+			return building.SiteLabel, m.buildLabel
+		}
+	}
+	return m.siteLabel, m.buildLabel
+}
+
+// minerPlacementIDsMatchNode reports whether the row's supplied *_id cells agree
+// with the existing miner's placement ids. The rack id is ignored when the row
+// declares no rack.
+func minerPlacementIDsMatchNode(m *resolvedMiner) bool {
+	checks := []struct {
+		cell   string
+		want   *int64
+		isRack bool
+	}{
+		{m.siteIDCell, m.existing.SiteID, false},
+		{m.buildingIDCell, m.existing.BuildingID, false},
+		{m.rackIDCell, m.existing.RackID, true},
+	}
+	for _, c := range checks {
+		if c.isRack && m.rackLabel == "" {
+			continue
+		}
+		if c.cell == "" {
+			continue
+		}
+		if c.cell != formatNullableInt64(c.want) {
+			return false
+		}
+	}
+	return true
+}
+
+// validateMinerRenamePermission rejects renaming an existing miner without the
+// miner rename permission.
+func validateMinerRenamePermission(miners []*resolvedMiner) []*pb.ImportValidationError {
+	var errs []*pb.ImportValidationError
+	for _, m := range miners {
+		if m.renamed {
+			errs = append(errs, csvErr(m.rowNum, "MINER", "miner:rename permission is required to change miner name"))
+		}
+	}
+	return errs
 }
 
 // validateKnownMiners rejects rows whose device identifier is not a live miner.
@@ -824,6 +911,17 @@ func countMinerRenameNodes(miners []*resolvedMiner) int32 {
 	return n
 }
 
+// countMinerMoveNodes counts existing miners whose placement changed.
+func countMinerMoveNodes(miners []*resolvedMiner) int32 {
+	var n int32
+	for _, m := range miners {
+		if m.moved {
+			n++
+		}
+	}
+	return n
+}
+
 // classifyTopologyActions marks each topology node: a row whose identity is not
 // already present in the live snapshot creates; a row matching an existing
 // entity updates when a tracked field differs.
@@ -918,7 +1016,7 @@ func computeChanges(resolved *resolvedPlan, parsed *parsedCSV, snap, targetSnap 
 	add(pb.ImportOperation_IMPORT_OPERATION_UPDATE, fieldBuilding, countBuildingUpdates(parsed.sections["BUILDING"], snap.buildings), "building rows with changed details")
 	add(pb.ImportOperation_IMPORT_OPERATION_UPDATE, "rack", countRackUpdates(parsed.sections["RACK"], snap.racks, targetSnap.buildings), "rack rows with changed details")
 	add(pb.ImportOperation_IMPORT_OPERATION_RENAME, "miner", countMinerRenameNodes(resolved.miners), "miner rows with changed names")
-	add(pb.ImportOperation_IMPORT_OPERATION_MOVE, "miner", countMinerPlacementUpdates(parsed.sections["MINER"], parsed.sections["RACK"], parsed.sections["BUILDING"], targetSnap), "miner placement rows with changed site, building, rack, or slot")
+	add(pb.ImportOperation_IMPORT_OPERATION_MOVE, "miner", countMinerMoveNodes(resolved.miners), "miner placement rows with changed site, building, rack, or slot")
 	if mode == pb.OmissionMode_OMISSION_MODE_REMOVE_OMITTED {
 		add(pb.ImportOperation_IMPORT_OPERATION_UNASSIGN, "miner", resolved.omissions.GetMiners(), "omitted miner rows to unassign")
 		add(pb.ImportOperation_IMPORT_OPERATION_DELETE, "rack", resolved.omissions.GetRacks(), "omitted rack rows to delete")

--- a/server/internal/domain/sitemap/resolved.go
+++ b/server/internal/domain/sitemap/resolved.go
@@ -58,9 +58,12 @@ type resolvedRack struct {
 	buildingLabel string
 	siteLabel     string
 	// siteRef / buildingRef are the raw row references, before building_id resolution.
-	siteRef         string
-	buildingRef     string
+	siteRef     string
+	buildingRef string
+	// hasBuildingID is true when the row supplied any building_id; buildingIDRef is
+	// the parsed value, nil when absent or unparseable.
 	hasBuildingID   bool
+	buildingIDRef   *int64
 	label           string
 	prevLabel       string
 	zone            string
@@ -109,12 +112,13 @@ type minerPopulation struct {
 // omission-target snapshot) that placement-target validators resolve references
 // against. Built once so validators do not each re-derive it.
 type topologyView struct {
-	sites           map[string]bool
-	buildingKeys    map[string]bool
-	buildingsByKey  map[string]buildingmodels.Building
-	buildingsByName map[string]buildingmodels.Building
-	buildingAmbig   map[string]bool
-	racksByLabel    map[string]rackSnapshot
+	sites               map[string]bool
+	buildingKeys        map[string]bool
+	buildingsByKey      map[string]buildingmodels.Building
+	buildingsByLayoutID map[int64]buildingmodels.Building
+	buildingsByName     map[string]buildingmodels.Building
+	buildingAmbig       map[string]bool
+	racksByLabel        map[string]rackSnapshot
 }
 
 type resolvedPlan struct {
@@ -181,10 +185,11 @@ func resolveTopologyView(parsed *parsedCSV, target *snapshot) *topologyView {
 	buildingRows := parsed.sections["BUILDING"]
 	rackRows := parsed.sections["RACK"]
 	tv := &topologyView{
-		sites:          desiredSiteSet(siteRows, target.sites),
-		buildingKeys:   rowSetFromDesiredBuildings(buildingRows, target.buildings),
-		buildingsByKey: desiredBuildingMap(buildingRows, target.buildings),
-		racksByLabel:   desiredRackMap(rackRows, target.racks, buildingRows, target.buildings),
+		sites:               desiredSiteSet(siteRows, target.sites),
+		buildingKeys:        rowSetFromDesiredBuildings(buildingRows, target.buildings),
+		buildingsByKey:      desiredBuildingMap(buildingRows, target.buildings),
+		buildingsByLayoutID: desiredBuildingLayoutIDMap(buildingRows, target.buildings),
+		racksByLabel:        desiredRackMap(rackRows, target.racks, buildingRows, target.buildings),
 	}
 	tv.buildingsByName, tv.buildingAmbig = desiredBuildingNameLookup(buildingRows, target.buildings)
 	return tv
@@ -292,6 +297,7 @@ func resolveRacks(
 			}
 		}
 		if buildingID, ok := idFromCell(row[fieldBuildingID]); ok {
+			node.buildingIDRef = int64Ptr(buildingID)
 			if building, found := buildingsByID[buildingID]; found {
 				node.buildingLabel = building.Name
 				node.siteLabel = building.SiteLabel
@@ -476,6 +482,105 @@ func validatePlacementConsistency(miners []*resolvedMiner, tv *topologyView) []*
 		}
 		if m.siteLabel != "" && !tv.sites[m.siteLabel] {
 			errs = append(errs, csvErr(m.rowNum, "MINER", fmt.Sprintf("unknown site %q", m.siteLabel)))
+		}
+	}
+	return errs
+}
+
+// validateRackGridPositions rejects rack aisle/position coordinates that are
+// malformed or out of bounds for their building's grid.
+func validateRackGridPositions(racks []*resolvedRack, tv *topologyView) []*pb.ImportValidationError {
+	var errs []*pb.ImportValidationError
+	for _, r := range racks {
+		if (r.aisleIndex == "") != (r.positionInAisle == "") {
+			errs = append(errs, csvErr(r.rowNum, "RACK", "aisle_index and position_in_aisle must both be set or both be blank"))
+			continue
+		}
+		if r.aisleIndex == "" {
+			continue
+		}
+		if r.buildingRef == "" {
+			errs = append(errs, csvErr(r.rowNum, "RACK", "rack grid position requires a building"))
+			continue
+		}
+		aisle, err := parseInt32Value(r.aisleIndex, "aisle_index")
+		if err != nil {
+			errs = append(errs, csvErr(r.rowNum, "RACK", err.Error()))
+			continue
+		}
+		position, err := parseInt32Value(r.positionInAisle, "position_in_aisle")
+		if err != nil {
+			errs = append(errs, csvErr(r.rowNum, "RACK", err.Error()))
+			continue
+		}
+		if aisle < 0 {
+			errs = append(errs, csvErr(r.rowNum, "RACK", fmt.Sprintf("aisle_index %d is out of bounds", aisle)))
+			continue
+		}
+		if position < 0 {
+			errs = append(errs, csvErr(r.rowNum, "RACK", fmt.Sprintf("position_in_aisle %d is out of bounds", position)))
+			continue
+		}
+		building, ok := rackGridBuilding(r, tv)
+		if !ok {
+			continue
+		}
+		if building.Aisles <= 0 || aisle >= building.Aisles {
+			errs = append(errs, csvErr(r.rowNum, "RACK", fmt.Sprintf("aisle_index %d is out of bounds for building %q with %d aisles", aisle, building.Name, building.Aisles)))
+		}
+		if building.RacksPerAisle <= 0 || position >= building.RacksPerAisle {
+			errs = append(errs, csvErr(r.rowNum, "RACK", fmt.Sprintf("position_in_aisle %d is out of bounds for building %q with %d racks per aisle", position, building.Name, building.RacksPerAisle)))
+		}
+	}
+	return errs
+}
+
+func rackGridBuilding(r *resolvedRack, tv *topologyView) (buildingmodels.Building, bool) {
+	if r.buildingIDRef != nil {
+		building, ok := tv.buildingsByLayoutID[*r.buildingIDRef]
+		return building, ok
+	}
+	building, ok := tv.buildingsByKey[r.siteRef+"\x00"+r.buildingRef]
+	return building, ok
+}
+
+// validateRackSlotBounds rejects miner rack_row/rack_col coordinates that are
+// malformed or out of bounds for their rack's dimensions.
+func validateRackSlotBounds(miners []*resolvedMiner, tv *topologyView) []*pb.ImportValidationError {
+	var errs []*pb.ImportValidationError
+	for _, m := range miners {
+		if m.rackLabel == "" {
+			if m.rackRow != "" || m.rackCol != "" {
+				errs = append(errs, csvErr(m.rowNum, "MINER", "rack_row and rack_col require rack"))
+			}
+			continue
+		}
+		if (m.rackRow == "") != (m.rackCol == "") {
+			errs = append(errs, csvErr(m.rowNum, "MINER", "rack_row and rack_col must both be set or both be blank"))
+			continue
+		}
+		if m.rackRow == "" {
+			continue
+		}
+		rack, ok := tv.racksByLabel[m.rackLabel]
+		if !ok {
+			continue
+		}
+		rackRow, err := parseInt32Value(m.rackRow, "rack_row")
+		if err != nil {
+			errs = append(errs, csvErr(m.rowNum, "MINER", err.Error()))
+			continue
+		}
+		rackCol, err := parseInt32Value(m.rackCol, "rack_col")
+		if err != nil {
+			errs = append(errs, csvErr(m.rowNum, "MINER", err.Error()))
+			continue
+		}
+		if rackRow < 0 || rack.Rows <= 0 || rackRow >= rack.Rows {
+			errs = append(errs, csvErr(m.rowNum, "MINER", fmt.Sprintf("rack_row %d is out of bounds for rack %q with %d rows", rackRow, m.rackLabel, rack.Rows)))
+		}
+		if rackCol < 0 || rack.Columns <= 0 || rackCol >= rack.Columns {
+			errs = append(errs, csvErr(m.rowNum, "MINER", fmt.Sprintf("rack_col %d is out of bounds for rack %q with %d columns", rackCol, m.rackLabel, rack.Columns)))
 		}
 	}
 	return errs

--- a/server/internal/domain/sitemap/resolved.go
+++ b/server/internal/domain/sitemap/resolved.go
@@ -112,13 +112,14 @@ type minerPopulation struct {
 // omission-target snapshot) that placement-target validators resolve references
 // against. Built once so validators do not each re-derive it.
 type topologyView struct {
-	sites               map[string]bool
-	buildingKeys        map[string]bool
-	buildingsByKey      map[string]buildingmodels.Building
-	buildingsByLayoutID map[int64]buildingmodels.Building
-	buildingsByName     map[string]buildingmodels.Building
-	buildingAmbig       map[string]bool
-	racksByLabel        map[string]rackSnapshot
+	sites                  map[string]bool
+	buildingKeys           map[string]bool
+	buildingsByKey         map[string]buildingmodels.Building
+	buildingsByLayoutID    map[int64]buildingmodels.Building
+	buildingsByCapacityKey map[string]buildingmodels.Building
+	buildingsByName        map[string]buildingmodels.Building
+	buildingAmbig          map[string]bool
+	racksByLabel           map[string]rackSnapshot
 }
 
 type resolvedPlan struct {
@@ -129,6 +130,9 @@ type resolvedPlan struct {
 	miners     []*resolvedMiner
 	population minerPopulation
 	topology   *topologyView
+	// target is the omission-scoped snapshot whose existing entities reference
+	// resolution and existing-topology reconciliation run against.
+	target *snapshot
 
 	omissions *pb.OmissionCounts
 	errors    []*pb.ImportValidationError
@@ -159,6 +163,7 @@ func resolvePlan(parsed *parsedCSV, snap *snapshot, mode pb.OmissionMode) *resol
 	// merged over the omission-target snapshot (which drops omitted topology under
 	// remove-omitted). Action classification and prevName below use the full snap.
 	target := snapshotForOmissionMode(snap, mode)
+	plan.target = target
 	plan.topology = resolveTopologyView(parsed, target)
 
 	plan.sites, plan.errors = resolveSites(parsed.sections["SITE"], sitesByID)
@@ -185,11 +190,12 @@ func resolveTopologyView(parsed *parsedCSV, target *snapshot) *topologyView {
 	buildingRows := parsed.sections["BUILDING"]
 	rackRows := parsed.sections["RACK"]
 	tv := &topologyView{
-		sites:               desiredSiteSet(siteRows, target.sites),
-		buildingKeys:        rowSetFromDesiredBuildings(buildingRows, target.buildings),
-		buildingsByKey:      desiredBuildingMap(buildingRows, target.buildings),
-		buildingsByLayoutID: desiredBuildingLayoutIDMap(buildingRows, target.buildings),
-		racksByLabel:        desiredRackMap(rackRows, target.racks, buildingRows, target.buildings),
+		sites:                  desiredSiteSet(siteRows, target.sites),
+		buildingKeys:           rowSetFromDesiredBuildings(buildingRows, target.buildings),
+		buildingsByKey:         desiredBuildingMap(buildingRows, target.buildings),
+		buildingsByLayoutID:    desiredBuildingLayoutIDMap(buildingRows, target.buildings),
+		buildingsByCapacityKey: desiredBuildingCapacityMap(buildingRows, target.buildings),
+		racksByLabel:           desiredRackMap(rackRows, target.racks, buildingRows, target.buildings),
 	}
 	tv.buildingsByName, tv.buildingAmbig = desiredBuildingNameLookup(buildingRows, target.buildings)
 	return tv
@@ -682,6 +688,127 @@ func validateRackCapacity(r *resolvedPlan) []*pb.ImportValidationError {
 		if count > capacity {
 			errs = append(errs, csvErr(0, "MINER", fmt.Sprintf("rack %q has %d assigned miners but capacity is %d", rackLabel, count, capacity)))
 		}
+	}
+	return errs
+}
+
+// validateBuildingRackCapacity rejects buildings whose desired assigned-rack
+// count exceeds their grid capacity.
+func validateBuildingRackCapacity(r *resolvedPlan) []*pb.ImportValidationError {
+	counts := map[string]int32{}
+	for _, rack := range r.topology.racksByLabel {
+		if key, ok := rackBuildingCapacityKey(rack); ok {
+			counts[key]++
+		}
+	}
+	var errs []*pb.ImportValidationError
+	for key, count := range counts {
+		building, ok := r.topology.buildingsByCapacityKey[key]
+		if !ok {
+			continue
+		}
+		if buildingmodels.RackCapacityExceeded(building.Aisles, building.RacksPerAisle, int64(count)) {
+			errs = append(errs, csvErr(0, "RACK", fmt.Sprintf("building %q has %d assigned racks but capacity is %d", building.Name, count, buildingmodels.GridCapacity(building.Aisles, building.RacksPerAisle))))
+		}
+	}
+	return errs
+}
+
+// validateBuildingExistingRacksFitLayout rejects an import that would shrink a
+// building's grid below the aisle/position an existing rack occupies.
+func validateBuildingExistingRacksFitLayout(r *resolvedPlan) []*pb.ImportValidationError {
+	desiredRacks := r.topology.racksByLabel
+	desiredRacksByID := map[int64]rackSnapshot{}
+	for _, rack := range desiredRacks {
+		if rack.ID > 0 {
+			desiredRacksByID[rack.ID] = rack
+		}
+	}
+	var errs []*pb.ImportValidationError
+	for _, rack := range r.target.racks {
+		desiredRack, ok := desiredRacksByID[rack.ID]
+		if !ok {
+			desiredRack, ok = desiredRacks[rack.Label]
+		}
+		if !ok {
+			desiredRack = rack
+		}
+		if desiredRack.Building == "" || desiredRack.AisleIndex == "" || desiredRack.PositionInAisle == "" {
+			continue
+		}
+		var building buildingmodels.Building
+		if desiredRack.BuildingID != nil {
+			building, ok = r.topology.buildingsByLayoutID[*desiredRack.BuildingID]
+		} else {
+			building, ok = r.topology.buildingsByKey[desiredRack.Site+"\x00"+desiredRack.Building]
+		}
+		if !ok {
+			continue
+		}
+		aisle, err := parseInt32Value(desiredRack.AisleIndex, "aisle_index")
+		if err != nil {
+			continue
+		}
+		position, err := parseInt32Value(desiredRack.PositionInAisle, "position_in_aisle")
+		if err != nil {
+			continue
+		}
+		if aisle >= building.Aisles || position >= building.RacksPerAisle {
+			errs = append(errs, csvErr(0, "RACK", fmt.Sprintf("rack %q grid position %d,%d does not fit building %q layout %dx%d", desiredRack.Label, aisle, position, building.Name, building.Aisles, building.RacksPerAisle)))
+		}
+	}
+	return errs
+}
+
+// validateSlotConflictsWithExisting rejects incoming miner placements that land
+// on a rack slot occupied by an existing miner that is not itself moving away.
+func validateSlotConflictsWithExisting(r *resolvedPlan) []*pb.ImportValidationError {
+	rackLabels := rackLabelsByID(r.racks)
+	desired := map[string]*resolvedMiner{}
+	for _, m := range r.miners {
+		desired[m.deviceID] = m
+	}
+	movingMiners := map[string]bool{}
+	for _, miner := range r.population.miners {
+		m, ok := desired[miner.DeviceIdentifier]
+		if !ok {
+			continue
+		}
+		currentRack := desiredRackLabel(miner, rackLabels)
+		currentKey, _ := normalizedRackSlotKey(currentRack, miner.RackRow, miner.RackCol)
+		desiredKey, _ := normalizedRackSlotKey(m.rackLabel, m.rackRow, m.rackCol)
+		if m.rackLabel != currentRack || desiredKey != currentKey {
+			movingMiners[miner.DeviceIdentifier] = true
+		}
+	}
+
+	currentOccupants := map[string]minerSnapshot{}
+	for _, miner := range r.population.miners {
+		key, ok := normalizedRackSlotKey(desiredRackLabel(miner, rackLabels), miner.RackRow, miner.RackCol)
+		if !ok {
+			continue
+		}
+		currentOccupants[key] = miner
+	}
+	for _, miner := range r.population.hiddenRackMembers {
+		key, ok := normalizedRackSlotKey(desiredRackLabel(miner, rackLabels), miner.RackRow, miner.RackCol)
+		if !ok {
+			continue
+		}
+		currentOccupants[key] = miner
+	}
+
+	var errs []*pb.ImportValidationError
+	for _, m := range r.miners {
+		key, ok := normalizedRackSlotKey(m.rackLabel, m.rackRow, m.rackCol)
+		if !ok {
+			continue
+		}
+		occupant, ok := currentOccupants[key]
+		if !ok || occupant.DeviceIdentifier == m.deviceID || movingMiners[occupant.DeviceIdentifier] {
+			continue
+		}
+		errs = append(errs, csvErr(m.rowNum, "MINER", fmt.Sprintf("rack slot already occupied by miner %s", occupant.DeviceIdentifier)))
 	}
 	return errs
 }

--- a/server/internal/domain/sitemap/resolved.go
+++ b/server/internal/domain/sitemap/resolved.go
@@ -1014,7 +1014,7 @@ func computeChanges(resolved *resolvedPlan, parsed *parsedCSV, snap, targetSnap 
 	add(pb.ImportOperation_IMPORT_OPERATION_CREATE, "rack", countRackCreateNodes(resolved.racks), "new rack rows")
 	add(pb.ImportOperation_IMPORT_OPERATION_UPDATE, "site", countSiteUpdates(parsed.sections["SITE"], snap.sites), "site rows with changed details")
 	add(pb.ImportOperation_IMPORT_OPERATION_UPDATE, fieldBuilding, countBuildingUpdates(parsed.sections["BUILDING"], snap.buildings), "building rows with changed details")
-	add(pb.ImportOperation_IMPORT_OPERATION_UPDATE, "rack", countRackUpdates(parsed.sections["RACK"], snap.racks, targetSnap.buildings), "rack rows with changed details")
+	add(pb.ImportOperation_IMPORT_OPERATION_UPDATE, "rack", countRackUpdates(parsed.sections["RACK"], snap.racks), "rack rows with changed details")
 	add(pb.ImportOperation_IMPORT_OPERATION_RENAME, "miner", countMinerRenameNodes(resolved.miners), "miner rows with changed names")
 	add(pb.ImportOperation_IMPORT_OPERATION_MOVE, "miner", countMinerMoveNodes(resolved.miners), "miner placement rows with changed site, building, rack, or slot")
 	if mode == pb.OmissionMode_OMISSION_MODE_REMOVE_OMITTED {

--- a/server/internal/domain/sitemap/resolved.go
+++ b/server/internal/domain/sitemap/resolved.go
@@ -10,9 +10,11 @@ import (
 )
 
 // resolved.go builds the canonical resolved plan for a sitemap import: parsed
-// rows and the live snapshot are collapsed into one graph of typed nodes keyed
-// by stable ID where one exists, with parents linked as pointers, so preview,
-// validation, the commit token, and apply all consume a single representation.
+// rows and the live snapshot are collapsed into one set of typed nodes keyed by
+// stable ID where one exists. Each node carries its parent references as
+// canonical names (siteRef/buildingRef) plus, where it resolved to an existing
+// entity, the parent's id — so preview, validation, the commit token, and apply
+// all consume a single representation.
 
 // nodeAction is the resolved verb for a topology node (site/building/rack).
 // Miners track renamed/moved/unassigned as independent booleans instead, since
@@ -35,9 +37,8 @@ type resolvedSite struct {
 }
 
 type resolvedBuilding struct {
-	id   *int64
-	site *resolvedSite // nil when the site could not be linked
-	// siteLabel is the desired site name even when no site node was linked.
+	id *int64
+	// siteLabel is the desired site name for this building.
 	siteLabel string
 	// siteRef is the canonical site name the row references, filled by resolveReferences.
 	siteRef       string
@@ -51,10 +52,8 @@ type resolvedBuilding struct {
 }
 
 type resolvedRack struct {
-	id       *int64
-	building *resolvedBuilding // nil ⇒ rack sits directly under a site
-	site     *resolvedSite
-	// buildingLabel / siteLabel are the desired names even when no parent was linked.
+	id *int64
+	// buildingLabel / siteLabel are the desired parent names for this rack.
 	buildingLabel string
 	siteLabel     string
 	// siteRef / buildingRef are the canonical site and building names the row
@@ -87,9 +86,6 @@ type resolvedMiner struct {
 	ipAddress    string
 	macAddress   string
 	existing     *minerSnapshot
-	rack         *resolvedRack
-	building     *resolvedBuilding
-	site         *resolvedSite
 	rackLabel    string
 	siteLabel    string
 	buildLabel   string
@@ -157,7 +153,6 @@ func resolvePlan(parsed *parsedCSV, snap *snapshot, mode pb.OmissionMode) *resol
 	}
 
 	sitesByID := existingSitesByID(snap.sites)
-	sitesByName := existingSitesByName(snap.sites)
 	buildingsByID := existingBuildingsByID(snap.buildings)
 	racksByID := existingRacksByID(snap.racks)
 
@@ -169,10 +164,9 @@ func resolvePlan(parsed *parsedCSV, snap *snapshot, mode pb.OmissionMode) *resol
 	plan.topology = resolveTopologyView(parsed, target)
 
 	plan.sites, plan.errors = resolveSites(parsed.sections["SITE"], sitesByID)
-	sitesByNode := indexSitesByIdentity(plan.sites)
 
 	var buildingErrs []*pb.ImportValidationError
-	plan.buildings, buildingErrs = resolveBuildings(parsed.sections["BUILDING"], buildingsByID, sitesByName, sitesByNode)
+	plan.buildings, buildingErrs = resolveBuildings(parsed.sections["BUILDING"], buildingsByID)
 	plan.errors = append(plan.errors, buildingErrs...)
 
 	var rackErrs []*pb.ImportValidationError
@@ -230,8 +224,6 @@ func resolveSites(rows []map[string]string, existingByID map[int64]sitemodels.Si
 func resolveBuildings(
 	rows []map[string]string,
 	existingByID map[int64]buildingmodels.Building,
-	sitesByName map[string]sitemodels.Site,
-	sitesByNode map[string]*resolvedSite,
 ) ([]*resolvedBuilding, []*pb.ImportValidationError) {
 	out := make([]*resolvedBuilding, 0, len(rows))
 	for i, row := range rows {
@@ -251,7 +243,6 @@ func resolveBuildings(
 			}
 		}
 		node.siteLabel = row[fieldSite]
-		node.site = linkSite(row[fieldSite], sitesByName, sitesByNode)
 		out = append(out, node)
 	}
 	return out, nil
@@ -374,7 +365,7 @@ func validateKnownMiners(miners []*resolvedMiner) []*pb.ImportValidationError {
 	var errs []*pb.ImportValidationError
 	for _, m := range miners {
 		if m.deviceID != "" && m.existing == nil {
-			errs = append(errs, csvErr(m.rowNum, "MINER", "unknown miner device_identifier"))
+			errs = append(errs, csvErr(m.rowNum, "MINER", fmt.Sprintf("unknown miner device_identifier %q", m.deviceID)))
 		}
 	}
 	return errs
@@ -453,16 +444,12 @@ func validatePlacementConsistency(miners []*resolvedMiner, tv *topologyView) []*
 	var errs []*pb.ImportValidationError
 	for _, m := range miners {
 		if m.rackLabel != "" {
-			rack, ok := tv.racksByLabel[m.rackLabel]
-			if !ok {
+			// A rack reference dictates the miner's building and site; resolveReferences
+			// has already canonicalized the row's site/building to the rack's parents
+			// (rack wins over building wins over site), so there is no explicit-ancestor
+			// mismatch left to check here — only that the referenced rack exists.
+			if _, ok := tv.racksByLabel[m.rackLabel]; !ok {
 				errs = append(errs, csvErr(m.rowNum, "MINER", fmt.Sprintf("unknown rack %q", m.rackLabel)))
-				continue
-			}
-			if m.siteLabel != "" && m.siteLabel != rack.Site {
-				errs = append(errs, csvErr(m.rowNum, "MINER", fmt.Sprintf("miner site %q does not match rack site %q", m.siteLabel, rack.Site)))
-			}
-			if m.buildLabel != "" && m.buildLabel != rack.Building {
-				errs = append(errs, csvErr(m.rowNum, "MINER", fmt.Sprintf("miner building %q does not match rack building %q", m.buildLabel, rack.Building)))
 			}
 			continue
 		}
@@ -1006,44 +993,10 @@ func computeOmissions(parsed *parsedCSV, snap *snapshot, _ pb.OmissionMode) *pb.
 	return out
 }
 
-func linkSite(name string, sitesByName map[string]sitemodels.Site, sitesByNode map[string]*resolvedSite) *resolvedSite {
-	if name == "" {
-		return nil
-	}
-	if node, ok := sitesByNode["name:"+name]; ok {
-		return node
-	}
-	if _, ok := sitesByName[name]; ok {
-		if node, ok := sitesByNode["name:"+name]; ok {
-			return node
-		}
-	}
-	return nil
-}
-
-func indexSitesByIdentity(sites []*resolvedSite) map[string]*resolvedSite {
-	out := map[string]*resolvedSite{}
-	for _, s := range sites {
-		out["name:"+s.name] = s
-		if s.id != nil {
-			out["id:"+strconv.FormatInt(*s.id, 10)] = s
-		}
-	}
-	return out
-}
-
 func existingSitesByID(sites []sitemodels.Site) map[int64]sitemodels.Site {
 	out := map[int64]sitemodels.Site{}
 	for _, s := range sites {
 		out[s.ID] = s
-	}
-	return out
-}
-
-func existingSitesByName(sites []sitemodels.Site) map[string]sitemodels.Site {
-	out := map[string]sitemodels.Site{}
-	for _, s := range sites {
-		out[s.Name] = s
 	}
 	return out
 }

--- a/server/internal/domain/sitemap/resolved.go
+++ b/server/internal/domain/sitemap/resolved.go
@@ -38,7 +38,9 @@ type resolvedBuilding struct {
 	id   *int64
 	site *resolvedSite // nil when the site could not be linked
 	// siteLabel is the desired site name even when no site node was linked.
-	siteLabel     string
+	siteLabel string
+	// siteRef is the raw site name from the row, before site_id resolution.
+	siteRef       string
 	name          string
 	prevName      string
 	prevSiteLabel string
@@ -53,8 +55,12 @@ type resolvedRack struct {
 	building *resolvedBuilding // nil ⇒ rack sits directly under a site
 	site     *resolvedSite
 	// buildingLabel / siteLabel are the desired names even when no parent was linked.
-	buildingLabel   string
-	siteLabel       string
+	buildingLabel string
+	siteLabel     string
+	// siteRef / buildingRef are the raw row references, before building_id resolution.
+	siteRef         string
+	buildingRef     string
+	hasBuildingID   bool
 	label           string
 	prevLabel       string
 	zone            string
@@ -71,24 +77,25 @@ type resolvedRack struct {
 // mutable facets. existing is the matched live miner, or nil when the device is
 // unknown.
 type resolvedMiner struct {
-	deviceID     string
-	name         string
-	serialNumber string
-	ipAddress    string
-	macAddress   string
-	existing     *minerSnapshot
-	rack         *resolvedRack
-	building     *resolvedBuilding
-	site         *resolvedSite
-	rackLabel    string
-	siteLabel    string
-	buildLabel   string
-	rackRow      string
-	rackCol      string
-	renamed      bool
-	moved        bool
-	unassigned   bool
-	rowNum       int
+	deviceID      string
+	name          string
+	serialNumber  string
+	ipAddress     string
+	macAddress    string
+	existing      *minerSnapshot
+	rack          *resolvedRack
+	building      *resolvedBuilding
+	site          *resolvedSite
+	rackLabel     string
+	siteLabel     string
+	buildLabel    string
+	rackRow       string
+	rackCol       string
+	hasBuildingID bool
+	renamed       bool
+	moved         bool
+	unassigned    bool
+	rowNum        int
 }
 
 // minerPopulation is the scoped mutable-miner set shared by omission counts,
@@ -98,6 +105,18 @@ type minerPopulation struct {
 	hiddenRackMembers []minerSnapshot
 }
 
+// topologyView is the desired end-state topology (CSV rows merged over the
+// omission-target snapshot) that placement-target validators resolve references
+// against. Built once so validators do not each re-derive it.
+type topologyView struct {
+	sites           map[string]bool
+	buildingKeys    map[string]bool
+	buildingsByKey  map[string]buildingmodels.Building
+	buildingsByName map[string]buildingmodels.Building
+	buildingAmbig   map[string]bool
+	racksByLabel    map[string]rackSnapshot
+}
+
 type resolvedPlan struct {
 	mode       pb.OmissionMode
 	sites      []*resolvedSite
@@ -105,6 +124,7 @@ type resolvedPlan struct {
 	racks      []*resolvedRack
 	miners     []*resolvedMiner
 	population minerPopulation
+	topology   *topologyView
 
 	omissions *pb.OmissionCounts
 	errors    []*pb.ImportValidationError
@@ -131,6 +151,12 @@ func resolvePlan(parsed *parsedCSV, snap *snapshot, mode pb.OmissionMode) *resol
 	buildingsByID := existingBuildingsByID(snap.buildings)
 	racksByID := existingRacksByID(snap.racks)
 
+	// Reference targets resolve against the desired end-state topology: CSV rows
+	// merged over the omission-target snapshot (which drops omitted topology under
+	// remove-omitted). Action classification and prevName below use the full snap.
+	target := snapshotForOmissionMode(snap, mode)
+	plan.topology = resolveTopologyView(parsed, target)
+
 	plan.sites, plan.errors = resolveSites(parsed.sections["SITE"], sitesByID)
 	sitesByNode := indexSitesByIdentity(plan.sites)
 
@@ -138,17 +164,8 @@ func resolvePlan(parsed *parsedCSV, snap *snapshot, mode pb.OmissionMode) *resol
 	plan.buildings, buildingErrs = resolveBuildings(parsed.sections["BUILDING"], buildingsByID, sitesByID, sitesByName, sitesByNode)
 	plan.errors = append(plan.errors, buildingErrs...)
 
-	// A rack's site can be inferred from an unambiguous building name reference.
-	// Under remove-omitted, existing buildings are deleted, so only CSV-declared
-	// buildings can supply the inferred site.
-	inferBuildings := snap.buildings
-	if mode == pb.OmissionMode_OMISSION_MODE_REMOVE_OMITTED {
-		inferBuildings = nil
-	}
-	inferSiteByBuilding, inferAmbiguous := desiredBuildingNameLookup(parsed.sections["BUILDING"], inferBuildings)
-
 	var rackErrs []*pb.ImportValidationError
-	plan.racks, rackErrs = resolveRacks(parsed.sections["RACK"], racksByID, buildingsByID, inferSiteByBuilding, inferAmbiguous)
+	plan.racks, rackErrs = resolveRacks(parsed.sections["RACK"], racksByID, buildingsByID, plan.topology.buildingsByName, plan.topology.buildingAmbig)
 	plan.errors = append(plan.errors, rackErrs...)
 
 	plan.miners = resolveMiners(parsed.sections["MINER"], minerMap(snap.miners))
@@ -157,6 +174,20 @@ func resolvePlan(parsed *parsedCSV, snap *snapshot, mode pb.OmissionMode) *resol
 	plan.omissions = computeOmissions(parsed, snap, mode)
 
 	return plan
+}
+
+func resolveTopologyView(parsed *parsedCSV, target *snapshot) *topologyView {
+	siteRows := parsed.sections["SITE"]
+	buildingRows := parsed.sections["BUILDING"]
+	rackRows := parsed.sections["RACK"]
+	tv := &topologyView{
+		sites:          desiredSiteSet(siteRows, target.sites),
+		buildingKeys:   rowSetFromDesiredBuildings(buildingRows, target.buildings),
+		buildingsByKey: desiredBuildingMap(buildingRows, target.buildings),
+		racksByLabel:   desiredRackMap(rackRows, target.racks, buildingRows, target.buildings),
+	}
+	tv.buildingsByName, tv.buildingAmbig = desiredBuildingNameLookup(buildingRows, target.buildings)
+	return tv
 }
 
 // resolveSites resolves SITE rows. A row with an id references an existing site;
@@ -195,6 +226,7 @@ func resolveBuildings(
 		rn := rowNumber(row, i+1)
 		node := &resolvedBuilding{
 			name:          buildingSectionName(row),
+			siteRef:       row[fieldSite],
 			aisles:        optInt32(row, "aisles"),
 			racksPerAisle: optInt32(row, "racks_per_aisle"),
 			rowNum:        rn,
@@ -248,6 +280,9 @@ func resolveRacks(
 			positionInAisle: row["position_in_aisle"],
 			buildingLabel:   row[fieldBuilding],
 			siteLabel:       row[fieldSite],
+			siteRef:         row[fieldSite],
+			buildingRef:     row[fieldBuilding],
+			hasBuildingID:   row[fieldBuildingID] != "",
 			rowNum:          rn,
 		}
 		if id, ok := rowID(row); ok {
@@ -277,17 +312,18 @@ func resolveMiners(rows []map[string]string, existingByID map[string]minerSnapsh
 	out := make([]*resolvedMiner, 0, len(rows))
 	for i, row := range rows {
 		node := &resolvedMiner{
-			deviceID:     row["device_identifier"],
-			name:         row[fieldName],
-			serialNumber: row["serial_number"],
-			ipAddress:    row["ip_address"],
-			macAddress:   row["mac_address"],
-			rackLabel:    row[fieldRack],
-			siteLabel:    row[fieldSite],
-			buildLabel:   row[fieldBuilding],
-			rackRow:      row["rack_row"],
-			rackCol:      row["rack_col"],
-			rowNum:       rowNumber(row, i+1),
+			deviceID:      row["device_identifier"],
+			name:          row[fieldName],
+			serialNumber:  row["serial_number"],
+			ipAddress:     row["ip_address"],
+			macAddress:    row["mac_address"],
+			rackLabel:     row[fieldRack],
+			siteLabel:     row[fieldSite],
+			buildLabel:    row[fieldBuilding],
+			rackRow:       row["rack_row"],
+			rackCol:       row["rack_col"],
+			hasBuildingID: row[fieldBuildingID] != "",
+			rowNum:        rowNumber(row, i+1),
 		}
 		if existing, ok := existingByID[node.deviceID]; ok {
 			e := existing
@@ -343,6 +379,104 @@ func validateSlotCollisions(miners []*resolvedMiner) []*pb.ImportValidationError
 			errs = append(errs, csvErr(m.rowNum, "MINER", "duplicate rack slot"))
 		}
 		seen[key] = true
+	}
+	return errs
+}
+
+// validateBuildingSiteTargets rejects building rows whose site reference is not
+// part of the desired topology.
+func validateBuildingSiteTargets(buildings []*resolvedBuilding, tv *topologyView) []*pb.ImportValidationError {
+	var errs []*pb.ImportValidationError
+	for _, b := range buildings {
+		if b.siteRef != "" && !tv.sites[b.siteRef] {
+			errs = append(errs, csvErr(b.rowNum, "BUILDING", fmt.Sprintf("unknown site %q", b.siteRef)))
+		}
+	}
+	return errs
+}
+
+// validateRackPlacementTargets rejects rack rows whose site or building
+// reference cannot be resolved in the desired topology.
+func validateRackPlacementTargets(racks []*resolvedRack, tv *topologyView) []*pb.ImportValidationError {
+	var errs []*pb.ImportValidationError
+	for _, r := range racks {
+		if r.siteRef != "" && !tv.sites[r.siteRef] {
+			errs = append(errs, csvErr(r.rowNum, "RACK", fmt.Sprintf("unknown site %q", r.siteRef)))
+		}
+		if r.buildingRef == "" {
+			continue
+		}
+		if r.siteRef == "" {
+			if r.hasBuildingID {
+				continue
+			}
+			if tv.buildingAmbig[r.buildingRef] {
+				errs = append(errs, csvErr(r.rowNum, "RACK", fmt.Sprintf("rack building %q is ambiguous; add site or building_id", r.buildingRef)))
+				continue
+			}
+			if _, ok := tv.buildingsByName[r.buildingRef]; !ok {
+				errs = append(errs, csvErr(r.rowNum, "RACK", fmt.Sprintf("unknown building %q", r.buildingRef)))
+			}
+			continue
+		}
+		if !tv.buildingKeys[r.siteRef+"\x00"+r.buildingRef] {
+			errs = append(errs, csvErr(r.rowNum, "RACK", fmt.Sprintf("unknown building %q for site %q", r.buildingRef, r.siteRef)))
+		}
+	}
+	return errs
+}
+
+// validatePlacementConsistency rejects miner rows whose declared site, building,
+// and rack references disagree with one another or with the desired topology.
+func validatePlacementConsistency(miners []*resolvedMiner, tv *topologyView) []*pb.ImportValidationError {
+	var errs []*pb.ImportValidationError
+	for _, m := range miners {
+		if m.rackLabel != "" {
+			rack, ok := tv.racksByLabel[m.rackLabel]
+			if !ok {
+				errs = append(errs, csvErr(m.rowNum, "MINER", fmt.Sprintf("unknown rack %q", m.rackLabel)))
+				continue
+			}
+			if m.siteLabel != "" && m.siteLabel != rack.Site {
+				errs = append(errs, csvErr(m.rowNum, "MINER", fmt.Sprintf("miner site %q does not match rack site %q", m.siteLabel, rack.Site)))
+			}
+			if m.buildLabel != "" && m.buildLabel != rack.Building {
+				errs = append(errs, csvErr(m.rowNum, "MINER", fmt.Sprintf("miner building %q does not match rack building %q", m.buildLabel, rack.Building)))
+			}
+			continue
+		}
+		if m.buildLabel != "" {
+			if m.hasBuildingID {
+				continue
+			}
+			if m.siteLabel != "" {
+				building, ok := tv.buildingsByKey[m.siteLabel+"\x00"+m.buildLabel]
+				if !ok {
+					errs = append(errs, csvErr(m.rowNum, "MINER", fmt.Sprintf("unknown building %q for site %q", m.buildLabel, m.siteLabel)))
+					continue
+				}
+				if m.siteLabel != building.SiteLabel {
+					errs = append(errs, csvErr(m.rowNum, "MINER", fmt.Sprintf("miner site %q does not match building site %q", m.siteLabel, building.SiteLabel)))
+				}
+				continue
+			}
+			if tv.buildingAmbig[m.buildLabel] {
+				errs = append(errs, csvErr(m.rowNum, "MINER", fmt.Sprintf("miner building %q is ambiguous; add site or building_id", m.buildLabel)))
+				continue
+			}
+			building, ok := tv.buildingsByName[m.buildLabel]
+			if !ok {
+				errs = append(errs, csvErr(m.rowNum, "MINER", fmt.Sprintf("unknown building %q", m.buildLabel)))
+				continue
+			}
+			if m.siteLabel != "" && m.siteLabel != building.SiteLabel {
+				errs = append(errs, csvErr(m.rowNum, "MINER", fmt.Sprintf("miner site %q does not match building site %q", m.siteLabel, building.SiteLabel)))
+			}
+			continue
+		}
+		if m.siteLabel != "" && !tv.sites[m.siteLabel] {
+			errs = append(errs, csvErr(m.rowNum, "MINER", fmt.Sprintf("unknown site %q", m.siteLabel)))
+		}
 	}
 	return errs
 }

--- a/server/internal/domain/sitemap/resolved.go
+++ b/server/internal/domain/sitemap/resolved.go
@@ -39,7 +39,7 @@ type resolvedBuilding struct {
 	site *resolvedSite // nil when the site could not be linked
 	// siteLabel is the desired site name even when no site node was linked.
 	siteLabel string
-	// siteRef is the raw site name from the row, before site_id resolution.
+	// siteRef is the canonical site name the row references, filled by resolveReferences.
 	siteRef       string
 	name          string
 	prevName      string
@@ -57,13 +57,10 @@ type resolvedRack struct {
 	// buildingLabel / siteLabel are the desired names even when no parent was linked.
 	buildingLabel string
 	siteLabel     string
-	// siteRef / buildingRef are the raw row references, before building_id resolution.
-	siteRef     string
-	buildingRef string
-	// hasBuildingID is true when the row supplied any building_id; buildingIDRef is
-	// the parsed value, nil when absent or unparseable.
-	hasBuildingID   bool
-	buildingIDRef   *int64
+	// siteRef / buildingRef are the canonical site and building names the row
+	// references, filled in by resolveReferences.
+	siteRef         string
+	buildingRef     string
 	label           string
 	prevLabel       string
 	zone            string
@@ -94,16 +91,10 @@ type resolvedMiner struct {
 	buildLabel   string
 	rackRow      string
 	rackCol      string
-	// siteIDCell / buildingIDCell / rackIDCell are the raw *_id row cells, used to
-	// detect placement identity changes against the existing miner.
-	siteIDCell     string
-	buildingIDCell string
-	rackIDCell     string
-	hasBuildingID  bool
-	renamed        bool
-	moved          bool
-	unassigned     bool
-	rowNum         int
+	renamed      bool
+	moved        bool
+	unassigned   bool
+	rowNum       int
 }
 
 // minerPopulation is the scoped mutable-miner set shared by omission counts,
@@ -122,8 +113,6 @@ type topologyView struct {
 	buildingsByKey         map[string]buildingmodels.Building
 	buildingsByLayoutID    map[int64]buildingmodels.Building
 	buildingsByCapacityKey map[string]buildingmodels.Building
-	buildingsByName        map[string]buildingmodels.Building
-	buildingAmbig          map[string]bool
 	racksByLabel           map[string]rackSnapshot
 }
 
@@ -175,11 +164,11 @@ func resolvePlan(parsed *parsedCSV, snap *snapshot, mode pb.OmissionMode) *resol
 	sitesByNode := indexSitesByIdentity(plan.sites)
 
 	var buildingErrs []*pb.ImportValidationError
-	plan.buildings, buildingErrs = resolveBuildings(parsed.sections["BUILDING"], buildingsByID, sitesByID, sitesByName, sitesByNode)
+	plan.buildings, buildingErrs = resolveBuildings(parsed.sections["BUILDING"], buildingsByID, sitesByName, sitesByNode)
 	plan.errors = append(plan.errors, buildingErrs...)
 
 	var rackErrs []*pb.ImportValidationError
-	plan.racks, rackErrs = resolveRacks(parsed.sections["RACK"], racksByID, buildingsByID, plan.topology.buildingsByName, plan.topology.buildingAmbig)
+	plan.racks, rackErrs = resolveRacks(parsed.sections["RACK"], racksByID)
 	plan.errors = append(plan.errors, rackErrs...)
 
 	plan.miners = resolveMiners(parsed.sections["MINER"], minerMap(snap.miners))
@@ -203,7 +192,6 @@ func resolveTopologyView(parsed *parsedCSV, target *snapshot) *topologyView {
 		buildingsByCapacityKey: desiredBuildingCapacityMap(buildingRows, target.buildings),
 		racksByLabel:           desiredRackMap(rackRows, target.racks, buildingRows, target.buildings),
 	}
-	tv.buildingsByName, tv.buildingAmbig = desiredBuildingNameLookup(buildingRows, target.buildings)
 	return tv
 }
 
@@ -228,17 +216,16 @@ func resolveSites(rows []map[string]string, existingByID map[int64]sitemodels.Si
 }
 
 // resolveBuildings resolves BUILDING rows, linking each to its resolved site.
-// Site precedence: site_id wins, then site name; a blank or unknown reference
-// keeps the raw label with no linked node. A site_id/site-name mismatch is an error.
+// The site reference cell has already been canonicalized to a site name by
+// resolveReferences; a blank or unknown name keeps the raw label with no linked
+// node.
 func resolveBuildings(
 	rows []map[string]string,
 	existingByID map[int64]buildingmodels.Building,
-	sitesByID map[int64]sitemodels.Site,
 	sitesByName map[string]sitemodels.Site,
 	sitesByNode map[string]*resolvedSite,
 ) ([]*resolvedBuilding, []*pb.ImportValidationError) {
 	out := make([]*resolvedBuilding, 0, len(rows))
-	var errs []*pb.ImportValidationError
 	for i, row := range rows {
 		rn := rowNumber(row, i+1)
 		node := &resolvedBuilding{
@@ -255,34 +242,19 @@ func resolveBuildings(
 				node.prevSiteLabel = existing.SiteLabel
 			}
 		}
-
-		siteName := row[fieldSite]
-		if siteID, ok := idFromCell(row[fieldSiteID]); ok {
-			if site, found := sitesByID[siteID]; found {
-				if siteName != "" && siteName != site.Name {
-					errs = append(errs, csvErr(rn, "BUILDING", "site_id "+quote(row[fieldSiteID])+" does not match site "+quote(siteName)))
-					out = append(out, node)
-					continue
-				}
-				siteName = site.Name
-			}
-		}
-		node.siteLabel = siteName
-		node.site = linkSite(siteName, sitesByName, sitesByNode)
+		node.siteLabel = row[fieldSite]
+		node.site = linkSite(row[fieldSite], sitesByName, sitesByNode)
 		out = append(out, node)
 	}
-	return out, errs
+	return out, nil
 }
 
-// resolveRacks resolves RACK rows, linking each to its building and site.
-// Precedence: building_id wins and dictates the site; otherwise a blank site is
-// inferred from an unambiguous building name.
+// resolveRacks resolves RACK rows. The building and site reference cells have
+// already been canonicalized to names by resolveReferences (a building reference
+// also fills the site), so this just records the resolved labels.
 func resolveRacks(
 	rows []map[string]string,
 	existingByID map[int64]rackSnapshot,
-	buildingsByID map[int64]buildingmodels.Building,
-	inferSiteByBuilding map[string]buildingmodels.Building,
-	inferAmbiguous map[string]bool,
 ) ([]*resolvedRack, []*pb.ImportValidationError) {
 	out := make([]*resolvedRack, 0, len(rows))
 	for i, row := range rows {
@@ -299,24 +271,12 @@ func resolveRacks(
 			siteLabel:       row[fieldSite],
 			siteRef:         row[fieldSite],
 			buildingRef:     row[fieldBuilding],
-			hasBuildingID:   row[fieldBuildingID] != "",
 			rowNum:          rn,
 		}
 		if id, ok := rowID(row); ok {
 			node.id = int64Ptr(id)
 			if existing, found := existingByID[id]; found {
 				node.prevLabel = existing.Label
-			}
-		}
-		if buildingID, ok := idFromCell(row[fieldBuildingID]); ok {
-			node.buildingIDRef = int64Ptr(buildingID)
-			if building, found := buildingsByID[buildingID]; found {
-				node.buildingLabel = building.Name
-				node.siteLabel = building.SiteLabel
-			}
-		} else if node.siteLabel == "" && node.buildingLabel != "" && !inferAmbiguous[node.buildingLabel] {
-			if b, found := inferSiteByBuilding[node.buildingLabel]; found {
-				node.siteLabel = b.SiteLabel
 			}
 		}
 		out = append(out, node)
@@ -330,21 +290,17 @@ func resolveMiners(rows []map[string]string, existingByID map[string]minerSnapsh
 	out := make([]*resolvedMiner, 0, len(rows))
 	for i, row := range rows {
 		node := &resolvedMiner{
-			deviceID:       row["device_identifier"],
-			name:           row[fieldName],
-			serialNumber:   row["serial_number"],
-			ipAddress:      row["ip_address"],
-			macAddress:     row["mac_address"],
-			rackLabel:      row[fieldRack],
-			siteLabel:      row[fieldSite],
-			buildLabel:     row[fieldBuilding],
-			rackRow:        row["rack_row"],
-			rackCol:        row["rack_col"],
-			siteIDCell:     row[fieldSiteID],
-			buildingIDCell: row[fieldBuildingID],
-			rackIDCell:     row[fieldRackID],
-			hasBuildingID:  row[fieldBuildingID] != "",
-			rowNum:         rowNumber(row, i+1),
+			deviceID:     row["device_identifier"],
+			name:         row[fieldName],
+			serialNumber: row["serial_number"],
+			ipAddress:    row["ip_address"],
+			macAddress:   row["mac_address"],
+			rackLabel:    row[fieldRack],
+			siteLabel:    row[fieldSite],
+			buildLabel:   row[fieldBuilding],
+			rackRow:      row["rack_row"],
+			rackCol:      row["rack_col"],
+			rowNum:       rowNumber(row, i+1),
 		}
 		if existing, ok := existingByID[node.deviceID]; ok {
 			e := existing
@@ -364,8 +320,7 @@ func classifyMinerMoves(miners []*resolvedMiner, tv *topologyView) {
 			continue
 		}
 		desiredSite, desiredBuilding := minerDesiredSiteBuilding(m, tv)
-		if !minerPlacementIDsMatchNode(m) ||
-			desiredSite != m.existing.Site ||
+		if desiredSite != m.existing.Site ||
 			desiredBuilding != m.existing.Building ||
 			m.rackLabel != m.existing.Rack ||
 			m.rackRow != m.existing.RackRow ||
@@ -375,51 +330,16 @@ func classifyMinerMoves(miners []*resolvedMiner, tv *topologyView) {
 	}
 }
 
-// minerDesiredSiteBuilding resolves the site and building a miner row targets,
-// following rack, then building_id, then unambiguous building name.
+// minerDesiredSiteBuilding resolves the site and building a miner row targets. A
+// rack reference dictates both; otherwise the row's canonicalized site/building
+// names are authoritative (resolveReferences already filled the site from a
+// building reference).
 func minerDesiredSiteBuilding(m *resolvedMiner, tv *topologyView) (string, string) {
 	if m.rackLabel != "" {
 		rack := tv.racksByLabel[m.rackLabel]
 		return rack.Site, rack.Building
 	}
-	if id, ok := idFromCell(m.buildingIDCell); ok {
-		if building, ok := tv.buildingsByLayoutID[id]; ok {
-			return building.SiteLabel, building.Name
-		}
-	}
-	if m.siteLabel == "" && m.buildLabel != "" && !tv.buildingAmbig[m.buildLabel] {
-		if building, ok := tv.buildingsByName[m.buildLabel]; ok {
-			return building.SiteLabel, m.buildLabel
-		}
-	}
 	return m.siteLabel, m.buildLabel
-}
-
-// minerPlacementIDsMatchNode reports whether the row's supplied *_id cells agree
-// with the existing miner's placement ids. The rack id is ignored when the row
-// declares no rack.
-func minerPlacementIDsMatchNode(m *resolvedMiner) bool {
-	checks := []struct {
-		cell   string
-		want   *int64
-		isRack bool
-	}{
-		{m.siteIDCell, m.existing.SiteID, false},
-		{m.buildingIDCell, m.existing.BuildingID, false},
-		{m.rackIDCell, m.existing.RackID, true},
-	}
-	for _, c := range checks {
-		if c.isRack && m.rackLabel == "" {
-			continue
-		}
-		if c.cell == "" {
-			continue
-		}
-		if c.cell != formatNullableInt64(c.want) {
-			return false
-		}
-	}
-	return true
 }
 
 // validateMinerRenamePermission rejects renaming an existing miner without the
@@ -505,19 +425,6 @@ func validateRackPlacementTargets(racks []*resolvedRack, tv *topologyView) []*pb
 		if r.buildingRef == "" {
 			continue
 		}
-		if r.siteRef == "" {
-			if r.hasBuildingID {
-				continue
-			}
-			if tv.buildingAmbig[r.buildingRef] {
-				errs = append(errs, csvErr(r.rowNum, "RACK", fmt.Sprintf("rack building %q is ambiguous; add site or building_id", r.buildingRef)))
-				continue
-			}
-			if _, ok := tv.buildingsByName[r.buildingRef]; !ok {
-				errs = append(errs, csvErr(r.rowNum, "RACK", fmt.Sprintf("unknown building %q", r.buildingRef)))
-			}
-			continue
-		}
 		if !tv.buildingKeys[r.siteRef+"\x00"+r.buildingRef] {
 			errs = append(errs, csvErr(r.rowNum, "RACK", fmt.Sprintf("unknown building %q for site %q", r.buildingRef, r.siteRef)))
 		}
@@ -545,31 +452,8 @@ func validatePlacementConsistency(miners []*resolvedMiner, tv *topologyView) []*
 			continue
 		}
 		if m.buildLabel != "" {
-			if m.hasBuildingID {
-				continue
-			}
-			if m.siteLabel != "" {
-				building, ok := tv.buildingsByKey[m.siteLabel+"\x00"+m.buildLabel]
-				if !ok {
-					errs = append(errs, csvErr(m.rowNum, "MINER", fmt.Sprintf("unknown building %q for site %q", m.buildLabel, m.siteLabel)))
-					continue
-				}
-				if m.siteLabel != building.SiteLabel {
-					errs = append(errs, csvErr(m.rowNum, "MINER", fmt.Sprintf("miner site %q does not match building site %q", m.siteLabel, building.SiteLabel)))
-				}
-				continue
-			}
-			if tv.buildingAmbig[m.buildLabel] {
-				errs = append(errs, csvErr(m.rowNum, "MINER", fmt.Sprintf("miner building %q is ambiguous; add site or building_id", m.buildLabel)))
-				continue
-			}
-			building, ok := tv.buildingsByName[m.buildLabel]
-			if !ok {
-				errs = append(errs, csvErr(m.rowNum, "MINER", fmt.Sprintf("unknown building %q", m.buildLabel)))
-				continue
-			}
-			if m.siteLabel != "" && m.siteLabel != building.SiteLabel {
-				errs = append(errs, csvErr(m.rowNum, "MINER", fmt.Sprintf("miner site %q does not match building site %q", m.siteLabel, building.SiteLabel)))
+			if _, ok := tv.buildingsByKey[m.siteLabel+"\x00"+m.buildLabel]; !ok {
+				errs = append(errs, csvErr(m.rowNum, "MINER", fmt.Sprintf("unknown building %q for site %q", m.buildLabel, m.siteLabel)))
 			}
 			continue
 		}
@@ -629,10 +513,6 @@ func validateRackGridPositions(racks []*resolvedRack, tv *topologyView) []*pb.Im
 }
 
 func rackGridBuilding(r *resolvedRack, tv *topologyView) (buildingmodels.Building, bool) {
-	if r.buildingIDRef != nil {
-		building, ok := tv.buildingsByLayoutID[*r.buildingIDRef]
-		return building, ok
-	}
 	building, ok := tv.buildingsByKey[r.siteRef+"\x00"+r.buildingRef]
 	return building, ok
 }

--- a/server/internal/domain/sitemap/resolved.go
+++ b/server/internal/domain/sitemap/resolved.go
@@ -586,6 +586,106 @@ func validateRackSlotBounds(miners []*resolvedMiner, tv *topologyView) []*pb.Imp
 	return errs
 }
 
+// rackLabelsByID maps a resolved rack's stable id to its desired label, so an
+// existing miner referencing a renamed rack by id resolves to the new label.
+func rackLabelsByID(racks []*resolvedRack) map[int64]string {
+	out := map[int64]string{}
+	for _, r := range racks {
+		if r.id != nil {
+			out[*r.id] = r.label
+		}
+	}
+	return out
+}
+
+// validateExistingSlotsFitRackDimensions rejects an import that would shrink a
+// rack below the slot coordinates its current or incoming miners occupy.
+func validateExistingSlotsFitRackDimensions(r *resolvedPlan) []*pb.ImportValidationError {
+	racks := r.topology.racksByLabel
+	rackLabels := rackLabelsByID(r.racks)
+	desired := map[string]*resolvedMiner{}
+	for _, m := range r.miners {
+		desired[m.deviceID] = m
+	}
+	var errs []*pb.ImportValidationError
+	fits := func(deviceID, rackLabel, rackRow, rackCol string) {
+		if rackLabel == "" || rackRow == "" || rackCol == "" {
+			return
+		}
+		rack, ok := racks[rackLabel]
+		if !ok {
+			return
+		}
+		rowValue, err := parseInt32Value(rackRow, "rack_row")
+		if err != nil {
+			return
+		}
+		colValue, err := parseInt32Value(rackCol, "rack_col")
+		if err != nil {
+			return
+		}
+		if rowValue >= rack.Rows || colValue >= rack.Columns {
+			errs = append(errs, csvErr(0, "MINER", fmt.Sprintf("miner %s slot %d,%d does not fit rack %q dimensions %dx%d", deviceID, rowValue, colValue, rackLabel, rack.Rows, rack.Columns)))
+		}
+	}
+	for _, miner := range r.population.miners {
+		m, ok := desired[miner.DeviceIdentifier]
+		if !ok && r.mode == pb.OmissionMode_OMISSION_MODE_REMOVE_OMITTED {
+			continue
+		}
+		if ok {
+			fits(miner.DeviceIdentifier, m.rackLabel, m.rackRow, m.rackCol)
+			continue
+		}
+		fits(miner.DeviceIdentifier, desiredRackLabel(miner, rackLabels), miner.RackRow, miner.RackCol)
+	}
+	for _, miner := range r.population.hiddenRackMembers {
+		fits(miner.DeviceIdentifier, desiredRackLabel(miner, rackLabels), miner.RackRow, miner.RackCol)
+	}
+	return errs
+}
+
+// validateRackCapacity rejects racks whose desired assigned-miner count exceeds
+// their slot capacity, counting both incoming and retained existing miners.
+func validateRackCapacity(r *resolvedPlan) []*pb.ImportValidationError {
+	racks := r.topology.racksByLabel
+	rackLabels := rackLabelsByID(r.racks)
+	counts := map[string]int32{}
+	presentMiners := map[string]bool{}
+	for _, m := range r.miners {
+		if m.deviceID != "" {
+			presentMiners[m.deviceID] = true
+		}
+		if m.rackLabel != "" {
+			counts[m.rackLabel]++
+		}
+	}
+	if r.mode != pb.OmissionMode_OMISSION_MODE_REMOVE_OMITTED {
+		for _, miner := range r.population.miners {
+			if miner.Rack != "" && !presentMiners[miner.DeviceIdentifier] {
+				counts[desiredRackLabel(miner, rackLabels)]++
+			}
+		}
+	}
+	for _, miner := range r.population.hiddenRackMembers {
+		if miner.Rack != "" && !presentMiners[miner.DeviceIdentifier] {
+			counts[desiredRackLabel(miner, rackLabels)]++
+		}
+	}
+	var errs []*pb.ImportValidationError
+	for rackLabel, count := range counts {
+		rack, ok := racks[rackLabel]
+		if !ok || rack.Rows <= 0 || rack.Columns <= 0 {
+			continue
+		}
+		capacity := rack.Rows * rack.Columns
+		if count > capacity {
+			errs = append(errs, csvErr(0, "MINER", fmt.Sprintf("rack %q has %d assigned miners but capacity is %d", rackLabel, count, capacity)))
+		}
+	}
+	return errs
+}
+
 // countMinerRenameNodes counts existing miners whose name changed.
 func countMinerRenameNodes(miners []*resolvedMiner) int32 {
 	var n int32

--- a/server/internal/domain/sitemap/resolved.go
+++ b/server/internal/domain/sitemap/resolved.go
@@ -1,0 +1,397 @@
+package sitemap
+
+import (
+	"strconv"
+
+	pb "github.com/block/proto-fleet/server/generated/grpc/sitemap/v1"
+	buildingmodels "github.com/block/proto-fleet/server/internal/domain/buildings/models"
+	sitemodels "github.com/block/proto-fleet/server/internal/domain/sites/models"
+)
+
+// resolved.go builds the canonical resolved plan for a sitemap import: parsed
+// rows and the live snapshot are collapsed into one graph of typed nodes keyed
+// by stable ID where one exists, with parents linked as pointers, so preview,
+// validation, the commit token, and apply all consume a single representation.
+
+// nodeAction is the resolved verb for a topology node (site/building/rack).
+// Miners track renamed/moved/unassigned as independent booleans instead, since
+// a miner can be both renamed and moved in one import.
+type nodeAction int
+
+const (
+	actionNone nodeAction = iota
+	actionCreate
+	actionUpdate
+	actionDelete
+)
+
+type resolvedSite struct {
+	id       *int64 // nil ⇒ create
+	name     string
+	prevName string // live name when id != nil
+	action   nodeAction
+	rowNum   int // 1-based CSV row for error provenance
+}
+
+type resolvedBuilding struct {
+	id   *int64
+	site *resolvedSite // nil when the site could not be linked
+	// siteLabel is the desired site name even when no site node was linked.
+	siteLabel     string
+	name          string
+	prevName      string
+	prevSiteLabel string
+	aisles        int32
+	racksPerAisle int32
+	action        nodeAction
+	rowNum        int
+}
+
+type resolvedRack struct {
+	id       *int64
+	building *resolvedBuilding // nil ⇒ rack sits directly under a site
+	site     *resolvedSite
+	// buildingLabel / siteLabel are the desired names even when no parent was linked.
+	buildingLabel   string
+	siteLabel       string
+	label           string
+	prevLabel       string
+	zone            string
+	rows            int32
+	columns         int32
+	orderIndex      string
+	aisleIndex      string
+	positionInAisle string
+	action          nodeAction
+	rowNum          int
+}
+
+// resolvedMiner is keyed by device identifier; name and placement are its only
+// mutable facets.
+type resolvedMiner struct {
+	deviceID   string
+	name       string
+	rack       *resolvedRack
+	building   *resolvedBuilding
+	site       *resolvedSite
+	rackLabel  string
+	siteLabel  string
+	buildLabel string
+	rackRow    string
+	rackCol    string
+	renamed    bool
+	moved      bool
+	unassigned bool
+	rowNum     int
+}
+
+// minerPopulation is the scoped mutable-miner set shared by omission counts,
+// hidden-resource checks, validation, and apply.
+type minerPopulation struct {
+	miners            []minerSnapshot
+	hiddenRackMembers []minerSnapshot
+}
+
+type resolvedPlan struct {
+	mode       pb.OmissionMode
+	sites      []*resolvedSite
+	buildings  []*resolvedBuilding
+	racks      []*resolvedRack
+	miners     []*resolvedMiner
+	population minerPopulation
+
+	omissions *pb.OmissionCounts
+	errors    []*pb.ImportValidationError
+}
+
+func scopePopulation(snap *snapshot, _ pb.OmissionMode) minerPopulation {
+	return minerPopulation{
+		miners:            snap.miners,
+		hiddenRackMembers: snap.hiddenRackMembers,
+	}
+}
+
+// resolvePlan builds the graph, records ID/name consistency errors, classifies
+// node actions, and counts omissions. It does not mutate parsed.
+func resolvePlan(parsed *parsedCSV, snap *snapshot, mode pb.OmissionMode) *resolvedPlan {
+	plan := &resolvedPlan{
+		mode:       mode,
+		population: scopePopulation(snap, mode),
+		omissions:  &pb.OmissionCounts{},
+	}
+
+	sitesByID := existingSitesByID(snap.sites)
+	sitesByName := existingSitesByName(snap.sites)
+	buildingsByID := existingBuildingsByID(snap.buildings)
+	racksByID := existingRacksByID(snap.racks)
+
+	plan.sites, plan.errors = resolveSites(parsed.sections["SITE"], sitesByID)
+	sitesByNode := indexSitesByIdentity(plan.sites)
+
+	var buildingErrs []*pb.ImportValidationError
+	plan.buildings, buildingErrs = resolveBuildings(parsed.sections["BUILDING"], buildingsByID, sitesByID, sitesByName, sitesByNode)
+	plan.errors = append(plan.errors, buildingErrs...)
+
+	// A rack's site can be inferred from an unambiguous building name reference.
+	// Under remove-omitted, existing buildings are deleted, so only CSV-declared
+	// buildings can supply the inferred site.
+	inferBuildings := snap.buildings
+	if mode == pb.OmissionMode_OMISSION_MODE_REMOVE_OMITTED {
+		inferBuildings = nil
+	}
+	inferSiteByBuilding, inferAmbiguous := desiredBuildingNameLookup(parsed.sections["BUILDING"], inferBuildings)
+
+	var rackErrs []*pb.ImportValidationError
+	plan.racks, rackErrs = resolveRacks(parsed.sections["RACK"], racksByID, buildingsByID, inferSiteByBuilding, inferAmbiguous)
+	plan.errors = append(plan.errors, rackErrs...)
+
+	classifyTopologyActions(plan, snap, mode)
+	plan.omissions = computeOmissions(parsed, snap, mode)
+
+	return plan
+}
+
+// resolveSites resolves SITE rows. A row with an id references an existing site;
+// a row without an id is a create keyed by name.
+func resolveSites(rows []map[string]string, existingByID map[int64]sitemodels.Site) ([]*resolvedSite, []*pb.ImportValidationError) {
+	out := make([]*resolvedSite, 0, len(rows))
+	for i, row := range rows {
+		node := &resolvedSite{
+			name:   siteSectionName(row),
+			rowNum: rowNumber(row, i+1),
+		}
+		if id, ok := rowID(row); ok {
+			node.id = int64Ptr(id)
+			if existing, found := existingByID[id]; found {
+				node.prevName = existing.Name
+			}
+		}
+		out = append(out, node)
+	}
+	return out, nil
+}
+
+// resolveBuildings resolves BUILDING rows, linking each to its resolved site.
+// Site precedence: site_id wins, then site name; a blank or unknown reference
+// keeps the raw label with no linked node. A site_id/site-name mismatch is an error.
+func resolveBuildings(
+	rows []map[string]string,
+	existingByID map[int64]buildingmodels.Building,
+	sitesByID map[int64]sitemodels.Site,
+	sitesByName map[string]sitemodels.Site,
+	sitesByNode map[string]*resolvedSite,
+) ([]*resolvedBuilding, []*pb.ImportValidationError) {
+	out := make([]*resolvedBuilding, 0, len(rows))
+	var errs []*pb.ImportValidationError
+	for i, row := range rows {
+		rn := rowNumber(row, i+1)
+		node := &resolvedBuilding{
+			name:          buildingSectionName(row),
+			aisles:        optInt32(row, "aisles"),
+			racksPerAisle: optInt32(row, "racks_per_aisle"),
+			rowNum:        rn,
+		}
+		if id, ok := rowID(row); ok {
+			node.id = int64Ptr(id)
+			if existing, found := existingByID[id]; found {
+				node.prevName = existing.Name
+				node.prevSiteLabel = existing.SiteLabel
+			}
+		}
+
+		siteName := row[fieldSite]
+		if siteID, ok := idFromCell(row[fieldSiteID]); ok {
+			if site, found := sitesByID[siteID]; found {
+				if siteName != "" && siteName != site.Name {
+					errs = append(errs, csvErr(rn, "BUILDING", "site_id "+quote(row[fieldSiteID])+" does not match site "+quote(siteName)))
+					out = append(out, node)
+					continue
+				}
+				siteName = site.Name
+			}
+		}
+		node.siteLabel = siteName
+		node.site = linkSite(siteName, sitesByName, sitesByNode)
+		out = append(out, node)
+	}
+	return out, errs
+}
+
+// resolveRacks resolves RACK rows, linking each to its building and site.
+// Precedence: building_id wins and dictates the site; otherwise a blank site is
+// inferred from an unambiguous building name.
+func resolveRacks(
+	rows []map[string]string,
+	existingByID map[int64]rackSnapshot,
+	buildingsByID map[int64]buildingmodels.Building,
+	inferSiteByBuilding map[string]buildingmodels.Building,
+	inferAmbiguous map[string]bool,
+) ([]*resolvedRack, []*pb.ImportValidationError) {
+	out := make([]*resolvedRack, 0, len(rows))
+	for i, row := range rows {
+		rn := rowNumber(row, i+1)
+		node := &resolvedRack{
+			label:           rackSectionLabel(row),
+			zone:            row["zone"],
+			rows:            optInt32(row, "rows"),
+			columns:         optInt32(row, "columns"),
+			orderIndex:      row["order_index"],
+			aisleIndex:      row["aisle_index"],
+			positionInAisle: row["position_in_aisle"],
+			buildingLabel:   row[fieldBuilding],
+			siteLabel:       row[fieldSite],
+			rowNum:          rn,
+		}
+		if id, ok := rowID(row); ok {
+			node.id = int64Ptr(id)
+			if existing, found := existingByID[id]; found {
+				node.prevLabel = existing.Label
+			}
+		}
+		if buildingID, ok := idFromCell(row[fieldBuildingID]); ok {
+			if building, found := buildingsByID[buildingID]; found {
+				node.buildingLabel = building.Name
+				node.siteLabel = building.SiteLabel
+			}
+		} else if node.siteLabel == "" && node.buildingLabel != "" && !inferAmbiguous[node.buildingLabel] {
+			if b, found := inferSiteByBuilding[node.buildingLabel]; found {
+				node.siteLabel = b.SiteLabel
+			}
+		}
+		out = append(out, node)
+	}
+	return out, nil
+}
+
+// classifyTopologyActions marks each topology node: rows without an existing id
+// create, and rows with an id update when a tracked field differs.
+func classifyTopologyActions(plan *resolvedPlan, snap *snapshot, mode pb.OmissionMode) {
+	for _, s := range plan.sites {
+		switch {
+		case s.id != nil:
+			if s.name != s.prevName {
+				s.action = actionUpdate
+			}
+		default:
+			s.action = actionCreate
+		}
+	}
+	for _, b := range plan.buildings {
+		switch {
+		case b.id != nil:
+			if b.name != b.prevName || b.siteLabel != b.prevSiteLabel {
+				b.action = actionUpdate
+			}
+		default:
+			b.action = actionCreate
+		}
+	}
+	for _, r := range plan.racks {
+		if r.id == nil {
+			r.action = actionCreate
+		} else if r.label != r.prevLabel {
+			r.action = actionUpdate
+		}
+	}
+	_ = snap
+	_ = mode
+}
+
+// computeOmissions counts live entities absent from the CSV.
+func computeOmissions(parsed *parsedCSV, snap *snapshot, _ pb.OmissionMode) *pb.OmissionCounts {
+	out := &pb.OmissionCounts{}
+	siteKeys := siteIdentitySet(parsed.sections["SITE"], snap.sites)
+	buildingKeys := buildingIdentitySet(parsed.sections["BUILDING"], snap.buildings)
+	rackKeys := rackIdentitySet(parsed.sections["RACK"], snap.racks)
+	minerKeys := rowSet(parsed.sections["MINER"], "device_identifier")
+	for _, site := range snap.sites {
+		if !siteKeys[siteIdentity(site)] {
+			out.Sites++
+		}
+	}
+	for _, building := range snap.buildings {
+		if !buildingKeys[buildingIdentity(building)] {
+			out.Buildings++
+		}
+	}
+	for _, rack := range snap.racks {
+		if !rackKeys[rackIdentity(rack)] {
+			out.Racks++
+		}
+	}
+	for _, miner := range snap.miners {
+		if !minerKeys[miner.DeviceIdentifier] {
+			out.Miners++
+		}
+	}
+	return out
+}
+
+func linkSite(name string, sitesByName map[string]sitemodels.Site, sitesByNode map[string]*resolvedSite) *resolvedSite {
+	if name == "" {
+		return nil
+	}
+	if node, ok := sitesByNode["name:"+name]; ok {
+		return node
+	}
+	if _, ok := sitesByName[name]; ok {
+		if node, ok := sitesByNode["name:"+name]; ok {
+			return node
+		}
+	}
+	return nil
+}
+
+func indexSitesByIdentity(sites []*resolvedSite) map[string]*resolvedSite {
+	out := map[string]*resolvedSite{}
+	for _, s := range sites {
+		out["name:"+s.name] = s
+		if s.id != nil {
+			out["id:"+strconv.FormatInt(*s.id, 10)] = s
+		}
+	}
+	return out
+}
+
+func existingSitesByID(sites []sitemodels.Site) map[int64]sitemodels.Site {
+	out := map[int64]sitemodels.Site{}
+	for _, s := range sites {
+		out[s.ID] = s
+	}
+	return out
+}
+
+func existingSitesByName(sites []sitemodels.Site) map[string]sitemodels.Site {
+	out := map[string]sitemodels.Site{}
+	for _, s := range sites {
+		out[s.Name] = s
+	}
+	return out
+}
+
+func existingBuildingsByID(buildings []buildingmodels.Building) map[int64]buildingmodels.Building {
+	out := map[int64]buildingmodels.Building{}
+	for _, b := range buildings {
+		out[b.ID] = b
+	}
+	return out
+}
+
+func existingRacksByID(racks []rackSnapshot) map[int64]rackSnapshot {
+	out := map[int64]rackSnapshot{}
+	for _, r := range racks {
+		out[r.ID] = r
+	}
+	return out
+}
+
+func optInt32(row map[string]string, field string) int32 {
+	if v, err := parseInt32Value(row[field], field); err == nil {
+		return v
+	}
+	return 0
+}
+
+func int64Ptr(v int64) *int64 { return &v }
+
+func quote(v string) string { return strconv.Quote(v) }

--- a/server/internal/domain/sitemap/resolved.go
+++ b/server/internal/domain/sitemap/resolved.go
@@ -182,7 +182,7 @@ func resolvePlan(parsed *parsedCSV, snap *snapshot, mode pb.OmissionMode) *resol
 	plan.miners = resolveMiners(parsed.sections["MINER"], minerMap(snap.miners))
 	classifyMinerMoves(plan.miners, plan.topology)
 
-	classifyTopologyActions(plan, snap, mode)
+	classifyTopologyActions(plan, parsed, snap)
 	plan.omissions = computeOmissions(parsed, snap, mode)
 
 	return plan
@@ -827,47 +827,65 @@ func countMinerMoveNodes(miners []*resolvedMiner) int32 {
 // classifyTopologyActions marks each topology node: a row whose identity is not
 // already present in the live snapshot creates; a row matching an existing
 // entity updates when a tracked field differs.
-func classifyTopologyActions(plan *resolvedPlan, snap *snapshot, _ pb.OmissionMode) {
-	siteNames := map[string]bool{}
-	for _, s := range snap.sites {
-		siteNames[s.Name] = true
+// classifyTopologyActions assigns each site/building/rack node its create/update
+// verb by comparing the (already canonicalized) CSV row against the live entity's
+// comparable row. A row that matches no live entity is a create; one that matches
+// but differs in any exported column is an update. This is the single derivation
+// preview counts, the commit token, and apply all read, so they cannot drift.
+// Node i corresponds to parsed section row i (resolve* build nodes in row order).
+func classifyTopologyActions(plan *resolvedPlan, parsed *parsedCSV, snap *snapshot) {
+	siteExisting := map[string]map[string]string{}
+	for _, site := range snap.sites {
+		row := rowMap(siteHeaders, siteRawRows([]sitemodels.Site{site})[0])
+		siteExisting[siteIdentity(site)] = row
+		siteExisting["name:"+site.Name] = row
 	}
-	buildingKeys := map[string]bool{}
-	for _, b := range snap.buildings {
-		buildingKeys[b.SiteLabel+"\x00"+b.Name] = true
+	buildingExisting := map[string]map[string]string{}
+	for _, building := range snap.buildings {
+		row := rowMap(buildingHeaders, buildingRawRows([]buildingmodels.Building{building})[0])
+		buildingExisting[buildingIdentity(building)] = row
+		buildingExisting["name:"+building.SiteLabel+"\x00"+building.Name] = row
 	}
-	rackLabels := map[string]bool{}
-	for _, r := range snap.racks {
-		rackLabels[r.Label] = true
+	rackExisting := map[string]map[string]string{}
+	for _, rack := range snap.racks {
+		row := rackComparableRow(rack)
+		rackExisting[rackIdentity(rack)] = row
+		rackExisting["label:"+rack.Label] = row
 	}
 
-	for _, s := range plan.sites {
-		if s.id == nil {
-			if !siteNames[s.name] {
-				s.action = actionCreate
-			}
-		} else if s.name != s.prevName {
-			s.action = actionUpdate
+	siteRows := parsed.sections["SITE"]
+	for i, s := range plan.sites {
+		s.action = rowNodeAction(siteRows[i], siteExisting, siteRowIdentity, siteHeaders)
+	}
+	buildingRows := parsed.sections["BUILDING"]
+	for i, b := range plan.buildings {
+		b.action = rowNodeAction(buildingRows[i], buildingExisting, buildingRowIdentity, buildingHeaders)
+	}
+	rackRows := parsed.sections["RACK"]
+	for i, r := range plan.racks {
+		r.action = rowNodeAction(rackRows[i], rackExisting, rackRowIdentity, rackHeaders)
+	}
+}
+
+// rowNodeAction classifies one CSV row against the live comparable rows: no
+// identity match is a create, a match that differs in any editable column is an
+// update, and an exact match is a no-op. The id column is the row's identity, not
+// an editable field, so it is excluded — a name-matched row with a blank id is
+// not an edit.
+func rowNodeAction(row map[string]string, existing map[string]map[string]string, identity func(map[string]string) string, headers []string) nodeAction {
+	current, ok := existing[identity(row)]
+	if !ok {
+		return actionCreate
+	}
+	for _, header := range headers {
+		if header == fieldID {
+			continue
+		}
+		if row[header] != current[header] {
+			return actionUpdate
 		}
 	}
-	for _, b := range plan.buildings {
-		if b.id == nil {
-			if !buildingKeys[b.siteLabel+"\x00"+b.name] {
-				b.action = actionCreate
-			}
-		} else if b.name != b.prevName || b.siteLabel != b.prevSiteLabel {
-			b.action = actionUpdate
-		}
-	}
-	for _, r := range plan.racks {
-		if r.id == nil {
-			if !rackLabels[r.label] {
-				r.action = actionCreate
-			}
-		} else if r.label != r.prevLabel {
-			r.action = actionUpdate
-		}
-	}
+	return actionNone
 }
 
 func countSiteCreateNodes(sites []*resolvedSite) int32 {
@@ -900,11 +918,41 @@ func countRackCreateNodes(racks []*resolvedRack) int32 {
 	return n
 }
 
+func countSiteUpdateNodes(sites []*resolvedSite) int32 {
+	var n int32
+	for _, s := range sites {
+		if s.action == actionUpdate {
+			n++
+		}
+	}
+	return n
+}
+
+func countBuildingUpdateNodes(buildings []*resolvedBuilding) int32 {
+	var n int32
+	for _, b := range buildings {
+		if b.action == actionUpdate {
+			n++
+		}
+	}
+	return n
+}
+
+func countRackUpdateNodes(racks []*resolvedRack) int32 {
+	var n int32
+	for _, r := range racks {
+		if r.action == actionUpdate {
+			n++
+		}
+	}
+	return n
+}
+
 // computeChanges produces the preview change summaries from the resolved plan.
 // Creates come from node classification and deletes from omission counts (the
 // two are the same identity math); updates and miner rename/move still use the
 // row-comparison helpers.
-func computeChanges(resolved *resolvedPlan, parsed *parsedCSV, snap, targetSnap *snapshot, mode pb.OmissionMode) []*pb.ImportChangeSummary {
+func computeChanges(resolved *resolvedPlan, mode pb.OmissionMode) []*pb.ImportChangeSummary {
 	var changes []*pb.ImportChangeSummary
 	add := func(op pb.ImportOperation, entityType string, count int32, description string) {
 		if count > 0 {
@@ -914,9 +962,9 @@ func computeChanges(resolved *resolvedPlan, parsed *parsedCSV, snap, targetSnap 
 	add(pb.ImportOperation_IMPORT_OPERATION_CREATE, "site", countSiteCreateNodes(resolved.sites), "new site rows")
 	add(pb.ImportOperation_IMPORT_OPERATION_CREATE, fieldBuilding, countBuildingCreateNodes(resolved.buildings), "new building rows")
 	add(pb.ImportOperation_IMPORT_OPERATION_CREATE, "rack", countRackCreateNodes(resolved.racks), "new rack rows")
-	add(pb.ImportOperation_IMPORT_OPERATION_UPDATE, "site", countSiteUpdates(parsed.sections["SITE"], snap.sites), "site rows with changed details")
-	add(pb.ImportOperation_IMPORT_OPERATION_UPDATE, fieldBuilding, countBuildingUpdates(parsed.sections["BUILDING"], snap.buildings), "building rows with changed details")
-	add(pb.ImportOperation_IMPORT_OPERATION_UPDATE, "rack", countRackUpdates(parsed.sections["RACK"], snap.racks), "rack rows with changed details")
+	add(pb.ImportOperation_IMPORT_OPERATION_UPDATE, "site", countSiteUpdateNodes(resolved.sites), "site rows with changed details")
+	add(pb.ImportOperation_IMPORT_OPERATION_UPDATE, fieldBuilding, countBuildingUpdateNodes(resolved.buildings), "building rows with changed details")
+	add(pb.ImportOperation_IMPORT_OPERATION_UPDATE, "rack", countRackUpdateNodes(resolved.racks), "rack rows with changed details")
 	add(pb.ImportOperation_IMPORT_OPERATION_RENAME, "miner", countMinerRenameNodes(resolved.miners), "miner rows with changed names")
 	add(pb.ImportOperation_IMPORT_OPERATION_MOVE, "miner", countMinerMoveNodes(resolved.miners), "miner placement rows with changed site, building, rack, or slot")
 	if mode == pb.OmissionMode_OMISSION_MODE_REMOVE_OMITTED {

--- a/server/internal/domain/sitemap/resolved.go
+++ b/server/internal/domain/sitemap/resolved.go
@@ -330,6 +330,23 @@ func validateReadOnlyMinerFields(miners []*resolvedMiner) []*pb.ImportValidation
 	return errs
 }
 
+// validateSlotCollisions rejects two miners claiming the same rack slot in one import.
+func validateSlotCollisions(miners []*resolvedMiner) []*pb.ImportValidationError {
+	seen := map[string]bool{}
+	var errs []*pb.ImportValidationError
+	for _, m := range miners {
+		key, ok := normalizedRackSlotKey(m.rackLabel, m.rackRow, m.rackCol)
+		if !ok {
+			continue
+		}
+		if seen[key] {
+			errs = append(errs, csvErr(m.rowNum, "MINER", "duplicate rack slot"))
+		}
+		seen[key] = true
+	}
+	return errs
+}
+
 // countMinerRenameNodes counts existing miners whose name changed.
 func countMinerRenameNodes(miners []*resolvedMiner) int32 {
 	var n int32

--- a/server/internal/domain/sitemap/resolved.go
+++ b/server/internal/domain/sitemap/resolved.go
@@ -263,38 +263,108 @@ func resolveRacks(
 	return out, nil
 }
 
-// classifyTopologyActions marks each topology node: rows without an existing id
-// create, and rows with an id update when a tracked field differs.
-func classifyTopologyActions(plan *resolvedPlan, snap *snapshot, mode pb.OmissionMode) {
+// classifyTopologyActions marks each topology node: a row whose identity is not
+// already present in the live snapshot creates; a row matching an existing
+// entity updates when a tracked field differs.
+func classifyTopologyActions(plan *resolvedPlan, snap *snapshot, _ pb.OmissionMode) {
+	siteNames := map[string]bool{}
+	for _, s := range snap.sites {
+		siteNames[s.Name] = true
+	}
+	buildingKeys := map[string]bool{}
+	for _, b := range snap.buildings {
+		buildingKeys[b.SiteLabel+"\x00"+b.Name] = true
+	}
+	rackLabels := map[string]bool{}
+	for _, r := range snap.racks {
+		rackLabels[r.Label] = true
+	}
+
 	for _, s := range plan.sites {
-		switch {
-		case s.id != nil:
-			if s.name != s.prevName {
-				s.action = actionUpdate
+		if s.id == nil {
+			if !siteNames[s.name] {
+				s.action = actionCreate
 			}
-		default:
-			s.action = actionCreate
+		} else if s.name != s.prevName {
+			s.action = actionUpdate
 		}
 	}
 	for _, b := range plan.buildings {
-		switch {
-		case b.id != nil:
-			if b.name != b.prevName || b.siteLabel != b.prevSiteLabel {
-				b.action = actionUpdate
+		if b.id == nil {
+			if !buildingKeys[b.siteLabel+"\x00"+b.name] {
+				b.action = actionCreate
 			}
-		default:
-			b.action = actionCreate
+		} else if b.name != b.prevName || b.siteLabel != b.prevSiteLabel {
+			b.action = actionUpdate
 		}
 	}
 	for _, r := range plan.racks {
 		if r.id == nil {
-			r.action = actionCreate
+			if !rackLabels[r.label] {
+				r.action = actionCreate
+			}
 		} else if r.label != r.prevLabel {
 			r.action = actionUpdate
 		}
 	}
-	_ = snap
-	_ = mode
+}
+
+func countSiteCreateNodes(sites []*resolvedSite) int32 {
+	var n int32
+	for _, s := range sites {
+		if s.action == actionCreate {
+			n++
+		}
+	}
+	return n
+}
+
+func countBuildingCreateNodes(buildings []*resolvedBuilding) int32 {
+	var n int32
+	for _, b := range buildings {
+		if b.action == actionCreate {
+			n++
+		}
+	}
+	return n
+}
+
+func countRackCreateNodes(racks []*resolvedRack) int32 {
+	var n int32
+	for _, r := range racks {
+		if r.action == actionCreate {
+			n++
+		}
+	}
+	return n
+}
+
+// computeChanges produces the preview change summaries from the resolved plan.
+// Creates come from node classification and deletes from omission counts (the
+// two are the same identity math); updates and miner rename/move still use the
+// row-comparison helpers.
+func computeChanges(resolved *resolvedPlan, parsed *parsedCSV, snap, targetSnap *snapshot, mode pb.OmissionMode) []*pb.ImportChangeSummary {
+	var changes []*pb.ImportChangeSummary
+	add := func(op pb.ImportOperation, entityType string, count int32, description string) {
+		if count > 0 {
+			changes = append(changes, &pb.ImportChangeSummary{Operation: op, EntityType: entityType, Count: count, Description: description})
+		}
+	}
+	add(pb.ImportOperation_IMPORT_OPERATION_CREATE, "site", countSiteCreateNodes(resolved.sites), "new site rows")
+	add(pb.ImportOperation_IMPORT_OPERATION_CREATE, fieldBuilding, countBuildingCreateNodes(resolved.buildings), "new building rows")
+	add(pb.ImportOperation_IMPORT_OPERATION_CREATE, "rack", countRackCreateNodes(resolved.racks), "new rack rows")
+	add(pb.ImportOperation_IMPORT_OPERATION_UPDATE, "site", countSiteUpdates(parsed.sections["SITE"], snap.sites), "site rows with changed details")
+	add(pb.ImportOperation_IMPORT_OPERATION_UPDATE, fieldBuilding, countBuildingUpdates(parsed.sections["BUILDING"], snap.buildings), "building rows with changed details")
+	add(pb.ImportOperation_IMPORT_OPERATION_UPDATE, "rack", countRackUpdates(parsed.sections["RACK"], snap.racks, targetSnap.buildings), "rack rows with changed details")
+	add(pb.ImportOperation_IMPORT_OPERATION_RENAME, "miner", countMinerRenames(parsed.sections["MINER"], snap.miners), "miner rows with changed names")
+	add(pb.ImportOperation_IMPORT_OPERATION_MOVE, "miner", countMinerPlacementUpdates(parsed.sections["MINER"], parsed.sections["RACK"], parsed.sections["BUILDING"], targetSnap), "miner placement rows with changed site, building, rack, or slot")
+	if mode == pb.OmissionMode_OMISSION_MODE_REMOVE_OMITTED {
+		add(pb.ImportOperation_IMPORT_OPERATION_UNASSIGN, "miner", resolved.omissions.GetMiners(), "omitted miner rows to unassign")
+		add(pb.ImportOperation_IMPORT_OPERATION_DELETE, "rack", resolved.omissions.GetRacks(), "omitted rack rows to delete")
+		add(pb.ImportOperation_IMPORT_OPERATION_DELETE, fieldBuilding, resolved.omissions.GetBuildings(), "omitted building rows to delete")
+		add(pb.ImportOperation_IMPORT_OPERATION_DELETE, "site", resolved.omissions.GetSites(), "omitted site rows to delete")
+	}
+	return changes
 }
 
 // computeOmissions counts live entities absent from the CSV.

--- a/server/internal/domain/sitemap/resolved.go
+++ b/server/internal/domain/sitemap/resolved.go
@@ -1,6 +1,7 @@
 package sitemap
 
 import (
+	"fmt"
 	"strconv"
 
 	pb "github.com/block/proto-fleet/server/generated/grpc/sitemap/v1"
@@ -67,22 +68,27 @@ type resolvedRack struct {
 }
 
 // resolvedMiner is keyed by device identifier; name and placement are its only
-// mutable facets.
+// mutable facets. existing is the matched live miner, or nil when the device is
+// unknown.
 type resolvedMiner struct {
-	deviceID   string
-	name       string
-	rack       *resolvedRack
-	building   *resolvedBuilding
-	site       *resolvedSite
-	rackLabel  string
-	siteLabel  string
-	buildLabel string
-	rackRow    string
-	rackCol    string
-	renamed    bool
-	moved      bool
-	unassigned bool
-	rowNum     int
+	deviceID     string
+	name         string
+	serialNumber string
+	ipAddress    string
+	macAddress   string
+	existing     *minerSnapshot
+	rack         *resolvedRack
+	building     *resolvedBuilding
+	site         *resolvedSite
+	rackLabel    string
+	siteLabel    string
+	buildLabel   string
+	rackRow      string
+	rackCol      string
+	renamed      bool
+	moved        bool
+	unassigned   bool
+	rowNum       int
 }
 
 // minerPopulation is the scoped mutable-miner set shared by omission counts,
@@ -144,6 +150,8 @@ func resolvePlan(parsed *parsedCSV, snap *snapshot, mode pb.OmissionMode) *resol
 	var rackErrs []*pb.ImportValidationError
 	plan.racks, rackErrs = resolveRacks(parsed.sections["RACK"], racksByID, buildingsByID, inferSiteByBuilding, inferAmbiguous)
 	plan.errors = append(plan.errors, rackErrs...)
+
+	plan.miners = resolveMiners(parsed.sections["MINER"], minerMap(snap.miners))
 
 	classifyTopologyActions(plan, snap, mode)
 	plan.omissions = computeOmissions(parsed, snap, mode)
@@ -263,6 +271,76 @@ func resolveRacks(
 	return out, nil
 }
 
+// resolveMiners resolves MINER rows, matching each to its live miner by device
+// identifier and flagging renames.
+func resolveMiners(rows []map[string]string, existingByID map[string]minerSnapshot) []*resolvedMiner {
+	out := make([]*resolvedMiner, 0, len(rows))
+	for i, row := range rows {
+		node := &resolvedMiner{
+			deviceID:     row["device_identifier"],
+			name:         row[fieldName],
+			serialNumber: row["serial_number"],
+			ipAddress:    row["ip_address"],
+			macAddress:   row["mac_address"],
+			rackLabel:    row[fieldRack],
+			siteLabel:    row[fieldSite],
+			buildLabel:   row[fieldBuilding],
+			rackRow:      row["rack_row"],
+			rackCol:      row["rack_col"],
+			rowNum:       rowNumber(row, i+1),
+		}
+		if existing, ok := existingByID[node.deviceID]; ok {
+			e := existing
+			node.existing = &e
+			node.renamed = node.name != existing.Name
+		}
+		out = append(out, node)
+	}
+	return out
+}
+
+// validateKnownMiners rejects rows whose device identifier is not a live miner.
+func validateKnownMiners(miners []*resolvedMiner) []*pb.ImportValidationError {
+	var errs []*pb.ImportValidationError
+	for _, m := range miners {
+		if m.deviceID != "" && m.existing == nil {
+			errs = append(errs, csvErr(m.rowNum, "MINER", "unknown miner device_identifier"))
+		}
+	}
+	return errs
+}
+
+// validateReadOnlyMinerFields rejects edits to serial/ip/mac on existing miners.
+func validateReadOnlyMinerFields(miners []*resolvedMiner) []*pb.ImportValidationError {
+	var errs []*pb.ImportValidationError
+	for _, m := range miners {
+		if m.existing == nil {
+			continue
+		}
+		for _, field := range []struct{ name, got, want string }{
+			{"serial_number", m.serialNumber, m.existing.SerialNumber},
+			{"ip_address", m.ipAddress, m.existing.IPAddress},
+			{"mac_address", m.macAddress, m.existing.MACAddress},
+		} {
+			if field.got != field.want {
+				errs = append(errs, csvErr(m.rowNum, "MINER", fmt.Sprintf("%s is read-only for existing miner %s", field.name, m.deviceID)))
+			}
+		}
+	}
+	return errs
+}
+
+// countMinerRenameNodes counts existing miners whose name changed.
+func countMinerRenameNodes(miners []*resolvedMiner) int32 {
+	var n int32
+	for _, m := range miners {
+		if m.renamed {
+			n++
+		}
+	}
+	return n
+}
+
 // classifyTopologyActions marks each topology node: a row whose identity is not
 // already present in the live snapshot creates; a row matching an existing
 // entity updates when a tracked field differs.
@@ -356,7 +434,7 @@ func computeChanges(resolved *resolvedPlan, parsed *parsedCSV, snap, targetSnap 
 	add(pb.ImportOperation_IMPORT_OPERATION_UPDATE, "site", countSiteUpdates(parsed.sections["SITE"], snap.sites), "site rows with changed details")
 	add(pb.ImportOperation_IMPORT_OPERATION_UPDATE, fieldBuilding, countBuildingUpdates(parsed.sections["BUILDING"], snap.buildings), "building rows with changed details")
 	add(pb.ImportOperation_IMPORT_OPERATION_UPDATE, "rack", countRackUpdates(parsed.sections["RACK"], snap.racks, targetSnap.buildings), "rack rows with changed details")
-	add(pb.ImportOperation_IMPORT_OPERATION_RENAME, "miner", countMinerRenames(parsed.sections["MINER"], snap.miners), "miner rows with changed names")
+	add(pb.ImportOperation_IMPORT_OPERATION_RENAME, "miner", countMinerRenameNodes(resolved.miners), "miner rows with changed names")
 	add(pb.ImportOperation_IMPORT_OPERATION_MOVE, "miner", countMinerPlacementUpdates(parsed.sections["MINER"], parsed.sections["RACK"], parsed.sections["BUILDING"], targetSnap), "miner placement rows with changed site, building, rack, or slot")
 	if mode == pb.OmissionMode_OMISSION_MODE_REMOVE_OMITTED {
 		add(pb.ImportOperation_IMPORT_OPERATION_UNASSIGN, "miner", resolved.omissions.GetMiners(), "omitted miner rows to unassign")

--- a/server/internal/domain/sitemap/resolved.go
+++ b/server/internal/domain/sitemap/resolved.go
@@ -186,13 +186,31 @@ func resolveTopologyView(parsed *parsedCSV, target *snapshot) *topologyView {
 	siteRows := parsed.sections["SITE"]
 	buildingRows := parsed.sections["BUILDING"]
 	rackRows := parsed.sections["RACK"]
+
+	// Resolve the desired buildings once, then index them the three ways the
+	// topology view needs (by (site,name), by id, by capacity key). Rack
+	// resolution reuses the same (site,name) and id indexes. Previously each
+	// index re-walked the rows+snapshot in its own helper, so a CSV column
+	// change meant editing several parallel walks.
+	desiredBuildings := desiredBuildingList(buildingRows, target.buildings)
+	buildingsByKey := make(map[string]buildingmodels.Building, len(desiredBuildings))
+	buildingsByID := map[int64]buildingmodels.Building{}
+	buildingsByCapacityKey := make(map[string]buildingmodels.Building, len(desiredBuildings))
+	for _, b := range desiredBuildings {
+		buildingsByKey[b.SiteLabel+"\x00"+b.Name] = b
+		if b.ID > 0 {
+			buildingsByID[b.ID] = b
+		}
+		buildingsByCapacityKey[buildingCapacityKey(b)] = b
+	}
+
 	tv := &topologyView{
 		sites:                  desiredSiteSet(siteRows, target.sites),
 		buildingKeys:           rowSetFromDesiredBuildings(buildingRows, target.buildings),
-		buildingsByKey:         desiredBuildingMap(buildingRows, target.buildings),
-		buildingsByLayoutID:    desiredBuildingLayoutIDMap(buildingRows, target.buildings),
-		buildingsByCapacityKey: desiredBuildingCapacityMap(buildingRows, target.buildings),
-		racksByLabel:           desiredRackMap(rackRows, target.racks, buildingRows, target.buildings),
+		buildingsByKey:         buildingsByKey,
+		buildingsByLayoutID:    buildingsByID,
+		buildingsByCapacityKey: buildingsByCapacityKey,
+		racksByLabel:           desiredRackMap(rackRows, target.racks, buildingsByKey, buildingsByID),
 	}
 	return tv
 }

--- a/server/internal/domain/sitemap/resolved_test.go
+++ b/server/internal/domain/sitemap/resolved_test.go
@@ -57,7 +57,7 @@ func TestResolvePlanCreateClassificationHonorsExistingNames(t *testing.T) {
 	}
 }
 
-func TestResolvePlanLinksBuildingToSiteByName(t *testing.T) {
+func TestResolvePlanCarriesBuildingSiteRef(t *testing.T) {
 	parsed := &parsedCSV{sections: map[string][]map[string]string{
 		"SITE":     {{"__row": "3", "name": "Site A", "id": "1"}},
 		"BUILDING": {{"__row": "6", "name": "Bldg", "id": "10", "site": "Site A", "aisles": "2", "racks_per_aisle": "2"}},
@@ -69,8 +69,8 @@ func TestResolvePlanLinksBuildingToSiteByName(t *testing.T) {
 
 	plan := resolvePlan(parsed, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
 	b := plan.buildings[0]
-	if b.site == nil || b.site != plan.sites[0] {
-		t.Fatalf("building.site = %v, want pointer to resolved Site A node", b.site)
+	if b.siteRef != "Site A" || b.siteLabel != "Site A" {
+		t.Fatalf("building site = (%q, %q), want Site A", b.siteRef, b.siteLabel)
 	}
 	if b.action != actionNone {
 		t.Errorf("building action = %v, want none (unchanged)", b.action)

--- a/server/internal/domain/sitemap/resolved_test.go
+++ b/server/internal/domain/sitemap/resolved_test.go
@@ -185,6 +185,28 @@ func TestResolveMinersFlagsIdentityRenameAndReadOnly(t *testing.T) {
 	}
 }
 
+func TestTopologyViewIsOmissionAware(t *testing.T) {
+	// A building references site "Drop", which exists live but is omitted from the
+	// CSV. Under unspecified mode the reference is known; under remove-omitted the
+	// omitted site is dropped from the desired topology, so the reference is unknown.
+	sections := map[string][]map[string]string{
+		"SITE":     {{"__row": "3", "name": "Keep"}},
+		"BUILDING": {{"__row": "6", "name": "Bldg", "site": "Drop"}},
+	}
+	snap := &snapshot{sites: []sitemodels.Site{{Name: "Keep"}, {Name: "Drop"}}}
+
+	keep := resolvePlan(&parsedCSV{sections: sections}, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
+	if errs := validateBuildingSiteTargets(keep.buildings, keep.topology); len(errs) != 0 {
+		t.Fatalf("unspecified mode = %+v, want no errors (Drop still live)", errs)
+	}
+
+	remove := resolvePlan(&parsedCSV{sections: sections}, snap, pb.OmissionMode_OMISSION_MODE_REMOVE_OMITTED)
+	errs := validateBuildingSiteTargets(remove.buildings, remove.topology)
+	if len(errs) != 1 || errs[0].GetRow() != 6 || errs[0].GetMessage() != `unknown site "Drop"` {
+		t.Fatalf("remove-omitted mode = %+v, want unknown site \"Drop\" on row 6", errs)
+	}
+}
+
 func TestScopePopulationIncludesHiddenRackMembers(t *testing.T) {
 	snap := &snapshot{
 		miners:            []minerSnapshot{{DeviceIdentifier: "m1"}},

--- a/server/internal/domain/sitemap/resolved_test.go
+++ b/server/internal/domain/sitemap/resolved_test.go
@@ -207,6 +207,33 @@ func TestTopologyViewIsOmissionAware(t *testing.T) {
 	}
 }
 
+func TestResolveMinersFlagsPlacementMoves(t *testing.T) {
+	sections := map[string][]map[string]string{
+		"MINER": {
+			{"__row": "20", "device_identifier": "m1", "name": "Orig", "rack": "Rack A", "rack_row": "0", "rack_col": "1"},
+			{"__row": "21", "device_identifier": "m2", "name": "Renamed", "rack": "Rack A", "rack_row": "0", "rack_col": "0"},
+		},
+	}
+	snap := &snapshot{miners: []minerSnapshot{
+		{DeviceIdentifier: "m1", Name: "Orig", Rack: "Rack A", RackRow: "0", RackCol: "0"}, // slot changed ⇒ moved
+		{DeviceIdentifier: "m2", Name: "Orig", Rack: "Rack A", RackRow: "0", RackCol: "0"}, // placement same ⇒ only renamed
+	}}
+
+	plan := resolvePlan(&parsedCSV{sections: sections}, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
+	if !plan.miners[0].moved || plan.miners[0].renamed {
+		t.Errorf("m1 = moved %v renamed %v, want moved-only", plan.miners[0].moved, plan.miners[0].renamed)
+	}
+	if plan.miners[1].moved || !plan.miners[1].renamed {
+		t.Errorf("m2 = moved %v renamed %v, want renamed-only", plan.miners[1].moved, plan.miners[1].renamed)
+	}
+	if got := countMinerMoveNodes(plan.miners); got != 1 {
+		t.Errorf("move count = %d, want 1", got)
+	}
+	if errs := validateMinerRenamePermission(plan.miners); len(errs) != 1 || errs[0].GetRow() != 21 {
+		t.Errorf("rename permission errs = %+v, want one on row 21", errs)
+	}
+}
+
 func TestScopePopulationIncludesHiddenRackMembers(t *testing.T) {
 	snap := &snapshot{
 		miners:            []minerSnapshot{{DeviceIdentifier: "m1"}},

--- a/server/internal/domain/sitemap/resolved_test.go
+++ b/server/internal/domain/sitemap/resolved_test.go
@@ -77,30 +77,11 @@ func TestResolvePlanLinksBuildingToSiteByName(t *testing.T) {
 	}
 }
 
-func TestResolvePlanReportsBuildingSiteIDNameMismatch(t *testing.T) {
-	parsed := &parsedCSV{sections: map[string][]map[string]string{
-		"SITE":     {{"__row": "3", "name": "Site A", "id": "1"}, {"__row": "4", "name": "Site B", "id": "2"}},
-		"BUILDING": {{"__row": "6", "name": "Bldg", "id": "10", "site_id": "1", "site": "Site B"}},
-	}}
-	snap := &snapshot{
-		sites:     []sitemodels.Site{{ID: 1, Name: "Site A"}, {ID: 2, Name: "Site B"}},
-		buildings: []buildingmodels.Building{{ID: 10, Name: "Bldg", SiteLabel: "Site A"}},
-	}
-
-	plan := resolvePlan(parsed, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
-	if len(plan.errors) == 0 {
-		t.Fatalf("errors = none, want site_id/site mismatch error")
-	}
-	if plan.errors[0].GetRow() != 6 {
-		t.Errorf("error row = %d, want 6", plan.errors[0].GetRow())
-	}
-}
-
-func TestResolvePlanInfersRackSiteFromBuildingName(t *testing.T) {
+func TestResolvePlanInfersRackSiteFromBuildingID(t *testing.T) {
 	parsed := &parsedCSV{sections: map[string][]map[string]string{
 		"SITE":     {{"__row": "3", "name": "Site A", "id": "1"}},
-		"BUILDING": {{"__row": "6", "name": "Bldg", "id": "10", "site": "Site A", "aisles": "2", "racks_per_aisle": "2"}},
-		"RACK":     {{"__row": "9", "label": "R1", "id": "20", "building": "Bldg", "site": ""}},
+		"BUILDING": {{"__row": "6", "name": "Bldg", "id": "10", "site": "1", "aisles": "2", "racks_per_aisle": "2"}},
+		"RACK":     {{"__row": "9", "label": "R1", "id": "20", "building": "10", "site": ""}},
 	}}
 	snap := &snapshot{
 		sites:     []sitemodels.Site{{ID: 1, Name: "Site A"}},
@@ -108,29 +89,15 @@ func TestResolvePlanInfersRackSiteFromBuildingName(t *testing.T) {
 		racks:     []rackSnapshot{{ID: 20, Label: "R1", Building: "Bldg", Site: "Site A"}},
 	}
 
-	plan := resolvePlan(parsed, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
-	r := plan.racks[0]
-	if r.siteLabel != "Site A" {
-		t.Errorf("rack siteLabel = %q, want inferred \"Site A\"", r.siteLabel)
+	// resolveReferences canonicalizes the rack's building id into a building name
+	// and fills the implied site; resolvePlan then reads those canonical names.
+	if errs := resolveReferences(parsed, snap); len(errs) != 0 {
+		t.Fatalf("resolveReferences errors = %+v", errs)
 	}
-}
-
-func TestResolvePlanRackBuildingIDDictatesSite(t *testing.T) {
-	parsed := &parsedCSV{sections: map[string][]map[string]string{
-		"SITE":     {{"__row": "3", "name": "Site A", "id": "1"}},
-		"BUILDING": {{"__row": "6", "name": "Bldg", "id": "10", "site": "Site A"}},
-		"RACK":     {{"__row": "9", "label": "R1", "id": "20", "building_id": "10", "building": "", "site": ""}},
-	}}
-	snap := &snapshot{
-		sites:     []sitemodels.Site{{ID: 1, Name: "Site A"}},
-		buildings: []buildingmodels.Building{{ID: 10, Name: "Bldg", SiteLabel: "Site A"}},
-		racks:     []rackSnapshot{{ID: 20, Label: "R1"}},
-	}
-
 	plan := resolvePlan(parsed, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
 	r := plan.racks[0]
 	if r.buildingLabel != "Bldg" || r.siteLabel != "Site A" {
-		t.Errorf("rack building/site = %q/%q, want Bldg/Site A from building_id", r.buildingLabel, r.siteLabel)
+		t.Errorf("rack building/site = %q/%q, want Bldg/Site A inferred from building id", r.buildingLabel, r.siteLabel)
 	}
 }
 

--- a/server/internal/domain/sitemap/resolved_test.go
+++ b/server/internal/domain/sitemap/resolved_test.go
@@ -39,7 +39,7 @@ func TestResolvePlanClassifiesSiteIdentity(t *testing.T) {
 func TestResolvePlanCreateClassificationHonorsExistingNames(t *testing.T) {
 	parsed := &parsedCSV{sections: map[string][]map[string]string{
 		"SITE": {
-			{"__row": "3", "name": "Site A", "id": ""},   // name-only, matches existing ⇒ not a create
+			{"__row": "3", "name": "Site A", "id": ""},    // name-only, matches existing ⇒ not a create
 			{"__row": "4", "name": "Brand New", "id": ""}, // new name ⇒ create
 		},
 	}}

--- a/server/internal/domain/sitemap/resolved_test.go
+++ b/server/internal/domain/sitemap/resolved_test.go
@@ -1,0 +1,147 @@
+package sitemap
+
+import (
+	"testing"
+
+	pb "github.com/block/proto-fleet/server/generated/grpc/sitemap/v1"
+	buildingmodels "github.com/block/proto-fleet/server/internal/domain/buildings/models"
+	sitemodels "github.com/block/proto-fleet/server/internal/domain/sites/models"
+)
+
+func TestResolvePlanClassifiesSiteIdentity(t *testing.T) {
+	parsed := &parsedCSV{sections: map[string][]map[string]string{
+		"SITE": {
+			{"__row": "3", "name": "Site A", "id": "1"},   // existing, unchanged
+			{"__row": "4", "name": "Renamed", "id": "2"},  // existing, renamed
+			{"__row": "5", "name": "Brand New", "id": ""}, // create
+		},
+	}}
+	snap := &snapshot{sites: []sitemodels.Site{
+		{ID: 1, Name: "Site A"},
+		{ID: 2, Name: "Site B"},
+	}}
+
+	plan := resolvePlan(parsed, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
+	if len(plan.sites) != 3 {
+		t.Fatalf("resolved sites = %d, want 3", len(plan.sites))
+	}
+	if plan.sites[0].action != actionNone {
+		t.Errorf("Site A action = %v, want none", plan.sites[0].action)
+	}
+	if plan.sites[1].action != actionUpdate || plan.sites[1].prevName != "Site B" {
+		t.Errorf("Renamed site = action %v prevName %q, want update/\"Site B\"", plan.sites[1].action, plan.sites[1].prevName)
+	}
+	if plan.sites[2].action != actionCreate || plan.sites[2].id != nil {
+		t.Errorf("Brand New site = action %v id %v, want create/nil", plan.sites[2].action, plan.sites[2].id)
+	}
+}
+
+func TestResolvePlanLinksBuildingToSiteByName(t *testing.T) {
+	parsed := &parsedCSV{sections: map[string][]map[string]string{
+		"SITE":     {{"__row": "3", "name": "Site A", "id": "1"}},
+		"BUILDING": {{"__row": "6", "name": "Bldg", "id": "10", "site": "Site A", "aisles": "2", "racks_per_aisle": "2"}},
+	}}
+	snap := &snapshot{
+		sites:     []sitemodels.Site{{ID: 1, Name: "Site A"}},
+		buildings: []buildingmodels.Building{{ID: 10, Name: "Bldg", SiteLabel: "Site A", Aisles: 2, RacksPerAisle: 2}},
+	}
+
+	plan := resolvePlan(parsed, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
+	b := plan.buildings[0]
+	if b.site == nil || b.site != plan.sites[0] {
+		t.Fatalf("building.site = %v, want pointer to resolved Site A node", b.site)
+	}
+	if b.action != actionNone {
+		t.Errorf("building action = %v, want none (unchanged)", b.action)
+	}
+}
+
+func TestResolvePlanReportsBuildingSiteIDNameMismatch(t *testing.T) {
+	parsed := &parsedCSV{sections: map[string][]map[string]string{
+		"SITE":     {{"__row": "3", "name": "Site A", "id": "1"}, {"__row": "4", "name": "Site B", "id": "2"}},
+		"BUILDING": {{"__row": "6", "name": "Bldg", "id": "10", "site_id": "1", "site": "Site B"}},
+	}}
+	snap := &snapshot{
+		sites:     []sitemodels.Site{{ID: 1, Name: "Site A"}, {ID: 2, Name: "Site B"}},
+		buildings: []buildingmodels.Building{{ID: 10, Name: "Bldg", SiteLabel: "Site A"}},
+	}
+
+	plan := resolvePlan(parsed, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
+	if len(plan.errors) == 0 {
+		t.Fatalf("errors = none, want site_id/site mismatch error")
+	}
+	if plan.errors[0].GetRow() != 6 {
+		t.Errorf("error row = %d, want 6", plan.errors[0].GetRow())
+	}
+}
+
+func TestResolvePlanInfersRackSiteFromBuildingName(t *testing.T) {
+	parsed := &parsedCSV{sections: map[string][]map[string]string{
+		"SITE":     {{"__row": "3", "name": "Site A", "id": "1"}},
+		"BUILDING": {{"__row": "6", "name": "Bldg", "id": "10", "site": "Site A", "aisles": "2", "racks_per_aisle": "2"}},
+		"RACK":     {{"__row": "9", "label": "R1", "id": "20", "building": "Bldg", "site": ""}},
+	}}
+	snap := &snapshot{
+		sites:     []sitemodels.Site{{ID: 1, Name: "Site A"}},
+		buildings: []buildingmodels.Building{{ID: 10, Name: "Bldg", SiteLabel: "Site A"}},
+		racks:     []rackSnapshot{{ID: 20, Label: "R1", Building: "Bldg", Site: "Site A"}},
+	}
+
+	plan := resolvePlan(parsed, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
+	r := plan.racks[0]
+	if r.siteLabel != "Site A" {
+		t.Errorf("rack siteLabel = %q, want inferred \"Site A\"", r.siteLabel)
+	}
+}
+
+func TestResolvePlanRackBuildingIDDictatesSite(t *testing.T) {
+	parsed := &parsedCSV{sections: map[string][]map[string]string{
+		"SITE":     {{"__row": "3", "name": "Site A", "id": "1"}},
+		"BUILDING": {{"__row": "6", "name": "Bldg", "id": "10", "site": "Site A"}},
+		"RACK":     {{"__row": "9", "label": "R1", "id": "20", "building_id": "10", "building": "", "site": ""}},
+	}}
+	snap := &snapshot{
+		sites:     []sitemodels.Site{{ID: 1, Name: "Site A"}},
+		buildings: []buildingmodels.Building{{ID: 10, Name: "Bldg", SiteLabel: "Site A"}},
+		racks:     []rackSnapshot{{ID: 20, Label: "R1"}},
+	}
+
+	plan := resolvePlan(parsed, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
+	r := plan.racks[0]
+	if r.buildingLabel != "Bldg" || r.siteLabel != "Site A" {
+		t.Errorf("rack building/site = %q/%q, want Bldg/Site A from building_id", r.buildingLabel, r.siteLabel)
+	}
+}
+
+func TestResolvePlanOmissionsMatchLegacyCounts(t *testing.T) {
+	parsed := &parsedCSV{sections: map[string][]map[string]string{
+		"SITE":     {{"__row": "3", "name": "Site A", "id": "1"}},
+		"BUILDING": nil,
+		"RACK":     nil,
+		"MINER":    nil,
+	}}
+	snap := &snapshot{
+		sites:  []sitemodels.Site{{ID: 1, Name: "Site A"}, {ID: 2, Name: "Site B"}},
+		miners: []minerSnapshot{{DeviceIdentifier: "m1"}},
+	}
+
+	plan := resolvePlan(parsed, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
+	want := computeOmissions(parsed, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
+	if plan.omissions.GetSites() != want.GetSites() || plan.omissions.GetSites() != 1 {
+		t.Errorf("site omissions = %d, want 1", plan.omissions.GetSites())
+	}
+	if plan.omissions.GetMiners() != 1 {
+		t.Errorf("miner omissions = %d, want 1", plan.omissions.GetMiners())
+	}
+}
+
+func TestScopePopulationIncludesHiddenRackMembers(t *testing.T) {
+	snap := &snapshot{
+		miners:            []minerSnapshot{{DeviceIdentifier: "m1"}},
+		hiddenRackMembers: []minerSnapshot{{DeviceIdentifier: "hidden1"}},
+	}
+	pop := scopePopulation(snap, pb.OmissionMode_OMISSION_MODE_REMOVE_OMITTED)
+	if len(pop.miners) != 1 || len(pop.hiddenRackMembers) != 1 {
+		t.Fatalf("population = %d miners / %d hidden, want 1/1", len(pop.miners), len(pop.hiddenRackMembers))
+	}
+}

--- a/server/internal/domain/sitemap/resolved_test.go
+++ b/server/internal/domain/sitemap/resolved_test.go
@@ -156,6 +156,35 @@ func TestResolvePlanOmissionsMatchLegacyCounts(t *testing.T) {
 	}
 }
 
+func TestResolveMinersFlagsIdentityRenameAndReadOnly(t *testing.T) {
+	rows := []map[string]string{
+		{"__row": "20", "device_identifier": "m1", "name": "Renamed", "serial_number": "SN1", "ip_address": "10.0.0.9", "mac_address": "aa"},
+		{"__row": "21", "device_identifier": "unknown", "name": "X"},
+	}
+	existing := map[string]minerSnapshot{
+		"m1": {DeviceIdentifier: "m1", Name: "Orig", SerialNumber: "SN1", IPAddress: "10.0.0.5", MACAddress: "aa"},
+	}
+
+	miners := resolveMiners(rows, existing)
+	if !miners[0].renamed {
+		t.Errorf("m1 renamed = false, want true")
+	}
+	if miners[1].existing != nil {
+		t.Errorf("unknown miner existing = %+v, want nil", miners[1].existing)
+	}
+
+	if got := countMinerRenameNodes(miners); got != 1 {
+		t.Errorf("rename count = %d, want 1", got)
+	}
+	if errs := validateKnownMiners(miners); len(errs) != 1 || errs[0].GetRow() != 21 {
+		t.Errorf("validateKnownMiners = %+v, want one error on row 21", errs)
+	}
+	roErrs := validateReadOnlyMinerFields(miners)
+	if len(roErrs) != 1 || roErrs[0].GetMessage() != "ip_address is read-only for existing miner m1" {
+		t.Errorf("read-only errs = %+v, want ip_address error", roErrs)
+	}
+}
+
 func TestScopePopulationIncludesHiddenRackMembers(t *testing.T) {
 	snap := &snapshot{
 		miners:            []minerSnapshot{{DeviceIdentifier: "m1"}},

--- a/server/internal/domain/sitemap/resolved_test.go
+++ b/server/internal/domain/sitemap/resolved_test.go
@@ -36,6 +36,27 @@ func TestResolvePlanClassifiesSiteIdentity(t *testing.T) {
 	}
 }
 
+func TestResolvePlanCreateClassificationHonorsExistingNames(t *testing.T) {
+	parsed := &parsedCSV{sections: map[string][]map[string]string{
+		"SITE": {
+			{"__row": "3", "name": "Site A", "id": ""},   // name-only, matches existing ⇒ not a create
+			{"__row": "4", "name": "Brand New", "id": ""}, // new name ⇒ create
+		},
+	}}
+	snap := &snapshot{sites: []sitemodels.Site{{ID: 1, Name: "Site A"}}}
+
+	plan := resolvePlan(parsed, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
+	if plan.sites[0].action != actionNone {
+		t.Errorf("name-only existing site action = %v, want none", plan.sites[0].action)
+	}
+	if plan.sites[1].action != actionCreate {
+		t.Errorf("new site action = %v, want create", plan.sites[1].action)
+	}
+	if got := countSiteCreateNodes(plan.sites); got != 1 {
+		t.Errorf("site create count = %d, want 1", got)
+	}
+}
+
 func TestResolvePlanLinksBuildingToSiteByName(t *testing.T) {
 	parsed := &parsedCSV{sections: map[string][]map[string]string{
 		"SITE":     {{"__row": "3", "name": "Site A", "id": "1"}},

--- a/server/internal/domain/sitemap/service.go
+++ b/server/internal/domain/sitemap/service.go
@@ -318,7 +318,7 @@ func (s *Service) ImportSiteMapCsv(ctx context.Context, orgID int64, req *pb.Imp
 	}
 	plan := buildPlan(parsed, snapshot, req.GetOmissionMode())
 	if !importPermissions.CanRenameMiners {
-		plan.errors = append(plan.errors, validateMinerRenamePermission(parsed.sections["MINER"], snapshot)...)
+		plan.errors = append(plan.errors, validateMinerRenamePermission(plan.resolved.miners)...)
 	}
 	if req.GetOmissionMode() == pb.OmissionMode_OMISSION_MODE_REMOVE_OMITTED {
 		impactErrs, err := s.validateOmittedSiteDeleteImpacts(ctx, orgID, omittedSites(parsed.sections["SITE"], snapshot.sites))
@@ -1144,6 +1144,7 @@ type importPlan struct {
 	errors    []*pb.ImportValidationError
 	warnings  []string
 	changes   []*pb.ImportChangeSummary
+	resolved  *resolvedPlan
 }
 
 func buildPlan(parsed *parsedCSV, snap *snapshot, mode pb.OmissionMode) importPlan {
@@ -1151,7 +1152,7 @@ func buildPlan(parsed *parsedCSV, snap *snapshot, mode pb.OmissionMode) importPl
 	normalizeIDErrors := normalizeIDReferences(parsed, snap)
 	normalizeInferredPlacement(parsed, targetSnap)
 	resolved := resolvePlan(parsed, snap, mode)
-	plan := importPlan{omissions: resolved.omissions}
+	plan := importPlan{omissions: resolved.omissions, resolved: resolved}
 
 	plan.errors = append(plan.errors, validateUnique(parsed.sections["SITE"], "SITE", fieldName)...)
 	plan.errors = append(plan.errors, validateUniqueBuildingRows(parsed.sections["BUILDING"])...)
@@ -3147,19 +3148,6 @@ func validateFieldLength(rows []map[string]string, section, field string, maxRun
 	return errs
 }
 
-func validateMinerRenamePermission(rows []map[string]string, snap *snapshot) []*pb.ImportValidationError {
-	miners := minerMap(snap.miners)
-	var errs []*pb.ImportValidationError
-	for i, row := range rows {
-		miner, ok := miners[row["device_identifier"]]
-		if !ok || row[fieldName] == miner.Name {
-			continue
-		}
-		errs = append(errs, csvErr(rowNumber(row, i+1), "MINER", "miner:rename permission is required to change miner name"))
-	}
-	return errs
-}
-
 func desiredBuildingCapacityMap(rows []map[string]string, buildings []buildingmodels.Building) map[string]buildingmodels.Building {
 	out := map[string]buildingmodels.Building{}
 	buildingsByID := map[int64]buildingmodels.Building{}
@@ -3479,30 +3467,6 @@ func countRackUpdates(rows []map[string]string, racks []rackSnapshot, buildings 
 		existing["label:"+rack.Label] = row
 	}
 	return countExistingRowUpdatesByIdentity(rows, existing, rackRowIdentity, rackHeaders)
-}
-
-func countMinerPlacementUpdates(rows, rackRows, buildingRows []map[string]string, snap *snapshot) int32 {
-	existing := minerMap(snap.miners)
-	racks := desiredRackMap(rackRows, snap.racks, buildingRows, snap.buildings)
-	buildingsByName, ambiguousBuildings := desiredBuildingNameLookup(buildingRows, snap.buildings)
-	buildingsByID := desiredBuildingIDMap(buildingRows, snap.buildings)
-	var count int32
-	for _, row := range rows {
-		miner, ok := existing[row["device_identifier"]]
-		if !ok {
-			continue
-		}
-		desiredSite, desiredBuilding := desiredMinerSiteBuilding(row, racks, buildingsByName, buildingsByID, ambiguousBuildings)
-		if !minerPlacementIDsMatch(row, miner) ||
-			desiredSite != miner.Site ||
-			desiredBuilding != miner.Building ||
-			row[fieldRack] != miner.Rack ||
-			row["rack_row"] != miner.RackRow ||
-			row["rack_col"] != miner.RackCol {
-			count++
-		}
-	}
-	return count
 }
 
 func countExistingRowUpdates(rows []map[string]string, existing map[string]map[string]string, keySpec string, headers []string) int32 {

--- a/server/internal/domain/sitemap/service.go
+++ b/server/internal/domain/sitemap/service.go
@@ -1174,9 +1174,9 @@ func buildPlan(parsed *parsedCSV, snap *snapshot, mode pb.OmissionMode) importPl
 	plan.errors = append(plan.errors, validateKnownMiners(resolved.miners)...)
 	plan.errors = append(plan.errors, validateReadOnlyMinerFields(resolved.miners)...)
 	if len(removeReferenceErrors) == 0 {
-		plan.errors = append(plan.errors, validateBuildingSiteTargets(parsed.sections["BUILDING"], parsed.sections["SITE"], targetSnap)...)
-		plan.errors = append(plan.errors, validateRackPlacementTargets(parsed.sections["RACK"], parsed.sections["BUILDING"], parsed.sections["SITE"], targetSnap)...)
-		plan.errors = append(plan.errors, validatePlacementConsistency(parsed.sections["MINER"], parsed.sections["RACK"], parsed.sections["BUILDING"], parsed.sections["SITE"], targetSnap)...)
+		plan.errors = append(plan.errors, validateBuildingSiteTargets(resolved.buildings, resolved.topology)...)
+		plan.errors = append(plan.errors, validateRackPlacementTargets(resolved.racks, resolved.topology)...)
+		plan.errors = append(plan.errors, validatePlacementConsistency(resolved.miners, resolved.topology)...)
 	}
 	plan.errors = append(plan.errors, validateBuildingLayoutBounds(parsed.sections["BUILDING"])...)
 	plan.errors = append(plan.errors, validateRackDimensions(parsed.sections["RACK"])...)
@@ -3006,106 +3006,6 @@ func desiredRacksByID(rows []map[string]string, racks []rackSnapshot, sitesByID 
 		out[id] = rack
 	}
 	return out
-}
-
-func validateBuildingSiteTargets(rows, siteRows []map[string]string, snap *snapshot) []*pb.ImportValidationError {
-	existingSites := desiredSiteSet(siteRows, snap.sites)
-	var errs []*pb.ImportValidationError
-	for i, row := range rows {
-		if row[fieldSite] != "" && !existingSites[row[fieldSite]] {
-			errs = append(errs, csvErr(rowNumber(row, i+1), "BUILDING", fmt.Sprintf("unknown site %q", row[fieldSite])))
-		}
-	}
-	return errs
-}
-
-func validateRackPlacementTargets(rows, buildingRows, siteRows []map[string]string, snap *snapshot) []*pb.ImportValidationError {
-	existingSites := desiredSiteSet(siteRows, snap.sites)
-	existingBuildings := rowSetFromDesiredBuildings(buildingRows, snap.buildings)
-	buildingsByName, ambiguousBuildings := desiredBuildingNameLookup(buildingRows, snap.buildings)
-	var errs []*pb.ImportValidationError
-	for i, row := range rows {
-		if row[fieldSite] != "" && !existingSites[row[fieldSite]] {
-			errs = append(errs, csvErr(rowNumber(row, i+1), "RACK", fmt.Sprintf("unknown site %q", row[fieldSite])))
-		}
-		if row[fieldBuilding] != "" {
-			if row[fieldSite] == "" {
-				if row[fieldBuildingID] != "" {
-					continue
-				}
-				if ambiguousBuildings[row[fieldBuilding]] {
-					errs = append(errs, csvErr(rowNumber(row, i+1), "RACK", fmt.Sprintf("rack building %q is ambiguous; add site or building_id", row[fieldBuilding])))
-					continue
-				}
-				if _, ok := buildingsByName[row[fieldBuilding]]; !ok {
-					errs = append(errs, csvErr(rowNumber(row, i+1), "RACK", fmt.Sprintf("unknown building %q", row[fieldBuilding])))
-				}
-				continue
-			}
-			key := row[fieldSite] + "\x00" + row[fieldBuilding]
-			if !existingBuildings[key] {
-				errs = append(errs, csvErr(rowNumber(row, i+1), "RACK", fmt.Sprintf("unknown building %q for site %q", row[fieldBuilding], row[fieldSite])))
-			}
-		}
-	}
-	return errs
-}
-
-func validatePlacementConsistency(minerRows, rackRows, buildingRows, siteRows []map[string]string, snap *snapshot) []*pb.ImportValidationError {
-	racks := desiredRackMap(rackRows, snap.racks, buildingRows, snap.buildings)
-	buildingsByName, ambiguousBuildings := desiredBuildingNameLookup(buildingRows, snap.buildings)
-	buildingsByKey := desiredBuildingMap(buildingRows, snap.buildings)
-	existingSites := desiredSiteSet(siteRows, snap.sites)
-	var errs []*pb.ImportValidationError
-	for i, row := range minerRows {
-		if row[fieldRack] != "" {
-			rack, ok := racks[row[fieldRack]]
-			if !ok {
-				errs = append(errs, csvErr(rowNumber(row, i+1), "MINER", fmt.Sprintf("unknown rack %q", row[fieldRack])))
-				continue
-			}
-			if row[fieldSite] != "" && row[fieldSite] != rack.Site {
-				errs = append(errs, csvErr(rowNumber(row, i+1), "MINER", fmt.Sprintf("miner site %q does not match rack site %q", row[fieldSite], rack.Site)))
-			}
-			if row[fieldBuilding] != "" && row[fieldBuilding] != rack.Building {
-				errs = append(errs, csvErr(rowNumber(row, i+1), "MINER", fmt.Sprintf("miner building %q does not match rack building %q", row[fieldBuilding], rack.Building)))
-			}
-			continue
-		}
-		if row[fieldBuilding] != "" {
-			if row[fieldBuildingID] != "" {
-				continue
-			}
-			if row[fieldSite] != "" {
-				building, ok := buildingsByKey[row[fieldSite]+"\x00"+row[fieldBuilding]]
-				if !ok {
-					errs = append(errs, csvErr(rowNumber(row, i+1), "MINER", fmt.Sprintf("unknown building %q for site %q", row[fieldBuilding], row[fieldSite])))
-					continue
-				}
-				if row[fieldSite] != building.SiteLabel {
-					errs = append(errs, csvErr(rowNumber(row, i+1), "MINER", fmt.Sprintf("miner site %q does not match building site %q", row[fieldSite], building.SiteLabel)))
-				}
-				continue
-			}
-			if ambiguousBuildings[row[fieldBuilding]] {
-				errs = append(errs, csvErr(rowNumber(row, i+1), "MINER", fmt.Sprintf("miner building %q is ambiguous; add site or building_id", row[fieldBuilding])))
-				continue
-			}
-			building, ok := buildingsByName[row[fieldBuilding]]
-			if !ok {
-				errs = append(errs, csvErr(rowNumber(row, i+1), "MINER", fmt.Sprintf("unknown building %q", row[fieldBuilding])))
-				continue
-			}
-			if row[fieldSite] != "" && row[fieldSite] != building.SiteLabel {
-				errs = append(errs, csvErr(rowNumber(row, i+1), "MINER", fmt.Sprintf("miner site %q does not match building site %q", row[fieldSite], building.SiteLabel)))
-			}
-			continue
-		}
-		if row[fieldSite] != "" && !existingSites[row[fieldSite]] {
-			errs = append(errs, csvErr(rowNumber(row, i+1), "MINER", fmt.Sprintf("unknown site %q", row[fieldSite])))
-		}
-	}
-	return errs
 }
 
 func validateBuildingLayoutBounds(rows []map[string]string) []*pb.ImportValidationError {

--- a/server/internal/domain/sitemap/service.go
+++ b/server/internal/domain/sitemap/service.go
@@ -1171,8 +1171,8 @@ func buildPlan(parsed *parsedCSV, snap *snapshot, mode pb.OmissionMode) importPl
 	plan.errors = append(plan.errors, validateRetainedTopologyUniqueness(parsed, snap, mode)...)
 	removeReferenceErrors := validateRemoveOmittedReferences(parsed, mode)
 	plan.errors = append(plan.errors, removeReferenceErrors...)
-	plan.errors = append(plan.errors, validateKnownMiners(parsed.sections["MINER"], snap)...)
-	plan.errors = append(plan.errors, validateReadOnlyMinerFields(parsed.sections["MINER"], snap)...)
+	plan.errors = append(plan.errors, validateKnownMiners(resolved.miners)...)
+	plan.errors = append(plan.errors, validateReadOnlyMinerFields(resolved.miners)...)
 	if len(removeReferenceErrors) == 0 {
 		plan.errors = append(plan.errors, validateBuildingSiteTargets(parsed.sections["BUILDING"], parsed.sections["SITE"], targetSnap)...)
 		plan.errors = append(plan.errors, validateRackPlacementTargets(parsed.sections["RACK"], parsed.sections["BUILDING"], parsed.sections["SITE"], targetSnap)...)
@@ -2712,41 +2712,6 @@ func validateRemoveOmittedReferences(parsed *parsedCSV, mode pb.OmissionMode) []
 	return errs
 }
 
-func validateKnownMiners(rows []map[string]string, snap *snapshot) []*pb.ImportValidationError {
-	known := rowSetFromMiners(snap.miners)
-	var errs []*pb.ImportValidationError
-	for i, row := range rows {
-		if row["device_identifier"] != "" && !known[row["device_identifier"]] {
-			errs = append(errs, csvErr(rowNumber(row, i+1), "MINER", "unknown miner device_identifier"))
-		}
-	}
-	return errs
-}
-
-func validateReadOnlyMinerFields(rows []map[string]string, snap *snapshot) []*pb.ImportValidationError {
-	known := minerMap(snap.miners)
-	var errs []*pb.ImportValidationError
-	for i, row := range rows {
-		miner, ok := known[row["device_identifier"]]
-		if !ok {
-			continue
-		}
-		for _, field := range []struct {
-			name string
-			want string
-		}{
-			{name: "serial_number", want: miner.SerialNumber},
-			{name: "ip_address", want: miner.IPAddress},
-			{name: "mac_address", want: miner.MACAddress},
-		} {
-			if row[field.name] != field.want {
-				errs = append(errs, csvErr(rowNumber(row, i+1), "MINER", fmt.Sprintf("%s is read-only for existing miner %s", field.name, row["device_identifier"])))
-			}
-		}
-	}
-	return errs
-}
-
 func validateKnownEntityIDs(parsed *parsedCSV, snap *snapshot) []*pb.ImportValidationError {
 	sitesByID := map[int64]sitemodels.Site{}
 	for _, site := range snap.sites {
@@ -3972,18 +3937,6 @@ func countMinerPlacementUpdates(rows, rackRows, buildingRows []map[string]string
 			row[fieldRack] != miner.Rack ||
 			row["rack_row"] != miner.RackRow ||
 			row["rack_col"] != miner.RackCol {
-			count++
-		}
-	}
-	return count
-}
-
-func countMinerRenames(rows []map[string]string, miners []minerSnapshot) int32 {
-	existing := minerMap(miners)
-	var count int32
-	for _, row := range rows {
-		miner, ok := existing[row["device_identifier"]]
-		if ok && row[fieldName] != miner.Name {
 			count++
 		}
 	}

--- a/server/internal/domain/sitemap/service.go
+++ b/server/internal/domain/sitemap/service.go
@@ -248,7 +248,7 @@ File structure
 
 Omissions and renames
 - Import preview reports omitted existing rows when a site, building, rack, or miner exists in Proto Fleet but is missing from the CSV.
-- The user chooses omission handling during import. Leave omitted rows in place keeps missing rows unchanged. Remove omitted rows soft-deletes omitted sites, buildings, and racks, and unassigns omitted miners.
+- Omitted rows are removed on import: omitted sites, buildings, and racks are soft-deleted and omitted miners are unassigned. The preview reports the omitted counts and asks you to confirm before removal.
 - Remove omitted rows can cascade placement cleanup: deleting an omitted site also deletes its buildings and unassigns racks/miners from that site; deleting an omitted building unassigns its racks and miners; deleting an omitted rack removes miners from that rack.
 - With a populated id, editing a site/building name or rack label renames the existing entity.
 - With a blank id, editing a site/building name or rack label creates a new entity and the old entity may be counted as omitted.

--- a/server/internal/domain/sitemap/service.go
+++ b/server/internal/domain/sitemap/service.go
@@ -1180,9 +1180,9 @@ func buildPlan(parsed *parsedCSV, snap *snapshot, mode pb.OmissionMode) importPl
 	}
 	plan.errors = append(plan.errors, validateBuildingLayoutBounds(parsed.sections["BUILDING"])...)
 	plan.errors = append(plan.errors, validateRackDimensions(parsed.sections["RACK"])...)
-	plan.errors = append(plan.errors, validateRackGridPositions(parsed.sections["RACK"], parsed.sections["BUILDING"], targetSnap)...)
+	plan.errors = append(plan.errors, validateRackGridPositions(resolved.racks, resolved.topology)...)
 	plan.errors = append(plan.errors, validateRackGridCollisions(parsed.sections["RACK"], snap, mode)...)
-	plan.errors = append(plan.errors, validateRackSlotBounds(parsed.sections["MINER"], parsed.sections["RACK"], targetSnap)...)
+	plan.errors = append(plan.errors, validateRackSlotBounds(resolved.miners, resolved.topology)...)
 	plan.errors = append(plan.errors, validateExistingSlotsFitRackDimensions(parsed.sections["MINER"], parsed.sections["RACK"], targetSnap, mode)...)
 	plan.errors = append(plan.errors, validateRackCapacity(parsed.sections["MINER"], parsed.sections["RACK"], targetSnap, mode)...)
 	plan.errors = append(plan.errors, validateBuildingRackCapacity(parsed.sections["RACK"], parsed.sections["BUILDING"], targetSnap)...)
@@ -3063,65 +3063,6 @@ func validateRackDimensions(rows []map[string]string) []*pb.ImportValidationErro
 	return errs
 }
 
-func validateRackGridPositions(rackRows, buildingRows []map[string]string, snap *snapshot) []*pb.ImportValidationError {
-	buildings := desiredBuildingMap(buildingRows, snap.buildings)
-	buildingsByID := desiredBuildingLayoutIDMap(buildingRows, snap.buildings)
-	var errs []*pb.ImportValidationError
-	for i, row := range rackRows {
-		aisleRaw := row["aisle_index"]
-		positionRaw := row["position_in_aisle"]
-		if (aisleRaw == "") != (positionRaw == "") {
-			errs = append(errs, csvErr(rowNumber(row, i+1), "RACK", "aisle_index and position_in_aisle must both be set or both be blank"))
-			continue
-		}
-		if aisleRaw == "" {
-			continue
-		}
-		if row[fieldBuilding] == "" {
-			errs = append(errs, csvErr(rowNumber(row, i+1), "RACK", "rack grid position requires a building"))
-			continue
-		}
-		aisle, err := parseInt32Value(aisleRaw, "aisle_index")
-		if err != nil {
-			errs = append(errs, csvErr(rowNumber(row, i+1), "RACK", err.Error()))
-			continue
-		}
-		position, err := parseInt32Value(positionRaw, "position_in_aisle")
-		if err != nil {
-			errs = append(errs, csvErr(rowNumber(row, i+1), "RACK", err.Error()))
-			continue
-		}
-		if aisle < 0 {
-			errs = append(errs, csvErr(rowNumber(row, i+1), "RACK", fmt.Sprintf("aisle_index %d is out of bounds", aisle)))
-			continue
-		}
-		if position < 0 {
-			errs = append(errs, csvErr(rowNumber(row, i+1), "RACK", fmt.Sprintf("position_in_aisle %d is out of bounds", position)))
-			continue
-		}
-		building, ok := desiredRackGridBuilding(row, buildings, buildingsByID)
-		if !ok {
-			continue
-		}
-		if building.Aisles <= 0 || aisle >= building.Aisles {
-			errs = append(errs, csvErr(rowNumber(row, i+1), "RACK", fmt.Sprintf("aisle_index %d is out of bounds for building %q with %d aisles", aisle, building.Name, building.Aisles)))
-		}
-		if building.RacksPerAisle <= 0 || position >= building.RacksPerAisle {
-			errs = append(errs, csvErr(rowNumber(row, i+1), "RACK", fmt.Sprintf("position_in_aisle %d is out of bounds for building %q with %d racks per aisle", position, building.Name, building.RacksPerAisle)))
-		}
-	}
-	return errs
-}
-
-func desiredRackGridBuilding(row map[string]string, buildings map[string]buildingmodels.Building, buildingsByID map[int64]buildingmodels.Building) (buildingmodels.Building, bool) {
-	if buildingID, ok := idFromCell(row[fieldBuildingID]); ok {
-		building, ok := buildingsByID[buildingID]
-		return building, ok
-	}
-	building, ok := buildings[row[fieldSite]+"\x00"+row[fieldBuilding]]
-	return building, ok
-}
-
 func validateRackGridCollisions(rackRows []map[string]string, snap *snapshot, mode pb.OmissionMode) []*pb.ImportValidationError {
 	presentRackIdentities := rackIdentitySet(rackRows, snap.racks)
 	buildingBySiteName := map[string]buildingmodels.Building{}
@@ -3215,47 +3156,6 @@ func validateMinerRenamePermission(rows []map[string]string, snap *snapshot) []*
 			continue
 		}
 		errs = append(errs, csvErr(rowNumber(row, i+1), "MINER", "miner:rename permission is required to change miner name"))
-	}
-	return errs
-}
-
-func validateRackSlotBounds(minerRows, rackRows []map[string]string, snap *snapshot) []*pb.ImportValidationError {
-	racks := desiredRackMap(rackRows, snap.racks, nil, snap.buildings)
-	var errs []*pb.ImportValidationError
-	for i, row := range minerRows {
-		if row[fieldRack] == "" {
-			if row["rack_row"] != "" || row["rack_col"] != "" {
-				errs = append(errs, csvErr(rowNumber(row, i+1), "MINER", "rack_row and rack_col require rack"))
-			}
-			continue
-		}
-		if (row["rack_row"] == "") != (row["rack_col"] == "") {
-			errs = append(errs, csvErr(rowNumber(row, i+1), "MINER", "rack_row and rack_col must both be set or both be blank"))
-			continue
-		}
-		if row["rack_row"] == "" {
-			continue
-		}
-		rack, ok := racks[row[fieldRack]]
-		if !ok {
-			continue
-		}
-		rackRow, err := parseInt32Value(row["rack_row"], "rack_row")
-		if err != nil {
-			errs = append(errs, csvErr(rowNumber(row, i+1), "MINER", err.Error()))
-			continue
-		}
-		rackCol, err := parseInt32Value(row["rack_col"], "rack_col")
-		if err != nil {
-			errs = append(errs, csvErr(rowNumber(row, i+1), "MINER", err.Error()))
-			continue
-		}
-		if rackRow < 0 || rack.Rows <= 0 || rackRow >= rack.Rows {
-			errs = append(errs, csvErr(rowNumber(row, i+1), "MINER", fmt.Sprintf("rack_row %d is out of bounds for rack %q with %d rows", rackRow, row[fieldRack], rack.Rows)))
-		}
-		if rackCol < 0 || rack.Columns <= 0 || rackCol >= rack.Columns {
-			errs = append(errs, csvErr(rowNumber(row, i+1), "MINER", fmt.Sprintf("rack_col %d is out of bounds for rack %q with %d columns", rackCol, row[fieldRack], rack.Columns)))
-		}
 	}
 	return errs
 }

--- a/server/internal/domain/sitemap/service.go
+++ b/server/internal/domain/sitemap/service.go
@@ -1150,32 +1150,8 @@ func buildPlan(parsed *parsedCSV, snap *snapshot, mode pb.OmissionMode) importPl
 	targetSnap := snapshotForOmissionMode(snap, mode)
 	normalizeIDErrors := normalizeIDReferences(parsed, snap)
 	normalizeInferredPlacement(parsed, targetSnap)
-	plan := importPlan{omissions: &pb.OmissionCounts{}}
-	siteKeys := siteIdentitySet(parsed.sections["SITE"], snap.sites)
-	buildingKeys := buildingIdentitySet(parsed.sections["BUILDING"], snap.buildings)
-	rackKeys := rackIdentitySet(parsed.sections["RACK"], snap.racks)
-	minerKeys := rowSet(parsed.sections["MINER"], "device_identifier")
-
-	for _, site := range snap.sites {
-		if !siteKeys[siteIdentity(site)] {
-			plan.omissions.Sites++
-		}
-	}
-	for _, building := range snap.buildings {
-		if !buildingKeys[buildingIdentity(building)] {
-			plan.omissions.Buildings++
-		}
-	}
-	for _, rack := range snap.racks {
-		if !rackKeys[rackIdentity(rack)] {
-			plan.omissions.Racks++
-		}
-	}
-	for _, miner := range snap.miners {
-		if !minerKeys[miner.DeviceIdentifier] {
-			plan.omissions.Miners++
-		}
-	}
+	resolved := resolvePlan(parsed, snap, mode)
+	plan := importPlan{omissions: resolved.omissions}
 
 	plan.errors = append(plan.errors, validateUnique(parsed.sections["SITE"], "SITE", fieldName)...)
 	plan.errors = append(plan.errors, validateUniqueBuildingRows(parsed.sections["BUILDING"])...)
@@ -1217,25 +1193,7 @@ func buildPlan(parsed *parsedCSV, snap *snapshot, mode pb.OmissionMode) importPl
 		return plan
 	}
 
-	addChange := func(op pb.ImportOperation, entityType string, count int32, description string) {
-		if count > 0 {
-			plan.changes = append(plan.changes, &pb.ImportChangeSummary{Operation: op, EntityType: entityType, Count: count, Description: description})
-		}
-	}
-	addChange(pb.ImportOperation_IMPORT_OPERATION_CREATE, "site", countSiteCreates(parsed.sections["SITE"], snap.sites), "new site rows")
-	addChange(pb.ImportOperation_IMPORT_OPERATION_CREATE, fieldBuilding, countBuildingCreates(parsed.sections["BUILDING"], snap.buildings), "new building rows")
-	addChange(pb.ImportOperation_IMPORT_OPERATION_CREATE, "rack", countRackCreates(parsed.sections["RACK"], snap.racks), "new rack rows")
-	addChange(pb.ImportOperation_IMPORT_OPERATION_UPDATE, "site", countSiteUpdates(parsed.sections["SITE"], snap.sites), "site rows with changed details")
-	addChange(pb.ImportOperation_IMPORT_OPERATION_UPDATE, fieldBuilding, countBuildingUpdates(parsed.sections["BUILDING"], snap.buildings), "building rows with changed details")
-	addChange(pb.ImportOperation_IMPORT_OPERATION_UPDATE, "rack", countRackUpdates(parsed.sections["RACK"], snap.racks, targetSnap.buildings), "rack rows with changed details")
-	addChange(pb.ImportOperation_IMPORT_OPERATION_RENAME, "miner", countMinerRenames(parsed.sections["MINER"], snap.miners), "miner rows with changed names")
-	addChange(pb.ImportOperation_IMPORT_OPERATION_MOVE, "miner", countMinerPlacementUpdates(parsed.sections["MINER"], parsed.sections["RACK"], parsed.sections["BUILDING"], targetSnap), "miner placement rows with changed site, building, rack, or slot")
-	if mode == pb.OmissionMode_OMISSION_MODE_REMOVE_OMITTED {
-		addChange(pb.ImportOperation_IMPORT_OPERATION_UNASSIGN, "miner", countDeletes(rowSetFromMiners(snap.miners), minerKeys), "omitted miner rows to unassign")
-		addChange(pb.ImportOperation_IMPORT_OPERATION_DELETE, "rack", countDeletes(rowSetFromRacks(snap.racks), rackKeys), "omitted rack rows to delete")
-		addChange(pb.ImportOperation_IMPORT_OPERATION_DELETE, fieldBuilding, countDeletes(rowSetFromBuildings(snap.buildings), buildingKeys), "omitted building rows to delete")
-		addChange(pb.ImportOperation_IMPORT_OPERATION_DELETE, "site", countDeletes(rowSetFromSites(snap.sites), siteKeys), "omitted site rows to delete")
-	}
+	plan.changes = computeChanges(resolved, parsed, snap, targetSnap, mode)
 	return plan
 }
 
@@ -3968,69 +3926,6 @@ func safeInt32(value int) int32 {
 	return int32(value) // #nosec G115 -- value is bounded above to MaxInt32.
 }
 
-func countCreates(existing, desired map[string]bool) int32 {
-	var count int32
-	for key := range desired {
-		if !existing[key] {
-			count++
-		}
-	}
-	return count
-}
-
-func countSiteCreates(rows []map[string]string, sites []sitemodels.Site) int32 {
-	existingByName := rowSetFromSiteNames(sites)
-	var count int32
-	for _, row := range rows {
-		if row[fieldID] != "" {
-			continue
-		}
-		if !existingByName[siteSectionName(row)] {
-			count++
-		}
-	}
-	return count
-}
-
-func countBuildingCreates(rows []map[string]string, buildings []buildingmodels.Building) int32 {
-	existingByKey := rowSetFromBuildingNames(buildings)
-	var count int32
-	for _, row := range rows {
-		if row[fieldID] != "" {
-			continue
-		}
-		key := row[fieldSite] + "\x00" + buildingSectionName(row)
-		if !existingByKey[key] {
-			count++
-		}
-	}
-	return count
-}
-
-func countRackCreates(rows []map[string]string, racks []rackSnapshot) int32 {
-	existingByLabel := rowSetFromRackLabels(racks)
-	var count int32
-	for _, row := range rows {
-		if row[fieldID] != "" {
-			continue
-		}
-		if !existingByLabel[rackSectionLabel(row)] {
-			count++
-		}
-	}
-	return count
-}
-
-func countDeletes(existing, desired map[string]bool) int32 {
-	var count int32
-	for key := range existing {
-		if !desired[key] {
-			count++
-		}
-	}
-	return count
-}
-
 func countSiteUpdates(rows []map[string]string, sites []sitemodels.Site) int32 {
 	existing := map[string]map[string]string{}
 	for _, site := range sites {
@@ -4596,14 +4491,6 @@ func minerPlacementIDsMatch(row map[string]string, miner minerSnapshot) bool {
 	return true
 }
 
-func rowSetFromSites(rows []sitemodels.Site) map[string]bool {
-	out := map[string]bool{}
-	for _, row := range rows {
-		out[siteIdentity(row)] = true
-	}
-	return out
-}
-
 func rowSetFromSiteNames(rows []sitemodels.Site) map[string]bool {
 	out := map[string]bool{}
 	for _, row := range rows {
@@ -4665,22 +4552,6 @@ func rowSetFromDesiredBuildings(rows []map[string]string, buildings []buildingmo
 		if buildingSectionName(row) != "" {
 			out[row[fieldSite]+"\x00"+buildingSectionName(row)] = true
 		}
-	}
-	return out
-}
-
-func rowSetFromRacks(rows []rackSnapshot) map[string]bool {
-	out := map[string]bool{}
-	for _, row := range rows {
-		out[rackIdentity(row)] = true
-	}
-	return out
-}
-
-func rowSetFromRackLabels(rows []rackSnapshot) map[string]bool {
-	out := map[string]bool{}
-	for _, row := range rows {
-		out[row.Label] = true
 	}
 	return out
 }

--- a/server/internal/domain/sitemap/service.go
+++ b/server/internal/domain/sitemap/service.go
@@ -164,10 +164,10 @@ func buildSiteMapCSV(snapshot *snapshot) ([]byte, error) {
 	if err := writeSection("BUILDING", buildingHeaders, buildingRows(snapshot.buildings)); err != nil {
 		return nil, fleeterror.NewInternalErrorf("failed to write BUILDING section: %v", err)
 	}
-	if err := writeSection("RACK", rackHeaders, rackExportRows(snapshot.racks, snapshot.buildings)); err != nil {
+	if err := writeSection("RACK", rackHeaders, rackExportRows(snapshot.racks)); err != nil {
 		return nil, fleeterror.NewInternalErrorf("failed to write RACK section: %v", err)
 	}
-	if err := writeSection("MINER", minerHeaders, minerRows(snapshot.miners, snapshot.buildings)); err != nil {
+	if err := writeSection("MINER", minerHeaders, minerRows(snapshot.miners)); err != nil {
 		return nil, fleeterror.NewInternalErrorf("failed to write MINER section: %v", err)
 	}
 
@@ -734,7 +734,10 @@ func buildingRows(buildings []buildingmodels.Building) [][]string {
 			clean(building.Name),
 			formatInt64(building.ID),
 			formatNullableInt64(building.SiteID),
-			clean(building.SiteLabel),
+			// Parent-reference name columns are blank on export: existing parents
+			// are identified by *_id. The name columns exist only so an author can
+			// point a new (blank-id) row at another new row created in the same file.
+			"",
 			formatInt32(building.Aisles),
 			formatInt32(building.RacksPerAisle),
 		})
@@ -749,6 +752,10 @@ func buildingRawRows(buildings []buildingmodels.Building) [][]string {
 			building.Name,
 			formatInt64(building.ID),
 			formatNullableInt64(building.SiteID),
+			// Change-detection compares against parsed rows *after*
+			// normalizeIDReferences back-fills the parent-name columns from ids,
+			// so the comparable row keeps the resolved names populated even though
+			// export blanks them.
 			building.SiteLabel,
 			formatInt32(building.Aisles),
 			formatInt32(building.RacksPerAisle),
@@ -757,27 +764,10 @@ func buildingRawRows(buildings []buildingmodels.Building) [][]string {
 	return rows
 }
 
-func rackRows(racks []rackSnapshot) [][]string {
-	rows := make([][]string, 0, len(racks))
-	for _, rack := range racks {
-		rows = append(rows, []string{
-			clean(rack.Label),
-			formatInt64(rack.ID),
-			formatNullableInt64(rack.BuildingID),
-			clean(rack.Building),
-			formatNullableInt64(rack.SiteID),
-			clean(rack.Site),
-			clean(rack.Zone),
-			formatInt32(rack.Rows),
-			formatInt32(rack.Columns),
-			rack.OrderIndex,
-			rack.AisleIndex,
-			rack.PositionInAisle,
-		})
-	}
-	return rows
-}
-
+// rackRawRows is the uncleaned canonical rack row used for change detection. It
+// carries both parent ids and the resolved parent names so it matches a parsed
+// row after normalizeIDReferences has back-filled names from ids (export itself
+// blanks the parent-name columns).
 func rackRawRows(racks []rackSnapshot) [][]string {
 	rows := make([][]string, 0, len(racks))
 	for _, rack := range racks {
@@ -799,71 +789,69 @@ func rackRawRows(racks []rackSnapshot) [][]string {
 	return rows
 }
 
-func rackExportRows(racks []rackSnapshot, buildings []buildingmodels.Building) [][]string {
+// rackExportRows emits id-authoritative rack rows: the rack's most-specific
+// parent is identified by building_id (or site_id when the rack sits directly
+// under a site). Parent-reference name columns are blank; they exist only to
+// point at a same-file create.
+func rackExportRows(racks []rackSnapshot) [][]string {
 	rows := make([][]string, 0, len(racks))
-	ambiguousBuildingNames := ambiguousBuildingLabels(buildings)
 	for _, rack := range racks {
-		site := rackExportSite(rack, ambiguousBuildingNames)
-		rows = append(rows, []string{
-			clean(rack.Label),
-			formatInt64(rack.ID),
-			rackExportBuildingID(rack, ambiguousBuildingNames),
-			clean(rack.Building),
-			rackExportSiteID(rack, site),
-			clean(site),
-			clean(rack.Zone),
-			formatInt32(rack.Rows),
-			formatInt32(rack.Columns),
-			rack.OrderIndex,
-			rack.AisleIndex,
-			rack.PositionInAisle,
-		})
+		rows = append(rows, rackExportRow(rack))
 	}
 	return rows
 }
 
-func rackExportBuildingID(rack rackSnapshot, ambiguousBuildingNames map[string]bool) string {
-	if rack.Building != "" && ambiguousBuildingNames[rack.Building] {
-		return formatNullableInt64(rack.BuildingID)
+func rackExportRow(rack rackSnapshot) []string {
+	buildingID, siteID := rackParentIDCells(rack)
+	return []string{
+		clean(rack.Label),
+		formatInt64(rack.ID),
+		buildingID,
+		"",
+		siteID,
+		"",
+		clean(rack.Zone),
+		formatInt32(rack.Rows),
+		formatInt32(rack.Columns),
+		rack.OrderIndex,
+		rack.AisleIndex,
+		rack.PositionInAisle,
 	}
-	return ""
 }
 
-func rackExportSiteID(rack rackSnapshot, site string) string {
-	if site != "" {
-		return ""
+// rackParentIDCells returns the building_id and site_id cells for a rack,
+// preferring the building (which implies its site) and falling back to a direct
+// site assignment.
+func rackParentIDCells(rack rackSnapshot) (buildingID, siteID string) {
+	if rack.BuildingID != nil {
+		return formatNullableInt64(rack.BuildingID), ""
 	}
-	if rack.Site != "" && rack.Building == "" {
-		return ""
+	if rack.SiteID != nil {
+		return "", formatNullableInt64(rack.SiteID)
 	}
-	return ""
+	return "", ""
 }
 
-func rackExportSite(rack rackSnapshot, ambiguousBuildingNames map[string]bool) string {
-	if rack.Building != "" && !ambiguousBuildingNames[rack.Building] {
-		return ""
-	}
-	return rack.Site
-}
-
-func minerRows(miners []minerSnapshot, buildings []buildingmodels.Building) [][]string {
+// minerRows emits id-authoritative miner rows: the miner's most-specific parent
+// is identified by rack_id (or building_id / site_id when there is no rack).
+// Parent-reference name columns are blank; they exist only to point at a
+// same-file create.
+func minerRows(miners []minerSnapshot) [][]string {
 	rows := make([][]string, 0, len(miners))
-	ambiguousBuildingNames := ambiguousBuildingLabels(buildings)
 	for _, miner := range miners {
-		site := minerExportSite(miner, ambiguousBuildingNames)
-		building := minerExportBuilding(miner)
+		siteID, buildingID, rackID := minerParentIDCells(miner)
 		rows = append(rows, []string{
 			clean(miner.DeviceIdentifier),
 			clean(miner.SerialNumber),
 			clean(miner.Name),
 			clean(miner.IPAddress),
 			clean(miner.MACAddress),
-			minerExportSiteID(miner, site),
-			clean(site),
-			minerExportBuildingID(miner, ambiguousBuildingNames, building),
-			clean(building),
+			siteID,
 			"",
-			clean(miner.Rack),
+			buildingID,
+			"",
+			rackID,
+			"",
 			miner.RackRow,
 			miner.RackCol,
 		})
@@ -871,35 +859,20 @@ func minerRows(miners []minerSnapshot, buildings []buildingmodels.Building) [][]
 	return rows
 }
 
-func minerExportSite(miner minerSnapshot, ambiguousBuildingNames map[string]bool) string {
-	if miner.Rack != "" {
-		return ""
+// minerParentIDCells returns the site_id, building_id, and rack_id cells for a
+// miner, emitting only the most-specific parent (rack implies building and site;
+// building implies site).
+func minerParentIDCells(miner minerSnapshot) (siteID, buildingID, rackID string) {
+	if miner.RackID != nil {
+		return "", "", formatNullableInt64(miner.RackID)
 	}
-	if miner.Building != "" && !ambiguousBuildingNames[miner.Building] {
-		return ""
+	if miner.BuildingID != nil {
+		return "", formatNullableInt64(miner.BuildingID), ""
 	}
-	return miner.Site
-}
-
-func minerExportBuilding(miner minerSnapshot) string {
-	if miner.Rack != "" {
-		return ""
+	if miner.SiteID != nil {
+		return formatNullableInt64(miner.SiteID), "", ""
 	}
-	return miner.Building
-}
-
-func minerExportSiteID(miner minerSnapshot, site string) string {
-	if site != "" {
-		return ""
-	}
-	return ""
-}
-
-func minerExportBuildingID(miner minerSnapshot, ambiguousBuildingNames map[string]bool, building string) string {
-	if building != "" && ambiguousBuildingNames[building] {
-		return formatNullableInt64(miner.BuildingID)
-	}
-	return ""
+	return "", "", ""
 }
 
 func placementLabels(refs *commonpb.PlacementRefs) (string, string) {
@@ -1761,7 +1734,7 @@ func (s *Service) applyRackRows(
 			})
 			continue
 		}
-		current := rackComparableRow(rack, buildingsByID)
+		current := rackComparableRow(rack)
 		if rowsEqual(row, current, rackHeaders) {
 			continue
 		}
@@ -2118,8 +2091,8 @@ func snapshotFingerprint(snap *snapshot) string {
 	}{
 		Sites:             siteRows(snap.sites),
 		Buildings:         buildingRows(snap.buildings),
-		Racks:             rackRows(snap.racks),
-		Miners:            minerRows(snap.miners, snap.buildings),
+		Racks:             rackExportRows(snap.racks),
+		Miners:            minerRows(snap.miners),
 		HiddenRackMembers: hiddenRackMemberRows(snap.hiddenRackMembers),
 	})
 	sum := sha256.Sum256(payload)
@@ -3458,11 +3431,10 @@ func countBuildingUpdates(rows []map[string]string, buildings []buildingmodels.B
 	return countExistingRowUpdatesByIdentity(rows, existing, buildingRowIdentity, buildingHeaders)
 }
 
-func countRackUpdates(rows []map[string]string, racks []rackSnapshot, buildings []buildingmodels.Building) int32 {
+func countRackUpdates(rows []map[string]string, racks []rackSnapshot) int32 {
 	existing := map[string]map[string]string{}
-	buildingsByID := buildingMapByID(buildings)
 	for _, rack := range racks {
-		row := rackComparableRow(rack, buildingsByID)
+		row := rackComparableRow(rack)
 		existing[rackIdentity(rack)] = row
 		existing["label:"+rack.Label] = row
 	}
@@ -3513,30 +3485,17 @@ func rowMap(headers, values []string) map[string]string {
 	return out
 }
 
-func rackComparableRow(rack rackSnapshot, buildingsByID map[int64]buildingmodels.Building) map[string]string {
-	buildings := make([]buildingmodels.Building, 0, len(buildingsByID))
-	for _, building := range buildingsByID {
-		buildings = append(buildings, building)
-	}
-	ambiguousBuildingNames := ambiguousBuildingLabels(buildings)
-	row := rowMap(rackHeaders, rackRawRows([]rackSnapshot{rack})[0])
-	row[fieldBuildingID] = rackExportBuildingID(rack, ambiguousBuildingNames)
-	row[fieldSiteID] = rackExportSiteID(rack, row[fieldSite])
-	return row
+// rackComparableRow is the canonical row an unedited exported rack row must
+// equal, so change detection reads identically to export (id-authoritative,
+// blank parent-name columns).
+func rackComparableRow(rack rackSnapshot) map[string]string {
+	return rowMap(rackHeaders, rackRawRows([]rackSnapshot{rack})[0])
 }
 
 func minerMap(miners []minerSnapshot) map[string]minerSnapshot {
 	out := map[string]minerSnapshot{}
 	for _, miner := range miners {
 		out[miner.DeviceIdentifier] = miner
-	}
-	return out
-}
-
-func buildingMapByID(buildings []buildingmodels.Building) map[int64]buildingmodels.Building {
-	out := map[int64]buildingmodels.Building{}
-	for _, building := range buildings {
-		out[building.ID] = building
 	}
 	return out
 }
@@ -3640,26 +3599,6 @@ func desiredBuildingNameLookup(rows []map[string]string, buildings []buildingmod
 		ambiguous[name] = true
 	}
 	return byName, ambiguous
-}
-
-func ambiguousBuildingLabels(buildings []buildingmodels.Building) map[string]bool {
-	firstSiteByName := map[string]string{}
-	countByName := map[string]int{}
-	ambiguous := map[string]bool{}
-	for _, building := range buildings {
-		countByName[building.Name]++
-		if countByName[building.Name] > 1 {
-			ambiguous[building.Name] = true
-		}
-		if site, ok := firstSiteByName[building.Name]; ok {
-			if site != building.SiteLabel {
-				ambiguous[building.Name] = true
-			}
-			continue
-		}
-		firstSiteByName[building.Name] = building.SiteLabel
-	}
-	return ambiguous
 }
 
 func desiredRackMap(rows []map[string]string, racks []rackSnapshot, buildingRows []map[string]string, buildings []buildingmodels.Building) map[string]rackSnapshot {

--- a/server/internal/domain/sitemap/service.go
+++ b/server/internal/domain/sitemap/service.go
@@ -1476,6 +1476,8 @@ func (s *Service) applySites(ctx context.Context, orgID int64, sites []*resolved
 			}
 			existingByName[site.Name] = *site
 			existingByID[site.ID] = *site
+		case actionNone, actionDelete:
+			// Unchanged nodes need no write; omitted sites are deleted by applyOmittedRows.
 		}
 	}
 	return nil
@@ -2743,6 +2745,8 @@ func resolveReferences(parsed *parsedCSV, snap *snapshot) []*pb.ImportValidation
 			errs = append(errs, csvErr(rn, section, fmt.Sprintf("site reference %s%s matches no SITE row in this import", refCreatePrefix, ref.name)))
 		case refInvalid:
 			errs = append(errs, csvErr(rn, section, fmt.Sprintf("site reference %q must be a numeric id or %sNAME", cell, refCreatePrefix)))
+		case refUnassigned:
+			// Blank cell: no site parent, resolves to empty.
 		}
 		return ""
 	}
@@ -2797,6 +2801,8 @@ func resolveReferences(parsed *parsedCSV, snap *snapshot) []*pb.ImportValidation
 			}
 		case refInvalid:
 			errs = append(errs, csvErr(rn, section, fmt.Sprintf("building reference %q must be a numeric id or %sNAME", cell, refCreatePrefix)))
+		case refUnassigned:
+			// Blank cell: no building parent, resolves to empty.
 		}
 		return "", "", 0
 	}
@@ -2852,6 +2858,8 @@ func resolveReferences(parsed *parsedCSV, snap *snapshot) []*pb.ImportValidation
 			errs = append(errs, csvErr(rn, section, fmt.Sprintf("rack reference %s%s matches no RACK row in this import", refCreatePrefix, ref.name)))
 		case refInvalid:
 			errs = append(errs, csvErr(rn, section, fmt.Sprintf("rack reference %q must be a numeric id or %sNAME", cell, refCreatePrefix)))
+		case refUnassigned:
+			// Blank cell: no rack parent, resolves to empty.
 		}
 		return "", "", "", nil
 	}

--- a/server/internal/domain/sitemap/service.go
+++ b/server/internal/domain/sitemap/service.go
@@ -353,7 +353,7 @@ func (s *Service) ImportSiteMapCsv(ctx context.Context, orgID int64, req *pb.Imp
 		}, nil
 	}
 
-	token := commitToken(parsed, req.GetOmissionMode(), plan, snapshot)
+	token := commitToken(req.GetOmissionMode(), plan, snapshot)
 	if !req.GetDryRun() {
 		if req.GetCommitToken() == "" {
 			return nil, fleeterror.NewInvalidArgumentError("commit_token is required when dry_run is false")
@@ -2005,22 +2005,66 @@ func (s *Service) applyMiners(
 	return nil
 }
 
-func commitToken(parsed *parsedCSV, mode pb.OmissionMode, plan importPlan, snap *snapshot) string {
+// commitToken binds a dry-run to the exact work a later commit would perform. It
+// hashes the resolved plan (the create/update node set apply iterates), the
+// omission counts and live snapshot fingerprint (the delete path reads the
+// snapshot directly), and the mode. Deriving the token from the resolved plan —
+// rather than the raw CSV rows and preview summary — means a token can never
+// validate a topology that apply would resolve differently.
+func commitToken(mode pb.OmissionMode, plan importPlan, snap *snapshot) string {
 	payload := mustMarshalJSON(struct {
-		Parsed              *parsedCSV
 		Mode                pb.OmissionMode
+		Plan                [][]string
 		Omissions           *pb.OmissionCounts
-		Changes             []*pb.ImportChangeSummary
 		SnapshotFingerprint string
 	}{
-		Parsed:              parsed,
 		Mode:                mode,
+		Plan:                resolvedPlanRows(plan.resolved),
 		Omissions:           plan.omissions,
-		Changes:             plan.changes,
 		SnapshotFingerprint: snapshotFingerprint(snap),
 	})
 	sum := sha256.Sum256(payload)
 	return hex.EncodeToString(sum[:])
+}
+
+// resolvedPlanRows serializes the resolved plan's create/update node set into a
+// deterministic row form for the commit token. Row order follows CSV order, and
+// each row carries the node's identity plus every mutable facet apply writes.
+func resolvedPlanRows(r *resolvedPlan) [][]string {
+	if r == nil {
+		return nil
+	}
+	rows := [][]string{}
+	for _, s := range r.sites {
+		rows = append(rows, []string{
+			"S", formatNullableInt64(s.id), s.name, strconv.Itoa(int(s.action)),
+		})
+	}
+	for _, b := range r.buildings {
+		rows = append(rows, []string{
+			"B", formatNullableInt64(b.id), b.siteRef, b.name,
+			strconv.Itoa(int(b.aisles)), strconv.Itoa(int(b.racksPerAisle)),
+			strconv.Itoa(int(b.action)),
+		})
+	}
+	for _, rk := range r.racks {
+		rows = append(rows, []string{
+			"R", formatNullableInt64(rk.id), rk.siteRef, rk.buildingRef,
+			formatNullableInt64(rk.buildingID), rk.label, rk.zone,
+			strconv.Itoa(int(rk.rows)), strconv.Itoa(int(rk.columns)),
+			rk.orderIndex, rk.aisleIndex, rk.positionInAisle,
+			strconv.Itoa(int(rk.action)),
+		})
+	}
+	for _, m := range r.miners {
+		rows = append(rows, []string{
+			"M", m.deviceID, m.name, m.siteLabel, m.buildLabel, m.rackLabel,
+			m.rackRow, m.rackCol, formatNullableInt64(m.buildingID),
+			strconv.FormatBool(m.renamed), strconv.FormatBool(m.moved),
+			strconv.FormatBool(m.unassigned),
+		})
+	}
+	return rows
 }
 
 func snapshotFingerprint(snap *snapshot) string {
@@ -3270,15 +3314,6 @@ func existingByIDRow[T any](row map[string]string, existing map[int64]T) (T, boo
 	return value, ok
 }
 
-func existingRackByIDRow(row map[string]string, existing map[int64]rackSnapshot) (rackSnapshot, bool) {
-	id, ok := rowID(row)
-	if !ok {
-		return rackSnapshot{}, false
-	}
-	value, ok := existing[id]
-	return value, ok
-}
-
 func siteIdentitySet(rows []map[string]string, sites []sitemodels.Site) map[string]bool {
 	byName := map[string]sitemodels.Site{}
 	for _, site := range sites {
@@ -3531,19 +3566,6 @@ func desiredBuildingsByID(rows []map[string]string, buildings []buildingmodels.B
 	return out
 }
 
-func rowsEqual(a, b map[string]string, headers []string) bool {
-	for _, header := range headers {
-		if a[header] != b[header] {
-			return false
-		}
-	}
-	return true
-}
-
-func parseInt32Field(row map[string]string, field string) (int32, error) {
-	return parseInt32Value(row[field], field)
-}
-
 func parseInt32Value(raw string, field string) (int32, error) {
 	if raw == "" {
 		return 0, nil
@@ -3593,21 +3615,6 @@ func parseRackCoolingType(value string) (collectionpb.RackCoolingType, error) {
 	}
 }
 
-func desiredRackGridPosition(row map[string]string) (*int32, *int32, error) {
-	if row["aisle_index"] == "" && row["position_in_aisle"] == "" {
-		return nil, nil, nil
-	}
-	aisle, err := parseInt32Value(row["aisle_index"], "aisle_index")
-	if err != nil {
-		return nil, nil, err
-	}
-	position, err := parseInt32Value(row["position_in_aisle"], "position_in_aisle")
-	if err != nil {
-		return nil, nil, err
-	}
-	return &aisle, &position, nil
-}
-
 // desiredSiteBuildingIDs resolves the site and building ids a placement targets.
 // Reference cells have already been canonicalized to names, so this is a pure
 // name lookup against the running apply maps (which include entities created
@@ -3640,15 +3647,8 @@ func desiredSiteBuildingIDs(
 	return siteID, buildingID, nil
 }
 
-func desiredRackZone(row map[string]string, current rackSnapshot) string {
-	if current.Building != "" && (row[fieldBuilding] != current.Building || row[fieldSite] != current.Site) {
-		return ""
-	}
-	return row["zone"]
-}
-
-// desiredRackZoneForNode is the node-based twin of desiredRackZone: a zone only
-// survives when the rack stays in the same building/site it currently occupies.
+// desiredRackZoneForNode clears a rack's zone when the rack leaves the building or
+// site it currently occupies; otherwise the desired zone survives.
 func desiredRackZoneForNode(node *resolvedRack, current rackSnapshot) string {
 	if current.Building != "" && (node.buildingRef != current.Building || node.siteRef != current.Site) {
 		return ""

--- a/server/internal/domain/sitemap/service.go
+++ b/server/internal/domain/sitemap/service.go
@@ -364,7 +364,7 @@ func (s *Service) ImportSiteMapCsv(ctx context.Context, orgID int64, req *pb.Imp
 		if err := ensureSupportedCommitPlan(plan); err != nil {
 			return nil, err
 		}
-		if err := s.applyImportPlan(ctx, orgID, parsed, snapshot, req.GetOmissionMode()); err != nil {
+		if err := s.applyImportPlan(ctx, orgID, plan.resolved, parsed, snapshot, req.GetOmissionMode()); err != nil {
 			return nil, err
 		}
 		s.logSiteMapImportActivity(ctx, orgID, plan)
@@ -1218,7 +1218,7 @@ func ensureSupportedCommitPlan(plan importPlan) error {
 	return nil
 }
 
-func (s *Service) applyImportPlan(ctx context.Context, orgID int64, parsed *parsedCSV, snap *snapshot, omissionMode pb.OmissionMode) error {
+func (s *Service) applyImportPlan(ctx context.Context, orgID int64, resolved *resolvedPlan, parsed *parsedCSV, snap *snapshot, omissionMode pb.OmissionMode) error {
 	if s.transactor == nil {
 		return fleeterror.NewInternalError("site map import requires a transactor")
 	}
@@ -1241,21 +1241,17 @@ func (s *Service) applyImportPlan(ctx context.Context, orgID int64, parsed *pars
 		racksByLabel[rack.Label] = rack
 		racksByID[rack.ID] = rack
 	}
-	minersByID := map[string]minerSnapshot{}
-	for _, miner := range snap.miners {
-		minersByID[miner.DeviceIdentifier] = miner
-	}
 	return s.transactor.RunInTx(ctx, func(txCtx context.Context) error {
-		if err := s.applySiteRows(txCtx, orgID, parsed.sections["SITE"], sitesByName, sitesByID); err != nil {
+		if err := s.applySites(txCtx, orgID, resolved.sites, sitesByName, sitesByID); err != nil {
 			return err
 		}
-		if err := s.applyBuildingRows(txCtx, orgID, parsed.sections["BUILDING"], sitesByName, buildingsByKey, buildingsByID); err != nil {
+		if err := s.applyBuildings(txCtx, orgID, resolved.buildings, sitesByName, buildingsByKey, buildingsByID); err != nil {
 			return err
 		}
-		if err := s.applyRackRows(txCtx, orgID, parsed.sections["RACK"], sitesByName, buildingsByKey, racksByLabel, racksByID); err != nil {
+		if err := s.applyRacks(txCtx, orgID, resolved.racks, sitesByName, buildingsByKey, buildingsByID, racksByLabel, racksByID); err != nil {
 			return err
 		}
-		if err := s.applyMinerRows(txCtx, orgID, parsed.sections["MINER"], sitesByName, buildingsByKey, racksByLabel, minersByID); err != nil {
+		if err := s.applyMiners(txCtx, orgID, resolved.miners, sitesByName, buildingsByKey, buildingsByID, racksByLabel); err != nil {
 			return err
 		}
 		if omissionMode == pb.OmissionMode_OMISSION_MODE_REMOVE_OMITTED {
@@ -1455,36 +1451,32 @@ func siteMapImportActivityChanges(changes []*pb.ImportChangeSummary) []map[strin
 	return out
 }
 
-func (s *Service) applySiteRows(ctx context.Context, orgID int64, rows []map[string]string, existingByName map[string]sitemodels.Site, existingByID map[int64]sitemodels.Site) error {
-	// Site-map CSV carries only the site identity. Existing site metadata is
-	// intentionally left to the site editor; unknown site names are created.
-	for _, row := range rows {
-		if id, ok := rowID(row); ok {
-			site := existingByID[id]
-			if site.Name == row[fieldName] {
-				continue
-			}
-			updated, err := s.updateSiteNameFromImport(ctx, orgID, site, row[fieldName])
+// applySites walks the resolved site nodes and enacts each node's classified
+// action. Site-map CSV carries only the site identity; existing site metadata is
+// intentionally left to the site editor.
+func (s *Service) applySites(ctx context.Context, orgID int64, sites []*resolvedSite, existingByName map[string]sitemodels.Site, existingByID map[int64]sitemodels.Site) error {
+	for _, node := range sites {
+		switch node.action {
+		case actionUpdate:
+			site := existingByID[*node.id]
+			updated, err := s.updateSiteNameFromImport(ctx, orgID, site, node.name)
 			if err != nil {
 				return err
 			}
 			delete(existingByName, site.Name)
 			existingByName[updated.Name] = *updated
 			existingByID[updated.ID] = *updated
-			continue
+		case actionCreate:
+			site, err := s.siteStore.CreateSite(ctx, sitemodels.CreateSiteParams{
+				OrgID: orgID,
+				Name:  node.name,
+			})
+			if err != nil {
+				return err
+			}
+			existingByName[site.Name] = *site
+			existingByID[site.ID] = *site
 		}
-		if _, ok := existingByName[row[fieldName]]; ok {
-			continue
-		}
-		site, err := s.siteStore.CreateSite(ctx, sitemodels.CreateSiteParams{
-			OrgID: orgID,
-			Name:  row[fieldName],
-		})
-		if err != nil {
-			return err
-		}
-		existingByName[site.Name] = *site
-		existingByID[site.ID] = *site
 	}
 	return nil
 }
@@ -1535,32 +1527,23 @@ func siteMapUsedSlugsExcluding(slugs []string, excluded string) []string {
 	return out
 }
 
-func (s *Service) applyBuildingRows(
+func (s *Service) applyBuildings(
 	ctx context.Context,
 	orgID int64,
-	rows []map[string]string,
+	buildings []*resolvedBuilding,
 	sitesByName map[string]sitemodels.Site,
 	existingByKey map[string]buildingmodels.Building,
 	existingByID map[int64]buildingmodels.Building,
 ) error {
-	for _, row := range rows {
-		building, ok := existingByIDRow(row, existingByID)
-		if !ok {
-			building, ok = existingByKey[row[fieldSite]+"\x00"+row[fieldName]]
+	for _, node := range buildings {
+		if node.action == actionNone {
+			continue
 		}
-		aisles, err := parseInt32Field(row, "aisles")
+		siteID, _, err := desiredSiteBuildingIDs(node.siteRef, "", sitesByName, nil)
 		if err != nil {
 			return err
 		}
-		racksPerAisle, err := parseInt32Field(row, "racks_per_aisle")
-		if err != nil {
-			return err
-		}
-		if !ok {
-			siteID, _, err := desiredSiteBuildingIDs(row[fieldSite], "", sitesByName, nil)
-			if err != nil {
-				return err
-			}
+		if node.action == actionCreate {
 			siteID, _, err = s.lockPlacementParents(ctx, orgID, siteID, nil)
 			if err != nil {
 				return err
@@ -1568,44 +1551,40 @@ func (s *Service) applyBuildingRows(
 			created, err := s.buildingStore.CreateBuilding(ctx, buildingmodels.CreateParams{
 				OrgID:         orgID,
 				SiteID:        siteID,
-				Name:          row[fieldName],
-				Aisles:        aisles,
-				RacksPerAisle: racksPerAisle,
+				Name:          node.name,
+				Aisles:        node.aisles,
+				RacksPerAisle: node.racksPerAisle,
 			})
 			if err != nil {
 				return err
 			}
-			created.SiteLabel = row[fieldSite]
-			existingByKey[row[fieldSite]+"\x00"+row[fieldName]] = *created
+			created.SiteLabel = node.siteRef
+			existingByKey[node.siteRef+"\x00"+node.name] = *created
 			existingByID[created.ID] = *created
 			continue
 		}
-		current := rowMap(buildingHeaders, buildingRawRows([]buildingmodels.Building{building})[0])
-		if rowsEqual(row, current, buildingHeaders) {
-			continue
-		}
-		siteID, _, err := desiredSiteBuildingIDs(row[fieldSite], "", sitesByName, nil)
-		if err != nil {
-			return err
+		building, ok := applyTargetBuilding(node, existingByKey, existingByID)
+		if !ok {
+			return fleeterror.NewNotFoundErrorf("building %q not found", node.name)
 		}
 		if !nullableInt64Equal(siteID, building.SiteID) {
 			if err := s.moveBuildingsToSite(ctx, orgID, []int64{building.ID}, siteID); err != nil {
 				return err
 			}
 		}
-		if err := s.enforceBuildingLayoutUnderLock(ctx, orgID, building.ID, aisles, racksPerAisle); err != nil {
+		if err := s.enforceBuildingLayoutUnderLock(ctx, orgID, building.ID, node.aisles, node.racksPerAisle); err != nil {
 			return err
 		}
 		if _, err := s.buildingStore.UpdateBuilding(ctx, buildingmodels.UpdateParams{
 			OrgID:                 orgID,
 			ID:                    building.ID,
-			Name:                  row[fieldName],
+			Name:                  node.name,
 			Description:           building.Description,
 			PowerKw:               building.PowerKw,
 			OverheadKw:            building.OverheadKw,
-			Aisles:                aisles,
+			Aisles:                node.aisles,
 			PhysicalRackCount:     building.PhysicalRackCount,
-			RacksPerAisle:         racksPerAisle,
+			RacksPerAisle:         node.racksPerAisle,
 			DefaultRackRows:       building.DefaultRackRows,
 			DefaultRackColumns:    building.DefaultRackColumns,
 			DefaultRackOrderIndex: building.DefaultRackOrderIndex,
@@ -1613,90 +1592,93 @@ func (s *Service) applyBuildingRows(
 			return err
 		}
 		delete(existingByKey, building.SiteLabel+"\x00"+building.Name)
-		building.Name = row[fieldName]
+		building.Name = node.name
 		building.SiteID = siteID
-		building.SiteLabel = row[fieldSite]
-		building.Aisles = aisles
-		building.RacksPerAisle = racksPerAisle
+		building.SiteLabel = node.siteRef
+		building.Aisles = node.aisles
+		building.RacksPerAisle = node.racksPerAisle
 		existingByKey[building.SiteLabel+"\x00"+building.Name] = building
 		existingByID[building.ID] = building
 	}
 	return nil
 }
 
-func (s *Service) applyRackRows(
+// applyTargetBuilding finds the live building an update node acts on: by id when
+// the row carried one, else by its current (site, name) key.
+func applyTargetBuilding(node *resolvedBuilding, existingByKey map[string]buildingmodels.Building, existingByID map[int64]buildingmodels.Building) (buildingmodels.Building, bool) {
+	if node.id != nil {
+		building, ok := existingByID[*node.id]
+		return building, ok
+	}
+	building, ok := existingByKey[node.siteRef+"\x00"+node.name]
+	return building, ok
+}
+
+func (s *Service) applyRacks(
 	ctx context.Context,
 	orgID int64,
-	rows []map[string]string,
+	racks []*resolvedRack,
 	sitesByName map[string]sitemodels.Site,
 	buildingsByKey map[string]buildingmodels.Building,
+	buildingsByID map[int64]buildingmodels.Building,
 	existingByLabel map[string]rackSnapshot,
 	existingByID map[int64]rackSnapshot,
 ) error {
 	var pendingGridPositions []pendingRackGridPosition
-	for _, row := range rows {
-		rack, ok := existingRackByIDRow(row, existingByID)
-		if !ok {
-			rack, ok = existingByLabel[row[fieldLabel]]
+	for _, node := range racks {
+		if node.action == actionNone {
+			continue
 		}
-		rowsValue, err := parseInt32Field(row, "rows")
+		orderIndex, err := parseRackOrderIndex(node.orderIndex)
 		if err != nil {
 			return err
 		}
-		columnsValue, err := parseInt32Field(row, "columns")
+		siteID, buildingID, err := desiredRackPlacementIDs(node, sitesByName, buildingsByKey, buildingsByID)
 		if err != nil {
 			return err
 		}
-		orderIndex, err := parseRackOrderIndex(row["order_index"])
+		aisleIndex, positionInAisle, err := resolvedRackGridPosition(node)
 		if err != nil {
 			return err
 		}
-		siteID, buildingID, err := desiredSiteBuildingIDs(row[fieldSite], row[fieldBuilding], sitesByName, buildingsByKey)
-		if err != nil {
-			return err
-		}
-		if !ok {
+		if node.action == actionCreate {
 			siteID, buildingID, err = s.lockPlacementParents(ctx, orgID, siteID, buildingID)
 			if err != nil {
 				return err
 			}
-			collection, err := s.collectionStore.CreateCollection(ctx, orgID, collectionpb.CollectionType_COLLECTION_TYPE_RACK, row[fieldLabel], "")
+			collection, err := s.collectionStore.CreateCollection(ctx, orgID, collectionpb.CollectionType_COLLECTION_TYPE_RACK, node.label, "")
 			if err != nil {
 				return err
 			}
 			if err := s.collectionStore.CreateRackExtension(ctx, interfaces.CreateRackExtensionParams{
 				OrgID:        orgID,
 				CollectionID: collection.Id,
-				Rows:         rowsValue,
-				Columns:      columnsValue,
+				Rows:         node.rows,
+				Columns:      node.columns,
 				OrderIndex:   int32(orderIndex),
 				CoolingType:  int32(collectionpb.RackCoolingType_RACK_COOLING_TYPE_UNSPECIFIED),
-				Zone:         row["zone"],
+				Zone:         node.zone,
 				SiteID:       siteID,
 				BuildingID:   buildingID,
 			}); err != nil {
 				return err
 			}
-			rack = rackSnapshot{
+			rack := rackSnapshot{
 				ID:              collection.Id,
 				SiteID:          siteID,
 				BuildingID:      buildingID,
-				Site:            row[fieldSite],
-				Building:        row[fieldBuilding],
-				Label:           row[fieldLabel],
-				Zone:            row["zone"],
-				Rows:            rowsValue,
-				Columns:         columnsValue,
-				OrderIndex:      row["order_index"],
-				AisleIndex:      row["aisle_index"],
-				PositionInAisle: row["position_in_aisle"],
+				Site:            node.siteRef,
+				Building:        node.buildingRef,
+				Label:           node.label,
+				Zone:            node.zone,
+				Rows:            node.rows,
+				Columns:         node.columns,
+				OrderIndex:      node.orderIndex,
+				AisleIndex:      node.aisleIndex,
+				PositionInAisle: node.positionInAisle,
 			}
-			existingByLabel[row[fieldLabel]] = rack
+			existingByLabel[node.label] = rack
 			existingByID[rack.ID] = rack
-			aisleIndex, positionInAisle, err := desiredRackGridPosition(row)
-			if err != nil {
-				return err
-			}
 			pendingGridPositions = append(pendingGridPositions, pendingRackGridPosition{
 				rackID:          rack.ID,
 				aisleIndex:      aisleIndex,
@@ -1704,17 +1686,17 @@ func (s *Service) applyRackRows(
 			})
 			continue
 		}
-		current := rackComparableRow(rack)
-		if rowsEqual(row, current, rackHeaders) {
-			continue
+		rack, ok := applyTargetRack(node, existingByLabel, existingByID)
+		if !ok {
+			return fleeterror.NewNotFoundErrorf("rack %q not found", node.label)
 		}
 		coolingType, err := parseRackCoolingType(rack.CoolingType)
 		if err != nil {
 			return err
 		}
-		finalZone := desiredRackZone(row, rack)
-		if row[fieldLabel] != rack.Label {
-			label := row[fieldLabel]
+		finalZone := desiredRackZoneForNode(node, rack)
+		if node.label != rack.Label {
+			label := node.label
 			if err := s.collectionStore.UpdateCollection(ctx, orgID, rack.ID, &label, nil); err != nil {
 				return err
 			}
@@ -1727,10 +1709,10 @@ func (s *Service) applyRackRows(
 		if err != nil {
 			return err
 		}
-		if err := s.enforceRackDimensionsFitCurrentMembers(ctx, orgID, rack.ID, rowsValue, columnsValue); err != nil {
+		if err := s.enforceRackDimensionsFitCurrentMembers(ctx, orgID, rack.ID, node.rows, node.columns); err != nil {
 			return err
 		}
-		if err := s.collectionStore.UpdateRackInfo(ctx, rack.ID, finalZone, rowsValue, columnsValue, int32(orderIndex), int32(coolingType), orgID); err != nil {
+		if err := s.collectionStore.UpdateRackInfo(ctx, rack.ID, finalZone, node.rows, node.columns, int32(orderIndex), int32(coolingType), orgID); err != nil {
 			return err
 		}
 		if err := s.collectionStore.UpdateRackPlacement(ctx, rack.ID, orgID, siteID, buildingID, finalZone); err != nil {
@@ -1746,10 +1728,6 @@ func (s *Service) applyRackRows(
 				return err
 			}
 		}
-		aisleIndex, positionInAisle, err := desiredRackGridPosition(row)
-		if err != nil {
-			return err
-		}
 		pendingGridPositions = append(pendingGridPositions, pendingRackGridPosition{
 			rackID:          rack.ID,
 			aisleIndex:      aisleIndex,
@@ -1758,15 +1736,15 @@ func (s *Service) applyRackRows(
 		delete(existingByLabel, rack.Label)
 		rack.SiteID = siteID
 		rack.BuildingID = buildingID
-		rack.Site = row[fieldSite]
-		rack.Building = row[fieldBuilding]
-		rack.Label = row[fieldLabel]
+		rack.Site = node.siteRef
+		rack.Building = node.buildingRef
+		rack.Label = node.label
 		rack.Zone = finalZone
-		rack.Rows = rowsValue
-		rack.Columns = columnsValue
-		rack.OrderIndex = row["order_index"]
-		rack.AisleIndex = row["aisle_index"]
-		rack.PositionInAisle = row["position_in_aisle"]
+		rack.Rows = node.rows
+		rack.Columns = node.columns
+		rack.OrderIndex = node.orderIndex
+		rack.AisleIndex = node.aisleIndex
+		rack.PositionInAisle = node.positionInAisle
 		existingByLabel[rack.Label] = rack
 		existingByID[rack.ID] = rack
 	}
@@ -1913,36 +1891,32 @@ func (s *Service) moveBuildingsToSite(ctx context.Context, orgID int64, building
 	return nil
 }
 
-func (s *Service) applyMinerRows(
+func (s *Service) applyMiners(
 	ctx context.Context,
 	orgID int64,
-	rows []map[string]string,
+	miners []*resolvedMiner,
 	sitesByName map[string]sitemodels.Site,
 	buildingsByKey map[string]buildingmodels.Building,
+	buildingsByID map[int64]buildingmodels.Building,
 	racksByLabel map[string]rackSnapshot,
-	existing map[string]minerSnapshot,
 ) error {
 	var pendingSlots []pendingMinerSlot
 	renamedMiners := map[string]string{}
-	for _, row := range rows {
-		miner, ok := existing[row["device_identifier"]]
-		if !ok {
+	for _, node := range miners {
+		if node.existing == nil {
 			continue
 		}
-		if row[fieldName] != miner.Name {
-			renamedMiners[row["device_identifier"]] = row[fieldName]
+		if node.renamed {
+			renamedMiners[node.deviceID] = node.name
 		}
-		// Reference cells are canonicalized names; a rack reference already carries
-		// its building and site.
-		desiredSite, desiredBuilding := row[fieldSite], row[fieldBuilding]
-		if desiredSite == miner.Site && desiredBuilding == miner.Building && row[fieldRack] == miner.Rack && row["rack_row"] == miner.RackRow && row["rack_col"] == miner.RackCol {
+		if !node.moved {
 			continue
 		}
-		deviceIDs := []string{row["device_identifier"]}
-		if row[fieldRack] != "" {
-			rack, ok := racksByLabel[row[fieldRack]]
+		deviceIDs := []string{node.deviceID}
+		if node.rackLabel != "" {
+			rack, ok := racksByLabel[node.rackLabel]
 			if !ok {
-				return fleeterror.NewFailedPreconditionErrorf("unknown rack %q for miner %q", row[fieldRack], row["device_identifier"])
+				return fleeterror.NewFailedPreconditionErrorf("unknown rack %q for miner %q", node.rackLabel, node.deviceID)
 			}
 			if _, err := s.collectionStore.LockRacksForReparent(ctx, orgID, deviceIDs, rack.ID); err != nil {
 				return err
@@ -1974,14 +1948,14 @@ func (s *Service) applyMinerRows(
 			}
 			pendingSlots = append(pendingSlots, pendingMinerSlot{
 				rackID:           rack.ID,
-				deviceIdentifier: row["device_identifier"],
-				row:              row["rack_row"],
-				col:              row["rack_col"],
+				deviceIdentifier: node.deviceID,
+				row:              node.rackRow,
+				col:              node.rackCol,
 			})
 			continue
 		}
 
-		siteID, buildingID, err := desiredSiteBuildingIDs(desiredSite, desiredBuilding, sitesByName, buildingsByKey)
+		siteID, buildingID, err := placementIDsFromRef(node.buildingID, node.siteLabel, node.buildLabel, sitesByName, buildingsByKey, buildingsByID)
 		if err != nil {
 			return err
 		}
@@ -3671,6 +3645,79 @@ func desiredRackZone(row map[string]string, current rackSnapshot) string {
 		return ""
 	}
 	return row["zone"]
+}
+
+// desiredRackZoneForNode is the node-based twin of desiredRackZone: a zone only
+// survives when the rack stays in the same building/site it currently occupies.
+func desiredRackZoneForNode(node *resolvedRack, current rackSnapshot) string {
+	if current.Building != "" && (node.buildingRef != current.Building || node.siteRef != current.Site) {
+		return ""
+	}
+	return node.zone
+}
+
+// resolvedRackGridPosition reads a rack node's desired aisle/position, parsing the
+// canonicalized string cells into the nullable ints the placement store wants.
+func resolvedRackGridPosition(node *resolvedRack) (*int32, *int32, error) {
+	if node.aisleIndex == "" && node.positionInAisle == "" {
+		return nil, nil, nil
+	}
+	aisle, err := parseInt32Value(node.aisleIndex, "aisle_index")
+	if err != nil {
+		return nil, nil, err
+	}
+	position, err := parseInt32Value(node.positionInAisle, "position_in_aisle")
+	if err != nil {
+		return nil, nil, err
+	}
+	return &aisle, &position, nil
+}
+
+// desiredRackPlacementIDs resolves the site/building ids a rack node targets,
+// preferring the resolved existing building id (which disambiguates two buildings
+// sharing a (site, name) pair) and falling back to the canonical name lookup.
+func desiredRackPlacementIDs(
+	node *resolvedRack,
+	sitesByName map[string]sitemodels.Site,
+	buildingsByKey map[string]buildingmodels.Building,
+	buildingsByID map[int64]buildingmodels.Building,
+) (*int64, *int64, error) {
+	return placementIDsFromRef(node.buildingID, node.siteRef, node.buildingRef, sitesByName, buildingsByKey, buildingsByID)
+}
+
+// placementIDsFromRef resolves site/building ids from a resolved building id when
+// present, else from canonical site/building names against the running apply maps.
+func placementIDsFromRef(
+	buildingID *int64,
+	siteRef string,
+	buildingRef string,
+	sitesByName map[string]sitemodels.Site,
+	buildingsByKey map[string]buildingmodels.Building,
+	buildingsByID map[int64]buildingmodels.Building,
+) (*int64, *int64, error) {
+	if buildingID != nil {
+		if b, ok := buildingsByID[*buildingID]; ok {
+			id := b.ID
+			return b.SiteID, &id, nil
+		}
+	}
+	return desiredSiteBuildingIDs(siteRef, buildingRef, sitesByName, buildingsByKey)
+}
+
+// applyTargetRack finds the live rack a node updates: by resolved id when the row
+// carried one, else by its current label.
+func applyTargetRack(node *resolvedRack, existingByLabel map[string]rackSnapshot, existingByID map[int64]rackSnapshot) (rackSnapshot, bool) {
+	if node.id != nil {
+		if rack, ok := existingByID[*node.id]; ok {
+			return rack, true
+		}
+	}
+	label := node.prevLabel
+	if label == "" {
+		label = node.label
+	}
+	rack, ok := existingByLabel[label]
+	return rack, ok
 }
 
 func rowSetFromSiteNames(rows []sitemodels.Site) map[string]bool {

--- a/server/internal/domain/sitemap/service.go
+++ b/server/internal/domain/sitemap/service.go
@@ -1183,8 +1183,8 @@ func buildPlan(parsed *parsedCSV, snap *snapshot, mode pb.OmissionMode) importPl
 	plan.errors = append(plan.errors, validateRackGridPositions(resolved.racks, resolved.topology)...)
 	plan.errors = append(plan.errors, validateRackGridCollisions(parsed.sections["RACK"], snap, mode)...)
 	plan.errors = append(plan.errors, validateRackSlotBounds(resolved.miners, resolved.topology)...)
-	plan.errors = append(plan.errors, validateExistingSlotsFitRackDimensions(parsed.sections["MINER"], parsed.sections["RACK"], targetSnap, mode)...)
-	plan.errors = append(plan.errors, validateRackCapacity(parsed.sections["MINER"], parsed.sections["RACK"], targetSnap, mode)...)
+	plan.errors = append(plan.errors, validateExistingSlotsFitRackDimensions(resolved)...)
+	plan.errors = append(plan.errors, validateRackCapacity(resolved)...)
 	plan.errors = append(plan.errors, validateBuildingRackCapacity(parsed.sections["RACK"], parsed.sections["BUILDING"], targetSnap)...)
 	plan.errors = append(plan.errors, validateBuildingExistingRacksFitLayout(parsed.sections["RACK"], parsed.sections["BUILDING"], targetSnap, mode)...)
 	plan.errors = append(plan.errors, validateSlotCollisions(resolved.miners)...)
@@ -3156,106 +3156,6 @@ func validateMinerRenamePermission(rows []map[string]string, snap *snapshot) []*
 			continue
 		}
 		errs = append(errs, csvErr(rowNumber(row, i+1), "MINER", "miner:rename permission is required to change miner name"))
-	}
-	return errs
-}
-
-func validateExistingSlotsFitRackDimensions(minerRows, rackRows []map[string]string, snap *snapshot, mode pb.OmissionMode) []*pb.ImportValidationError {
-	racks := desiredRackMap(rackRows, snap.racks, nil, snap.buildings)
-	desiredRackLabels := desiredRackLabelsByID(rackRows)
-	desiredMiners := map[string]map[string]string{}
-	for _, row := range minerRows {
-		desiredMiners[row["device_identifier"]] = row
-	}
-	var errs []*pb.ImportValidationError
-	for _, miner := range snap.miners {
-		row, ok := desiredMiners[miner.DeviceIdentifier]
-		if !ok && mode == pb.OmissionMode_OMISSION_MODE_REMOVE_OMITTED {
-			continue
-		}
-		rackLabel := desiredRackLabel(miner, desiredRackLabels)
-		rackRow := miner.RackRow
-		rackCol := miner.RackCol
-		if ok {
-			rackLabel = row[fieldRack]
-			rackRow = row["rack_row"]
-			rackCol = row["rack_col"]
-		}
-		if rackLabel == "" || rackRow == "" || rackCol == "" {
-			continue
-		}
-		rack, ok := racks[rackLabel]
-		if !ok {
-			continue
-		}
-		rowValue, err := parseInt32Value(rackRow, "rack_row")
-		if err != nil {
-			continue
-		}
-		colValue, err := parseInt32Value(rackCol, "rack_col")
-		if err != nil {
-			continue
-		}
-		if rowValue >= rack.Rows || colValue >= rack.Columns {
-			errs = append(errs, csvErr(0, "MINER", fmt.Sprintf("miner %s slot %d,%d does not fit rack %q dimensions %dx%d", miner.DeviceIdentifier, rowValue, colValue, rackLabel, rack.Rows, rack.Columns)))
-		}
-	}
-	for _, miner := range snap.hiddenRackMembers {
-		rackLabel := desiredRackLabel(miner, desiredRackLabels)
-		if rackLabel == "" || miner.RackRow == "" || miner.RackCol == "" {
-			continue
-		}
-		rack, ok := racks[rackLabel]
-		if !ok {
-			continue
-		}
-		rowValue, err := parseInt32Value(miner.RackRow, "rack_row")
-		if err != nil {
-			continue
-		}
-		colValue, err := parseInt32Value(miner.RackCol, "rack_col")
-		if err != nil {
-			continue
-		}
-		if rowValue >= rack.Rows || colValue >= rack.Columns {
-			errs = append(errs, csvErr(0, "MINER", fmt.Sprintf("miner %s slot %d,%d does not fit rack %q dimensions %dx%d", miner.DeviceIdentifier, rowValue, colValue, rackLabel, rack.Rows, rack.Columns)))
-		}
-	}
-	return errs
-}
-
-func validateRackCapacity(minerRows, rackRows []map[string]string, snap *snapshot, mode pb.OmissionMode) []*pb.ImportValidationError {
-	racks := desiredRackMap(rackRows, snap.racks, nil, snap.buildings)
-	desiredRackLabels := desiredRackLabelsByID(rackRows)
-	counts := map[string]int32{}
-	presentMiners := rowSet(minerRows, "device_identifier")
-	for _, row := range minerRows {
-		if row[fieldRack] != "" {
-			counts[row[fieldRack]]++
-		}
-	}
-	if mode != pb.OmissionMode_OMISSION_MODE_REMOVE_OMITTED {
-		for _, miner := range snap.miners {
-			if miner.Rack != "" && !presentMiners[miner.DeviceIdentifier] {
-				counts[desiredRackLabel(miner, desiredRackLabels)]++
-			}
-		}
-	}
-	for _, miner := range snap.hiddenRackMembers {
-		if miner.Rack != "" && !presentMiners[miner.DeviceIdentifier] {
-			counts[desiredRackLabel(miner, desiredRackLabels)]++
-		}
-	}
-	var errs []*pb.ImportValidationError
-	for rackLabel, count := range counts {
-		rack, ok := racks[rackLabel]
-		if !ok || rack.Rows <= 0 || rack.Columns <= 0 {
-			continue
-		}
-		capacity := rack.Rows * rack.Columns
-		if count > capacity {
-			errs = append(errs, csvErr(0, "MINER", fmt.Sprintf("rack %q has %d assigned miners but capacity is %d", rackLabel, count, capacity)))
-		}
 	}
 	return errs
 }

--- a/server/internal/domain/sitemap/service.go
+++ b/server/internal/domain/sitemap/service.go
@@ -1187,7 +1187,7 @@ func buildPlan(parsed *parsedCSV, snap *snapshot, mode pb.OmissionMode) importPl
 	plan.errors = append(plan.errors, validateRackCapacity(parsed.sections["MINER"], parsed.sections["RACK"], targetSnap, mode)...)
 	plan.errors = append(plan.errors, validateBuildingRackCapacity(parsed.sections["RACK"], parsed.sections["BUILDING"], targetSnap)...)
 	plan.errors = append(plan.errors, validateBuildingExistingRacksFitLayout(parsed.sections["RACK"], parsed.sections["BUILDING"], targetSnap, mode)...)
-	plan.errors = append(plan.errors, validateSlotCollisions(parsed.sections["MINER"])...)
+	plan.errors = append(plan.errors, validateSlotCollisions(resolved.miners)...)
 	plan.errors = append(plan.errors, validateSlotConflictsWithExisting(parsed.sections["MINER"], parsed.sections["RACK"], snap, mode)...)
 	if len(plan.errors) > 0 || (mode == pb.OmissionMode_OMISSION_MODE_UNSPECIFIED && hasOmissions(plan.omissions)) {
 		return plan
@@ -3602,22 +3602,6 @@ func validateBuildingExistingRacksFitLayout(rackRows, buildingRows []map[string]
 		if aisle >= building.Aisles || position >= building.RacksPerAisle {
 			errs = append(errs, csvErr(0, "RACK", fmt.Sprintf("rack %q grid position %d,%d does not fit building %q layout %dx%d", desiredRack.Label, aisle, position, building.Name, building.Aisles, building.RacksPerAisle)))
 		}
-	}
-	return errs
-}
-
-func validateSlotCollisions(rows []map[string]string) []*pb.ImportValidationError {
-	seen := map[string]bool{}
-	var errs []*pb.ImportValidationError
-	for i, row := range rows {
-		key, ok := normalizedRackSlotKey(row[fieldRack], row["rack_row"], row["rack_col"])
-		if !ok {
-			continue
-		}
-		if seen[key] {
-			errs = append(errs, csvErr(rowNumber(row, i+1), "MINER", "duplicate rack slot"))
-		}
-		seen[key] = true
 	}
 	return errs
 }

--- a/server/internal/domain/sitemap/service.go
+++ b/server/internal/domain/sitemap/service.go
@@ -2599,6 +2599,17 @@ func validateRemoveOmittedReferences(parsed *parsedCSV, mode pb.OmissionMode) []
 	presentSites := rowSet(siteRows, fieldName)
 	presentBuildings := compoundRowSet(buildingRows, fieldSite, fieldName)
 	presentRacks := rowSet(rackRows, fieldLabel)
+	// Two unassigned buildings can share a (site, name) pair via distinct NULL
+	// site_ids, so a rack/miner may reference one specific building by id.
+	// resolveReferences preserves that resolved id in refBuildingIDCell; check it
+	// against the retained BUILDING rows' own ids, since the (site, name) presence
+	// check alone would accept a reference to the omitted twin.
+	retainedBuildingIDs := map[int64]bool{}
+	for _, row := range buildingRows {
+		if id, ok := rowID(row); ok {
+			retainedBuildingIDs[id] = true
+		}
+	}
 
 	// Reference cells have been canonicalized to names with implied parents filled,
 	// so a reference to an omitted entity shows up as a name not present in the CSV.
@@ -2610,6 +2621,12 @@ func validateRemoveOmittedReferences(parsed *parsedCSV, mode pb.OmissionMode) []
 	}
 	for i, row := range rackRows {
 		if row[fieldBuilding] != "" {
+			if bID := refID(row, refBuildingIDCell); bID != nil {
+				if !retainedBuildingIDs[*bID] {
+					errs = append(errs, csvErr(rowNumber(row, i+1), "RACK", fmt.Sprintf("rack building %q (id %d) is omitted; add the BUILDING row or choose leave omitted rows in place", row[fieldBuilding], *bID)))
+				}
+				continue
+			}
 			if !presentBuildings[row[fieldSite]+"\x00"+row[fieldBuilding]] {
 				errs = append(errs, csvErr(rowNumber(row, i+1), "RACK", fmt.Sprintf("rack building %q for site %q is omitted; add the BUILDING row or choose leave omitted rows in place", row[fieldBuilding], row[fieldSite])))
 			}
@@ -2627,6 +2644,12 @@ func validateRemoveOmittedReferences(parsed *parsedCSV, mode pb.OmissionMode) []
 			continue
 		}
 		if row[fieldBuilding] != "" {
+			if bID := refID(row, refBuildingIDCell); bID != nil {
+				if !retainedBuildingIDs[*bID] {
+					errs = append(errs, csvErr(rowNumber(row, i+1), "MINER", fmt.Sprintf("miner building %q (id %d) is omitted; add the BUILDING row or choose leave omitted rows in place", row[fieldBuilding], *bID)))
+				}
+				continue
+			}
 			if !presentBuildings[row[fieldSite]+"\x00"+row[fieldBuilding]] {
 				errs = append(errs, csvErr(rowNumber(row, i+1), "MINER", fmt.Sprintf("miner building %q for site %q is omitted; add the BUILDING row or choose leave omitted rows in place", row[fieldBuilding], row[fieldSite])))
 			}

--- a/server/internal/domain/sitemap/service.go
+++ b/server/internal/domain/sitemap/service.go
@@ -1119,7 +1119,6 @@ type importPlan struct {
 }
 
 func buildPlan(parsed *parsedCSV, snap *snapshot, mode pb.OmissionMode) importPlan {
-	targetSnap := snapshotForOmissionMode(snap, mode)
 	referenceErrors := resolveReferences(parsed, snap)
 	resolved := resolvePlan(parsed, snap, mode)
 	plan := importPlan{omissions: resolved.omissions, resolved: resolved}
@@ -1164,7 +1163,7 @@ func buildPlan(parsed *parsedCSV, snap *snapshot, mode pb.OmissionMode) importPl
 		return plan
 	}
 
-	plan.changes = computeChanges(resolved, parsed, snap, targetSnap, mode)
+	plan.changes = computeChanges(resolved, mode)
 	return plan
 }
 
@@ -3378,68 +3377,6 @@ func safeInt32(value int) int32 {
 	return int32(value) // #nosec G115 -- value is bounded above to MaxInt32.
 }
 
-func countSiteUpdates(rows []map[string]string, sites []sitemodels.Site) int32 {
-	existing := map[string]map[string]string{}
-	for _, site := range sites {
-		existing[siteIdentity(site)] = rowMap(siteHeaders, siteRawRows([]sitemodels.Site{site})[0])
-	}
-	return countExistingRowUpdatesByIdentity(rows, existing, siteRowIdentity, siteHeaders)
-}
-
-func countBuildingUpdates(rows []map[string]string, buildings []buildingmodels.Building) int32 {
-	existing := map[string]map[string]string{}
-	for _, building := range buildings {
-		row := rowMap(buildingHeaders, buildingRawRows([]buildingmodels.Building{building})[0])
-		existing[buildingIdentity(building)] = row
-		existing["name:"+building.SiteLabel+"\x00"+building.Name] = row
-	}
-	return countExistingRowUpdatesByIdentity(rows, existing, buildingRowIdentity, buildingHeaders)
-}
-
-func countRackUpdates(rows []map[string]string, racks []rackSnapshot) int32 {
-	existing := map[string]map[string]string{}
-	for _, rack := range racks {
-		row := rackComparableRow(rack)
-		existing[rackIdentity(rack)] = row
-		existing["label:"+rack.Label] = row
-	}
-	return countExistingRowUpdatesByIdentity(rows, existing, rackRowIdentity, rackHeaders)
-}
-
-func countExistingRowUpdates(rows []map[string]string, existing map[string]map[string]string, keySpec string, headers []string) int32 {
-	var count int32
-	for _, row := range rows {
-		existingRow, ok := existing[rowKey(row, keySpec)]
-		if !ok {
-			continue
-		}
-		for _, header := range headers {
-			if row[header] != existingRow[header] {
-				count++
-				break
-			}
-		}
-	}
-	return count
-}
-
-func countExistingRowUpdatesByIdentity(rows []map[string]string, existing map[string]map[string]string, identity func(map[string]string) string, headers []string) int32 {
-	var count int32
-	for _, row := range rows {
-		existingRow, ok := existing[identity(row)]
-		if !ok {
-			continue
-		}
-		for _, header := range headers {
-			if row[header] != existingRow[header] {
-				count++
-				break
-			}
-		}
-	}
-	return count
-}
-
 func rowMap(headers, values []string) map[string]string {
 	out := map[string]string{}
 	for i, header := range headers {
@@ -3627,15 +3564,6 @@ func rowsEqual(a, b map[string]string, headers []string) bool {
 		}
 	}
 	return true
-}
-
-func rowKey(row map[string]string, keySpec string) string {
-	parts := strings.Split(keySpec, "\x00")
-	values := make([]string, 0, len(parts))
-	for _, part := range parts {
-		values = append(values, row[part])
-	}
-	return strings.Join(values, "\x00")
 }
 
 func parseInt32Field(row map[string]string, field string) (int32, error) {

--- a/server/internal/domain/sitemap/service.go
+++ b/server/internal/domain/sitemap/service.go
@@ -48,15 +48,17 @@ const (
 	siteMapExportCSVPath      = siteMapExportFolder + "/site-map.csv"
 	siteMapExportGuideTXTPath = siteMapExportFolder + "/agent-editing-guide.txt"
 
-	fieldID         = "id"
-	fieldName       = "name"
-	fieldLabel      = "label"
-	fieldSite       = "site"
-	fieldSiteID     = "site_id"
-	fieldBuilding   = "building"
-	fieldBuildingID = "building_id"
-	fieldRack       = "rack"
-	fieldRackID     = "rack_id"
+	fieldID       = "id"
+	fieldName     = "name"
+	fieldLabel    = "label"
+	fieldSite     = "site"
+	fieldBuilding = "building"
+	fieldRack     = "rack"
+
+	// refCreatePrefix marks a reference cell that points at an entity being
+	// created in the same import, by its own name/label (e.g. "NAME:Building 2").
+	// A bare integer references an existing entity by id; blank is unassigned.
+	refCreatePrefix = "NAME:"
 )
 
 var (
@@ -64,15 +66,15 @@ var (
 		fieldName, fieldID,
 	}
 	buildingHeaders = []string{
-		fieldName, fieldID, fieldSiteID, fieldSite, "aisles", "racks_per_aisle",
+		fieldName, fieldID, fieldSite, "aisles", "racks_per_aisle",
 	}
 	rackHeaders = []string{
-		fieldLabel, fieldID, fieldBuildingID, fieldBuilding, fieldSiteID, fieldSite, "zone", "rows", "columns",
+		fieldLabel, fieldID, fieldBuilding, fieldSite, "zone", "rows", "columns",
 		"order_index", "aisle_index", "position_in_aisle",
 	}
 	minerHeaders = []string{
 		"device_identifier", "serial_number", "name", "ip_address", "mac_address",
-		fieldSiteID, fieldSite, fieldBuildingID, fieldBuilding, fieldRackID, fieldRack, "rack_row", "rack_col",
+		fieldSite, fieldBuilding, fieldRack, "rack_row", "rack_col",
 	}
 	siteMapMinerPairingStatuses = []fleetpb.PairingStatus{
 		fleetpb.PairingStatus_PAIRING_STATUS_PAIRED,
@@ -230,9 +232,10 @@ File structure
 - The CSV is UTF-8 and includes sections marked exactly as "# SECTION: SITE", "# SECTION: BUILDING", "# SECTION: RACK", and "# SECTION: MINER".
 - Keep section markers, section order, header rows, and column count unchanged.
 - Blank spacer rows between sections are allowed.
-- ID columns identify existing records or disambiguate references. Do not edit read-only identity IDs on existing rows.
-- Prefer name references unless an ID is needed to disambiguate. The importer validates that any ID and adjacent name/label refer to the same entity.
-- Site, building, and rack rows are upserts keyed by id when present, otherwise by name/label. Blank id creates a new entity. Miner rows must reference existing miners; unknown miner identifiers fail validation.
+- Each row has a read-only "id" column that identifies an existing record. Do not edit it. A blank id means the row creates a new entity.
+- Every parent relationship (a building's site, a rack's building or site, a miner's rack/building/site) is a single reference cell that accepts one of: blank (unassigned); a bare integer (an existing entity, referenced by its id); or "NAME:x" (an entity being created in this same import, referenced by its own name or label x). Any other value fails validation.
+- Reference an existing entity by its id, and a same-import new entity by NAME:. To point a rack at an existing building, put that building's id in the rack's building cell. To point a rack at a building this import creates, put "NAME:" followed by that new building's name.
+- Site, building, and rack rows are upserts: an id updates that entity, a blank id creates one. Miner rows must reference existing miners; unknown miner identifiers fail validation.
 
 Omissions and renames
 - Import preview reports omitted existing rows when a site, building, rack, or miner exists in Proto Fleet but is missing from the CSV.
@@ -240,7 +243,7 @@ Omissions and renames
 - Remove omitted rows can cascade placement cleanup: deleting an omitted site also deletes its buildings and unassigns racks/miners from that site; deleting an omitted building unassigns its racks and miners; deleting an omitted rack removes miners from that rack.
 - With a populated id, editing a site/building name or rack label renames the existing entity.
 - With a blank id, editing a site/building name or rack label creates a new entity and the old entity may be counted as omitted.
-- If you rename or move a site/building/rack, update dependent name references in the CSV or use the relevant *_id reference column.
+- Renaming or moving an entity does not break references to it: existing entities are referenced by id, which is stable across renames.
 - Miner omission is different from miner deletion: miners cannot be created or deleted by site map import. With remove omitted rows, omitted miners are only unassigned from site/building/rack placement.
 
 Formatting rules
@@ -256,18 +259,17 @@ SITE section
 - Existing rows are matched by id when present. Editing name on an existing id renames the site.
 
 BUILDING section
-- Columns: name, id (read only), site_id, site, aisles, racks_per_aisle.
-- Add a new row with a blank id and new name to create a building. The site value must reference an existing or newly-created site, or may be blank for an unassigned building.
-- Prefer site name. Use site_id only when a reference needs ID precision; if both site_id and site are filled, they must agree.
+- Columns: name, id (read only), site, aisles, racks_per_aisle.
+- Add a new row with a blank id and new name to create a building.
+- site is a reference cell: blank (unassigned building), an existing site's id, or "NAME:" plus a same-import site's name.
 - aisles and racks_per_aisle define rack layout capacity for the building.
-- Existing rows are matched by id when present. Editing name on an existing id renames the building; editing site/site_id moves it.
+- Existing rows are matched by id when present. Editing name on an existing id renames the building; changing site moves it.
 
 RACK section
-- Columns: label, id (read only), building_id, building, site_id, site, zone, rows, columns, order_index, aisle_index, position_in_aisle.
+- Columns: label, id (read only), building, site, zone, rows, columns, order_index, aisle_index, position_in_aisle.
 - Add a new row with a blank id and new rack label to create a rack. Rack labels must be unique across the organization.
-- Prefer building/site names. Use building_id or site_id only when a reference needs ID precision; if an ID and name are both filled, they must agree.
-- Set building to place a rack in a building. If the building name is unique, site may be blank and will be inferred.
-- If the building name is ambiguous across sites, set site or building_id to disambiguate it.
+- building and site are reference cells: blank, an existing entity's id, or "NAME:" plus a same-import entity's name/label.
+- Set building to place a rack in a building; the building determines the site, so site may be left blank.
 - Set site and leave building blank to assign a rack directly to a site.
 - Leave both building and site blank to unassign a rack.
 - zone is scoped to a building. Moving a rack to another building, directly to a site, or unassigned clears incompatible zone assignment.
@@ -276,12 +278,12 @@ RACK section
 - aisle_index and position_in_aisle place a rack in the building layout. They must both be blank or both be set. Aisle and position indexes are zero-based and must fit within aisles and racks_per_aisle.
 
 MINER section
-- Columns: device_identifier (read only), serial_number (read only), name, ip_address (read only), mac_address (read only), site_id, site, building_id, building, rack_id, rack, rack_row, rack_col.
+- Columns: device_identifier (read only), serial_number (read only), name, ip_address (read only), mac_address (read only), site, building, rack, rack_row, rack_col.
 - Edit name and placement columns in this section.
 - device_identifier identifies the miner. Unknown miner identifiers fail validation.
-- If rack is set, the rack determines the miner's building and site. Leave miner site and building blank unless needed to disambiguate duplicate rack labels.
-- If building is set and rack is blank, the building determines the miner's site when the building name is unique. Leave miner site blank unless needed to disambiguate duplicate building names.
-- Use rack_id, building_id, or site_id only when a name reference is ambiguous or when preserving a precise existing reference matters. New entities have no id yet, so reference them by name.
+- site, building, and rack are reference cells: blank, an existing entity's id, or "NAME:" plus a same-import entity's name/label.
+- If rack is set, the rack determines the miner's building and site; leave building and site blank.
+- If building is set and rack is blank, the building determines the miner's site; leave site blank.
 - Set site and leave building and rack blank to assign a miner directly to a site.
 - Leave site, building, and rack blank to unassign a miner.
 - rack_row and rack_col must both be blank or both be set. They are zero-based and must fit within the rack's rows and columns.
@@ -727,6 +729,8 @@ func siteRawRows(sites []sitemodels.Site) [][]string {
 	return rows
 }
 
+// buildingRows emits id-authoritative BUILDING rows: the site reference cell
+// holds the site id (blank for a site-less building).
 func buildingRows(buildings []buildingmodels.Building) [][]string {
 	rows := make([][]string, 0, len(buildings))
 	for _, building := range buildings {
@@ -734,10 +738,6 @@ func buildingRows(buildings []buildingmodels.Building) [][]string {
 			clean(building.Name),
 			formatInt64(building.ID),
 			formatNullableInt64(building.SiteID),
-			// Parent-reference name columns are blank on export: existing parents
-			// are identified by *_id. The name columns exist only so an author can
-			// point a new (blank-id) row at another new row created in the same file.
-			"",
 			formatInt32(building.Aisles),
 			formatInt32(building.RacksPerAisle),
 		})
@@ -745,17 +745,15 @@ func buildingRows(buildings []buildingmodels.Building) [][]string {
 	return rows
 }
 
+// buildingRawRows is the uncleaned canonical building row used for change
+// detection. Its site reference cell holds the resolved site name so it matches
+// a parsed row after resolveReferences canonicalizes the id cell into a name.
 func buildingRawRows(buildings []buildingmodels.Building) [][]string {
 	rows := make([][]string, 0, len(buildings))
 	for _, building := range buildings {
 		rows = append(rows, []string{
 			building.Name,
 			formatInt64(building.ID),
-			formatNullableInt64(building.SiteID),
-			// Change-detection compares against parsed rows *after*
-			// normalizeIDReferences back-fills the parent-name columns from ids,
-			// so the comparable row keeps the resolved names populated even though
-			// export blanks them.
 			building.SiteLabel,
 			formatInt32(building.Aisles),
 			formatInt32(building.RacksPerAisle),
@@ -764,19 +762,16 @@ func buildingRawRows(buildings []buildingmodels.Building) [][]string {
 	return rows
 }
 
-// rackRawRows is the uncleaned canonical rack row used for change detection. It
-// carries both parent ids and the resolved parent names so it matches a parsed
-// row after normalizeIDReferences has back-filled names from ids (export itself
-// blanks the parent-name columns).
+// rackRawRows is the uncleaned canonical rack row used for change detection. Its
+// building and site reference cells hold the resolved parent names so it matches
+// a parsed row after resolveReferences canonicalizes the id cells into names.
 func rackRawRows(racks []rackSnapshot) [][]string {
 	rows := make([][]string, 0, len(racks))
 	for _, rack := range racks {
 		rows = append(rows, []string{
 			rack.Label,
 			formatInt64(rack.ID),
-			formatNullableInt64(rack.BuildingID),
 			rack.Building,
-			formatNullableInt64(rack.SiteID),
 			rack.Site,
 			rack.Zone,
 			formatInt32(rack.Rows),
@@ -790,9 +785,9 @@ func rackRawRows(racks []rackSnapshot) [][]string {
 }
 
 // rackExportRows emits id-authoritative rack rows: the rack's most-specific
-// parent is identified by building_id (or site_id when the rack sits directly
-// under a site). Parent-reference name columns are blank; they exist only to
-// point at a same-file create.
+// parent is identified by id in a single reference cell — the building reference
+// (which implies its site) or, when the rack sits directly under a site, the
+// site reference.
 func rackExportRows(racks []rackSnapshot) [][]string {
 	rows := make([][]string, 0, len(racks))
 	for _, rack := range racks {
@@ -802,14 +797,12 @@ func rackExportRows(racks []rackSnapshot) [][]string {
 }
 
 func rackExportRow(rack rackSnapshot) []string {
-	buildingID, siteID := rackParentIDCells(rack)
+	buildingRef, siteRef := rackParentIDCells(rack)
 	return []string{
 		clean(rack.Label),
 		formatInt64(rack.ID),
-		buildingID,
-		"",
-		siteID,
-		"",
+		buildingRef,
+		siteRef,
 		clean(rack.Zone),
 		formatInt32(rack.Rows),
 		formatInt32(rack.Columns),
@@ -819,10 +812,10 @@ func rackExportRow(rack rackSnapshot) []string {
 	}
 }
 
-// rackParentIDCells returns the building_id and site_id cells for a rack,
+// rackParentIDCells returns the building and site reference cells for a rack,
 // preferring the building (which implies its site) and falling back to a direct
 // site assignment.
-func rackParentIDCells(rack rackSnapshot) (buildingID, siteID string) {
+func rackParentIDCells(rack rackSnapshot) (buildingRef, siteRef string) {
 	if rack.BuildingID != nil {
 		return formatNullableInt64(rack.BuildingID), ""
 	}
@@ -833,25 +826,21 @@ func rackParentIDCells(rack rackSnapshot) (buildingID, siteID string) {
 }
 
 // minerRows emits id-authoritative miner rows: the miner's most-specific parent
-// is identified by rack_id (or building_id / site_id when there is no rack).
-// Parent-reference name columns are blank; they exist only to point at a
-// same-file create.
+// is identified by id in a single reference cell — rack, else building, else
+// site.
 func minerRows(miners []minerSnapshot) [][]string {
 	rows := make([][]string, 0, len(miners))
 	for _, miner := range miners {
-		siteID, buildingID, rackID := minerParentIDCells(miner)
+		siteRef, buildingRef, rackRef := minerParentIDCells(miner)
 		rows = append(rows, []string{
 			clean(miner.DeviceIdentifier),
 			clean(miner.SerialNumber),
 			clean(miner.Name),
 			clean(miner.IPAddress),
 			clean(miner.MACAddress),
-			siteID,
-			"",
-			buildingID,
-			"",
-			rackID,
-			"",
+			siteRef,
+			buildingRef,
+			rackRef,
 			miner.RackRow,
 			miner.RackCol,
 		})
@@ -859,10 +848,10 @@ func minerRows(miners []minerSnapshot) [][]string {
 	return rows
 }
 
-// minerParentIDCells returns the site_id, building_id, and rack_id cells for a
+// minerParentIDCells returns the site, building, and rack reference cells for a
 // miner, emitting only the most-specific parent (rack implies building and site;
 // building implies site).
-func minerParentIDCells(miner minerSnapshot) (siteID, buildingID, rackID string) {
+func minerParentIDCells(miner minerSnapshot) (siteRef, buildingRef, rackRef string) {
 	if miner.RackID != nil {
 		return "", "", formatNullableInt64(miner.RackID)
 	}
@@ -1122,8 +1111,7 @@ type importPlan struct {
 
 func buildPlan(parsed *parsedCSV, snap *snapshot, mode pb.OmissionMode) importPlan {
 	targetSnap := snapshotForOmissionMode(snap, mode)
-	normalizeIDErrors := normalizeIDReferences(parsed, snap)
-	normalizeInferredPlacement(parsed, targetSnap)
+	referenceErrors := resolveReferences(parsed, snap)
 	resolved := resolvePlan(parsed, snap, mode)
 	plan := importPlan{omissions: resolved.omissions, resolved: resolved}
 
@@ -1141,7 +1129,7 @@ func buildPlan(parsed *parsedCSV, snap *snapshot, mode pb.OmissionMode) importPl
 	plan.errors = append(plan.errors, validateRackRenameTargets(parsed.sections["RACK"], snap.racks)...)
 	plan.errors = append(plan.errors, validateImportedNameLengths(parsed)...)
 	plan.errors = append(plan.errors, validateKnownEntityIDs(parsed, snap)...)
-	plan.errors = append(plan.errors, normalizeIDErrors...)
+	plan.errors = append(plan.errors, referenceErrors...)
 	plan.errors = append(plan.errors, validateRetainedTopologyUniqueness(parsed, snap, mode)...)
 	removeReferenceErrors := validateRemoveOmittedReferences(parsed, mode)
 	plan.errors = append(plan.errors, removeReferenceErrors...)
@@ -1178,18 +1166,6 @@ func snapshotForOmissionMode(snap *snapshot, mode pb.OmissionMode) *snapshot {
 	return &snapshot{
 		miners:            snap.miners,
 		hiddenRackMembers: snap.hiddenRackMembers,
-	}
-}
-
-func normalizeInferredPlacement(parsed *parsedCSV, snap *snapshot) {
-	buildingsByName, ambiguousBuildings := desiredBuildingNameLookup(parsed.sections["BUILDING"], snap.buildings)
-	for _, row := range parsed.sections["RACK"] {
-		if row[fieldSite] != "" || row[fieldBuilding] == "" || ambiguousBuildings[row[fieldBuilding]] {
-			continue
-		}
-		if building, ok := buildingsByName[row[fieldBuilding]]; ok {
-			row[fieldSite] = building.SiteLabel
-		}
 	}
 }
 
@@ -1265,13 +1241,13 @@ func (s *Service) applyImportPlan(ctx context.Context, orgID int64, parsed *pars
 		if err := s.applySiteRows(txCtx, orgID, parsed.sections["SITE"], sitesByName, sitesByID); err != nil {
 			return err
 		}
-		if err := s.applyBuildingRows(txCtx, orgID, parsed.sections["BUILDING"], sitesByName, sitesByID, buildingsByKey, buildingsByID); err != nil {
+		if err := s.applyBuildingRows(txCtx, orgID, parsed.sections["BUILDING"], sitesByName, buildingsByKey, buildingsByID); err != nil {
 			return err
 		}
-		if err := s.applyRackRows(txCtx, orgID, parsed.sections["RACK"], sitesByName, sitesByID, buildingsByKey, buildingsByID, racksByLabel, racksByID); err != nil {
+		if err := s.applyRackRows(txCtx, orgID, parsed.sections["RACK"], sitesByName, buildingsByKey, racksByLabel, racksByID); err != nil {
 			return err
 		}
-		if err := s.applyMinerRows(txCtx, orgID, parsed.sections["MINER"], parsed.sections["BUILDING"], snap.buildings, sitesByName, buildingsByKey, buildingsByID, racksByLabel, minersByID); err != nil {
+		if err := s.applyMinerRows(txCtx, orgID, parsed.sections["MINER"], sitesByName, buildingsByKey, racksByLabel, minersByID); err != nil {
 			return err
 		}
 		if omissionMode == pb.OmissionMode_OMISSION_MODE_REMOVE_OMITTED {
@@ -1556,25 +1532,13 @@ func (s *Service) applyBuildingRows(
 	orgID int64,
 	rows []map[string]string,
 	sitesByName map[string]sitemodels.Site,
-	sitesByID map[int64]sitemodels.Site,
 	existingByKey map[string]buildingmodels.Building,
 	existingByID map[int64]buildingmodels.Building,
 ) error {
-	existingBySiteIDName := map[string]buildingmodels.Building{}
-	for _, building := range existingByID {
-		if building.SiteID != nil {
-			existingBySiteIDName[fmt.Sprintf("%d\x00%s", *building.SiteID, building.Name)] = building
-		}
-	}
 	for _, row := range rows {
 		building, ok := existingByIDRow(row, existingByID)
 		if !ok {
 			building, ok = existingByKey[row[fieldSite]+"\x00"+row[fieldName]]
-		}
-		if !ok {
-			if siteID, idOK := idFromCell(row[fieldSiteID]); idOK {
-				building, ok = existingBySiteIDName[fmt.Sprintf("%d\x00%s", siteID, row[fieldName])]
-			}
 		}
 		aisles, err := parseInt32Field(row, "aisles")
 		if err != nil {
@@ -1585,7 +1549,7 @@ func (s *Service) applyBuildingRows(
 			return err
 		}
 		if !ok {
-			siteID, _, err := desiredSiteBuildingIDs(row[fieldSiteID], row[fieldSite], "", "", sitesByName, sitesByID, nil, nil)
+			siteID, _, err := desiredSiteBuildingIDs(row[fieldSite], "", sitesByName, nil)
 			if err != nil {
 				return err
 			}
@@ -1612,7 +1576,7 @@ func (s *Service) applyBuildingRows(
 		if rowsEqual(row, current, buildingHeaders) {
 			continue
 		}
-		siteID, _, err := desiredSiteBuildingIDs(row[fieldSiteID], row[fieldSite], "", "", sitesByName, sitesByID, nil, nil)
+		siteID, _, err := desiredSiteBuildingIDs(row[fieldSite], "", sitesByName, nil)
 		if err != nil {
 			return err
 		}
@@ -1657,9 +1621,7 @@ func (s *Service) applyRackRows(
 	orgID int64,
 	rows []map[string]string,
 	sitesByName map[string]sitemodels.Site,
-	sitesByID map[int64]sitemodels.Site,
 	buildingsByKey map[string]buildingmodels.Building,
-	buildingsByID map[int64]buildingmodels.Building,
 	existingByLabel map[string]rackSnapshot,
 	existingByID map[int64]rackSnapshot,
 ) error {
@@ -1681,7 +1643,7 @@ func (s *Service) applyRackRows(
 		if err != nil {
 			return err
 		}
-		siteID, buildingID, err := desiredSiteBuildingIDs(row[fieldSiteID], row[fieldSite], row[fieldBuildingID], row[fieldBuilding], sitesByName, sitesByID, buildingsByKey, buildingsByID)
+		siteID, buildingID, err := desiredSiteBuildingIDs(row[fieldSite], row[fieldBuilding], sitesByName, buildingsByKey)
 		if err != nil {
 			return err
 		}
@@ -1947,15 +1909,11 @@ func (s *Service) applyMinerRows(
 	ctx context.Context,
 	orgID int64,
 	rows []map[string]string,
-	buildingRows []map[string]string,
-	buildings []buildingmodels.Building,
 	sitesByName map[string]sitemodels.Site,
 	buildingsByKey map[string]buildingmodels.Building,
-	buildingsByID map[int64]buildingmodels.Building,
 	racksByLabel map[string]rackSnapshot,
 	existing map[string]minerSnapshot,
 ) error {
-	buildingsByName, ambiguousBuildings := desiredBuildingNameLookup(buildingRows, buildings)
 	var pendingSlots []pendingMinerSlot
 	renamedMiners := map[string]string{}
 	for _, row := range rows {
@@ -1966,8 +1924,10 @@ func (s *Service) applyMinerRows(
 		if row[fieldName] != miner.Name {
 			renamedMiners[row["device_identifier"]] = row[fieldName]
 		}
-		desiredSite, desiredBuilding := desiredMinerSiteBuilding(row, racksByLabel, buildingsByName, buildingsByID, ambiguousBuildings)
-		if minerPlacementIDsMatch(row, miner) && desiredSite == miner.Site && desiredBuilding == miner.Building && row[fieldRack] == miner.Rack && row["rack_row"] == miner.RackRow && row["rack_col"] == miner.RackCol {
+		// Reference cells are canonicalized names; a rack reference already carries
+		// its building and site.
+		desiredSite, desiredBuilding := row[fieldSite], row[fieldBuilding]
+		if desiredSite == miner.Site && desiredBuilding == miner.Building && row[fieldRack] == miner.Rack && row["rack_row"] == miner.RackRow && row["rack_col"] == miner.RackCol {
 			continue
 		}
 		deviceIDs := []string{row["device_identifier"]}
@@ -2013,7 +1973,7 @@ func (s *Service) applyMinerRows(
 			continue
 		}
 
-		siteID, buildingID, err := desiredSiteBuildingIDs(row[fieldSiteID], desiredSite, row[fieldBuildingID], desiredBuilding, sitesByName, nil, buildingsByKey, buildingsByID)
+		siteID, buildingID, err := desiredSiteBuildingIDs(desiredSite, desiredBuilding, sitesByName, buildingsByKey)
 		if err != nil {
 			return err
 		}
@@ -2612,10 +2572,10 @@ func validateRemoveOmittedReferences(parsed *parsedCSV, mode pb.OmissionMode) []
 
 	presentSites := rowSet(siteRows, fieldName)
 	presentBuildings := compoundRowSet(buildingRows, fieldSite, fieldName)
-	presentBuildingIDs := rowIDSet(buildingRows)
 	presentRacks := rowSet(rackRows, fieldLabel)
-	buildingsByName, ambiguousBuildings := desiredBuildingNameLookup(buildingRows, nil)
 
+	// Reference cells have been canonicalized to names with implied parents filled,
+	// so a reference to an omitted entity shows up as a name not present in the CSV.
 	var errs []*pb.ImportValidationError
 	for i, row := range buildingRows {
 		if row[fieldSite] != "" && !presentSites[row[fieldSite]] {
@@ -2623,31 +2583,14 @@ func validateRemoveOmittedReferences(parsed *parsedCSV, mode pb.OmissionMode) []
 		}
 	}
 	for i, row := range rackRows {
-		if row[fieldSite] != "" && !presentSites[row[fieldSite]] {
-			errs = append(errs, csvErr(rowNumber(row, i+1), "RACK", fmt.Sprintf("rack site %q is omitted; add the SITE row or choose leave omitted rows in place", row[fieldSite])))
-		}
-		if id, ok := idFromCell(row[fieldBuildingID]); ok && !presentBuildingIDs[id] {
-			errs = append(errs, csvErr(rowNumber(row, i+1), "RACK", fmt.Sprintf("rack building_id %q is omitted; add the BUILDING row or choose leave omitted rows in place", row[fieldBuildingID])))
-			continue
-		}
-		if row[fieldBuilding] == "" {
-			continue
-		}
-		if id, ok := idFromCell(row[fieldBuildingID]); ok && presentBuildingIDs[id] {
-			continue
-		}
-		if row[fieldSite] != "" {
+		if row[fieldBuilding] != "" {
 			if !presentBuildings[row[fieldSite]+"\x00"+row[fieldBuilding]] {
 				errs = append(errs, csvErr(rowNumber(row, i+1), "RACK", fmt.Sprintf("rack building %q for site %q is omitted; add the BUILDING row or choose leave omitted rows in place", row[fieldBuilding], row[fieldSite])))
 			}
 			continue
 		}
-		if ambiguousBuildings[row[fieldBuilding]] {
-			errs = append(errs, csvErr(rowNumber(row, i+1), "RACK", fmt.Sprintf("rack building %q is ambiguous; add site or building_id", row[fieldBuilding])))
-			continue
-		}
-		if _, ok := buildingsByName[row[fieldBuilding]]; !ok {
-			errs = append(errs, csvErr(rowNumber(row, i+1), "RACK", fmt.Sprintf("rack building %q is omitted; add the BUILDING row or choose leave omitted rows in place", row[fieldBuilding])))
+		if row[fieldSite] != "" && !presentSites[row[fieldSite]] {
+			errs = append(errs, csvErr(rowNumber(row, i+1), "RACK", fmt.Sprintf("rack site %q is omitted; add the SITE row or choose leave omitted rows in place", row[fieldSite])))
 		}
 	}
 	for i, row := range minerRows {
@@ -2657,25 +2600,9 @@ func validateRemoveOmittedReferences(parsed *parsedCSV, mode pb.OmissionMode) []
 			}
 			continue
 		}
-		if row[fieldBuildingID] != "" || row[fieldBuilding] != "" {
-			if id, ok := idFromCell(row[fieldBuildingID]); ok {
-				if !presentBuildingIDs[id] {
-					errs = append(errs, csvErr(rowNumber(row, i+1), "MINER", fmt.Sprintf("miner building_id %q is omitted; add the BUILDING row or choose leave omitted rows in place", row[fieldBuildingID])))
-				}
-				continue
-			}
-			if row[fieldSite] != "" {
-				if !presentBuildings[row[fieldSite]+"\x00"+row[fieldBuilding]] {
-					errs = append(errs, csvErr(rowNumber(row, i+1), "MINER", fmt.Sprintf("miner building %q for site %q is omitted; add the BUILDING row or choose leave omitted rows in place", row[fieldBuilding], row[fieldSite])))
-				}
-				continue
-			}
-			if ambiguousBuildings[row[fieldBuilding]] {
-				errs = append(errs, csvErr(rowNumber(row, i+1), "MINER", fmt.Sprintf("miner building %q is ambiguous; add site or building_id", row[fieldBuilding])))
-				continue
-			}
-			if _, ok := buildingsByName[row[fieldBuilding]]; !ok {
-				errs = append(errs, csvErr(rowNumber(row, i+1), "MINER", fmt.Sprintf("miner building %q is omitted; add the BUILDING row or choose leave omitted rows in place", row[fieldBuilding])))
+		if row[fieldBuilding] != "" {
+			if !presentBuildings[row[fieldSite]+"\x00"+row[fieldBuilding]] {
+				errs = append(errs, csvErr(rowNumber(row, i+1), "MINER", fmt.Sprintf("miner building %q for site %q is omitted; add the BUILDING row or choose leave omitted rows in place", row[fieldBuilding], row[fieldSite])))
 			}
 			continue
 		}
@@ -2699,23 +2626,17 @@ func validateKnownEntityIDs(parsed *parsedCSV, snap *snapshot) []*pb.ImportValid
 	for _, rack := range snap.racks {
 		racksByID[rack.ID] = rack
 	}
+	// Only the row's own id column is validated here; parent references are checked
+	// by resolveReferences.
 	var errs []*pb.ImportValidationError
 	for i, row := range parsed.sections["SITE"] {
 		errs = append(errs, validateKnownIDCell(row, i, "SITE", fieldID, sitesByID)...)
 	}
 	for i, row := range parsed.sections["BUILDING"] {
 		errs = append(errs, validateKnownIDCell(row, i, "BUILDING", fieldID, buildingsByID)...)
-		errs = append(errs, validateKnownIDCell(row, i, "BUILDING", fieldSiteID, sitesByID)...)
 	}
 	for i, row := range parsed.sections["RACK"] {
 		errs = append(errs, validateKnownIDCell(row, i, "RACK", fieldID, racksByID)...)
-		errs = append(errs, validateKnownIDCell(row, i, "RACK", fieldSiteID, sitesByID)...)
-		errs = append(errs, validateKnownIDCell(row, i, "RACK", fieldBuildingID, buildingsByID)...)
-	}
-	for i, row := range parsed.sections["MINER"] {
-		errs = append(errs, validateKnownIDCell(row, i, "MINER", fieldSiteID, sitesByID)...)
-		errs = append(errs, validateKnownIDCell(row, i, "MINER", fieldBuildingID, buildingsByID)...)
-		errs = append(errs, validateKnownIDCell(row, i, "MINER", fieldRackID, racksByID)...)
 	}
 	return errs
 }
@@ -2734,252 +2655,213 @@ func validateKnownIDCell[T any](row map[string]string, index int, section, field
 	return nil
 }
 
-func normalizeIDReferences(parsed *parsedCSV, snap *snapshot) []*pb.ImportValidationError {
-	sitesByID := desiredSitesByID(parsed.sections["SITE"], snap.sites)
-	buildingsByID := desiredBuildingsByID(parsed.sections["BUILDING"], snap.buildings, sitesByID)
-	racksByID := desiredRacksByID(parsed.sections["RACK"], snap.racks, sitesByID, buildingsByID)
+// resolveReferences canonicalizes every parent reference cell in place. Each
+// parent relationship is a single cell: blank (unassigned), a bare integer (an
+// existing entity referenced by id), or "NAME:x" (a same-import create whose own
+// name/label is x). After this pass every reference cell holds a canonical name
+// and any implied ancestor is filled in too (a rack that references a building
+// also gets that building's site), so resolve, validation, and apply read names
+// exclusively and never re-interpret an id. Unresolvable references are errors.
+func resolveReferences(parsed *parsedCSV, snap *snapshot) []*pb.ImportValidationError {
 	var errs []*pb.ImportValidationError
+
+	// SITE: existing sites by id (with same-import renames), creates by name.
+	sitesByID := map[int64]sitemodels.Site{}
+	for _, site := range snap.sites {
+		sitesByID[site.ID] = site
+	}
+	createSites := map[string]bool{}
+	for _, row := range parsed.sections["SITE"] {
+		if id, ok := rowID(row); ok {
+			site := sitesByID[id]
+			site.Name = row[fieldName]
+			sitesByID[id] = site
+		} else if name := row[fieldName]; name != "" {
+			createSites[name] = true
+		}
+	}
+	resolveSite := func(cell, section string, rn int) string {
+		switch ref := parseParentRef(cell); ref.kind {
+		case refExisting:
+			if site, ok := sitesByID[ref.id]; ok {
+				return site.Name
+			}
+			errs = append(errs, csvErr(rn, section, fmt.Sprintf("site reference %d matches no existing site", ref.id)))
+		case refCreate:
+			if createSites[ref.name] {
+				return ref.name
+			}
+			errs = append(errs, csvErr(rn, section, fmt.Sprintf("site reference %s%s matches no SITE row in this import", refCreatePrefix, ref.name)))
+		case refInvalid:
+			errs = append(errs, csvErr(rn, section, fmt.Sprintf("site reference %q must be a numeric id or %sNAME", cell, refCreatePrefix)))
+		}
+		return ""
+	}
+
+	// BUILDING: canonicalize each site reference, then index existing buildings by
+	// id (with same-import moves/renames) and creates by name with their site.
 	for i, row := range parsed.sections["BUILDING"] {
-		if siteID, ok := idFromCell(row[fieldSiteID]); ok {
-			site, ok := sitesByID[siteID]
-			if !ok {
-				continue
-			}
-			if row[fieldSite] != "" && row[fieldSite] != site.Name {
-				errs = append(errs, csvErr(rowNumber(row, i+1), "BUILDING", fmt.Sprintf("site_id %q does not match site %q", row[fieldSiteID], row[fieldSite])))
-				continue
-			}
-			row[fieldSite] = site.Name
+		row[fieldSite] = resolveSite(row[fieldSite], "BUILDING", rowNumber(row, i+1))
+	}
+	buildingsByID := map[int64]buildingmodels.Building{}
+	for _, building := range snap.buildings {
+		buildingsByID[building.ID] = building
+	}
+	createBuildings := map[string][]string{} // name -> resolved site names
+	for _, row := range parsed.sections["BUILDING"] {
+		if id, ok := rowID(row); ok {
+			building := buildingsByID[id]
+			building.Name = row[fieldName]
+			building.SiteLabel = row[fieldSite]
+			buildingsByID[id] = building
+		} else if name := row[fieldName]; name != "" {
+			createBuildings[name] = append(createBuildings[name], row[fieldSite])
 		}
 	}
+	// resolveBuilding returns the canonical building name and its site. siteHint is
+	// the row's own already-resolved site reference, used only to disambiguate a
+	// create reference that names more than one same-import building.
+	resolveBuilding := func(cell, siteHint, section string, rn int) (name, site string) {
+		switch ref := parseParentRef(cell); ref.kind {
+		case refExisting:
+			if building, ok := buildingsByID[ref.id]; ok {
+				return building.Name, building.SiteLabel
+			}
+			errs = append(errs, csvErr(rn, section, fmt.Sprintf("building reference %d matches no existing building", ref.id)))
+		case refCreate:
+			sites := createBuildings[ref.name]
+			switch len(sites) {
+			case 0:
+				errs = append(errs, csvErr(rn, section, fmt.Sprintf("building reference %s%s matches no BUILDING row in this import", refCreatePrefix, ref.name)))
+			case 1:
+				return ref.name, sites[0]
+			default:
+				if siteHint != "" {
+					for _, s := range sites {
+						if s == siteHint {
+							return ref.name, s
+						}
+					}
+				}
+				errs = append(errs, csvErr(rn, section, fmt.Sprintf("building reference %s%s is ambiguous; set site to choose one", refCreatePrefix, ref.name)))
+			}
+		case refInvalid:
+			errs = append(errs, csvErr(rn, section, fmt.Sprintf("building reference %q must be a numeric id or %sNAME", cell, refCreatePrefix)))
+		}
+		return "", ""
+	}
+
+	// RACK: resolve the site reference, then the building reference (which wins and
+	// dictates the site). Then index existing racks by id and creates by label.
 	for i, row := range parsed.sections["RACK"] {
-		if buildingID, ok := idFromCell(row[fieldBuildingID]); ok {
-			building, ok := buildingsByID[buildingID]
-			if !ok {
-				continue
-			}
-			if row[fieldBuilding] != "" && row[fieldBuilding] != building.Name {
-				errs = append(errs, csvErr(rowNumber(row, i+1), "RACK", fmt.Sprintf("building_id %q does not match building %q", row[fieldBuildingID], row[fieldBuilding])))
-				continue
-			}
-			if siteID, ok := idFromCell(row[fieldSiteID]); ok && !nullableInt64Equal(&siteID, building.SiteID) {
-				errs = append(errs, csvErr(rowNumber(row, i+1), "RACK", fmt.Sprintf("building_id %q does not match site_id %q", row[fieldBuildingID], row[fieldSiteID])))
-				continue
-			}
-			if row[fieldSite] != "" && row[fieldSite] != building.SiteLabel {
-				errs = append(errs, csvErr(rowNumber(row, i+1), "RACK", fmt.Sprintf("building_id %q does not match site %q", row[fieldBuildingID], row[fieldSite])))
-				continue
-			}
-			row[fieldBuilding] = building.Name
-			if row[fieldSite] == "" {
-				row[fieldSite] = building.SiteLabel
-			}
-			if row[fieldSiteID] == "" && building.SiteID != nil {
-				row[fieldSiteID] = formatNullableInt64(building.SiteID)
+		rn := rowNumber(row, i+1)
+		site := resolveSite(row[fieldSite], "RACK", rn)
+		if row[fieldBuilding] != "" {
+			building, bSite := resolveBuilding(row[fieldBuilding], site, "RACK", rn)
+			row[fieldBuilding] = building
+			if bSite != "" {
+				site = bSite
 			}
 		}
-		if siteID, ok := idFromCell(row[fieldSiteID]); ok {
-			site, ok := sitesByID[siteID]
-			if !ok {
-				continue
-			}
-			if row[fieldSite] != "" && row[fieldSite] != site.Name {
-				errs = append(errs, csvErr(rowNumber(row, i+1), "RACK", fmt.Sprintf("site_id %q does not match site %q", row[fieldSiteID], row[fieldSite])))
-				continue
-			}
-			row[fieldSite] = site.Name
+		row[fieldSite] = site
+	}
+	racksByID := map[int64]rackSnapshot{}
+	for _, rack := range snap.racks {
+		racksByID[rack.ID] = rack
+	}
+	type rackPlacement struct{ building, site string }
+	createRacks := map[string]rackPlacement{} // label -> placement
+	for _, row := range parsed.sections["RACK"] {
+		if id, ok := rowID(row); ok {
+			rack := racksByID[id]
+			rack.Label = row[fieldLabel]
+			rack.Building = row[fieldBuilding]
+			rack.Site = row[fieldSite]
+			racksByID[id] = rack
+		} else if label := row[fieldLabel]; label != "" {
+			createRacks[label] = rackPlacement{building: row[fieldBuilding], site: row[fieldSite]}
 		}
 	}
+	resolveRack := func(cell, section string, rn int) (label, building, site string) {
+		switch ref := parseParentRef(cell); ref.kind {
+		case refExisting:
+			if rack, ok := racksByID[ref.id]; ok {
+				return rack.Label, rack.Building, rack.Site
+			}
+			errs = append(errs, csvErr(rn, section, fmt.Sprintf("rack reference %d matches no existing rack", ref.id)))
+		case refCreate:
+			if placement, ok := createRacks[ref.name]; ok {
+				return ref.name, placement.building, placement.site
+			}
+			errs = append(errs, csvErr(rn, section, fmt.Sprintf("rack reference %s%s matches no RACK row in this import", refCreatePrefix, ref.name)))
+		case refInvalid:
+			errs = append(errs, csvErr(rn, section, fmt.Sprintf("rack reference %q must be a numeric id or %sNAME", cell, refCreatePrefix)))
+		}
+		return "", "", ""
+	}
+
+	// MINER: resolve site, then building (wins over site), then rack (wins over
+	// both, dictating building and site).
 	for i, row := range parsed.sections["MINER"] {
-		if rackID, ok := idFromCell(row[fieldRackID]); ok {
-			rack, ok := racksByID[rackID]
-			if !ok {
-				continue
-			}
-			if row[fieldRack] != "" && row[fieldRack] != rack.Label {
-				errs = append(errs, csvErr(rowNumber(row, i+1), "MINER", fmt.Sprintf("rack_id %q does not match rack %q", row[fieldRackID], row[fieldRack])))
-				continue
-			}
-			if buildingID, ok := idFromCell(row[fieldBuildingID]); ok {
-				building, ok := buildingsByID[buildingID]
-				if !ok {
-					continue
-				}
-				if row[fieldBuilding] != "" && row[fieldBuilding] != building.Name {
-					errs = append(errs, csvErr(rowNumber(row, i+1), "MINER", fmt.Sprintf("building_id %q does not match building %q", row[fieldBuildingID], row[fieldBuilding])))
-					continue
-				}
-				if !nullableInt64Equal(&building.ID, rack.BuildingID) {
-					errs = append(errs, csvErr(rowNumber(row, i+1), "MINER", fmt.Sprintf("building_id %q does not match rack_id %q", row[fieldBuildingID], row[fieldRackID])))
-					continue
-				}
-			}
-			if row[fieldBuilding] != "" && row[fieldBuilding] != rack.Building {
-				errs = append(errs, csvErr(rowNumber(row, i+1), "MINER", fmt.Sprintf("building %q does not match rack_id %q", row[fieldBuilding], row[fieldRackID])))
-				continue
-			}
-			if siteID, ok := idFromCell(row[fieldSiteID]); ok {
-				site, ok := sitesByID[siteID]
-				if !ok {
-					continue
-				}
-				if row[fieldSite] != "" && row[fieldSite] != site.Name {
-					errs = append(errs, csvErr(rowNumber(row, i+1), "MINER", fmt.Sprintf("site_id %q does not match site %q", row[fieldSiteID], row[fieldSite])))
-					continue
-				}
-				if !nullableInt64Equal(&site.ID, rack.SiteID) {
-					errs = append(errs, csvErr(rowNumber(row, i+1), "MINER", fmt.Sprintf("site_id %q does not match rack_id %q", row[fieldSiteID], row[fieldRackID])))
-					continue
-				}
-			}
-			if row[fieldSite] != "" && row[fieldSite] != rack.Site {
-				errs = append(errs, csvErr(rowNumber(row, i+1), "MINER", fmt.Sprintf("site %q does not match rack_id %q", row[fieldSite], row[fieldRackID])))
-				continue
-			}
-			row[fieldRack] = rack.Label
-			continue
-		}
-		if buildingID, ok := idFromCell(row[fieldBuildingID]); ok {
-			building, ok := buildingsByID[buildingID]
-			if !ok {
-				continue
-			}
-			if row[fieldBuilding] != "" && row[fieldBuilding] != building.Name {
-				errs = append(errs, csvErr(rowNumber(row, i+1), "MINER", fmt.Sprintf("building_id %q does not match building %q", row[fieldBuildingID], row[fieldBuilding])))
-				continue
-			}
-			row[fieldBuilding] = building.Name
-			if row[fieldSite] == "" {
-				row[fieldSite] = building.SiteLabel
-			}
-			if row[fieldSiteID] == "" && building.SiteID != nil {
-				row[fieldSiteID] = formatNullableInt64(building.SiteID)
+		rn := rowNumber(row, i+1)
+		site := resolveSite(row[fieldSite], "MINER", rn)
+		building := ""
+		if row[fieldBuilding] != "" {
+			b, bSite := resolveBuilding(row[fieldBuilding], site, "MINER", rn)
+			building = b
+			if bSite != "" {
+				site = bSite
 			}
 		}
-		if siteID, ok := idFromCell(row[fieldSiteID]); ok {
-			site, ok := sitesByID[siteID]
-			if !ok {
-				continue
+		if row[fieldRack] != "" {
+			label, rBuilding, rSite := resolveRack(row[fieldRack], "MINER", rn)
+			row[fieldRack] = label
+			if rBuilding != "" {
+				building = rBuilding
 			}
-			if row[fieldSite] != "" && row[fieldSite] != site.Name {
-				errs = append(errs, csvErr(rowNumber(row, i+1), "MINER", fmt.Sprintf("site_id %q does not match site %q", row[fieldSiteID], row[fieldSite])))
-				continue
+			if rSite != "" {
+				site = rSite
 			}
-			row[fieldSite] = site.Name
 		}
+		row[fieldBuilding] = building
+		row[fieldSite] = site
 	}
 	return errs
 }
 
-func idFromCell(raw string) (int64, bool) {
-	if raw == "" {
-		return 0, false
-	}
-	id, err := parseInt64Value(raw, fieldID)
-	return id, err == nil
+// refKind classifies a parent reference cell.
+type refKind int
+
+const (
+	refUnassigned refKind = iota // blank cell: no parent
+	refExisting                  // bare integer: existing entity by id
+	refCreate                    // "NAME:x": same-import new entity named x
+	refInvalid                   // a non-empty, non-integer cell without the NAME: prefix
+)
+
+// parentRef is a parsed parent reference cell.
+type parentRef struct {
+	kind refKind
+	id   int64  // set when kind == refExisting
+	name string // set when kind == refCreate
 }
 
-func desiredSitesByID(rows []map[string]string, sites []sitemodels.Site) map[int64]sitemodels.Site {
-	out := map[int64]sitemodels.Site{}
-	for _, site := range sites {
-		out[site.ID] = site
+// parseParentRef interprets a single reference cell. A blank cell is
+// unassigned; a value with the NAME: prefix references a same-import create by
+// its own name/label (the prefix is stripped once, so a create literally named
+// "NAME:x" is referenced as "NAME:NAME:x"); a bare integer references an
+// existing entity by id; anything else is invalid.
+func parseParentRef(cell string) parentRef {
+	if cell == "" {
+		return parentRef{kind: refUnassigned}
 	}
-	for _, row := range rows {
-		id, ok := rowID(row)
-		if !ok {
-			continue
-		}
-		site := out[id]
-		site.Name = row[fieldName]
-		out[id] = site
+	if name, ok := strings.CutPrefix(cell, refCreatePrefix); ok {
+		return parentRef{kind: refCreate, name: name}
 	}
-	return out
-}
-
-func desiredBuildingsByID(rows []map[string]string, buildings []buildingmodels.Building, sitesByID map[int64]sitemodels.Site) map[int64]buildingmodels.Building {
-	out := map[int64]buildingmodels.Building{}
-	for _, building := range buildings {
-		out[building.ID] = building
+	if id, err := parseInt64Value(cell, "reference"); err == nil {
+		return parentRef{kind: refExisting, id: id}
 	}
-	sitesByName := map[string]sitemodels.Site{}
-	for _, site := range sitesByID {
-		sitesByName[site.Name] = site
-	}
-	for _, row := range rows {
-		id, ok := rowID(row)
-		if !ok {
-			continue
-		}
-		building := out[id]
-		building.Name = row[fieldName]
-		if siteID, ok := idFromCell(row[fieldSiteID]); ok {
-			site := sitesByID[siteID]
-			building.SiteID = &site.ID
-			building.SiteLabel = site.Name
-		} else if site, ok := sitesByName[row[fieldSite]]; ok {
-			building.SiteID = &site.ID
-			building.SiteLabel = site.Name
-		} else {
-			building.SiteID = nil
-			building.SiteLabel = row[fieldSite]
-		}
-		out[id] = building
-	}
-	return out
-}
-
-func desiredRacksByID(rows []map[string]string, racks []rackSnapshot, sitesByID map[int64]sitemodels.Site, buildingsByID map[int64]buildingmodels.Building) map[int64]rackSnapshot {
-	out := map[int64]rackSnapshot{}
-	for _, rack := range racks {
-		out[rack.ID] = rack
-	}
-	sitesByName := map[string]sitemodels.Site{}
-	for _, site := range sitesByID {
-		sitesByName[site.Name] = site
-	}
-	buildingsBySiteName := map[string]buildingmodels.Building{}
-	for _, building := range buildingsByID {
-		if building.SiteLabel != "" {
-			buildingsBySiteName[building.SiteLabel+"\x00"+building.Name] = building
-		}
-	}
-	for _, row := range rows {
-		id, ok := rowID(row)
-		if !ok {
-			continue
-		}
-		rack := out[id]
-		rack.Label = row[fieldLabel]
-		if buildingID, ok := idFromCell(row[fieldBuildingID]); ok {
-			building := buildingsByID[buildingID]
-			rack.BuildingID = &building.ID
-			rack.Building = building.Name
-			rack.SiteID = building.SiteID
-			rack.Site = building.SiteLabel
-		} else {
-			rack.Building = row[fieldBuilding]
-			if building, ok := buildingsBySiteName[row[fieldSite]+"\x00"+row[fieldBuilding]]; ok {
-				if building.ID > 0 {
-					rack.BuildingID = &building.ID
-				}
-				rack.Building = building.Name
-				rack.SiteID = building.SiteID
-				rack.Site = building.SiteLabel
-			}
-		}
-		if siteID, ok := idFromCell(row[fieldSiteID]); ok {
-			site := sitesByID[siteID]
-			rack.SiteID = &site.ID
-			rack.Site = site.Name
-		} else if row[fieldSite] != "" {
-			if site, ok := sitesByName[row[fieldSite]]; ok {
-				rack.SiteID = &site.ID
-			}
-			rack.Site = row[fieldSite]
-		}
-		out[id] = rack
-	}
-	return out
+	return parentRef{kind: refInvalid}
 }
 
 func validateBuildingLayoutBounds(rows []map[string]string) []*pb.ImportValidationError {
@@ -3039,12 +2921,6 @@ func validateRackDimensions(rows []map[string]string) []*pb.ImportValidationErro
 
 func validateRackGridCollisions(rackRows []map[string]string, snap *snapshot, mode pb.OmissionMode) []*pb.ImportValidationError {
 	presentRackIdentities := rackIdentitySet(rackRows, snap.racks)
-	buildingBySiteName := map[string]buildingmodels.Building{}
-	for _, building := range snap.buildings {
-		if building.SiteLabel != "" {
-			buildingBySiteName[building.SiteLabel+"\x00"+building.Name] = building
-		}
-	}
 	seen := map[string]string{}
 	var errs []*pb.ImportValidationError
 	for _, rack := range snap.racks {
@@ -3062,7 +2938,7 @@ func validateRackGridCollisions(rackRows []map[string]string, snap *snapshot, mo
 		if err != nil {
 			continue
 		}
-		key := rackGridCollisionKey(rack.BuildingID, rack.Site, rack.Building, aisle, position)
+		key := rackGridCollisionKey(rack.Site, rack.Building, aisle, position)
 		seen[key] = rack.Label
 	}
 	for i, row := range rackRows {
@@ -3077,13 +2953,7 @@ func validateRackGridCollisions(rackRows []map[string]string, snap *snapshot, mo
 		if err != nil {
 			continue
 		}
-		buildingID, _ := parseOptionalInt64(row[fieldBuildingID], fieldBuildingID)
-		if buildingID == nil {
-			if building, ok := buildingBySiteName[row[fieldSite]+"\x00"+row[fieldBuilding]]; ok {
-				buildingID = &building.ID
-			}
-		}
-		key := rackGridCollisionKey(buildingID, row[fieldSite], row[fieldBuilding], aisle, position)
+		key := rackGridCollisionKey(row[fieldSite], row[fieldBuilding], aisle, position)
 		if existingRack, ok := seen[key]; ok {
 			errs = append(errs, csvErr(rowNumber(row, i+1), "RACK", fmt.Sprintf("rack grid cell already occupied by rack %s", existingRack)))
 			continue
@@ -3093,10 +2963,7 @@ func validateRackGridCollisions(rackRows []map[string]string, snap *snapshot, mo
 	return errs
 }
 
-func rackGridCollisionKey(buildingID *int64, site, building string, aisle, position int32) string {
-	if buildingID != nil {
-		return fmt.Sprintf("building_id:%d\x00%d\x00%d", *buildingID, aisle, position)
-	}
+func rackGridCollisionKey(site, building string, aisle, position int32) string {
 	return fmt.Sprintf("building:%s\x00%s\x00%d\x00%d", site, building, aisle, position)
 }
 
@@ -3584,23 +3451,6 @@ func applyDesiredBuildingRow(row map[string]string, building *buildingmodels.Bui
 	}
 }
 
-func desiredBuildingNameLookup(rows []map[string]string, buildings []buildingmodels.Building) (map[string]buildingmodels.Building, map[string]bool) {
-	byName := map[string]buildingmodels.Building{}
-	ambiguous := map[string]bool{}
-	byBuildingName := map[string][]buildingmodels.Building{}
-	for _, building := range desiredBuildingList(rows, buildings) {
-		byBuildingName[building.Name] = append(byBuildingName[building.Name], building)
-	}
-	for name, candidates := range byBuildingName {
-		if len(candidates) == 1 {
-			byName[name] = candidates[0]
-			continue
-		}
-		ambiguous[name] = true
-	}
-	return byName, ambiguous
-}
-
 func desiredRackMap(rows []map[string]string, racks []rackSnapshot, buildingRows []map[string]string, buildings []buildingmodels.Building) map[string]rackSnapshot {
 	out := map[string]rackSnapshot{}
 	for _, rack := range racks {
@@ -3621,18 +3471,14 @@ func desiredRackMap(rows []map[string]string, racks []rackSnapshot, buildingRows
 		rack.Label = rackSectionLabel(row)
 		rack.Site = row[fieldSite]
 		rack.Building = row[fieldBuilding]
-		if id, err := parseOptionalInt64(row[fieldSiteID], fieldSiteID); err == nil {
-			rack.SiteID = id
-		}
-		if id, err := parseOptionalInt64(row[fieldBuildingID], fieldBuildingID); err == nil {
-			rack.BuildingID = id
-			if id == nil {
-				if building, ok := buildingBySiteName[row[fieldSite]+"\x00"+row[fieldBuilding]]; ok {
-					if building.ID > 0 {
-						rack.BuildingID = &building.ID
-					}
-				}
+		// Reference cells are canonical names; derive parent ids from the desired
+		// building the (site, building) pair names.
+		rack.BuildingID = nil
+		if building, ok := buildingBySiteName[row[fieldSite]+"\x00"+row[fieldBuilding]]; ok {
+			if building.ID > 0 {
+				rack.BuildingID = &building.ID
 			}
+			rack.SiteID = building.SiteID
 		}
 		rack.Zone = row["zone"]
 		if rows, err := parseInt32Value(row["rows"], "rows"); err == nil {
@@ -3745,74 +3591,26 @@ func desiredRackGridPosition(row map[string]string) (*int32, *int32, error) {
 	return &aisle, &position, nil
 }
 
+// desiredSiteBuildingIDs resolves the site and building ids a placement targets.
+// Reference cells have already been canonicalized to names, so this is a pure
+// name lookup against the running apply maps (which include entities created
+// earlier in this same import).
 func desiredSiteBuildingIDs(
-	siteIDRaw string,
 	siteName string,
-	buildingIDRaw string,
 	buildingName string,
 	sitesByName map[string]sitemodels.Site,
-	sitesByID map[int64]sitemodels.Site,
 	buildingsByKey map[string]buildingmodels.Building,
-	buildingsByID map[int64]buildingmodels.Building,
 ) (*int64, *int64, error) {
 	var siteID *int64
-	if siteIDRaw != "" {
-		id, err := parseInt64Value(siteIDRaw, fieldSiteID)
-		if err != nil {
-			return nil, nil, err
-		}
-		siteID = &id
-		if sitesByID != nil {
-			site, ok := sitesByID[id]
-			if !ok {
-				return nil, nil, fleeterror.NewFailedPreconditionErrorf("unknown site_id %q", siteIDRaw)
-			}
-			if siteName != "" && siteName != site.Name {
-				return nil, nil, fleeterror.NewFailedPreconditionErrorf("site_id %q does not match site %q", siteIDRaw, siteName)
-			}
-		}
-	}
 	if siteName != "" {
 		site, ok := sitesByName[siteName]
 		if !ok {
 			return nil, nil, fleeterror.NewFailedPreconditionErrorf("unknown site %q", siteName)
 		}
-		if siteID != nil && *siteID != site.ID {
-			return nil, nil, fleeterror.NewFailedPreconditionErrorf("site_id %q does not match site %q", siteIDRaw, siteName)
-		}
 		siteID = &site.ID
 	}
 	var buildingID *int64
-	if buildingIDRaw != "" {
-		id, err := parseInt64Value(buildingIDRaw, fieldBuildingID)
-		if err != nil {
-			return nil, nil, err
-		}
-		buildingID = &id
-		if buildingsByID != nil {
-			building, ok := buildingsByID[id]
-			if !ok {
-				return nil, nil, fleeterror.NewFailedPreconditionErrorf("unknown building_id %q", buildingIDRaw)
-			}
-			if buildingName != "" && buildingName != building.Name {
-				return nil, nil, fleeterror.NewFailedPreconditionErrorf("building_id %q does not match building %q", buildingIDRaw, buildingName)
-			}
-			if siteName != "" && siteName != building.SiteLabel {
-				return nil, nil, fleeterror.NewFailedPreconditionErrorf("building_id %q does not match site %q", buildingIDRaw, siteName)
-			}
-			if siteID != nil {
-				if building.SiteID == nil || *building.SiteID != *siteID {
-					return nil, nil, fleeterror.NewFailedPreconditionErrorf("building_id %q does not match site_id %q", buildingIDRaw, siteIDRaw)
-				}
-			} else if building.SiteID != nil {
-				siteID = building.SiteID
-			}
-		}
-	}
 	if buildingName != "" {
-		if buildingID != nil {
-			return siteID, buildingID, nil
-		}
 		if buildingsByKey == nil {
 			return siteID, nil, nil
 		}
@@ -3822,11 +3620,6 @@ func desiredSiteBuildingIDs(
 		}
 		buildingID = &building.ID
 	}
-	if buildingsByID != nil && buildingID != nil {
-		if _, ok := buildingsByID[*buildingID]; !ok {
-			return nil, nil, fleeterror.NewFailedPreconditionErrorf("unknown building_id %q", strconv.FormatInt(*buildingID, 10))
-		}
-	}
 	return siteID, buildingID, nil
 }
 
@@ -3835,77 +3628,6 @@ func desiredRackZone(row map[string]string, current rackSnapshot) string {
 		return ""
 	}
 	return row["zone"]
-}
-
-func desiredMinerSiteBuilding(
-	row map[string]string,
-	racksByLabel map[string]rackSnapshot,
-	buildingsByName map[string]buildingmodels.Building,
-	buildingsByID map[int64]buildingmodels.Building,
-	ambiguousBuildings map[string]bool,
-) (string, string) {
-	if row[fieldRack] != "" {
-		rack := racksByLabel[row[fieldRack]]
-		return rack.Site, rack.Building
-	}
-	if id, ok := idFromCell(row[fieldBuildingID]); ok {
-		if building, ok := buildingsByID[id]; ok {
-			return building.SiteLabel, building.Name
-		}
-	}
-	if row[fieldSite] == "" && row[fieldBuilding] != "" && !ambiguousBuildings[row[fieldBuilding]] {
-		if building, ok := buildingsByName[row[fieldBuilding]]; ok {
-			return building.SiteLabel, row[fieldBuilding]
-		}
-	}
-	return row[fieldSite], row[fieldBuilding]
-}
-
-func desiredBuildingIDMap(rows []map[string]string, buildings []buildingmodels.Building) map[int64]buildingmodels.Building {
-	out := map[int64]buildingmodels.Building{}
-	for _, building := range buildings {
-		if building.ID > 0 {
-			out[building.ID] = building
-		}
-	}
-	for _, row := range rows {
-		id, ok := rowID(row)
-		if !ok {
-			continue
-		}
-		building := out[id]
-		building.ID = id
-		building.Name = buildingSectionName(row)
-		building.SiteLabel = row[fieldSite]
-		if siteID, ok := idFromCell(row[fieldSiteID]); ok {
-			building.SiteID = &siteID
-		}
-		out[id] = building
-	}
-	return out
-}
-
-func minerPlacementIDsMatch(row map[string]string, miner minerSnapshot) bool {
-	for _, check := range []struct {
-		field string
-		want  *int64
-	}{
-		{field: fieldSiteID, want: miner.SiteID},
-		{field: fieldBuildingID, want: miner.BuildingID},
-		{field: fieldRackID, want: miner.RackID},
-	} {
-		if check.field == fieldRackID && row[fieldRack] == "" {
-			continue
-		}
-		got := row[check.field]
-		if got == "" {
-			continue
-		}
-		if got != formatNullableInt64(check.want) {
-			return false
-		}
-	}
-	return true
 }
 
 func rowSetFromSiteNames(rows []sitemodels.Site) map[string]bool {

--- a/server/internal/domain/sitemap/service.go
+++ b/server/internal/domain/sitemap/service.go
@@ -3506,12 +3506,11 @@ func validateBuildingRackCapacity(rackRows, buildingRows []map[string]string, sn
 	var errs []*pb.ImportValidationError
 	for key, count := range counts {
 		building, ok := buildings[key]
-		if !ok || building.Aisles <= 0 || building.RacksPerAisle <= 0 {
+		if !ok {
 			continue
 		}
-		capacity := building.Aisles * building.RacksPerAisle
-		if count > capacity {
-			errs = append(errs, csvErr(0, "RACK", fmt.Sprintf("building %q has %d assigned racks but capacity is %d", building.Name, count, capacity)))
+		if buildingmodels.RackCapacityExceeded(building.Aisles, building.RacksPerAisle, int64(count)) {
+			errs = append(errs, csvErr(0, "RACK", fmt.Sprintf("building %q has %d assigned racks but capacity is %d", building.Name, count, buildingmodels.GridCapacity(building.Aisles, building.RacksPerAisle))))
 		}
 	}
 	return errs

--- a/server/internal/domain/sitemap/service.go
+++ b/server/internal/domain/sitemap/service.go
@@ -59,6 +59,15 @@ const (
 	// created in the same import, by its own name/label (e.g. "NAME:Building 2").
 	// A bare integer references an existing entity by id; blank is unassigned.
 	refCreatePrefix = "NAME:"
+
+	// refBuildingIDCell is an internal companion cell that resolveReferences writes
+	// next to a canonicalized building reference to preserve the resolved existing
+	// building's id. Canonicalizing a reference to a name loses id precision when
+	// two buildings share a (site, name) pair (a distinct-NULL-site_id case the DB
+	// permits), so id-sensitive validators read the companion cell to key by
+	// identity. The NUL prefix keeps it out of the header-driven CSV export and
+	// every field-scoped reader.
+	refBuildingIDCell = "\x00ref_building_id"
 )
 
 var (
@@ -2718,14 +2727,15 @@ func resolveReferences(parsed *parsedCSV, snap *snapshot) []*pb.ImportValidation
 			createBuildings[name] = append(createBuildings[name], row[fieldSite])
 		}
 	}
-	// resolveBuilding returns the canonical building name and its site. siteHint is
-	// the row's own already-resolved site reference, used only to disambiguate a
+	// resolveBuilding returns the canonical building name, its site, and the id of
+	// the existing building it resolves to (0 for a same-import create). siteHint
+	// is the row's own already-resolved site reference, used only to disambiguate a
 	// create reference that names more than one same-import building.
-	resolveBuilding := func(cell, siteHint, section string, rn int) (name, site string) {
+	resolveBuilding := func(cell, siteHint, section string, rn int) (name, site string, id int64) {
 		switch ref := parseParentRef(cell); ref.kind {
 		case refExisting:
 			if building, ok := buildingsByID[ref.id]; ok {
-				return building.Name, building.SiteLabel
+				return building.Name, building.SiteLabel, ref.id
 			}
 			errs = append(errs, csvErr(rn, section, fmt.Sprintf("building reference %d matches no existing building", ref.id)))
 		case refCreate:
@@ -2734,12 +2744,12 @@ func resolveReferences(parsed *parsedCSV, snap *snapshot) []*pb.ImportValidation
 			case 0:
 				errs = append(errs, csvErr(rn, section, fmt.Sprintf("building reference %s%s matches no BUILDING row in this import", refCreatePrefix, ref.name)))
 			case 1:
-				return ref.name, sites[0]
+				return ref.name, sites[0], 0
 			default:
 				if siteHint != "" {
 					for _, s := range sites {
 						if s == siteHint {
-							return ref.name, s
+							return ref.name, s, 0
 						}
 					}
 				}
@@ -2748,7 +2758,7 @@ func resolveReferences(parsed *parsedCSV, snap *snapshot) []*pb.ImportValidation
 		case refInvalid:
 			errs = append(errs, csvErr(rn, section, fmt.Sprintf("building reference %q must be a numeric id or %sNAME", cell, refCreatePrefix)))
 		}
-		return "", ""
+		return "", "", 0
 	}
 
 	// RACK: resolve the site reference, then the building reference (which wins and
@@ -2757,8 +2767,9 @@ func resolveReferences(parsed *parsedCSV, snap *snapshot) []*pb.ImportValidation
 		rn := rowNumber(row, i+1)
 		site := resolveSite(row[fieldSite], "RACK", rn)
 		if row[fieldBuilding] != "" {
-			building, bSite := resolveBuilding(row[fieldBuilding], site, "RACK", rn)
+			building, bSite, bID := resolveBuilding(row[fieldBuilding], site, "RACK", rn)
 			row[fieldBuilding] = building
+			setRefID(row, refBuildingIDCell, bID)
 			if bSite != "" {
 				site = bSite
 			}
@@ -2769,7 +2780,10 @@ func resolveReferences(parsed *parsedCSV, snap *snapshot) []*pb.ImportValidation
 	for _, rack := range snap.racks {
 		racksByID[rack.ID] = rack
 	}
-	type rackPlacement struct{ building, site string }
+	type rackPlacement struct {
+		building, site string
+		buildingID     *int64
+	}
 	createRacks := map[string]rackPlacement{} // label -> placement
 	for _, row := range parsed.sections["RACK"] {
 		if id, ok := rowID(row); ok {
@@ -2779,25 +2793,27 @@ func resolveReferences(parsed *parsedCSV, snap *snapshot) []*pb.ImportValidation
 			rack.Site = row[fieldSite]
 			racksByID[id] = rack
 		} else if label := row[fieldLabel]; label != "" {
-			createRacks[label] = rackPlacement{building: row[fieldBuilding], site: row[fieldSite]}
+			createRacks[label] = rackPlacement{building: row[fieldBuilding], site: row[fieldSite], buildingID: refID(row, refBuildingIDCell)}
 		}
 	}
-	resolveRack := func(cell, section string, rn int) (label, building, site string) {
+	// resolveRack returns the canonical rack label, its building and site, and the
+	// id of that rack's building when the rack sits under an existing building.
+	resolveRack := func(cell, section string, rn int) (label, building, site string, buildingID *int64) {
 		switch ref := parseParentRef(cell); ref.kind {
 		case refExisting:
 			if rack, ok := racksByID[ref.id]; ok {
-				return rack.Label, rack.Building, rack.Site
+				return rack.Label, rack.Building, rack.Site, rack.BuildingID
 			}
 			errs = append(errs, csvErr(rn, section, fmt.Sprintf("rack reference %d matches no existing rack", ref.id)))
 		case refCreate:
 			if placement, ok := createRacks[ref.name]; ok {
-				return ref.name, placement.building, placement.site
+				return ref.name, placement.building, placement.site, placement.buildingID
 			}
 			errs = append(errs, csvErr(rn, section, fmt.Sprintf("rack reference %s%s matches no RACK row in this import", refCreatePrefix, ref.name)))
 		case refInvalid:
 			errs = append(errs, csvErr(rn, section, fmt.Sprintf("rack reference %q must be a numeric id or %sNAME", cell, refCreatePrefix)))
 		}
-		return "", "", ""
+		return "", "", "", nil
 	}
 
 	// MINER: resolve site, then building (wins over site), then rack (wins over
@@ -2806,18 +2822,21 @@ func resolveReferences(parsed *parsedCSV, snap *snapshot) []*pb.ImportValidation
 		rn := rowNumber(row, i+1)
 		site := resolveSite(row[fieldSite], "MINER", rn)
 		building := ""
+		var buildingID *int64
 		if row[fieldBuilding] != "" {
-			b, bSite := resolveBuilding(row[fieldBuilding], site, "MINER", rn)
+			b, bSite, bID := resolveBuilding(row[fieldBuilding], site, "MINER", rn)
 			building = b
+			buildingID = nonZeroInt64Ptr(bID)
 			if bSite != "" {
 				site = bSite
 			}
 		}
 		if row[fieldRack] != "" {
-			label, rBuilding, rSite := resolveRack(row[fieldRack], "MINER", rn)
+			label, rBuilding, rSite, rBuildingID := resolveRack(row[fieldRack], "MINER", rn)
 			row[fieldRack] = label
 			if rBuilding != "" {
 				building = rBuilding
+				buildingID = rBuildingID
 			}
 			if rSite != "" {
 				site = rSite
@@ -2825,8 +2844,48 @@ func resolveReferences(parsed *parsedCSV, snap *snapshot) []*pb.ImportValidation
 		}
 		row[fieldBuilding] = building
 		row[fieldSite] = site
+		setRefIDPtr(row, refBuildingIDCell, buildingID)
 	}
 	return errs
+}
+
+// setRefID writes an existing-entity id companion cell, deleting it when id is 0
+// so a re-resolution never leaves a stale id behind.
+func setRefID(row map[string]string, cell string, id int64) {
+	if id > 0 {
+		row[cell] = strconv.FormatInt(id, 10)
+		return
+	}
+	delete(row, cell)
+}
+
+// setRefIDPtr is setRefID for an optional id.
+func setRefIDPtr(row map[string]string, cell string, id *int64) {
+	if id != nil {
+		setRefID(row, cell, *id)
+		return
+	}
+	delete(row, cell)
+}
+
+// refID reads an existing-entity id companion cell, returning nil when unset.
+func refID(row map[string]string, cell string) *int64 {
+	raw := row[cell]
+	if raw == "" {
+		return nil
+	}
+	id, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || id <= 0 {
+		return nil
+	}
+	return &id
+}
+
+func nonZeroInt64Ptr(id int64) *int64 {
+	if id <= 0 {
+		return nil
+	}
+	return &id
 }
 
 // refKind classifies a parent reference cell.
@@ -2921,6 +2980,7 @@ func validateRackDimensions(rows []map[string]string) []*pb.ImportValidationErro
 
 func validateRackGridCollisions(rackRows []map[string]string, snap *snapshot, mode pb.OmissionMode) []*pb.ImportValidationError {
 	presentRackIdentities := rackIdentitySet(rackRows, snap.racks)
+	buildingIDByName := uniqueBuildingIDsByName(snap.buildings)
 	seen := map[string]string{}
 	var errs []*pb.ImportValidationError
 	for _, rack := range snap.racks {
@@ -2938,8 +2998,8 @@ func validateRackGridCollisions(rackRows []map[string]string, snap *snapshot, mo
 		if err != nil {
 			continue
 		}
-		key := rackGridCollisionKey(rack.Site, rack.Building, aisle, position)
-		seen[key] = rack.Label
+		bKey := buildingIdentityKey(rack.BuildingID, rack.Site, rack.Building, buildingIDByName)
+		seen[rackGridCollisionKey(bKey, aisle, position)] = rack.Label
 	}
 	for i, row := range rackRows {
 		if row[fieldBuilding] == "" || row["aisle_index"] == "" || row["position_in_aisle"] == "" {
@@ -2953,7 +3013,8 @@ func validateRackGridCollisions(rackRows []map[string]string, snap *snapshot, mo
 		if err != nil {
 			continue
 		}
-		key := rackGridCollisionKey(row[fieldSite], row[fieldBuilding], aisle, position)
+		bKey := buildingIdentityKey(refID(row, refBuildingIDCell), row[fieldSite], row[fieldBuilding], buildingIDByName)
+		key := rackGridCollisionKey(bKey, aisle, position)
 		if existingRack, ok := seen[key]; ok {
 			errs = append(errs, csvErr(rowNumber(row, i+1), "RACK", fmt.Sprintf("rack grid cell already occupied by rack %s", existingRack)))
 			continue
@@ -2963,8 +3024,45 @@ func validateRackGridCollisions(rackRows []map[string]string, snap *snapshot, mo
 	return errs
 }
 
-func rackGridCollisionKey(site, building string, aisle, position int32) string {
-	return fmt.Sprintf("building:%s\x00%s\x00%d\x00%d", site, building, aisle, position)
+func rackGridCollisionKey(buildingKey string, aisle, position int32) string {
+	return fmt.Sprintf("%s\x00%d\x00%d", buildingKey, aisle, position)
+}
+
+// buildingIdentityKey keys a building by its stable id so two buildings sharing
+// a (site, name) pair stay distinct. It prefers an explicit id, then a unique
+// snapshot building of that (site, name), and finally the (site, name) pair for
+// same-import creates that have no id yet.
+func buildingIdentityKey(id *int64, site, building string, idByName map[string]int64) string {
+	if id != nil {
+		return "id:" + strconv.FormatInt(*id, 10)
+	}
+	if resolved, ok := idByName[site+"\x00"+building]; ok {
+		return "id:" + strconv.FormatInt(resolved, 10)
+	}
+	return "name:" + site + "\x00" + building
+}
+
+// uniqueBuildingIDsByName maps a (site, name) pair to its building id, omitting
+// any pair shared by more than one building so ambiguous names fall back to
+// name keying.
+func uniqueBuildingIDsByName(buildings []buildingmodels.Building) map[string]int64 {
+	out := map[string]int64{}
+	ambiguous := map[string]bool{}
+	for _, building := range buildings {
+		if building.ID <= 0 {
+			continue
+		}
+		key := building.SiteLabel + "\x00" + building.Name
+		if _, ok := out[key]; ok {
+			ambiguous[key] = true
+			continue
+		}
+		out[key] = building.ID
+	}
+	for key := range ambiguous {
+		delete(out, key)
+	}
+	return out
 }
 
 func validateImportedNameLengths(parsed *parsedCSV) []*pb.ImportValidationError {
@@ -3457,6 +3555,7 @@ func desiredRackMap(rows []map[string]string, racks []rackSnapshot, buildingRows
 		out[rack.Label] = rack
 	}
 	buildingBySiteName := desiredBuildingsBySiteName(buildingRows, buildings)
+	buildingByID := desiredBuildingsByID(buildingRows, buildings)
 	for _, row := range rows {
 		rack := out[rackSectionLabel(row)]
 		if id, ok := rowID(row); ok {
@@ -3471,10 +3570,16 @@ func desiredRackMap(rows []map[string]string, racks []rackSnapshot, buildingRows
 		rack.Label = rackSectionLabel(row)
 		rack.Site = row[fieldSite]
 		rack.Building = row[fieldBuilding]
-		// Reference cells are canonical names; derive parent ids from the desired
-		// building the (site, building) pair names.
+		// Prefer the resolved building id recorded by resolveReferences so two
+		// buildings sharing a (site, name) pair stay distinct; fall back to the
+		// (site, name) key for creates, whose uniqueness is enforced elsewhere.
 		rack.BuildingID = nil
-		if building, ok := buildingBySiteName[row[fieldSite]+"\x00"+row[fieldBuilding]]; ok {
+		if bID := refID(row, refBuildingIDCell); bID != nil {
+			rack.BuildingID = bID
+			if building, ok := buildingByID[*bID]; ok {
+				rack.SiteID = building.SiteID
+			}
+		} else if building, ok := buildingBySiteName[row[fieldSite]+"\x00"+row[fieldBuilding]]; ok {
 			if building.ID > 0 {
 				rack.BuildingID = &building.ID
 			}
@@ -3500,6 +3605,16 @@ func desiredBuildingsBySiteName(rows []map[string]string, buildings []buildingmo
 	for _, building := range desiredBuildingList(rows, buildings) {
 		if building.SiteLabel != "" {
 			out[building.SiteLabel+"\x00"+building.Name] = building
+		}
+	}
+	return out
+}
+
+func desiredBuildingsByID(rows []map[string]string, buildings []buildingmodels.Building) map[int64]buildingmodels.Building {
+	out := map[int64]buildingmodels.Building{}
+	for _, building := range desiredBuildingList(rows, buildings) {
+		if building.ID > 0 {
+			out[building.ID] = building
 		}
 	}
 	return out

--- a/server/internal/domain/sitemap/service.go
+++ b/server/internal/domain/sitemap/service.go
@@ -334,7 +334,7 @@ func (s *Service) ImportSiteMapCsv(ctx context.Context, orgID int64, req *pb.Imp
 			Warnings:       plan.warnings,
 		}, nil
 	}
-	if hasOmissions(plan.omissions) && req.GetOmissionMode() == pb.OmissionMode_OMISSION_MODE_UNSPECIFIED {
+	if hasOmissions(plan.omissions) && req.GetOmissionMode() != pb.OmissionMode_OMISSION_MODE_REMOVE_OMITTED {
 		return &pb.ImportSiteMapCsvResponse{
 			OmissionChoiceRequired: true,
 			OmissionCounts:         plan.omissions,
@@ -1190,7 +1190,7 @@ func buildPlan(parsed *parsedCSV, snap *snapshot, mode pb.OmissionMode) importPl
 	plan.errors = append(plan.errors, validateBuildingExistingRacksFitLayout(resolved)...)
 	plan.errors = append(plan.errors, validateSlotCollisions(resolved.miners)...)
 	plan.errors = append(plan.errors, validateSlotConflictsWithExisting(resolved)...)
-	if len(plan.errors) > 0 || (mode == pb.OmissionMode_OMISSION_MODE_UNSPECIFIED && hasOmissions(plan.omissions)) {
+	if len(plan.errors) > 0 || (mode != pb.OmissionMode_OMISSION_MODE_REMOVE_OMITTED && hasOmissions(plan.omissions)) {
 		return plan
 	}
 

--- a/server/internal/domain/sitemap/service.go
+++ b/server/internal/domain/sitemap/service.go
@@ -1185,10 +1185,10 @@ func buildPlan(parsed *parsedCSV, snap *snapshot, mode pb.OmissionMode) importPl
 	plan.errors = append(plan.errors, validateRackSlotBounds(resolved.miners, resolved.topology)...)
 	plan.errors = append(plan.errors, validateExistingSlotsFitRackDimensions(resolved)...)
 	plan.errors = append(plan.errors, validateRackCapacity(resolved)...)
-	plan.errors = append(plan.errors, validateBuildingRackCapacity(parsed.sections["RACK"], parsed.sections["BUILDING"], targetSnap)...)
-	plan.errors = append(plan.errors, validateBuildingExistingRacksFitLayout(parsed.sections["RACK"], parsed.sections["BUILDING"], targetSnap, mode)...)
+	plan.errors = append(plan.errors, validateBuildingRackCapacity(resolved)...)
+	plan.errors = append(plan.errors, validateBuildingExistingRacksFitLayout(resolved)...)
 	plan.errors = append(plan.errors, validateSlotCollisions(resolved.miners)...)
-	plan.errors = append(plan.errors, validateSlotConflictsWithExisting(parsed.sections["MINER"], parsed.sections["RACK"], snap, mode)...)
+	plan.errors = append(plan.errors, validateSlotConflictsWithExisting(resolved)...)
 	if len(plan.errors) > 0 || (mode == pb.OmissionMode_OMISSION_MODE_UNSPECIFIED && hasOmissions(plan.omissions)) {
 		return plan
 	}
@@ -3160,27 +3160,6 @@ func validateMinerRenamePermission(rows []map[string]string, snap *snapshot) []*
 	return errs
 }
 
-func validateBuildingRackCapacity(rackRows, buildingRows []map[string]string, snap *snapshot) []*pb.ImportValidationError {
-	buildings := desiredBuildingCapacityMap(buildingRows, snap.buildings)
-	counts := map[string]int32{}
-	for _, rack := range desiredRackMap(rackRows, snap.racks, buildingRows, snap.buildings) {
-		if key, ok := rackBuildingCapacityKey(rack); ok {
-			counts[key]++
-		}
-	}
-	var errs []*pb.ImportValidationError
-	for key, count := range counts {
-		building, ok := buildings[key]
-		if !ok {
-			continue
-		}
-		if buildingmodels.RackCapacityExceeded(building.Aisles, building.RacksPerAisle, int64(count)) {
-			errs = append(errs, csvErr(0, "RACK", fmt.Sprintf("building %q has %d assigned racks but capacity is %d", building.Name, count, buildingmodels.GridCapacity(building.Aisles, building.RacksPerAisle))))
-		}
-	}
-	return errs
-}
-
 func desiredBuildingCapacityMap(rows []map[string]string, buildings []buildingmodels.Building) map[string]buildingmodels.Building {
 	out := map[string]buildingmodels.Building{}
 	buildingsByID := map[int64]buildingmodels.Building{}
@@ -3254,107 +3233,6 @@ func buildingCapacityKey(building buildingmodels.Building) string {
 		return "id:" + strconv.FormatInt(building.ID, 10)
 	}
 	return "name:" + building.SiteLabel + "\x00" + building.Name
-}
-
-func validateBuildingExistingRacksFitLayout(rackRows, buildingRows []map[string]string, snap *snapshot, mode pb.OmissionMode) []*pb.ImportValidationError {
-	buildings := desiredBuildingMap(buildingRows, snap.buildings)
-	buildingsByID := desiredBuildingLayoutIDMap(buildingRows, snap.buildings)
-	desiredRacks := desiredRackMap(rackRows, snap.racks, buildingRows, snap.buildings)
-	desiredRacksByID := map[int64]rackSnapshot{}
-	for _, rack := range desiredRacks {
-		if rack.ID > 0 {
-			desiredRacksByID[rack.ID] = rack
-		}
-	}
-	presentRacks := rowSet(rackRows, "rack")
-	var errs []*pb.ImportValidationError
-	for _, rack := range snap.racks {
-		if !presentRacks[rack.Label] && mode == pb.OmissionMode_OMISSION_MODE_REMOVE_OMITTED {
-			continue
-		}
-		desiredRack, ok := desiredRacksByID[rack.ID]
-		if !ok {
-			desiredRack, ok = desiredRacks[rack.Label]
-		}
-		if !ok {
-			desiredRack = rack
-		}
-		if desiredRack.Building == "" || desiredRack.AisleIndex == "" || desiredRack.PositionInAisle == "" {
-			continue
-		}
-		var building buildingmodels.Building
-		if desiredRack.BuildingID != nil {
-			building, ok = buildingsByID[*desiredRack.BuildingID]
-		} else {
-			building, ok = buildings[desiredRack.Site+"\x00"+desiredRack.Building]
-		}
-		if !ok {
-			continue
-		}
-		aisle, err := parseInt32Value(desiredRack.AisleIndex, "aisle_index")
-		if err != nil {
-			continue
-		}
-		position, err := parseInt32Value(desiredRack.PositionInAisle, "position_in_aisle")
-		if err != nil {
-			continue
-		}
-		if aisle >= building.Aisles || position >= building.RacksPerAisle {
-			errs = append(errs, csvErr(0, "RACK", fmt.Sprintf("rack %q grid position %d,%d does not fit building %q layout %dx%d", desiredRack.Label, aisle, position, building.Name, building.Aisles, building.RacksPerAisle)))
-		}
-	}
-	return errs
-}
-
-func validateSlotConflictsWithExisting(rows, rackRows []map[string]string, snap *snapshot, mode pb.OmissionMode) []*pb.ImportValidationError {
-	desiredRackLabels := desiredRackLabelsByID(rackRows)
-	desiredRows := map[string]map[string]string{}
-	movingMiners := map[string]bool{}
-	for _, row := range rows {
-		desiredRows[row["device_identifier"]] = row
-	}
-	for _, miner := range snap.miners {
-		row, ok := desiredRows[miner.DeviceIdentifier]
-		if !ok {
-			continue
-		}
-		currentRack := desiredRackLabel(miner, desiredRackLabels)
-		currentKey, _ := normalizedRackSlotKey(currentRack, miner.RackRow, miner.RackCol)
-		desiredKey, _ := normalizedRackSlotKey(row[fieldRack], row["rack_row"], row["rack_col"])
-		if row[fieldRack] != currentRack || desiredKey != currentKey {
-			movingMiners[miner.DeviceIdentifier] = true
-		}
-	}
-
-	currentOccupants := map[string]minerSnapshot{}
-	for _, miner := range snap.miners {
-		key, ok := normalizedRackSlotKey(desiredRackLabel(miner, desiredRackLabels), miner.RackRow, miner.RackCol)
-		if !ok {
-			continue
-		}
-		currentOccupants[key] = miner
-	}
-	for _, miner := range snap.hiddenRackMembers {
-		key, ok := normalizedRackSlotKey(desiredRackLabel(miner, desiredRackLabels), miner.RackRow, miner.RackCol)
-		if !ok {
-			continue
-		}
-		currentOccupants[key] = miner
-	}
-
-	var errs []*pb.ImportValidationError
-	for i, row := range rows {
-		key, ok := normalizedRackSlotKey(row[fieldRack], row["rack_row"], row["rack_col"])
-		if !ok {
-			continue
-		}
-		occupant, ok := currentOccupants[key]
-		if !ok || occupant.DeviceIdentifier == row["device_identifier"] || movingMiners[occupant.DeviceIdentifier] {
-			continue
-		}
-		errs = append(errs, csvErr(rowNumber(row, i+1), "MINER", fmt.Sprintf("rack slot already occupied by miner %s", occupant.DeviceIdentifier)))
-	}
-	return errs
 }
 
 func desiredRackLabelsByID(rows []map[string]string) map[int64]string {

--- a/server/internal/domain/sitemap/service.go
+++ b/server/internal/domain/sitemap/service.go
@@ -3134,64 +3134,6 @@ func validateFieldLength(rows []map[string]string, section, field string, maxRun
 	return errs
 }
 
-func desiredBuildingCapacityMap(rows []map[string]string, buildings []buildingmodels.Building) map[string]buildingmodels.Building {
-	out := map[string]buildingmodels.Building{}
-	buildingsByID := map[int64]buildingmodels.Building{}
-	buildingsByKey := map[string]buildingmodels.Building{}
-	for _, building := range buildings {
-		buildingsByID[building.ID] = building
-		buildingsByKey[building.SiteLabel+"\x00"+building.Name] = building
-		out[buildingCapacityKey(building)] = building
-	}
-	for _, row := range rows {
-		building := buildingsByKey[row[fieldSite]+"\x00"+buildingSectionName(row)]
-		if id, ok := rowID(row); ok {
-			if existing, ok := buildingsByID[id]; ok {
-				building = existing
-			} else {
-				building.ID = id
-			}
-		}
-		building.SiteLabel = row[fieldSite]
-		building.Name = buildingSectionName(row)
-		if aisles, err := parseInt32Value(row["aisles"], "aisles"); err == nil {
-			building.Aisles = aisles
-		}
-		if racksPerAisle, err := parseInt32Value(row["racks_per_aisle"], "racks_per_aisle"); err == nil {
-			building.RacksPerAisle = racksPerAisle
-		}
-		out[buildingCapacityKey(building)] = building
-	}
-	return out
-}
-
-func desiredBuildingLayoutIDMap(rows []map[string]string, buildings []buildingmodels.Building) map[int64]buildingmodels.Building {
-	out := map[int64]buildingmodels.Building{}
-	for _, building := range buildings {
-		if building.ID > 0 {
-			out[building.ID] = building
-		}
-	}
-	for _, row := range rows {
-		id, ok := rowID(row)
-		if !ok {
-			continue
-		}
-		building := out[id]
-		building.ID = id
-		building.SiteLabel = row[fieldSite]
-		building.Name = buildingSectionName(row)
-		if aisles, err := parseInt32Value(row["aisles"], "aisles"); err == nil {
-			building.Aisles = aisles
-		}
-		if racksPerAisle, err := parseInt32Value(row["racks_per_aisle"], "racks_per_aisle"); err == nil {
-			building.RacksPerAisle = racksPerAisle
-		}
-		out[id] = building
-	}
-	return out
-}
-
 func rackBuildingCapacityKey(rack rackSnapshot) (string, bool) {
 	if rack.BuildingID != nil {
 		return "id:" + strconv.FormatInt(*rack.BuildingID, 10), true
@@ -3442,36 +3384,6 @@ func minerMap(miners []minerSnapshot) map[string]minerSnapshot {
 	return out
 }
 
-func desiredBuildingMap(rows []map[string]string, buildings []buildingmodels.Building) map[string]buildingmodels.Building {
-	out := map[string]buildingmodels.Building{}
-	for _, building := range buildings {
-		out[building.SiteLabel+"\x00"+building.Name] = building
-	}
-	for _, row := range rows {
-		key := row[fieldSite] + "\x00" + buildingSectionName(row)
-		building := out[key]
-		if id, ok := rowID(row); ok {
-			for _, existing := range buildings {
-				if existing.ID == id {
-					building = existing
-					delete(out, existing.SiteLabel+"\x00"+existing.Name)
-					break
-				}
-			}
-		}
-		building.SiteLabel = row[fieldSite]
-		building.Name = buildingSectionName(row)
-		if aisles, err := parseInt32Value(row["aisles"], "aisles"); err == nil {
-			building.Aisles = aisles
-		}
-		if racksPerAisle, err := parseInt32Value(row["racks_per_aisle"], "racks_per_aisle"); err == nil {
-			building.RacksPerAisle = racksPerAisle
-		}
-		out[building.SiteLabel+"\x00"+building.Name] = building
-	}
-	return out
-}
-
 func desiredBuildingList(rows []map[string]string, buildings []buildingmodels.Building) []buildingmodels.Building {
 	out := append([]buildingmodels.Building(nil), buildings...)
 	byID := map[int64]int{}
@@ -3526,13 +3438,11 @@ func applyDesiredBuildingRow(row map[string]string, building *buildingmodels.Bui
 	}
 }
 
-func desiredRackMap(rows []map[string]string, racks []rackSnapshot, buildingRows []map[string]string, buildings []buildingmodels.Building) map[string]rackSnapshot {
+func desiredRackMap(rows []map[string]string, racks []rackSnapshot, buildingsByKey map[string]buildingmodels.Building, buildingsByID map[int64]buildingmodels.Building) map[string]rackSnapshot {
 	out := map[string]rackSnapshot{}
 	for _, rack := range racks {
 		out[rack.Label] = rack
 	}
-	buildingBySiteName := desiredBuildingsBySiteName(buildingRows, buildings)
-	buildingByID := desiredBuildingsByID(buildingRows, buildings)
 	for _, row := range rows {
 		rack := out[rackSectionLabel(row)]
 		if id, ok := rowID(row); ok {
@@ -3553,10 +3463,10 @@ func desiredRackMap(rows []map[string]string, racks []rackSnapshot, buildingRows
 		rack.BuildingID = nil
 		if bID := refID(row, refBuildingIDCell); bID != nil {
 			rack.BuildingID = bID
-			if building, ok := buildingByID[*bID]; ok {
+			if building, ok := buildingsByID[*bID]; ok {
 				rack.SiteID = building.SiteID
 			}
-		} else if building, ok := buildingBySiteName[row[fieldSite]+"\x00"+row[fieldBuilding]]; ok {
+		} else if building, ok := buildingsByKey[row[fieldSite]+"\x00"+row[fieldBuilding]]; ok {
 			if building.ID > 0 {
 				rack.BuildingID = &building.ID
 			}
@@ -3573,26 +3483,6 @@ func desiredRackMap(rows []map[string]string, racks []rackSnapshot, buildingRows
 		rack.AisleIndex = row["aisle_index"]
 		rack.PositionInAisle = row["position_in_aisle"]
 		out[rack.Label] = rack
-	}
-	return out
-}
-
-func desiredBuildingsBySiteName(rows []map[string]string, buildings []buildingmodels.Building) map[string]buildingmodels.Building {
-	out := map[string]buildingmodels.Building{}
-	for _, building := range desiredBuildingList(rows, buildings) {
-		if building.SiteLabel != "" {
-			out[building.SiteLabel+"\x00"+building.Name] = building
-		}
-	}
-	return out
-}
-
-func desiredBuildingsByID(rows []map[string]string, buildings []buildingmodels.Building) map[int64]buildingmodels.Building {
-	out := map[int64]buildingmodels.Building{}
-	for _, building := range desiredBuildingList(rows, buildings) {
-		if building.ID > 0 {
-			out[building.ID] = building
-		}
 	}
 	return out
 }

--- a/server/internal/domain/sitemap/service_test.go
+++ b/server/internal/domain/sitemap/service_test.go
@@ -1810,55 +1810,61 @@ func TestValidateSlotConflictsWithExistingNormalizesCoordinates(t *testing.T) {
 	}
 }
 
-func TestCountBuildingUpdatesMatchesExistingRowsByID(t *testing.T) {
-	rows := []map[string]string{{
+func TestClassifyBuildingUpdateMatchesExistingRowsByID(t *testing.T) {
+	parsed := &parsedCSV{sections: map[string][]map[string]string{"BUILDING": {{
 		fieldName:         "Building A",
 		fieldID:           "20",
 		fieldSite:         "Site A",
 		"aisles":          "2",
 		"racks_per_aisle": "2",
-	}}
+	}}}}
 	siteID := int64(10)
-	buildings := []buildingmodels.Building{{ID: 20, SiteID: &siteID, SiteLabel: "Site A", Name: "Building A", Aisles: 1, RacksPerAisle: 2}}
+	snap := &snapshot{buildings: []buildingmodels.Building{{ID: 20, SiteID: &siteID, SiteLabel: "Site A", Name: "Building A", Aisles: 1, RacksPerAisle: 2}}}
 
-	if got := countBuildingUpdates(rows, buildings); got != 1 {
-		t.Fatalf("countBuildingUpdates = %d, want existing row update counted by id", got)
+	p := resolvePlan(parsed, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
+	if got := countBuildingUpdateNodes(p.buildings); got != 1 {
+		t.Fatalf("countBuildingUpdateNodes = %d, want existing row update counted by id", got)
 	}
 }
 
-func TestCountBuildingUpdatesIgnoresBlankIDCreateRows(t *testing.T) {
+func TestClassifyBuildingUpdateIgnoresBlankIDCreateRows(t *testing.T) {
 	// A blank-id row whose canonical (site, name) matches no existing building is a
 	// create, not an update.
-	rows := []map[string]string{{
+	parsed := &parsedCSV{sections: map[string][]map[string]string{"BUILDING": {{
 		fieldName:         "Building A",
 		fieldSite:         "Site B",
 		"aisles":          "2",
 		"racks_per_aisle": "2",
-	}}
+	}}}}
 	siteID := int64(10)
-	buildings := []buildingmodels.Building{{ID: 20, SiteID: &siteID, SiteLabel: "Site A", Name: "Building A", Aisles: 1, RacksPerAisle: 2}}
+	snap := &snapshot{buildings: []buildingmodels.Building{{ID: 20, SiteID: &siteID, SiteLabel: "Site A", Name: "Building A", Aisles: 1, RacksPerAisle: 2}}}
 
-	if got := countBuildingUpdates(rows, buildings); got != 0 {
-		t.Fatalf("countBuildingUpdates = %d, want blank-id create row to not count as update", got)
+	p := resolvePlan(parsed, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
+	if got := countBuildingUpdateNodes(p.buildings); got != 0 {
+		t.Fatalf("countBuildingUpdateNodes = %d, want blank-id create row to not count as update", got)
+	}
+	if p.buildings[0].action != actionCreate {
+		t.Fatalf("action = %v, want create", p.buildings[0].action)
 	}
 }
 
-func TestCountRackUpdatesMatchesExistingRowsByID(t *testing.T) {
-	rows := []map[string]string{{
+func TestClassifyRackUpdateMatchesExistingRowsByID(t *testing.T) {
+	parsed := &parsedCSV{sections: map[string][]map[string]string{"RACK": {{
 		fieldLabel:    "Rack A",
 		fieldID:       "20",
 		"rows":        "4",
 		"columns":     "8",
 		"order_index": "BOTTOM_LEFT",
-	}}
-	racks := []rackSnapshot{{ID: 20, Label: "Rack A", Rows: 4, Columns: 6, OrderIndex: "BOTTOM_LEFT"}}
+	}}}}
+	snap := &snapshot{racks: []rackSnapshot{{ID: 20, Label: "Rack A", Rows: 4, Columns: 6, OrderIndex: "BOTTOM_LEFT"}}}
 
-	if got := countRackUpdates(rows, racks); got != 1 {
-		t.Fatalf("countRackUpdates = %d, want existing row update counted by id", got)
+	p := resolvePlan(parsed, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
+	if got := countRackUpdateNodes(p.racks); got != 1 {
+		t.Fatalf("countRackUpdateNodes = %d, want existing row update counted by id", got)
 	}
 }
 
-func TestCountRackUpdatesTreatsCanonicalRowAsNoOp(t *testing.T) {
+func TestClassifyRackUpdateTreatsCanonicalRowAsNoOp(t *testing.T) {
 	siteID := int64(1)
 	buildingID := int64(10)
 	racks := []rackSnapshot{{
@@ -1879,8 +1885,10 @@ func TestCountRackUpdatesTreatsCanonicalRowAsNoOp(t *testing.T) {
 	// no-op against change detection.
 	canonical := rackComparableRow(racks[0])
 
-	if got := countRackUpdates([]map[string]string{canonical}, racks); got != 0 {
-		t.Fatalf("countRackUpdates = %d, want canonical rack row to be a no-op", got)
+	parsed := &parsedCSV{sections: map[string][]map[string]string{"RACK": {canonical}}}
+	p := resolvePlan(parsed, &snapshot{racks: racks}, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
+	if got := countRackUpdateNodes(p.racks); got != 0 {
+		t.Fatalf("countRackUpdateNodes = %d, want canonical rack row to be a no-op", got)
 	}
 }
 

--- a/server/internal/domain/sitemap/service_test.go
+++ b/server/internal/domain/sitemap/service_test.go
@@ -911,8 +911,43 @@ func TestCommitTokenChangesWithSnapshotDrift(t *testing.T) {
 	after := testSnapshotMatchingValidCSV()
 	after.miners[0].RackCol = "1"
 
-	if commitToken(parsed, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED, plan, before) == commitToken(parsed, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED, plan, after) {
+	if commitToken(pb.OmissionMode_OMISSION_MODE_UNSPECIFIED, plan, before) == commitToken(pb.OmissionMode_OMISSION_MODE_UNSPECIFIED, plan, after) {
 		t.Fatal("commit token must change when live site-map snapshot changes")
+	}
+}
+
+// TestCommitTokenChangesWithPlanEdit locks in that the token is derived from the
+// resolved plan: editing the CSV so the plan resolves a different placement must
+// change the token even when the live snapshot is identical.
+func TestCommitTokenChangesWithPlanEdit(t *testing.T) {
+	snap := testSnapshotMatchingValidCSV()
+
+	base, errs := parseSiteMapCSV([]byte(validCSV()))
+	if len(errs) != 0 {
+		t.Fatalf("parse errors = %v", errs)
+	}
+	planBase := buildPlan(base, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
+	if len(planBase.errors) != 0 {
+		t.Fatalf("base plan errors = %v", planBase.errors)
+	}
+
+	editedCSV := strings.Replace(
+		validCSV(),
+		"miner-1,SN1,Miner 1,10.0.0.5,aa:bb:cc:dd:ee:ff,,,NAME:Rack A,0,0",
+		"miner-1,SN1,Miner 1,10.0.0.5,aa:bb:cc:dd:ee:ff,,,NAME:Rack A,0,1",
+		1,
+	)
+	edited, errs := parseSiteMapCSV([]byte(editedCSV))
+	if len(errs) != 0 {
+		t.Fatalf("edited parse errors = %v", errs)
+	}
+	planEdited := buildPlan(edited, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
+	if len(planEdited.errors) != 0 {
+		t.Fatalf("edited plan errors = %v", planEdited.errors)
+	}
+
+	if commitToken(pb.OmissionMode_OMISSION_MODE_UNSPECIFIED, planBase, snap) == commitToken(pb.OmissionMode_OMISSION_MODE_UNSPECIFIED, planEdited, snap) {
+		t.Fatal("commit token must change when the resolved plan changes")
 	}
 }
 
@@ -1126,16 +1161,16 @@ func TestBuildPlanTreatsEscapedExportValuesAsNoOp(t *testing.T) {
 	}
 }
 
-func TestDesiredRackZoneClearsWhenRackLeavesBuildingScope(t *testing.T) {
+func TestDesiredRackZoneForNodeClearsWhenRackLeavesBuildingScope(t *testing.T) {
 	current := rackSnapshot{Site: "Site A", Building: "Building A", Zone: "Old Zone"}
 
-	if got := desiredRackZone(map[string]string{"site": "Site A", "building": "Building B", "zone": "Old Zone"}, current); got != "" {
+	if got := desiredRackZoneForNode(&resolvedRack{siteRef: "Site A", buildingRef: "Building B", zone: "Old Zone"}, current); got != "" {
 		t.Fatalf("zone crossing building = %q, want cleared", got)
 	}
-	if got := desiredRackZone(map[string]string{"site": "", "building": "", "zone": "Old Zone"}, current); got != "" {
+	if got := desiredRackZoneForNode(&resolvedRack{siteRef: "", buildingRef: "", zone: "Old Zone"}, current); got != "" {
 		t.Fatalf("zone leaving building = %q, want cleared", got)
 	}
-	if got := desiredRackZone(map[string]string{"site": "Site A", "building": "Building A", "zone": "New Zone"}, current); got != "New Zone" {
+	if got := desiredRackZoneForNode(&resolvedRack{siteRef: "Site A", buildingRef: "Building A", zone: "New Zone"}, current); got != "New Zone" {
 		t.Fatalf("zone staying in building = %q, want New Zone", got)
 	}
 }

--- a/server/internal/domain/sitemap/service_test.go
+++ b/server/internal/domain/sitemap/service_test.go
@@ -48,8 +48,7 @@ func TestBuildSiteMapExportZipIncludesCSVAndAgentGuide(t *testing.T) {
 	for _, want := range []string{
 		"Edit proto-fleet-site-map/site-map.csv",
 		"If rack is set, the rack determines the miner's building and site; leave building and site blank.",
-		"Leave omitted rows in place keeps missing rows unchanged.",
-		"Remove omitted rows soft-deletes omitted sites, buildings, and racks, and unassigns omitted miners.",
+		"Omitted rows are removed on import: omitted sites, buildings, and racks are soft-deleted and omitted miners are unassigned.",
 	} {
 		if !strings.Contains(guideText, want) {
 			t.Fatalf("%s missing %q: %q", siteMapExportGuideTXTPath, want, guideText)

--- a/server/internal/domain/sitemap/service_test.go
+++ b/server/internal/domain/sitemap/service_test.go
@@ -2223,7 +2223,7 @@ func TestValidateReadOnlyMinerFieldsIncludesIP(t *testing.T) {
 		MACAddress:       "aa:bb:cc:dd:ee:ff",
 	}}}
 
-	errs := validateReadOnlyMinerFields(rows, snap)
+	errs := validateReadOnlyMinerFields(resolveMiners(rows, minerMap(snap.miners)))
 	if len(errs) != 1 || errs[0].GetMessage() != "ip_address is read-only for existing miner miner-1" {
 		t.Fatalf("errors = %+v, want ip_address read-only error", errs)
 	}
@@ -2246,7 +2246,7 @@ func TestValidateReadOnlyMinerFieldsAllowsName(t *testing.T) {
 		MACAddress:       "aa:bb:cc:dd:ee:ff",
 	}}}
 
-	errs := validateReadOnlyMinerFields(rows, snap)
+	errs := validateReadOnlyMinerFields(resolveMiners(rows, minerMap(snap.miners)))
 	if len(errs) != 0 {
 		t.Fatalf("errors = %+v, want name changes allowed", errs)
 	}

--- a/server/internal/domain/sitemap/service_test.go
+++ b/server/internal/domain/sitemap/service_test.go
@@ -1230,15 +1230,22 @@ func TestExportedSectionMarkerShapedSiteRoundTrips(t *testing.T) {
 }
 
 func TestBuildPlanTreatsEscapedExportValuesAsNoOp(t *testing.T) {
+	siteID := int64(1)
+	buildingID := int64(2)
 	snap := &snapshot{
-		sites: []sitemodels.Site{{Name: "-Site"}},
+		sites: []sitemodels.Site{{ID: siteID, Name: "-Site"}},
 		buildings: []buildingmodels.Building{{
+			ID:            buildingID,
+			SiteID:        &siteID,
 			SiteLabel:     "-Site",
 			Name:          "+Building",
 			Aisles:        2,
 			RacksPerAisle: 2,
 		}},
 		racks: []rackSnapshot{{
+			ID:              3,
+			SiteID:          &siteID,
+			BuildingID:      &buildingID,
 			Site:            "-Site",
 			Building:        "+Building",
 			Label:           "-Rack",
@@ -1958,10 +1965,11 @@ func TestValidateSlotConflictsWithExistingNormalizesCoordinates(t *testing.T) {
 	}
 }
 
-func TestCountBuildingUpdatesMatchesBlankIDExistingRowsByName(t *testing.T) {
+func TestCountBuildingUpdatesMatchesExistingRowsByID(t *testing.T) {
 	rows := []map[string]string{{
 		fieldName:         "Building A",
-		fieldSite:         "Site A",
+		fieldID:           "20",
+		fieldSiteID:       "10",
 		"aisles":          "2",
 		"racks_per_aisle": "2",
 	}}
@@ -1969,28 +1977,45 @@ func TestCountBuildingUpdatesMatchesBlankIDExistingRowsByName(t *testing.T) {
 	buildings := []buildingmodels.Building{{ID: 20, SiteID: &siteID, SiteLabel: "Site A", Name: "Building A", Aisles: 1, RacksPerAisle: 2}}
 
 	if got := countBuildingUpdates(rows, buildings); got != 1 {
-		t.Fatalf("countBuildingUpdates = %d, want blank-ID existing row update counted", got)
+		t.Fatalf("countBuildingUpdates = %d, want existing row update counted by id", got)
 	}
 }
 
-func TestCountRackUpdatesMatchesBlankIDExistingRowsByLabel(t *testing.T) {
+func TestCountBuildingUpdatesIgnoresBlankIDCreateRows(t *testing.T) {
+	// Under id-authoritative resolution a blank-id row is a create, never a
+	// name-match against an existing building, so it is not an update.
+	rows := []map[string]string{{
+		fieldName:         "Building A",
+		fieldSiteID:       "10",
+		"aisles":          "2",
+		"racks_per_aisle": "2",
+	}}
+	siteID := int64(10)
+	buildings := []buildingmodels.Building{{ID: 20, SiteID: &siteID, SiteLabel: "Site A", Name: "Building A", Aisles: 1, RacksPerAisle: 2}}
+
+	if got := countBuildingUpdates(rows, buildings); got != 0 {
+		t.Fatalf("countBuildingUpdates = %d, want blank-id create row to not count as update", got)
+	}
+}
+
+func TestCountRackUpdatesMatchesExistingRowsByID(t *testing.T) {
 	rows := []map[string]string{{
 		fieldLabel:    "Rack A",
+		fieldID:       "20",
 		"rows":        "4",
 		"columns":     "8",
 		"order_index": "BOTTOM_LEFT",
 	}}
 	racks := []rackSnapshot{{ID: 20, Label: "Rack A", Rows: 4, Columns: 6, OrderIndex: "BOTTOM_LEFT"}}
 
-	if got := countRackUpdates(rows, racks, nil); got != 1 {
-		t.Fatalf("countRackUpdates = %d, want blank-ID existing row update counted", got)
+	if got := countRackUpdates(rows, racks); got != 1 {
+		t.Fatalf("countRackUpdates = %d, want existing row update counted by id", got)
 	}
 }
 
-func TestCountRackUpdatesIgnoresExportInferredPlacementIDs(t *testing.T) {
+func TestCountRackUpdatesTreatsCanonicalRowAsNoOp(t *testing.T) {
 	siteID := int64(1)
 	buildingID := int64(10)
-	buildings := []buildingmodels.Building{{ID: buildingID, SiteID: &siteID, SiteLabel: "Site A", Name: "Building A", Aisles: 1, RacksPerAisle: 2}}
 	racks := []rackSnapshot{{
 		ID:              20,
 		SiteID:          &siteID,
@@ -2005,88 +2030,74 @@ func TestCountRackUpdatesIgnoresExportInferredPlacementIDs(t *testing.T) {
 		AisleIndex:      "0",
 		PositionInAisle: "1",
 	}}
-	exported := rowMap(rackHeaders, rackExportRows(racks, buildings)[0])
-	exported[fieldSite] = "Site A"
+	// The canonical row is what an exported rack row normalizes to; it must be a
+	// no-op against change detection.
+	canonical := rackComparableRow(racks[0])
 
-	if got := countRackUpdates([]map[string]string{exported}, racks, buildings); got != 0 {
-		t.Fatalf("countRackUpdates = %d, want exported rack row to be a no-op", got)
+	if got := countRackUpdates([]map[string]string{canonical}, racks); got != 0 {
+		t.Fatalf("countRackUpdates = %d, want canonical rack row to be a no-op", got)
 	}
 }
 
-func TestMinerRowsBlankSiteAndBuildingForRackedMiners(t *testing.T) {
+func TestMinerRowsUseRackIDAndBlankNamesForRackedMiners(t *testing.T) {
+	rackID := int64(30)
+	siteID := int64(10)
+	buildingID := int64(20)
 	rows := minerRows([]minerSnapshot{{
 		DeviceIdentifier: "miner-1",
 		SerialNumber:     "SN1",
 		Name:             "Miner 1",
 		IPAddress:        "10.0.0.5",
 		MACAddress:       "aa:bb:cc:dd:ee:ff",
+		SiteID:           &siteID,
 		Site:             "Site A",
+		BuildingID:       &buildingID,
 		Building:         "Building A",
+		RackID:           &rackID,
 		Rack:             "Rack A",
 		RackRow:          "0",
 		RackCol:          "0",
-	}}, nil)
+	}})
 
-	if got := rows[0][6]; got != "" {
-		t.Fatalf("exported miner site = %q, want blank when rack is set", got)
+	if got := rows[0][9]; got != "30" {
+		t.Fatalf("exported miner rack_id = %q, want 30", got)
 	}
-	if got := rows[0][8]; got != "" {
-		t.Fatalf("exported miner building = %q, want blank when rack is set", got)
+	for _, idx := range []int{5, 6, 7, 8, 10} {
+		if got := rows[0][idx]; got != "" {
+			t.Fatalf("exported miner col %d = %q, want blank when rack_id is set", idx, got)
+		}
 	}
 }
 
-func TestMinerRowsUseRackMembershipDerivedRackForExport(t *testing.T) {
+func TestMinerRowsUseBuildingIDForDirectBuildingAssignment(t *testing.T) {
+	siteID := int64(10)
+	buildingID := int64(20)
 	rows := minerRows([]minerSnapshot{{
 		DeviceIdentifier: "miner-1",
-		SerialNumber:     "SN1",
-		Name:             "Miner 1",
-		IPAddress:        "10.0.0.5",
-		MACAddress:       "aa:bb:cc:dd:ee:ff",
+		SiteID:           &siteID,
 		Site:             "Site A",
+		BuildingID:       &buildingID,
 		Building:         "Building A",
-		Rack:             "Rack A",
-		RackRow:          "0",
-		RackCol:          "0",
-	}}, nil)
+	}})
 
-	if got := rows[0][10]; got != "Rack A" {
-		t.Fatalf("exported miner rack = %q, want Rack A", got)
+	if got := rows[0][7]; got != "20" {
+		t.Fatalf("exported miner building_id = %q, want 20", got)
+	}
+	if got := rows[0][5]; got != "" {
+		t.Fatalf("exported miner site_id = %q, want blank when building_id is set", got)
 	}
 }
 
-func TestMinerRowsBlankSiteForDirectBuildingAssignment(t *testing.T) {
+func TestMinerRowsUseSiteIDForDirectSiteAssignment(t *testing.T) {
+	siteID := int64(10)
 	rows := minerRows([]minerSnapshot{{
 		DeviceIdentifier: "miner-1",
+		SiteID:           &siteID,
 		Site:             "Site A",
-		Building:         "Building A",
-	}}, []buildingmodels.Building{{SiteLabel: "Site A", Name: "Building A"}})
+	}})
 
-	if got := rows[0][6]; got != "" {
-		t.Fatalf("exported miner site = %q, want blank when building is set", got)
-	}
-	if got := rows[0][8]; got != "Building A" {
-		t.Fatalf("exported miner building = %q, want Building A", got)
-	}
-}
-
-func TestMinerRowsPreserveSiteForAmbiguousDirectBuildingAssignment(t *testing.T) {
-	rows := minerRows(
-		[]minerSnapshot{{
-			DeviceIdentifier: "miner-1",
-			Site:             "Site A",
-			Building:         "Building A",
-		}},
-		[]buildingmodels.Building{
-			{SiteLabel: "Site A", Name: "Building A"},
-			{SiteLabel: "Site B", Name: "Building A"},
-		},
-	)
-
-	if got := rows[0][6]; got != "Site A" {
-		t.Fatalf("exported miner site = %q, want Site A when building name is ambiguous", got)
-	}
-	if got := rows[0][8]; got != "Building A" {
-		t.Fatalf("exported miner building = %q, want Building A", got)
+	if got := rows[0][5]; got != "10" {
+		t.Fatalf("exported miner site_id = %q, want 10", got)
 	}
 }
 
@@ -2105,52 +2116,34 @@ func TestDisplayHeadersMarkReadOnlyIdentityColumns(t *testing.T) {
 	}
 }
 
-func TestRackExportRowsBlankSiteForUnambiguousBuildingAssignment(t *testing.T) {
-	rows := rackExportRows(
-		[]rackSnapshot{{Site: "Site A", Building: "Building A", Label: "Rack A"}},
-		[]buildingmodels.Building{{SiteLabel: "Site A", Name: "Building A"}},
-	)
-
-	if got := rows[0][3]; got != "Building A" {
-		t.Fatalf("exported rack building = %q, want Building A", got)
-	}
-	if got := rows[0][5]; got != "" {
-		t.Fatalf("exported rack site = %q, want blank when building is unambiguous", got)
-	}
-}
-
-func TestRackExportRowsPreserveSiteForAmbiguousBuildingAssignment(t *testing.T) {
-	rows := rackExportRows(
-		[]rackSnapshot{{Site: "Site A", Building: "Building A", Label: "Rack A"}},
-		[]buildingmodels.Building{
-			{SiteLabel: "Site A", Name: "Building A"},
-			{SiteLabel: "Site B", Name: "Building A"},
-		},
-	)
-
-	if got := rows[0][5]; got != "Site A" {
-		t.Fatalf("exported rack site = %q, want Site A when building name is ambiguous", got)
-	}
-}
-
-func TestRackExportRowsUseBuildingIDForDuplicateUnassignedBuildingNames(t *testing.T) {
+func TestRackExportRowsUseBuildingIDAndBlankNames(t *testing.T) {
+	siteID := int64(1)
 	buildingID := int64(10)
 	rows := rackExportRows(
-		[]rackSnapshot{{BuildingID: &buildingID, Building: "Building A", Label: "Rack A"}},
-		[]buildingmodels.Building{
-			{ID: 10, Name: "Building A"},
-			{ID: 11, Name: "Building A"},
-		},
+		[]rackSnapshot{{SiteID: &siteID, BuildingID: &buildingID, Site: "Site A", Building: "Building A", Label: "Rack A"}},
 	)
 
 	if got := rows[0][2]; got != "10" {
-		t.Fatalf("exported rack building_id = %q, want 10 when building name is ambiguous", got)
+		t.Fatalf("exported rack building_id = %q, want 10", got)
 	}
-	if got := rows[0][3]; got != "Building A" {
-		t.Fatalf("exported rack building = %q, want readable building name", got)
+	for _, idx := range []int{3, 4, 5} {
+		if got := rows[0][idx]; got != "" {
+			t.Fatalf("exported rack col %d = %q, want blank when building_id is set", idx, got)
+		}
 	}
-	if got := rows[0][5]; got != "" {
-		t.Fatalf("exported rack site = %q, want blank for unassigned building", got)
+}
+
+func TestRackExportRowsUseSiteIDForDirectSiteAssignment(t *testing.T) {
+	siteID := int64(1)
+	rows := rackExportRows(
+		[]rackSnapshot{{SiteID: &siteID, Site: "Site A", Label: "Rack A"}},
+	)
+
+	if got := rows[0][4]; got != "1" {
+		t.Fatalf("exported rack site_id = %q, want 1", got)
+	}
+	if got := rows[0][2]; got != "" {
+		t.Fatalf("exported rack building_id = %q, want blank for direct site assignment", got)
 	}
 }
 

--- a/server/internal/domain/sitemap/service_test.go
+++ b/server/internal/domain/sitemap/service_test.go
@@ -2482,6 +2482,124 @@ func TestValidateBuildingExistingRacksFitLayoutUsesBuildingIDForDuplicateBuildin
 	}
 }
 
+func TestBuildPlanCountsMinerMoveDisambiguatedByBuildingID(t *testing.T) {
+	buildingAID := int64(10)
+	parsed := &parsedCSV{sections: map[string][]map[string]string{
+		"SITE": nil,
+		"BUILDING": {
+			{"__row": "5", fieldID: "10", fieldName: "Building A", "aisles": "1", "racks_per_aisle": "2"},
+			{"__row": "6", fieldID: "11", fieldName: "Building A", "aisles": "1", "racks_per_aisle": "2"},
+		},
+		"RACK": nil,
+		"MINER": {
+			{"__row": "13", "device_identifier": "miner-1", "serial_number": "SN1", fieldName: "Miner 1", "ip_address": "10.0.0.5", "mac_address": "aa:bb:cc:dd:ee:ff", fieldBuilding: "11"},
+		},
+	}}
+	snap := &snapshot{
+		buildings: []buildingmodels.Building{
+			{ID: 10, Name: "Building A", Aisles: 1, RacksPerAisle: 2},
+			{ID: 11, Name: "Building A", Aisles: 1, RacksPerAisle: 2},
+		},
+		miners: []minerSnapshot{{DeviceIdentifier: "miner-1", SerialNumber: "SN1", Name: "Miner 1", IPAddress: "10.0.0.5", MACAddress: "aa:bb:cc:dd:ee:ff", BuildingID: &buildingAID, Building: "Building A"}},
+	}
+
+	plan := buildPlan(parsed, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
+	if len(plan.errors) != 0 {
+		t.Fatalf("plan errors = %+v, want building_id-disambiguated miner move accepted", plan.errors)
+	}
+	if !hasChange(plan.changes, pb.ImportOperation_IMPORT_OPERATION_MOVE, "miner", 1) {
+		t.Fatalf("changes = %+v, want miner move summary", plan.changes)
+	}
+}
+
+func TestValidateRackGridPositionsUsesBuildingIDForDuplicateBuildingNames(t *testing.T) {
+	parsed := &parsedCSV{sections: map[string][]map[string]string{
+		"BUILDING": {
+			{fieldID: "11", fieldName: "Building A", "aisles": "2", "racks_per_aisle": "1"},
+			{fieldID: "10", fieldName: "Building A", "aisles": "1", "racks_per_aisle": "1"},
+		},
+		"RACK": {
+			{fieldBuilding: "11", fieldLabel: "Rack A", "aisle_index": "1", "position_in_aisle": "0"},
+		},
+	}}
+	snap := &snapshot{buildings: []buildingmodels.Building{
+		{ID: 10, Name: "Building A", Aisles: 1, RacksPerAisle: 1},
+		{ID: 11, Name: "Building A", Aisles: 2, RacksPerAisle: 1},
+	}}
+
+	resolveReferences(parsed, snap)
+	p := resolvePlan(parsed, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
+	errs := validateRackGridPositions(p.racks, p.topology)
+	if len(errs) != 0 {
+		t.Fatalf("errors = %+v, want building_id-specific bounds", errs)
+	}
+}
+
+func TestValidateRackGridCollisionsSeparatesIDQualifiedDuplicateBuildings(t *testing.T) {
+	buildingAID := int64(10)
+	buildingBID := int64(11)
+	parsed := &parsedCSV{sections: map[string][]map[string]string{
+		"BUILDING": {
+			{fieldID: "10", fieldName: "Building A", "aisles": "1", "racks_per_aisle": "1"},
+			{fieldID: "11", fieldName: "Building A", "aisles": "1", "racks_per_aisle": "1"},
+		},
+		"RACK": {
+			{"__row": "10", fieldBuilding: "10", fieldLabel: "Rack A", "aisle_index": "0", "position_in_aisle": "0"},
+			{"__row": "11", fieldBuilding: "11", fieldLabel: "Rack B", "aisle_index": "0", "position_in_aisle": "0"},
+		},
+	}}
+	snap := &snapshot{
+		buildings: []buildingmodels.Building{
+			{ID: 10, Name: "Building A", Aisles: 1, RacksPerAisle: 1},
+			{ID: 11, Name: "Building A", Aisles: 1, RacksPerAisle: 1},
+		},
+		racks: []rackSnapshot{
+			{ID: 20, Label: "Rack A", BuildingID: &buildingAID, Building: "Building A", AisleIndex: "0", PositionInAisle: "0"},
+			{ID: 21, Label: "Rack B", BuildingID: &buildingBID, Building: "Building A", AisleIndex: "0", PositionInAisle: "0"},
+		},
+	}
+
+	resolveReferences(parsed, snap)
+	errs := validateRackGridCollisions(parsed.sections["RACK"], snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
+	if len(errs) != 0 {
+		t.Fatalf("errors = %+v, want ID-qualified duplicate buildings to have independent grids", errs)
+	}
+}
+
+func TestValidateBuildingRackCapacitySeparatesIDQualifiedDuplicateBuildings(t *testing.T) {
+	siteID := int64(5)
+	buildingAID := int64(10)
+	buildingBID := int64(11)
+	parsed := &parsedCSV{sections: map[string][]map[string]string{
+		"BUILDING": {
+			{fieldID: "10", fieldSite: "5", fieldName: "Building A", "aisles": "1", "racks_per_aisle": "1"},
+			{fieldID: "11", fieldSite: "5", fieldName: "Building A", "aisles": "1", "racks_per_aisle": "1"},
+		},
+		"RACK": {
+			{fieldBuilding: "10", fieldLabel: "Rack A"},
+			{fieldBuilding: "11", fieldLabel: "Rack B"},
+		},
+	}}
+	snap := &snapshot{
+		sites: []sitemodels.Site{{ID: 5, Name: "Site A"}},
+		buildings: []buildingmodels.Building{
+			{ID: 10, SiteID: &siteID, SiteLabel: "Site A", Name: "Building A", Aisles: 1, RacksPerAisle: 1},
+			{ID: 11, SiteID: &siteID, SiteLabel: "Site A", Name: "Building A", Aisles: 1, RacksPerAisle: 1},
+		},
+		racks: []rackSnapshot{
+			{ID: 20, Label: "Rack A", SiteID: &siteID, Site: "Site A", BuildingID: &buildingAID, Building: "Building A"},
+			{ID: 21, Label: "Rack B", SiteID: &siteID, Site: "Site A", BuildingID: &buildingBID, Building: "Building A"},
+		},
+	}
+
+	resolveReferences(parsed, snap)
+	p := resolvePlan(parsed, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
+	errs := validateBuildingRackCapacity(p)
+	if len(errs) != 0 {
+		t.Fatalf("errors = %+v, want ID-qualified duplicate buildings counted separately", errs)
+	}
+}
+
 func TestParseSiteMapCSVAcceptsSpreadsheetPaddedSectionRows(t *testing.T) {
 	csv := validCSV()
 	csv = strings.Replace(csv, "# SECTION: SITE\n", "# SECTION: SITE,,,,,,,,,,\n", 1)

--- a/server/internal/domain/sitemap/service_test.go
+++ b/server/internal/domain/sitemap/service_test.go
@@ -1931,7 +1931,7 @@ func TestValidateSlotCollisionsNormalizesCoordinates(t *testing.T) {
 		{"__row": "22", "device_identifier": "miner-2", "rack": "Rack A", "rack_row": "01", "rack_col": "1"},
 	}
 
-	errs := validateSlotCollisions(rows)
+	errs := validateSlotCollisions(resolveMiners(rows, nil))
 	if len(errs) != 1 || errs[0].GetRow() != 22 || errs[0].GetMessage() != "duplicate rack slot" {
 		t.Fatalf("errors = %+v, want normalized duplicate slot", errs)
 	}

--- a/server/internal/domain/sitemap/service_test.go
+++ b/server/internal/domain/sitemap/service_test.go
@@ -1847,7 +1847,8 @@ func TestValidateSlotConflictsWithExistingAllowsSlotSwaps(t *testing.T) {
 		{DeviceIdentifier: "miner-2", Rack: "Rack A", RackRow: "0", RackCol: "1"},
 	}}
 
-	if errs := validateSlotConflictsWithExisting(rows, nil, snap, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE); len(errs) != 0 {
+	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"MINER": rows}}, snap, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	if errs := validateSlotConflictsWithExisting(p); len(errs) != 0 {
 		t.Fatalf("slot swap should not conflict, got %+v", errs)
 	}
 }
@@ -1861,7 +1862,8 @@ func TestValidateSlotConflictsWithExistingBlocksUnchangedOccupant(t *testing.T) 
 		{DeviceIdentifier: "miner-2", Rack: "Rack A", RackRow: "0", RackCol: "1"},
 	}}
 
-	errs := validateSlotConflictsWithExisting(rows, nil, snap, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"MINER": rows}}, snap, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	errs := validateSlotConflictsWithExisting(p)
 	if len(errs) != 1 {
 		t.Fatalf("errors = %+v, want one conflict", errs)
 	}
@@ -1879,7 +1881,8 @@ func TestValidateSlotConflictsWithExistingBlocksRemoveOmittedVacatedSlot(t *test
 		{DeviceIdentifier: "miner-2", Rack: "Rack A", RackRow: "0", RackCol: "1"},
 	}}
 
-	errs := validateSlotConflictsWithExisting(rows, nil, snap, pb.OmissionMode_OMISSION_MODE_REMOVE_OMITTED)
+	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"MINER": rows}}, snap, pb.OmissionMode_OMISSION_MODE_REMOVE_OMITTED)
+	errs := validateSlotConflictsWithExisting(p)
 	if len(errs) != 1 || errs[0].GetMessage() != "rack slot already occupied by miner miner-2" {
 		t.Fatalf("errors = %+v, want omitted miner slot to remain occupied until apply clears it", errs)
 	}
@@ -1894,7 +1897,8 @@ func TestValidateSlotConflictsWithExistingBlocksHiddenOccupant(t *testing.T) {
 		hiddenRackMembers: []minerSnapshot{{DeviceIdentifier: "hidden-1", Rack: "Rack A", RackRow: "0", RackCol: "1"}},
 	}
 
-	errs := validateSlotConflictsWithExisting(rows, nil, snap, pb.OmissionMode_OMISSION_MODE_REMOVE_OMITTED)
+	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"MINER": rows}}, snap, pb.OmissionMode_OMISSION_MODE_REMOVE_OMITTED)
+	errs := validateSlotConflictsWithExisting(p)
 	if len(errs) != 1 {
 		t.Fatalf("errors = %+v, want one conflict", errs)
 	}
@@ -1916,7 +1920,8 @@ func TestValidateSlotConflictsWithExistingUsesDesiredRackLabelForHiddenOccupants
 		hiddenRackMembers: []minerSnapshot{{DeviceIdentifier: "hidden-1", RackID: &rackID, Rack: "Old Rack", RackRow: "0", RackCol: "1"}},
 	}
 
-	errs := validateSlotConflictsWithExisting(rows, rackRows, snap, pb.OmissionMode_OMISSION_MODE_REMOVE_OMITTED)
+	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"MINER": rows, "RACK": rackRows}}, snap, pb.OmissionMode_OMISSION_MODE_REMOVE_OMITTED)
+	errs := validateSlotConflictsWithExisting(p)
 	if len(errs) != 1 {
 		t.Fatalf("errors = %+v, want one conflict", errs)
 	}
@@ -1946,7 +1951,8 @@ func TestValidateSlotConflictsWithExistingNormalizesCoordinates(t *testing.T) {
 		{DeviceIdentifier: "miner-2", Rack: "Rack A", RackRow: "1", RackCol: "1"},
 	}}
 
-	errs := validateSlotConflictsWithExisting(rows, nil, snap, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"MINER": rows}}, snap, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	errs := validateSlotConflictsWithExisting(p)
 	if len(errs) != 1 || errs[0].GetRow() != 21 || errs[0].GetMessage() != "rack slot already occupied by miner miner-2" {
 		t.Fatalf("errors = %+v, want normalized existing slot conflict", errs)
 	}
@@ -2586,7 +2592,8 @@ func TestValidateBuildingRackCapacityBlocksOverfilledBuilding(t *testing.T) {
 	}
 	buildingRows := []map[string]string{{"site": "Site A", "building": "Building A", "aisles": "1", "racks_per_aisle": "1"}}
 
-	errs := validateBuildingRackCapacity(rackRows, buildingRows, &snapshot{})
+	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"RACK": rackRows, "BUILDING": buildingRows}}, &snapshot{}, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
+	errs := validateBuildingRackCapacity(p)
 	if len(errs) != 1 || errs[0].GetSection() != "RACK" {
 		t.Fatalf("errors = %+v, want building rack capacity error", errs)
 	}
@@ -2599,7 +2606,8 @@ func TestValidateBuildingRackCapacityCountsSiteLessBuildings(t *testing.T) {
 	}
 	buildingRows := []map[string]string{{"site": "", "building": "Building A", "aisles": "1", "racks_per_aisle": "1"}}
 
-	errs := validateBuildingRackCapacity(rackRows, buildingRows, &snapshot{})
+	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"RACK": rackRows, "BUILDING": buildingRows}}, &snapshot{}, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
+	errs := validateBuildingRackCapacity(p)
 	if len(errs) != 1 || errs[0].GetSection() != "RACK" {
 		t.Fatalf("errors = %+v, want site-less building rack capacity error", errs)
 	}
@@ -2627,7 +2635,8 @@ func TestValidateBuildingRackCapacitySeparatesIDQualifiedDuplicateBuildings(t *t
 		},
 	}
 
-	errs := validateBuildingRackCapacity(rackRows, buildingRows, snap)
+	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"RACK": rackRows, "BUILDING": buildingRows}}, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
+	errs := validateBuildingRackCapacity(p)
 	if len(errs) != 0 {
 		t.Fatalf("errors = %+v, want ID-qualified duplicate buildings counted separately", errs)
 	}
@@ -2651,7 +2660,8 @@ func TestValidateBuildingRackCapacityResolvesNameOnlyRackBuildingIDs(t *testing.
 		},
 	}
 
-	errs := validateBuildingRackCapacity(rackRows, buildingRows, snap)
+	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"RACK": rackRows, "BUILDING": buildingRows}}, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
+	errs := validateBuildingRackCapacity(p)
 	if len(errs) != 1 || errs[0].GetSection() != "RACK" {
 		t.Fatalf("errors = %+v, want name-only rack rows counted against building_id capacity", errs)
 	}
@@ -2675,7 +2685,8 @@ func TestValidateBuildingRackCapacityResolvesRenamedBuildingIDs(t *testing.T) {
 		},
 	}
 
-	errs := validateBuildingRackCapacity(rackRows, buildingRows, snap)
+	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"RACK": rackRows, "BUILDING": buildingRows}}, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
+	errs := validateBuildingRackCapacity(p)
 	if len(errs) != 1 || errs[0].GetSection() != "RACK" {
 		t.Fatalf("errors = %+v, want renamed building name references counted against building_id capacity", errs)
 	}
@@ -2691,7 +2702,8 @@ func TestValidateBuildingExistingRacksFitLayoutCountsSiteLessBuildings(t *testin
 		PositionInAisle: "0",
 	}}}
 
-	errs := validateBuildingExistingRacksFitLayout(nil, buildingRows, snap, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"BUILDING": buildingRows}}, snap, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	errs := validateBuildingExistingRacksFitLayout(p)
 	if len(errs) != 1 || !strings.Contains(errs[0].GetMessage(), "does not fit building") {
 		t.Fatalf("errors = %+v, want site-less building layout fit error", errs)
 	}
@@ -2718,7 +2730,8 @@ func TestValidateBuildingExistingRacksFitLayoutUsesBuildingIDForDuplicateBuildin
 		}},
 	}
 
-	errs := validateBuildingExistingRacksFitLayout(nil, buildingRows, snap, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"BUILDING": buildingRows}}, snap, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	errs := validateBuildingExistingRacksFitLayout(p)
 	if len(errs) != 0 {
 		t.Fatalf("errors = %+v, want building_id-specific layout accepted", errs)
 	}

--- a/server/internal/domain/sitemap/service_test.go
+++ b/server/internal/domain/sitemap/service_test.go
@@ -1237,6 +1237,47 @@ func TestApplyMinerRowsClearsDirectPlacementWhenAssigningUnassignedRack(t *testi
 	}
 }
 
+// TestApplyOmittedRowsLeavesHiddenRackMembersUntouched locks in the invariant that
+// remove-omitted only ever acts on the caller-visible snapshot. A miner the
+// importer cannot see (RBAC-hidden, tracked in hiddenRackMembers rather than
+// snap.miners) must never be unassigned just because the CSV omits it — the CSV
+// omits it because the importer never knew it existed. The mock controller fails
+// on any store call naming the hidden device, so the guarantee is enforced by the
+// absence of expectations for it.
+func TestApplyOmittedRowsLeavesHiddenRackMembersUntouched(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	ctx := context.Background()
+	orgID := int64(42)
+	siteStore := mocks.NewMockSiteStore(ctrl)
+	buildingStore := mocks.NewMockBuildingStore(ctrl)
+	collectionStore := mocks.NewMockCollectionStore(ctrl)
+	svc := NewService(siteStore, buildingStore, collectionStore, nil, nil, nil, nil)
+
+	visibleIDs := []string{"miner-visible"}
+	snap := &snapshot{
+		miners: []minerSnapshot{
+			{DeviceIdentifier: "miner-visible", Rack: "Rack A", RackRow: "0", RackCol: "0"},
+		},
+		hiddenRackMembers: []minerSnapshot{
+			{DeviceIdentifier: "miner-hidden", Rack: "Rack A", RackRow: "1", RackCol: "0"},
+		},
+	}
+	// Empty MINER section: the visible miner is omitted; the hidden miner is not in
+	// snap.miners at all, so it is not even a deletion candidate.
+	parsed := &parsedCSV{sections: map[string][]map[string]string{"MINER": nil}}
+
+	gomock.InOrder(
+		collectionStore.EXPECT().LockRacksForReparent(ctx, orgID, visibleIDs, int64(0)).Return(nil, nil),
+		collectionStore.EXPECT().RemoveDevicesFromAnyRack(ctx, orgID, visibleIDs, int64(0)).Return(int64(1), nil),
+		siteStore.EXPECT().AssignDevicesToSite(ctx, orgID, nil, visibleIDs).Return(int64(1), nil),
+		buildingStore.EXPECT().AssignDevicesToBuilding(ctx, orgID, nil, visibleIDs).Return(int64(1), nil),
+	)
+
+	if err := svc.applyOmittedRows(ctx, orgID, parsed, snap); err != nil {
+		t.Fatalf("applyOmittedRows error = %v", err)
+	}
+}
+
 func TestDeleteOmittedSitesRejectsInfrastructureDevicesReferencedByProfiles(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	ctx := context.Background()

--- a/server/internal/domain/sitemap/service_test.go
+++ b/server/internal/domain/sitemap/service_test.go
@@ -40,18 +40,16 @@ func TestBuildSiteMapExportZipIncludesCSVAndAgentGuide(t *testing.T) {
 	if !strings.Contains(csvText, "# SECTION: MINER") {
 		t.Fatalf("%s missing MINER section: %q", siteMapExportCSVPath, csvText)
 	}
-	if !strings.Contains(csvText, "label,id (read only),building_id,building,site_id,site,zone,rows,columns,order_index,aisle_index,position_in_aisle") {
+	if !strings.Contains(csvText, "label,id (read only),building,site,zone,rows,columns,order_index,aisle_index,position_in_aisle") {
 		t.Fatalf("%s missing expected RACK headers: %q", siteMapExportCSVPath, csvText)
 	}
 
 	guideText := files[siteMapExportGuideTXTPath]
 	for _, want := range []string{
 		"Edit proto-fleet-site-map/site-map.csv",
-		"If rack is set, the rack determines the miner's building and site.",
-		"ID columns identify existing records or disambiguate references.",
+		"If rack is set, the rack determines the miner's building and site; leave building and site blank.",
 		"Leave omitted rows in place keeps missing rows unchanged.",
 		"Remove omitted rows soft-deletes omitted sites, buildings, and racks, and unassigns omitted miners.",
-		"Prefer name references unless an ID is needed to disambiguate.",
 	} {
 		if !strings.Contains(guideText, want) {
 			t.Fatalf("%s missing %q: %q", siteMapExportGuideTXTPath, want, guideText)
@@ -93,11 +91,11 @@ name,id (read only)
 Site A,1
 
 # SECTION: BUILDING
-name,id (read only),site_id,site,aisles,racks_per_aisle
-Building A,10,1,Site A,1,1
+name,id (read only),site,aisles,racks_per_aisle
+Building A,10,1,1,1
 
 # SECTION: MINER
-device_identifier (read only),serial_number (read only),name,ip_address (read only),mac_address (read only),site_id,site,building_id,building,rack_id,rack,rack_row,rack_col
+device_identifier (read only),serial_number (read only),name,ip_address (read only),mac_address (read only),site,building,rack,rack_row,rack_col
 `
 	_, errs := parseSiteMapCSV([]byte(csv))
 	if !hasValidationError(errs, "RACK", "missing section") {
@@ -149,8 +147,8 @@ func TestBuildPlanWithRemoveOmittedSummarizesDeletes(t *testing.T) {
 
 func TestBuildPlanSummarizesNewTopologyRows(t *testing.T) {
 	csv := strings.Replace(validCSV(), "Site A,\n", "Site A,\nNew Site,\n", 1)
-	csv = strings.Replace(csv, "Building A,,,Site A,2,2\n", "Building A,,,Site A,2,2\nNew Building,,,Site A,2,2\n", 1)
-	csv = strings.Replace(csv, "Rack A,,,Building A,,,Z1,4,6,BOTTOM_LEFT,0,0\n", "Rack A,,,Building A,,,Z1,4,6,BOTTOM_LEFT,0,0\nNew Rack,,,Building A,,,Z1,4,6,BOTTOM_LEFT,0,1\n", 1)
+	csv = strings.Replace(csv, "Building A,,NAME:Site A,2,2\n", "Building A,,NAME:Site A,2,2\nNew Building,,NAME:Site A,2,2\n", 1)
+	csv = strings.Replace(csv, "Rack A,,NAME:Building A,,Z1,4,6,BOTTOM_LEFT,0,0\n", "Rack A,,NAME:Building A,,Z1,4,6,BOTTOM_LEFT,0,0\nNew Rack,,NAME:Building A,,Z1,4,6,BOTTOM_LEFT,0,1\n", 1)
 	parsed, errs := parseSiteMapCSV([]byte(csv))
 	if len(errs) != 0 {
 		t.Fatalf("parse errors = %v", errs)
@@ -169,9 +167,9 @@ func TestBuildPlanSummarizesNewTopologyRows(t *testing.T) {
 
 func TestBuildPlanAllowsMinerPlacementIntoNewTopologyRows(t *testing.T) {
 	csv := strings.Replace(validCSV(), "Site A,\n", "Site A,\nNew Site,\n", 1)
-	csv = strings.Replace(csv, "Building A,,,Site A,2,2\n", "Building A,,,Site A,2,2\nNew Building,,,New Site,2,2\n", 1)
-	csv = strings.Replace(csv, "Rack A,,,Building A,,,Z1,4,6,BOTTOM_LEFT,0,0\n", "Rack A,,,Building A,,,Z1,4,6,BOTTOM_LEFT,0,0\nNew Rack,,,New Building,,,Z2,4,6,BOTTOM_LEFT,0,1\n", 1)
-	csv = strings.Replace(csv, "miner-1,SN1,Miner 1,10.0.0.5,aa:bb:cc:dd:ee:ff,,,,,,Rack A,0,0", "miner-1,SN1,Miner 1,10.0.0.5,aa:bb:cc:dd:ee:ff,,,,,,New Rack,0,0", 1)
+	csv = strings.Replace(csv, "Building A,,NAME:Site A,2,2\n", "Building A,,NAME:Site A,2,2\nNew Building,,NAME:New Site,2,2\n", 1)
+	csv = strings.Replace(csv, "Rack A,,NAME:Building A,,Z1,4,6,BOTTOM_LEFT,0,0\n", "Rack A,,NAME:Building A,,Z1,4,6,BOTTOM_LEFT,0,0\nNew Rack,,NAME:New Building,,Z2,4,6,BOTTOM_LEFT,0,1\n", 1)
+	csv = strings.Replace(csv, "miner-1,SN1,Miner 1,10.0.0.5,aa:bb:cc:dd:ee:ff,,,NAME:Rack A,0,0", "miner-1,SN1,Miner 1,10.0.0.5,aa:bb:cc:dd:ee:ff,,,NAME:New Rack,0,0", 1)
 	parsed, errs := parseSiteMapCSV([]byte(csv))
 	if len(errs) != 0 {
 		t.Fatalf("parse errors = %v", errs)
@@ -314,10 +312,10 @@ func TestBuildPlanInfersRackSiteAfterBuildingSiteIDNormalization(t *testing.T) {
 			{"__row": "3", fieldID: "1", fieldName: "Site A"},
 		},
 		"BUILDING": {
-			{"__row": "7", fieldName: "Building A", fieldSiteID: "1", "aisles": "1", "racks_per_aisle": "2"},
+			{"__row": "7", fieldName: "Building A", fieldSite: "1", "aisles": "1", "racks_per_aisle": "2"},
 		},
 		"RACK": {
-			{"__row": "11", fieldLabel: "Rack A", fieldBuilding: "Building A", "rows": "4", "columns": "6", "order_index": "BOTTOM_LEFT"},
+			{"__row": "11", fieldLabel: "Rack A", fieldBuilding: "NAME:Building A", "rows": "4", "columns": "6", "order_index": "BOTTOM_LEFT"},
 		},
 		"MINER": nil,
 	}}
@@ -325,70 +323,24 @@ func TestBuildPlanInfersRackSiteAfterBuildingSiteIDNormalization(t *testing.T) {
 
 	plan := buildPlan(parsed, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
 	if len(plan.errors) != 0 {
-		t.Fatalf("plan errors = %+v, want site_id-backed rack inference accepted", plan.errors)
+		t.Fatalf("plan errors = %+v, want site-backed rack inference accepted", plan.errors)
 	}
 	if got := parsed.sections["RACK"][0][fieldSite]; got != "Site A" {
 		t.Fatalf("rack site = %q, want inferred Site A", got)
 	}
 }
 
-func TestBuildPlanRejectsRackIDWithContradictoryMinerParentIDs(t *testing.T) {
-	parsed := &parsedCSV{sections: map[string][]map[string]string{
-		"SITE": {
-			{"__row": "3", fieldID: "1", fieldName: "Site A"},
-			{"__row": "4", fieldID: "2", fieldName: "Site B"},
-		},
-		"BUILDING": {
-			{"__row": "7", fieldID: "10", fieldName: "Building A", fieldSiteID: "1", "aisles": "1", "racks_per_aisle": "2"},
-			{"__row": "8", fieldID: "11", fieldName: "Building B", fieldSiteID: "2", "aisles": "1", "racks_per_aisle": "2"},
-		},
-		"RACK": {
-			{"__row": "11", fieldID: "20", fieldLabel: "Rack A", fieldBuildingID: "10", "rows": "4", "columns": "6", "order_index": "BOTTOM_LEFT"},
-		},
-		"MINER": {
-			{"__row": "15", "device_identifier": "miner-1", "serial_number": "SN1", fieldName: "Miner 1", "ip_address": "10.0.0.1", "mac_address": "aa:bb:cc:dd:ee:ff", fieldSiteID: "2", fieldRackID: "20"},
-			{"__row": "16", "device_identifier": "miner-2", "serial_number": "SN2", fieldName: "Miner 2", "ip_address": "10.0.0.2", "mac_address": "aa:bb:cc:dd:ee:00", fieldBuildingID: "11", fieldRackID: "20"},
-		},
-	}}
-	siteAID := int64(1)
-	siteBID := int64(2)
-	buildingAID := int64(10)
-	snap := &snapshot{
-		sites: []sitemodels.Site{
-			{ID: 1, Name: "Site A"},
-			{ID: 2, Name: "Site B"},
-		},
-		buildings: []buildingmodels.Building{
-			{ID: 10, SiteID: &siteAID, SiteLabel: "Site A", Name: "Building A", Aisles: 1, RacksPerAisle: 2},
-			{ID: 11, SiteID: &siteBID, SiteLabel: "Site B", Name: "Building B", Aisles: 1, RacksPerAisle: 2},
-		},
-		racks: []rackSnapshot{{ID: 20, SiteID: &siteAID, BuildingID: &buildingAID, Site: "Site A", Building: "Building A", Label: "Rack A", Rows: 4, Columns: 6, OrderIndex: "BOTTOM_LEFT"}},
-		miners: []minerSnapshot{
-			{DeviceIdentifier: "miner-1", SerialNumber: "SN1", Name: "Miner 1", IPAddress: "10.0.0.1", MACAddress: "aa:bb:cc:dd:ee:ff"},
-			{DeviceIdentifier: "miner-2", SerialNumber: "SN2", Name: "Miner 2", IPAddress: "10.0.0.2", MACAddress: "aa:bb:cc:dd:ee:00"},
-		},
-	}
-
-	plan := buildPlan(parsed, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
-	if !hasValidationError(plan.errors, "MINER", `site_id "2" does not match rack_id "20"`) {
-		t.Fatalf("plan errors = %+v, want site_id/rack_id mismatch", plan.errors)
-	}
-	if !hasValidationError(plan.errors, "MINER", `building_id "11" does not match rack_id "20"`) {
-		t.Fatalf("plan errors = %+v, want building_id/rack_id mismatch", plan.errors)
-	}
-}
-
-func TestNormalizeIDReferencesRefreshesRackSiteIDFromSiteName(t *testing.T) {
+func TestResolveReferencesRefreshesRackSiteFromSiteID(t *testing.T) {
 	siteAID := int64(1)
 	siteBID := int64(2)
 	parsed := &parsedCSV{sections: map[string][]map[string]string{
 		"SITE":     nil,
 		"BUILDING": nil,
 		"RACK": {
-			{"__row": "11", fieldID: "20", fieldLabel: "Rack A", fieldSite: "Site B"},
+			{"__row": "11", fieldID: "20", fieldLabel: "Rack A", fieldSite: "2"},
 		},
 		"MINER": {
-			{"__row": "15", "device_identifier": "miner-1", fieldSiteID: "2", fieldRackID: "20"},
+			{"__row": "15", "device_identifier": "miner-1", fieldRack: "20"},
 		},
 	}}
 	snap := &snapshot{
@@ -400,13 +352,16 @@ func TestNormalizeIDReferencesRefreshesRackSiteIDFromSiteName(t *testing.T) {
 		miners: []minerSnapshot{{DeviceIdentifier: "miner-1"}},
 	}
 
-	errs := normalizeIDReferences(parsed, snap)
+	errs := resolveReferences(parsed, snap)
 	if len(errs) != 0 {
-		t.Fatalf("normalizeIDReferences errors = %+v, want rack site name to refresh desired site_id", errs)
+		t.Fatalf("resolveReferences errors = %+v, want rack site id to canonicalize", errs)
+	}
+	if got := parsed.sections["RACK"][0][fieldSite]; got != "Site B" {
+		t.Fatalf("rack site = %q, want canonical Site B", got)
 	}
 }
 
-func TestNormalizeIDReferencesResolvesRackBuildingMoveFromNames(t *testing.T) {
+func TestResolveReferencesResolvesRackBuildingMoveFromID(t *testing.T) {
 	siteAID := int64(1)
 	siteBID := int64(2)
 	buildingAID := int64(10)
@@ -414,10 +369,10 @@ func TestNormalizeIDReferencesResolvesRackBuildingMoveFromNames(t *testing.T) {
 		"SITE":     nil,
 		"BUILDING": nil,
 		"RACK": {
-			{"__row": "11", fieldID: "20", fieldLabel: "Rack A", fieldSite: "Site B", fieldBuilding: "Building B"},
+			{"__row": "11", fieldID: "20", fieldLabel: "Rack A", fieldBuilding: "11"},
 		},
 		"MINER": {
-			{"__row": "15", "device_identifier": "miner-1", fieldBuildingID: "11", fieldRackID: "20"},
+			{"__row": "15", "device_identifier": "miner-1", fieldRack: "20"},
 		},
 	}}
 	snap := &snapshot{
@@ -433,34 +388,15 @@ func TestNormalizeIDReferencesResolvesRackBuildingMoveFromNames(t *testing.T) {
 		miners: []minerSnapshot{{DeviceIdentifier: "miner-1"}},
 	}
 
-	errs := normalizeIDReferences(parsed, snap)
+	errs := resolveReferences(parsed, snap)
 	if len(errs) != 0 {
-		t.Fatalf("normalizeIDReferences errors = %+v, want name-based rack building move to refresh desired building_id", errs)
+		t.Fatalf("resolveReferences errors = %+v, want id-based rack building move to canonicalize", errs)
 	}
-}
-
-func TestNormalizeIDReferencesRejectsRackBuildingIDSiteMismatch(t *testing.T) {
-	siteAID := int64(1)
-	siteBID := int64(2)
-	parsed := &parsedCSV{sections: map[string][]map[string]string{
-		"SITE":     nil,
-		"BUILDING": nil,
-		"RACK": {
-			{"__row": "11", fieldLabel: "Rack A", fieldBuildingID: "10", fieldBuilding: "Building A", fieldSiteID: "2", fieldSite: "Site B"},
-		},
-		"MINER": nil,
-	}}
-	snap := &snapshot{
-		sites: []sitemodels.Site{
-			{ID: siteAID, Name: "Site A"},
-			{ID: siteBID, Name: "Site B"},
-		},
-		buildings: []buildingmodels.Building{{ID: 10, SiteID: &siteAID, SiteLabel: "Site A", Name: "Building A"}},
+	if got := parsed.sections["RACK"][0][fieldBuilding]; got != "Building B" {
+		t.Fatalf("rack building = %q, want canonical Building B", got)
 	}
-
-	errs := normalizeIDReferences(parsed, snap)
-	if !hasValidationError(errs, "RACK", `building_id "10" does not match site_id "2"`) {
-		t.Fatalf("normalizeIDReferences errors = %+v, want building_id/site_id mismatch", errs)
+	if got := parsed.sections["RACK"][0][fieldSite]; got != "Site B" {
+		t.Fatalf("rack site = %q, want Site B inherited from building", got)
 	}
 }
 
@@ -470,14 +406,13 @@ func TestBuildPlanRejectsIDRenamesCollidingWithRetainedOmittedTopology(t *testin
 			{"__row": "3", fieldID: "1", fieldName: "Site B"},
 		},
 		"BUILDING": {
-			{"__row": "7", fieldID: "10", fieldName: "Building B", fieldSite: "Site A", "aisles": "1", "racks_per_aisle": "1"},
+			{"__row": "7", fieldID: "10", fieldName: "Building B", fieldSite: "3", "aisles": "1", "racks_per_aisle": "1"},
 		},
 		"RACK": {
 			{"__row": "11", fieldID: "20", fieldLabel: "Rack B", "rows": "4", "columns": "6", "order_index": "BOTTOM_LEFT"},
 		},
 		"MINER": nil,
 	}}
-	siteAID := int64(1)
 	siteCID := int64(3)
 	snap := &snapshot{
 		sites: []sitemodels.Site{
@@ -487,7 +422,7 @@ func TestBuildPlanRejectsIDRenamesCollidingWithRetainedOmittedTopology(t *testin
 		},
 		buildings: []buildingmodels.Building{
 			{ID: 10, SiteID: &siteCID, SiteLabel: "Site C", Name: "Building A", Aisles: 1, RacksPerAisle: 1},
-			{ID: 11, SiteID: &siteAID, SiteLabel: "Site A", Name: "Building B", Aisles: 1, RacksPerAisle: 1},
+			{ID: 11, SiteID: &siteCID, SiteLabel: "Site C", Name: "Building B", Aisles: 1, RacksPerAisle: 1},
 		},
 		racks: []rackSnapshot{
 			{ID: 20, Label: "Rack A", Rows: 4, Columns: 6},
@@ -540,8 +475,8 @@ func TestBuildPlanRejectsRemoveOmittedDuplicateFinalBuildingNames(t *testing.T) 
 			{"__row": "3", fieldID: "1", fieldName: "Site A"},
 		},
 		"BUILDING": {
-			{"__row": "7", fieldID: "10", fieldName: "Building B", fieldSite: "Site A", "aisles": "1", "racks_per_aisle": "1"},
-			{"__row": "8", fieldID: "11", fieldName: "Building B", fieldSite: "Site A", "aisles": "1", "racks_per_aisle": "1"},
+			{"__row": "7", fieldID: "10", fieldName: "Building B", fieldSite: "1", "aisles": "1", "racks_per_aisle": "1"},
+			{"__row": "8", fieldID: "11", fieldName: "Building B", fieldSite: "1", "aisles": "1", "racks_per_aisle": "1"},
 		},
 		"RACK":  nil,
 		"MINER": nil,
@@ -568,7 +503,7 @@ func TestBuildPlanRejectsTransientBuildingMoveRenameCollisions(t *testing.T) {
 			{"__row": "4", fieldID: "2", fieldName: "Site B"},
 		},
 		"BUILDING": {
-			{"__row": "7", fieldID: "10", fieldName: "Building Y", fieldSite: "Site B", "aisles": "1", "racks_per_aisle": "1"},
+			{"__row": "7", fieldID: "10", fieldName: "Building Y", fieldSite: "2", "aisles": "1", "racks_per_aisle": "1"},
 		},
 		"RACK":  nil,
 		"MINER": nil,
@@ -599,8 +534,8 @@ func TestBuildPlanRejectsSameSiteBuildingRenameSwaps(t *testing.T) {
 			{"__row": "3", fieldID: "1", fieldName: "Site A"},
 		},
 		"BUILDING": {
-			{"__row": "7", fieldID: "10", fieldName: "Building Y", fieldSite: "Site A", "aisles": "1", "racks_per_aisle": "1"},
-			{"__row": "8", fieldID: "11", fieldName: "Building X", fieldSite: "Site A", "aisles": "1", "racks_per_aisle": "1"},
+			{"__row": "7", fieldID: "10", fieldName: "Building Y", fieldSite: "1", "aisles": "1", "racks_per_aisle": "1"},
+			{"__row": "8", fieldID: "11", fieldName: "Building X", fieldSite: "1", "aisles": "1", "racks_per_aisle": "1"},
 		},
 		"RACK":  nil,
 		"MINER": nil,
@@ -672,7 +607,7 @@ func TestBuildPlanRejectsUnassignedBuildingIDMoveCollidingWithRetainedBuilding(t
 			{"__row": "3", fieldName: "Site A"},
 		},
 		"BUILDING": {
-			{"__row": "7", fieldID: "10", fieldName: "Building B", fieldSite: "Site A", "aisles": "1", "racks_per_aisle": "1"},
+			{"__row": "7", fieldID: "10", fieldName: "Building B", fieldSite: "NAME:Site A", "aisles": "1", "racks_per_aisle": "1"},
 		},
 		"RACK":  nil,
 		"MINER": nil,
@@ -698,7 +633,7 @@ func TestBuildPlanRejectsOldSiteReferenceAfterIDRename(t *testing.T) {
 			{"__row": "3", fieldID: "1", fieldName: "New Site"},
 		},
 		"BUILDING": {
-			{"__row": "7", fieldName: "Building A", fieldSite: "Old Site", "aisles": "1", "racks_per_aisle": "1"},
+			{"__row": "7", fieldName: "Building A", fieldSite: "NAME:Old Site", "aisles": "1", "racks_per_aisle": "1"},
 		},
 		"RACK":  nil,
 		"MINER": nil,
@@ -708,7 +643,7 @@ func TestBuildPlanRejectsOldSiteReferenceAfterIDRename(t *testing.T) {
 	}
 
 	plan := buildPlan(parsed, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
-	if !hasValidationError(plan.errors, "BUILDING", `unknown site "Old Site"`) {
+	if !hasValidationError(plan.errors, "BUILDING", "site reference NAME:Old Site matches no SITE row in this import") {
 		t.Fatalf("plan errors = %+v, want old site reference rejected after ID rename", plan.errors)
 	}
 }
@@ -719,10 +654,10 @@ func TestBuildPlanRejectsOldBuildingReferenceAfterIDRename(t *testing.T) {
 			{"__row": "3", fieldName: "Site A"},
 		},
 		"BUILDING": {
-			{"__row": "7", fieldID: "10", fieldName: "New Building", fieldSite: "Site A", "aisles": "2", "racks_per_aisle": "2"},
+			{"__row": "7", fieldID: "10", fieldName: "New Building", fieldSite: "NAME:Site A", "aisles": "2", "racks_per_aisle": "2"},
 		},
 		"RACK": {
-			{"__row": "11", fieldLabel: "Rack A", fieldBuilding: "Old Building", fieldSite: "Site A", "rows": "4", "columns": "6"},
+			{"__row": "11", fieldLabel: "Rack A", fieldBuilding: "NAME:Old Building", "rows": "4", "columns": "6"},
 		},
 		"MINER": nil,
 	}}
@@ -736,7 +671,7 @@ func TestBuildPlanRejectsOldBuildingReferenceAfterIDRename(t *testing.T) {
 		t.Fatal("plan errors = nil, want old building reference rejected after ID rename")
 	}
 	for _, err := range plan.errors {
-		if strings.Contains(err.GetMessage(), `unknown building "Old Building"`) {
+		if strings.Contains(err.GetMessage(), "building reference NAME:Old Building matches no BUILDING row in this import") {
 			return
 		}
 	}
@@ -750,13 +685,13 @@ func TestBuildPlanResolvesSiteNameBuildingMoveForIDReferences(t *testing.T) {
 	parsed := &parsedCSV{sections: map[string][]map[string]string{
 		"SITE": nil,
 		"BUILDING": {
-			{"__row": "7", fieldID: "10", fieldName: "Building A", fieldSite: "Site B", "aisles": "1", "racks_per_aisle": "2"},
+			{"__row": "7", fieldID: "10", fieldName: "Building A", fieldSite: "2", "aisles": "1", "racks_per_aisle": "2"},
 		},
 		"RACK": {
-			{"__row": "11", fieldLabel: "Rack A", fieldBuildingID: "10", fieldBuilding: "Building A", "rows": "4", "columns": "6"},
+			{"__row": "11", fieldLabel: "Rack A", fieldBuilding: "10", "rows": "4", "columns": "6"},
 		},
 		"MINER": {
-			{"__row": "13", "device_identifier": "miner-1", "serial_number": "SN1", fieldName: "Miner 1", "ip_address": "10.0.0.5", "mac_address": "aa:bb:cc:dd:ee:ff", fieldBuildingID: "10", fieldBuilding: "Building A"},
+			{"__row": "13", "device_identifier": "miner-1", "serial_number": "SN1", fieldName: "Miner 1", "ip_address": "10.0.0.5", "mac_address": "aa:bb:cc:dd:ee:ff", fieldBuilding: "10"},
 		},
 	}}
 	snap := &snapshot{
@@ -774,11 +709,11 @@ func TestBuildPlanResolvesSiteNameBuildingMoveForIDReferences(t *testing.T) {
 	if len(plan.errors) != 0 {
 		t.Fatalf("plan errors = %+v, want site-name building move accepted", plan.errors)
 	}
-	if got := parsed.sections["RACK"][0][fieldSiteID]; got != "2" {
-		t.Fatalf("rack site_id = %q, want normalized Site B id", got)
+	if got := parsed.sections["RACK"][0][fieldSite]; got != "Site B" {
+		t.Fatalf("rack site = %q, want inherited Site B", got)
 	}
-	if got := parsed.sections["MINER"][0][fieldSiteID]; got != "2" {
-		t.Fatalf("miner site_id = %q, want normalized Site B id", got)
+	if got := parsed.sections["MINER"][0][fieldSite]; got != "Site B" {
+		t.Fatalf("miner site = %q, want inherited Site B", got)
 	}
 }
 
@@ -790,7 +725,7 @@ func TestBuildPlanAllowsRackTargetDisambiguatedByBuildingID(t *testing.T) {
 			{"__row": "6", fieldID: "11", fieldName: "Building A", "aisles": "1", "racks_per_aisle": "2"},
 		},
 		"RACK": {
-			{"__row": "9", fieldLabel: "Rack A", fieldBuildingID: "10", fieldBuilding: "Building A", "rows": "4", "columns": "6"},
+			{"__row": "9", fieldLabel: "Rack A", fieldBuilding: "10", "rows": "4", "columns": "6"},
 		},
 		"MINER": nil,
 	}}
@@ -801,65 +736,7 @@ func TestBuildPlanAllowsRackTargetDisambiguatedByBuildingID(t *testing.T) {
 
 	plan := buildPlan(parsed, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
 	if len(plan.errors) != 0 {
-		t.Fatalf("plan errors = %+v, want building_id-disambiguated rack accepted", plan.errors)
-	}
-}
-
-func TestBuildPlanRejectsNameOnlyDuplicateUnassignedBuildingReferences(t *testing.T) {
-	parsed := &parsedCSV{sections: map[string][]map[string]string{
-		"SITE":     nil,
-		"BUILDING": nil,
-		"RACK": {
-			{"__row": "9", fieldLabel: "Rack A", fieldBuilding: "Building A", "rows": "4", "columns": "6"},
-		},
-		"MINER": {
-			{"__row": "13", "device_identifier": "miner-1", "serial_number": "SN1", fieldName: "Miner 1", "ip_address": "10.0.0.5", "mac_address": "aa:bb:cc:dd:ee:ff", fieldBuilding: "Building A"},
-		},
-	}}
-	snap := &snapshot{
-		buildings: []buildingmodels.Building{
-			{ID: 10, Name: "Building A", Aisles: 1, RacksPerAisle: 2},
-			{ID: 11, Name: "Building A", Aisles: 1, RacksPerAisle: 2},
-		},
-		miners: []minerSnapshot{{DeviceIdentifier: "miner-1", SerialNumber: "SN1", Name: "Miner 1", IPAddress: "10.0.0.5", MACAddress: "aa:bb:cc:dd:ee:ff"}},
-	}
-
-	plan := buildPlan(parsed, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
-	if !hasValidationError(plan.errors, "RACK", `rack building "Building A" is ambiguous; add site or building_id`) {
-		t.Fatalf("plan errors = %+v, want rack ambiguous building error", plan.errors)
-	}
-	if !hasValidationError(plan.errors, "MINER", `miner building "Building A" is ambiguous; add site or building_id`) {
-		t.Fatalf("plan errors = %+v, want miner ambiguous building error", plan.errors)
-	}
-}
-
-func TestBuildPlanRejectsNameOnlyBuildingReferenceWithUnassignedTwin(t *testing.T) {
-	siteID := int64(1)
-	parsed := &parsedCSV{sections: map[string][]map[string]string{
-		"SITE":     nil,
-		"BUILDING": nil,
-		"RACK": {
-			{"__row": "9", fieldLabel: "Rack A", fieldBuilding: "Building A", "rows": "4", "columns": "6"},
-		},
-		"MINER": {
-			{"__row": "13", "device_identifier": "miner-1", "serial_number": "SN1", fieldName: "Miner 1", "ip_address": "10.0.0.5", "mac_address": "aa:bb:cc:dd:ee:ff", fieldBuilding: "Building A"},
-		},
-	}}
-	snap := &snapshot{
-		sites: []sitemodels.Site{{ID: siteID, Name: "Site A"}},
-		buildings: []buildingmodels.Building{
-			{ID: 10, SiteID: &siteID, SiteLabel: "Site A", Name: "Building A", Aisles: 1, RacksPerAisle: 2},
-			{ID: 11, Name: "Building A", Aisles: 1, RacksPerAisle: 2},
-		},
-		miners: []minerSnapshot{{DeviceIdentifier: "miner-1", SerialNumber: "SN1", Name: "Miner 1", IPAddress: "10.0.0.5", MACAddress: "aa:bb:cc:dd:ee:ff"}},
-	}
-
-	plan := buildPlan(parsed, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
-	if !hasValidationError(plan.errors, "RACK", `rack building "Building A" is ambiguous; add site or building_id`) {
-		t.Fatalf("plan errors = %+v, want rack ambiguous building error", plan.errors)
-	}
-	if !hasValidationError(plan.errors, "MINER", `miner building "Building A" is ambiguous; add site or building_id`) {
-		t.Fatalf("plan errors = %+v, want miner ambiguous building error", plan.errors)
+		t.Fatalf("plan errors = %+v, want building-id-disambiguated rack accepted", plan.errors)
 	}
 }
 
@@ -873,10 +750,10 @@ func TestBuildPlanRemoveOmittedAllowsIDQualifiedDuplicateUnassignedBuildingRefer
 			{"__row": "6", fieldID: "11", fieldName: "Building A", "aisles": "1", "racks_per_aisle": "2"},
 		},
 		"RACK": {
-			{"__row": "9", fieldID: "20", fieldLabel: "Rack A", fieldBuildingID: "10", fieldBuilding: "Building A", "rows": "4", "columns": "6"},
+			{"__row": "9", fieldID: "20", fieldLabel: "Rack A", fieldBuilding: "10", "rows": "4", "columns": "6"},
 		},
 		"MINER": {
-			{"__row": "13", "device_identifier": "miner-1", "serial_number": "SN1", fieldName: "Miner 1", "ip_address": "10.0.0.5", "mac_address": "aa:bb:cc:dd:ee:ff", fieldBuildingID: "11", fieldBuilding: "Building A"},
+			{"__row": "13", "device_identifier": "miner-1", "serial_number": "SN1", fieldName: "Miner 1", "ip_address": "10.0.0.5", "mac_address": "aa:bb:cc:dd:ee:ff", fieldBuilding: "11"},
 		},
 	}}
 	snap := &snapshot{
@@ -898,7 +775,7 @@ func TestBuildPlanRemoveOmittedAllowsIDQualifiedDuplicateUnassignedBuildingRefer
 
 	plan := buildPlan(parsed, snap, pb.OmissionMode_OMISSION_MODE_REMOVE_OMITTED)
 	if len(plan.errors) != 0 {
-		t.Fatalf("plan errors = %+v, want ID-qualified duplicate building references accepted", plan.errors)
+		t.Fatalf("plan errors = %+v, want ID-qualified building references accepted", plan.errors)
 	}
 }
 
@@ -911,18 +788,18 @@ func TestBuildPlanRemoveOmittedRejectsOmittedBuildingIDReferences(t *testing.T) 
 			{"__row": "6", fieldID: "11", fieldName: "Building A", "aisles": "1", "racks_per_aisle": "2"},
 		},
 		"RACK": {
-			{"__row": "9", fieldID: "20", fieldLabel: "Rack A", fieldBuildingID: "10", fieldBuilding: "Building A", "rows": "4", "columns": "6"},
+			{"__row": "9", fieldID: "20", fieldLabel: "Rack A", fieldBuilding: "10", "rows": "4", "columns": "6"},
 		},
 		"MINER": {
-			{"__row": "13", "device_identifier": "miner-1", "serial_number": "SN1", fieldName: "Miner 1", "ip_address": "10.0.0.5", "mac_address": "aa:bb:cc:dd:ee:ff", fieldBuildingID: "10", fieldBuilding: "Building A"},
+			{"__row": "13", "device_identifier": "miner-1", "serial_number": "SN1", fieldName: "Miner 1", "ip_address": "10.0.0.5", "mac_address": "aa:bb:cc:dd:ee:ff", fieldBuilding: "10"},
 		},
 	}}
 	snap := &snapshot{
 		buildings: []buildingmodels.Building{
-			{ID: omittedBuildingID, Name: "Building A", Aisles: 1, RacksPerAisle: 2},
+			{ID: omittedBuildingID, Name: "Building X", Aisles: 1, RacksPerAisle: 2},
 			{ID: retainedBuildingID, Name: "Building A", Aisles: 1, RacksPerAisle: 2},
 		},
-		racks: []rackSnapshot{{ID: 20, Label: "Rack A", BuildingID: &omittedBuildingID, Building: "Building A", Rows: 4, Columns: 6}},
+		racks: []rackSnapshot{{ID: 20, Label: "Rack A", BuildingID: &omittedBuildingID, Building: "Building X", Rows: 4, Columns: 6}},
 		miners: []minerSnapshot{{
 			DeviceIdentifier: "miner-1",
 			SerialNumber:     "SN1",
@@ -930,16 +807,16 @@ func TestBuildPlanRemoveOmittedRejectsOmittedBuildingIDReferences(t *testing.T) 
 			IPAddress:        "10.0.0.5",
 			MACAddress:       "aa:bb:cc:dd:ee:ff",
 			BuildingID:       &omittedBuildingID,
-			Building:         "Building A",
+			Building:         "Building X",
 		}},
 	}
 
 	plan := buildPlan(parsed, snap, pb.OmissionMode_OMISSION_MODE_REMOVE_OMITTED)
-	if !hasValidationError(plan.errors, "RACK", `rack building_id "10" is omitted`) {
-		t.Fatalf("plan errors = %+v, want rack omitted building_id error", plan.errors)
+	if !hasValidationError(plan.errors, "RACK", `rack building "Building X" for site "" is omitted`) {
+		t.Fatalf("plan errors = %+v, want rack omitted building error", plan.errors)
 	}
-	if !hasValidationError(plan.errors, "MINER", `miner building_id "10" is omitted`) {
-		t.Fatalf("plan errors = %+v, want miner omitted building_id error", plan.errors)
+	if !hasValidationError(plan.errors, "MINER", `miner building "Building X" for site "" is omitted`) {
+		t.Fatalf("plan errors = %+v, want miner omitted building error", plan.errors)
 	}
 }
 
@@ -951,7 +828,7 @@ func TestBuildPlanRejectsOldRackReferenceAfterIDRename(t *testing.T) {
 			{"__row": "9", fieldID: "20", fieldLabel: "New Rack", "rows": "4", "columns": "6"},
 		},
 		"MINER": {
-			{"__row": "13", "device_identifier": "miner-1", "serial_number": "SN1", fieldName: "Miner 1", "ip_address": "10.0.0.5", "mac_address": "aa:bb:cc:dd:ee:ff", fieldRack: "Old Rack", "rack_row": "0", "rack_col": "0"},
+			{"__row": "13", "device_identifier": "miner-1", "serial_number": "SN1", fieldName: "Miner 1", "ip_address": "10.0.0.5", "mac_address": "aa:bb:cc:dd:ee:ff", fieldRack: "NAME:Old Rack", "rack_row": "0", "rack_col": "0"},
 		},
 	}}
 	snap := &snapshot{
@@ -960,38 +837,8 @@ func TestBuildPlanRejectsOldRackReferenceAfterIDRename(t *testing.T) {
 	}
 
 	plan := buildPlan(parsed, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
-	if !hasValidationError(plan.errors, "MINER", `unknown rack "Old Rack"`) {
+	if !hasValidationError(plan.errors, "MINER", "rack reference NAME:Old Rack matches no RACK row in this import") {
 		t.Fatalf("plan errors = %+v, want old rack reference rejected after ID rename", plan.errors)
-	}
-}
-
-func TestBuildPlanCountsMinerMoveDisambiguatedByBuildingID(t *testing.T) {
-	parsed := &parsedCSV{sections: map[string][]map[string]string{
-		"SITE": nil,
-		"BUILDING": {
-			{"__row": "5", fieldID: "10", fieldName: "Building A", "aisles": "1", "racks_per_aisle": "2"},
-			{"__row": "6", fieldID: "11", fieldName: "Building A", "aisles": "1", "racks_per_aisle": "2"},
-		},
-		"RACK": nil,
-		"MINER": {
-			{"__row": "13", "device_identifier": "miner-1", "serial_number": "SN1", fieldName: "Miner 1", "ip_address": "10.0.0.5", "mac_address": "aa:bb:cc:dd:ee:ff", fieldBuildingID: "11", fieldBuilding: "Building A"},
-		},
-	}}
-	buildingID := int64(10)
-	snap := &snapshot{
-		buildings: []buildingmodels.Building{
-			{ID: 10, Name: "Building A", Aisles: 1, RacksPerAisle: 2},
-			{ID: 11, Name: "Building A", Aisles: 1, RacksPerAisle: 2},
-		},
-		miners: []minerSnapshot{{DeviceIdentifier: "miner-1", SerialNumber: "SN1", Name: "Miner 1", IPAddress: "10.0.0.5", MACAddress: "aa:bb:cc:dd:ee:ff", BuildingID: &buildingID, Building: "Building A"}},
-	}
-
-	plan := buildPlan(parsed, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
-	if len(plan.errors) != 0 {
-		t.Fatalf("plan errors = %+v, want building_id-disambiguated miner move accepted", plan.errors)
-	}
-	if !hasChange(plan.changes, pb.ImportOperation_IMPORT_OPERATION_MOVE, "miner", 1) {
-		t.Fatalf("changes = %+v, want miner move summary", plan.changes)
 	}
 }
 
@@ -999,7 +846,7 @@ func TestBuildPlanRejectsBuildingUnknownSite(t *testing.T) {
 	parsed := &parsedCSV{sections: map[string][]map[string]string{
 		"SITE": nil,
 		"BUILDING": {
-			{"__row": "5", "site": "Typo Site", "building": "New Building", "aisles": "1", "racks_per_aisle": "1"},
+			{"__row": "5", "site": "NAME:Typo Site", "building": "New Building", "aisles": "1", "racks_per_aisle": "1"},
 		},
 		"RACK":  nil,
 		"MINER": nil,
@@ -1007,7 +854,7 @@ func TestBuildPlanRejectsBuildingUnknownSite(t *testing.T) {
 	snap := &snapshot{sites: []sitemodels.Site{{Name: "Site A"}}}
 
 	plan := buildPlan(parsed, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
-	if len(plan.errors) != 1 || plan.errors[0].GetSection() != "BUILDING" || plan.errors[0].GetMessage() != `unknown site "Typo Site"` {
+	if len(plan.errors) != 1 || plan.errors[0].GetSection() != "BUILDING" || plan.errors[0].GetMessage() != "site reference NAME:Typo Site matches no SITE row in this import" {
 		t.Fatalf("plan errors = %+v, want building unknown site error", plan.errors)
 	}
 	if len(plan.changes) != 0 {
@@ -1019,19 +866,21 @@ func TestBuildPlanRemoveOmittedRejectsReferencesToOmittedParents(t *testing.T) {
 	parsed := &parsedCSV{sections: map[string][]map[string]string{
 		"SITE": nil,
 		"BUILDING": {
-			{"__row": "5", "site": "Site A", "building": "Building A", "aisles": "1", "racks_per_aisle": "1"},
+			{"__row": "5", fieldID: "10", "name": "Building A", "site": "1", "aisles": "1", "racks_per_aisle": "1"},
 		},
 		"RACK": {
-			{"__row": "9", "rack": "Rack A", "site": "Site A", "building": "Building A", "rows": "4", "columns": "6"},
+			{"__row": "9", fieldID: "20", "label": "Rack A", "building": "10", "rows": "4", "columns": "6"},
 		},
 		"MINER": {
-			{"__row": "13", "device_identifier": "miner-1", "serial_number": "SN1", "name": "Miner 1", "ip_address": "10.0.0.5", "mac_address": "aa:bb:cc:dd:ee:ff", "site": "Site A"},
+			{"__row": "13", "device_identifier": "miner-1", "serial_number": "SN1", "name": "Miner 1", "ip_address": "10.0.0.5", "mac_address": "aa:bb:cc:dd:ee:ff", "site": "1"},
 		},
 	}}
+	siteID := int64(1)
+	buildingID := int64(10)
 	snap := &snapshot{
-		sites:     []sitemodels.Site{{Name: "Site A"}},
-		buildings: []buildingmodels.Building{{SiteLabel: "Site A", Name: "Building A"}},
-		racks:     []rackSnapshot{{Label: "Rack A", Site: "Site A", Building: "Building A", Rows: 4, Columns: 6}},
+		sites:     []sitemodels.Site{{ID: 1, Name: "Site A"}},
+		buildings: []buildingmodels.Building{{ID: 10, SiteID: &siteID, SiteLabel: "Site A", Name: "Building A"}},
+		racks:     []rackSnapshot{{ID: 20, BuildingID: &buildingID, Label: "Rack A", Site: "Site A", Building: "Building A", Rows: 4, Columns: 6}},
 		miners:    []minerSnapshot{{DeviceIdentifier: "miner-1", SerialNumber: "SN1", Name: "Miner 1", IPAddress: "10.0.0.5", MACAddress: "aa:bb:cc:dd:ee:ff", Site: "Site A"}},
 	}
 
@@ -1068,7 +917,7 @@ func TestCommitTokenChangesWithSnapshotDrift(t *testing.T) {
 }
 
 func TestBuildPlanWithNoOmissionsSummarizesMinerPlacementChanges(t *testing.T) {
-	csv := strings.Replace(validCSV(), "miner-1,SN1,Miner 1,10.0.0.5,aa:bb:cc:dd:ee:ff,,,,,,Rack A,0,0", "miner-1,SN1,Miner 1,10.0.0.5,aa:bb:cc:dd:ee:ff,,,,,,Rack A,0,1", 1)
+	csv := strings.Replace(validCSV(), "miner-1,SN1,Miner 1,10.0.0.5,aa:bb:cc:dd:ee:ff,,,NAME:Rack A,0,0", "miner-1,SN1,Miner 1,10.0.0.5,aa:bb:cc:dd:ee:ff,,,NAME:Rack A,0,1", 1)
 	parsed, errs := parseSiteMapCSV([]byte(csv))
 	if len(errs) != 0 {
 		t.Fatalf("parse errors = %v", errs)
@@ -1094,7 +943,7 @@ func TestBuildPlanWithNoOmissionsSummarizesMinerPlacementChanges(t *testing.T) {
 }
 
 func TestBuildPlanSummarizesMinerRenames(t *testing.T) {
-	csv := strings.Replace(validCSV(), "miner-1,SN1,Miner 1,10.0.0.5,aa:bb:cc:dd:ee:ff,,,,,,Rack A,0,0", "miner-1,SN1,Renamed Miner,10.0.0.5,aa:bb:cc:dd:ee:ff,,,,,,Rack A,0,0", 1)
+	csv := strings.Replace(validCSV(), "miner-1,SN1,Miner 1,10.0.0.5,aa:bb:cc:dd:ee:ff,,,NAME:Rack A,0,0", "miner-1,SN1,Renamed Miner,10.0.0.5,aa:bb:cc:dd:ee:ff,,,NAME:Rack A,0,0", 1)
 	parsed, errs := parseSiteMapCSV([]byte(csv))
 	if len(errs) != 0 {
 		t.Fatalf("parse errors = %v", errs)
@@ -1112,8 +961,8 @@ func TestBuildPlanSummarizesMinerRenames(t *testing.T) {
 func TestBuildPlanReportsRowCitedErrors(t *testing.T) {
 	csv := strings.Replace(
 		validCSV(),
-		"miner-1,SN1,Miner 1,10.0.0.5,aa:bb:cc:dd:ee:ff,,,,,,Rack A,0,0\n",
-		"miner-1,SN1,Miner 1,10.0.0.5,aa:bb:cc:dd:ee:ff,,,,,,Rack A,0,0\nminer-1,SN1,Miner 1,10.0.0.5,aa:bb:cc:dd:ee:ff,,,,,,Rack A,0,0\n",
+		"miner-1,SN1,Miner 1,10.0.0.5,aa:bb:cc:dd:ee:ff,,,NAME:Rack A,0,0\n",
+		"miner-1,SN1,Miner 1,10.0.0.5,aa:bb:cc:dd:ee:ff,,,NAME:Rack A,0,0\nminer-1,SN1,Miner 1,10.0.0.5,aa:bb:cc:dd:ee:ff,,,NAME:Rack A,0,0\n",
 		1,
 	)
 	parsed, errs := parseSiteMapCSV([]byte(csv))
@@ -1140,8 +989,10 @@ func TestBuildPlanReportsRowCitedErrors(t *testing.T) {
 }
 
 func TestParseSiteMapCSVUnescapesFormulaProtectedExports(t *testing.T) {
-	csv := strings.Replace(validCSV(), "Rack A", "'-Rack", 1)
-	csv = strings.Replace(csv, "Rack A", "'-Rack", 1)
+	// Only the identity cell (the rack's own label) is escaped; the miner's rack
+	// reference points at that same-import rack by its (unescaped) label.
+	csv := strings.Replace(validCSV(), "Rack A,,NAME:Building A", "'-Rack,,NAME:Building A", 1)
+	csv = strings.Replace(csv, "NAME:Rack A", "NAME:-Rack", 1)
 	parsed, errs := parseSiteMapCSV([]byte(csv))
 	if len(errs) != 0 {
 		t.Fatalf("parse errors = %v", errs)
@@ -1150,8 +1001,8 @@ func TestParseSiteMapCSVUnescapesFormulaProtectedExports(t *testing.T) {
 	if got := parsed.sections["RACK"][0]["label"]; got != "-Rack" {
 		t.Fatalf("rack = %q, want unescaped -Rack", got)
 	}
-	if got := parsed.sections["MINER"][0]["rack"]; got != "-Rack" {
-		t.Fatalf("miner rack = %q, want unescaped -Rack", got)
+	if got := parsed.sections["MINER"][0]["rack"]; got != "NAME:-Rack" {
+		t.Fatalf("miner rack = %q, want reference to -Rack", got)
 	}
 }
 
@@ -1378,7 +1229,7 @@ func TestApplyMinerRowsClearsDirectPlacementWhenAssigningUnassignedRack(t *testi
 	buildingStore.EXPECT().AssignDevicesToBuilding(ctx, orgID, nil, deviceIDs).Return(int64(1), nil)
 	collectionStore.EXPECT().ClearRackSlotPosition(ctx, rack.ID, "miner-1", orgID).Return(nil)
 
-	if err := svc.applyMinerRows(ctx, orgID, rows, nil, nil, nil, nil, nil, map[string]rackSnapshot{"Rack A": rack}, existing); err != nil {
+	if err := svc.applyMinerRows(ctx, orgID, rows, nil, nil, map[string]rackSnapshot{"Rack A": rack}, existing); err != nil {
 		t.Fatalf("applyMinerRows error = %v", err)
 	}
 }
@@ -1467,7 +1318,7 @@ func TestApplyImportPlanMovesBuildingsBeforeDeletingOmittedSites(t *testing.T) {
 			{"__row": "3", fieldID: "2", fieldName: "Site B"},
 		},
 		"BUILDING": {
-			{"__row": "7", fieldID: "10", fieldName: "Building A", fieldSiteID: "2", fieldSite: "Site B", "aisles": "1", "racks_per_aisle": "2"},
+			{"__row": "7", fieldID: "10", fieldName: "Building A", fieldSite: "Site B", "aisles": "1", "racks_per_aisle": "2"},
 		},
 		"RACK":  nil,
 		"MINER": nil,
@@ -1554,7 +1405,6 @@ func TestApplyBuildingRowsLocksParentSiteBeforeCreate(t *testing.T) {
 	svc := NewService(siteStore, buildingStore, nil, nil, nil, nil, nil)
 	rows := []map[string]string{{
 		fieldName:         "Building A",
-		fieldSiteID:       "99",
 		fieldSite:         "Site A",
 		"aisles":          "2",
 		"racks_per_aisle": "3",
@@ -1570,12 +1420,12 @@ func TestApplyBuildingRowsLocksParentSiteBeforeCreate(t *testing.T) {
 		}),
 	)
 
-	if err := svc.applyBuildingRows(ctx, orgID, rows, map[string]sitemodels.Site{"Site A": {ID: siteID, Name: "Site A"}}, map[int64]sitemodels.Site{siteID: {ID: siteID, Name: "Site A"}}, map[string]buildingmodels.Building{}, map[int64]buildingmodels.Building{}); err != nil {
+	if err := svc.applyBuildingRows(ctx, orgID, rows, map[string]sitemodels.Site{"Site A": {ID: siteID, Name: "Site A"}}, map[string]buildingmodels.Building{}, map[int64]buildingmodels.Building{}); err != nil {
 		t.Fatalf("applyBuildingRows error = %v", err)
 	}
 }
 
-func TestApplyBuildingRowsMatchesBlankIDBySiteIDAfterSiteRename(t *testing.T) {
+func TestApplyBuildingRowsMatchesBlankIDBySiteAndName(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	ctx := context.Background()
 	orgID := int64(42)
@@ -1584,13 +1434,12 @@ func TestApplyBuildingRowsMatchesBlankIDBySiteIDAfterSiteRename(t *testing.T) {
 	siteStore := mocks.NewMockSiteStore(ctrl)
 	buildingStore := mocks.NewMockBuildingStore(ctrl)
 	svc := NewService(siteStore, buildingStore, nil, nil, nil, nil, nil)
-	building := buildingmodels.Building{ID: buildingID, Name: "Building A", SiteID: &siteID, SiteLabel: "Old Site", Aisles: 2, RacksPerAisle: 3}
+	building := buildingmodels.Building{ID: buildingID, Name: "Building A", SiteID: &siteID, SiteLabel: "Site A", Aisles: 2, RacksPerAisle: 3}
 	rows := []map[string]string{{
 		fieldName:         "Building A",
-		fieldSiteID:       "99",
-		fieldSite:         "New Site",
+		fieldSite:         "Site A",
 		"aisles":          "2",
-		"racks_per_aisle": "3",
+		"racks_per_aisle": "4",
 	}}
 
 	gomock.InOrder(
@@ -1601,7 +1450,7 @@ func TestApplyBuildingRowsMatchesBlankIDBySiteIDAfterSiteRename(t *testing.T) {
 			if params.ID != buildingID {
 				t.Fatalf("building id = %d, want %d", params.ID, buildingID)
 			}
-			return &buildingmodels.Building{ID: params.ID, Name: params.Name, SiteID: &siteID, SiteLabel: "New Site", Aisles: params.Aisles, RacksPerAisle: params.RacksPerAisle}, nil
+			return &buildingmodels.Building{ID: params.ID, Name: params.Name, SiteID: &siteID, SiteLabel: "Site A", Aisles: params.Aisles, RacksPerAisle: params.RacksPerAisle}, nil
 		}),
 	)
 
@@ -1609,9 +1458,8 @@ func TestApplyBuildingRowsMatchesBlankIDBySiteIDAfterSiteRename(t *testing.T) {
 		ctx,
 		orgID,
 		rows,
-		map[string]sitemodels.Site{"New Site": {ID: siteID, Name: "New Site"}},
-		map[int64]sitemodels.Site{siteID: {ID: siteID, Name: "New Site"}},
-		map[string]buildingmodels.Building{"Old Site\x00Building A": building},
+		map[string]sitemodels.Site{"Site A": {ID: siteID, Name: "Site A"}},
+		map[string]buildingmodels.Building{"Site A\x00Building A": building},
 		map[int64]buildingmodels.Building{buildingID: building},
 	); err != nil {
 		t.Fatalf("applyBuildingRows error = %v", err)
@@ -1632,7 +1480,6 @@ func TestApplyBuildingRowsMovesBeforeRename(t *testing.T) {
 	rows := []map[string]string{{
 		fieldID:           "10",
 		fieldName:         "Target Name",
-		fieldSiteID:       "2",
 		fieldSite:         "Site B",
 		"aisles":          "1",
 		"racks_per_aisle": "2",
@@ -1662,7 +1509,6 @@ func TestApplyBuildingRowsMovesBeforeRename(t *testing.T) {
 		orgID,
 		rows,
 		map[string]sitemodels.Site{"Site B": {ID: newSiteID, Name: "Site B"}},
-		map[int64]sitemodels.Site{newSiteID: {ID: newSiteID, Name: "Site B"}},
 		map[string]buildingmodels.Building{"Site A\x00Old Name": building},
 		map[int64]buildingmodels.Building{buildingID: building},
 	); err != nil {
@@ -1699,7 +1545,7 @@ func TestApplyBuildingRowsRechecksLayoutUnderLock(t *testing.T) {
 		}}, nil),
 	)
 
-	err := svc.applyBuildingRows(ctx, orgID, rows, nil, nil, map[string]buildingmodels.Building{"\x00Building A": building}, map[int64]buildingmodels.Building{buildingID: building})
+	err := svc.applyBuildingRows(ctx, orgID, rows, nil, map[string]buildingmodels.Building{"\x00Building A": building}, map[int64]buildingmodels.Building{buildingID: building})
 	if err == nil || !strings.Contains(err.Error(), "cannot shrink layout") {
 		t.Fatalf("applyBuildingRows error = %v, want shrink-layout rejection", err)
 	}
@@ -1717,13 +1563,12 @@ func TestApplyRackRowsUsesCurrentLockedBuildingSite(t *testing.T) {
 	collectionStore := mocks.NewMockCollectionStore(ctrl)
 	svc := NewService(siteStore, buildingStore, collectionStore, nil, nil, nil, nil)
 	rows := []map[string]string{{
-		fieldLabel:      "Rack A",
-		fieldBuildingID: "11",
-		fieldBuilding:   "Building A",
-		fieldSiteID:     "5",
-		"rows":          "4",
-		"columns":       "6",
-		"order_index":   "BOTTOM_LEFT",
+		fieldLabel:    "Rack A",
+		fieldBuilding: "Building A",
+		fieldSite:     "Old Site",
+		"rows":        "4",
+		"columns":     "6",
+		"order_index": "BOTTOM_LEFT",
 	}}
 
 	gomock.InOrder(
@@ -1742,7 +1587,7 @@ func TestApplyRackRowsUsesCurrentLockedBuildingSite(t *testing.T) {
 		buildingStore.EXPECT().SetRackBuildingPositionBulkClear(ctx, orgID, []int64{20}).Return(nil),
 	)
 
-	if err := svc.applyRackRows(ctx, orgID, rows, nil, map[int64]sitemodels.Site{staleSiteID: {ID: staleSiteID, Name: "Old Site"}}, nil, map[int64]buildingmodels.Building{buildingID: {ID: buildingID, Name: "Building A", SiteID: &staleSiteID}}, map[string]rackSnapshot{}, map[int64]rackSnapshot{}); err != nil {
+	if err := svc.applyRackRows(ctx, orgID, rows, map[string]sitemodels.Site{"Old Site": {ID: staleSiteID, Name: "Old Site"}}, map[string]buildingmodels.Building{"Old Site\x00Building A": {ID: buildingID, Name: "Building A", SiteID: &staleSiteID, SiteLabel: "Old Site"}}, map[string]rackSnapshot{}, map[int64]rackSnapshot{}); err != nil {
 		t.Fatalf("applyRackRows error = %v", err)
 	}
 }
@@ -1772,7 +1617,7 @@ func TestApplyRackRowsRechecksDimensionsUnderRackLock(t *testing.T) {
 		}}, nil),
 	)
 
-	err := svc.applyRackRows(ctx, orgID, rows, nil, nil, nil, nil, map[string]rackSnapshot{"Rack A": rack}, map[int64]rackSnapshot{20: rack})
+	err := svc.applyRackRows(ctx, orgID, rows, nil, nil, map[string]rackSnapshot{"Rack A": rack}, map[int64]rackSnapshot{20: rack})
 	if err == nil || !strings.Contains(err.Error(), "cannot resize rack") {
 		t.Fatalf("applyRackRows error = %v, want resize rejection", err)
 	}
@@ -1793,8 +1638,8 @@ func TestApplyMinerRowsUsesCurrentLockedBuildingSiteForDirectPlacement(t *testin
 	rows := []map[string]string{{
 		"device_identifier": "miner-1",
 		fieldName:           "Miner 1",
-		fieldBuildingID:     "11",
 		fieldBuilding:       "Building A",
+		fieldSite:           "Old Site",
 	}}
 	existing := map[string]minerSnapshot{
 		"miner-1": {DeviceIdentifier: "miner-1", Name: "Miner 1"},
@@ -1809,7 +1654,7 @@ func TestApplyMinerRowsUsesCurrentLockedBuildingSiteForDirectPlacement(t *testin
 		buildingStore.EXPECT().AssignDevicesToBuilding(ctx, orgID, &buildingID, deviceIDs).Return(int64(1), nil),
 	)
 
-	if err := svc.applyMinerRows(ctx, orgID, rows, nil, nil, nil, nil, map[int64]buildingmodels.Building{buildingID: {ID: buildingID, Name: "Building A", SiteID: &staleSiteID}}, nil, existing); err != nil {
+	if err := svc.applyMinerRows(ctx, orgID, rows, map[string]sitemodels.Site{"Old Site": {ID: staleSiteID, Name: "Old Site"}}, map[string]buildingmodels.Building{"Old Site\x00Building A": {ID: buildingID, Name: "Building A", SiteID: &staleSiteID, SiteLabel: "Old Site"}}, nil, existing); err != nil {
 		t.Fatalf("applyMinerRows error = %v", err)
 	}
 }
@@ -1969,7 +1814,7 @@ func TestCountBuildingUpdatesMatchesExistingRowsByID(t *testing.T) {
 	rows := []map[string]string{{
 		fieldName:         "Building A",
 		fieldID:           "20",
-		fieldSiteID:       "10",
+		fieldSite:         "Site A",
 		"aisles":          "2",
 		"racks_per_aisle": "2",
 	}}
@@ -1982,11 +1827,11 @@ func TestCountBuildingUpdatesMatchesExistingRowsByID(t *testing.T) {
 }
 
 func TestCountBuildingUpdatesIgnoresBlankIDCreateRows(t *testing.T) {
-	// Under id-authoritative resolution a blank-id row is a create, never a
-	// name-match against an existing building, so it is not an update.
+	// A blank-id row whose canonical (site, name) matches no existing building is a
+	// create, not an update.
 	rows := []map[string]string{{
 		fieldName:         "Building A",
-		fieldSiteID:       "10",
+		fieldSite:         "Site B",
 		"aisles":          "2",
 		"racks_per_aisle": "2",
 	}}
@@ -2059,12 +1904,12 @@ func TestMinerRowsUseRackIDAndBlankNamesForRackedMiners(t *testing.T) {
 		RackCol:          "0",
 	}})
 
-	if got := rows[0][9]; got != "30" {
-		t.Fatalf("exported miner rack_id = %q, want 30", got)
+	if got := rows[0][7]; got != "30" {
+		t.Fatalf("exported miner rack ref = %q, want 30", got)
 	}
-	for _, idx := range []int{5, 6, 7, 8, 10} {
+	for _, idx := range []int{5, 6} {
 		if got := rows[0][idx]; got != "" {
-			t.Fatalf("exported miner col %d = %q, want blank when rack_id is set", idx, got)
+			t.Fatalf("exported miner col %d = %q, want blank when rack is set", idx, got)
 		}
 	}
 }
@@ -2080,11 +1925,11 @@ func TestMinerRowsUseBuildingIDForDirectBuildingAssignment(t *testing.T) {
 		Building:         "Building A",
 	}})
 
-	if got := rows[0][7]; got != "20" {
-		t.Fatalf("exported miner building_id = %q, want 20", got)
+	if got := rows[0][6]; got != "20" {
+		t.Fatalf("exported miner building ref = %q, want 20", got)
 	}
 	if got := rows[0][5]; got != "" {
-		t.Fatalf("exported miner site_id = %q, want blank when building_id is set", got)
+		t.Fatalf("exported miner site ref = %q, want blank when building is set", got)
 	}
 }
 
@@ -2105,13 +1950,13 @@ func TestDisplayHeadersMarkReadOnlyIdentityColumns(t *testing.T) {
 	if got := strings.Join(displayHeaders("SITE", siteHeaders), ","); got != "name,id (read only)" {
 		t.Fatalf("SITE headers = %q", got)
 	}
-	if got := strings.Join(displayHeaders("BUILDING", buildingHeaders), ","); got != "name,id (read only),site_id,site,aisles,racks_per_aisle" {
+	if got := strings.Join(displayHeaders("BUILDING", buildingHeaders), ","); got != "name,id (read only),site,aisles,racks_per_aisle" {
 		t.Fatalf("BUILDING headers = %q", got)
 	}
-	if got := strings.Join(displayHeaders("RACK", rackHeaders), ","); got != "label,id (read only),building_id,building,site_id,site,zone,rows,columns,order_index,aisle_index,position_in_aisle" {
+	if got := strings.Join(displayHeaders("RACK", rackHeaders), ","); got != "label,id (read only),building,site,zone,rows,columns,order_index,aisle_index,position_in_aisle" {
 		t.Fatalf("RACK headers = %q", got)
 	}
-	if got := strings.Join(displayHeaders("MINER", minerHeaders), ","); got != "device_identifier (read only),serial_number (read only),name,ip_address (read only),mac_address (read only),site_id,site,building_id,building,rack_id,rack,rack_row,rack_col" {
+	if got := strings.Join(displayHeaders("MINER", minerHeaders), ","); got != "device_identifier (read only),serial_number (read only),name,ip_address (read only),mac_address (read only),site,building,rack,rack_row,rack_col" {
 		t.Fatalf("MINER headers = %q", got)
 	}
 }
@@ -2124,12 +1969,10 @@ func TestRackExportRowsUseBuildingIDAndBlankNames(t *testing.T) {
 	)
 
 	if got := rows[0][2]; got != "10" {
-		t.Fatalf("exported rack building_id = %q, want 10", got)
+		t.Fatalf("exported rack building ref = %q, want 10", got)
 	}
-	for _, idx := range []int{3, 4, 5} {
-		if got := rows[0][idx]; got != "" {
-			t.Fatalf("exported rack col %d = %q, want blank when building_id is set", idx, got)
-		}
+	if got := rows[0][3]; got != "" {
+		t.Fatalf("exported rack site ref = %q, want blank when building is set", got)
 	}
 }
 
@@ -2139,50 +1982,30 @@ func TestRackExportRowsUseSiteIDForDirectSiteAssignment(t *testing.T) {
 		[]rackSnapshot{{SiteID: &siteID, Site: "Site A", Label: "Rack A"}},
 	)
 
-	if got := rows[0][4]; got != "1" {
-		t.Fatalf("exported rack site_id = %q, want 1", got)
+	if got := rows[0][3]; got != "1" {
+		t.Fatalf("exported rack site ref = %q, want 1", got)
 	}
 	if got := rows[0][2]; got != "" {
-		t.Fatalf("exported rack building_id = %q, want blank for direct site assignment", got)
+		t.Fatalf("exported rack building ref = %q, want blank for direct site assignment", got)
 	}
 }
 
 func TestDesiredMinerSiteBuildingResolvesDirectBuildingSite(t *testing.T) {
-	buildingsByName, ambiguous := desiredBuildingNameLookup(
-		[]map[string]string{{"site": "Site A", "building": "Building A"}},
-		nil,
-	)
+	minerRows := []map[string]string{{"__row": "21", "device_identifier": "miner-1", "building": "10"}}
+	snap := &snapshot{
+		sites:     []sitemodels.Site{{ID: 1, Name: "Site A"}},
+		buildings: []buildingmodels.Building{{ID: 10, SiteLabel: "Site A", Name: "Building A"}},
+		miners:    []minerSnapshot{{DeviceIdentifier: "miner-1"}},
+	}
 
-	site, building := desiredMinerSiteBuilding(
-		map[string]string{"site": "", "building": "Building A", "rack": ""},
-		nil,
-		buildingsByName,
-		nil,
-		ambiguous,
-	)
+	parsed := &parsedCSV{sections: map[string][]map[string]string{"MINER": minerRows}}
+	if errs := resolveReferences(parsed, snap); len(errs) != 0 {
+		t.Fatalf("resolveReferences errors = %+v", errs)
+	}
+	p := resolvePlan(parsed, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
+	site, building := minerDesiredSiteBuilding(p.miners[0], p.topology)
 	if site != "Site A" || building != "Building A" {
 		t.Fatalf("placement = (%q, %q), want (Site A, Building A)", site, building)
-	}
-}
-
-func TestDesiredMinerSiteBuildingMarksUnassignedDuplicateBuildingAmbiguous(t *testing.T) {
-	buildingsByName, ambiguous := desiredBuildingNameLookup(nil, []buildingmodels.Building{
-		{SiteLabel: "", Name: "Building A"},
-		{SiteLabel: "Site A", Name: "Building A"},
-	})
-
-	site, building := desiredMinerSiteBuilding(
-		map[string]string{"site": "", "building": "Building A", "rack": ""},
-		nil,
-		buildingsByName,
-		nil,
-		ambiguous,
-	)
-	if site != "" || building != "Building A" {
-		t.Fatalf("placement = (%q, %q), want raw row placement", site, building)
-	}
-	if !ambiguous["Building A"] {
-		t.Fatal("assigned and unassigned duplicate building names should require site or building_id")
 	}
 }
 
@@ -2391,30 +2214,6 @@ func TestValidateRackGridPositionsBlocksOutOfBounds(t *testing.T) {
 	}
 }
 
-func TestValidateRackGridPositionsUsesBuildingIDForDuplicateBuildingNames(t *testing.T) {
-	rackRows := []map[string]string{{
-		fieldBuildingID:     "11",
-		fieldBuilding:       "Building A",
-		fieldLabel:          "Rack A",
-		"aisle_index":       "1",
-		"position_in_aisle": "0",
-	}}
-	buildingRows := []map[string]string{
-		{fieldID: "11", fieldName: "Building A", "aisles": "2", "racks_per_aisle": "1"},
-		{fieldID: "10", fieldName: "Building A", "aisles": "1", "racks_per_aisle": "1"},
-	}
-	snap := &snapshot{buildings: []buildingmodels.Building{
-		{ID: 10, Name: "Building A", Aisles: 1, RacksPerAisle: 1},
-		{ID: 11, Name: "Building A", Aisles: 2, RacksPerAisle: 1},
-	}}
-
-	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"RACK": rackRows, "BUILDING": buildingRows}}, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
-	errs := validateRackGridPositions(p.racks, p.topology)
-	if len(errs) != 0 {
-		t.Fatalf("errors = %+v, want building_id-specific bounds", errs)
-	}
-}
-
 func TestValidateRackGridCollisionsRejectsDuplicateCsvCells(t *testing.T) {
 	rackRows := []map[string]string{
 		{"__row": "10", "site": "Site A", "building": "Building A", "rack": "Rack A", "aisle_index": "0", "position_in_aisle": "0"},
@@ -2505,24 +2304,6 @@ func TestValidateRackGridCollisionsAllowsIDRenameSameCell(t *testing.T) {
 	}
 }
 
-func TestValidateRackGridCollisionsSeparatesIDQualifiedDuplicateBuildings(t *testing.T) {
-	buildingAID := int64(10)
-	buildingBID := int64(11)
-	rackRows := []map[string]string{
-		{"__row": "10", fieldBuildingID: "10", fieldBuilding: "Building A", fieldLabel: "Rack A", "aisle_index": "0", "position_in_aisle": "0"},
-		{"__row": "11", fieldBuildingID: "11", fieldBuilding: "Building A", fieldLabel: "Rack B", "aisle_index": "0", "position_in_aisle": "0"},
-	}
-	snap := &snapshot{racks: []rackSnapshot{
-		{ID: 20, Label: "Rack A", BuildingID: &buildingAID, Building: "Building A", AisleIndex: "0", PositionInAisle: "0"},
-		{ID: 21, Label: "Rack B", BuildingID: &buildingBID, Building: "Building A", AisleIndex: "0", PositionInAisle: "0"},
-	}}
-
-	errs := validateRackGridCollisions(rackRows, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
-	if len(errs) != 0 {
-		t.Fatalf("errors = %+v, want ID-qualified duplicate buildings to have independent grids", errs)
-	}
-}
-
 func TestValidateExistingSlotsFitRackDimensionsBlocksShrink(t *testing.T) {
 	rackRows := []map[string]string{{"rack": "Rack A", "rows": "1", "columns": "1"}}
 	snap := &snapshot{
@@ -2603,35 +2384,6 @@ func TestValidateBuildingRackCapacityCountsSiteLessBuildings(t *testing.T) {
 	errs := validateBuildingRackCapacity(p)
 	if len(errs) != 1 || errs[0].GetSection() != "RACK" {
 		t.Fatalf("errors = %+v, want site-less building rack capacity error", errs)
-	}
-}
-
-func TestValidateBuildingRackCapacitySeparatesIDQualifiedDuplicateBuildings(t *testing.T) {
-	buildingAID := int64(10)
-	buildingBID := int64(11)
-	rackRows := []map[string]string{
-		{fieldBuildingID: "10", fieldBuilding: "Building A", fieldLabel: "Rack A"},
-		{fieldBuildingID: "11", fieldBuilding: "Building A", fieldLabel: "Rack B"},
-	}
-	buildingRows := []map[string]string{
-		{fieldID: "10", fieldName: "Building A", "aisles": "1", "racks_per_aisle": "1"},
-		{fieldID: "11", fieldName: "Building A", "aisles": "1", "racks_per_aisle": "1"},
-	}
-	snap := &snapshot{
-		buildings: []buildingmodels.Building{
-			{ID: 10, Name: "Building A", Aisles: 1, RacksPerAisle: 1},
-			{ID: 11, Name: "Building A", Aisles: 1, RacksPerAisle: 1},
-		},
-		racks: []rackSnapshot{
-			{ID: 20, Label: "Rack A", BuildingID: &buildingAID, Building: "Building A"},
-			{ID: 21, Label: "Rack B", BuildingID: &buildingBID, Building: "Building A"},
-		},
-	}
-
-	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"RACK": rackRows, "BUILDING": buildingRows}}, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
-	errs := validateBuildingRackCapacity(p)
-	if len(errs) != 0 {
-		t.Fatalf("errors = %+v, want ID-qualified duplicate buildings counted separately", errs)
 	}
 }
 
@@ -2738,7 +2490,7 @@ func TestParseSiteMapCSVAcceptsSpreadsheetPaddedSectionRows(t *testing.T) {
 	csv = strings.Replace(csv, "\n\n# SECTION: MINER\n", "\n,,,,,,,,,,\n# SECTION: MINER,,,,,,,,,,\n", 1)
 	csv = strings.Replace(csv, "name,id (read only)\n", "name,id (read only),\n", 1)
 	csv = strings.Replace(csv, "Site A,\n", "Site A,,\n", 1)
-	csv = strings.Replace(csv, "miner-1,SN1,Miner 1,10.0.0.5,aa:bb:cc:dd:ee:ff,,,,,,Rack A,0,0\n", "miner-1,SN1,Miner 1,10.0.0.5,aa:bb:cc:dd:ee:ff,,,,,,Rack A,0,,\n", 1)
+	csv = strings.Replace(csv, "miner-1,SN1,Miner 1,10.0.0.5,aa:bb:cc:dd:ee:ff,,,NAME:Rack A,0,0\n", "miner-1,SN1,Miner 1,10.0.0.5,aa:bb:cc:dd:ee:ff,,,NAME:Rack A,0,,\n", 1)
 
 	parsed, errs := parseSiteMapCSV([]byte(csv))
 	if len(errs) != 0 {
@@ -2809,16 +2561,16 @@ name,id (read only)
 Site A,
 
 # SECTION: BUILDING
-name,id (read only),site_id,site,aisles,racks_per_aisle
-Building A,,,Site A,2,2
+name,id (read only),site,aisles,racks_per_aisle
+Building A,,NAME:Site A,2,2
 
 # SECTION: RACK
-label,id (read only),building_id,building,site_id,site,zone,rows,columns,order_index,aisle_index,position_in_aisle
-Rack A,,,Building A,,,Z1,4,6,BOTTOM_LEFT,0,0
+label,id (read only),building,site,zone,rows,columns,order_index,aisle_index,position_in_aisle
+Rack A,,NAME:Building A,,Z1,4,6,BOTTOM_LEFT,0,0
 
 # SECTION: MINER
-device_identifier (read only),serial_number (read only),name,ip_address (read only),mac_address (read only),site_id,site,building_id,building,rack_id,rack,rack_row,rack_col
-miner-1,SN1,Miner 1,10.0.0.5,aa:bb:cc:dd:ee:ff,,,,,,Rack A,0,0
+device_identifier (read only),serial_number (read only),name,ip_address (read only),mac_address (read only),site,building,rack,rack_row,rack_col
+miner-1,SN1,Miner 1,10.0.0.5,aa:bb:cc:dd:ee:ff,,,NAME:Rack A,0,0
 `
 }
 

--- a/server/internal/domain/sitemap/service_test.go
+++ b/server/internal/domain/sitemap/service_test.go
@@ -1207,10 +1207,6 @@ func TestApplyMinerRowsClearsDirectPlacementWhenAssigningUnassignedRack(t *testi
 	orgID := int64(42)
 	deviceIDs := []string{"miner-1"}
 	rack := rackSnapshot{ID: 7, Label: "Rack A"}
-	rows := []map[string]string{{
-		"device_identifier": "miner-1",
-		"rack":              "Rack A",
-	}}
 	existing := map[string]minerSnapshot{
 		"miner-1": {
 			DeviceIdentifier: "miner-1",
@@ -1229,8 +1225,15 @@ func TestApplyMinerRowsClearsDirectPlacementWhenAssigningUnassignedRack(t *testi
 	buildingStore.EXPECT().AssignDevicesToBuilding(ctx, orgID, nil, deviceIDs).Return(int64(1), nil)
 	collectionStore.EXPECT().ClearRackSlotPosition(ctx, rack.ID, "miner-1", orgID).Return(nil)
 
-	if err := svc.applyMinerRows(ctx, orgID, rows, nil, nil, map[string]rackSnapshot{"Rack A": rack}, existing); err != nil {
-		t.Fatalf("applyMinerRows error = %v", err)
+	existingMiner := existing["miner-1"]
+	node := &resolvedMiner{
+		deviceID:  "miner-1",
+		rackLabel: "Rack A",
+		moved:     true,
+		existing:  &existingMiner,
+	}
+	if err := svc.applyMiners(ctx, orgID, []*resolvedMiner{node}, nil, nil, nil, map[string]rackSnapshot{"Rack A": rack}); err != nil {
+		t.Fatalf("applyMiners error = %v", err)
 	}
 }
 
@@ -1318,7 +1321,7 @@ func TestApplyImportPlanMovesBuildingsBeforeDeletingOmittedSites(t *testing.T) {
 			{"__row": "3", fieldID: "2", fieldName: "Site B"},
 		},
 		"BUILDING": {
-			{"__row": "7", fieldID: "10", fieldName: "Building A", fieldSite: "Site B", "aisles": "1", "racks_per_aisle": "2"},
+			{"__row": "7", fieldID: "10", fieldName: "Building A", fieldSite: "2", "aisles": "1", "racks_per_aisle": "2"},
 		},
 		"RACK":  nil,
 		"MINER": nil,
@@ -1365,7 +1368,9 @@ func TestApplyImportPlanMovesBuildingsBeforeDeletingOmittedSites(t *testing.T) {
 		siteStore.EXPECT().SoftDeleteSite(ctx, orgID, siteAID).Return(int64(1), nil),
 	)
 
-	if err := svc.applyImportPlan(ctx, orgID, parsed, snap, pb.OmissionMode_OMISSION_MODE_REMOVE_OMITTED); err != nil {
+	resolveReferences(parsed, snap)
+	resolved := resolvePlan(parsed, snap, pb.OmissionMode_OMISSION_MODE_REMOVE_OMITTED)
+	if err := svc.applyImportPlan(ctx, orgID, resolved, parsed, snap, pb.OmissionMode_OMISSION_MODE_REMOVE_OMITTED); err != nil {
 		t.Fatalf("applyImportPlan error = %v", err)
 	}
 }
@@ -1403,12 +1408,13 @@ func TestApplyBuildingRowsLocksParentSiteBeforeCreate(t *testing.T) {
 	siteStore := mocks.NewMockSiteStore(ctrl)
 	buildingStore := mocks.NewMockBuildingStore(ctrl)
 	svc := NewService(siteStore, buildingStore, nil, nil, nil, nil, nil)
-	rows := []map[string]string{{
-		fieldName:         "Building A",
-		fieldSite:         "Site A",
-		"aisles":          "2",
-		"racks_per_aisle": "3",
-	}}
+	node := &resolvedBuilding{
+		action:        actionCreate,
+		siteRef:       "Site A",
+		name:          "Building A",
+		aisles:        2,
+		racksPerAisle: 3,
+	}
 
 	gomock.InOrder(
 		siteStore.EXPECT().LockSiteForWrite(ctx, orgID, siteID).Return(nil),
@@ -1420,8 +1426,8 @@ func TestApplyBuildingRowsLocksParentSiteBeforeCreate(t *testing.T) {
 		}),
 	)
 
-	if err := svc.applyBuildingRows(ctx, orgID, rows, map[string]sitemodels.Site{"Site A": {ID: siteID, Name: "Site A"}}, map[string]buildingmodels.Building{}, map[int64]buildingmodels.Building{}); err != nil {
-		t.Fatalf("applyBuildingRows error = %v", err)
+	if err := svc.applyBuildings(ctx, orgID, []*resolvedBuilding{node}, map[string]sitemodels.Site{"Site A": {ID: siteID, Name: "Site A"}}, map[string]buildingmodels.Building{}, map[int64]buildingmodels.Building{}); err != nil {
+		t.Fatalf("applyBuildings error = %v", err)
 	}
 }
 
@@ -1435,12 +1441,13 @@ func TestApplyBuildingRowsMatchesBlankIDBySiteAndName(t *testing.T) {
 	buildingStore := mocks.NewMockBuildingStore(ctrl)
 	svc := NewService(siteStore, buildingStore, nil, nil, nil, nil, nil)
 	building := buildingmodels.Building{ID: buildingID, Name: "Building A", SiteID: &siteID, SiteLabel: "Site A", Aisles: 2, RacksPerAisle: 3}
-	rows := []map[string]string{{
-		fieldName:         "Building A",
-		fieldSite:         "Site A",
-		"aisles":          "2",
-		"racks_per_aisle": "4",
-	}}
+	node := &resolvedBuilding{
+		action:        actionUpdate,
+		siteRef:       "Site A",
+		name:          "Building A",
+		aisles:        2,
+		racksPerAisle: 4,
+	}
 
 	gomock.InOrder(
 		siteStore.EXPECT().LockBuildingForWrite(ctx, orgID, buildingID).Return(nil),
@@ -1454,15 +1461,15 @@ func TestApplyBuildingRowsMatchesBlankIDBySiteAndName(t *testing.T) {
 		}),
 	)
 
-	if err := svc.applyBuildingRows(
+	if err := svc.applyBuildings(
 		ctx,
 		orgID,
-		rows,
+		[]*resolvedBuilding{node},
 		map[string]sitemodels.Site{"Site A": {ID: siteID, Name: "Site A"}},
 		map[string]buildingmodels.Building{"Site A\x00Building A": building},
 		map[int64]buildingmodels.Building{buildingID: building},
 	); err != nil {
-		t.Fatalf("applyBuildingRows error = %v", err)
+		t.Fatalf("applyBuildings error = %v", err)
 	}
 }
 
@@ -1477,13 +1484,14 @@ func TestApplyBuildingRowsMovesBeforeRename(t *testing.T) {
 	buildingStore := mocks.NewMockBuildingStore(ctrl)
 	svc := NewService(siteStore, buildingStore, nil, nil, nil, nil, nil)
 	building := buildingmodels.Building{ID: buildingID, Name: "Old Name", SiteID: &oldSiteID, SiteLabel: "Site A", Aisles: 1, RacksPerAisle: 2}
-	rows := []map[string]string{{
-		fieldID:           "10",
-		fieldName:         "Target Name",
-		fieldSite:         "Site B",
-		"aisles":          "1",
-		"racks_per_aisle": "2",
-	}}
+	node := &resolvedBuilding{
+		action:        actionUpdate,
+		id:            &buildingID,
+		siteRef:       "Site B",
+		name:          "Target Name",
+		aisles:        1,
+		racksPerAisle: 2,
+	}
 	buildingIDs := []int64{buildingID}
 
 	gomock.InOrder(
@@ -1504,15 +1512,15 @@ func TestApplyBuildingRowsMovesBeforeRename(t *testing.T) {
 		}),
 	)
 
-	if err := svc.applyBuildingRows(
+	if err := svc.applyBuildings(
 		ctx,
 		orgID,
-		rows,
+		[]*resolvedBuilding{node},
 		map[string]sitemodels.Site{"Site B": {ID: newSiteID, Name: "Site B"}},
 		map[string]buildingmodels.Building{"Site A\x00Old Name": building},
 		map[int64]buildingmodels.Building{buildingID: building},
 	); err != nil {
-		t.Fatalf("applyBuildingRows error = %v", err)
+		t.Fatalf("applyBuildings error = %v", err)
 	}
 }
 
@@ -1527,12 +1535,13 @@ func TestApplyBuildingRowsRechecksLayoutUnderLock(t *testing.T) {
 	buildingStore := mocks.NewMockBuildingStore(ctrl)
 	svc := NewService(siteStore, buildingStore, nil, nil, nil, nil, nil)
 	building := buildingmodels.Building{ID: buildingID, Name: "Building A", Aisles: 2, RacksPerAisle: 1}
-	rows := []map[string]string{{
-		fieldID:           "10",
-		fieldName:         "Building A",
-		"aisles":          "1",
-		"racks_per_aisle": "1",
-	}}
+	node := &resolvedBuilding{
+		action:        actionUpdate,
+		id:            &buildingID,
+		name:          "Building A",
+		aisles:        1,
+		racksPerAisle: 1,
+	}
 
 	gomock.InOrder(
 		siteStore.EXPECT().LockBuildingForWrite(ctx, orgID, buildingID).Return(nil),
@@ -1545,9 +1554,9 @@ func TestApplyBuildingRowsRechecksLayoutUnderLock(t *testing.T) {
 		}}, nil),
 	)
 
-	err := svc.applyBuildingRows(ctx, orgID, rows, nil, map[string]buildingmodels.Building{"\x00Building A": building}, map[int64]buildingmodels.Building{buildingID: building})
+	err := svc.applyBuildings(ctx, orgID, []*resolvedBuilding{node}, nil, map[string]buildingmodels.Building{"\x00Building A": building}, map[int64]buildingmodels.Building{buildingID: building})
 	if err == nil || !strings.Contains(err.Error(), "cannot shrink layout") {
-		t.Fatalf("applyBuildingRows error = %v, want shrink-layout rejection", err)
+		t.Fatalf("applyBuildings error = %v, want shrink-layout rejection", err)
 	}
 }
 
@@ -1562,14 +1571,15 @@ func TestApplyRackRowsUsesCurrentLockedBuildingSite(t *testing.T) {
 	buildingStore := mocks.NewMockBuildingStore(ctrl)
 	collectionStore := mocks.NewMockCollectionStore(ctrl)
 	svc := NewService(siteStore, buildingStore, collectionStore, nil, nil, nil, nil)
-	rows := []map[string]string{{
-		fieldLabel:    "Rack A",
-		fieldBuilding: "Building A",
-		fieldSite:     "Old Site",
-		"rows":        "4",
-		"columns":     "6",
-		"order_index": "BOTTOM_LEFT",
-	}}
+	node := &resolvedRack{
+		action:      actionCreate,
+		label:       "Rack A",
+		buildingRef: "Building A",
+		siteRef:     "Old Site",
+		rows:        4,
+		columns:     6,
+		orderIndex:  "BOTTOM_LEFT",
+	}
 
 	gomock.InOrder(
 		siteStore.EXPECT().LockBuildingForWrite(ctx, orgID, buildingID).Return(nil),
@@ -1587,8 +1597,8 @@ func TestApplyRackRowsUsesCurrentLockedBuildingSite(t *testing.T) {
 		buildingStore.EXPECT().SetRackBuildingPositionBulkClear(ctx, orgID, []int64{20}).Return(nil),
 	)
 
-	if err := svc.applyRackRows(ctx, orgID, rows, map[string]sitemodels.Site{"Old Site": {ID: staleSiteID, Name: "Old Site"}}, map[string]buildingmodels.Building{"Old Site\x00Building A": {ID: buildingID, Name: "Building A", SiteID: &staleSiteID, SiteLabel: "Old Site"}}, map[string]rackSnapshot{}, map[int64]rackSnapshot{}); err != nil {
-		t.Fatalf("applyRackRows error = %v", err)
+	if err := svc.applyRacks(ctx, orgID, []*resolvedRack{node}, map[string]sitemodels.Site{"Old Site": {ID: staleSiteID, Name: "Old Site"}}, map[string]buildingmodels.Building{"Old Site\x00Building A": {ID: buildingID, Name: "Building A", SiteID: &staleSiteID, SiteLabel: "Old Site"}}, map[int64]buildingmodels.Building{}, map[string]rackSnapshot{}, map[int64]rackSnapshot{}); err != nil {
+		t.Fatalf("applyRacks error = %v", err)
 	}
 }
 
@@ -1600,13 +1610,16 @@ func TestApplyRackRowsRechecksDimensionsUnderRackLock(t *testing.T) {
 	buildingStore := mocks.NewMockBuildingStore(ctrl)
 	collectionStore := mocks.NewMockCollectionStore(ctrl)
 	svc := NewService(siteStore, buildingStore, collectionStore, nil, nil, nil, nil)
-	rows := []map[string]string{{
-		fieldID:       "20",
-		fieldLabel:    "Rack A",
-		"rows":        "1",
-		"columns":     "1",
-		"order_index": "BOTTOM_LEFT",
-	}}
+	rackID := int64(20)
+	node := &resolvedRack{
+		action:     actionUpdate,
+		id:         &rackID,
+		label:      "Rack A",
+		prevLabel:  "Rack A",
+		rows:       1,
+		columns:    1,
+		orderIndex: "BOTTOM_LEFT",
+	}
 	rack := rackSnapshot{ID: 20, Label: "Rack A", Rows: 4, Columns: 6, OrderIndex: "BOTTOM_LEFT"}
 
 	gomock.InOrder(
@@ -1617,9 +1630,9 @@ func TestApplyRackRowsRechecksDimensionsUnderRackLock(t *testing.T) {
 		}}, nil),
 	)
 
-	err := svc.applyRackRows(ctx, orgID, rows, nil, nil, map[string]rackSnapshot{"Rack A": rack}, map[int64]rackSnapshot{20: rack})
+	err := svc.applyRacks(ctx, orgID, []*resolvedRack{node}, nil, nil, map[int64]buildingmodels.Building{}, map[string]rackSnapshot{"Rack A": rack}, map[int64]rackSnapshot{20: rack})
 	if err == nil || !strings.Contains(err.Error(), "cannot resize rack") {
-		t.Fatalf("applyRackRows error = %v, want resize rejection", err)
+		t.Fatalf("applyRacks error = %v, want resize rejection", err)
 	}
 }
 
@@ -1635,14 +1648,14 @@ func TestApplyMinerRowsUsesCurrentLockedBuildingSiteForDirectPlacement(t *testin
 	collectionStore := mocks.NewMockCollectionStore(ctrl)
 	svc := NewService(siteStore, buildingStore, collectionStore, nil, nil, nil, nil)
 	deviceIDs := []string{"miner-1"}
-	rows := []map[string]string{{
-		"device_identifier": "miner-1",
-		fieldName:           "Miner 1",
-		fieldBuilding:       "Building A",
-		fieldSite:           "Old Site",
-	}}
-	existing := map[string]minerSnapshot{
-		"miner-1": {DeviceIdentifier: "miner-1", Name: "Miner 1"},
+	existingMiner := minerSnapshot{DeviceIdentifier: "miner-1", Name: "Miner 1"}
+	node := &resolvedMiner{
+		deviceID:   "miner-1",
+		name:       "Miner 1",
+		buildLabel: "Building A",
+		siteLabel:  "Old Site",
+		moved:      true,
+		existing:   &existingMiner,
 	}
 
 	gomock.InOrder(
@@ -1654,8 +1667,8 @@ func TestApplyMinerRowsUsesCurrentLockedBuildingSiteForDirectPlacement(t *testin
 		buildingStore.EXPECT().AssignDevicesToBuilding(ctx, orgID, &buildingID, deviceIDs).Return(int64(1), nil),
 	)
 
-	if err := svc.applyMinerRows(ctx, orgID, rows, map[string]sitemodels.Site{"Old Site": {ID: staleSiteID, Name: "Old Site"}}, map[string]buildingmodels.Building{"Old Site\x00Building A": {ID: buildingID, Name: "Building A", SiteID: &staleSiteID, SiteLabel: "Old Site"}}, nil, existing); err != nil {
-		t.Fatalf("applyMinerRows error = %v", err)
+	if err := svc.applyMiners(ctx, orgID, []*resolvedMiner{node}, map[string]sitemodels.Site{"Old Site": {ID: staleSiteID, Name: "Old Site"}}, map[string]buildingmodels.Building{"Old Site\x00Building A": {ID: buildingID, Name: "Building A", SiteID: &staleSiteID, SiteLabel: "Old Site"}}, map[int64]buildingmodels.Building{}, nil); err != nil {
+		t.Fatalf("applyMiners error = %v", err)
 	}
 }
 
@@ -1668,7 +1681,13 @@ func TestApplySiteRowsRegeneratesSlugWhenRenamingByID(t *testing.T) {
 	site := sitemodels.Site{ID: 11, Name: "Old Site", Slug: "old-site"}
 	existingByName := map[string]sitemodels.Site{site.Name: site}
 	existingByID := map[int64]sitemodels.Site{site.ID: site}
-	rows := []map[string]string{{fieldID: "11", fieldName: "New Site"}}
+	siteID := int64(11)
+	node := &resolvedSite{
+		action:   actionUpdate,
+		id:       &siteID,
+		name:     "New Site",
+		prevName: "Old Site",
+	}
 
 	siteStore.EXPECT().ListSiteSlugs(ctx, orgID).Return([]string{"old-site"}, nil)
 	siteStore.EXPECT().UpdateSite(ctx, gomock.Any()).DoAndReturn(func(_ context.Context, params sitemodels.UpdateSiteParams) (*sitemodels.Site, error) {
@@ -1678,8 +1697,8 @@ func TestApplySiteRowsRegeneratesSlugWhenRenamingByID(t *testing.T) {
 		return &sitemodels.Site{ID: params.ID, Name: params.Name, Slug: params.Slug}, nil
 	})
 
-	if err := svc.applySiteRows(ctx, orgID, rows, existingByName, existingByID); err != nil {
-		t.Fatalf("applySiteRows error = %v", err)
+	if err := svc.applySites(ctx, orgID, []*resolvedSite{node}, existingByName, existingByID); err != nil {
+		t.Fatalf("applySites error = %v", err)
 	}
 	if _, ok := existingByName["Old Site"]; ok {
 		t.Fatal("old site name still present in lookup")

--- a/server/internal/domain/sitemap/service_test.go
+++ b/server/internal/domain/sitemap/service_test.go
@@ -2354,7 +2354,8 @@ func TestValidateRackSlotBoundsRejectsPartialCoordinates(t *testing.T) {
 	minerRows := []map[string]string{{"__row": "21", "device_identifier": "miner-1", "rack": "Rack A", "rack_row": "", "rack_col": "3"}}
 	rackRows := []map[string]string{{"rack": "Rack A", "rows": "4", "columns": "6"}}
 
-	errs := validateRackSlotBounds(minerRows, rackRows, &snapshot{})
+	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"MINER": minerRows, "RACK": rackRows}}, &snapshot{}, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
+	errs := validateRackSlotBounds(p.miners, p.topology)
 	if len(errs) != 1 || errs[0].GetMessage() != "rack_row and rack_col must both be set or both be blank" {
 		t.Fatalf("errors = %+v, want partial coordinate error", errs)
 	}
@@ -2380,7 +2381,8 @@ func TestValidateRackGridPositionsBlocksOutOfBounds(t *testing.T) {
 	}}
 	buildingRows := []map[string]string{{"site": "Site A", "building": "Building A", "aisles": "2", "racks_per_aisle": "6"}}
 
-	errs := validateRackGridPositions(rackRows, buildingRows, &snapshot{})
+	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"RACK": rackRows, "BUILDING": buildingRows}}, &snapshot{}, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
+	errs := validateRackGridPositions(p.racks, p.topology)
 	if len(errs) != 1 || !strings.Contains(errs[0].GetMessage(), "aisle_index 2 is out of bounds") {
 		t.Fatalf("errors = %+v, want aisle bounds error", errs)
 	}
@@ -2403,7 +2405,8 @@ func TestValidateRackGridPositionsUsesBuildingIDForDuplicateBuildingNames(t *tes
 		{ID: 11, Name: "Building A", Aisles: 2, RacksPerAisle: 1},
 	}}
 
-	errs := validateRackGridPositions(rackRows, buildingRows, snap)
+	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"RACK": rackRows, "BUILDING": buildingRows}}, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
+	errs := validateRackGridPositions(p.racks, p.topology)
 	if len(errs) != 0 {
 		t.Fatalf("errors = %+v, want building_id-specific bounds", errs)
 	}

--- a/server/internal/domain/sitemap/service_test.go
+++ b/server/internal/domain/sitemap/service_test.go
@@ -2310,7 +2310,8 @@ func TestValidateRackCapacityBlocksOverfilledRack(t *testing.T) {
 	}
 	rackRows := []map[string]string{{"rack": "Rack A", "rows": "1", "columns": "1"}}
 
-	errs := validateRackCapacity(minerRows, rackRows, &snapshot{}, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
+	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"MINER": minerRows, "RACK": rackRows}}, &snapshot{}, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
+	errs := validateRackCapacity(p)
 	if len(errs) != 1 || errs[0].GetSection() != "MINER" {
 		t.Fatalf("errors = %+v, want rack capacity error", errs)
 	}
@@ -2321,7 +2322,8 @@ func TestValidateRackCapacityCountsRetainedOmittedMiners(t *testing.T) {
 	rackRows := []map[string]string{{"rack": "Rack A", "rows": "1", "columns": "1"}}
 	snap := &snapshot{miners: []minerSnapshot{{DeviceIdentifier: "miner-1", Rack: "Rack A"}}}
 
-	errs := validateRackCapacity(minerRows, rackRows, snap, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"MINER": minerRows, "RACK": rackRows}}, snap, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	errs := validateRackCapacity(p)
 	if len(errs) != 1 || errs[0].GetSection() != "MINER" {
 		t.Fatalf("errors = %+v, want rack capacity error", errs)
 	}
@@ -2332,7 +2334,8 @@ func TestValidateRackCapacityCountsHiddenRackMembers(t *testing.T) {
 	rackRows := []map[string]string{{"rack": "Rack A", "rows": "1", "columns": "1"}}
 	snap := &snapshot{hiddenRackMembers: []minerSnapshot{{DeviceIdentifier: "hidden-1", Rack: "Rack A"}}}
 
-	errs := validateRackCapacity(minerRows, rackRows, snap, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"MINER": minerRows, "RACK": rackRows}}, snap, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	errs := validateRackCapacity(p)
 	if len(errs) != 1 || errs[0].GetSection() != "MINER" {
 		t.Fatalf("errors = %+v, want rack capacity error", errs)
 	}
@@ -2344,7 +2347,8 @@ func TestValidateRackCapacityMapsHiddenMembersThroughRackRename(t *testing.T) {
 	rackRows := []map[string]string{{fieldID: "20", fieldLabel: "New Rack", "rows": "1", "columns": "1"}}
 	snap := &snapshot{hiddenRackMembers: []minerSnapshot{{DeviceIdentifier: "hidden-1", RackID: &rackID, Rack: "Old Rack"}}}
 
-	errs := validateRackCapacity(minerRows, rackRows, snap, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"MINER": minerRows, "RACK": rackRows}}, snap, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	errs := validateRackCapacity(p)
 	if len(errs) != 1 || errs[0].GetSection() != "MINER" || !strings.Contains(errs[0].GetMessage(), `rack "New Rack"`) {
 		t.Fatalf("errors = %+v, want renamed-rack capacity error", errs)
 	}
@@ -2527,7 +2531,8 @@ func TestValidateExistingSlotsFitRackDimensionsBlocksShrink(t *testing.T) {
 		miners: []minerSnapshot{{DeviceIdentifier: "miner-1", Rack: "Rack A", RackRow: "1", RackCol: "0"}},
 	}
 
-	errs := validateExistingSlotsFitRackDimensions(nil, rackRows, snap, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"RACK": rackRows}}, snap, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	errs := validateExistingSlotsFitRackDimensions(p)
 	if len(errs) != 1 || !strings.Contains(errs[0].GetMessage(), "does not fit rack") {
 		t.Fatalf("errors = %+v, want slot fit error", errs)
 	}
@@ -2537,7 +2542,8 @@ func TestValidateExistingSlotsFitRackDimensionsCountsHiddenRackMembers(t *testin
 	rackRows := []map[string]string{{"rack": "Rack A", "rows": "1", "columns": "1"}}
 	snap := &snapshot{hiddenRackMembers: []minerSnapshot{{DeviceIdentifier: "hidden-1", Rack: "Rack A", RackRow: "1", RackCol: "0"}}}
 
-	errs := validateExistingSlotsFitRackDimensions(nil, rackRows, snap, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"RACK": rackRows}}, snap, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	errs := validateExistingSlotsFitRackDimensions(p)
 	if len(errs) != 1 || errs[0].GetSection() != "MINER" {
 		t.Fatalf("errors = %+v, want hidden member slot dimension error", errs)
 	}
@@ -2551,7 +2557,8 @@ func TestValidateExistingSlotsFitRackDimensionsMapsRetainedMembersThroughRackRen
 		miners: []minerSnapshot{{DeviceIdentifier: "miner-1", RackID: &rackID, Rack: "Old Rack", RackRow: "1", RackCol: "0"}},
 	}
 
-	errs := validateExistingSlotsFitRackDimensions(nil, rackRows, snap, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"RACK": rackRows}}, snap, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	errs := validateExistingSlotsFitRackDimensions(p)
 	if len(errs) != 1 || errs[0].GetSection() != "MINER" || !strings.Contains(errs[0].GetMessage(), `rack "New Rack"`) {
 		t.Fatalf("errors = %+v, want renamed-rack slot fit error", errs)
 	}
@@ -2565,7 +2572,8 @@ func TestValidateExistingSlotsFitRackDimensionsMapsHiddenMembersThroughRackRenam
 		hiddenRackMembers: []minerSnapshot{{DeviceIdentifier: "hidden-1", RackID: &rackID, Rack: "Old Rack", RackRow: "1", RackCol: "0"}},
 	}
 
-	errs := validateExistingSlotsFitRackDimensions(nil, rackRows, snap, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"RACK": rackRows}}, snap, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	errs := validateExistingSlotsFitRackDimensions(p)
 	if len(errs) != 1 || errs[0].GetSection() != "MINER" || !strings.Contains(errs[0].GetMessage(), `rack "New Rack"`) {
 		t.Fatalf("errors = %+v, want hidden renamed-rack slot fit error", errs)
 	}

--- a/server/internal/domain/sitemap/service_test.go
+++ b/server/internal/domain/sitemap/service_test.go
@@ -811,10 +811,10 @@ func TestBuildPlanRemoveOmittedRejectsOmittedBuildingIDReferences(t *testing.T) 
 	}
 
 	plan := buildPlan(parsed, snap, pb.OmissionMode_OMISSION_MODE_REMOVE_OMITTED)
-	if !hasValidationError(plan.errors, "RACK", `rack building "Building X" for site "" is omitted`) {
+	if !hasValidationError(plan.errors, "RACK", `rack building "Building X" (id 10) is omitted`) {
 		t.Fatalf("plan errors = %+v, want rack omitted building error", plan.errors)
 	}
-	if !hasValidationError(plan.errors, "MINER", `miner building "Building X" for site "" is omitted`) {
+	if !hasValidationError(plan.errors, "MINER", `miner building "Building X" (id 10) is omitted`) {
 		t.Fatalf("plan errors = %+v, want miner omitted building error", plan.errors)
 	}
 }
@@ -2874,5 +2874,46 @@ func testSnapshotMatchingValidCSV() *snapshot {
 				RackCol:          "0",
 			},
 		},
+	}
+}
+
+// TestValidateRemoveOmittedReferencesRejectsOmittedBuildingTwin locks in the
+// id-precise omission check: when two unassigned buildings share a (site, name)
+// pair and a rack references the omitted twin by id, the (site, name) presence
+// check alone would accept it. The preserved building id must catch it.
+func TestValidateRemoveOmittedReferencesRejectsOmittedBuildingTwin(t *testing.T) {
+	// Live org: two unassigned buildings both named "B" (ids 5 and 7).
+	snap := &snapshot{
+		buildings: []buildingmodels.Building{
+			{ID: 5, Name: "B"}, // omitted from the CSV
+			{ID: 7, Name: "B"}, // retained
+		},
+	}
+	base := func() *parsedCSV {
+		return &parsedCSV{sections: map[string][]map[string]string{
+			"BUILDING": {{"__row": "6", "name": "B", "id": "7"}},
+			"RACK":     {{"__row": "9", "label": "R1", "building": "5"}},
+		}}
+	}
+
+	// Rack references the omitted twin (id 5) — must be rejected even though a
+	// same-name building row (id 7) is retained.
+	parsed := base()
+	if errs := resolveReferences(parsed, snap); len(errs) != 0 {
+		t.Fatalf("resolveReferences errors = %+v", errs)
+	}
+	errs := validateRemoveOmittedReferences(parsed, pb.OmissionMode_OMISSION_MODE_REMOVE_OMITTED)
+	if len(errs) != 1 || errs[0].GetRow() != 9 {
+		t.Fatalf("omitted-twin reference = %+v, want one error on row 9", errs)
+	}
+
+	// Rack references the retained twin (id 7) — must be accepted.
+	ok := base()
+	ok.sections["RACK"][0]["building"] = "7"
+	if errs := resolveReferences(ok, snap); len(errs) != 0 {
+		t.Fatalf("resolveReferences errors = %+v", errs)
+	}
+	if errs := validateRemoveOmittedReferences(ok, pb.OmissionMode_OMISSION_MODE_REMOVE_OMITTED); len(errs) != 0 {
+		t.Fatalf("retained-twin reference = %+v, want no errors", errs)
 	}
 }

--- a/server/internal/domain/sitemap/service_test.go
+++ b/server/internal/domain/sitemap/service_test.go
@@ -2201,7 +2201,8 @@ func TestValidatePlacementConsistencyHonorsSiteForDuplicateBuildingNames(t *test
 		},
 	}
 
-	if errs := validatePlacementConsistency(rows, nil, nil, nil, snap); len(errs) != 0 {
+	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"MINER": rows}}, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
+	if errs := validatePlacementConsistency(p.miners, p.topology); len(errs) != 0 {
 		t.Fatalf("site-qualified duplicate building should validate, got %+v", errs)
 	}
 }
@@ -2264,7 +2265,8 @@ func TestValidateRackPlacementTargetsRejectsUnknownSiteBuilding(t *testing.T) {
 		buildings: []buildingmodels.Building{{SiteLabel: "Site A", Name: "Building A"}},
 	}
 
-	errs := validateRackPlacementTargets(rows, nil, nil, snap)
+	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"RACK": rows}}, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
+	errs := validateRackPlacementTargets(p.racks, p.topology)
 	if len(errs) != 2 {
 		t.Fatalf("errors = %+v, want site and building target errors", errs)
 	}
@@ -2280,7 +2282,8 @@ func TestValidateBuildingSiteTargetsUsesExistingAndCsvSites(t *testing.T) {
 	siteRows := []map[string]string{{"site": "New Site"}}
 	snap := &snapshot{sites: []sitemodels.Site{{Name: "Site A"}}}
 
-	errs := validateBuildingSiteTargets(rows, siteRows, snap)
+	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"SITE": siteRows, "BUILDING": rows}}, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
+	errs := validateBuildingSiteTargets(p.buildings, p.topology)
 	if len(errs) != 1 || errs[0].GetRow() != 8 || errs[0].GetMessage() != `unknown site "Typo Site"` {
 		t.Fatalf("errors = %+v, want only typo site rejected", errs)
 	}
@@ -2293,7 +2296,8 @@ func TestValidatePlacementConsistencyRejectsUnknownDirectSite(t *testing.T) {
 	}}
 	snap := &snapshot{sites: []sitemodels.Site{{Name: "Site A"}}}
 
-	errs := validatePlacementConsistency(rows, nil, nil, nil, snap)
+	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"MINER": rows}}, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
+	errs := validatePlacementConsistency(p.miners, p.topology)
 	if len(errs) != 1 || errs[0].GetMessage() != `unknown site "Typo Site"` {
 		t.Fatalf("errors = %+v, want unknown site error", errs)
 	}

--- a/server/internal/domain/sitemap/service_test.go
+++ b/server/internal/domain/sitemap/service_test.go
@@ -495,7 +495,7 @@ func TestBuildPlanRejectsIDRenamesCollidingWithRetainedOmittedTopology(t *testin
 		},
 	}
 
-	plan := buildPlan(parsed, snap, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	plan := buildPlan(parsed, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
 	for _, want := range []struct {
 		section string
 		message string
@@ -613,7 +613,7 @@ func TestBuildPlanRejectsSameSiteBuildingRenameSwaps(t *testing.T) {
 		},
 	}
 
-	plan := buildPlan(parsed, snap, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	plan := buildPlan(parsed, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
 	if !hasValidationError(plan.errors, "BUILDING", `building rename target "Site A"/"Building Y" is currently used by building_id 11`) {
 		t.Fatalf("plan errors = %+v, want first transient building rename collision", plan.errors)
 	}
@@ -637,7 +637,7 @@ func TestBuildPlanRejectsTransientRackLabelCollisions(t *testing.T) {
 		{ID: 21, Label: "Rack B", Rows: 4, Columns: 6},
 	}}
 
-	plan := buildPlan(parsed, snap, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	plan := buildPlan(parsed, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
 	if !hasValidationError(plan.errors, "RACK", `rack rename target "Rack B" is currently used by rack_id 21`) {
 		t.Fatalf("plan errors = %+v, want transient rack label collision", plan.errors)
 	}
@@ -686,7 +686,7 @@ func TestBuildPlanRejectsUnassignedBuildingIDMoveCollidingWithRetainedBuilding(t
 		},
 	}
 
-	plan := buildPlan(parsed, snap, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	plan := buildPlan(parsed, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
 	if !hasValidationError(plan.errors, "BUILDING", "duplicate retained building name at site") {
 		t.Fatalf("plan errors = %+v, want retained building collision", plan.errors)
 	}
@@ -707,7 +707,7 @@ func TestBuildPlanRejectsOldSiteReferenceAfterIDRename(t *testing.T) {
 		sites: []sitemodels.Site{{ID: 1, Name: "Old Site"}},
 	}
 
-	plan := buildPlan(parsed, snap, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	plan := buildPlan(parsed, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
 	if !hasValidationError(plan.errors, "BUILDING", `unknown site "Old Site"`) {
 		t.Fatalf("plan errors = %+v, want old site reference rejected after ID rename", plan.errors)
 	}
@@ -854,7 +854,7 @@ func TestBuildPlanRejectsNameOnlyBuildingReferenceWithUnassignedTwin(t *testing.
 		miners: []minerSnapshot{{DeviceIdentifier: "miner-1", SerialNumber: "SN1", Name: "Miner 1", IPAddress: "10.0.0.5", MACAddress: "aa:bb:cc:dd:ee:ff"}},
 	}
 
-	plan := buildPlan(parsed, snap, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	plan := buildPlan(parsed, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
 	if !hasValidationError(plan.errors, "RACK", `rack building "Building A" is ambiguous; add site or building_id`) {
 		t.Fatalf("plan errors = %+v, want rack ambiguous building error", plan.errors)
 	}
@@ -1121,7 +1121,7 @@ func TestBuildPlanReportsRowCitedErrors(t *testing.T) {
 		t.Fatalf("parse errors = %v", errs)
 	}
 
-	plan := buildPlan(parsed, testSnapshot(), pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	plan := buildPlan(parsed, testSnapshot(), pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
 	if len(plan.errors) == 0 {
 		t.Fatal("expected validation errors")
 	}
@@ -1847,7 +1847,7 @@ func TestValidateSlotConflictsWithExistingAllowsSlotSwaps(t *testing.T) {
 		{DeviceIdentifier: "miner-2", Rack: "Rack A", RackRow: "0", RackCol: "1"},
 	}}
 
-	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"MINER": rows}}, snap, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"MINER": rows}}, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
 	if errs := validateSlotConflictsWithExisting(p); len(errs) != 0 {
 		t.Fatalf("slot swap should not conflict, got %+v", errs)
 	}
@@ -1862,7 +1862,7 @@ func TestValidateSlotConflictsWithExistingBlocksUnchangedOccupant(t *testing.T) 
 		{DeviceIdentifier: "miner-2", Rack: "Rack A", RackRow: "0", RackCol: "1"},
 	}}
 
-	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"MINER": rows}}, snap, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"MINER": rows}}, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
 	errs := validateSlotConflictsWithExisting(p)
 	if len(errs) != 1 {
 		t.Fatalf("errors = %+v, want one conflict", errs)
@@ -1951,7 +1951,7 @@ func TestValidateSlotConflictsWithExistingNormalizesCoordinates(t *testing.T) {
 		{DeviceIdentifier: "miner-2", Rack: "Rack A", RackRow: "1", RackCol: "1"},
 	}}
 
-	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"MINER": rows}}, snap, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"MINER": rows}}, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
 	errs := validateSlotConflictsWithExisting(p)
 	if len(errs) != 1 || errs[0].GetRow() != 21 || errs[0].GetMessage() != "rack slot already occupied by miner miner-2" {
 		t.Fatalf("errors = %+v, want normalized existing slot conflict", errs)
@@ -2328,7 +2328,7 @@ func TestValidateRackCapacityCountsRetainedOmittedMiners(t *testing.T) {
 	rackRows := []map[string]string{{"rack": "Rack A", "rows": "1", "columns": "1"}}
 	snap := &snapshot{miners: []minerSnapshot{{DeviceIdentifier: "miner-1", Rack: "Rack A"}}}
 
-	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"MINER": minerRows, "RACK": rackRows}}, snap, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"MINER": minerRows, "RACK": rackRows}}, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
 	errs := validateRackCapacity(p)
 	if len(errs) != 1 || errs[0].GetSection() != "MINER" {
 		t.Fatalf("errors = %+v, want rack capacity error", errs)
@@ -2340,7 +2340,7 @@ func TestValidateRackCapacityCountsHiddenRackMembers(t *testing.T) {
 	rackRows := []map[string]string{{"rack": "Rack A", "rows": "1", "columns": "1"}}
 	snap := &snapshot{hiddenRackMembers: []minerSnapshot{{DeviceIdentifier: "hidden-1", Rack: "Rack A"}}}
 
-	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"MINER": minerRows, "RACK": rackRows}}, snap, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"MINER": minerRows, "RACK": rackRows}}, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
 	errs := validateRackCapacity(p)
 	if len(errs) != 1 || errs[0].GetSection() != "MINER" {
 		t.Fatalf("errors = %+v, want rack capacity error", errs)
@@ -2353,7 +2353,7 @@ func TestValidateRackCapacityMapsHiddenMembersThroughRackRename(t *testing.T) {
 	rackRows := []map[string]string{{fieldID: "20", fieldLabel: "New Rack", "rows": "1", "columns": "1"}}
 	snap := &snapshot{hiddenRackMembers: []minerSnapshot{{DeviceIdentifier: "hidden-1", RackID: &rackID, Rack: "Old Rack"}}}
 
-	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"MINER": minerRows, "RACK": rackRows}}, snap, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"MINER": minerRows, "RACK": rackRows}}, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
 	errs := validateRackCapacity(p)
 	if len(errs) != 1 || errs[0].GetSection() != "MINER" || !strings.Contains(errs[0].GetMessage(), `rack "New Rack"`) {
 		t.Fatalf("errors = %+v, want renamed-rack capacity error", errs)
@@ -2428,7 +2428,7 @@ func TestValidateRackGridCollisionsRejectsDuplicateCsvCells(t *testing.T) {
 		{"__row": "11", "site": "Site A", "building": "Building A", "rack": "Rack B", "aisle_index": "0", "position_in_aisle": "0"},
 	}
 
-	errs := validateRackGridCollisions(rackRows, &snapshot{}, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	errs := validateRackGridCollisions(rackRows, &snapshot{}, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
 	if len(errs) != 1 || errs[0].GetRow() != 11 || errs[0].GetMessage() != "rack grid cell already occupied by rack Rack A" {
 		t.Fatalf("errors = %+v, want duplicate grid cell", errs)
 	}
@@ -2446,7 +2446,7 @@ func TestValidateRackGridCollisionsCountsRetainedOmittedRacks(t *testing.T) {
 		PositionInAisle: "0",
 	}}}
 
-	errs := validateRackGridCollisions(rackRows, snap, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	errs := validateRackGridCollisions(rackRows, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
 	if len(errs) != 1 || errs[0].GetMessage() != "rack grid cell already occupied by rack Rack A" {
 		t.Fatalf("errors = %+v, want retained rack duplicate grid cell", errs)
 	}
@@ -2506,7 +2506,7 @@ func TestValidateRackGridCollisionsAllowsIDRenameSameCell(t *testing.T) {
 		PositionInAisle: "0",
 	}}}
 
-	errs := validateRackGridCollisions(rackRows, snap, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	errs := validateRackGridCollisions(rackRows, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
 	if len(errs) != 0 {
 		t.Fatalf("errors = %+v, want ID-based rack rename to keep its grid cell", errs)
 	}
@@ -2524,7 +2524,7 @@ func TestValidateRackGridCollisionsSeparatesIDQualifiedDuplicateBuildings(t *tes
 		{ID: 21, Label: "Rack B", BuildingID: &buildingBID, Building: "Building A", AisleIndex: "0", PositionInAisle: "0"},
 	}}
 
-	errs := validateRackGridCollisions(rackRows, snap, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	errs := validateRackGridCollisions(rackRows, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
 	if len(errs) != 0 {
 		t.Fatalf("errors = %+v, want ID-qualified duplicate buildings to have independent grids", errs)
 	}
@@ -2537,7 +2537,7 @@ func TestValidateExistingSlotsFitRackDimensionsBlocksShrink(t *testing.T) {
 		miners: []minerSnapshot{{DeviceIdentifier: "miner-1", Rack: "Rack A", RackRow: "1", RackCol: "0"}},
 	}
 
-	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"RACK": rackRows}}, snap, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"RACK": rackRows}}, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
 	errs := validateExistingSlotsFitRackDimensions(p)
 	if len(errs) != 1 || !strings.Contains(errs[0].GetMessage(), "does not fit rack") {
 		t.Fatalf("errors = %+v, want slot fit error", errs)
@@ -2548,7 +2548,7 @@ func TestValidateExistingSlotsFitRackDimensionsCountsHiddenRackMembers(t *testin
 	rackRows := []map[string]string{{"rack": "Rack A", "rows": "1", "columns": "1"}}
 	snap := &snapshot{hiddenRackMembers: []minerSnapshot{{DeviceIdentifier: "hidden-1", Rack: "Rack A", RackRow: "1", RackCol: "0"}}}
 
-	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"RACK": rackRows}}, snap, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"RACK": rackRows}}, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
 	errs := validateExistingSlotsFitRackDimensions(p)
 	if len(errs) != 1 || errs[0].GetSection() != "MINER" {
 		t.Fatalf("errors = %+v, want hidden member slot dimension error", errs)
@@ -2563,7 +2563,7 @@ func TestValidateExistingSlotsFitRackDimensionsMapsRetainedMembersThroughRackRen
 		miners: []minerSnapshot{{DeviceIdentifier: "miner-1", RackID: &rackID, Rack: "Old Rack", RackRow: "1", RackCol: "0"}},
 	}
 
-	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"RACK": rackRows}}, snap, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"RACK": rackRows}}, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
 	errs := validateExistingSlotsFitRackDimensions(p)
 	if len(errs) != 1 || errs[0].GetSection() != "MINER" || !strings.Contains(errs[0].GetMessage(), `rack "New Rack"`) {
 		t.Fatalf("errors = %+v, want renamed-rack slot fit error", errs)
@@ -2578,7 +2578,7 @@ func TestValidateExistingSlotsFitRackDimensionsMapsHiddenMembersThroughRackRenam
 		hiddenRackMembers: []minerSnapshot{{DeviceIdentifier: "hidden-1", RackID: &rackID, Rack: "Old Rack", RackRow: "1", RackCol: "0"}},
 	}
 
-	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"RACK": rackRows}}, snap, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"RACK": rackRows}}, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
 	errs := validateExistingSlotsFitRackDimensions(p)
 	if len(errs) != 1 || errs[0].GetSection() != "MINER" || !strings.Contains(errs[0].GetMessage(), `rack "New Rack"`) {
 		t.Fatalf("errors = %+v, want hidden renamed-rack slot fit error", errs)
@@ -2702,7 +2702,7 @@ func TestValidateBuildingExistingRacksFitLayoutCountsSiteLessBuildings(t *testin
 		PositionInAisle: "0",
 	}}}
 
-	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"BUILDING": buildingRows}}, snap, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"BUILDING": buildingRows}}, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
 	errs := validateBuildingExistingRacksFitLayout(p)
 	if len(errs) != 1 || !strings.Contains(errs[0].GetMessage(), "does not fit building") {
 		t.Fatalf("errors = %+v, want site-less building layout fit error", errs)
@@ -2730,7 +2730,7 @@ func TestValidateBuildingExistingRacksFitLayoutUsesBuildingIDForDuplicateBuildin
 		}},
 	}
 
-	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"BUILDING": buildingRows}}, snap, pb.OmissionMode_OMISSION_MODE_LEAVE_IN_PLACE)
+	p := resolvePlan(&parsedCSV{sections: map[string][]map[string]string{"BUILDING": buildingRows}}, snap, pb.OmissionMode_OMISSION_MODE_UNSPECIFIED)
 	errs := validateBuildingExistingRacksFitLayout(p)
 	if len(errs) != 0 {
 		t.Fatalf("errors = %+v, want building_id-specific layout accepted", errs)


### PR DESCRIPTION
Reviewable diff: +2135/-1594 across 6 files (excludes generated, test, and story files).

## Summary

Site-map CSV import lets an operator upload a spreadsheet of sites, buildings, racks, and miners and have Proto Fleet reconcile the fleet's topology to match it. Previously each stage of that flow — the dry-run preview, the validation errors, the "did anything change since you previewed" token, and the final database writes — worked out *from scratch* what the CSV meant. Those four independent re-derivations drifted apart, which is where most of the reported edge-case bugs came from.

This PR makes the import resolve the CSV into **one canonical plan** first, and then has preview, validation, the commit token, and apply all read from that single plan. Same feature, same CSV format from the user's point of view; the internals now have a single source of truth instead of four.

## How it works

The import runs in one direction: raw CSV → resolved plan → everything else.

1. **Parse.** The uploaded bytes are split into the four sections (SITE, BUILDING, RACK, MINER), each a list of rows.

2. **Load a snapshot.** The server reads what currently exists in the database: all sites, buildings, and racks for the org, plus the miners the uploader is allowed to see. Miners the uploader *can't* see but which still occupy a rack slot are kept in a separate "hidden members" list so they're never silently trampled or deleted.

3. **Resolve references.** Every parent link in the CSV is a single cell, read like this:
   - blank → unassigned
   - a bare number (e.g. `building` = `12`) → the existing building with id 12
   - `NAME:x` (e.g. `building` = `NAME:Warehouse B`) → a building being *created in this same import* whose name is "Warehouse B"

   This replaces the old scheme where each link was two columns (a name *and* an id) that could disagree. Resolving also fills in implied ancestors (a rack that names a building inherits that building's site) and records the matched building's real id internally, so two different buildings that happen to share the same (site, name) stay distinct.

4. **Build the plan.** Each row becomes a resolved node (site / building / rack / miner) tagged with an action — **none**, **create**, or **update** — decided by comparing the canonical CSV row against the live row field by field. Alongside the nodes, a "topology view" describes the desired end state (CSV merged over the current snapshot) that the validators check against.

5. **Validate, count, tokenize — all off the plan.** Grid-position collisions, rack and building capacity, slot conflicts and bounds, and rename permissions all read the resolved nodes and the shared topology view (and fold in those hidden members). The preview change-counts come from the node actions. The commit token is a hash of the resolved plan plus the live snapshot fingerprint.

6. **Apply.** On commit, the token is re-checked (if the CSV or the live database changed since the dry-run, the token won't match and the commit is refused). Then a single database transaction walks the resolved nodes and performs each create/update, and — because "remove omitted rows" is now the only removal mode — deletes anything the CSV left out.

Example of the token guard: you dry-run and get a token. A teammate moves a rack in the UI before you hit commit. Your token no longer matches the fresh snapshot, so the commit is rejected and you're asked to dry-run again, rather than applying a stale plan.

```mermaid
flowchart TD
    CSV["Uploaded CSV"] --> Parse["Parse into SITE/BUILDING/RACK/MINER rows"]
    DB["Live database"] --> Snap["Load snapshot (org topology + visible miners + hidden members)"]
    Parse --> Resolve["Resolve references (single-cell: blank / id / NAME:x)"]
    Snap --> Resolve
    Resolve --> Plan["Resolved plan: nodes tagged none/create/update + topology view"]
    Plan --> Preview["Preview change counts"]
    Plan --> Validate["Validation (grid, capacity, slots, renames)"]
    Plan --> Token["Commit token = hash(plan + snapshot)"]
    Plan --> Apply["Apply: one transaction, walk nodes, delete omitted"]
    Apply --> DB
```

```mermaid
sequenceDiagram
    actor User
    participant Import as Import service
    participant DB
    User->>Import: Upload CSV (dry_run)
    Import->>DB: Load snapshot
    Import->>Import: Resolve plan, validate, count
    Import-->>User: Preview + commit token
    User->>Import: Commit (with token)
    Import->>DB: Reload snapshot
    Import->>Import: Recompute token
    alt token matches
        Import->>DB: Apply plan in one transaction
        Import-->>User: Success + changes
    else snapshot drifted
        Import-->>User: Rejected — dry-run again
    end
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/internal/domain/sitemap/resolved.go` | **New.** The canonical plan: resolved node types, `resolveReferences`, `resolvePlan`, the topology view, action classification, and all validators that now read the plan. | This is the heart of the PR — the single source of truth everything else consumes. |
| `server/internal/domain/sitemap/service.go` | Rewritten around the plan: export is id-authoritative, preview/token/apply read the plan, and the old per-stage re-derivation helpers are deleted (net ~-900 lines). | Confirm preview, token, and apply all derive from the plan and that the deleted helpers have no remaining callers. |
| `server/internal/domain/buildings/models/models.go` | **New helpers** `GridCapacity` and `RackCapacityExceeded` — the building rack-capacity rule extracted so both the buildings domain and sitemap import share one implementation. | A previously duplicated invariant; check the two callers agree on semantics. |
| `server/internal/domain/buildings/service.go` | Uses the extracted capacity helper instead of its own inline arithmetic. | Behavior-preserving; verify the net-membership count passed in is unchanged. |
| `client/.../SiteMapCsvImportModal.tsx` | Removes the "leave omitted rows in place" radio option; the omission prompt now just confirms removal. | Matches the server: remove-omitted is the only committable behavior. |
| `docs/plans/2026-07-22-767-sitemap-canonical-plan-tdd.md` | **New** design/plan document. | Optional context for the refactor's phasing and out-of-scope items. |

## Key technical decisions & trade-offs

- **Single reference cell (id or `NAME:`) instead of a name+id column pair.** The old pair could contradict itself and needed reconciliation logic; one cell removes that whole class of ambiguity. Trade-off: existing entities must be referenced by id, and same-import creations by `NAME:` — bare names are a validation error.
- **Id-precise building identity via an internal companion cell.** Two buildings can legitimately share a (site, name) pair, so the resolved building id is carried alongside the canonical name to keep them distinct in grid/capacity/move checks. Alternative — keying purely on (site, name) — silently merged them.
- **Remove-omitted is the only removal mode.** "Leave in place" was dropped as a committable option (server and client). Simpler contract; the dead `OMISSION_MODE_LEAVE_IN_PLACE` proto enum value is left for a follow-up because proto regen is unreliable in this worktree.
- **Commit token hashes the resolved plan, not the raw rows + preview summary.** A token can no longer certify a topology that apply would resolve differently. Trade-off: token values change (they're opaque to clients, so this is safe).
- **Extracted the rack-capacity invariant into the buildings domain** rather than keeping sitemap's private copy, so the rule has one home. Kept the signature capacity-agnostic (`aisles, racksPerAisle, resultingCount`) so a future interactive-reparent fix (#778) can reuse it.

## Testing & validation

- `go build ./...`, `go vet`, and `gofmt -l` clean; the full `internal/domain/sitemap` package test suite passes, as do the new `buildings/models` capacity tests.
- Behavior is asserted against the resolved plan so the previously-reported edge cases can't silently regress, including: renamed/moved buildings staying visible to the rack grid/capacity validators; id-disambiguation of duplicate (site, name) buildings; hidden rack members counted in slot/capacity/conflict checks; and remove-omitted never unassigning a hidden miner.
- Commit-token behavior is covered both ways: the token changes when the live snapshot drifts, and when a CSV edit changes the resolved plan even against an identical snapshot.
- **Not covered:** deletion of the now-dead `OMISSION_MODE_LEAVE_IN_PLACE` proto enum value (deferred — needs proto regen outside a worktree); no new end-to-end/integration test beyond the existing service-level suite.
