### PR TITLE
chore(ci): update GitHub Actions to latest pinned versions

### DIFF
--- a/.github/actions/hermit-setup/action.yml
+++ b/.github/actions/hermit-setup/action.yml
@@ -10,7 +10,7 @@ runs:
   using: "composite"
   steps:
     - name: Activate hermit
-      uses: cashapp/activate-hermit@12a728b03ad41eace0f9abaf98a035e7e8ea2318 # v1.1.4
+      uses: cashapp/activate-hermit@cea9af7913204a965fd488637a8d1811bba2e616 # v1.1.5
       with:
         cache: "false" # Disable hermit cache to avoid it evicting yocto cache for now
 

--- a/.github/client-e2e-tests.yml
+++ b/.github/client-e2e-tests.yml
@@ -9,8 +9,8 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24.15.0
       - name: Install dependencies

--- a/.github/workflows/asicrs-plugin-checks.yml
+++ b/.github/workflows/asicrs-plugin-checks.yml
@@ -27,7 +27,7 @@ jobs:
         working-directory: plugin/asicrs
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Rust toolchain
         run: |
@@ -65,7 +65,7 @@ jobs:
         working-directory: plugin/asicrs
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Rust toolchain
         run: |

--- a/.github/workflows/codex-security-review.yml
+++ b/.github/workflows/codex-security-review.yml
@@ -25,7 +25,7 @@ jobs:
       REVIEW_DIFF_FILE: .git/codex-review.diff
     steps:
       - name: Checkout PR head commit
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
@@ -214,7 +214,7 @@ jobs:
 
       - name: Upload security review result
         if: steps.run_codex.outputs.final-message != ''
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: codex-security-review-result
           path: codex-security-review-result.json
@@ -222,7 +222,7 @@ jobs:
 
       - name: Upload security review markdown
         if: steps.run_codex.outputs.final-message != ''
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: codex-security-review-markdown
           path: codex-security-review.md

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Checkout code
         if: ${{ !github.event.repository.private }}
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Dependency Review
         if: ${{ !github.event.repository.private }}

--- a/.github/workflows/deployment-config-checks.yml
+++ b/.github/workflows/deployment-config-checks.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Validate host profiles and compose interpolation
         run: ./deployment-files/tests/test-profiles.sh

--- a/.github/workflows/generated-code-check.yml
+++ b/.github/workflows/generated-code-check.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Hermit
         uses: ./.github/actions/hermit-setup

--- a/.github/workflows/mdk-api-docs.yml
+++ b/.github/workflows/mdk-api-docs.yml
@@ -30,8 +30,8 @@ jobs:
     name: Build Redoc site
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24.15.0
       - name: Render branded API docs

