### PR TITLE
feat(telemetry): forward request spans to Datadog APM with RUM correlation

### DIFF
--- a/.github/workflows/proto-fleet-artifact-build.yml
+++ b/.github/workflows/proto-fleet-artifact-build.yml
@@ -446,9 +446,11 @@ jobs:
           cp deployment-files/client/nginx.https.conf deployment/client/
           cp -r deployment-files/client/docker-entrypoint.d deployment/client/
           cp deployment-files/server/Dockerfile deployment/server/
+          cp deployment-files/server/otel-collector-config.datadog.yaml deployment/server/
           cp deployment-files/docker-compose.yaml deployment/
           cp deployment-files/docker-compose.alerts.yaml deployment/
           cp deployment-files/docker-compose.system-monitoring.yaml deployment/
+          cp deployment-files/docker-compose.tracing.yaml deployment/
           cp -a server/monitoring deployment/server/
           cp server/docker-compose.base.yaml deployment/server/
           cp deployment-files/run-fleet.sh deployment/

--- a/deployment-files/README.md
+++ b/deployment-files/README.md
@@ -328,3 +328,43 @@ errors, and injects distributed-tracing headers on same-origin
 `/api-proxy` calls. Session Replay is off by default and masks all
 text/inputs when enabled. Data goes only to the Datadog org identified by
 your keys.
+
+## Server Tracing (Datadog APM)
+
+Request tracing on fleet-api is **off by default**. It lives in a
+separate compose file, `docker-compose.tracing.yaml`, that
+`run-fleet.sh` layers in when the `--enable-tracing` flag is passed
+(or `ENABLE_TRACING=true` is set in `.env`). The overlay starts an
+OpenTelemetry collector sidecar and forwards fleet-api request spans
+to Datadog APM:
+
+```bash
+./run-fleet.sh --enable-tracing
+```
+
+```dotenv
+# Required (run-fleet.sh refuses to start without it when tracing is on)
+DD_API_KEY=your-datadog-api-key
+
+# Optional
+DD_SITE=datadoghq.com            # your Datadog site (default: datadoghq.com)
+DD_ENV=production                # APM env tag (default: production)
+FLEET_TELEMETRY_SAMPLE_RATE=1.0  # server-side trace sample cap (default: 1.0)
+FLEET_TELEMETRY_TRUST_INCOMING_TRACES=true  # parent spans to RUM trace context (default: true)
+```
+
+Unlike the RUM client token, `DD_API_KEY` is a secret Datadog API key;
+it stays in `.env` (mode 0600) and the collector container's
+environment.
+
+With `FLEET_TELEMETRY_TRUST_INCOMING_TRACES=true` (this overlay's
+default), fleet-api parents its request spans to the `traceparent`
+header Datadog RUM injects on `/api-proxy` calls, so RUM sessions link
+to their APM traces. Trusting that header means any client on the LAN
+can influence tracing of its own requests: a not-sampled flag is
+honored (an unsampled RUM trace records no server span), sampled
+requests are still capped by `FLEET_TELEMETRY_SAMPLE_RATE`, and trace
+IDs are client-chosen. Set
+`FLEET_TELEMETRY_TRUST_INCOMING_TRACES=false` to ignore client trace
+context; spans then start fresh traces that reference the client
+context as a link only.

