### PR TITLE
Curtailment: Enable end-to-end curtailment confirmation with dev-stack fake miners

### DIFF
--- a/plugin/proto/internal/device/device.go
+++ b/plugin/proto/internal/device/device.go
@@ -105,19 +105,6 @@ func miningStateBeforeFullCurtail(wasMining bool) fullCurtailMiningState {
 	return fullCurtailMiningStateWasNotMining
 }
 
-func (s fullCurtailMiningState) restoreMiningDecision() (bool, bool) {
-	switch s {
-	case fullCurtailMiningStateUnknown:
-		return false, false
-	case fullCurtailMiningStateWasMining:
-		return true, true
-	case fullCurtailMiningStateWasNotMining:
-		return false, true
-	default:
-		return false, false
-	}
-}
-
 type DeviceOption func(*Device)
 
 func SetStatusTTL(ttl time.Duration) func(*Device) {
@@ -637,11 +624,23 @@ func (d *Device) curtailFull(ctx context.Context) error {
 	}
 	wasMining := isMiningHealth(metrics.Health)
 
-	if err := d.stopMining(ctx); err != nil {
+	if err := d.curtailMining(ctx); err != nil {
 		return wrapCurtailDispatchError(d.id, err)
 	}
 	d.recordFullCurtailment(wasMining)
 	d.invalidateStatusCache()
+	return nil
+}
+
+func (d *Device) curtailMining(ctx context.Context) error {
+	slog.Info("Plugin device entering full curtailment",
+		"device_id", d.id,
+		"host", d.deviceInfo.Host)
+
+	if err := d.client.CurtailMining(ctx); err != nil {
+		return fmt.Errorf("failed to stop mining for curtailment: %w", err)
+	}
+
 	return nil
 }
 
@@ -666,40 +665,45 @@ func (d *Device) curtailEfficiency(ctx context.Context) error {
 // Uncurtail restores the device based on the active curtailment level.
 func (d *Device) Uncurtail(ctx context.Context, _ sdk.UncurtailRequest) error {
 	snapshot := d.restoreCurtailmentState()
-	restored := false
 
 	if snapshot.preEfficiencyTarget != nil {
 		if err := d.client.SetPowerTarget(ctx, snapshot.preEfficiencyTarget.CurrentW, snapshot.preEfficiencyTarget.Mode); err != nil {
 			return wrapCurtailDispatchError(d.id, err)
 		}
 		d.invalidateStatusCache()
-		restored = true
 	}
 
-	shouldStartMining := false
-	fullRestoreKnown := false
-	if restoreMining, ok := snapshot.preFullMiningState.restoreMiningDecision(); ok {
-		shouldStartMining = restoreMining
-		fullRestoreKnown = true
-	} else if snapshot.activeLevel == sdk.CurtailLevelFull ||
-		(snapshot.activeLevel == sdk.CurtailLevelUnspecified && snapshot.preEfficiencyTarget == nil) {
+	miningStateToRestore := snapshot.preFullMiningState
+	if miningStateToRestore == fullCurtailMiningStateUnknown &&
+		(snapshot.activeLevel == sdk.CurtailLevelFull ||
+			(snapshot.activeLevel == sdk.CurtailLevelUnspecified && snapshot.preEfficiencyTarget == nil)) {
 		// If plugin-local restore state was lost, keep direct Uncurtail's legacy
 		// explicit-restore behavior.
-		shouldStartMining = true
+		miningStateToRestore = fullCurtailMiningStateWasMining
 	}
 
-	if shouldStartMining {
-		if err := d.startMining(ctx); err != nil {
-			return wrapCurtailDispatchError(d.id, err)
-		}
+	var miningRestoreErr error
+	switch miningStateToRestore {
+	case fullCurtailMiningStateUnknown:
+	case fullCurtailMiningStateWasMining:
+		miningRestoreErr = d.startMining(ctx)
+	case fullCurtailMiningStateWasNotMining:
+		miningRestoreErr = d.stopMining(ctx)
+	}
+	if miningRestoreErr != nil {
+		return wrapCurtailDispatchError(d.id, miningRestoreErr)
+	}
+	if miningStateToRestore != fullCurtailMiningStateUnknown {
 		d.invalidateStatusCache()
 	}
 
-	if snapshot.preEfficiencyTarget == nil && !fullRestoreKnown && snapshot.activeLevel == sdk.CurtailLevelEfficiency {
+	if snapshot.preEfficiencyTarget == nil &&
+		snapshot.preFullMiningState == fullCurtailMiningStateUnknown &&
+		snapshot.activeLevel == sdk.CurtailLevelEfficiency {
 		return sdk.NewErrCurtailTransient(d.id, fmt.Errorf("efficiency curtail restore state missing"))
 	}
 
-	if restored || fullRestoreKnown || shouldStartMining {
+	if snapshot.preEfficiencyTarget != nil || miningStateToRestore != fullCurtailMiningStateUnknown {
 		d.clearCurtailmentState()
 	}
 

--- a/plugin/proto/internal/device/device.go
+++ b/plugin/proto/internal/device/device.go
@@ -266,6 +266,9 @@ func (d *Device) Status(ctx context.Context) (sdk.DeviceMetrics, error) {
 	if err != nil {
 		return sdk.DeviceMetrics{}, fmt.Errorf("failed to get miner status: %w", err)
 	}
+	if minerStatus.IsCurtailed && d.hasActiveFullCurtailment() {
+		minerStatus.State = sdk.HealthHealthyInactive
+	}
 
 	telemetryResp, err := d.client.GetTelemetryValues(ctx)
 	if err != nil {
@@ -745,6 +748,13 @@ func (d *Device) restoreCurtailmentState() curtailmentRestoreSnapshot {
 		snapshot.preEfficiencyTarget = &targetCopy
 	}
 	return snapshot
+}
+
+func (d *Device) hasActiveFullCurtailment() bool {
+	d.curtailmentMutex.Lock()
+	defer d.curtailmentMutex.Unlock()
+
+	return d.curtailmentState.activeLevel == sdk.CurtailLevelFull
 }
 
 func (d *Device) clearCurtailmentState() {

--- a/plugin/proto/internal/device/device_test.go
+++ b/plugin/proto/internal/device/device_test.go
@@ -369,21 +369,55 @@ func TestDevice_CurtailFullStopsAndUncurtailStartsMining(t *testing.T) {
 }
 
 func TestDevice_CurtailFullOnInactiveMinerDoesNotStartOnUncurtail(t *testing.T) {
-	var stopped, started bool
+	var stopCount int
+	var started bool
 	dev := newMiningControlTestDeviceWithMiningState(t, http.StatusOK, "Stopped", func(path string) {
 		switch path {
 		case "/api/v1/mining/stop":
-			stopped = true
+			stopCount++
 		case "/api/v1/mining/start":
 			started = true
 		}
 	})
 
 	require.NoError(t, dev.Curtail(context.Background(), sdk.CurtailRequest{Level: sdk.CurtailLevelFull}))
-	require.True(t, stopped)
+	require.Equal(t, 1, stopCount)
 
 	require.NoError(t, dev.Uncurtail(context.Background(), sdk.UncurtailRequest{}))
 	require.False(t, started)
+	require.Equal(t, 2, stopCount)
+}
+
+func TestDevice_CurtailFullOnPoollessMinerRestoresIdleWithoutStarting(t *testing.T) {
+	var stopCount int
+	var started bool
+	dev := newMiningControlTestDeviceWithPools(t, http.StatusOK, "NoPools", `{"pools":[]}`, func(path string) {
+		switch path {
+		case "/api/v1/mining/stop":
+			stopCount++
+		case "/api/v1/mining/start":
+			started = true
+		}
+	})
+
+	require.NoError(t, dev.Curtail(context.Background(), sdk.CurtailRequest{Level: sdk.CurtailLevelFull}))
+	require.Equal(t, 1, stopCount)
+
+	require.NoError(t, dev.Uncurtail(context.Background(), sdk.UncurtailRequest{}))
+	require.False(t, started)
+	require.Equal(t, 2, stopCount)
+}
+
+func TestDevice_CurtailFullMarksStopRequestAsCurtailment(t *testing.T) {
+	var curtailmentHeader string
+	dev := newMiningControlTestDeviceWithRequestCallback(t, http.StatusOK, "Mining", func(r *http.Request) {
+		if r.URL.Path == "/api/v1/mining/stop" {
+			curtailmentHeader = r.Header.Get("X-Proto-Fleet-Curtailment")
+		}
+	})
+
+	require.NoError(t, dev.Curtail(context.Background(), sdk.CurtailRequest{Level: sdk.CurtailLevelFull}))
+	require.Equal(t, "full", curtailmentHeader)
 }
 
 func TestDevice_CurtailFullRefreshesStatusBeforeSnapshot(t *testing.T) {
@@ -547,6 +581,8 @@ func TestDevice_CurtailEfficiencyMissingTargetReturnsTransient(t *testing.T) {
 	assert.Contains(t, sdkErr.Err.Error(), "power target not available")
 }
 
+const configuredPoolsJSON = `{"pools":[{"id":0,"url":"stratum+tcp://pool.example:3333","user":"worker"}]}`
+
 func newMiningControlTestDevice(t *testing.T, miningControlStatus int) *Device {
 	t.Helper()
 	return newMiningControlTestDeviceWithCallback(t, miningControlStatus, nil)
@@ -563,6 +599,51 @@ func newMiningControlTestDeviceWithMiningState(t *testing.T, miningControlStatus
 
 func newMiningControlTestDeviceWithDynamicMiningState(t *testing.T, miningControlStatus int, miningState *string, onControl func(path string), opts ...DeviceOption) *Device {
 	t.Helper()
+	return newMiningControlTestDeviceWithDynamicStateAndPools(
+		t,
+		miningControlStatus,
+		miningState,
+		configuredPoolsJSON,
+		requestPathCallback(onControl),
+		opts...,
+	)
+}
+
+func newMiningControlTestDeviceWithPools(t *testing.T, miningControlStatus int, miningState, poolsJSON string, onControl func(path string)) *Device {
+	t.Helper()
+	return newMiningControlTestDeviceWithDynamicStateAndPools(
+		t,
+		miningControlStatus,
+		&miningState,
+		poolsJSON,
+		requestPathCallback(onControl),
+		SetStatusTTL(0*time.Second),
+	)
+}
+
+func newMiningControlTestDeviceWithRequestCallback(t *testing.T, miningControlStatus int, miningState string, onControl func(*http.Request)) *Device {
+	t.Helper()
+	return newMiningControlTestDeviceWithDynamicStateAndPools(
+		t,
+		miningControlStatus,
+		&miningState,
+		configuredPoolsJSON,
+		onControl,
+		SetStatusTTL(0*time.Second),
+	)
+}
+
+func requestPathCallback(callback func(path string)) func(*http.Request) {
+	if callback == nil {
+		return nil
+	}
+	return func(r *http.Request) {
+		callback(r.URL.Path)
+	}
+}
+
+func newMiningControlTestDeviceWithDynamicStateAndPools(t *testing.T, miningControlStatus int, miningState *string, poolsJSON string, onControl func(*http.Request), opts ...DeviceOption) *Device {
+	t.Helper()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
@@ -574,10 +655,10 @@ func newMiningControlTestDeviceWithDynamicMiningState(t *testing.T, miningContro
 			_, _ = w.Write([]byte(fmt.Sprintf(`{"mining-status":{"status":%q}}`, *miningState)))
 		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/pools":
 			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"pools":[{"id":0,"url":"stratum+tcp://pool.example:3333","user":"worker"}]}`))
+			_, _ = w.Write([]byte(poolsJSON))
 		case r.Method == http.MethodPost && (r.URL.Path == "/api/v1/mining/start" || r.URL.Path == "/api/v1/mining/stop"):
 			if onControl != nil {
-				onControl(r.URL.Path)
+				onControl(r)
 			}
 			w.WriteHeader(miningControlStatus)
 		default:

--- a/plugin/proto/internal/device/device_test.go
+++ b/plugin/proto/internal/device/device_test.go
@@ -408,6 +408,64 @@ func TestDevice_CurtailFullOnPoollessMinerRestoresIdleWithoutStarting(t *testing
 	require.Equal(t, 2, stopCount)
 }
 
+func TestDevice_StatusOnlyTrustsLocallyInitiatedCurtailment(t *testing.T) {
+	miningState := "Curtailed"
+	dev := newMiningControlTestDeviceWithDynamicStateAndPools(
+		t,
+		http.StatusOK,
+		&miningState,
+		`{"pools":[]}`,
+		func(r *http.Request) {
+			if r.URL.Path == "/api/v1/mining/stop" {
+				miningState = "Curtailed"
+			}
+		},
+		SetStatusTTL(0*time.Second),
+	)
+
+	metrics, err := dev.Status(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, sdk.HealthNeedsMiningPool, metrics.Health)
+
+	miningState = "NoPools"
+	require.NoError(t, dev.Curtail(context.Background(), sdk.CurtailRequest{Level: sdk.CurtailLevelFull}))
+
+	metrics, err = dev.Status(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, sdk.HealthHealthyInactive, metrics.Health)
+}
+
+func TestDevice_UncurtailInactiveMinerRetriesStopWithoutLosingSnapshot(t *testing.T) {
+	miningState := "Stopped"
+	var stopCount, startCount int
+	dev := newMiningControlTestDeviceWithDynamicStateAndPoolsAndControlStatus(
+		t,
+		&miningState,
+		configuredPoolsJSON,
+		func(r *http.Request) int {
+			switch r.URL.Path {
+			case "/api/v1/mining/stop":
+				stopCount++
+				if stopCount == 2 {
+					return http.StatusInternalServerError
+				}
+			case "/api/v1/mining/start":
+				startCount++
+			}
+			return http.StatusOK
+		},
+		nil,
+		SetStatusTTL(0*time.Second),
+	)
+
+	require.NoError(t, dev.Curtail(context.Background(), sdk.CurtailRequest{Level: sdk.CurtailLevelFull}))
+	require.Error(t, dev.Uncurtail(context.Background(), sdk.UncurtailRequest{}))
+	require.NoError(t, dev.Uncurtail(context.Background(), sdk.UncurtailRequest{}))
+
+	require.Equal(t, 3, stopCount)
+	require.Zero(t, startCount)
+}
+
 func TestDevice_CurtailFullMarksStopRequestAsCurtailment(t *testing.T) {
 	var curtailmentHeader string
 	dev := newMiningControlTestDeviceWithRequestCallback(t, http.StatusOK, "Mining", func(r *http.Request) {
@@ -644,6 +702,27 @@ func requestPathCallback(callback func(path string)) func(*http.Request) {
 
 func newMiningControlTestDeviceWithDynamicStateAndPools(t *testing.T, miningControlStatus int, miningState *string, poolsJSON string, onControl func(*http.Request), opts ...DeviceOption) *Device {
 	t.Helper()
+	return newMiningControlTestDeviceWithDynamicStateAndPoolsAndControlStatus(
+		t,
+		miningState,
+		poolsJSON,
+		func(*http.Request) int {
+			return miningControlStatus
+		},
+		onControl,
+		opts...,
+	)
+}
+
+func newMiningControlTestDeviceWithDynamicStateAndPoolsAndControlStatus(
+	t *testing.T,
+	miningState *string,
+	poolsJSON string,
+	controlStatus func(*http.Request) int,
+	onControl func(*http.Request),
+	opts ...DeviceOption,
+) *Device {
+	t.Helper()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
@@ -660,7 +739,7 @@ func newMiningControlTestDeviceWithDynamicStateAndPools(t *testing.T, miningCont
 			if onControl != nil {
 				onControl(r)
 			}
-			w.WriteHeader(miningControlStatus)
+			w.WriteHeader(controlStatus(r))
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}

--- a/plugin/proto/pkg/proto/client.go
+++ b/plugin/proto/pkg/proto/client.go
@@ -855,15 +855,19 @@ func (c *Client) GetStatus(ctx context.Context) (*Status, error) {
 	}
 
 	state := sdk.HealthHealthyInactive
+	isCurtailed := false
 	if statusCode != http.StatusNoContent {
 		state = mapMiningState(resp.MiningStatus.Status)
+		isCurtailed = strings.EqualFold(resp.MiningStatus.Status, "curtailed")
 	}
 
-	// The actual pool list is the source of truth, not MiningState (which can be stale).
+	// The actual pool list is normally the source of truth because MiningState
+	// can be stale. Explicit curtailment takes precedence so a pool-less device
+	// remains visibly inactive while it is held at minimal power.
 	needsPool, err := c.checkNeedsMiningPool(ctx)
 	if err != nil {
 		slog.Warn("failed to check pool configuration", "error", err)
-	} else if needsPool {
+	} else if needsPool && !isCurtailed {
 		state = sdk.HealthNeedsMiningPool
 	} else if state == sdk.HealthNeedsMiningPool {
 		state = sdk.HealthHealthyInactive

--- a/plugin/proto/pkg/proto/client.go
+++ b/plugin/proto/pkg/proto/client.go
@@ -582,6 +582,10 @@ func (c *Client) Close() error {
 // doRequest executes an authenticated request, re-logging in and retrying once on
 // a 401 (token expired or invalidated by an out-of-band login).
 func (c *Client) doRequest(ctx context.Context, method, path string, body any) (*http.Response, error) {
+	return c.doRequestWithHeaders(ctx, method, path, body, nil)
+}
+
+func (c *Client) doRequestWithHeaders(ctx context.Context, method, path string, body any, headers http.Header) (*http.Response, error) {
 	var bodyBytes []byte
 	if body != nil {
 		b, err := json.Marshal(body)
@@ -596,7 +600,7 @@ func (c *Client) doRequest(ctx context.Context, method, path string, body any) (
 		return nil, err
 	}
 
-	resp, err := c.sendRequest(ctx, method, path, bodyBytes, token)
+	resp, err := c.sendRequest(ctx, method, path, bodyBytes, token, headers)
 	if err != nil {
 		return nil, err
 	}
@@ -607,13 +611,13 @@ func (c *Client) doRequest(ctx context.Context, method, path string, body any) (
 		if err != nil {
 			return nil, err
 		}
-		return c.sendRequest(ctx, method, path, bodyBytes, token)
+		return c.sendRequest(ctx, method, path, bodyBytes, token, headers)
 	}
 
 	return resp, nil
 }
 
-func (c *Client) sendRequest(ctx context.Context, method, path string, bodyBytes []byte, token string) (*http.Response, error) {
+func (c *Client) sendRequest(ctx context.Context, method, path string, bodyBytes []byte, token string, headers http.Header) (*http.Response, error) {
 	var bodyReader io.Reader
 	if bodyBytes != nil {
 		bodyReader = bytes.NewReader(bodyBytes)
@@ -629,6 +633,11 @@ func (c *Client) sendRequest(ctx context.Context, method, path string, bodyBytes
 	}
 	if token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	for key, values := range headers {
+		for _, value := range values {
+			req.Header.Add(key, value)
+		}
 	}
 
 	resp, err := c.httpClient.Do(req)
@@ -686,7 +695,11 @@ func (c *Client) doGetWithStatus(ctx context.Context, path string, result any) (
 
 // doPost performs a POST request and checks the response.
 func (c *Client) doPost(ctx context.Context, path string) error {
-	resp, err := c.doRequest(ctx, http.MethodPost, path, nil)
+	return c.doPostWithHeaders(ctx, path, nil)
+}
+
+func (c *Client) doPostWithHeaders(ctx context.Context, path string, headers http.Header) error {
+	resp, err := c.doRequestWithHeaders(ctx, http.MethodPost, path, nil, headers)
 	if err != nil {
 		return err
 	}
@@ -870,7 +883,7 @@ func mapMiningState(status string) sdk.HealthStatus {
 		return sdk.HealthHealthyActive
 	case "degradedmining", "degraded_mining", "degraded":
 		return sdk.HealthWarning
-	case "stopped":
+	case "stopped", "curtailed":
 		return sdk.HealthHealthyInactive
 	case "poweringon", "powering_on":
 		return sdk.HealthHealthyInactive
@@ -1116,6 +1129,14 @@ func (c *Client) StartMining(ctx context.Context) error {
 // StopMining stops mining operations.
 func (c *Client) StopMining(ctx context.Context) error {
 	return c.doPost(ctx, "/api/v1/mining/stop")
+}
+
+// CurtailMining enters the same minimal-power mode as StopMining while
+// identifying that the command came from the full-curtailment workflow.
+func (c *Client) CurtailMining(ctx context.Context) error {
+	return c.doPostWithHeaders(ctx, "/api/v1/mining/stop", http.Header{
+		"X-Proto-Fleet-Curtailment": []string{"full"},
+	})
 }
 
 // SetCoolingMode configures the cooling system.

--- a/plugin/proto/pkg/proto/client.go
+++ b/plugin/proto/pkg/proto/client.go
@@ -80,6 +80,7 @@ type DeviceInfo struct {
 type Status struct {
 	State        sdk.HealthStatus
 	ErrorMessage string
+	IsCurtailed  bool
 }
 
 // Pool represents a mining pool configuration.
@@ -855,19 +856,15 @@ func (c *Client) GetStatus(ctx context.Context) (*Status, error) {
 	}
 
 	state := sdk.HealthHealthyInactive
-	isCurtailed := false
 	if statusCode != http.StatusNoContent {
 		state = mapMiningState(resp.MiningStatus.Status)
-		isCurtailed = strings.EqualFold(resp.MiningStatus.Status, "curtailed")
 	}
 
-	// The actual pool list is normally the source of truth because MiningState
-	// can be stale. Explicit curtailment takes precedence so a pool-less device
-	// remains visibly inactive while it is held at minimal power.
+	// The actual pool list is the source of truth because MiningState can be stale.
 	needsPool, err := c.checkNeedsMiningPool(ctx)
 	if err != nil {
 		slog.Warn("failed to check pool configuration", "error", err)
-	} else if needsPool && !isCurtailed {
+	} else if needsPool {
 		state = sdk.HealthNeedsMiningPool
 	} else if state == sdk.HealthNeedsMiningPool {
 		state = sdk.HealthHealthyInactive
@@ -876,6 +873,7 @@ func (c *Client) GetStatus(ctx context.Context) (*Status, error) {
 	return &Status{
 		State:        state,
 		ErrorMessage: "", // TODO: Extract from API when available
+		IsCurtailed:  strings.EqualFold(resp.MiningStatus.Status, "curtailed"),
 	}, nil
 }
 

--- a/plugin/proto/pkg/proto/client_test.go
+++ b/plugin/proto/pkg/proto/client_test.go
@@ -935,6 +935,12 @@ func TestGetStatusPoolStateOverride(t *testing.T) {
 			expectedState: sdk.HealthHealthyInactive,
 		},
 		{
+			name:          "firmware reports curtailed and no pools are configured",
+			miningStatus:  "curtailed",
+			pools:         []poolData{},
+			expectedState: sdk.HealthHealthyInactive,
+		},
+		{
 			name:          "firmware reports stopped but no pools",
 			miningStatus:  "stopped",
 			pools:         []poolData{},

--- a/plugin/proto/pkg/proto/client_test.go
+++ b/plugin/proto/pkg/proto/client_test.go
@@ -927,6 +927,14 @@ func TestGetStatusPoolStateOverride(t *testing.T) {
 			expectedState: sdk.HealthHealthyActive,
 		},
 		{
+			name:         "firmware reports curtailed and pools are configured",
+			miningStatus: "curtailed",
+			pools: []poolData{
+				{URL: "stratum+tcp://pool.example.com:3333"},
+			},
+			expectedState: sdk.HealthHealthyInactive,
+		},
+		{
 			name:          "firmware reports stopped but no pools",
 			miningStatus:  "stopped",
 			pools:         []poolData{},

--- a/plugin/proto/pkg/proto/client_test.go
+++ b/plugin/proto/pkg/proto/client_test.go
@@ -938,7 +938,7 @@ func TestGetStatusPoolStateOverride(t *testing.T) {
 			name:          "firmware reports curtailed and no pools are configured",
 			miningStatus:  "curtailed",
 			pools:         []poolData{},
-			expectedState: sdk.HealthHealthyInactive,
+			expectedState: sdk.HealthNeedsMiningPool,
 		},
 		{
 			name:          "firmware reports stopped but no pools",
@@ -967,6 +967,7 @@ func TestGetStatusPoolStateOverride(t *testing.T) {
 			require.NoError(t, err, "GetStatus should not return error")
 			assert.Equal(t, tt.expectedState, status.State,
 				"State should match expected value based on actual pool configuration")
+			assert.Equal(t, strings.EqualFold(tt.miningStatus, "curtailed"), status.IsCurtailed)
 		})
 	}
 }

--- a/server/fake-antminer/http_handlers.go
+++ b/server/fake-antminer/http_handlers.go
@@ -126,6 +126,7 @@ func createStatsHandler(state *MinerState) http.HandlerFunc {
 
 		now := time.Now().Unix()
 		hashRate := state.effectiveHashRateLocked()
+		powerWatts := state.effectivePowerWattsLocked()
 
 		const chainCount = 3
 		chains := make([]map[string]interface{}, chainCount)
@@ -183,16 +184,17 @@ func createStatsHandler(state *MinerState) http.HandlerFunc {
 			},
 			"STATS": []map[string]interface{}{
 				{
-					"elapsed":    3600,
-					"rate_5s":    hashRate * 1000,
-					"rate_30m":   hashRate * 1000,
-					"rate_avg":   hashRate * 1000,
-					"rate_ideal": hashRate * 1000,
-					"rate_unit":  "GH/s",
-					"chain_num":  chainCount,
-					"fan_num":    4,
-					"fan":        fanSpeeds,
-					"hwp_total":  0.0006,
+					"elapsed":     3600,
+					"rate_5s":     hashRate * 1000,
+					"rate_30m":    hashRate * 1000,
+					"rate_avg":    hashRate * 1000,
+					"rate_ideal":  hashRate * 1000,
+					"rate_unit":   "GH/s",
+					"chain_power": fmt.Sprintf("%d W", powerWatts),
+					"chain_num":   chainCount,
+					"fan_num":     4,
+					"fan":         fanSpeeds,
+					"hwp_total":   0.0006,
 					"psu": map[string]interface{}{
 						"index":  0,
 						"status": psuStatus,

--- a/server/fake-antminer/models.go
+++ b/server/fake-antminer/models.go
@@ -14,6 +14,8 @@ const (
 	DefaultDifficulty     = 1024.0
 	DefaultLastShareDelay = 600  // seconds ago
 	DefaultTemperature    = 72.0 // Celsius - realistic ASIC chip temperature
+	DefaultMiningPowerW   = 3250
+	DefaultSleepPowerW    = 30
 	WorkModeNormal        = "0"
 	WorkModeSleep         = "1"
 )
@@ -201,6 +203,14 @@ type DevsResponse struct {
 	ID      int          `json:"id"`
 }
 
+// StatsResponse represents the mixed firmware metadata and mining statistics
+// returned by the cgminer "stats" command.
+type StatsResponse struct {
+	Status []StatusInfo             `json:"STATUS"`
+	Stats  []map[string]interface{} `json:"STATS"`
+	ID     int                      `json:"id"`
+}
+
 func (s *MinerState) currentWorkModeLocked() string {
 	switch {
 	case s.MinerMode != "":
@@ -229,6 +239,14 @@ func (s *MinerState) effectiveHashRateLocked() float64 {
 	}
 
 	return s.HashRate
+}
+
+func (s *MinerState) effectivePowerWattsLocked() int {
+	if s.currentWorkModeLocked() == WorkModeSleep {
+		return DefaultSleepPowerW
+	}
+
+	return DefaultMiningPowerW
 }
 
 func (s *MinerState) summaryStatusLocked() string {

--- a/server/fake-antminer/rpc_handlers.go
+++ b/server/fake-antminer/rpc_handlers.go
@@ -17,6 +17,7 @@ const (
 	statusCodeSummary = 11
 	statusCodePools   = 7
 	statusCodeDevices = 9
+	statusCodeStats   = 70
 
 	// Hashrate variation values (GH/s)
 	hashrate5sVariation  = 2000
@@ -82,6 +83,8 @@ func handleRPCConnection(conn net.Conn, state *MinerState) {
 		response = generatePoolsResponse(state)
 	case "devs":
 		response = generateDevsResponse(state)
+	case "stats":
+		response = generateStatsResponse(state)
 	default:
 		log.Printf("Unknown command: %s", request.Command)
 		response = map[string]string{"error": "unknown command"}
@@ -90,6 +93,44 @@ func handleRPCConnection(conn net.Conn, state *MinerState) {
 	if err := json.NewEncoder(conn).Encode(response); err != nil {
 		log.Printf("Failed to encode response: %v", err)
 		return
+	}
+}
+
+func generateStatsResponse(state *MinerState) StatsResponse {
+	state.mu.RLock()
+	defer state.mu.RUnlock()
+
+	now := time.Now().Unix()
+	hashRateGHS := state.effectiveHashRateLocked() * thsToGhsConversionFactor
+	powerWatts := state.effectivePowerWattsLocked()
+
+	return StatsResponse{
+		Status: []StatusInfo{
+			{
+				Status:      "S",
+				When:        now,
+				Code:        statusCodeStats,
+				Msg:         "CGMiner stats",
+				Description: "cgminer 1.0.0",
+			},
+		},
+		Stats: []map[string]interface{}{
+			{
+				"BMMiner":     "2.0.0",
+				"Miner":       state.MinerType,
+				"CompileTime": "2023-05-01",
+				"Type":        state.MinerType,
+			},
+			{
+				"STATS":       0,
+				"ID":          "BTM_SOC0",
+				"Elapsed":     DefaultElapsedTime,
+				"GHS 5s":      hashRateGHS,
+				"GHS av":      hashRateGHS,
+				"chain_power": fmt.Sprintf("%d W", powerWatts),
+			},
+		},
+		ID: mockMessageID,
 	}
 }
 

--- a/server/fake-antminer/sleep_mode_test.go
+++ b/server/fake-antminer/sleep_mode_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -89,8 +90,9 @@ func TestSetConfigSleepModePersistsAndZeroesHashrate(t *testing.T) {
 
 	var stats struct {
 		Stats []struct {
-			Rate5s float64 `json:"rate_5s"`
-			Chain  []struct {
+			Rate5s     float64 `json:"rate_5s"`
+			ChainPower string  `json:"chain_power"`
+			Chain      []struct {
 				RateReal float64 `json:"rate_real"`
 			} `json:"chain"`
 		} `json:"STATS"`
@@ -103,6 +105,9 @@ func TestSetConfigSleepModePersistsAndZeroesHashrate(t *testing.T) {
 	}
 	if got := stats.Stats[0].Rate5s; got != 0 {
 		t.Fatalf("expected stats rate_5s 0, got %v", got)
+	}
+	if got := stats.Stats[0].ChainPower; got != "30 W" {
+		t.Fatalf("expected stats chain_power %q, got %q", "30 W", got)
 	}
 	for _, chain := range stats.Stats[0].Chain {
 		if chain.RateReal != 0 {
@@ -134,6 +139,51 @@ func TestSetConfigSleepModePersistsAndZeroesHashrate(t *testing.T) {
 	if got := rpcDevs.Devices[0].MHSav; got != 0 {
 		t.Fatalf("expected RPC MHS av 0, got %v", got)
 	}
+
+	rpcStats := generateStatsResponse(state)
+	if len(rpcStats.Stats) != 2 {
+		t.Fatalf("expected 2 RPC stats entries, got %d", len(rpcStats.Stats))
+	}
+	if got := rpcStats.Stats[1]["chain_power"]; got != "30 W" {
+		t.Fatalf("expected RPC chain_power %q, got %#v", "30 W", got)
+	}
+}
+
+func TestRPCStatsReportsMiningPower(t *testing.T) {
+	state := &MinerState{
+		MinerType:       "Antminer S19j Pro",
+		HashRate:        110,
+		BitmainWorkMode: WorkModeNormal,
+	}
+
+	response := requestRPCStats(t, state)
+	if len(response.Stats) != 2 {
+		t.Fatalf("expected firmware and mining stats entries, got %d", len(response.Stats))
+	}
+	if got := response.Stats[0]["Type"]; got != state.MinerType {
+		t.Fatalf("expected firmware type %q, got %#v", state.MinerType, got)
+	}
+	if got := response.Stats[1]["chain_power"]; got != "3250 W" {
+		t.Fatalf("expected RPC chain_power %q, got %#v", "3250 W", got)
+	}
+}
+
+func requestRPCStats(t *testing.T, state *MinerState) StatsResponse {
+	t.Helper()
+
+	serverConn, clientConn := net.Pipe()
+	t.Cleanup(func() { _ = clientConn.Close() })
+	go handleRPCConnection(serverConn, state)
+
+	if err := json.NewEncoder(clientConn).Encode(RPCRequest{Command: "stats"}); err != nil {
+		t.Fatalf("encode RPC stats request: %v", err)
+	}
+
+	var response StatsResponse
+	if err := json.NewDecoder(clientConn).Decode(&response); err != nil {
+		t.Fatalf("decode RPC stats response: %v", err)
+	}
+	return response
 }
 
 func TestSetConfigLegacySleepModePersists(t *testing.T) {

--- a/server/fake-proto-rig/curtailment_power_test.go
+++ b/server/fake-proto-rig/curtailment_power_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestMinerTelemetryPowerStates(t *testing.T) {
+	tests := []struct {
+		name       string
+		state      MiningState
+		withPool   bool
+		wantState  MiningState
+		wantPowerW float64
+	}{
+		{
+			name:       "mining",
+			state:      MiningStateMining,
+			withPool:   true,
+			wantState:  MiningStateMining,
+			wantPowerW: defaultPowerW,
+		},
+		{
+			name:       "stopped idle",
+			state:      MiningStateStopped,
+			withPool:   true,
+			wantState:  MiningStateStopped,
+			wantPowerW: defaultIdlePowerW,
+		},
+		{
+			name:       "poolless idle",
+			state:      MiningStateMining,
+			wantState:  MiningStateNoPools,
+			wantPowerW: defaultIdlePowerW,
+		},
+		{
+			name:       "poolless curtailed",
+			state:      MiningStateCurtailed,
+			wantState:  MiningStateCurtailed,
+			wantPowerW: defaultCurtailPowerW,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := newPowerTestMinerState(tt.state, tt.withPool)
+			assertPowerState(t, state, tt.wantState, tt.wantPowerW)
+		})
+	}
+}
+
+func TestMiningCommandsCurtailAndRestorePowerState(t *testing.T) {
+	tests := []struct {
+		name         string
+		initialState MiningState
+		withPool     bool
+		wantRestored MiningState
+		wantPowerW   float64
+	}{
+		{
+			name:         "mining device",
+			initialState: MiningStateMining,
+			withPool:     true,
+			wantRestored: MiningStateMining,
+			wantPowerW:   defaultPowerW,
+		},
+		{
+			name:         "intentionally stopped device",
+			initialState: MiningStateStopped,
+			withPool:     true,
+			wantRestored: MiningStateStopped,
+			wantPowerW:   defaultIdlePowerW,
+		},
+		{
+			name:         "poolless device",
+			initialState: MiningStateMining,
+			wantRestored: MiningStateNoPools,
+			wantPowerW:   defaultIdlePowerW,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := newPowerTestMinerState(tt.initialState, tt.withPool)
+			handler := NewRESTApiHandler(state)
+
+			curtailReq := httptest.NewRequest(http.MethodPost, "/api/v1/mining/stop", nil)
+			curtailReq.Header.Set("X-Proto-Fleet-Curtailment", "full")
+			curtailResp := httptest.NewRecorder()
+			handler.handleMiningStop(curtailResp, curtailReq)
+
+			if curtailResp.Code != http.StatusAccepted {
+				t.Fatalf("expected curtail status %d, got %d", http.StatusAccepted, curtailResp.Code)
+			}
+			assertPowerState(t, state, MiningStateCurtailed, defaultCurtailPowerW)
+
+			restorePath := "/api/v1/mining/stop"
+			restoreHandler := handler.handleMiningStop
+			if tt.initialState == MiningStateMining && tt.withPool {
+				restorePath = "/api/v1/mining/start"
+				restoreHandler = handler.handleMiningStart
+			}
+			restoreResp := httptest.NewRecorder()
+			restoreHandler(restoreResp, httptest.NewRequest(http.MethodPost, restorePath, nil))
+
+			if restoreResp.Code != http.StatusAccepted {
+				t.Fatalf("expected restore status %d, got %d", http.StatusAccepted, restoreResp.Code)
+			}
+			assertPowerState(t, state, tt.wantRestored, tt.wantPowerW)
+		})
+	}
+}
+
+func newPowerTestMinerState(miningState MiningState, withPool bool) *MinerState {
+	state := NewMinerState("SN12345678", "00:11:22:33:44:55")
+	state.SetMiningState(miningState)
+	if withPool {
+		state.AddPool(&Pool{Idx: 0, Url: "stratum+tcp://pool.example:3333", Username: "worker"})
+	}
+	return state
+}
+
+func assertPowerState(t *testing.T, state *MinerState, wantState MiningState, wantPower float64) {
+	t.Helper()
+
+	if got := state.GetMiningState(); got != wantState {
+		t.Fatalf("expected mining state %q, got %q", wantState, got)
+	}
+	hashrate, _, power, _ := state.GetMinerTelemetry()
+	minPower := wantPower * (1 - telemetryVariation)
+	maxPower := wantPower * (1 + telemetryVariation)
+	if power < minPower || power > maxPower {
+		t.Fatalf("expected power in [%v, %v], got %v", minPower, maxPower, power)
+	}
+	if wantState == MiningStateMining && hashrate <= 0 {
+		t.Fatalf("expected positive hashrate, got %v", hashrate)
+	}
+	if wantState != MiningStateMining && hashrate != 0 {
+		t.Fatalf("expected zero hashrate, got %v", hashrate)
+	}
+}

--- a/server/fake-proto-rig/models.go
+++ b/server/fake-proto-rig/models.go
@@ -12,6 +12,8 @@ const (
 	defaultHashrateTHS    = 140.0  // TH/s
 	defaultTemperatureC   = 55.0   // Celsius
 	defaultPowerW         = 3400.0 // Watts
+	defaultIdlePowerW     = 200.0  // Watts
+	defaultCurtailPowerW  = 30.0   // Watts
 	defaultEfficiencyJTH  = 24.3   // J/TH
 	defaultIdealHashrate  = 145.0  // TH/s
 	defaultFanSpeedRPM    = 4500
@@ -389,7 +391,13 @@ func (s *MinerState) miningState() MiningState {
 		return *s.ErrorConfig.ForceMiningState
 	}
 
-	// If no pools configured, report NO_POOLS state
+	// Full curtailment must remain visible even on a pool-less device so
+	// telemetry can expose its minimal-power state.
+	if s.MiningStateVal == MiningStateCurtailed {
+		return MiningStateCurtailed
+	}
+
+	// If no pools configured, report NO_POOLS state.
 	if len(s.Pools) == 0 {
 		return MiningStateNoPools
 	}
@@ -413,14 +421,17 @@ func (s *MinerState) GetMinerTelemetry() (hashrate, temperature, power, efficien
 		temperature = s.ErrorConfig.OverrideTemperature
 	}
 
-	// If not actively mining, reduce hashrate to 0
-	effectiveState := s.miningState()
-	if effectiveState != MiningStateMining &&
-		effectiveState != MiningStateDegraded {
-		hashrate = 0
-		power = applyVariation(200.0, telemetryVariation) // Idle power
+	// Model mining, idle/non-mining, and full-curtail draw separately.
+	switch s.miningState() {
+	case MiningStateMining, MiningStateDegraded:
+		return
+	case MiningStateCurtailed:
+		power = applyVariation(defaultCurtailPowerW, telemetryVariation)
+	default:
+		power = applyVariation(defaultIdlePowerW, telemetryVariation)
 	}
 
+	hashrate = 0
 	return
 }
 

--- a/server/fake-proto-rig/rest_api_handler.go
+++ b/server/fake-proto-rig/rest_api_handler.go
@@ -2208,8 +2208,16 @@ func (h *RESTApiHandler) handleMiningStop(w http.ResponseWriter, r *http.Request
 		h.writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Method not allowed")
 		return
 	}
-	h.state.SetMiningState(MiningStateStopped)
-	h.writeJSON(w, http.StatusAccepted, MessageResponse{Message: "Mining stopped"})
+
+	state := MiningStateStopped
+	message := "Mining stopped"
+	if r.Header.Get("X-Proto-Fleet-Curtailment") == "full" {
+		state = MiningStateCurtailed
+		message = "Mining curtailed"
+	}
+
+	h.state.SetMiningState(state)
+	h.writeJSON(w, http.StatusAccepted, MessageResponse{Message: message})
 }
 
 func (h *RESTApiHandler) handleMiningTuning(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Reviewable diff: +165/-56 across 7 files (excludes generated, test, and story files).

## Summary

This PR lets the local dev-stack fake Proto and Antminer devices produce the power transitions required for end-to-end curtailment confirmation. Full curtailment now reports minimal draw, while restore returns each device to mining or idle power according to its pre-curtail state, including pool-less and intentionally stopped Proto devices.


https://github.com/user-attachments/assets/e6fafd46-f0a3-42ce-9288-20a5ba8c1c7c



## How it works

For Proto devices, the plugin snapshots whether the miner was active before full curtailment and marks the stop request as curtailment intent. The fake rig uses that marker to enter a distinct `Curtailed` state at approximately 30 W; ordinary stop remains an idle state at approximately 200 W. During restore, the plugin starts devices that were mining and sends an ordinary stop to devices that were not, moving them out of curtailment without incorrectly starting hash production.

For Antminers, the existing sleep/wake workflow remains the control path. The fake cgminer server now implements `stats` with the firmware metadata and mining-stat records expected by the Antminer plugin, including dynamic `chain_power` at approximately 3,250 W while mining and 30 W while sleeping. HTTP stats report the same power value for consistency.

## Diagrams

```mermaid
flowchart TD
  A["Curtailment reconciler dispatches FULL"] --> B["Miner plugin command"]
  B --> C["Proto plugin snapshots mining state"]
  B --> D["Antminer plugin selects sleep mode"]
  C --> E["POST mining/stop with curtailment marker"]
  E --> F["Fake Proto rig reports Curtailed and about 30 W"]
  D --> G["Fake Antminer enters sleep mode"]
  G --> H["cgminer stats reports chain_power about 30 W"]
  F --> I["Persisted telemetry confirms target"]
  H --> I
  I --> J["Restore dispatch"]
  J --> K["Previously mining devices start or wake"]
  J --> L["Previously idle Proto devices receive ordinary stop"]
  K --> M["Mining power returns"]
  L --> N["Idle power returns without hashing"]
```

```mermaid
stateDiagram-v2
  [*] --> Mining
  [*] --> Idle
  Mining --> Curtailed: FULL curtail
  Idle --> Curtailed: FULL curtail
  Curtailed --> Mining: restore previous mining state
  Curtailed --> Idle: restore previous non-mining state
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `plugin/proto/internal/device/` | Marks full-curtail stop requests and restores both active and inactive pre-curtail states explicitly. | Defines the production command semantics used to return low-power curtailed devices to their prior state. |
| `plugin/proto/pkg/proto/` | Adds optional request headers, maps `curtailed` as healthy-inactive, and exposes the curtail-specific stop call. | Carries curtailment intent across the HTTP boundary while preserving normal stop behavior. |
| `server/fake-proto-rig/` | Separates mining, idle, and curtailed power; allows curtailment to remain visible on pool-less rigs. | Supplies truthful telemetry for both confirmation and restore without starting pool-less devices. |
| `server/fake-antminer/` | Implements cgminer `stats` and reports mode-dependent power through RPC and HTTP. | Matches the actual Antminer parser path used to populate `PowerWatts`. |
| Focused tests | Covers Proto restore intent, request marking, fake Proto power states, and Antminer RPC/HTTP power. | Pins the state transitions and parser-facing response shapes used by confirmation. |

## Key technical decisions & trade-offs

- Reuse the existing Proto mining-stop endpoint with a backward-compatible request marker instead of adding a simulator-only endpoint; normal manual stop remains distinguishable from full curtailment.
- Issue an ordinary stop when restoring a previously non-mining Proto device instead of doing nothing; the redundant command is idempotent and moves the fake from curtailed draw back to idle draw.
- Give `Curtailed` precedence over the pool-derived `NoPools` presentation so telemetry can expose the temporary low-power state, then return to `NoPools` after restore.
- Match the Antminer plugin's existing second-record `chain_power` contract instead of introducing a fake-only power field or changing the production parser.
- Keep virtual-miner handle persistence and load-test behavior out of scope; this change targets the process-backed dev-stack fake miners.

## Testing & validation

- Passed Proto plugin formatting, `golangci-lint`, package/unit tests, and `go build ./...`.
- Passed server `golangci-lint`.
- Passed `GOWORK=off go test --count=1 .` in both `server/fake-antminer` and `server/fake-proto-rig`.
- Passed `go test --count=1 ./pkg/antminer/...` in `plugin/antminer`.
- The full Proto plugin test command reached the Docker integration package after all package/unit tests passed, but the local Docker connection closed while creating its container.
- `just test-contract` could not start because Cargo, required by its asicrs prerequisite, is not installed locally.
- The complete `just dev` curtailment lifecycle and Docker E2E suites were not run locally.

Closes #709