--- a/.github/workflows/migration-hygiene.yml
+++ b/.github/workflows/migration-hygiene.yml
@@ -15,14 +15,14 @@ jobs:
     steps:
       - name: Checkout PR merge result
         if: ${{ github.event.pull_request != null }}
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
           fetch-depth: 0
 
       - name: Checkout current ref
         if: ${{ github.event.pull_request == null }}
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -105,7 +105,7 @@ jobs:
       VERSION: ${{ needs.metadata.outputs.version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Download deployment bundle artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/powershell-lint.yml
+++ b/.github/workflows/powershell-lint.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install PSScriptAnalyzer
         shell: powershell

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Checkout
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Detect changed areas
         id: filter
         if: github.event_name == 'pull_request'
@@ -181,7 +181,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Run review policy tests

--- a/.github/workflows/proto-fleet-artifact-build.yml
+++ b/.github/workflows/proto-fleet-artifact-build.yml
@@ -89,10 +89,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup .NET SDK from global.json
-        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           global-json-file: deployment-files/windows/global.json
 
@@ -156,7 +156,7 @@ jobs:
       VERSION: ${{ needs.metadata.outputs.version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Hermit
         uses: ./.github/actions/hermit-setup
@@ -228,13 +228,13 @@ jobs:
       VERSION: ${{ needs.metadata.outputs.version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Hermit
         uses: ./.github/actions/hermit-setup
 
       - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           cache: "npm"
           cache-dependency-path: "./client/package-lock.json"
@@ -279,13 +279,13 @@ jobs:
       VERSION: ${{ needs.metadata.outputs.version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Hermit
         uses: ./.github/actions/hermit-setup
 
       - name: Set up Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           cache: "npm"
           cache-dependency-path: "./client/package-lock.json"
@@ -346,7 +346,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
@@ -385,7 +385,7 @@ jobs:
       VERSION: ${{ needs.metadata.outputs.version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Create deployment directory structure
         run: |

--- a/.github/workflows/protofleet-antminer-plugin-checks.yml
+++ b/.github/workflows/protofleet-antminer-plugin-checks.yml
@@ -33,7 +33,7 @@ jobs:
         working-directory: plugin/antminer
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Hermit
         uses: ./.github/actions/hermit-setup

--- a/.github/workflows/protofleet-client-checks.yml
+++ b/.github/workflows/protofleet-client-checks.yml
@@ -23,7 +23,7 @@ jobs:
         working-directory: client
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Hermit
         uses: ./.github/actions/hermit-setup
@@ -56,7 +56,7 @@ jobs:
         working-directory: client
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Hermit
         uses: ./.github/actions/hermit-setup
@@ -84,7 +84,7 @@ jobs:
         working-directory: client
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Hermit
         uses: ./.github/actions/hermit-setup

--- a/.github/workflows/protofleet-contract-checks.yml
+++ b/.github/workflows/protofleet-contract-checks.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Hermit
         uses: ./.github/actions/hermit-setup

--- a/.github/workflows/protofleet-e2e-real-miners-manual.yml
+++ b/.github/workflows/protofleet-e2e-real-miners-manual.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Activate hermit
-        uses: cashapp/activate-hermit@12a728b03ad41eace0f9abaf98a035e7e8ea2318 # v1.1.4
+        uses: cashapp/activate-hermit@cea9af7913204a965fd488637a8d1811bba2e616 # v1.1.5
 
       - name: Cleanup
         shell: bash

--- a/.github/workflows/protofleet-e2e-tests.yml
+++ b/.github/workflows/protofleet-e2e-tests.yml
@@ -14,7 +14,7 @@ jobs:
       specs: ${{ steps.detect.outputs.specs }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -37,7 +37,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -174,7 +174,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -348,7 +348,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/protofleet-example-python-plugin-checks.yml
+++ b/.github/workflows/protofleet-example-python-plugin-checks.yml
@@ -26,7 +26,7 @@ jobs:
         working-directory: plugin/example-python
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Hermit
         uses: ./.github/actions/hermit-setup

--- a/.github/workflows/protofleet-proto-checks.yml
+++ b/.github/workflows/protofleet-proto-checks.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Hermit
         uses: ./.github/actions/hermit-setup

--- a/.github/workflows/protofleet-proto-plugin-checks.yml
+++ b/.github/workflows/protofleet-proto-plugin-checks.yml
@@ -34,7 +34,7 @@ jobs:
         working-directory: plugin/proto
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Hermit
         uses: ./.github/actions/hermit-setup

--- a/.github/workflows/protofleet-server-checks.yml
+++ b/.github/workflows/protofleet-server-checks.yml
@@ -31,7 +31,7 @@ jobs:
         working-directory: server
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Hermit
         uses: ./.github/actions/hermit-setup
@@ -53,7 +53,7 @@ jobs:
         working-directory: server
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Hermit
         uses: ./.github/actions/hermit-setup

--- a/.github/workflows/protofleet-virtual-plugin-checks.yml
+++ b/.github/workflows/protofleet-virtual-plugin-checks.yml
@@ -31,7 +31,7 @@ jobs:
         working-directory: plugin/virtual
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Hermit
         uses: ./.github/actions/hermit-setup

--- a/.github/workflows/protoos-e2e-tests.yml
+++ b/.github/workflows/protoos-e2e-tests.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Apply labels
-        uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
+        uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           sync-labels: true

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -28,7 +28,7 @@ jobs:
         working-directory: packages/proto-python-gen
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Hermit
         uses: ./.github/actions/hermit-setup
@@ -49,7 +49,7 @@ jobs:
         working-directory: server/sdk/v1/python
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Hermit
         uses: ./.github/actions/hermit-setup
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Hermit
         uses: ./.github/actions/hermit-setup
@@ -92,7 +92,7 @@ jobs:
         working-directory: packages/proto-python-gen
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Hermit
         uses: ./.github/actions/hermit-setup

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
     needs: [build-artifacts]
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Download deployment bundle artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/review-policy.yml
+++ b/.github/workflows/review-policy.yml
@@ -178,7 +178,7 @@ jobs:
 
       - name: Checkout trusted base policy
         if: steps.pr.outputs.found == 'true'
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ steps.pr.outputs.base_sha }}
           fetch-depth: 0
@@ -296,7 +296,7 @@ jobs:
           steps.preflight.outputs.eligible == 'true'
         continue-on-error: true
         timeout-minutes: 10
-        uses: openai/codex-action@e0fdf01220eb9a88167c4898839d273e3f2609d1 # v1.8
+        uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1.11
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           model: ${{ env.CODEX_MODEL }}

--- a/.github/workflows/rust-sdk-checks.yml
+++ b/.github/workflows/rust-sdk-checks.yml
@@ -26,7 +26,7 @@ jobs:
         working-directory: sdk/rust/proto-fleet-plugin
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Rust toolchain
         run: |
@@ -67,7 +67,7 @@ jobs:
         working-directory: sdk/rust/proto-fleet-plugin
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install Rust toolchain
         run: |

--- a/.github/workflows/windows-csharp-checks.yml
+++ b/.github/workflows/windows-csharp-checks.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup .NET SDK from global.json
-        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
         with:
           global-json-file: deployment-files/windows/global.json
 


### PR DESCRIPTION
Reviewable diff: +58/-58 across 30 files (excludes generated, test, and story files).

## Summary
Proto Fleet workflows now use the latest stable releases for every external GitHub Action while retaining immutable commit-SHA pins. This refreshes checkout, Node and .NET setup, labeling, artifact upload, Codex, and Hermit integrations without changing workflow inputs or job structure.

## How it works
Each external action invocation continues to target a full 40-character commit SHA, with the corresponding stable release tag preserved in an inline comment for auditability. Shared action pins are updated alongside workflow-local pins so all 130 invocations resolve consistently.

```mermaid
flowchart LR
  E["GitHub event"] --> W["Proto Fleet workflow"]
  W --> P["Immutable action commit SHA"]
  P --> J["Existing job inputs and steps"]
  P --> V["Stable version comment for audits"]
```

## Areas of the code involved
| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `.github/workflows/` | Refreshed external action SHAs and version comments across CI, release, review, and automation workflows | Confirm major action upgrades preserve existing inputs and security boundaries |
| `.github/actions/hermit-setup/action.yml` | Updated the shared Hermit activation action | This setup path is reused by most build and test jobs |
| `.github/client-e2e-tests.yml` | Updated checkout and Node setup pins | Keeps the reusable client E2E job aligned with the main workflows |

## Key technical decisions & trade-offs
- Pin exact release commits rather than mutable major-version tags, preserving the repository's supply-chain convention.
- Select the highest stable semantic tag published upstream, including major upgrades, rather than waiting for the monthly Dependabot cooldown.
- Keep all action inputs and workflow topology unchanged so the diff remains an auditable dependency-only update.

## Testing & validation
- `just lint`
- Parsed all 38 files under `.github/` as YAML.
- Verified all 130 external action references across 19 action paths against live upstream stable tags and commit SHAs.
- `git diff --check`
- Application tests were not run because this change only updates external workflow dependencies; PR CI provides the executable integration check.
- Code review: skipped (mechanical dependency-version diff).

## Post-Deploy Monitoring & Validation
No additional production-runtime monitoring is required because these changes only affect GitHub Actions. During PR CI and the first post-merge nightly/release run, the PR author should inspect Actions logs for `Unable to resolve action`, Node runtime errors, and artifact upload/download failures; healthy signals are all required checks passing and Codex review artifacts/comments being published. Any action startup or artifact compatibility failure is a rollback trigger; revert this commit or restore the affected prior SHA.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Cursor: GPT-5.6 Sol](https://img.shields.io/badge/Cursor-GPT--5.6_Sol-000000)