--- a/deployment-files/docker-compose.tracing.yaml
+++ b/deployment-files/docker-compose.tracing.yaml
@@ -1,0 +1,43 @@
+# Tracing overlay (run-fleet.sh --enable-tracing): fleet-api request spans →
+# OTel collector → Datadog APM. Requires DD_API_KEY in the operator .env;
+# run-fleet.sh enforces that before layering this file.
+services:
+  fleet-api:
+    environment:
+      # Hard-coded on: the overlay is the feature toggle.
+      FLEET_TELEMETRY_ENABLED: "true"
+      FLEET_TELEMETRY_SAMPLE_RATE: "${FLEET_TELEMETRY_SAMPLE_RATE:-1.0}"
+      # Parent server spans to the traceparent header Datadog RUM injects on
+      # API calls (client observability), so RUM sessions link to APM traces.
+      FLEET_TELEMETRY_TRUST_INCOMING_TRACES: "${FLEET_TELEMETRY_TRUST_INCOMING_TRACES:-true}"
+    depends_on:
+      otel-collector:
+        condition: service_started
+    # Host-networked fleet-api inherits FLEET_TELEMETRY_ENDPOINT=http://otel-collector:4318
+    # from the base compose; resolve it to the loopback port published below.
+    extra_hosts:
+      - "otel-collector:127.0.0.1"
+
+  otel-collector:
+    extends:
+      file: ./server/docker-compose.base.yaml
+      service: otel-collector
+    environment:
+      DD_API_KEY: "${DD_API_KEY:?DD_API_KEY is required for the tracing overlay (set it in .env)}"
+      DD_SITE: "${DD_SITE:-datadoghq.com}"
+      DD_ENV: "${DD_ENV:-production}"
+    volumes:
+      - ./server/otel-collector-config.datadog.yaml:/etc/otelcol-contrib/config.yaml:ro
+    ports:
+      # Loopback-only OTLP ingest for the host-networked fleet-api; not exposed on the LAN.
+      - "127.0.0.1:4318:4318"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "20m"
+        max-file: "3"
+        compress: "true"
+
+networks:
+  monitoring:
+    driver: bridge

--- a/deployment-files/run-fleet.sh
+++ b/deployment-files/run-fleet.sh
@@ -8,10 +8,12 @@ PROJECT_ROOT="$(pwd)"
 COMPOSE_FILE="$PROJECT_ROOT/docker-compose.yaml"
 COMPOSE_ALERTS_FILE="$PROJECT_ROOT/docker-compose.alerts.yaml"
 COMPOSE_SYSTEM_MONITORING_FILE="$PROJECT_ROOT/docker-compose.system-monitoring.yaml"
+COMPOSE_TRACING_FILE="$PROJECT_ROOT/docker-compose.tracing.yaml"
 ENV_FILE="$PROJECT_ROOT/.env"
 
 ENABLE_BETA_ALERTS=false
 ENABLE_SYSTEM_MONITORING=false
+ENABLE_TRACING=false
 
 # How long the post-start steps wait for fleet-api to finish its migrations.
 # 300 x 2s = 10 minutes: a first boot on SD-card-class hardware (Raspberry Pi)
@@ -20,6 +22,10 @@ ENABLE_SYSTEM_MONITORING=false
 # database these polls return on the first attempt, so the high cap only costs
 # time when migrations are genuinely stuck.
 MIGRATION_WAIT_ATTEMPTS=300
+
+env_has_nonempty_value() {
+    grep -Eq "^${1}=.+" "$ENV_FILE" 2>/dev/null
+}
 
 usage() {
     cat <<'EOF'
@@ -37,6 +43,12 @@ Options:
                                 default. Can also be enabled by setting
                                 ENABLE_SYSTEM_MONITORING=true in the .env
                                 file.
+  --enable-tracing              Layer in request tracing (fleet-api spans
+                                forwarded to Datadog APM via an OTel
+                                collector sidecar). Requires DD_API_KEY in
+                                the .env file. Off by default. Can also be
+                                enabled by setting ENABLE_TRACING=true in
+                                the .env file.
   -h, --help                    Show this help and exit.
 EOF
 }
@@ -49,6 +61,10 @@ while [ $# -gt 0 ]; do
             ;;
         --enable-system-monitoring)
             ENABLE_SYSTEM_MONITORING=true
+            shift
+            ;;
+        --enable-tracing)
+            ENABLE_TRACING=true
             shift
             ;;
         -h|--help)
@@ -74,6 +90,10 @@ fi
 if grep -Eqi "^ENABLE_SYSTEM_MONITORING=true$" "$ENV_FILE" 2>/dev/null; then
     ENABLE_SYSTEM_MONITORING=true
 fi
+# [[:space:]]*$ tolerates CRLF line endings from Windows/WSL-edited .env files.
+if grep -Eqi "^ENABLE_TRACING=true[[:space:]]*$" "$ENV_FILE" 2>/dev/null; then
+    ENABLE_TRACING=true
+fi
 
 # System monitoring rides the alerts stack (the in-process metrics writer,
 # Grafana rule evaluation, and webhook delivery are all alerts-gated), so it
@@ -82,6 +102,20 @@ if [ "$ENABLE_SYSTEM_MONITORING" = "true" ] && [ "$ENABLE_BETA_ALERTS" != "true"
     echo "Error: --enable-system-monitoring requires the beta alerts stack." >&2
     echo "       Pass --enable-beta-alerts as well, or set ENABLE_BETA_ALERTS=true in $ENV_FILE." >&2
     exit 1
+fi
+
+# Validate tracing prerequisites before the overlay is layered: its ${DD_API_KEY:?}
+# interpolation would otherwise abort every compose command, even `compose down`.
+if [ "$ENABLE_TRACING" = "true" ]; then
+    if [ ! -f "$COMPOSE_TRACING_FILE" ]; then
+        echo "Error: --enable-tracing was passed but $COMPOSE_TRACING_FILE is missing." >&2
+        exit 1
+    fi
+    # Compose interpolation reads the shell environment and the .env file; accept either.
+    if [ -z "${DD_API_KEY:-}" ] && ! env_has_nonempty_value DD_API_KEY; then
+        echo "Error: --enable-tracing requires DD_API_KEY (a Datadog API key) in $ENV_FILE." >&2
+        exit 1
+    fi
 fi
 
 refresh_compose_files() {
@@ -93,6 +127,9 @@ refresh_compose_files() {
     # dashboards placeholder inside the alerts overlay's provisioning mount.
     if [ "$ENABLE_SYSTEM_MONITORING" = "true" ] && [ -f "$COMPOSE_SYSTEM_MONITORING_FILE" ]; then
         COMPOSE_FILES+=(-f "$COMPOSE_SYSTEM_MONITORING_FILE")
+    fi
+    if [ "$ENABLE_TRACING" = "true" ] && [ -f "$COMPOSE_TRACING_FILE" ]; then
+        COMPOSE_FILES+=(-f "$COMPOSE_TRACING_FILE")
     fi
 }
 refresh_compose_files
@@ -478,10 +515,6 @@ for flag in --wait --wait-timeout; do
     fi
 done
 
-env_has_nonempty_value() {
-    grep -Eq "^${1}=.+" "$ENV_FILE" 2>/dev/null
-}
-
 scrub_env_key() {
     local key="$1"
     local tmp
@@ -747,6 +780,17 @@ else
     echo "System monitoring: disabled (pass --enable-system-monitoring alongside --enable-beta-alerts to turn it on)"
 fi
 
+if [ "$ENABLE_TRACING" = "true" ]; then
+    # Re-check after env setup: regenerating .env above drops keys the pre-layering check accepted.
+    if [ -z "${DD_API_KEY:-}" ] && ! env_has_nonempty_value DD_API_KEY; then
+        echo "Error: $ENV_FILE was regenerated without DD_API_KEY; add it and re-run with --enable-tracing." >&2
+        exit 1
+    fi
+    echo "Tracing: enabled (fleet-api request spans forwarded to Datadog APM)"
+else
+    echo "Tracing: disabled (pass --enable-tracing with DD_API_KEY in .env to forward request spans to Datadog)"
+fi
+
 # ----------------------------------------------------------------------------
 # SSL/TLS Configuration
 # ----------------------------------------------------------------------------
@@ -872,7 +916,7 @@ echo "Starting services..."
 # host networking), producing a false "Proto Fleet is now running!" banner.
 if ! compose up --remove-orphans -d --wait --wait-timeout 300; then
     echo "Error: services failed to reach running state."
-    echo "Check logs with: docker compose ${COMPOSE_FILES[*]} logs"
+    echo "Check logs with: docker compose ${COMPOSE_ENV_ARGS[*]} ${COMPOSE_FILES[*]} logs"
     exit 1
 fi
 

--- a/deployment-files/server/otel-collector-config.datadog.yaml
+++ b/deployment-files/server/otel-collector-config.datadog.yaml
@@ -1,0 +1,55 @@
+# Production collector config for the tracing overlay: forwards fleet-api
+# request spans to Datadog APM. The dev stack keeps server/otel-collector-config.yaml (Jaeger).
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+    # Datadog recommends 10s batching for its exporter.
+    timeout: 10s
+  resource:
+    attributes:
+      # Maps to Datadog's `env` tag; service/version come from fleetd's OTel resource.
+      # Both spellings: `.name` is current semconv, the bare key covers older mappings.
+      - key: deployment.environment.name
+        value: ${env:DD_ENV}
+        action: upsert
+      - key: deployment.environment
+        value: ${env:DD_ENV}
+        action: upsert
+
+connectors:
+  # Computes APM stats (hit/error/latency metrics); the exporter stopped doing this in contrib 0.95.
+  datadog/connector:
+
+exporters:
+  datadog:
+    api:
+      key: ${env:DD_API_KEY}
+      site: ${env:DD_SITE}
+
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+
+service:
+  extensions: [health_check]
+  pipelines:
+    # Datadog's documented two-hop layout: traces feed the stats connector, which re-emits them.
+    traces:
+      receivers: [otlp]
+      processors: [resource, batch]
+      exporters: [datadog/connector]
+    traces/export:
+      receivers: [datadog/connector]
+      processors: [batch]
+      exporters: [datadog]
+    metrics:
+      receivers: [datadog/connector]
+      processors: [batch]
+      exporters: [datadog]

--- a/server/cmd/fleetd/main.go
+++ b/server/cmd/fleetd/main.go
@@ -656,7 +656,7 @@ func start(config *Config) error {
 
 	middlewares := []server.Middleware{
 		middleware.NewCORSMiddleware(config.HTTP.SuppressCors),
-		middleware.TelemetryMiddleware{},
+		middleware.TelemetryMiddleware{TrustIncomingTraces: config.FleetTelemetry.TrustIncomingTraces},
 	}
 
 	validateInterceptor := validate.NewInterceptor()

--- a/server/internal/handlers/middleware/telemetry.go
+++ b/server/internal/handlers/middleware/telemetry.go
@@ -9,11 +9,15 @@ import (
 )
 
 // TelemetryMiddleware creates a span for every HTTP request and records the response status code.
-type TelemetryMiddleware struct{}
+type TelemetryMiddleware struct {
+	// TrustIncomingTraces parents request spans to client trace context (traceparent) instead of
+	// starting a new trace with a link; required for Datadog RUM↔APM session correlation.
+	TrustIncomingTraces bool
+}
 
 func (t TelemetryMiddleware) Wrap(next http.Handler) http.Handler {
 	return otelhttp.NewHandler(next, "http.request",
-		otelhttp.WithPublicEndpointFn(func(*http.Request) bool { return true }),
+		otelhttp.WithPublicEndpointFn(func(*http.Request) bool { return !t.TrustIncomingTraces }),
 		otelhttp.WithTracerProvider(otel.GetTracerProvider()),
 		otelhttp.WithSpanNameFormatter(func(_ string, r *http.Request) string {
 			return httpSpanName(r)

--- a/server/internal/handlers/middleware/telemetry_test.go
+++ b/server/internal/handlers/middleware/telemetry_test.go
@@ -1,0 +1,68 @@
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace/noop"
+
+	"github.com/block/proto-fleet/server/internal/handlers/middleware"
+)
+
+// serveTracedRequest runs one request carrying a W3C traceparent header through
+// the middleware against a fresh recorder, swapping the otel globals the
+// middleware reads (reset to no-ops via t.Cleanup).
+func serveTracedRequest(t *testing.T, trust bool) sdktrace.ReadOnlySpan {
+	t.Helper()
+
+	recorder := tracetest.NewSpanRecorder()
+	otel.SetTracerProvider(sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder)))
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	t.Cleanup(func() {
+		// Reset to no-ops: restoring the pre-test defaults would re-install delegators already bound to this test's provider.
+		otel.SetTracerProvider(noop.NewTracerProvider())
+		otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator())
+	})
+
+	handler := middleware.TelemetryMiddleware{TrustIncomingTraces: trust}.Wrap(
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+	req.Header.Set("Traceparent", "00-"+clientTraceID+"-"+clientSpanID+"-01")
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+
+	spans := recorder.Ended()
+	require.Len(t, spans, 1)
+	return spans[0]
+}
+
+const (
+	clientTraceID = "0af7651916cd43dd8448eb211c80319c"
+	clientSpanID  = "b7ad6b7169203331"
+)
+
+func TestTelemetryMiddlewareUntrustedStartsNewTrace(t *testing.T) {
+	span := serveTracedRequest(t, false)
+
+	require.NotEqual(t, clientTraceID, span.SpanContext().TraceID().String())
+	require.False(t, span.Parent().IsValid())
+	// Public-endpoint mode keeps the client context as a link, not a parent.
+	require.Len(t, span.Links(), 1)
+	require.Equal(t, clientTraceID, span.Links()[0].SpanContext.TraceID().String())
+}
+
+func TestTelemetryMiddlewareTrustedParentsToClientTrace(t *testing.T) {
+	span := serveTracedRequest(t, true)
+
+	require.Equal(t, clientTraceID, span.SpanContext().TraceID().String())
+	require.Equal(t, clientSpanID, span.Parent().SpanID().String())
+}

--- a/server/internal/infrastructure/fleet-telemetry/telemetry.go
+++ b/server/internal/infrastructure/fleet-telemetry/telemetry.go
@@ -15,10 +15,11 @@ import (
 )
 
 type Config struct {
-	Enabled     bool    `help:"Enable OpenTelemetry metrics" default:"false" env:"ENABLED"`
-	Endpoint    string  `help:"OTLP HTTP endpoint for traces (e.g. http://localhost:4318)" default:"http://localhost:4318" env:"ENDPOINT"`
-	ServiceName string  `help:"Service name reported in traces" default:"fleetd" env:"SERVICE_NAME"`
-	SampleRate  float64 `help:"Fraction of traces to sample (0.0–1.0)" default:"1.0" env:"SAMPLE_RATE"`
+	Enabled             bool    `help:"Enable OpenTelemetry traces" default:"false" env:"ENABLED"`
+	Endpoint            string  `help:"OTLP HTTP endpoint for traces (e.g. http://localhost:4318)" default:"http://localhost:4318" env:"ENDPOINT"`
+	ServiceName         string  `help:"Service name reported in traces" default:"fleetd" env:"SERVICE_NAME"`
+	SampleRate          float64 `help:"Fraction of traces to sample (0.0–1.0); also caps trusted incoming traces" default:"1.0" env:"SAMPLE_RATE"`
+	TrustIncomingTraces bool    `help:"Parent request spans to incoming trace context instead of linking (enables RUM↔APM correlation); an incoming not-sampled flag is honored" default:"false" env:"TRUST_INCOMING_TRACES"`
 }
 
 // Setup initialises a global TracerProvider and returns a shutdown function.
@@ -54,7 +55,11 @@ func Setup(ctx context.Context, version string, cfg Config) (func(context.Contex
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithBatcher(exporter),
 		sdktrace.WithResource(res),
-		sdktrace.WithSampler(sdktrace.ParentBased(sdktrace.TraceIDRatioBased(cfg.SampleRate))),
+		// Cap trusted remote parents at SampleRate too; the ParentBased default would let a client's sampled flag bypass the configured rate.
+		sdktrace.WithSampler(sdktrace.ParentBased(
+			sdktrace.TraceIDRatioBased(cfg.SampleRate),
+			sdktrace.WithRemoteParentSampled(sdktrace.TraceIDRatioBased(cfg.SampleRate)),
+		)),
 	)
 
 	otel.SetTracerProvider(tp)

--- a/server/internal/infrastructure/fleet-telemetry/telemetry_test.go
+++ b/server/internal/infrastructure/fleet-telemetry/telemetry_test.go
@@ -1,0 +1,58 @@
+package fleet_telemetry_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+
+	fleet_telemetry "github.com/block/proto-fleet/server/internal/infrastructure/fleet-telemetry"
+)
+
+// startWithRemoteSampledParent runs Setup with the given sample rate and starts a span
+// under a remote sampled parent, returning whether the SDK sampled it.
+func startWithRemoteSampledParent(t *testing.T, sampleRate float64) bool {
+	t.Helper()
+
+	shutdown, err := fleet_telemetry.Setup(context.Background(), "test", fleet_telemetry.Config{
+		Enabled:    true,
+		Endpoint:   "http://127.0.0.1:0",
+		SampleRate: sampleRate,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		// Reset the globals Setup installed; shutdown errors are expected (nothing listens on the endpoint).
+		_ = shutdown(context.Background())
+		otel.SetTracerProvider(noop.NewTracerProvider())
+		otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator())
+	})
+
+	traceID, err := trace.TraceIDFromHex("0af7651916cd43dd8448eb211c80319c")
+	require.NoError(t, err)
+	spanID, err := trace.SpanIDFromHex("b7ad6b7169203331")
+	require.NoError(t, err)
+	parent := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: trace.FlagsSampled,
+		Remote:     true,
+	})
+
+	ctx := trace.ContextWithRemoteSpanContext(context.Background(), parent)
+	_, span := otel.GetTracerProvider().Tracer("test").Start(ctx, "op")
+	defer span.End()
+	return span.SpanContext().IsSampled()
+}
+
+func TestSetupSampleRateCapsRemoteSampledParents(t *testing.T) {
+	// A client sampled flag must not bypass the configured rate (RUM/attacker-controlled input).
+	require.False(t, startWithRemoteSampledParent(t, 0))
+}
+
+func TestSetupSampleRateOneKeepsRemoteSampledParents(t *testing.T) {
+	require.True(t, startWithRemoteSampledParent(t, 1.0))
+}


### PR DESCRIPTION
Reviewable diff: +206/-13 across 8 files (excludes generated, test, and story files).

## Summary

Adds a production tracing overlay so operators can forward fleet-api request spans to Datadog APM with one flag (`run-fleet.sh --enable-tracing` + `DD_API_KEY` in `.env`). Spans parent to the `traceparent` header the existing Datadog RUM integration already injects on API calls, so browser sessions link directly to backend traces in Datadog. The dev stack (Jaeger) is unchanged, and deployments without the overlay see no behavior change.

## How it works

fleetd's tracing pipeline was already vendor-neutral OTLP (built for the dev Jaeger stack); this PR wires it to Datadog in production and closes the RUM↔APM gap:

1. **Overlay activation** — `run-fleet.sh --enable-tracing` (or `ENABLE_TRACING=true` in `.env`) validates prerequisites (overlay file present, `DD_API_KEY` set) *before* any compose invocation — the overlay's `${DD_API_KEY:?}` interpolation would otherwise abort every compose command including `down` — then layers `docker-compose.tracing.yaml` onto the stack.
2. **Span production** — the overlay hard-codes `FLEET_TELEMETRY_ENABLED=true` on fleet-api. The existing `otelhttp` middleware creates a span per HTTP request and exports OTLP/HTTP to the collector. Host-networked fleet-api reaches it via `extra_hosts: otel-collector=127.0.0.1` against a loopback-only published port.
3. **RUM correlation** — new `FLEET_TELEMETRY_TRUST_INCOMING_TRACES` (overlay default: on) disables `otelhttp`'s public-endpoint mode, so server spans parent to the client's W3C `traceparent` instead of starting a fresh trace with a link. Datadog RUM already injects that header on same-origin API calls (`allowedTracingUrls`), giving session→trace navigation in Datadog. The sampler caps remote-sampled parents at `FLEET_TELEMETRY_SAMPLE_RATE`, so a client's sampled flag cannot force ingestion past the configured rate.
4. **Export** — the collector runs Datadog's documented two-hop pipeline: traces feed the `datadog/connector` (computes APM hit/error/latency stats, which the exporter itself stopped doing in contrib 0.95), and both the re-emitted traces and the stats metrics export to Datadog keyed by `DD_API_KEY`/`DD_SITE`, tagged with `env` from `DD_ENV`.

## Diagrams

```mermaid
flowchart LR
    subgraph Browser
        RUM["Datadog RUM SDK"]
    end
    subgraph Host["Fleet host"]
        NGINX["fleet-client nginx"]
        API["fleet-api (otelhttp middleware)"]
        COLL["otel-collector sidecar"]
    end
    DD["Datadog APM"]
    RUM -- "fetch + traceparent" --> NGINX
    NGINX -- "/api-proxy strip" --> API
    API -- "OTLP HTTP (loopback 4318)" --> COLL
    COLL -- "traces + APM stats" --> DD
    RUM -. "RUM events" .-> DD
```

```mermaid
flowchart TD
    REQ["Incoming request with traceparent"] --> TRUST{"TRUST_INCOMING_TRACES?"}
    TRUST -- "false (default)" --> NEW["New trace, client context kept as span link"]
    TRUST -- "true (overlay default)" --> PARENT["Span parents to client trace"]
    PARENT --> CAP["Sampler caps remote-sampled parents at SAMPLE_RATE"]
```

## Areas of the code involved

| Area | What changed | Why it matters for review |
|---|---|---|
| `server/internal/infrastructure/fleet-telemetry/telemetry.go` | New `TrustIncomingTraces` config; sampler adds `WithRemoteParentSampled(TraceIDRatioBased)` | Security/cost boundary: decides how much authority clients get over tracing |
| `server/internal/handlers/middleware/telemetry.go` | Trust flag toggles `otelhttp` public-endpoint mode | The actual parent-vs-link semantics for RUM correlation |
| `server/cmd/fleetd/main.go` | Threads the flag into the middleware | One-line wiring |
| `deployment-files/docker-compose.tracing.yaml` | New overlay: collector sidecar, loopback OTLP, fleet-api tracing env | Networking (host-mode fleet-api ↔ bridged collector) and `DD_API_KEY` fail-fast |
| `deployment-files/server/otel-collector-config.datadog.yaml` | New collector config: `datadog/connector` two-hop pipeline | Without the connector, APM service pages show no stats |
| `deployment-files/run-fleet.sh` | `--enable-tracing` flag, `.env` toggle, early prerequisite validation | Validation must precede overlay layering; see decision below |
| `deployment-files/README.md` | New "Server Tracing (Datadog APM)" operator section | Documents the trust-by-default posture and how to disable it |
| `.github/workflows/proto-fleet-artifact-build.yml` | Packages the two new files into the deployment bundle | Missing this = overlay absent from installs |

## Key technical decisions & trade-offs

- **Collector sidecar with the `datadog` exporter over the Datadog Agent or `dd-trace-go`** — fleetd stays vendor-neutral OTLP and dev keeps Jaeger; the Agent would add a heavy container for traces alone, and `dd-trace-go` would fork the instrumentation path per backend.
- **Trust incoming trace context by default in the overlay (off by default in fleetd)** — required for RUM↔APM correlation; means any client on the operator LAN can supply trace IDs pre-auth. Blast radius is Datadog trace data only (no first-party code consumes span context); documented in the README with a per-site opt-out. Per-route scoping was rejected: nginx strips `/api-proxy` before fleet-api sees requests, so there is no clean server-side discriminator for RUM traffic.
- **`WithRemoteParentSampled(TraceIDRatioBased)` instead of ParentBased defaults** — the default honors any remote sampled flag, letting clients bypass `SAMPLE_RATE` (ingest cost). Capping is deterministic per trace ID, so correlation survives for traces that are recorded; an incoming not-sampled flag is still honored.
- **Prerequisite validation before compose layering in run-fleet.sh** — `${DD_API_KEY:?}` in the overlay aborts *every* compose command once layered; validating late corrupted the data-volume reinit path (compose down fails, script proceeds).
- **`datadog/connector` two-hop pipeline** — since collector-contrib 0.95 the exporter no longer computes APM stats; without the connector, Trace Explorer works but service/resource pages stay empty.

## Testing & validation

- `just lint` clean (buf, eslint, golangci-lint x3).
- `go test` green for both changed packages. New tests: middleware parent-vs-link semantics under both trust modes (span parents to client trace vs. new trace with link), and sampler regression tests proving a remote-sampled parent is dropped at rate 0 and kept at rate 1.
- Collector config validated with the pinned `otelcol-contrib:0.150.1` image (`validate` exit 0).
- Compose merge validated in a simulated artifact-bundle layout: overlay alone and stacked with alerts + system-monitoring both render (`docker compose config`), `extra_hosts`/`depends_on`/env merges confirmed; missing `DD_API_KEY` fails with the intended message.
- `bash -n` clean; CRLF-tolerant `.env` toggle verified in a debian container.
- Not covered: no E2E run (no UI/API behavior change — spans only), and no live Datadog ingest test; first real deployment should confirm spans and APM stats arrive and that RUM session→trace links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)