### PR TITLE
feat(firmware): add target metadata and compatible update workflows

### DIFF
--- a/client/e2eTests/protoFleet/pages/settingsFirmware.ts
+++ b/client/e2eTests/protoFleet/pages/settingsFirmware.ts
@@ -13,7 +13,10 @@ export class SettingsFirmwarePage extends BasePage {
     await this.validateTitleInModal("Upload firmware");
   }
 
-  async uploadFirmwareFile(fileName: string, fileContents: string) {
+  async uploadFirmwareFile(fileName: string, fileContents: string, product = "Proto", model = "Rig") {
+    const modal = this.page.getByTestId("modal");
+    await modal.getByLabel("Product").fill(product);
+    await modal.getByLabel("Model").fill(model);
     await this.page.getByTestId("firmware-file-input").setInputFiles({
       name: fileName,
       mimeType: "application/octet-stream",

--- a/client/e2eTests/protoFleet/pages/settingsFirmware.ts
+++ b/client/e2eTests/protoFleet/pages/settingsFirmware.ts
@@ -13,10 +13,19 @@ export class SettingsFirmwarePage extends BasePage {
     await this.validateTitleInModal("Upload firmware");
   }
 
-  async uploadFirmwareFile(fileName: string, fileContents: string, product = "Proto", model = "Rig") {
+  async uploadFirmwareFile(
+    fileName: string,
+    fileContents: string,
+    manufacturer = "Proto",
+    model = "Rig",
+    firmwareVersion = "2.4.6",
+  ) {
     const modal = this.page.getByTestId("modal");
-    await modal.getByLabel("Product").fill(product);
-    await modal.getByLabel("Model").fill(model);
+    await modal.getByLabel("Manufacturer").click();
+    await this.page.getByRole("option", { name: manufacturer, exact: true }).click();
+    await modal.getByLabel("Model").click();
+    await this.page.getByRole("option", { name: model, exact: true }).click();
+    await modal.getByLabel("Firmware version").fill(firmwareVersion);
     await this.page.getByTestId("firmware-file-input").setInputFiles({
       name: fileName,
       mimeType: "application/octet-stream",

--- a/client/e2eTests/protoFleet/pages/settingsFirmware.ts
+++ b/client/e2eTests/protoFleet/pages/settingsFirmware.ts
@@ -2,6 +2,12 @@ import { expect } from "@playwright/test";
 import { DEFAULT_INTERVAL, DEFAULT_TIMEOUT } from "../config/test.config";
 import { BasePage } from "./base";
 
+type FirmwareUploadMetadata = {
+  manufacturer: string;
+  model: string;
+  firmwareVersion: string;
+};
+
 export class SettingsFirmwarePage extends BasePage {
   async validateFirmwarePageOpened() {
     await expect(this.page).toHaveURL(/.*\/settings\/firmware/);
@@ -16,9 +22,7 @@ export class SettingsFirmwarePage extends BasePage {
   async uploadFirmwareFile(
     fileName: string,
     fileContents: string,
-    manufacturer = "Proto",
-    model = "Rig",
-    firmwareVersion = "2.4.6",
+    { manufacturer, model, firmwareVersion }: FirmwareUploadMetadata,
   ) {
     const modal = this.page.getByTestId("modal");
     await modal.getByLabel("Manufacturer").click();
@@ -31,10 +35,8 @@ export class SettingsFirmwarePage extends BasePage {
       mimeType: "application/octet-stream",
       buffer: Buffer.from(fileContents),
     });
-  }
-
-  async clickDoneInUploadDialog() {
-    await this.clickIn("Done", "modal");
+    await modal.getByRole("button", { name: "Upload", exact: true }).click();
+    await expect(modal).toBeHidden();
   }
 
   async validateFirmwareFileVisible(fileName: string) {

--- a/client/e2eTests/protoFleet/spec/firmware.spec.ts
+++ b/client/e2eTests/protoFleet/spec/firmware.spec.ts
@@ -141,6 +141,7 @@ test.describe("Firmware", () => {
       await minersPage.validateMinerStatusSettled(rigMinerIp, "Updating firmware", firmwareStatusTimeout);
       await waitForFirmwareActivation(minersPage, rigMinerIp, firmwareStatusTimeout);
       await minersPage.validateMinerStatusSettled(rigMinerIp, "Hashing", firmwareStatusTimeout);
+      await minersPage.validateMinerValue(rigMinerIp, "firmware", firmwareVersion);
     });
   });
 });

--- a/client/e2eTests/protoFleet/spec/firmware.spec.ts
+++ b/client/e2eTests/protoFleet/spec/firmware.spec.ts
@@ -93,7 +93,8 @@ test.describe("Firmware", () => {
   test("Upload firmware and update a rig miner", async ({ minersPage, settingsFirmwarePage }) => {
     test.setTimeout(testConfig.testTimeout * 4);
 
-    const firmwareFileName = `firmware-${Date.now()}.swu`;
+    const firmwareVersion = "2.4.6";
+    const firmwareFileName = `firmware-${firmwareVersion}-${Date.now()}.swu`;
     const firmwareFileContents = `fake firmware payload ${Date.now()}`;
     const firmwareStatusTimeout = testConfig.testTimeout;
 
@@ -103,8 +104,11 @@ test.describe("Firmware", () => {
       await settingsFirmwarePage.deleteAllFirmwareFilesIfAny();
 
       await settingsFirmwarePage.clickUploadFirmware();
-      await settingsFirmwarePage.uploadFirmwareFile(firmwareFileName, firmwareFileContents);
-      await settingsFirmwarePage.clickDoneInUploadDialog();
+      await settingsFirmwarePage.uploadFirmwareFile(firmwareFileName, firmwareFileContents, {
+        manufacturer: "Proto",
+        model: "Rig",
+        firmwareVersion,
+      });
       await settingsFirmwarePage.validateTextInToast("Firmware file uploaded successfully");
       await settingsFirmwarePage.validateFirmwareFileVisible(firmwareFileName);
     });

--- a/client/src/protoFleet/api/useFileUpload.ts
+++ b/client/src/protoFleet/api/useFileUpload.ts
@@ -13,6 +13,8 @@ export interface FileUploadOptions {
   onProgress?: (percent: number) => void;
   signal?: AbortSignal;
   fieldName?: string;
+  formFields?: Record<string, string>;
+  initiateFields?: Record<string, string | number | boolean>;
   chunked?: ChunkedUploadConfig;
 }
 
@@ -138,7 +140,7 @@ async function uploadChunked(
     method: "POST",
     credentials: "include",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ filename: file.name, file_size: file.size }),
+    body: JSON.stringify({ filename: file.name, file_size: file.size, ...options.initiateFields }),
     signal,
   });
 
@@ -250,6 +252,9 @@ function uploadDirect(
     });
 
     const formData = new FormData();
+    for (const [key, value] of Object.entries(options?.formFields ?? {})) {
+      formData.append(key, value);
+    }
     formData.append(options?.fieldName ?? "file", file);
     xhr.send(formData);
   });

--- a/client/src/protoFleet/api/useFirmwareApi.test.ts
+++ b/client/src/protoFleet/api/useFirmwareApi.test.ts
@@ -4,6 +4,7 @@ import { _resetConfigCache, useFirmwareApi, validateFirmwareFile } from "./useFi
 
 const mockLogout = vi.fn();
 const mockUpload = vi.fn();
+const firmwareTarget = { targetManufacturer: "Proto", targetModel: "S21" };
 
 vi.mock("@/protoFleet/store", () => ({
   useLogout: () => mockLogout,
@@ -90,7 +91,7 @@ describe("useFirmwareApi", () => {
       vi.stubGlobal("fetch", mockFetch);
 
       const { result } = renderHook(() => useFirmwareApi());
-      await result.current.checkFirmwareFile("abc123");
+      await result.current.checkFirmwareFile("abc123", firmwareTarget);
 
       expect(mockFetch).toHaveBeenCalledWith(
         "/api-proxy/api/v1/firmware/check",
@@ -98,7 +99,7 @@ describe("useFirmwareApi", () => {
           method: "POST",
           credentials: "include",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ sha256: "abc123" }),
+          body: JSON.stringify({ sha256: "abc123", target_manufacturer: "Proto", target_model: "S21" }),
         }),
       );
     });
@@ -114,7 +115,7 @@ describe("useFirmwareApi", () => {
       );
 
       const { result } = renderHook(() => useFirmwareApi());
-      const data = await result.current.checkFirmwareFile("abc123");
+      const data = await result.current.checkFirmwareFile("abc123", firmwareTarget);
 
       expect(data).toEqual({ exists: true, firmwareFileId: "file-123" });
     });
@@ -130,7 +131,7 @@ describe("useFirmwareApi", () => {
       );
 
       const { result } = renderHook(() => useFirmwareApi());
-      const data = await result.current.checkFirmwareFile("abc123");
+      const data = await result.current.checkFirmwareFile("abc123", firmwareTarget);
 
       expect(data).toEqual({ exists: false, firmwareFileId: undefined });
     });
@@ -146,7 +147,7 @@ describe("useFirmwareApi", () => {
       );
 
       const { result } = renderHook(() => useFirmwareApi());
-      await expect(result.current.checkFirmwareFile("abc123")).rejects.toThrow("Session expired");
+      await expect(result.current.checkFirmwareFile("abc123", firmwareTarget)).rejects.toThrow("Session expired");
 
       expect(mockLogout).toHaveBeenCalledOnce();
     });
@@ -163,7 +164,9 @@ describe("useFirmwareApi", () => {
       );
 
       const { result } = renderHook(() => useFirmwareApi());
-      await expect(result.current.checkFirmwareFile("abc123")).rejects.toThrow("Firmware check failed: 500");
+      await expect(result.current.checkFirmwareFile("abc123", firmwareTarget)).rejects.toThrow(
+        "Firmware check failed: 500",
+      );
 
       expect(mockLogout).not.toHaveBeenCalled();
     });
@@ -180,7 +183,9 @@ describe("useFirmwareApi", () => {
       );
 
       const { result } = renderHook(() => useFirmwareApi());
-      await expect(result.current.checkFirmwareFile("bad")).rejects.toThrow("sha256 must be a 64-character hex string");
+      await expect(result.current.checkFirmwareFile("bad", firmwareTarget)).rejects.toThrow(
+        "sha256 must be a 64-character hex string",
+      );
     });
   });
 
@@ -201,7 +206,7 @@ describe("useFirmwareApi", () => {
 
       const file = new File(["data"], "firmware.swu");
       const { result } = renderHook(() => useFirmwareApi());
-      const id = await result.current.uploadFirmwareFile(file);
+      const id = await result.current.uploadFirmwareFile(file, firmwareTarget);
 
       expect(id).toBe("fw-abc");
       expect(mockUpload).toHaveBeenCalledWith(
@@ -210,6 +215,10 @@ describe("useFirmwareApi", () => {
         expect.objectContaining({
           onProgress: undefined,
           signal: undefined,
+          formFields: {
+            target_manufacturer: "Proto",
+            target_model: "S21",
+          },
         }),
       );
     });
@@ -230,7 +239,7 @@ describe("useFirmwareApi", () => {
       const file = new File(["a".repeat(10)], "firmware.swu");
       const onProgress = vi.fn();
       const { result } = renderHook(() => useFirmwareApi());
-      const id = await result.current.uploadFirmwareFile(file, { onProgress });
+      const id = await result.current.uploadFirmwareFile(file, { ...firmwareTarget, onProgress });
 
       expect(id).toBe("fw-chunked");
       expect(mockUpload).toHaveBeenCalledWith(
@@ -238,6 +247,10 @@ describe("useFirmwareApi", () => {
         file,
         expect.objectContaining({
           onProgress,
+          initiateFields: {
+            target_manufacturer: "Proto",
+            target_model: "S21",
+          },
           chunked: expect.objectContaining({
             enabled: true,
             chunkSize: 5,
@@ -265,7 +278,7 @@ describe("useFirmwareApi", () => {
       const file = new File(["data"], "firmware.swu");
       const { result } = renderHook(() => useFirmwareApi());
 
-      await expect(result.current.uploadFirmwareFile(file)).rejects.toThrow(
+      await expect(result.current.uploadFirmwareFile(file, firmwareTarget)).rejects.toThrow(
         "Server response missing firmware_file_id.",
       );
     });
@@ -290,7 +303,7 @@ describe("useFirmwareApi", () => {
       const file = new File(["data"], "firmware.swu");
       const { result } = renderHook(() => useFirmwareApi());
 
-      await result.current.uploadFirmwareFile(file, { signal: controller.signal });
+      await result.current.uploadFirmwareFile(file, { ...firmwareTarget, signal: controller.signal });
 
       expect(mockUpload).toHaveBeenCalledWith(
         expect.any(String),
@@ -302,7 +315,16 @@ describe("useFirmwareApi", () => {
 
   describe("listFirmwareFiles", () => {
     it("sends GET with credentials and returns file list", async () => {
-      const mockFiles = [{ id: "f1", filename: "fw.swu", size: 1024, uploaded_at: "2025-01-01T00:00:00Z" }];
+      const mockFiles = [
+        {
+          id: "f1",
+          filename: "fw.swu",
+          size: 1024,
+          uploaded_at: "2025-01-01T00:00:00Z",
+          target_manufacturer: "Proto",
+          target_model: "S21",
+        },
+      ];
       const mockFetch = vi.fn().mockResolvedValue({
         ok: true,
         status: 200,

--- a/client/src/protoFleet/api/useFirmwareApi.test.ts
+++ b/client/src/protoFleet/api/useFirmwareApi.test.ts
@@ -4,7 +4,7 @@ import { _resetConfigCache, useFirmwareApi, validateFirmwareFile } from "./useFi
 
 const mockLogout = vi.fn();
 const mockUpload = vi.fn();
-const firmwareTarget = { targetManufacturer: "Proto", targetModel: "S21" };
+const firmwareTarget = { targetManufacturer: "Proto", targetModel: "S21", firmwareVersion: "v2.0.0" };
 
 vi.mock("@/protoFleet/store", () => ({
   useLogout: () => mockLogout,
@@ -99,7 +99,12 @@ describe("useFirmwareApi", () => {
           method: "POST",
           credentials: "include",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ sha256: "abc123", target_manufacturer: "Proto", target_model: "S21" }),
+          body: JSON.stringify({
+            sha256: "abc123",
+            target_manufacturer: "Proto",
+            target_model: "S21",
+            firmware_version: "v2.0.0",
+          }),
         }),
       );
     });
@@ -218,6 +223,7 @@ describe("useFirmwareApi", () => {
           formFields: {
             target_manufacturer: "Proto",
             target_model: "S21",
+            firmware_version: "v2.0.0",
           },
         }),
       );
@@ -250,6 +256,7 @@ describe("useFirmwareApi", () => {
           initiateFields: {
             target_manufacturer: "Proto",
             target_model: "S21",
+            firmware_version: "v2.0.0",
           },
           chunked: expect.objectContaining({
             enabled: true,
@@ -257,6 +264,54 @@ describe("useFirmwareApi", () => {
           }),
         }),
       );
+    });
+
+    it("requires metadata for swu upload", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              allowed_extensions: [".swu"],
+              max_file_size_bytes: 500 * 1024 * 1024,
+              chunk_size_bytes: 1 * 1024 * 1024,
+            }),
+        }),
+      );
+
+      const file = new File(["data"], "proto-rig.swu");
+      const { result } = renderHook(() => useFirmwareApi());
+
+      await expect(result.current.uploadFirmwareFile(file)).rejects.toThrow(
+        "Manufacturer, model, and firmware version are required.",
+      );
+      expect(mockUpload).not.toHaveBeenCalled();
+    });
+
+    it("requires metadata for non-swu upload", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              allowed_extensions: [".zip"],
+              max_file_size_bytes: 500 * 1024 * 1024,
+              chunk_size_bytes: 1 * 1024 * 1024,
+            }),
+        }),
+      );
+
+      const file = new File(["data"], "firmware.zip");
+      const { result } = renderHook(() => useFirmwareApi());
+
+      await expect(result.current.uploadFirmwareFile(file)).rejects.toThrow(
+        "Manufacturer, model, and firmware version are required.",
+      );
+      expect(mockUpload).not.toHaveBeenCalled();
     });
 
     it("throws when upload response is missing firmware_file_id", async () => {
@@ -323,6 +378,7 @@ describe("useFirmwareApi", () => {
           uploaded_at: "2025-01-01T00:00:00Z",
           target_manufacturer: "Proto",
           target_model: "S21",
+          firmware_version: "v2.0.0",
         },
       ];
       const mockFetch = vi.fn().mockResolvedValue({

--- a/client/src/protoFleet/api/useFirmwareApi.test.ts
+++ b/client/src/protoFleet/api/useFirmwareApi.test.ts
@@ -499,6 +499,70 @@ describe("useFirmwareApi", () => {
     });
   });
 
+  describe("updateFirmwareMetadata", () => {
+    it("sends trimmed metadata in a PATCH request", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 204 });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const { result } = renderHook(() => useFirmwareApi());
+      await result.current.updateFirmwareMetadata("file 123", {
+        targetManufacturer: " Proto ",
+        targetModel: " Rig ",
+        firmwareVersion: " 2.0.0 ",
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api-proxy/api/v1/firmware/files/file%20123",
+        expect.objectContaining({
+          method: "PATCH",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            target_manufacturer: "Proto",
+            target_model: "Rig",
+            firmware_version: "2.0.0",
+          }),
+        }),
+      );
+    });
+
+    it("rejects incomplete metadata before sending a request", async () => {
+      const mockFetch = vi.fn();
+      vi.stubGlobal("fetch", mockFetch);
+      const { result } = renderHook(() => useFirmwareApi());
+
+      await expect(
+        result.current.updateFirmwareMetadata("file-123", {
+          targetManufacturer: "Proto",
+          targetModel: "",
+          firmwareVersion: "2.0.0",
+        }),
+      ).rejects.toThrow("Manufacturer, model, and firmware version are required");
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("returns the server error when metadata cannot be updated", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: false,
+          status: 404,
+          statusText: "Not Found",
+          json: () => Promise.resolve({ error: "firmware file not found" }),
+        }),
+      );
+      const { result } = renderHook(() => useFirmwareApi());
+
+      await expect(
+        result.current.updateFirmwareMetadata("missing", {
+          targetManufacturer: "Proto",
+          targetModel: "Rig",
+          firmwareVersion: "2.0.0",
+        }),
+      ).rejects.toThrow("firmware file not found");
+    });
+  });
+
   describe("deleteAllFirmwareFiles", () => {
     it("sends DELETE and returns deleted count", async () => {
       const mockFetch = vi.fn().mockResolvedValue({

--- a/client/src/protoFleet/api/useFirmwareApi.test.ts
+++ b/client/src/protoFleet/api/useFirmwareApi.test.ts
@@ -284,6 +284,7 @@ describe("useFirmwareApi", () => {
       const file = new File(["data"], "proto-rig.swu");
       const { result } = renderHook(() => useFirmwareApi());
 
+      // @ts-expect-error Runtime validation still protects untyped callers.
       await expect(result.current.uploadFirmwareFile(file)).rejects.toThrow(
         "Manufacturer, model, and firmware version are required.",
       );
@@ -308,6 +309,7 @@ describe("useFirmwareApi", () => {
       const file = new File(["data"], "firmware.zip");
       const { result } = renderHook(() => useFirmwareApi());
 
+      // @ts-expect-error Runtime validation still protects untyped callers.
       await expect(result.current.uploadFirmwareFile(file)).rejects.toThrow(
         "Manufacturer, model, and firmware version are required.",
       );

--- a/client/src/protoFleet/api/useFirmwareApi.test.ts
+++ b/client/src/protoFleet/api/useFirmwareApi.test.ts
@@ -4,7 +4,7 @@ import { _resetConfigCache, useFirmwareApi, validateFirmwareFile } from "./useFi
 
 const mockLogout = vi.fn();
 const mockUpload = vi.fn();
-const firmwareTarget = { targetManufacturer: "Proto", targetModel: "S21", firmwareVersion: "v2.0.0" };
+const firmwareTarget = { targetManufacturer: "Proto", targetModel: "Rig", firmwareVersion: "v2.0.0" };
 
 vi.mock("@/protoFleet/store", () => ({
   useLogout: () => mockLogout,
@@ -102,7 +102,7 @@ describe("useFirmwareApi", () => {
           body: JSON.stringify({
             sha256: "abc123",
             target_manufacturer: "Proto",
-            target_model: "S21",
+            target_model: "Rig",
             firmware_version: "v2.0.0",
           }),
         }),
@@ -222,7 +222,7 @@ describe("useFirmwareApi", () => {
           signal: undefined,
           formFields: {
             target_manufacturer: "Proto",
-            target_model: "S21",
+            target_model: "Rig",
             firmware_version: "v2.0.0",
           },
         }),
@@ -255,7 +255,7 @@ describe("useFirmwareApi", () => {
           onProgress,
           initiateFields: {
             target_manufacturer: "Proto",
-            target_model: "S21",
+            target_model: "Rig",
             firmware_version: "v2.0.0",
           },
           chunked: expect.objectContaining({
@@ -377,7 +377,7 @@ describe("useFirmwareApi", () => {
           size: 1024,
           uploaded_at: "2025-01-01T00:00:00Z",
           target_manufacturer: "Proto",
-          target_model: "S21",
+          target_model: "Rig",
           firmware_version: "v2.0.0",
         },
       ];

--- a/client/src/protoFleet/api/useFirmwareApi.ts
+++ b/client/src/protoFleet/api/useFirmwareApi.ts
@@ -66,6 +66,8 @@ async function fetchFirmwareConfig(logout: () => void): Promise<FirmwareConfig> 
 }
 
 export interface FirmwareUploadOptions {
+  targetManufacturer: string;
+  targetModel: string;
   onProgress?: (percent: number) => void;
   signal?: AbortSignal;
 }
@@ -96,6 +98,8 @@ export interface FirmwareFileInfo {
   filename: string;
   size: number;
   uploaded_at: string;
+  target_manufacturer: string;
+  target_model: string;
 }
 
 interface CheckFirmwareResponse {
@@ -112,12 +116,20 @@ export const useFirmwareApi = () => {
   }, [logout]);
 
   const checkFirmwareFile = useCallback(
-    async (sha256: string, signal?: AbortSignal): Promise<{ exists: boolean; firmwareFileId?: string }> => {
+    async (
+      sha256: string,
+      target: { targetManufacturer: string; targetModel: string },
+      signal?: AbortSignal,
+    ): Promise<{ exists: boolean; firmwareFileId?: string }> => {
       const response = await fetch(`${API_BASE}/check`, {
         method: "POST",
         credentials: "include",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ sha256 }),
+        body: JSON.stringify({
+          sha256,
+          target_manufacturer: target.targetManufacturer,
+          target_model: target.targetModel,
+        }),
         signal,
       });
 
@@ -146,6 +158,14 @@ export const useFirmwareApi = () => {
   const uploadFirmwareFile = useCallback(
     async (file: File, options?: FirmwareUploadOptions): Promise<string> => {
       const config = await fetchFirmwareConfig(logout);
+      const targetManufacturer = options?.targetManufacturer.trim();
+      const targetModel = options?.targetModel.trim();
+      if (!targetManufacturer) {
+        throw new Error("Product is required.");
+      }
+      if (!targetModel) {
+        throw new Error("Model is required.");
+      }
 
       let data: unknown;
       const useChunked = file.size > config.chunkSizeBytes;
@@ -153,6 +173,10 @@ export const useFirmwareApi = () => {
         data = await upload(`${API_BASE}/upload`, file, {
           onProgress: options?.onProgress,
           signal: options?.signal,
+          initiateFields: {
+            target_manufacturer: targetManufacturer,
+            target_model: targetModel,
+          },
           chunked: {
             enabled: true,
             chunkSize: config.chunkSizeBytes,
@@ -165,6 +189,10 @@ export const useFirmwareApi = () => {
         data = await upload(`${API_BASE}/upload`, file, {
           onProgress: options?.onProgress,
           signal: options?.signal,
+          formFields: {
+            target_manufacturer: targetManufacturer,
+            target_model: targetModel,
+          },
         });
       }
 

--- a/client/src/protoFleet/api/useFirmwareApi.ts
+++ b/client/src/protoFleet/api/useFirmwareApi.ts
@@ -115,23 +115,19 @@ interface CheckFirmwareResponse {
   firmware_file_id?: string;
 }
 
-function hasCompleteFirmwareTarget(target: {
-  targetManufacturer?: string;
-  targetModel?: string;
-  firmwareVersion?: string;
-}): boolean {
+export const FIRMWARE_TARGET_REQUIRED_MESSAGE = "Manufacturer, model, and firmware version are required.";
+
+/** The client mirror of the server's upload metadata completeness rule. */
+export function hasCompleteFirmwareTarget(target: Partial<FirmwareMetadataInput>): boolean {
   return Boolean(target.targetManufacturer?.trim() && target.targetModel?.trim() && target.firmwareVersion?.trim());
 }
 
-function firmwareMetadataFields(options?: FirmwareUploadOptions): Record<string, string> {
-  const fields: Record<string, string> = {};
-  const targetManufacturer = options?.targetManufacturer?.trim();
-  const targetModel = options?.targetModel?.trim();
-  const firmwareVersion = options?.firmwareVersion?.trim();
-  if (targetManufacturer) fields.target_manufacturer = targetManufacturer;
-  if (targetModel) fields.target_model = targetModel;
-  if (firmwareVersion) fields.firmware_version = firmwareVersion;
-  return fields;
+function firmwareMetadataFields(target: FirmwareMetadataInput): Record<string, string> {
+  return {
+    target_manufacturer: target.targetManufacturer.trim(),
+    target_model: target.targetModel.trim(),
+    firmware_version: target.firmwareVersion.trim(),
+  };
 }
 
 export const useFirmwareApi = () => {
@@ -145,19 +141,14 @@ export const useFirmwareApi = () => {
   const checkFirmwareFile = useCallback(
     async (
       sha256: string,
-      target: { targetManufacturer: string; targetModel: string; firmwareVersion: string },
+      target: FirmwareMetadataInput,
       signal?: AbortSignal,
     ): Promise<{ exists: boolean; firmwareFileId?: string }> => {
       const response = await fetch(`${API_BASE}/check`, {
         method: "POST",
         credentials: "include",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          sha256,
-          target_manufacturer: target.targetManufacturer,
-          target_model: target.targetModel,
-          firmware_version: target.firmwareVersion,
-        }),
+        body: JSON.stringify({ sha256, ...firmwareMetadataFields(target) }),
         signal,
       });
 
@@ -186,10 +177,12 @@ export const useFirmwareApi = () => {
   const uploadFirmwareFile = useCallback(
     async (file: File, options?: FirmwareUploadOptions): Promise<string> => {
       const config = await fetchFirmwareConfig(logout);
-      if (!hasCompleteFirmwareTarget(options ?? {})) {
-        throw new Error("Manufacturer, model, and firmware version are required.");
+      const { targetManufacturer = "", targetModel = "", firmwareVersion = "" } = options ?? {};
+      const target = { targetManufacturer, targetModel, firmwareVersion };
+      if (!hasCompleteFirmwareTarget(target)) {
+        throw new Error(FIRMWARE_TARGET_REQUIRED_MESSAGE);
       }
-      const metadataFields = firmwareMetadataFields(options);
+      const metadataFields = firmwareMetadataFields(target);
 
       let data: unknown;
       const useChunked = file.size > config.chunkSizeBytes;
@@ -277,17 +270,13 @@ export const useFirmwareApi = () => {
   const updateFirmwareMetadata = useCallback(
     async (fileId: string, metadata: FirmwareMetadataInput, signal?: AbortSignal): Promise<void> => {
       if (!hasCompleteFirmwareTarget(metadata)) {
-        throw new Error("Manufacturer, model, and firmware version are required.");
+        throw new Error(FIRMWARE_TARGET_REQUIRED_MESSAGE);
       }
       const response = await fetch(`${API_BASE}/files/${encodeURIComponent(fileId)}`, {
         method: "PATCH",
         credentials: "include",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          target_manufacturer: metadata.targetManufacturer.trim(),
-          target_model: metadata.targetModel.trim(),
-          firmware_version: metadata.firmwareVersion.trim(),
-        }),
+        body: JSON.stringify(firmwareMetadataFields(metadata)),
         signal,
       });
 

--- a/client/src/protoFleet/api/useFirmwareApi.ts
+++ b/client/src/protoFleet/api/useFirmwareApi.ts
@@ -104,6 +104,12 @@ export interface FirmwareFileInfo {
   firmware_version?: string;
 }
 
+export interface FirmwareMetadataInput {
+  targetManufacturer: string;
+  targetModel: string;
+  firmwareVersion: string;
+}
+
 interface CheckFirmwareResponse {
   exists: boolean;
   firmware_file_id?: string;
@@ -268,6 +274,39 @@ export const useFirmwareApi = () => {
     [logout],
   );
 
+  const updateFirmwareMetadata = useCallback(
+    async (fileId: string, metadata: FirmwareMetadataInput, signal?: AbortSignal): Promise<void> => {
+      if (!hasCompleteFirmwareTarget(metadata)) {
+        throw new Error("Manufacturer, model, and firmware version are required.");
+      }
+      const response = await fetch(`${API_BASE}/files/${encodeURIComponent(fileId)}`, {
+        method: "PATCH",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          target_manufacturer: metadata.targetManufacturer.trim(),
+          target_model: metadata.targetModel.trim(),
+          firmware_version: metadata.firmwareVersion.trim(),
+        }),
+        signal,
+      });
+
+      if (response.status === 401) {
+        logout();
+        throw new Error("Session expired. Please log in again.");
+      }
+
+      if (!response.ok) {
+        const message = await extractFetchError(
+          response,
+          `Couldn't update firmware metadata: ${response.status} ${response.statusText}`,
+        );
+        throw new Error(message);
+      }
+    },
+    [logout],
+  );
+
   const deleteAllFirmwareFiles = useCallback(
     async (signal?: AbortSignal): Promise<{ deleted_count: number }> => {
       const response = await fetch(`${API_BASE}/files`, {
@@ -300,9 +339,18 @@ export const useFirmwareApi = () => {
       checkFirmwareFile,
       uploadFirmwareFile,
       listFirmwareFiles,
+      updateFirmwareMetadata,
       deleteFirmwareFile,
       deleteAllFirmwareFiles,
     }),
-    [getConfig, checkFirmwareFile, uploadFirmwareFile, listFirmwareFiles, deleteFirmwareFile, deleteAllFirmwareFiles],
+    [
+      getConfig,
+      checkFirmwareFile,
+      uploadFirmwareFile,
+      listFirmwareFiles,
+      updateFirmwareMetadata,
+      deleteFirmwareFile,
+      deleteAllFirmwareFiles,
+    ],
   );
 };

--- a/client/src/protoFleet/api/useFirmwareApi.ts
+++ b/client/src/protoFleet/api/useFirmwareApi.ts
@@ -66,8 +66,9 @@ async function fetchFirmwareConfig(logout: () => void): Promise<FirmwareConfig> 
 }
 
 export interface FirmwareUploadOptions {
-  targetManufacturer: string;
-  targetModel: string;
+  targetManufacturer?: string;
+  targetModel?: string;
+  firmwareVersion?: string;
   onProgress?: (percent: number) => void;
   signal?: AbortSignal;
 }
@@ -100,11 +101,31 @@ export interface FirmwareFileInfo {
   uploaded_at: string;
   target_manufacturer: string;
   target_model: string;
+  firmware_version?: string;
 }
 
 interface CheckFirmwareResponse {
   exists: boolean;
   firmware_file_id?: string;
+}
+
+function hasCompleteFirmwareTarget(target: {
+  targetManufacturer?: string;
+  targetModel?: string;
+  firmwareVersion?: string;
+}): boolean {
+  return Boolean(target.targetManufacturer?.trim() && target.targetModel?.trim() && target.firmwareVersion?.trim());
+}
+
+function firmwareMetadataFields(options?: FirmwareUploadOptions): Record<string, string> {
+  const fields: Record<string, string> = {};
+  const targetManufacturer = options?.targetManufacturer?.trim();
+  const targetModel = options?.targetModel?.trim();
+  const firmwareVersion = options?.firmwareVersion?.trim();
+  if (targetManufacturer) fields.target_manufacturer = targetManufacturer;
+  if (targetModel) fields.target_model = targetModel;
+  if (firmwareVersion) fields.firmware_version = firmwareVersion;
+  return fields;
 }
 
 export const useFirmwareApi = () => {
@@ -118,7 +139,7 @@ export const useFirmwareApi = () => {
   const checkFirmwareFile = useCallback(
     async (
       sha256: string,
-      target: { targetManufacturer: string; targetModel: string },
+      target: { targetManufacturer: string; targetModel: string; firmwareVersion: string },
       signal?: AbortSignal,
     ): Promise<{ exists: boolean; firmwareFileId?: string }> => {
       const response = await fetch(`${API_BASE}/check`, {
@@ -129,6 +150,7 @@ export const useFirmwareApi = () => {
           sha256,
           target_manufacturer: target.targetManufacturer,
           target_model: target.targetModel,
+          firmware_version: target.firmwareVersion,
         }),
         signal,
       });
@@ -158,14 +180,10 @@ export const useFirmwareApi = () => {
   const uploadFirmwareFile = useCallback(
     async (file: File, options?: FirmwareUploadOptions): Promise<string> => {
       const config = await fetchFirmwareConfig(logout);
-      const targetManufacturer = options?.targetManufacturer.trim();
-      const targetModel = options?.targetModel.trim();
-      if (!targetManufacturer) {
-        throw new Error("Product is required.");
+      if (!hasCompleteFirmwareTarget(options ?? {})) {
+        throw new Error("Manufacturer, model, and firmware version are required.");
       }
-      if (!targetModel) {
-        throw new Error("Model is required.");
-      }
+      const metadataFields = firmwareMetadataFields(options);
 
       let data: unknown;
       const useChunked = file.size > config.chunkSizeBytes;
@@ -173,10 +191,7 @@ export const useFirmwareApi = () => {
         data = await upload(`${API_BASE}/upload`, file, {
           onProgress: options?.onProgress,
           signal: options?.signal,
-          initiateFields: {
-            target_manufacturer: targetManufacturer,
-            target_model: targetModel,
-          },
+          initiateFields: metadataFields,
           chunked: {
             enabled: true,
             chunkSize: config.chunkSizeBytes,
@@ -189,10 +204,7 @@ export const useFirmwareApi = () => {
         data = await upload(`${API_BASE}/upload`, file, {
           onProgress: options?.onProgress,
           signal: options?.signal,
-          formFields: {
-            target_manufacturer: targetManufacturer,
-            target_model: targetModel,
-          },
+          formFields: metadataFields,
         });
       }
 

--- a/client/src/protoFleet/api/useFirmwareApi.ts
+++ b/client/src/protoFleet/api/useFirmwareApi.ts
@@ -66,10 +66,13 @@ async function fetchFirmwareConfig(logout: () => void): Promise<FirmwareConfig> 
   return configPromise;
 }
 
-export interface FirmwareUploadOptions {
-  targetManufacturer?: string;
-  targetModel?: string;
-  firmwareVersion?: string;
+export interface FirmwareMetadataInput {
+  targetManufacturer: string;
+  targetModel: string;
+  firmwareVersion: string;
+}
+
+export interface FirmwareUploadOptions extends FirmwareMetadataInput {
   onProgress?: (percent: number) => void;
   signal?: AbortSignal;
 }
@@ -103,12 +106,6 @@ export interface FirmwareFileInfo {
   target_manufacturer: string;
   target_model: string;
   firmware_version?: string;
-}
-
-export interface FirmwareMetadataInput {
-  targetManufacturer: string;
-  targetModel: string;
-  firmwareVersion: string;
 }
 
 interface CheckFirmwareResponse {
@@ -174,7 +171,7 @@ export const useFirmwareApi = () => {
   );
 
   const uploadFirmwareFile = useCallback(
-    async (file: File, options?: FirmwareUploadOptions): Promise<string> => {
+    async (file: File, options: FirmwareUploadOptions): Promise<string> => {
       const config = await fetchFirmwareConfig(logout);
       const { targetManufacturer = "", targetModel = "", firmwareVersion = "" } = options ?? {};
       const target = { targetManufacturer, targetModel, firmwareVersion };

--- a/client/src/protoFleet/api/useFirmwareApi.ts
+++ b/client/src/protoFleet/api/useFirmwareApi.ts
@@ -9,6 +9,7 @@ const API_BASE = `${API_PROXY_BASE}/api/v1/firmware`;
 
 const DEFAULT_MAX_FILE_SIZE = 500 * 1024 * 1024;
 const DEFAULT_CHUNK_SIZE = 32 * 1024 * 1024;
+export const FIRMWARE_TARGET_REQUIRED_MESSAGE = "Manufacturer, model, and firmware version are required.";
 
 export interface FirmwareConfig {
   allowedExtensions: string[];
@@ -114,8 +115,6 @@ interface CheckFirmwareResponse {
   exists: boolean;
   firmware_file_id?: string;
 }
-
-export const FIRMWARE_TARGET_REQUIRED_MESSAGE = "Manufacturer, model, and firmware version are required.";
 
 /** The client mirror of the server's upload metadata completeness rule. */
 export function hasCompleteFirmwareTarget(target: Partial<FirmwareMetadataInput>): boolean {

--- a/client/src/protoFleet/components/FirmwareUpload/FirmwareUploadComponents.test.tsx
+++ b/client/src/protoFleet/components/FirmwareUpload/FirmwareUploadComponents.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { FileDropZone } from "./FirmwareUploadComponents";
+import { FileDropZone, FileSelectedStatus } from "./FirmwareUploadComponents";
 
 describe("FileDropZone", () => {
   it("does not accept files while disabled", () => {
@@ -13,5 +13,17 @@ describe("FileDropZone", () => {
 
     fireEvent.change(input, { target: { files: [new File(["firmware"], "update.swu")] } });
     expect(onFileSelect).not.toHaveBeenCalled();
+  });
+});
+
+describe("FileSelectedStatus", () => {
+  it("shows the selected file and allows it to be removed", () => {
+    const onRemove = vi.fn();
+    render(<FileSelectedStatus fileName="firmware-2.0.0.swu" fileSize={8} onRemove={onRemove} />);
+
+    expect(screen.getByText("firmware-2.0.0.swu")).toHaveAttribute("title", "firmware-2.0.0.swu");
+    fireEvent.click(screen.getByText("Remove"));
+
+    expect(onRemove).toHaveBeenCalledOnce();
   });
 });

--- a/client/src/protoFleet/components/FirmwareUpload/FirmwareUploadComponents.test.tsx
+++ b/client/src/protoFleet/components/FirmwareUpload/FirmwareUploadComponents.test.tsx
@@ -1,0 +1,17 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { FileDropZone } from "./FirmwareUploadComponents";
+
+describe("FileDropZone", () => {
+  it("does not accept files while disabled", () => {
+    const onFileSelect = vi.fn();
+    render(<FileDropZone extensions={[".swu"]} onFileSelect={onFileSelect} disabled />);
+
+    const input = screen.getByTestId("firmware-file-input");
+    expect(input).toBeDisabled();
+    expect(screen.getByTestId("firmware-drop-zone")).toHaveAttribute("aria-disabled", "true");
+
+    fireEvent.change(input, { target: { files: [new File(["firmware"], "update.swu")] } });
+    expect(onFileSelect).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/protoFleet/components/FirmwareUpload/FirmwareUploadComponents.test.tsx
+++ b/client/src/protoFleet/components/FirmwareUpload/FirmwareUploadComponents.test.tsx
@@ -3,15 +3,43 @@ import { describe, expect, it, vi } from "vitest";
 import { FileDropZone, FileSelectedStatus } from "./FirmwareUploadComponents";
 
 describe("FileDropZone", () => {
+  it("opens the file picker with Enter or Space", () => {
+    render(<FileDropZone extensions={[".swu"]} onFileSelect={vi.fn()} />);
+
+    const dropZone = screen.getByTestId("firmware-drop-zone");
+    const input = screen.getByTestId("firmware-file-input");
+    const clickSpy = vi.spyOn(input, "click");
+
+    fireEvent.keyDown(dropZone, { key: "Enter" });
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+
+    expect(fireEvent.keyDown(dropZone, { key: " " })).toBe(false);
+    expect(clickSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not handle keyboard events from the nested choose-file button", () => {
+    render(<FileDropZone extensions={[".swu"]} onFileSelect={vi.fn()} />);
+
+    const input = screen.getByTestId("firmware-file-input");
+    const clickSpy = vi.spyOn(input, "click");
+    fireEvent.keyDown(screen.getByText("Choose file"), { key: "Enter" });
+
+    expect(clickSpy).not.toHaveBeenCalled();
+  });
+
   it("does not accept files while disabled", () => {
     const onFileSelect = vi.fn();
     render(<FileDropZone extensions={[".swu"]} onFileSelect={onFileSelect} disabled />);
 
     const input = screen.getByTestId("firmware-file-input");
+    const clickSpy = vi.spyOn(input, "click");
     expect(input).toBeDisabled();
-    expect(screen.getByTestId("firmware-drop-zone")).toHaveAttribute("aria-disabled", "true");
+    const dropZone = screen.getByTestId("firmware-drop-zone");
+    expect(dropZone).toHaveAttribute("aria-disabled", "true");
 
+    fireEvent.keyDown(dropZone, { key: "Enter" });
     fireEvent.change(input, { target: { files: [new File(["firmware"], "update.swu")] } });
+    expect(clickSpy).not.toHaveBeenCalled();
     expect(onFileSelect).not.toHaveBeenCalled();
   });
 });

--- a/client/src/protoFleet/components/FirmwareUpload/FirmwareUploadComponents.tsx
+++ b/client/src/protoFleet/components/FirmwareUpload/FirmwareUploadComponents.tsx
@@ -130,6 +130,33 @@ interface FileProcessingStatusProps {
   uploadProgress: number;
 }
 
+interface FileSelectedStatusProps {
+  fileName: string;
+  fileSize: number;
+  onRemove: () => void;
+}
+
+export function FileSelectedStatus({ fileName, fileSize, onRemove }: FileSelectedStatusProps) {
+  return (
+    <div className="flex items-center justify-between gap-4 rounded-lg border border-border-5 p-4">
+      <div className="flex min-w-0 flex-col">
+        <div className="truncate text-300 text-text-primary" title={fileName}>
+          {fileName}
+        </div>
+        <div className="text-200 text-text-primary-70">{formatFileSize(fileSize)}</div>
+      </div>
+      <Button
+        variant={variants.textOnly}
+        textColor="text-core-accent-fill"
+        textOnlyUnderlineOnHover={false}
+        className="shrink-0"
+        onClick={onRemove}
+        text="Remove"
+      />
+    </div>
+  );
+}
+
 export function FileProcessingStatus({ state, fileName, fileSize, uploadProgress }: FileProcessingStatusProps) {
   return (
     <div className="flex items-center gap-4 rounded-lg border border-border-5 p-4">

--- a/client/src/protoFleet/components/FirmwareUpload/FirmwareUploadComponents.tsx
+++ b/client/src/protoFleet/components/FirmwareUpload/FirmwareUploadComponents.tsx
@@ -60,16 +60,18 @@ export function FileDropZone({ extensions, onFileSelect, disabled }: FileDropZon
   );
 
   const handleClick = useCallback(() => {
+    if (disabled) return;
     fileInputRef.current?.click();
-  }, []);
+  }, [disabled]);
 
   const handleFileInputChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
+      if (disabled) return;
       const selected = e.target.files?.[0];
       if (selected) onFileSelect(selected);
       if (fileInputRef.current) fileInputRef.current.value = "";
     },
-    [onFileSelect],
+    [disabled, onFileSelect],
   );
 
   const formattedExtensions =
@@ -92,7 +94,8 @@ export function FileDropZone({ extensions, onFileSelect, disabled }: FileDropZon
         onDrop={handleDrop}
         data-testid="firmware-drop-zone"
         role="button"
-        tabIndex={0}
+        aria-disabled={disabled}
+        tabIndex={disabled ? -1 : 0}
       >
         <div className="text-300 text-text-primary">Drag update files here</div>
         <div className="text-200 text-text-primary-70">or</div>
@@ -112,6 +115,7 @@ export function FileDropZone({ extensions, onFileSelect, disabled }: FileDropZon
         type="file"
         accept={buildAcceptString(extensions)}
         onChange={handleFileInputChange}
+        disabled={disabled}
         className="hidden"
         data-testid="firmware-file-input"
       />

--- a/client/src/protoFleet/components/FirmwareUpload/FirmwareUploadComponents.tsx
+++ b/client/src/protoFleet/components/FirmwareUpload/FirmwareUploadComponents.tsx
@@ -1,4 +1,4 @@
-import type { ChangeEvent, DragEvent } from "react";
+import type { ChangeEvent, DragEvent, KeyboardEvent } from "react";
 import { useCallback, useRef, useState } from "react";
 import clsx from "clsx";
 import { Checkmark } from "@/shared/assets/icons";
@@ -64,6 +64,15 @@ export function FileDropZone({ extensions, onFileSelect, disabled }: FileDropZon
     fileInputRef.current?.click();
   }, [disabled]);
 
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLDivElement>) => {
+      if (e.target !== e.currentTarget || (e.key !== "Enter" && e.key !== " ")) return;
+      if (e.key === " ") e.preventDefault();
+      handleClick();
+    },
+    [handleClick],
+  );
+
   const handleFileInputChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
       if (disabled) return;
@@ -88,6 +97,7 @@ export function FileDropZone({ extensions, onFileSelect, disabled }: FileDropZon
           isDragActive && "ring-2 ring-border-primary",
         )}
         onClick={handleClick}
+        onKeyDown={handleKeyDown}
         onDragEnter={handleDragEnter}
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}

--- a/client/src/protoFleet/components/FirmwareUpload/firmwareVersion.test.ts
+++ b/client/src/protoFleet/components/FirmwareUpload/firmwareVersion.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { firmwareVersionFromFilename } from "./firmwareVersion";
+
+describe("firmwareVersionFromFilename", () => {
+  it.each([
+    ["miner-image-release-c3-p1-1.3.5.swu", "1.3.5"],
+    ["antminer-s19-v2.1.0.tar.gz", "2.1.0"],
+    ["3.4.5", "3.4.5"],
+  ])("reads %s as version %s", (filename, expected) => {
+    expect(firmwareVersionFromFilename(filename)).toBe(expected);
+  });
+
+  it.each(["antminer-firmware.tar.gz", "antminer-2.1.tar.gz", "build-1.2.3.4.swu"])(
+    "does not infer a version from %s",
+    (filename) => {
+      expect(firmwareVersionFromFilename(filename)).toBeNull();
+    },
+  );
+});

--- a/client/src/protoFleet/components/FirmwareUpload/firmwareVersion.ts
+++ b/client/src/protoFleet/components/FirmwareUpload/firmwareVersion.ts
@@ -1,0 +1,5 @@
+const FIRMWARE_FILENAME_VERSION_RE = /(?:^|[^0-9.])v?([0-9]+\.[0-9]+\.[0-9]+)(?:$|[^0-9.]|\.[A-Za-z])/;
+
+export function firmwareVersionFromFilename(filename: string): string | null {
+  return FIRMWARE_FILENAME_VERSION_RE.exec(filename)?.[1] ?? null;
+}

--- a/client/src/protoFleet/components/FirmwareUpload/index.ts
+++ b/client/src/protoFleet/components/FirmwareUpload/index.ts
@@ -1,3 +1,10 @@
 export { useFirmwareUpload } from "./useFirmwareUpload";
 export type { UploadState, UseFirmwareUploadReturn } from "./useFirmwareUpload";
-export { FileDropZone, FileProcessingStatus, FileReadyStatus, FileErrorStatus } from "./FirmwareUploadComponents";
+export {
+  FileDropZone,
+  FileSelectedStatus,
+  FileProcessingStatus,
+  FileReadyStatus,
+  FileErrorStatus,
+} from "./FirmwareUploadComponents";
+export { firmwareVersionFromFilename } from "./firmwareVersion";

--- a/client/src/protoFleet/components/FirmwareUpload/useFirmwareUpload.fixtures.ts
+++ b/client/src/protoFleet/components/FirmwareUpload/useFirmwareUpload.fixtures.ts
@@ -1,0 +1,19 @@
+import { vi } from "vitest";
+
+/**
+ * Builds a useFirmwareUpload return value for tests that mock the hook. Keeps
+ * the fake in one place so a new field on the hook does not have to be added to
+ * every `mockReturnValue` call across the dialogs that consume it.
+ */
+export const uploadHookState = (overrides: Record<string, unknown> = {}) => ({
+  state: "idle",
+  file: null,
+  firmwareFileId: null,
+  uploadProgress: 0,
+  errorMessage: null,
+  serverConfig: null,
+  processFile: vi.fn(),
+  reset: vi.fn(),
+  retry: vi.fn(),
+  ...overrides,
+});

--- a/client/src/protoFleet/components/FirmwareUpload/useFirmwareUpload.test.ts
+++ b/client/src/protoFleet/components/FirmwareUpload/useFirmwareUpload.test.ts
@@ -16,6 +16,8 @@ vi.mock("@/protoFleet/api/useFirmwareApi", () => ({
   validateFirmwareFile: vi.fn().mockReturnValue(null),
 }));
 
+const firmwareTarget = { targetManufacturer: "Proto", targetModel: "S21" };
+
 const defaultConfig = {
   allowedExtensions: [".swu", ".tar.gz", ".zip"],
   maxFileSizeBytes: 500 * 1024 * 1024,
@@ -106,7 +108,7 @@ describe("useFirmwareUpload", () => {
       const file = new File(["data"], "firmware.swu");
 
       act(() => {
-        result.current.processFile(file);
+        result.current.processFile(file, firmwareTarget);
       });
 
       await vi.waitFor(() => {
@@ -129,7 +131,7 @@ describe("useFirmwareUpload", () => {
       const file = new File(["data"], "firmware.swu");
 
       act(() => {
-        result.current.processFile(file);
+        result.current.processFile(file, firmwareTarget);
       });
 
       await vi.waitFor(() => {
@@ -148,7 +150,7 @@ describe("useFirmwareUpload", () => {
       expect(result.current.serverConfig).toBeNull();
 
       act(() => {
-        result.current.processFile(new File(["data"], "firmware.swu"));
+        result.current.processFile(new File(["data"], "firmware.swu"), firmwareTarget);
       });
 
       await vi.waitFor(() => {
@@ -168,7 +170,7 @@ describe("useFirmwareUpload", () => {
       });
 
       act(() => {
-        result.current.processFile(new File(["data"], "firmware.swu"));
+        result.current.processFile(new File(["data"], "firmware.swu"), firmwareTarget);
       });
 
       await vi.waitFor(() => {
@@ -191,7 +193,7 @@ describe("useFirmwareUpload", () => {
       });
 
       act(() => {
-        result.current.processFile(new File(["data"], "first.swu"));
+        result.current.processFile(new File(["data"], "first.swu"), firmwareTarget);
       });
 
       await vi.waitFor(() => {
@@ -199,7 +201,7 @@ describe("useFirmwareUpload", () => {
       });
 
       act(() => {
-        result.current.processFile(new File(["data"], "second.swu"));
+        result.current.processFile(new File(["data"], "second.swu"), firmwareTarget);
       });
 
       await vi.waitFor(() => {
@@ -224,7 +226,7 @@ describe("useFirmwareUpload", () => {
       });
 
       act(() => {
-        result.current.processFile(new File(["data"], "firmware.swu"));
+        result.current.processFile(new File(["data"], "firmware.swu"), firmwareTarget);
       });
 
       await vi.waitFor(() => {
@@ -244,7 +246,7 @@ describe("useFirmwareUpload", () => {
       });
 
       act(() => {
-        result.current.processFile(new File(["data"], "firmware.bin"));
+        result.current.processFile(new File(["data"], "firmware.bin"), firmwareTarget);
       });
 
       await vi.waitFor(() => {
@@ -265,7 +267,7 @@ describe("useFirmwareUpload", () => {
       });
 
       act(() => {
-        result.current.processFile(new File(["data"], "firmware.swu"));
+        result.current.processFile(new File(["data"], "firmware.swu"), firmwareTarget);
       });
 
       await vi.waitFor(() => {
@@ -298,7 +300,7 @@ describe("useFirmwareUpload", () => {
       });
 
       act(() => {
-        result.current.processFile(new File(["data"], "firmware.swu"));
+        result.current.processFile(new File(["data"], "firmware.swu"), firmwareTarget);
       });
 
       await vi.waitFor(() => {

--- a/client/src/protoFleet/components/FirmwareUpload/useFirmwareUpload.test.ts
+++ b/client/src/protoFleet/components/FirmwareUpload/useFirmwareUpload.test.ts
@@ -106,9 +106,10 @@ describe("useFirmwareUpload", () => {
       });
 
       const file = new File(["data"], "firmware.swu");
+      const onReady = vi.fn();
 
       act(() => {
-        result.current.processFile(file, firmwareTarget);
+        result.current.processFile(file, firmwareTarget, onReady);
       });
 
       await vi.waitFor(() => {
@@ -117,6 +118,7 @@ describe("useFirmwareUpload", () => {
       expect(result.current.firmwareFileId).toBe("fw-new-id");
       expect(result.current.file).toBe(file);
       expect(mockUploadFirmwareFile).toHaveBeenCalled();
+      expect(onReady).toHaveBeenCalledOnce();
     });
 
     it("skips upload when file already exists on server (SHA-256 dedup)", async () => {
@@ -129,9 +131,10 @@ describe("useFirmwareUpload", () => {
       });
 
       const file = new File(["data"], "firmware.swu");
+      const onReady = vi.fn();
 
       act(() => {
-        result.current.processFile(file, firmwareTarget);
+        result.current.processFile(file, firmwareTarget, onReady);
       });
 
       await vi.waitFor(() => {
@@ -139,6 +142,7 @@ describe("useFirmwareUpload", () => {
       });
       expect(result.current.firmwareFileId).toBe("fw-existing");
       expect(mockUploadFirmwareFile).not.toHaveBeenCalled();
+      expect(onReady).toHaveBeenCalledOnce();
     });
 
     it("sets error state when target metadata is incomplete", async () => {

--- a/client/src/protoFleet/components/FirmwareUpload/useFirmwareUpload.test.ts
+++ b/client/src/protoFleet/components/FirmwareUpload/useFirmwareUpload.test.ts
@@ -16,7 +16,7 @@ vi.mock("@/protoFleet/api/useFirmwareApi", () => ({
   validateFirmwareFile: vi.fn().mockReturnValue(null),
 }));
 
-const firmwareTarget = { targetManufacturer: "Proto", targetModel: "S21" };
+const firmwareTarget = { targetManufacturer: "Proto", targetModel: "S21", firmwareVersion: "v2.0.0" };
 
 const defaultConfig = {
   allowedExtensions: [".swu", ".tar.gz", ".zip"],
@@ -138,6 +138,27 @@ describe("useFirmwareUpload", () => {
         expect(result.current.state).toBe("ready");
       });
       expect(result.current.firmwareFileId).toBe("fw-existing");
+      expect(mockUploadFirmwareFile).not.toHaveBeenCalled();
+    });
+
+    it("sets error state when target metadata is incomplete", async () => {
+      const { result } = renderHook(() => useFirmwareUpload(true));
+
+      await vi.waitFor(() => {
+        expect(result.current.serverConfig).not.toBeNull();
+      });
+
+      const file = new File(["data"], "proto-rig.swu");
+
+      act(() => {
+        result.current.processFile(file, { targetManufacturer: "", targetModel: "", firmwareVersion: "" });
+      });
+
+      await vi.waitFor(() => {
+        expect(result.current.state).toBe("error");
+      });
+      expect(result.current.errorMessage).toBe("Manufacturer, model, and firmware version are required.");
+      expect(mockCheckFirmwareFile).not.toHaveBeenCalled();
       expect(mockUploadFirmwareFile).not.toHaveBeenCalled();
     });
 

--- a/client/src/protoFleet/components/FirmwareUpload/useFirmwareUpload.test.ts
+++ b/client/src/protoFleet/components/FirmwareUpload/useFirmwareUpload.test.ts
@@ -6,7 +6,8 @@ const mockGetConfig = vi.fn();
 const mockCheckFirmwareFile = vi.fn();
 const mockUploadFirmwareFile = vi.fn();
 
-vi.mock("@/protoFleet/api/useFirmwareApi", () => ({
+vi.mock("@/protoFleet/api/useFirmwareApi", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/protoFleet/api/useFirmwareApi")>()),
   useFirmwareApi: () => ({
     getConfig: mockGetConfig,
     checkFirmwareFile: mockCheckFirmwareFile,
@@ -106,10 +107,9 @@ describe("useFirmwareUpload", () => {
       });
 
       const file = new File(["data"], "firmware.swu");
-      const onReady = vi.fn();
 
       act(() => {
-        result.current.processFile(file, firmwareTarget, onReady);
+        result.current.processFile(file, firmwareTarget);
       });
 
       await vi.waitFor(() => {
@@ -118,7 +118,6 @@ describe("useFirmwareUpload", () => {
       expect(result.current.firmwareFileId).toBe("fw-new-id");
       expect(result.current.file).toBe(file);
       expect(mockUploadFirmwareFile).toHaveBeenCalled();
-      expect(onReady).toHaveBeenCalledOnce();
     });
 
     it("skips upload when file already exists on server (SHA-256 dedup)", async () => {
@@ -131,10 +130,9 @@ describe("useFirmwareUpload", () => {
       });
 
       const file = new File(["data"], "firmware.swu");
-      const onReady = vi.fn();
 
       act(() => {
-        result.current.processFile(file, firmwareTarget, onReady);
+        result.current.processFile(file, firmwareTarget);
       });
 
       await vi.waitFor(() => {
@@ -142,7 +140,6 @@ describe("useFirmwareUpload", () => {
       });
       expect(result.current.firmwareFileId).toBe("fw-existing");
       expect(mockUploadFirmwareFile).not.toHaveBeenCalled();
-      expect(onReady).toHaveBeenCalledOnce();
     });
 
     it("sets error state when target metadata is incomplete", async () => {

--- a/client/src/protoFleet/components/FirmwareUpload/useFirmwareUpload.test.ts
+++ b/client/src/protoFleet/components/FirmwareUpload/useFirmwareUpload.test.ts
@@ -17,7 +17,7 @@ vi.mock("@/protoFleet/api/useFirmwareApi", async (importOriginal) => ({
   validateFirmwareFile: vi.fn().mockReturnValue(null),
 }));
 
-const firmwareTarget = { targetManufacturer: "Proto", targetModel: "S21", firmwareVersion: "v2.0.0" };
+const firmwareTarget = { targetManufacturer: "Proto", targetModel: "Rig", firmwareVersion: "v2.0.0" };
 
 const defaultConfig = {
   allowedExtensions: [".swu", ".tar.gz", ".zip"],

--- a/client/src/protoFleet/components/FirmwareUpload/useFirmwareUpload.ts
+++ b/client/src/protoFleet/components/FirmwareUpload/useFirmwareUpload.ts
@@ -19,6 +19,13 @@ export interface UseFirmwareUploadReturn {
 export interface FirmwareUploadTarget {
   targetManufacturer: string;
   targetModel: string;
+  firmwareVersion: string;
+}
+
+function hasCompleteFirmwareTarget(target: FirmwareUploadTarget): boolean {
+  return (
+    target.targetManufacturer.trim() !== "" && target.targetModel.trim() !== "" && target.firmwareVersion.trim() !== ""
+  );
 }
 
 export function useFirmwareUpload(active: boolean): UseFirmwareUploadReturn {
@@ -96,6 +103,11 @@ export function useFirmwareUpload(active: boolean): UseFirmwareUploadReturn {
           setState("error");
           return;
         }
+        if (!hasCompleteFirmwareTarget(target)) {
+          setErrorMessage("Manufacturer, model, and firmware version are required.");
+          setState("error");
+          return;
+        }
 
         setFile(selectedFile);
         setState("hashing");
@@ -117,6 +129,7 @@ export function useFirmwareUpload(active: boolean): UseFirmwareUploadReturn {
         const newId = await uploadFirmwareFile(selectedFile, {
           targetManufacturer: target.targetManufacturer,
           targetModel: target.targetModel,
+          firmwareVersion: target.firmwareVersion,
           onProgress: setUploadProgress,
           signal: controller.signal,
         });

--- a/client/src/protoFleet/components/FirmwareUpload/useFirmwareUpload.ts
+++ b/client/src/protoFleet/components/FirmwareUpload/useFirmwareUpload.ts
@@ -11,9 +11,14 @@ export interface UseFirmwareUploadReturn {
   uploadProgress: number;
   errorMessage: string | null;
   serverConfig: FirmwareConfig | null;
-  processFile: (file: File) => void;
+  processFile: (file: File, target: FirmwareUploadTarget) => void;
   reset: () => void;
   retry: () => void;
+}
+
+export interface FirmwareUploadTarget {
+  targetManufacturer: string;
+  targetModel: string;
 }
 
 export function useFirmwareUpload(active: boolean): UseFirmwareUploadReturn {
@@ -76,7 +81,7 @@ export function useFirmwareUpload(active: boolean): UseFirmwareUploadReturn {
   }, [reset]);
 
   const processFile = useCallback(
-    async (selectedFile: File) => {
+    async (selectedFile: File, target: FirmwareUploadTarget) => {
       abortControllerRef.current?.abort();
       const controller = new AbortController();
       abortControllerRef.current = controller;
@@ -98,7 +103,7 @@ export function useFirmwareUpload(active: boolean): UseFirmwareUploadReturn {
         if (controller.signal.aborted) return;
 
         setState("checking");
-        const { exists, firmwareFileId: existingId } = await checkFirmwareFile(sha256, controller.signal);
+        const { exists, firmwareFileId: existingId } = await checkFirmwareFile(sha256, target, controller.signal);
         if (controller.signal.aborted) return;
 
         if (exists && existingId) {
@@ -110,6 +115,8 @@ export function useFirmwareUpload(active: boolean): UseFirmwareUploadReturn {
         setState("uploading");
         setUploadProgress(0);
         const newId = await uploadFirmwareFile(selectedFile, {
+          targetManufacturer: target.targetManufacturer,
+          targetModel: target.targetModel,
           onProgress: setUploadProgress,
           signal: controller.signal,
         });
@@ -125,7 +132,10 @@ export function useFirmwareUpload(active: boolean): UseFirmwareUploadReturn {
     [checkFirmwareFile, uploadFirmwareFile, serverConfig, getConfig],
   );
 
-  const wrappedProcessFile = useCallback((f: File) => void processFile(f), [processFile]);
+  const wrappedProcessFile = useCallback(
+    (f: File, target: FirmwareUploadTarget) => void processFile(f, target),
+    [processFile],
+  );
 
   return {
     state,

--- a/client/src/protoFleet/components/FirmwareUpload/useFirmwareUpload.ts
+++ b/client/src/protoFleet/components/FirmwareUpload/useFirmwareUpload.ts
@@ -11,7 +11,7 @@ export interface UseFirmwareUploadReturn {
   uploadProgress: number;
   errorMessage: string | null;
   serverConfig: FirmwareConfig | null;
-  processFile: (file: File, target: FirmwareUploadTarget) => void;
+  processFile: (file: File, target: FirmwareUploadTarget, onReady?: () => void) => void;
   reset: () => void;
   retry: () => void;
 }
@@ -88,7 +88,7 @@ export function useFirmwareUpload(active: boolean): UseFirmwareUploadReturn {
   }, [reset]);
 
   const processFile = useCallback(
-    async (selectedFile: File, target: FirmwareUploadTarget) => {
+    async (selectedFile: File, target: FirmwareUploadTarget, onReady?: () => void) => {
       abortControllerRef.current?.abort();
       const controller = new AbortController();
       abortControllerRef.current = controller;
@@ -121,6 +121,7 @@ export function useFirmwareUpload(active: boolean): UseFirmwareUploadReturn {
         if (exists && existingId) {
           setFirmwareFileId(existingId);
           setState("ready");
+          onReady?.();
           return;
         }
 
@@ -136,6 +137,7 @@ export function useFirmwareUpload(active: boolean): UseFirmwareUploadReturn {
         if (controller.signal.aborted) return;
         setFirmwareFileId(newId);
         setState("ready");
+        onReady?.();
       } catch (err) {
         if (controller.signal.aborted) return;
         setErrorMessage(err instanceof Error ? err.message : String(err));
@@ -146,7 +148,7 @@ export function useFirmwareUpload(active: boolean): UseFirmwareUploadReturn {
   );
 
   const wrappedProcessFile = useCallback(
-    (f: File, target: FirmwareUploadTarget) => void processFile(f, target),
+    (f: File, target: FirmwareUploadTarget, onReady?: () => void) => void processFile(f, target, onReady),
     [processFile],
   );
 

--- a/client/src/protoFleet/components/FirmwareUpload/useFirmwareUpload.ts
+++ b/client/src/protoFleet/components/FirmwareUpload/useFirmwareUpload.ts
@@ -1,6 +1,12 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { FirmwareConfig } from "@/protoFleet/api/useFirmwareApi";
-import { computeSha256, useFirmwareApi, validateFirmwareFile } from "@/protoFleet/api/useFirmwareApi";
+import type { FirmwareConfig, FirmwareMetadataInput } from "@/protoFleet/api/useFirmwareApi";
+import {
+  computeSha256,
+  FIRMWARE_TARGET_REQUIRED_MESSAGE,
+  hasCompleteFirmwareTarget,
+  useFirmwareApi,
+  validateFirmwareFile,
+} from "@/protoFleet/api/useFirmwareApi";
 
 export type UploadState = "idle" | "hashing" | "checking" | "uploading" | "ready" | "error";
 
@@ -11,21 +17,9 @@ export interface UseFirmwareUploadReturn {
   uploadProgress: number;
   errorMessage: string | null;
   serverConfig: FirmwareConfig | null;
-  processFile: (file: File, target: FirmwareUploadTarget, onReady?: () => void) => void;
+  processFile: (file: File, target: FirmwareMetadataInput) => void;
   reset: () => void;
   retry: () => void;
-}
-
-export interface FirmwareUploadTarget {
-  targetManufacturer: string;
-  targetModel: string;
-  firmwareVersion: string;
-}
-
-function hasCompleteFirmwareTarget(target: FirmwareUploadTarget): boolean {
-  return (
-    target.targetManufacturer.trim() !== "" && target.targetModel.trim() !== "" && target.firmwareVersion.trim() !== ""
-  );
 }
 
 export function useFirmwareUpload(active: boolean): UseFirmwareUploadReturn {
@@ -88,7 +82,7 @@ export function useFirmwareUpload(active: boolean): UseFirmwareUploadReturn {
   }, [reset]);
 
   const processFile = useCallback(
-    async (selectedFile: File, target: FirmwareUploadTarget, onReady?: () => void) => {
+    async (selectedFile: File, target: FirmwareMetadataInput) => {
       abortControllerRef.current?.abort();
       const controller = new AbortController();
       abortControllerRef.current = controller;
@@ -104,7 +98,7 @@ export function useFirmwareUpload(active: boolean): UseFirmwareUploadReturn {
           return;
         }
         if (!hasCompleteFirmwareTarget(target)) {
-          setErrorMessage("Manufacturer, model, and firmware version are required.");
+          setErrorMessage(FIRMWARE_TARGET_REQUIRED_MESSAGE);
           setState("error");
           return;
         }
@@ -121,7 +115,6 @@ export function useFirmwareUpload(active: boolean): UseFirmwareUploadReturn {
         if (exists && existingId) {
           setFirmwareFileId(existingId);
           setState("ready");
-          onReady?.();
           return;
         }
 
@@ -137,7 +130,6 @@ export function useFirmwareUpload(active: boolean): UseFirmwareUploadReturn {
         if (controller.signal.aborted) return;
         setFirmwareFileId(newId);
         setState("ready");
-        onReady?.();
       } catch (err) {
         if (controller.signal.aborted) return;
         setErrorMessage(err instanceof Error ? err.message : String(err));
@@ -148,7 +140,7 @@ export function useFirmwareUpload(active: boolean): UseFirmwareUploadReturn {
   );
 
   const wrappedProcessFile = useCallback(
-    (f: File, target: FirmwareUploadTarget, onReady?: () => void) => void processFile(f, target, onReady),
+    (f: File, target: FirmwareMetadataInput) => void processFile(f, target),
     [processFile],
   );
 

--- a/client/src/protoFleet/components/FirmwareUpload/useFirmwareUpload.ts
+++ b/client/src/protoFleet/components/FirmwareUpload/useFirmwareUpload.ts
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { FirmwareConfig, FirmwareMetadataInput } from "@/protoFleet/api/useFirmwareApi";
 import {
   computeSha256,
   FIRMWARE_TARGET_REQUIRED_MESSAGE,
+  type FirmwareConfig,
+  type FirmwareMetadataInput,
   hasCompleteFirmwareTarget,
   useFirmwareApi,
   validateFirmwareFile,

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/FirmwareUpdateModal/FirmwareUpdateModal.stories.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/FirmwareUpdateModal/FirmwareUpdateModal.stories.tsx
@@ -21,6 +21,7 @@ export const Default = () => {
       ) : null}
       <FirmwareUpdateModal
         open={open}
+        target={{ targetManufacturer: "Proto", targetModel: "Rig" }}
         onConfirm={(firmwareFileId) => {
           action("onConfirm")(firmwareFileId);
           setOpen(false);

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/FirmwareUpdateModal/FirmwareUpdateModal.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/FirmwareUpdateModal/FirmwareUpdateModal.test.tsx
@@ -5,6 +5,7 @@ import FirmwareUpdateModal from "./FirmwareUpdateModal";
 
 const mockListFirmwareFiles = vi.fn();
 const mockUseFirmwareUpload = vi.fn();
+const target = { targetManufacturer: "Proto", targetModel: "S21" };
 
 vi.mock("@/protoFleet/api/useFirmwareApi", () => ({
   useFirmwareApi: () => ({
@@ -65,7 +66,7 @@ describe("FirmwareUpdateModal", () => {
       }),
     );
 
-    render(<FirmwareUpdateModal open onConfirm={vi.fn()} onDismiss={vi.fn()} />);
+    render(<FirmwareUpdateModal open target={target} onConfirm={vi.fn()} onDismiss={vi.fn()} />);
 
     expect(screen.getByTestId("progress-circular")).toBeInTheDocument();
 
@@ -90,7 +91,7 @@ describe("FirmwareUpdateModal", () => {
       },
     ]);
 
-    render(<FirmwareUpdateModal open onConfirm={vi.fn()} onDismiss={vi.fn()} />);
+    render(<FirmwareUpdateModal open target={target} onConfirm={vi.fn()} onDismiss={vi.fn()} />);
 
     expect(await screen.findByText("Select an existing firmware file")).toBeInTheDocument();
     expect(screen.getByText("alpha.swu")).toBeInTheDocument();
@@ -114,12 +115,20 @@ describe("FirmwareUpdateModal", () => {
         target_manufacturer: "Bitmain",
         target_model: "S21",
       },
+      {
+        id: "legacy",
+        filename: "legacy.swu",
+        size: 1024,
+        uploaded_at: "2025-01-01T00:00:00Z",
+        target_manufacturer: "",
+        target_model: "",
+      },
     ]);
 
     render(
       <FirmwareUpdateModal
         open
-        target={{ targetManufacturer: "Proto", targetModel: "Rig" }}
+        target={{ targetManufacturer: " proto ", targetModel: "rig" }}
         onConfirm={vi.fn()}
         onDismiss={vi.fn()}
       />,
@@ -127,13 +136,33 @@ describe("FirmwareUpdateModal", () => {
 
     expect(await screen.findByText("alpha.swu")).toBeInTheDocument();
     expect(screen.queryByText("beta.swu")).not.toBeInTheDocument();
+    expect(screen.queryByText("legacy.swu")).not.toBeInTheDocument();
   });
 
   it("explains that miners reboot automatically after firmware installation", () => {
     mockListFirmwareFiles.mockResolvedValue([]);
 
-    render(<FirmwareUpdateModal open onConfirm={vi.fn()} onDismiss={vi.fn()} />);
+    render(<FirmwareUpdateModal open target={target} onConfirm={vi.fn()} onDismiss={vi.fn()} />);
 
     expect(screen.getByText(/reboot automatically after installation completes/i)).toBeInTheDocument();
+  });
+
+  it("fails closed when the selected miner target is unavailable", async () => {
+    mockListFirmwareFiles.mockResolvedValue([
+      {
+        id: "fw-1",
+        filename: "alpha.swu",
+        size: 1024,
+        uploaded_at: "2025-01-01T00:00:00Z",
+        target_manufacturer: "Proto",
+        target_model: "S21",
+      },
+    ]);
+
+    render(<FirmwareUpdateModal open onConfirm={vi.fn()} onDismiss={vi.fn()} />);
+
+    expect(screen.getByText(/unable to determine the selected miners/i)).toBeInTheDocument();
+    expect(screen.queryByText("alpha.swu")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("file-drop-zone")).not.toBeInTheDocument();
   });
 });

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/FirmwareUpdateModal/FirmwareUpdateModal.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/FirmwareUpdateModal/FirmwareUpdateModal.test.tsx
@@ -80,13 +80,53 @@ describe("FirmwareUpdateModal", () => {
 
   it("renders existing files immediately even while config is still loading", async () => {
     mockListFirmwareFiles.mockResolvedValue([
-      { id: "fw-1", filename: "alpha.swu", size: 1024, uploaded_at: "2025-01-01T00:00:00Z" },
+      {
+        id: "fw-1",
+        filename: "alpha.swu",
+        size: 1024,
+        uploaded_at: "2025-01-01T00:00:00Z",
+        target_manufacturer: "Proto",
+        target_model: "S21",
+      },
     ]);
 
     render(<FirmwareUpdateModal open onConfirm={vi.fn()} onDismiss={vi.fn()} />);
 
     expect(await screen.findByText("Select an existing firmware file")).toBeInTheDocument();
     expect(screen.getByText("alpha.swu")).toBeInTheDocument();
+  });
+
+  it("filters existing files to the selected miner target", async () => {
+    mockListFirmwareFiles.mockResolvedValue([
+      {
+        id: "fw-1",
+        filename: "alpha.swu",
+        size: 1024,
+        uploaded_at: "2025-01-01T00:00:00Z",
+        target_manufacturer: "Proto",
+        target_model: "Rig",
+      },
+      {
+        id: "fw-2",
+        filename: "beta.swu",
+        size: 1024,
+        uploaded_at: "2025-01-01T00:00:00Z",
+        target_manufacturer: "Bitmain",
+        target_model: "S21",
+      },
+    ]);
+
+    render(
+      <FirmwareUpdateModal
+        open
+        target={{ targetManufacturer: "Proto", targetModel: "Rig" }}
+        onConfirm={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByText("alpha.swu")).toBeInTheDocument();
+    expect(screen.queryByText("beta.swu")).not.toBeInTheDocument();
   });
 
   it("explains that miners reboot automatically after firmware installation", () => {

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/FirmwareUpdateModal/FirmwareUpdateModal.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/FirmwareUpdateModal/FirmwareUpdateModal.test.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { act, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import FirmwareUpdateModal from "./FirmwareUpdateModal";
 
@@ -145,6 +145,43 @@ describe("FirmwareUpdateModal", () => {
     render(<FirmwareUpdateModal open target={target} onConfirm={vi.fn()} onDismiss={vi.fn()} />);
 
     expect(screen.getByText(/reboot automatically after installation completes/i)).toBeInTheDocument();
+  });
+
+  it("keeps uploaded firmware metadata visible and read-only", async () => {
+    mockListFirmwareFiles.mockResolvedValue([]);
+    mockUseFirmwareUpload.mockReturnValue({
+      state: "idle",
+      file: null,
+      firmwareFileId: null,
+      uploadProgress: 0,
+      errorMessage: null,
+      serverConfig: { allowedExtensions: [".swu"] },
+      processFile: vi.fn(),
+      reset: vi.fn(),
+      retry: vi.fn(),
+    });
+    const view = render(<FirmwareUpdateModal open target={target} onConfirm={vi.fn()} onDismiss={vi.fn()} />);
+    fireEvent.change(await screen.findByLabelText("Firmware version"), { target: { value: "2.0.0" } });
+
+    mockUseFirmwareUpload.mockReturnValue({
+      state: "ready",
+      file: new File(["firmware"], "update.swu"),
+      firmwareFileId: "fw-uploaded",
+      uploadProgress: 100,
+      errorMessage: null,
+      serverConfig: { allowedExtensions: [".swu"] },
+      processFile: vi.fn(),
+      reset: vi.fn(),
+      retry: vi.fn(),
+    });
+    view.rerender(<FirmwareUpdateModal open target={target} onConfirm={vi.fn()} onDismiss={vi.fn()} />);
+
+    expect(await screen.findByLabelText("Product")).toBeDisabled();
+    expect(screen.getByLabelText("Model")).toBeDisabled();
+    expect(screen.getByLabelText("Firmware version")).toBeDisabled();
+    expect(screen.getByLabelText("Firmware version")).toHaveValue("2.0.0");
+    expect(screen.getByTestId("file-ready-status")).toBeInTheDocument();
+    expect(screen.queryByTestId("file-drop-zone")).not.toBeInTheDocument();
   });
 
   it("fails closed when the selected miner target is unavailable", async () => {

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/FirmwareUpdateModal/FirmwareUpdateModal.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/FirmwareUpdateModal/FirmwareUpdateModal.test.tsx
@@ -7,7 +7,8 @@ const mockListFirmwareFiles = vi.fn();
 const mockUseFirmwareUpload = vi.fn();
 const target = { targetManufacturer: "Proto", targetModel: "S21" };
 
-vi.mock("@/protoFleet/api/useFirmwareApi", () => ({
+vi.mock("@/protoFleet/api/useFirmwareApi", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/protoFleet/api/useFirmwareApi")>()),
   useFirmwareApi: () => ({
     listFirmwareFiles: mockListFirmwareFiles,
   }),

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/FirmwareUpdateModal/FirmwareUpdateModal.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/FirmwareUpdateModal/FirmwareUpdateModal.test.tsx
@@ -5,7 +5,7 @@ import FirmwareUpdateModal from "./FirmwareUpdateModal";
 
 const mockListFirmwareFiles = vi.fn();
 const mockUseFirmwareUpload = vi.fn();
-const target = { targetManufacturer: "Proto", targetModel: "S21" };
+const target = { targetManufacturer: "Proto", targetModel: "Rig" };
 
 vi.mock("@/protoFleet/api/useFirmwareApi", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/protoFleet/api/useFirmwareApi")>()),
@@ -88,7 +88,7 @@ describe("FirmwareUpdateModal", () => {
         size: 1024,
         uploaded_at: "2025-01-01T00:00:00Z",
         target_manufacturer: "Proto",
-        target_model: "S21",
+        target_model: "Rig",
       },
     ]);
 
@@ -193,7 +193,7 @@ describe("FirmwareUpdateModal", () => {
         size: 1024,
         uploaded_at: "2025-01-01T00:00:00Z",
         target_manufacturer: "Proto",
-        target_model: "S21",
+        target_model: "Rig",
       },
     ]);
 

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/FirmwareUpdateModal/FirmwareUpdateModal.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/FirmwareUpdateModal/FirmwareUpdateModal.test.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import FirmwareUpdateModal from "./FirmwareUpdateModal";
+import { uploadHookState } from "@/protoFleet/components/FirmwareUpload/useFirmwareUpload.fixtures";
 
 const mockListFirmwareFiles = vi.fn();
 const mockUseFirmwareUpload = vi.fn();
@@ -46,17 +47,7 @@ vi.mock("@/shared/features/toaster", () => ({
 describe("FirmwareUpdateModal", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockUseFirmwareUpload.mockReturnValue({
-      state: "idle",
-      file: null,
-      firmwareFileId: null,
-      uploadProgress: 0,
-      errorMessage: null,
-      serverConfig: null,
-      processFile: vi.fn(),
-      reset: vi.fn(),
-      retry: vi.fn(),
-    });
+    mockUseFirmwareUpload.mockReturnValue(uploadHookState());
   });
 
   it("keeps showing the loading spinner when the file list resolves empty before config loads", async () => {
@@ -150,31 +141,19 @@ describe("FirmwareUpdateModal", () => {
 
   it("keeps uploaded firmware metadata visible and read-only", async () => {
     mockListFirmwareFiles.mockResolvedValue([]);
-    mockUseFirmwareUpload.mockReturnValue({
-      state: "idle",
-      file: null,
-      firmwareFileId: null,
-      uploadProgress: 0,
-      errorMessage: null,
-      serverConfig: { allowedExtensions: [".swu"] },
-      processFile: vi.fn(),
-      reset: vi.fn(),
-      retry: vi.fn(),
-    });
+    mockUseFirmwareUpload.mockReturnValue(uploadHookState({ serverConfig: { allowedExtensions: [".swu"] } }));
     const view = render(<FirmwareUpdateModal open target={target} onConfirm={vi.fn()} onDismiss={vi.fn()} />);
     fireEvent.change(await screen.findByLabelText("Firmware version"), { target: { value: "2.0.0" } });
 
-    mockUseFirmwareUpload.mockReturnValue({
-      state: "ready",
-      file: new File(["firmware"], "update.swu"),
-      firmwareFileId: "fw-uploaded",
-      uploadProgress: 100,
-      errorMessage: null,
-      serverConfig: { allowedExtensions: [".swu"] },
-      processFile: vi.fn(),
-      reset: vi.fn(),
-      retry: vi.fn(),
-    });
+    mockUseFirmwareUpload.mockReturnValue(
+      uploadHookState({
+        state: "ready",
+        file: new File(["firmware"], "update.swu"),
+        firmwareFileId: "fw-uploaded",
+        uploadProgress: 100,
+        serverConfig: { allowedExtensions: [".swu"] },
+      }),
+    );
     view.rerender(<FirmwareUpdateModal open target={target} onConfirm={vi.fn()} onDismiss={vi.fn()} />);
 
     expect(await screen.findByLabelText("Product")).toBeDisabled();

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/FirmwareUpdateModal/FirmwareUpdateModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/FirmwareUpdateModal/FirmwareUpdateModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import clsx from "clsx";
 import type { FirmwareFileInfo } from "@/protoFleet/api/useFirmwareApi";
 import { useFirmwareApi } from "@/protoFleet/api/useFirmwareApi";
@@ -11,6 +11,7 @@ import {
 } from "@/protoFleet/components/FirmwareUpload";
 import Button, { sizes as buttonSizes, variants } from "@/shared/components/Button";
 import { formatFileSize } from "@/shared/components/FileSizeValue";
+import Input from "@/shared/components/Input";
 import Modal from "@/shared/components/Modal/Modal";
 import ProgressCircular from "@/shared/components/ProgressCircular/ProgressCircular";
 import { pushToast, STATUSES } from "@/shared/features/toaster";
@@ -18,11 +19,23 @@ import { formatTimestamp, isoToEpochSeconds } from "@/shared/utils/formatTimesta
 
 interface FirmwareUpdateModalProps {
   open?: boolean;
+  target?: {
+    targetManufacturer: string;
+    targetModel: string;
+  } | null;
   onConfirm: (firmwareFileId: string) => void;
   onDismiss: () => void;
 }
 
-const FirmwareUpdateModal = ({ open, onConfirm, onDismiss }: FirmwareUpdateModalProps) => {
+const fileMatchesTarget = (
+  file: FirmwareFileInfo,
+  target: { targetManufacturer: string; targetModel: string } | null | undefined,
+) => {
+  if (!target) return true;
+  return file.target_manufacturer === target.targetManufacturer && file.target_model === target.targetModel;
+};
+
+const FirmwareUpdateModal = ({ open, target, onConfirm, onDismiss }: FirmwareUpdateModalProps) => {
   const {
     state: uploadState,
     file: uploadFile,
@@ -39,6 +52,16 @@ const FirmwareUpdateModal = ({ open, onConfirm, onDismiss }: FirmwareUpdateModal
   const [existingFiles, setExistingFiles] = useState<FirmwareFileInfo[] | null>(null);
   const [selectedExistingFileId, setSelectedExistingFileId] = useState<string | null>(null);
   const [showUploadZone, setShowUploadZone] = useState(false);
+  const [targetManufacturer, setTargetManufacturer] = useState("");
+  const [targetModel, setTargetModel] = useState("");
+
+  const effectiveTargetManufacturer = target?.targetManufacturer ?? targetManufacturer;
+  const effectiveTargetModel = target?.targetModel ?? targetModel;
+  const uploadTarget = useMemo(
+    () => ({ targetManufacturer: effectiveTargetManufacturer.trim(), targetModel: effectiveTargetModel.trim() }),
+    [effectiveTargetManufacturer, effectiveTargetModel],
+  );
+  const hasUploadTarget = uploadTarget.targetManufacturer !== "" && uploadTarget.targetModel !== "";
 
   useEffect(() => {
     if (open) {
@@ -74,13 +97,18 @@ const FirmwareUpdateModal = ({ open, onConfirm, onDismiss }: FirmwareUpdateModal
     (file: File) => {
       setSelectedExistingFileId(null);
       setShowUploadZone(true);
-      processFile(file);
+      processFile(file, uploadTarget);
     },
-    [processFile],
+    [processFile, uploadTarget],
   );
 
   const effectiveFirmwareFileId = selectedExistingFileId ?? uploadedFileId;
   const isReady = selectedExistingFileId != null || uploadState === "ready";
+  const compatibleExistingFiles = useMemo(
+    () => existingFiles?.filter((file) => fileMatchesTarget(file, target)) ?? null,
+    [existingFiles, target],
+  );
+  const visibleExistingFiles = compatibleExistingFiles ?? [];
 
   const handleConfirm = useCallback(() => {
     if (effectiveFirmwareFileId) {
@@ -89,6 +117,8 @@ const FirmwareUpdateModal = ({ open, onConfirm, onDismiss }: FirmwareUpdateModal
       setSelectedExistingFileId(null);
       setExistingFiles(null);
       setShowUploadZone(false);
+      setTargetManufacturer("");
+      setTargetModel("");
     }
   }, [effectiveFirmwareFileId, onConfirm, reset]);
 
@@ -97,12 +127,14 @@ const FirmwareUpdateModal = ({ open, onConfirm, onDismiss }: FirmwareUpdateModal
     setSelectedExistingFileId(null);
     setExistingFiles(null);
     setShowUploadZone(false);
+    setTargetManufacturer("");
+    setTargetModel("");
     onDismiss();
   }, [onDismiss, reset]);
 
   const isProcessing = uploadState === "hashing" || uploadState === "checking" || uploadState === "uploading";
   const configLoading = uploadState !== "error" && !serverConfig;
-  const hasExistingFiles = existingFiles != null && existingFiles.length > 0;
+  const hasExistingFiles = visibleExistingFiles.length > 0;
   const showLoadingSpinner = configLoading && !hasExistingFiles;
 
   const buttons = isReady ? [{ text: "Continue", variant: variants.primary, onClick: handleConfirm }] : undefined;
@@ -127,7 +159,7 @@ const FirmwareUpdateModal = ({ open, onConfirm, onDismiss }: FirmwareUpdateModal
               role="radiogroup"
               aria-label="Existing firmware files"
             >
-              {existingFiles.map((f) => (
+              {visibleExistingFiles.map((f) => (
                 <button
                   key={f.id}
                   type="button"
@@ -151,7 +183,8 @@ const FirmwareUpdateModal = ({ open, onConfirm, onDismiss }: FirmwareUpdateModal
                   <div className="flex min-w-0 flex-col">
                     <div className="truncate text-300 text-text-primary">{f.filename}</div>
                     <div className="text-200 text-text-primary-70">
-                      {formatFileSize(f.size)}, {formatTimestamp(isoToEpochSeconds(f.uploaded_at))}
+                      {f.target_manufacturer} {f.target_model} · {formatFileSize(f.size)} ·{" "}
+                      {formatTimestamp(isoToEpochSeconds(f.uploaded_at))}
                     </div>
                   </div>
                 </button>
@@ -176,7 +209,31 @@ const FirmwareUpdateModal = ({ open, onConfirm, onDismiss }: FirmwareUpdateModal
         {uploadState === "error" && errorMessage ? <FileErrorStatus message={errorMessage} onRetry={retry} /> : null}
 
         {uploadState === "idle" && serverConfig && (!hasExistingFiles || showUploadZone) ? (
-          <FileDropZone extensions={serverConfig.allowedExtensions} onFileSelect={handleUploadFileSelect} />
+          <>
+            <div className="grid gap-4 tablet:grid-cols-2">
+              <Input
+                id="firmware-update-target-manufacturer"
+                label="Product"
+                initValue={effectiveTargetManufacturer}
+                onChange={setTargetManufacturer}
+                disabled={!!target}
+                required
+              />
+              <Input
+                id="firmware-update-target-model"
+                label="Model"
+                initValue={effectiveTargetModel}
+                onChange={setTargetModel}
+                disabled={!!target}
+                required
+              />
+            </div>
+            <FileDropZone
+              extensions={serverConfig.allowedExtensions}
+              onFileSelect={handleUploadFileSelect}
+              disabled={!hasUploadTarget}
+            />
+          </>
         ) : null}
 
         {isProcessing && uploadFile ? (

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/FirmwareUpdateModal/FirmwareUpdateModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/FirmwareUpdateModal/FirmwareUpdateModal.tsx
@@ -31,8 +31,13 @@ const fileMatchesTarget = (
   file: FirmwareFileInfo,
   target: { targetManufacturer: string; targetModel: string } | null | undefined,
 ) => {
-  if (!target) return true;
-  return file.target_manufacturer === target.targetManufacturer && file.target_model === target.targetModel;
+  const targetManufacturer = target?.targetManufacturer.trim() ?? "";
+  const targetModel = target?.targetModel.trim() ?? "";
+  if (!targetManufacturer || !targetModel) return false;
+  return (
+    file.target_manufacturer.trim().toLowerCase() === targetManufacturer.toLowerCase() &&
+    file.target_model.trim().toLowerCase() === targetModel.toLowerCase()
+  );
 };
 
 const FirmwareUpdateModal = ({ open, target, onConfirm, onDismiss }: FirmwareUpdateModalProps) => {
@@ -52,12 +57,10 @@ const FirmwareUpdateModal = ({ open, target, onConfirm, onDismiss }: FirmwareUpd
   const [existingFiles, setExistingFiles] = useState<FirmwareFileInfo[] | null>(null);
   const [selectedExistingFileId, setSelectedExistingFileId] = useState<string | null>(null);
   const [showUploadZone, setShowUploadZone] = useState(false);
-  const [targetManufacturer, setTargetManufacturer] = useState("");
-  const [targetModel, setTargetModel] = useState("");
   const [firmwareVersion, setFirmwareVersion] = useState("");
 
-  const effectiveTargetManufacturer = target?.targetManufacturer ?? targetManufacturer;
-  const effectiveTargetModel = target?.targetModel ?? targetModel;
+  const effectiveTargetManufacturer = target?.targetManufacturer ?? "";
+  const effectiveTargetModel = target?.targetModel ?? "";
   const uploadTarget = useMemo(
     () => ({
       targetManufacturer: effectiveTargetManufacturer.trim(),
@@ -123,8 +126,6 @@ const FirmwareUpdateModal = ({ open, target, onConfirm, onDismiss }: FirmwareUpd
       setSelectedExistingFileId(null);
       setExistingFiles(null);
       setShowUploadZone(false);
-      setTargetManufacturer("");
-      setTargetModel("");
       setFirmwareVersion("");
     }
   }, [effectiveFirmwareFileId, onConfirm, reset]);
@@ -134,16 +135,16 @@ const FirmwareUpdateModal = ({ open, target, onConfirm, onDismiss }: FirmwareUpd
     setSelectedExistingFileId(null);
     setExistingFiles(null);
     setShowUploadZone(false);
-    setTargetManufacturer("");
-    setTargetModel("");
     setFirmwareVersion("");
     onDismiss();
   }, [onDismiss, reset]);
 
   const isProcessing = uploadState === "hashing" || uploadState === "checking" || uploadState === "uploading";
+  const missingTarget =
+    !!open && (effectiveTargetManufacturer.trim() === "" || effectiveTargetModel.trim() === "");
   const configLoading = uploadState !== "error" && !serverConfig;
   const hasExistingFiles = visibleExistingFiles.length > 0;
-  const showLoadingSpinner = configLoading && !hasExistingFiles;
+  const showLoadingSpinner = !missingTarget && configLoading && !hasExistingFiles;
 
   const buttons = isReady ? [{ text: "Continue", variant: variants.primary, onClick: handleConfirm }] : undefined;
 
@@ -156,6 +157,12 @@ const FirmwareUpdateModal = ({ open, target, onConfirm, onDismiss }: FirmwareUpd
         {showLoadingSpinner ? (
           <div className="flex items-center justify-center p-8">
             <ProgressCircular indeterminate size={24} />
+          </div>
+        ) : null}
+
+        {missingTarget ? (
+          <div className="text-300 text-intent-warning-fill">
+            Unable to determine the selected miners&apos; manufacturer and model. Close this dialog and try again.
           </div>
         ) : null}
 
@@ -217,23 +224,21 @@ const FirmwareUpdateModal = ({ open, target, onConfirm, onDismiss }: FirmwareUpd
 
         {uploadState === "error" && errorMessage ? <FileErrorStatus message={errorMessage} onRetry={retry} /> : null}
 
-        {uploadState === "idle" && serverConfig && (!hasExistingFiles || showUploadZone) ? (
+        {!missingTarget && uploadState === "idle" && serverConfig && (!hasExistingFiles || showUploadZone) ? (
           <>
             <div className="grid gap-4 tablet:grid-cols-2">
               <Input
                 id="firmware-update-target-manufacturer"
                 label="Product"
                 initValue={effectiveTargetManufacturer}
-                onChange={setTargetManufacturer}
-                disabled={!!target}
+                disabled
                 required
               />
               <Input
                 id="firmware-update-target-model"
                 label="Model"
                 initValue={effectiveTargetModel}
-                onChange={setTargetModel}
-                disabled={!!target}
+                disabled
                 required
               />
             </div>

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/FirmwareUpdateModal/FirmwareUpdateModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/FirmwareUpdateModal/FirmwareUpdateModal.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import clsx from "clsx";
 import type { FirmwareFileInfo } from "@/protoFleet/api/useFirmwareApi";
-import { useFirmwareApi } from "@/protoFleet/api/useFirmwareApi";
+import { hasCompleteFirmwareTarget, useFirmwareApi } from "@/protoFleet/api/useFirmwareApi";
 import {
   FileDropZone,
   FileErrorStatus,
@@ -9,6 +9,10 @@ import {
   FileReadyStatus,
   useFirmwareUpload,
 } from "@/protoFleet/components/FirmwareUpload";
+import {
+  type FirmwareUpdateTarget,
+  minerTargetKey,
+} from "@/protoFleet/features/fleetManagement/components/MinerActionsMenu/minerTarget";
 import Button, { sizes as buttonSizes, variants } from "@/shared/components/Button";
 import { formatFileSize } from "@/shared/components/FileSizeValue";
 import Input from "@/shared/components/Input";
@@ -19,25 +23,14 @@ import { formatTimestamp, isoToEpochSeconds } from "@/shared/utils/formatTimesta
 
 interface FirmwareUpdateModalProps {
   open?: boolean;
-  target?: {
-    targetManufacturer: string;
-    targetModel: string;
-  } | null;
+  target?: FirmwareUpdateTarget | null;
   onConfirm: (firmwareFileId: string) => void;
   onDismiss: () => void;
 }
 
-const fileMatchesTarget = (
-  file: FirmwareFileInfo,
-  target: { targetManufacturer: string; targetModel: string } | null | undefined,
-) => {
-  const targetManufacturer = target?.targetManufacturer.trim() ?? "";
-  const targetModel = target?.targetModel.trim() ?? "";
-  if (!targetManufacturer || !targetModel) return false;
-  return (
-    file.target_manufacturer.trim().toLowerCase() === targetManufacturer.toLowerCase() &&
-    file.target_model.trim().toLowerCase() === targetModel.toLowerCase()
-  );
+const fileMatchesTarget = (file: FirmwareFileInfo, target: FirmwareUpdateTarget | null | undefined) => {
+  const targetKey = minerTargetKey(target?.targetManufacturer, target?.targetModel);
+  return targetKey !== null && targetKey === minerTargetKey(file.target_manufacturer, file.target_model);
 };
 
 const FirmwareUpdateModal = ({ open, target, onConfirm, onDismiss }: FirmwareUpdateModalProps) => {
@@ -63,14 +56,13 @@ const FirmwareUpdateModal = ({ open, target, onConfirm, onDismiss }: FirmwareUpd
   const effectiveTargetModel = target?.targetModel ?? "";
   const uploadTarget = useMemo(
     () => ({
-      targetManufacturer: effectiveTargetManufacturer.trim(),
-      targetModel: effectiveTargetModel.trim(),
-      firmwareVersion: firmwareVersion.trim(),
+      targetManufacturer: effectiveTargetManufacturer,
+      targetModel: effectiveTargetModel,
+      firmwareVersion,
     }),
     [effectiveTargetManufacturer, effectiveTargetModel, firmwareVersion],
   );
-  const hasUploadTarget =
-    uploadTarget.targetManufacturer !== "" && uploadTarget.targetModel !== "" && uploadTarget.firmwareVersion !== "";
+  const hasUploadTarget = hasCompleteFirmwareTarget(uploadTarget);
 
   useEffect(() => {
     if (open) {
@@ -113,11 +105,10 @@ const FirmwareUpdateModal = ({ open, target, onConfirm, onDismiss }: FirmwareUpd
 
   const effectiveFirmwareFileId = selectedExistingFileId ?? uploadedFileId;
   const isReady = selectedExistingFileId != null || uploadState === "ready";
-  const compatibleExistingFiles = useMemo(
-    () => existingFiles?.filter((file) => fileMatchesTarget(file, target)) ?? null,
+  const visibleExistingFiles = useMemo(
+    () => existingFiles?.filter((file) => fileMatchesTarget(file, target)) ?? [],
     [existingFiles, target],
   );
-  const visibleExistingFiles = compatibleExistingFiles ?? [];
 
   const handleConfirm = useCallback(() => {
     if (effectiveFirmwareFileId) {
@@ -140,7 +131,7 @@ const FirmwareUpdateModal = ({ open, target, onConfirm, onDismiss }: FirmwareUpd
   }, [onDismiss, reset]);
 
   const isProcessing = uploadState === "hashing" || uploadState === "checking" || uploadState === "uploading";
-  const missingTarget = !!open && (effectiveTargetManufacturer.trim() === "" || effectiveTargetModel.trim() === "");
+  const missingTarget = !!open && minerTargetKey(effectiveTargetManufacturer, effectiveTargetModel) === null;
   const configLoading = uploadState !== "error" && !serverConfig;
   const hasExistingFiles = visibleExistingFiles.length > 0;
   const showLoadingSpinner = !missingTarget && configLoading && !hasExistingFiles;

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/FirmwareUpdateModal/FirmwareUpdateModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/FirmwareUpdateModal/FirmwareUpdateModal.tsx
@@ -140,11 +140,12 @@ const FirmwareUpdateModal = ({ open, target, onConfirm, onDismiss }: FirmwareUpd
   }, [onDismiss, reset]);
 
   const isProcessing = uploadState === "hashing" || uploadState === "checking" || uploadState === "uploading";
-  const missingTarget =
-    !!open && (effectiveTargetManufacturer.trim() === "" || effectiveTargetModel.trim() === "");
+  const missingTarget = !!open && (effectiveTargetManufacturer.trim() === "" || effectiveTargetModel.trim() === "");
   const configLoading = uploadState !== "error" && !serverConfig;
   const hasExistingFiles = visibleExistingFiles.length > 0;
   const showLoadingSpinner = !missingTarget && configLoading && !hasExistingFiles;
+  const showUploadFields = !missingTarget && serverConfig && (!hasExistingFiles || showUploadZone);
+  const uploadMetadataLocked = uploadState !== "idle";
 
   const buttons = isReady ? [{ text: "Continue", variant: variants.primary, onClick: handleConfirm }] : undefined;
 
@@ -224,7 +225,7 @@ const FirmwareUpdateModal = ({ open, target, onConfirm, onDismiss }: FirmwareUpd
 
         {uploadState === "error" && errorMessage ? <FileErrorStatus message={errorMessage} onRetry={retry} /> : null}
 
-        {!missingTarget && uploadState === "idle" && serverConfig && (!hasExistingFiles || showUploadZone) ? (
+        {showUploadFields ? (
           <>
             <div className="grid gap-4 tablet:grid-cols-2">
               <Input
@@ -247,13 +248,16 @@ const FirmwareUpdateModal = ({ open, target, onConfirm, onDismiss }: FirmwareUpd
               label="Firmware version"
               initValue={firmwareVersion}
               onChange={setFirmwareVersion}
+              disabled={uploadMetadataLocked}
               required
             />
-            <FileDropZone
-              extensions={serverConfig.allowedExtensions}
-              onFileSelect={handleUploadFileSelect}
-              disabled={!hasUploadTarget}
-            />
+            {uploadState === "idle" ? (
+              <FileDropZone
+                extensions={serverConfig.allowedExtensions}
+                onFileSelect={handleUploadFileSelect}
+                disabled={!hasUploadTarget}
+              />
+            ) : null}
           </>
         ) : null}
 

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/FirmwareUpdateModal/FirmwareUpdateModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/FirmwareUpdateModal/FirmwareUpdateModal.tsx
@@ -54,14 +54,20 @@ const FirmwareUpdateModal = ({ open, target, onConfirm, onDismiss }: FirmwareUpd
   const [showUploadZone, setShowUploadZone] = useState(false);
   const [targetManufacturer, setTargetManufacturer] = useState("");
   const [targetModel, setTargetModel] = useState("");
+  const [firmwareVersion, setFirmwareVersion] = useState("");
 
   const effectiveTargetManufacturer = target?.targetManufacturer ?? targetManufacturer;
   const effectiveTargetModel = target?.targetModel ?? targetModel;
   const uploadTarget = useMemo(
-    () => ({ targetManufacturer: effectiveTargetManufacturer.trim(), targetModel: effectiveTargetModel.trim() }),
-    [effectiveTargetManufacturer, effectiveTargetModel],
+    () => ({
+      targetManufacturer: effectiveTargetManufacturer.trim(),
+      targetModel: effectiveTargetModel.trim(),
+      firmwareVersion: firmwareVersion.trim(),
+    }),
+    [effectiveTargetManufacturer, effectiveTargetModel, firmwareVersion],
   );
-  const hasUploadTarget = uploadTarget.targetManufacturer !== "" && uploadTarget.targetModel !== "";
+  const hasUploadTarget =
+    uploadTarget.targetManufacturer !== "" && uploadTarget.targetModel !== "" && uploadTarget.firmwareVersion !== "";
 
   useEffect(() => {
     if (open) {
@@ -119,6 +125,7 @@ const FirmwareUpdateModal = ({ open, target, onConfirm, onDismiss }: FirmwareUpd
       setShowUploadZone(false);
       setTargetManufacturer("");
       setTargetModel("");
+      setFirmwareVersion("");
     }
   }, [effectiveFirmwareFileId, onConfirm, reset]);
 
@@ -129,6 +136,7 @@ const FirmwareUpdateModal = ({ open, target, onConfirm, onDismiss }: FirmwareUpd
     setShowUploadZone(false);
     setTargetManufacturer("");
     setTargetModel("");
+    setFirmwareVersion("");
     onDismiss();
   }, [onDismiss, reset]);
 
@@ -183,7 +191,8 @@ const FirmwareUpdateModal = ({ open, target, onConfirm, onDismiss }: FirmwareUpd
                   <div className="flex min-w-0 flex-col">
                     <div className="truncate text-300 text-text-primary">{f.filename}</div>
                     <div className="text-200 text-text-primary-70">
-                      {f.target_manufacturer} {f.target_model} · {formatFileSize(f.size)} ·{" "}
+                      {f.target_manufacturer} {f.target_model}
+                      {f.firmware_version ? ` · ${f.firmware_version}` : ""} · {formatFileSize(f.size)} ·{" "}
                       {formatTimestamp(isoToEpochSeconds(f.uploaded_at))}
                     </div>
                   </div>
@@ -228,6 +237,13 @@ const FirmwareUpdateModal = ({ open, target, onConfirm, onDismiss }: FirmwareUpd
                 required
               />
             </div>
+            <Input
+              id="firmware-update-version"
+              label="Firmware version"
+              initValue={firmwareVersion}
+              onChange={setFirmwareVersion}
+              required
+            />
             <FileDropZone
               extensions={serverConfig.allowedExtensions}
               onFileSelect={handleUploadFileSelect}

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/FirmwareUpdateModal/FirmwareUpdateModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/FirmwareUpdateModal/FirmwareUpdateModal.tsx
@@ -28,11 +28,6 @@ interface FirmwareUpdateModalProps {
   onDismiss: () => void;
 }
 
-const fileMatchesTarget = (file: FirmwareFileInfo, target: FirmwareUpdateTarget | null | undefined) => {
-  const targetKey = minerTargetKey(target?.targetManufacturer, target?.targetModel);
-  return targetKey !== null && targetKey === minerTargetKey(file.target_manufacturer, file.target_model);
-};
-
 const FirmwareUpdateModal = ({ open, target, onConfirm, onDismiss }: FirmwareUpdateModalProps) => {
   const {
     state: uploadState,
@@ -105,10 +100,11 @@ const FirmwareUpdateModal = ({ open, target, onConfirm, onDismiss }: FirmwareUpd
 
   const effectiveFirmwareFileId = selectedExistingFileId ?? uploadedFileId;
   const isReady = selectedExistingFileId != null || uploadState === "ready";
-  const visibleExistingFiles = useMemo(
-    () => existingFiles?.filter((file) => fileMatchesTarget(file, target)) ?? [],
-    [existingFiles, target],
-  );
+  const visibleExistingFiles = useMemo(() => {
+    const targetKey = minerTargetKey(target?.targetManufacturer, target?.targetModel);
+    if (targetKey === null || existingFiles === null) return [];
+    return existingFiles.filter((file) => minerTargetKey(file.target_manufacturer, file.target_model) === targetKey);
+  }, [existingFiles, target]);
 
   const handleConfirm = useCallback(() => {
     if (effectiveFirmwareFileId) {

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerActionModalStack.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/MinerActionModalStack.tsx
@@ -180,6 +180,7 @@ const MinerActionModalStack = ({
         open={
           minerActions.currentAction === deviceActions.firmwareUpdate ? minerActions.showFirmwareUpdateModal : false
         }
+        target={minerActions.firmwareUpdateTarget}
         onConfirm={wrap(minerActions.handleFirmwareUpdateConfirm)}
         onDismiss={wrap(minerActions.handleFirmwareUpdateDismiss)}
       />

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/minerTarget.ts
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/minerTarget.ts
@@ -1,0 +1,16 @@
+export interface FirmwareUpdateTarget {
+  targetManufacturer: string;
+  targetModel: string;
+}
+
+/**
+ * Canonical identity key for a miner (manufacturer, model) target — trimmed and
+ * case-insensitive. Returns null when either part is missing, so absent targets
+ * never match anything.
+ */
+export function minerTargetKey(manufacturer: string | undefined, model: string | undefined): string | null {
+  const manufacturerKey = manufacturer?.trim().toLowerCase() ?? "";
+  const modelKey = model?.trim().toLowerCase() ?? "";
+  if (!manufacturerKey || !modelKey) return null;
+  return `${manufacturerKey}\u0000${modelKey}`;
+}

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.test.tsx
@@ -4060,9 +4060,14 @@ describe("useMinerActions", () => {
     });
 
     it("should show error toast and not open modal when selected miners have mixed models", async () => {
-      testMiners["device-1"] = createProto(MinerStateSnapshotSchema, { deviceIdentifier: "device-1", model: "S19" });
+      testMiners["device-1"] = createProto(MinerStateSnapshotSchema, {
+        deviceIdentifier: "device-1",
+        manufacturer: "Bitmain",
+        model: "S19",
+      });
       testMiners["device-2"] = createProto(MinerStateSnapshotSchema, {
         deviceIdentifier: "device-2",
+        manufacturer: "Proto",
         model: "Proto Rig",
       });
 
@@ -4089,7 +4094,7 @@ describe("useMinerActions", () => {
 
       expect(toaster.pushToast).toHaveBeenCalledWith(
         expect.objectContaining({
-          message: expect.stringContaining("same model"),
+          message: expect.stringContaining("same manufacturer and model"),
           status: "error",
         }),
       );
@@ -4098,8 +4103,16 @@ describe("useMinerActions", () => {
     });
 
     it("should open modal when all selected miners have the same model", async () => {
-      testMiners["device-1"] = createProto(MinerStateSnapshotSchema, { deviceIdentifier: "device-1", model: "S19" });
-      testMiners["device-2"] = createProto(MinerStateSnapshotSchema, { deviceIdentifier: "device-2", model: "S19" });
+      testMiners["device-1"] = createProto(MinerStateSnapshotSchema, {
+        deviceIdentifier: "device-1",
+        manufacturer: "Bitmain",
+        model: "S19",
+      });
+      testMiners["device-2"] = createProto(MinerStateSnapshotSchema, {
+        deviceIdentifier: "device-2",
+        manufacturer: "Bitmain",
+        model: "S19",
+      });
 
       const { result } = renderHook(() =>
         useMinerActions({
@@ -4119,6 +4132,121 @@ describe("useMinerActions", () => {
       });
 
       expect(result.current.showFirmwareUpdateModal).toBe(true);
+      expect(result.current.firmwareUpdateTarget).toEqual({ targetManufacturer: "Bitmain", targetModel: "S19" });
+    });
+
+    it("derives the firmware target from the capability-filtered selection", async () => {
+      mockCheckCommandCapabilities.mockImplementationOnce(({ onSuccess }: any) => {
+        onSuccess({
+          allSupported: false,
+          noneSupported: false,
+          supportedCount: 1,
+          unsupportedCount: 1,
+          totalCount: 2,
+          unsupportedGroups: [{ model: "S19", firmwareVersion: "1.0.0", count: 1 }],
+          supportedDeviceIdentifiers: ["device-1"],
+        });
+      });
+      testMiners["device-1"] = createProto(MinerStateSnapshotSchema, {
+        deviceIdentifier: "device-1",
+        manufacturer: "Proto",
+        model: "Rig",
+      });
+      testMiners["device-2"] = createProto(MinerStateSnapshotSchema, {
+        deviceIdentifier: "device-2",
+        manufacturer: "Bitmain",
+        model: "S19",
+      });
+
+      const { result } = renderHook(() =>
+        useMinerActions({
+          ...batchOpsParams(),
+          selectedMiners: [
+            { deviceIdentifier: "device-1", deviceStatus: DeviceStatus.ONLINE },
+            { deviceIdentifier: "device-2", deviceStatus: DeviceStatus.ONLINE },
+          ],
+          selectionMode: "subset",
+        }),
+      );
+
+      const fwAction = result.current.popoverActions.find((a) => a.action === deviceActions.firmwareUpdate);
+      await act(async () => {
+        await fwAction!.actionHandler();
+      });
+      expect(result.current.unsupportedMinersInfo.visible).toBe(true);
+      expect(result.current.showFirmwareUpdateModal).toBe(false);
+
+      act(() => {
+        result.current.handleUnsupportedMinersContinue();
+      });
+
+      expect(result.current.showFirmwareUpdateModal).toBe(true);
+      expect(result.current.firmwareUpdateTarget).toEqual({ targetManufacturer: "Proto", targetModel: "Rig" });
+    });
+
+    it("does not open the modal for the same model from different manufacturers", async () => {
+      testMiners["device-1"] = createProto(MinerStateSnapshotSchema, {
+        deviceIdentifier: "device-1",
+        manufacturer: "Bitmain",
+        model: "S19",
+      });
+      testMiners["device-2"] = createProto(MinerStateSnapshotSchema, {
+        deviceIdentifier: "device-2",
+        manufacturer: "Other",
+        model: "S19",
+      });
+      const onActionComplete = vi.fn();
+
+      const { result } = renderHook(() =>
+        useMinerActions({
+          ...batchOpsParams(),
+          selectedMiners: [
+            { deviceIdentifier: "device-1", deviceStatus: DeviceStatus.ONLINE },
+            { deviceIdentifier: "device-2", deviceStatus: DeviceStatus.ONLINE },
+          ],
+          selectionMode: "subset",
+          onActionComplete,
+        }),
+      );
+
+      const fwAction = result.current.popoverActions.find((a) => a.action === deviceActions.firmwareUpdate);
+      await act(async () => {
+        await fwAction!.actionHandler();
+      });
+
+      expect(result.current.showFirmwareUpdateModal).toBe(false);
+      expect(result.current.firmwareUpdateTarget).toBeNull();
+      expect(onActionComplete).toHaveBeenCalled();
+    });
+
+    it("does not open the modal when a selected miner has an unknown target", async () => {
+      testMiners["device-1"] = createProto(MinerStateSnapshotSchema, {
+        deviceIdentifier: "device-1",
+        manufacturer: "",
+        model: "S19",
+      });
+      const onActionComplete = vi.fn();
+
+      const { result } = renderHook(() =>
+        useMinerActions({
+          ...batchOpsParams(),
+          selectedMiners: [{ deviceIdentifier: "device-1", deviceStatus: DeviceStatus.ONLINE }],
+          selectionMode: "subset",
+          onActionComplete,
+        }),
+      );
+
+      const fwAction = result.current.popoverActions.find((a) => a.action === deviceActions.firmwareUpdate);
+      await act(async () => {
+        await fwAction!.actionHandler();
+      });
+
+      expect(result.current.showFirmwareUpdateModal).toBe(false);
+      expect(result.current.firmwareUpdateTarget).toBeNull();
+      expect(onActionComplete).toHaveBeenCalled();
+      expect(toaster.pushToast).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining("manufacturer and model"), status: "error" }),
+      );
     });
   });
 });

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.tsx
@@ -89,6 +89,11 @@ export interface MinerSelection {
   deviceStatus?: DeviceStatus;
 }
 
+export interface FirmwareUpdateTarget {
+  targetManufacturer: string;
+  targetModel: string;
+}
+
 interface UseMinerActionsParams {
   selectedMiners: MinerSelection[];
   selectionMode: SelectionMode;
@@ -148,19 +153,26 @@ const generateUnpairBatchIdentifier = (): string => {
   return `unpair-${Math.random().toString(36).slice(2)}-${Date.now().toString(36)}`;
 };
 
-function getUniqueModels(
+function getUniqueFirmwareTargets(
   deviceIds: string[],
   miners: Record<string, MinerStateSnapshot>,
-): { models: Set<string>; hasMissing: boolean } {
-  const models = new Set<string>();
+): { targets: FirmwareUpdateTarget[]; hasMissing: boolean } {
+  const targets = new Map<string, FirmwareUpdateTarget>();
   let hasMissing = false;
   for (const id of deviceIds) {
     const miner = miners[id];
-    const model = miner?.model;
-    if (model) models.add(model);
-    else hasMissing = true;
+    const manufacturer = miner?.manufacturer?.trim();
+    const model = miner?.model?.trim();
+    if (!manufacturer || !model) {
+      hasMissing = true;
+      continue;
+    }
+    const key = `${manufacturer.toLowerCase()}\u0000${model.toLowerCase()}`;
+    if (!targets.has(key)) {
+      targets.set(key, { targetManufacturer: manufacturer, targetModel: model });
+    }
   }
-  return { models, hasMissing };
+  return { targets: [...targets.values()], hasMissing };
 }
 
 /**
@@ -340,6 +352,7 @@ export const useMinerActions = ({
   const [currentCoolingMode, setCurrentCoolingMode] = useState<CoolingMode | undefined>(undefined);
   const [showAddToGroupModal, setShowAddToGroupModal] = useState(false);
   const [showFirmwareUpdateModal, setShowFirmwareUpdateModal] = useState(false);
+  const [firmwareUpdateTarget, setFirmwareUpdateTarget] = useState<FirmwareUpdateTarget | null>(null);
   const [firmwareUpdateFilteredSelector, setFirmwareUpdateFilteredSelector] = useState<DeviceSelector | undefined>();
   const [firmwareUpdateFilteredDeviceIds, setFirmwareUpdateFilteredDeviceIds] = useState<string[] | undefined>(
     undefined,
@@ -811,6 +824,7 @@ export const useMinerActions = ({
       const deviceIdsToUse = firmwareUpdateFilteredDeviceIds ?? deviceIdentifiers;
       if (!selectorToUse) return;
       setShowFirmwareUpdateModal(false);
+      setFirmwareUpdateTarget(null);
       setFirmwareUpdateFilteredSelector(undefined);
       setFirmwareUpdateFilteredDeviceIds(undefined);
       setCurrentAction(null);
@@ -960,6 +974,7 @@ export const useMinerActions = ({
 
   const handleFirmwareUpdateDismiss = useCallback(() => {
     setShowFirmwareUpdateModal(false);
+    setFirmwareUpdateTarget(null);
     setFirmwareUpdateFilteredSelector(undefined);
     setFirmwareUpdateFilteredDeviceIds(undefined);
     setCurrentAction(null);
@@ -1497,6 +1512,7 @@ export const useMinerActions = ({
 
     const handleFirmwareUpdate = async () => {
       onActionStart?.();
+      setFirmwareUpdateTarget(null);
 
       if (selectionMode === "all") {
         pushToast({
@@ -1509,14 +1525,14 @@ export const useMinerActions = ({
 
       await withCapabilityCheck(deviceActions.firmwareUpdate, (filteredSelector, filteredDeviceIds) => {
         const idsToCheck = filteredDeviceIds ?? deviceIdentifiers;
-        const { models, hasMissing } =
+        const { targets, hasMissing } =
           idsToCheck.length > 0
-            ? getUniqueModels(idsToCheck, miners)
-            : { models: new Set<string>(), hasMissing: false };
+            ? getUniqueFirmwareTargets(idsToCheck, miners)
+            : { targets: [], hasMissing: false };
 
-        if (models.size === 0) {
+        if (targets.length === 0) {
           pushToast({
-            message: "Unable to verify miner model compatibility. Please select specific miners.",
+            message: "Unable to verify miner manufacturer and model compatibility. Please select specific miners.",
             status: TOAST_STATUSES.error,
           });
           onActionComplete?.();
@@ -1525,22 +1541,24 @@ export const useMinerActions = ({
 
         if (hasMissing) {
           pushToast({
-            message: "Some selected miners have unknown models. Please deselect them before updating firmware.",
+            message: "Some selected miners have an unknown manufacturer or model. Please deselect them before updating firmware.",
             status: TOAST_STATUSES.error,
           });
           onActionComplete?.();
           return;
         }
 
-        if (models.size > 1) {
+        if (targets.length > 1) {
           pushToast({
-            message: "Firmware update requires miners of the same model. Your selection includes multiple models.",
+            message:
+              "Firmware update requires miners from the same manufacturer and model. Your selection includes multiple targets.",
             status: TOAST_STATUSES.error,
           });
           onActionComplete?.();
           return;
         }
 
+        setFirmwareUpdateTarget(targets[0]);
         setFirmwareUpdateFilteredSelector(filteredSelector);
         setFirmwareUpdateFilteredDeviceIds(filteredDeviceIds);
         setCurrentAction(deviceActions.firmwareUpdate);
@@ -1751,6 +1769,7 @@ export const useMinerActions = ({
     handleManagePowerConfirm,
     handleManagePowerDismiss,
     showFirmwareUpdateModal,
+    firmwareUpdateTarget,
     handleFirmwareUpdateConfirm,
     handleFirmwareUpdateDismiss,
     showCoolingModeModal,

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.tsx
@@ -1526,9 +1526,7 @@ export const useMinerActions = ({
       await withCapabilityCheck(deviceActions.firmwareUpdate, (filteredSelector, filteredDeviceIds) => {
         const idsToCheck = filteredDeviceIds ?? deviceIdentifiers;
         const { targets, hasMissing } =
-          idsToCheck.length > 0
-            ? getUniqueFirmwareTargets(idsToCheck, miners)
-            : { targets: [], hasMissing: false };
+          idsToCheck.length > 0 ? getUniqueFirmwareTargets(idsToCheck, miners) : { targets: [], hasMissing: false };
 
         if (targets.length === 0) {
           pushToast({
@@ -1541,7 +1539,8 @@ export const useMinerActions = ({
 
         if (hasMissing) {
           pushToast({
-            message: "Some selected miners have an unknown manufacturer or model. Please deselect them before updating firmware.",
+            message:
+              "Some selected miners have an unknown manufacturer or model. Please deselect them before updating firmware.",
             status: TOAST_STATUSES.error,
           });
           onActionComplete?.();

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/useMinerActions.tsx
@@ -13,6 +13,7 @@ import {
   successMessages,
   SupportedAction,
 } from "./constants";
+import { type FirmwareUpdateTarget, minerTargetKey } from "./minerTarget";
 import { useFleetAuthentication } from "./useFleetAuthentication";
 import { useManageSecurityFlow } from "./useManageSecurityFlow";
 import { CoolingMode } from "@/protoFleet/api/generated/common/v1/cooling_pb";
@@ -89,11 +90,6 @@ export interface MinerSelection {
   deviceStatus?: DeviceStatus;
 }
 
-export interface FirmwareUpdateTarget {
-  targetManufacturer: string;
-  targetModel: string;
-}
-
 interface UseMinerActionsParams {
   selectedMiners: MinerSelection[];
   selectionMode: SelectionMode;
@@ -161,13 +157,13 @@ function getUniqueFirmwareTargets(
   let hasMissing = false;
   for (const id of deviceIds) {
     const miner = miners[id];
-    const manufacturer = miner?.manufacturer?.trim();
-    const model = miner?.model?.trim();
-    if (!manufacturer || !model) {
+    const manufacturer = miner?.manufacturer?.trim() ?? "";
+    const model = miner?.model?.trim() ?? "";
+    const key = minerTargetKey(manufacturer, model);
+    if (!key) {
       hasMissing = true;
       continue;
     }
-    const key = `${manufacturer.toLowerCase()}\u0000${model.toLowerCase()}`;
     if (!targets.has(key)) {
       targets.set(key, { targetManufacturer: manufacturer, targetModel: model });
     }
@@ -1525,8 +1521,7 @@ export const useMinerActions = ({
 
       await withCapabilityCheck(deviceActions.firmwareUpdate, (filteredSelector, filteredDeviceIds) => {
         const idsToCheck = filteredDeviceIds ?? deviceIdentifiers;
-        const { targets, hasMissing } =
-          idsToCheck.length > 0 ? getUniqueFirmwareTargets(idsToCheck, miners) : { targets: [], hasMissing: false };
+        const { targets, hasMissing } = getUniqueFirmwareTargets(idsToCheck, miners);
 
         if (targets.length === 0) {
           pushToast({

--- a/client/src/protoFleet/features/settings/components/EditFirmwareMetadataDialog.test.tsx
+++ b/client/src/protoFleet/features/settings/components/EditFirmwareMetadataDialog.test.tsx
@@ -1,0 +1,99 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import EditFirmwareMetadataDialog from "./EditFirmwareMetadataDialog";
+
+const mockGetMinerModelGroups = vi.fn();
+
+vi.mock("@/protoFleet/api/useMinerModelGroups", () => ({
+  default: () => ({ getMinerModelGroups: mockGetMinerModelGroups }),
+}));
+
+vi.mock("@/shared/components/Modal/Modal", () => ({
+  default: ({ open, title, children, buttons, testId }: any) =>
+    open ? (
+      <div data-testid={testId}>
+        <h1>{title}</h1>
+        {children}
+        {buttons?.map((button: any) => (
+          <button key={button.text} disabled={button.disabled} onClick={button.onClick}>
+            {button.text}
+          </button>
+        ))}
+      </div>
+    ) : null,
+}));
+
+vi.mock("@/shared/components/Select", () => ({
+  default: ({ id, value, onChange, disabled }: any) => (
+    <button
+      type="button"
+      data-testid={id}
+      data-value={value}
+      disabled={disabled}
+      onClick={() => onChange(id.includes("manufacturer") ? "Proto" : "Rig")}
+    >
+      {value}
+    </button>
+  ),
+}));
+
+vi.mock("@/shared/components/Input", () => ({
+  default: ({ id, initValue, onChange, disabled }: any) => (
+    <input data-testid={id} value={initValue} disabled={disabled} onChange={(event) => onChange(event.target.value)} />
+  ),
+}));
+
+const firmwareFile = {
+  id: "firmware-1",
+  filename: "proto-rig-2.0.0.swu",
+  targetManufacturer: "Proto",
+  targetModel: "Rig",
+  firmwareVersion: "2.0.0",
+};
+
+describe("EditFirmwareMetadataDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetMinerModelGroups.mockResolvedValue([{ manufacturer: "Proto", model: "Rig", count: 1 }]);
+  });
+
+  it("loads the stored metadata and saves it", async () => {
+    const onConfirm = vi.fn();
+    render(
+      <EditFirmwareMetadataDialog
+        open
+        file={firmwareFile}
+        isSubmitting={false}
+        onConfirm={onConfirm}
+        onDismiss={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByTestId("edit-firmware-target-manufacturer")).toHaveAttribute("data-value", "Proto");
+    expect(screen.getByTestId("edit-firmware-target-model")).toHaveAttribute("data-value", "Rig");
+    expect(screen.getByTestId("edit-firmware-version")).toHaveValue("2.0.0");
+
+    fireEvent.click(screen.getByText("Save changes"));
+
+    expect(onConfirm).toHaveBeenCalledWith({
+      targetManufacturer: "Proto",
+      targetModel: "Rig",
+      firmwareVersion: "2.0.0",
+    });
+  });
+
+  it("keeps save disabled for legacy firmware until metadata is complete", async () => {
+    render(
+      <EditFirmwareMetadataDialog
+        open
+        file={{ ...firmwareFile, targetManufacturer: "", targetModel: "", firmwareVersion: "" }}
+        isSubmitting={false}
+        onConfirm={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+
+    await screen.findByTestId("edit-firmware-target-manufacturer");
+    expect(screen.getByText("Save changes")).toBeDisabled();
+  });
+});

--- a/client/src/protoFleet/features/settings/components/EditFirmwareMetadataDialog.test.tsx
+++ b/client/src/protoFleet/features/settings/components/EditFirmwareMetadataDialog.test.tsx
@@ -24,13 +24,14 @@ vi.mock("@/shared/components/Modal/Modal", () => ({
 }));
 
 vi.mock("@/shared/components/Select", () => ({
-  default: ({ id, value, onChange, disabled }: any) => (
+  default: ({ id, value, options, onChange, disabled }: any) => (
     <button
       type="button"
       data-testid={id}
       data-value={value}
+      data-options={options.map((option: { value: string }) => option.value).join(",")}
       disabled={disabled}
-      onClick={() => onChange(id.includes("manufacturer") ? "Proto" : "Rig")}
+      onClick={() => onChange(id.includes("manufacturer") ? "Bitmain" : "Rig")}
     >
       {value}
     </button>
@@ -95,5 +96,36 @@ describe("EditFirmwareMetadataDialog", () => {
 
     await screen.findByTestId("edit-firmware-target-manufacturer");
     expect(screen.getByText("Save changes")).toBeDisabled();
+  });
+
+  it("clears the seeded model after changing manufacturer", async () => {
+    const onConfirm = vi.fn();
+    mockGetMinerModelGroups.mockResolvedValue([
+      { manufacturer: "Proto", model: "Rig", count: 1 },
+      { manufacturer: "Bitmain", model: "S19", count: 1 },
+    ]);
+    render(
+      <EditFirmwareMetadataDialog
+        open
+        file={firmwareFile}
+        isSubmitting={false}
+        onConfirm={onConfirm}
+        onDismiss={vi.fn()}
+      />,
+    );
+
+    const manufacturerSelect = await screen.findByTestId("edit-firmware-target-manufacturer");
+    fireEvent.click(manufacturerSelect);
+
+    const modelSelect = screen.getByTestId("edit-firmware-target-model");
+    expect(modelSelect).toHaveAttribute("data-value", "");
+    expect(modelSelect).toHaveAttribute("data-options", ",S19");
+
+    fireEvent.click(modelSelect);
+
+    expect(modelSelect).toHaveAttribute("data-value", "");
+    expect(screen.getByText("Save changes")).toBeDisabled();
+    fireEvent.click(screen.getByText("Save changes"));
+    expect(onConfirm).not.toHaveBeenCalled();
   });
 });

--- a/client/src/protoFleet/features/settings/components/EditFirmwareMetadataDialog.tsx
+++ b/client/src/protoFleet/features/settings/components/EditFirmwareMetadataDialog.tsx
@@ -1,0 +1,162 @@
+import { useEffect, useMemo, useState } from "react";
+import type { MinerModelGroup } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
+import type { FirmwareMetadataInput } from "@/protoFleet/api/useFirmwareApi";
+import useMinerModelGroups from "@/protoFleet/api/useMinerModelGroups";
+import { Alert } from "@/shared/assets/icons";
+import { variants } from "@/shared/components/Button";
+import Callout from "@/shared/components/Callout";
+import Input from "@/shared/components/Input";
+import Modal from "@/shared/components/Modal/Modal";
+import ProgressCircular from "@/shared/components/ProgressCircular/ProgressCircular";
+import Select from "@/shared/components/Select";
+
+interface EditableFirmwareFile {
+  id: string;
+  filename: string;
+  targetManufacturer: string;
+  targetModel: string;
+  firmwareVersion: string;
+}
+
+interface EditFirmwareMetadataDialogProps {
+  open: boolean;
+  file: EditableFirmwareFile | null;
+  isSubmitting: boolean;
+  onConfirm: (metadata: FirmwareMetadataInput) => void;
+  onDismiss: () => void;
+}
+
+const EditFirmwareMetadataDialog = ({
+  open,
+  file,
+  isSubmitting,
+  onConfirm,
+  onDismiss,
+}: EditFirmwareMetadataDialogProps) => {
+  const { getMinerModelGroups } = useMinerModelGroups();
+  const [targetManufacturer, setTargetManufacturer] = useState(file?.targetManufacturer ?? "");
+  const [targetModel, setTargetModel] = useState(file?.targetModel ?? "");
+  const [firmwareVersion, setFirmwareVersion] = useState(file?.firmwareVersion ?? "");
+  const [modelGroups, setModelGroups] = useState<MinerModelGroup[] | null>(null);
+  const [modelsError, setModelsError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open || modelGroups !== null || modelsError !== null) return;
+    let cancelled = false;
+    void getMinerModelGroups(null)
+      .then((groups) => {
+        if (!cancelled) setModelGroups(groups);
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setModelGroups([]);
+          setModelsError("Couldn't load fleet miner models.");
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [getMinerModelGroups, modelGroups, modelsError, open]);
+
+  const manufacturerOptions = useMemo(() => {
+    const manufacturers = new Set((modelGroups ?? []).map((group) => group.manufacturer.trim()).filter(Boolean));
+    if (targetManufacturer.trim()) manufacturers.add(targetManufacturer.trim());
+    return [
+      { value: "", label: "Select manufacturer" },
+      ...[...manufacturers].sort().map((manufacturer) => ({ value: manufacturer, label: manufacturer })),
+    ];
+  }, [modelGroups, targetManufacturer]);
+
+  const modelOptions = useMemo(() => {
+    const models = new Set(
+      (modelGroups ?? [])
+        .filter((group) => group.manufacturer.trim() === targetManufacturer.trim())
+        .map((group) => group.model.trim())
+        .filter(Boolean),
+    );
+    if (targetModel.trim()) models.add(targetModel.trim());
+    return [
+      { value: "", label: "Select model" },
+      ...[...models].sort().map((model) => ({ value: model, label: model })),
+    ];
+  }, [modelGroups, targetManufacturer, targetModel]);
+
+  const metadata = {
+    targetManufacturer: targetManufacturer.trim(),
+    targetModel: targetModel.trim(),
+    firmwareVersion: firmwareVersion.trim(),
+  };
+  const canSubmit =
+    modelGroups !== null &&
+    modelsError === null &&
+    metadata.targetManufacturer !== "" &&
+    metadata.targetModel !== "" &&
+    metadata.firmwareVersion !== "" &&
+    !isSubmitting;
+
+  return (
+    <Modal
+      open={Boolean(open && file !== null)}
+      title="Edit firmware metadata"
+      description={file ? file.filename : undefined}
+      onDismiss={onDismiss}
+      buttons={[
+        {
+          text: isSubmitting ? "Saving…" : "Save changes",
+          variant: variants.primary,
+          disabled: !canSubmit,
+          dismissModalOnClick: false,
+          onClick: () => onConfirm(metadata),
+        },
+      ]}
+      divider={false}
+      testId="edit-firmware-metadata-dialog"
+    >
+      <div className="mt-2 text-300 text-text-primary-70">Set the miner target and version for this firmware file.</div>
+      <div className="mt-6 flex flex-col gap-4">
+        {modelGroups === null && modelsError === null ? (
+          <div className="flex items-center justify-center p-8">
+            <ProgressCircular indeterminate size={24} />
+          </div>
+        ) : (
+          <>
+            <div className="grid gap-4 tablet:grid-cols-2">
+              <Select
+                id="edit-firmware-target-manufacturer"
+                label="Manufacturer"
+                options={manufacturerOptions}
+                value={targetManufacturer}
+                onChange={(value) => {
+                  setTargetManufacturer(value);
+                  setTargetModel("");
+                }}
+                disabled={isSubmitting}
+                forceBelow
+              />
+              <Select
+                id="edit-firmware-target-model"
+                label="Model"
+                options={modelOptions}
+                value={targetModel}
+                onChange={setTargetModel}
+                disabled={isSubmitting || !targetManufacturer}
+                forceBelow
+              />
+            </div>
+            <Input
+              id="edit-firmware-version"
+              label="Firmware version"
+              initValue={firmwareVersion}
+              onChange={setFirmwareVersion}
+              disabled={isSubmitting}
+              required
+            />
+          </>
+        )}
+        {modelsError ? <Callout intent="danger" prefixIcon={<Alert />} title={modelsError} /> : null}
+      </div>
+    </Modal>
+  );
+};
+
+export default EditFirmwareMetadataDialog;

--- a/client/src/protoFleet/features/settings/components/EditFirmwareMetadataDialog.tsx
+++ b/client/src/protoFleet/features/settings/components/EditFirmwareMetadataDialog.tsx
@@ -1,17 +1,15 @@
-import { useEffect, useMemo, useState } from "react";
-import type { MinerModelGroup } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
+import { useState } from "react";
 import type { FirmwareMetadataInput } from "@/protoFleet/api/useFirmwareApi";
-import useMinerModelGroups from "@/protoFleet/api/useMinerModelGroups";
+import { hasCompleteFirmwareTarget } from "@/protoFleet/api/useFirmwareApi";
+import FirmwareTargetFields from "@/protoFleet/features/settings/components/FirmwareTargetFields";
+import { useMinerTargetOptions } from "@/protoFleet/features/settings/components/useMinerTargetOptions";
 import { Alert } from "@/shared/assets/icons";
 import { variants } from "@/shared/components/Button";
 import Callout from "@/shared/components/Callout";
-import Input from "@/shared/components/Input";
 import Modal from "@/shared/components/Modal/Modal";
 import ProgressCircular from "@/shared/components/ProgressCircular/ProgressCircular";
-import Select from "@/shared/components/Select";
 
 interface EditableFirmwareFile {
-  id: string;
   filename: string;
   targetManufacturer: string;
   targetModel: string;
@@ -33,66 +31,19 @@ const EditFirmwareMetadataDialog = ({
   onConfirm,
   onDismiss,
 }: EditFirmwareMetadataDialogProps) => {
-  const { getMinerModelGroups } = useMinerModelGroups();
   const [targetManufacturer, setTargetManufacturer] = useState(file?.targetManufacturer ?? "");
   const [targetModel, setTargetModel] = useState(file?.targetModel ?? "");
   const [firmwareVersion, setFirmwareVersion] = useState(file?.firmwareVersion ?? "");
-  const [modelGroups, setModelGroups] = useState<MinerModelGroup[] | null>(null);
-  const [modelsError, setModelsError] = useState<string | null>(null);
+  const { modelGroups, modelsError, manufacturerOptions, modelOptions } = useMinerTargetOptions({
+    active: open,
+    selectedManufacturer: targetManufacturer,
+    seedManufacturer: targetManufacturer,
+    seedModel: targetModel,
+  });
 
-  useEffect(() => {
-    if (!open || modelGroups !== null || modelsError !== null) return;
-    let cancelled = false;
-    void getMinerModelGroups(null)
-      .then((groups) => {
-        if (!cancelled) setModelGroups(groups);
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setModelGroups([]);
-          setModelsError("Couldn't load fleet miner models.");
-        }
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [getMinerModelGroups, modelGroups, modelsError, open]);
-
-  const manufacturerOptions = useMemo(() => {
-    const manufacturers = new Set((modelGroups ?? []).map((group) => group.manufacturer.trim()).filter(Boolean));
-    if (targetManufacturer.trim()) manufacturers.add(targetManufacturer.trim());
-    return [
-      { value: "", label: "Select manufacturer" },
-      ...[...manufacturers].sort().map((manufacturer) => ({ value: manufacturer, label: manufacturer })),
-    ];
-  }, [modelGroups, targetManufacturer]);
-
-  const modelOptions = useMemo(() => {
-    const models = new Set(
-      (modelGroups ?? [])
-        .filter((group) => group.manufacturer.trim() === targetManufacturer.trim())
-        .map((group) => group.model.trim())
-        .filter(Boolean),
-    );
-    if (targetModel.trim()) models.add(targetModel.trim());
-    return [
-      { value: "", label: "Select model" },
-      ...[...models].sort().map((model) => ({ value: model, label: model })),
-    ];
-  }, [modelGroups, targetManufacturer, targetModel]);
-
-  const metadata = {
-    targetManufacturer: targetManufacturer.trim(),
-    targetModel: targetModel.trim(),
-    firmwareVersion: firmwareVersion.trim(),
-  };
+  const metadata = { targetManufacturer, targetModel, firmwareVersion };
   const canSubmit =
-    modelGroups !== null &&
-    modelsError === null &&
-    metadata.targetManufacturer !== "" &&
-    metadata.targetModel !== "" &&
-    metadata.firmwareVersion !== "" &&
-    !isSubmitting;
+    modelGroups !== null && modelsError === null && hasCompleteFirmwareTarget(metadata) && !isSubmitting;
 
   return (
     <Modal
@@ -119,39 +70,18 @@ const EditFirmwareMetadataDialog = ({
             <ProgressCircular indeterminate size={24} />
           </div>
         ) : (
-          <>
-            <div className="grid gap-4 tablet:grid-cols-2">
-              <Select
-                id="edit-firmware-target-manufacturer"
-                label="Manufacturer"
-                options={manufacturerOptions}
-                value={targetManufacturer}
-                onChange={(value) => {
-                  setTargetManufacturer(value);
-                  setTargetModel("");
-                }}
-                disabled={isSubmitting}
-                forceBelow
-              />
-              <Select
-                id="edit-firmware-target-model"
-                label="Model"
-                options={modelOptions}
-                value={targetModel}
-                onChange={setTargetModel}
-                disabled={isSubmitting || !targetManufacturer}
-                forceBelow
-              />
-            </div>
-            <Input
-              id="edit-firmware-version"
-              label="Firmware version"
-              initValue={firmwareVersion}
-              onChange={setFirmwareVersion}
-              disabled={isSubmitting}
-              required
-            />
-          </>
+          <FirmwareTargetFields
+            idPrefix="edit-firmware"
+            manufacturerOptions={manufacturerOptions}
+            modelOptions={modelOptions}
+            manufacturer={targetManufacturer}
+            model={targetModel}
+            version={firmwareVersion}
+            disabled={isSubmitting}
+            onManufacturerChange={setTargetManufacturer}
+            onModelChange={setTargetModel}
+            onVersionChange={setFirmwareVersion}
+          />
         )}
         {modelsError ? <Callout intent="danger" prefixIcon={<Alert />} title={modelsError} /> : null}
       </div>

--- a/client/src/protoFleet/features/settings/components/EditFirmwareMetadataDialog.tsx
+++ b/client/src/protoFleet/features/settings/components/EditFirmwareMetadataDialog.tsx
@@ -34,14 +34,15 @@ const EditFirmwareMetadataDialog = ({
   const [targetManufacturer, setTargetManufacturer] = useState(file?.targetManufacturer ?? "");
   const [targetModel, setTargetModel] = useState(file?.targetModel ?? "");
   const [firmwareVersion, setFirmwareVersion] = useState(file?.firmwareVersion ?? "");
-  const { modelGroups, modelsError, manufacturerOptions, modelOptions } = useMinerTargetOptions({
+  const { modelGroups, modelsError, manufacturerOptions, modelOptions, resolvedModel } = useMinerTargetOptions({
     active: open,
     selectedManufacturer: targetManufacturer,
+    selectedModel: targetModel,
     seedManufacturer: targetManufacturer,
     seedModel: targetModel,
   });
 
-  const metadata = { targetManufacturer, targetModel, firmwareVersion };
+  const metadata = { targetManufacturer, targetModel: resolvedModel, firmwareVersion };
   const canSubmit =
     modelGroups !== null && modelsError === null && hasCompleteFirmwareTarget(metadata) && !isSubmitting;
 
@@ -75,7 +76,7 @@ const EditFirmwareMetadataDialog = ({
             manufacturerOptions={manufacturerOptions}
             modelOptions={modelOptions}
             manufacturer={targetManufacturer}
-            model={targetModel}
+            model={resolvedModel}
             version={firmwareVersion}
             disabled={isSubmitting}
             onManufacturerChange={setTargetManufacturer}

--- a/client/src/protoFleet/features/settings/components/EditFirmwareMetadataDialog.tsx
+++ b/client/src/protoFleet/features/settings/components/EditFirmwareMetadataDialog.tsx
@@ -38,8 +38,8 @@ const EditFirmwareMetadataDialog = ({
     active: open,
     selectedManufacturer: targetManufacturer,
     selectedModel: targetModel,
-    seedManufacturer: targetManufacturer,
-    seedModel: targetModel,
+    seedManufacturer: file?.targetManufacturer,
+    seedModel: file?.targetModel,
   });
 
   const metadata = { targetManufacturer, targetModel: resolvedModel, firmwareVersion };

--- a/client/src/protoFleet/features/settings/components/Firmware.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Firmware.test.tsx
@@ -24,8 +24,22 @@ beforeEach(() => {
 });
 
 const sampleFiles = [
-  { id: "f1", filename: "alpha.swu", size: 1024, uploaded_at: "2025-06-01T12:00:00Z" },
-  { id: "f2", filename: "beta.tar.gz", size: 2048000, uploaded_at: "2025-06-02T14:30:00Z" },
+  {
+    id: "f1",
+    filename: "alpha.swu",
+    size: 1024,
+    uploaded_at: "2025-06-01T12:00:00Z",
+    target_manufacturer: "Proto",
+    target_model: "S21",
+  },
+  {
+    id: "f2",
+    filename: "beta.tar.gz",
+    size: 2048000,
+    uploaded_at: "2025-06-02T14:30:00Z",
+    target_manufacturer: "Bitmain",
+    target_model: "S19",
+  },
 ];
 
 describe("Firmware", () => {

--- a/client/src/protoFleet/features/settings/components/Firmware.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Firmware.test.tsx
@@ -5,13 +5,29 @@ import Firmware from "./Firmware";
 const mockListFirmwareFiles = vi.fn();
 const mockDeleteFirmwareFile = vi.fn();
 const mockDeleteAllFirmwareFiles = vi.fn();
+const mockUpdateFirmwareMetadata = vi.fn();
 
 vi.mock("@/protoFleet/api/useFirmwareApi", () => ({
   useFirmwareApi: () => ({
     listFirmwareFiles: mockListFirmwareFiles,
+    updateFirmwareMetadata: mockUpdateFirmwareMetadata,
     deleteFirmwareFile: mockDeleteFirmwareFile,
     deleteAllFirmwareFiles: mockDeleteAllFirmwareFiles,
   }),
+}));
+
+vi.mock("@/protoFleet/features/settings/components/EditFirmwareMetadataDialog", () => ({
+  default: ({ open, file, onConfirm }: any) =>
+    open ? (
+      <div data-testid="edit-firmware-metadata-dialog">
+        <span>{file.filename}</span>
+        <button
+          onClick={() => onConfirm({ targetManufacturer: "Proto", targetModel: "Rig", firmwareVersion: "2.0.0" })}
+        >
+          Save changes
+        </button>
+      </div>
+    ) : null,
 }));
 
 vi.mock("@/shared/features/toaster");
@@ -20,6 +36,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockListFirmwareFiles.mockResolvedValue([]);
   mockDeleteFirmwareFile.mockResolvedValue(undefined);
+  mockUpdateFirmwareMetadata.mockResolvedValue(undefined);
   mockDeleteAllFirmwareFiles.mockResolvedValue({ deleted_count: 0 });
 });
 
@@ -81,6 +98,70 @@ describe("Firmware", () => {
     });
   });
 
+  it("expands and collapses a truncated filename", async () => {
+    const filename = "proto-rig-firmware-with-a-very-long-release-name-2.0.0.swu";
+    mockListFirmwareFiles.mockResolvedValue([{ ...sampleFiles[0], filename }]);
+    const scrollWidthSpy = vi.spyOn(HTMLElement.prototype, "scrollWidth", "get").mockReturnValue(500);
+    const clientWidthSpy = vi.spyOn(HTMLElement.prototype, "clientWidth", "get").mockReturnValue(200);
+
+    render(<Firmware />);
+
+    const expandButton = await screen.findByRole("button", { name: `Show full file name: ${filename}` });
+    expect(expandButton).toHaveAttribute("aria-expanded", "false");
+    expect(within(expandButton).getByText(filename)).toHaveClass("truncate");
+
+    fireEvent.click(expandButton);
+
+    const collapseButton = screen.getByRole("button", { name: `Hide full file name: ${filename}` });
+    expect(collapseButton).toHaveAttribute("aria-expanded", "true");
+    expect(within(collapseButton).getByText(filename)).not.toHaveClass("truncate");
+
+    fireEvent.click(collapseButton);
+
+    expect(screen.getByRole("button", { name: `Show full file name: ${filename}` })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+
+    scrollWidthSpy.mockRestore();
+    clientWidthSpy.mockRestore();
+  });
+
+  it("does not show an expand control when the full filename fits", async () => {
+    const filename = "firmware-2.0.0.swu";
+    mockListFirmwareFiles.mockResolvedValue([{ ...sampleFiles[0], filename }]);
+    const scrollWidthSpy = vi.spyOn(HTMLElement.prototype, "scrollWidth", "get").mockReturnValue(150);
+    const clientWidthSpy = vi.spyOn(HTMLElement.prototype, "clientWidth", "get").mockReturnValue(384);
+
+    render(<Firmware />);
+
+    expect(await screen.findByText(filename, { selector: "span:not([aria-hidden])" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: `Show full file name: ${filename}` })).not.toBeInTheDocument();
+
+    scrollWidthSpy.mockRestore();
+    clientWidthSpy.mockRestore();
+  });
+
+  it("updates metadata from the row action", async () => {
+    mockListFirmwareFiles.mockResolvedValue(sampleFiles);
+    render(<Firmware />);
+
+    await screen.findByText("alpha.swu");
+    fireEvent.click(screen.getAllByTestId("list-actions-trigger")[0]);
+    fireEvent.click(await screen.findByText("Edit metadata"));
+    expect(screen.getByTestId("edit-firmware-metadata-dialog")).toHaveTextContent("alpha.swu");
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Save changes"));
+    });
+
+    expect(mockUpdateFirmwareMetadata).toHaveBeenCalledWith("f1", {
+      targetManufacturer: "Proto",
+      targetModel: "Rig",
+      firmwareVersion: "2.0.0",
+    });
+  });
+
   it("renders legacy firmware targets as unknown", async () => {
     mockListFirmwareFiles.mockResolvedValue([
       {
@@ -128,6 +209,7 @@ describe("Firmware", () => {
       expect(getByText("alpha.swu")).toBeInTheDocument();
     });
 
+    fireEvent.click(screen.getAllByTestId("list-actions-trigger")[0]);
     const deleteButtons = getAllByText("Delete");
     fireEvent.click(deleteButtons[0]);
 
@@ -146,6 +228,7 @@ describe("Firmware", () => {
       expect(getByText("alpha.swu")).toBeInTheDocument();
     });
 
+    fireEvent.click(screen.getAllByTestId("list-actions-trigger")[0]);
     const deleteButtons = getAllByText("Delete");
     fireEvent.click(deleteButtons[0]);
 
@@ -175,6 +258,7 @@ describe("Firmware", () => {
 
     mockListFirmwareFiles.mockClear();
 
+    fireEvent.click(screen.getAllByTestId("list-actions-trigger")[0]);
     const deleteButtons = getAllByText("Delete");
     fireEvent.click(deleteButtons[0]);
 

--- a/client/src/protoFleet/features/settings/components/Firmware.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Firmware.test.tsx
@@ -81,6 +81,23 @@ describe("Firmware", () => {
     });
   });
 
+  it("renders legacy firmware targets as unknown", async () => {
+    mockListFirmwareFiles.mockResolvedValue([
+      {
+        id: "legacy",
+        filename: "legacy.swu",
+        size: 1024,
+        uploaded_at: "2025-06-01T12:00:00Z",
+        target_manufacturer: "",
+        target_model: "",
+      },
+    ]);
+
+    render(<Firmware />);
+
+    expect(await screen.findByText("Unknown")).toBeInTheDocument();
+  });
+
   it("hides Delete all button when no files exist", async () => {
     mockListFirmwareFiles.mockResolvedValue([]);
 

--- a/client/src/protoFleet/features/settings/components/Firmware.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Firmware.test.tsx
@@ -7,7 +7,8 @@ const mockDeleteFirmwareFile = vi.fn();
 const mockDeleteAllFirmwareFiles = vi.fn();
 const mockUpdateFirmwareMetadata = vi.fn();
 
-vi.mock("@/protoFleet/api/useFirmwareApi", () => ({
+vi.mock("@/protoFleet/api/useFirmwareApi", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/protoFleet/api/useFirmwareApi")>()),
   useFirmwareApi: () => ({
     listFirmwareFiles: mockListFirmwareFiles,
     updateFirmwareMetadata: mockUpdateFirmwareMetadata,

--- a/client/src/protoFleet/features/settings/components/Firmware.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Firmware.test.tsx
@@ -48,7 +48,7 @@ const sampleFiles = [
     size: 1024,
     uploaded_at: "2025-06-01T12:00:00Z",
     target_manufacturer: "Proto",
-    target_model: "S21",
+    target_model: "Rig",
   },
   {
     id: "f2",

--- a/client/src/protoFleet/features/settings/components/Firmware.tsx
+++ b/client/src/protoFleet/features/settings/components/Firmware.tsx
@@ -1,11 +1,13 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import clsx from "clsx";
 import { type FirmwareFileInfo, useFirmwareApi } from "@/protoFleet/api/useFirmwareApi";
 import DeleteAllFirmwareDialog from "@/protoFleet/features/settings/components/DeleteAllFirmwareDialog";
 import DeleteFirmwareDialog from "@/protoFleet/features/settings/components/DeleteFirmwareDialog";
+import EditFirmwareMetadataDialog from "@/protoFleet/features/settings/components/EditFirmwareMetadataDialog";
 import FirmwareUploadDialog from "@/protoFleet/features/settings/components/FirmwareUploadDialog";
 import SettingsEmptyState from "@/protoFleet/features/settings/components/SettingsEmptyState";
 import SettingsPageHeader from "@/protoFleet/features/settings/components/SettingsPageHeader";
-import { Trash } from "@/shared/assets/icons";
+import { ChevronDown, Edit, Trash } from "@/shared/assets/icons";
 import Button, { sizes, variants } from "@/shared/components/Button";
 import { formatFileSize } from "@/shared/components/FileSizeValue";
 import List from "@/shared/components/List";
@@ -17,6 +19,8 @@ type FirmwareFileData = {
   id: string;
   filename: string;
   target: string;
+  targetManufacturer: string;
+  targetModel: string;
   firmwareVersion: string;
   size: number;
   uploadedAt: number;
@@ -32,10 +36,67 @@ const colTitles: ColTitles<FirmwareColumns> = {
   size: "Size",
 };
 
+const ExpandableFilename = ({ filename }: { filename: string }) => {
+  const [expanded, setExpanded] = useState(false);
+  const [overflows, setOverflows] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const measurementRef = useRef<HTMLSpanElement>(null);
+  const actionLabel = `${expanded ? "Hide" : "Show"} full file name: ${filename}`;
+
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    const measurement = measurementRef.current;
+    if (!container || !measurement) return;
+
+    const updateOverflow = (): void => {
+      const nextOverflows = measurement.scrollWidth > container.clientWidth;
+      setOverflows(nextOverflows);
+      if (!nextOverflows) setExpanded(false);
+    };
+
+    updateOverflow();
+    const observer = typeof ResizeObserver !== "undefined" ? new ResizeObserver(updateOverflow) : undefined;
+    observer?.observe(container);
+    window.addEventListener("resize", updateOverflow);
+
+    return () => {
+      observer?.disconnect();
+      window.removeEventListener("resize", updateOverflow);
+    };
+  }, [filename]);
+
+  return (
+    <div ref={containerRef} className="relative w-full text-emphasis-300">
+      <span
+        ref={measurementRef}
+        aria-hidden
+        data-filename={filename}
+        className="pointer-events-none invisible absolute whitespace-nowrap before:content-[attr(data-filename)]"
+      />
+      {overflows ? (
+        <button
+          type="button"
+          aria-expanded={expanded}
+          aria-label={actionLabel}
+          title={actionLabel}
+          className="flex w-full cursor-pointer items-start gap-1.5 text-left"
+          onClick={() => setExpanded((current) => !current)}
+        >
+          <span className={clsx("min-w-0", expanded ? "break-all whitespace-normal" : "truncate")}>{filename}</span>
+          <ChevronDown width="w-3" className={clsx("mt-1 shrink-0 transition-transform", expanded && "rotate-180")} />
+        </button>
+      ) : (
+        <span className="block truncate">{filename}</span>
+      )}
+    </div>
+  );
+};
+
 const colConfig: ColConfig<FirmwareFileData, string, FirmwareColumns> = {
   filename: {
-    component: (file) => <span className="text-emphasis-300">{file.filename}</span>,
-    width: "w-60",
+    component: (file) => <ExpandableFilename filename={file.filename} />,
+    width: "w-96",
+    allowWrap: true,
   },
   target: {
     component: (file) => <span>{file.target}</span>,
@@ -63,6 +124,8 @@ function toFileData(info: FirmwareFileInfo): FirmwareFileData {
     id: info.id,
     filename: info.filename,
     target: `${info.target_manufacturer} ${info.target_model}`.trim() || "Unknown",
+    targetManufacturer: info.target_manufacturer,
+    targetModel: info.target_model,
     firmwareVersion: info.firmware_version ?? "",
     size: info.size,
     uploadedAt: isoToEpochSeconds(info.uploaded_at),
@@ -70,7 +133,7 @@ function toFileData(info: FirmwareFileInfo): FirmwareFileData {
 }
 
 const Firmware = () => {
-  const { listFirmwareFiles, deleteFirmwareFile, deleteAllFirmwareFiles } = useFirmwareApi();
+  const { listFirmwareFiles, updateFirmwareMetadata, deleteFirmwareFile, deleteAllFirmwareFiles } = useFirmwareApi();
   const [files, setFiles] = useState<FirmwareFileData[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [showUploadDialog, setShowUploadDialog] = useState(false);
@@ -78,6 +141,8 @@ const Firmware = () => {
   const [isDeletingAll, setIsDeletingAll] = useState(false);
   const [fileToDelete, setFileToDelete] = useState<FirmwareFileData | null>(null);
   const [isDeletingSingle, setIsDeletingSingle] = useState(false);
+  const [fileToEdit, setFileToEdit] = useState<FirmwareFileData | null>(null);
+  const [isEditing, setIsEditing] = useState(false);
 
   const fetchFiles = useCallback(() => {
     setIsLoading(true);
@@ -104,6 +169,33 @@ const Firmware = () => {
   const handleDeleteFile = useCallback((file: FirmwareFileData) => {
     setFileToDelete(file);
   }, []);
+
+  const handleEditMetadata = useCallback((file: FirmwareFileData) => {
+    setFileToEdit(file);
+  }, []);
+
+  const handleEditConfirm = useCallback(
+    (metadata: { targetManufacturer: string; targetModel: string; firmwareVersion: string }) => {
+      if (!fileToEdit) return;
+      setIsEditing(true);
+      updateFirmwareMetadata(fileToEdit.id, metadata)
+        .then(() => {
+          pushToast({ message: "Firmware metadata updated", status: STATUSES.success });
+          setFileToEdit(null);
+          fetchFiles();
+        })
+        .catch((error) => {
+          pushToast({
+            message: error?.message || "Couldn't update firmware metadata",
+            status: STATUSES.error,
+          });
+        })
+        .finally(() => {
+          setIsEditing(false);
+        });
+    },
+    [fetchFiles, fileToEdit, updateFirmwareMetadata],
+  );
 
   const handleDeleteFileConfirm = useCallback(() => {
     if (!fileToDelete) return;
@@ -162,13 +254,18 @@ const Firmware = () => {
   const availableActions = useMemo(
     () => [
       {
+        title: "Edit metadata",
+        icon: <Edit />,
+        actionHandler: handleEditMetadata,
+      },
+      {
         title: "Delete",
         icon: <Trash />,
         variant: "destructive" as const,
         actionHandler: handleDeleteFile,
       },
     ],
-    [handleDeleteFile],
+    [handleDeleteFile, handleEditMetadata],
   );
 
   return (
@@ -231,6 +328,17 @@ const Firmware = () => {
           if (!isDeletingSingle) setFileToDelete(null);
         }}
         isSubmitting={isDeletingSingle}
+      />
+
+      <EditFirmwareMetadataDialog
+        key={fileToEdit?.id ?? "no-firmware-selected"}
+        open={fileToEdit !== null}
+        file={fileToEdit}
+        isSubmitting={isEditing}
+        onConfirm={handleEditConfirm}
+        onDismiss={() => {
+          if (!isEditing) setFileToEdit(null);
+        }}
       />
 
       <DeleteAllFirmwareDialog

--- a/client/src/protoFleet/features/settings/components/Firmware.tsx
+++ b/client/src/protoFleet/features/settings/components/Firmware.tsx
@@ -16,14 +16,16 @@ import { formatTimestamp, isoToEpochSeconds } from "@/shared/utils/formatTimesta
 type FirmwareFileData = {
   id: string;
   filename: string;
+  target: string;
   size: number;
   uploadedAt: number;
 };
 
-type FirmwareColumns = "filename" | "uploadedAt" | "size";
+type FirmwareColumns = "filename" | "target" | "uploadedAt" | "size";
 
 const colTitles: ColTitles<FirmwareColumns> = {
   filename: "File name",
+  target: "Target",
   uploadedAt: "Uploaded",
   size: "Size",
 };
@@ -32,6 +34,10 @@ const colConfig: ColConfig<FirmwareFileData, string, FirmwareColumns> = {
   filename: {
     component: (file) => <span className="text-emphasis-300">{file.filename}</span>,
     width: "w-60",
+  },
+  target: {
+    component: (file) => <span>{file.target}</span>,
+    width: "w-48",
   },
   uploadedAt: {
     component: (file) => <span>{formatTimestamp(file.uploadedAt)}</span>,
@@ -43,13 +49,14 @@ const colConfig: ColConfig<FirmwareFileData, string, FirmwareColumns> = {
   },
 };
 
-const activeCols: FirmwareColumns[] = ["filename", "uploadedAt", "size"];
+const activeCols: FirmwareColumns[] = ["filename", "target", "uploadedAt", "size"];
 const FIRMWARE_PAGE_DESCRIPTION = "Upload and manage firmware files available to your fleet.";
 
 function toFileData(info: FirmwareFileInfo): FirmwareFileData {
   return {
     id: info.id,
     filename: info.filename,
+    target: `${info.target_manufacturer} ${info.target_model}`.trim(),
     size: info.size,
     uploadedAt: isoToEpochSeconds(info.uploaded_at),
   };

--- a/client/src/protoFleet/features/settings/components/Firmware.tsx
+++ b/client/src/protoFleet/features/settings/components/Firmware.tsx
@@ -17,15 +17,17 @@ type FirmwareFileData = {
   id: string;
   filename: string;
   target: string;
+  firmwareVersion: string;
   size: number;
   uploadedAt: number;
 };
 
-type FirmwareColumns = "filename" | "target" | "uploadedAt" | "size";
+type FirmwareColumns = "filename" | "target" | "firmwareVersion" | "uploadedAt" | "size";
 
 const colTitles: ColTitles<FirmwareColumns> = {
   filename: "File name",
   target: "Target",
+  firmwareVersion: "Version",
   uploadedAt: "Uploaded",
   size: "Size",
 };
@@ -39,6 +41,10 @@ const colConfig: ColConfig<FirmwareFileData, string, FirmwareColumns> = {
     component: (file) => <span>{file.target}</span>,
     width: "w-48",
   },
+  firmwareVersion: {
+    component: (file) => <span>{file.firmwareVersion || "-"}</span>,
+    width: "w-36",
+  },
   uploadedAt: {
     component: (file) => <span>{formatTimestamp(file.uploadedAt)}</span>,
     width: "w-48",
@@ -49,7 +55,7 @@ const colConfig: ColConfig<FirmwareFileData, string, FirmwareColumns> = {
   },
 };
 
-const activeCols: FirmwareColumns[] = ["filename", "target", "uploadedAt", "size"];
+const activeCols: FirmwareColumns[] = ["filename", "target", "firmwareVersion", "uploadedAt", "size"];
 const FIRMWARE_PAGE_DESCRIPTION = "Upload and manage firmware files available to your fleet.";
 
 function toFileData(info: FirmwareFileInfo): FirmwareFileData {
@@ -57,6 +63,7 @@ function toFileData(info: FirmwareFileInfo): FirmwareFileData {
     id: info.id,
     filename: info.filename,
     target: `${info.target_manufacturer} ${info.target_model}`.trim(),
+    firmwareVersion: info.firmware_version ?? "",
     size: info.size,
     uploadedAt: isoToEpochSeconds(info.uploaded_at),
   };

--- a/client/src/protoFleet/features/settings/components/Firmware.tsx
+++ b/client/src/protoFleet/features/settings/components/Firmware.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import clsx from "clsx";
-import { type FirmwareFileInfo, useFirmwareApi } from "@/protoFleet/api/useFirmwareApi";
+import { type FirmwareFileInfo, type FirmwareMetadataInput, useFirmwareApi } from "@/protoFleet/api/useFirmwareApi";
 import DeleteAllFirmwareDialog from "@/protoFleet/features/settings/components/DeleteAllFirmwareDialog";
 import DeleteFirmwareDialog from "@/protoFleet/features/settings/components/DeleteFirmwareDialog";
 import EditFirmwareMetadataDialog from "@/protoFleet/features/settings/components/EditFirmwareMetadataDialog";
@@ -18,7 +18,6 @@ import { formatTimestamp, isoToEpochSeconds } from "@/shared/utils/formatTimesta
 type FirmwareFileData = {
   id: string;
   filename: string;
-  target: string;
   targetManufacturer: string;
   targetModel: string;
   firmwareVersion: string;
@@ -55,14 +54,15 @@ const ExpandableFilename = ({ filename }: { filename: string }) => {
     };
 
     updateOverflow();
-    const observer = typeof ResizeObserver !== "undefined" ? new ResizeObserver(updateOverflow) : undefined;
-    observer?.observe(container);
-    window.addEventListener("resize", updateOverflow);
+    if (typeof ResizeObserver === "undefined") {
+      // Without ResizeObserver, approximate container resizes with window resizes.
+      window.addEventListener("resize", updateOverflow);
+      return () => window.removeEventListener("resize", updateOverflow);
+    }
 
-    return () => {
-      observer?.disconnect();
-      window.removeEventListener("resize", updateOverflow);
-    };
+    const observer = new ResizeObserver(updateOverflow);
+    observer.observe(container);
+    return () => observer.disconnect();
   }, [filename]);
 
   return (
@@ -99,7 +99,7 @@ const colConfig: ColConfig<FirmwareFileData, string, FirmwareColumns> = {
     allowWrap: true,
   },
   target: {
-    component: (file) => <span>{file.target}</span>,
+    component: (file) => <span>{`${file.targetManufacturer} ${file.targetModel}`.trim() || "Unknown"}</span>,
     width: "w-48",
   },
   firmwareVersion: {
@@ -123,7 +123,6 @@ function toFileData(info: FirmwareFileInfo): FirmwareFileData {
   return {
     id: info.id,
     filename: info.filename,
-    target: `${info.target_manufacturer} ${info.target_model}`.trim() || "Unknown",
     targetManufacturer: info.target_manufacturer,
     targetModel: info.target_model,
     firmwareVersion: info.firmware_version ?? "",
@@ -175,7 +174,7 @@ const Firmware = () => {
   }, []);
 
   const handleEditConfirm = useCallback(
-    (metadata: { targetManufacturer: string; targetModel: string; firmwareVersion: string }) => {
+    (metadata: FirmwareMetadataInput) => {
       if (!fileToEdit) return;
       setIsEditing(true);
       updateFirmwareMetadata(fileToEdit.id, metadata)

--- a/client/src/protoFleet/features/settings/components/Firmware.tsx
+++ b/client/src/protoFleet/features/settings/components/Firmware.tsx
@@ -62,7 +62,7 @@ function toFileData(info: FirmwareFileInfo): FirmwareFileData {
   return {
     id: info.id,
     filename: info.filename,
-    target: `${info.target_manufacturer} ${info.target_model}`.trim(),
+    target: `${info.target_manufacturer} ${info.target_model}`.trim() || "Unknown",
     firmwareVersion: info.firmware_version ?? "",
     size: info.size,
     uploadedAt: isoToEpochSeconds(info.uploaded_at),

--- a/client/src/protoFleet/features/settings/components/FirmwareTargetFields.tsx
+++ b/client/src/protoFleet/features/settings/components/FirmwareTargetFields.tsx
@@ -1,0 +1,70 @@
+import Input from "@/shared/components/Input";
+import Select, { type SelectOption } from "@/shared/components/Select";
+
+interface FirmwareTargetFieldsProps {
+  /** Field-id prefix: `${idPrefix}-target-manufacturer`, `${idPrefix}-target-model`, `${idPrefix}-version`. */
+  idPrefix: string;
+  manufacturerOptions: SelectOption[];
+  modelOptions: SelectOption[];
+  manufacturer: string;
+  model: string;
+  version: string;
+  disabled: boolean;
+  onManufacturerChange: (value: string) => void;
+  onModelChange: (value: string) => void;
+  onVersionChange: (value: string) => void;
+}
+
+/**
+ * The Manufacturer/Model selects and firmware version input shared by the
+ * firmware upload and edit-metadata dialogs. Selecting a manufacturer clears
+ * the model.
+ */
+const FirmwareTargetFields = ({
+  idPrefix,
+  manufacturerOptions,
+  modelOptions,
+  manufacturer,
+  model,
+  version,
+  disabled,
+  onManufacturerChange,
+  onModelChange,
+  onVersionChange,
+}: FirmwareTargetFieldsProps) => (
+  <>
+    <div className="grid gap-4 tablet:grid-cols-2">
+      <Select
+        id={`${idPrefix}-target-manufacturer`}
+        label="Manufacturer"
+        options={manufacturerOptions}
+        value={manufacturer}
+        onChange={(value) => {
+          onManufacturerChange(value);
+          onModelChange("");
+        }}
+        disabled={disabled}
+        forceBelow
+      />
+      <Select
+        id={`${idPrefix}-target-model`}
+        label="Model"
+        options={modelOptions}
+        value={model}
+        onChange={onModelChange}
+        disabled={disabled || !manufacturer}
+        forceBelow
+      />
+    </div>
+    <Input
+      id={`${idPrefix}-version`}
+      label="Firmware version"
+      initValue={version}
+      onChange={onVersionChange}
+      disabled={disabled}
+      required
+    />
+  </>
+);
+
+export default FirmwareTargetFields;

--- a/client/src/protoFleet/features/settings/components/FirmwareUploadDialog.test.tsx
+++ b/client/src/protoFleet/features/settings/components/FirmwareUploadDialog.test.tsx
@@ -103,22 +103,25 @@ vi.mock("@/shared/components/Input", () => ({
   ),
 }));
 
+const uploadHookState = (overrides: Record<string, unknown> = {}) => ({
+  state: "idle",
+  file: null,
+  firmwareFileId: null,
+  uploadProgress: 0,
+  errorMessage: null,
+  serverConfig: { allowedExtensions: [".swu"] },
+  processFile: mockProcessFile,
+  reset: vi.fn(),
+  retry: vi.fn(),
+  ...overrides,
+});
+
 describe("FirmwareUploadDialog", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSelectedFile = new File(["firmware"], "update-2.0.0.swu");
     mockGetMinerModelGroups.mockResolvedValue([{ manufacturer: "Proto", model: "Rig", count: 1 }]);
-    mockUseFirmwareUpload.mockReturnValue({
-      state: "idle",
-      file: null,
-      firmwareFileId: null,
-      uploadProgress: 0,
-      errorMessage: null,
-      serverConfig: { allowedExtensions: [".swu"] },
-      processFile: mockProcessFile,
-      reset: vi.fn(),
-      retry: vi.fn(),
-    });
+    mockUseFirmwareUpload.mockReturnValue(uploadHookState());
   });
 
   it("selects a file before metadata is complete and infers its version", async () => {
@@ -139,15 +142,11 @@ describe("FirmwareUploadDialog", () => {
     expect(screen.getByText("Upload")).not.toBeDisabled();
     fireEvent.click(screen.getByText("Upload"));
 
-    expect(mockProcessFile).toHaveBeenCalledWith(
-      mockSelectedFile,
-      {
-        targetManufacturer: "Proto",
-        targetModel: "Rig",
-        firmwareVersion: "2.0.0",
-      },
-      expect.any(Function),
-    );
+    expect(mockProcessFile).toHaveBeenCalledWith(mockSelectedFile, {
+      targetManufacturer: "Proto",
+      targetModel: "Rig",
+      firmwareVersion: "2.0.0",
+    });
   });
 
   it("does not replace a version entered before file selection", async () => {
@@ -176,7 +175,8 @@ describe("FirmwareUploadDialog", () => {
 
   it("closes and refreshes after the upload becomes ready", async () => {
     const onSuccess = vi.fn();
-    render(<FirmwareUploadDialog open onSuccess={onSuccess} onDismiss={vi.fn()} />);
+    const onDismiss = vi.fn();
+    const { rerender } = render(<FirmwareUploadDialog open onSuccess={onSuccess} onDismiss={onDismiss} />);
 
     await screen.findByTestId("firmware-target-manufacturer");
     fireEvent.click(screen.getByTestId("firmware-target-manufacturer"));
@@ -184,13 +184,14 @@ describe("FirmwareUploadDialog", () => {
     fireEvent.change(screen.getByTestId("firmware-version"), { target: { value: "2.0.0" } });
     fireEvent.click(screen.getByTestId("file-drop-zone"));
     fireEvent.click(screen.getByText("Upload"));
+    expect(mockProcessFile).toHaveBeenCalledOnce();
 
-    const onReady = mockProcessFile.mock.calls[0]?.[2] as (() => void) | undefined;
-    onReady?.();
+    mockUseFirmwareUpload.mockReturnValue(uploadHookState({ state: "ready" }));
+    rerender(<FirmwareUploadDialog open onSuccess={onSuccess} onDismiss={onDismiss} />);
 
     await waitFor(() => {
       expect(onSuccess).toHaveBeenCalledOnce();
     });
-    expect(screen.queryByText("Done")).not.toBeInTheDocument();
+    expect(onDismiss).not.toHaveBeenCalled();
   });
 });

--- a/client/src/protoFleet/features/settings/components/FirmwareUploadDialog.test.tsx
+++ b/client/src/protoFleet/features/settings/components/FirmwareUploadDialog.test.tsx
@@ -1,0 +1,76 @@
+import type { ChangeEvent, ReactNode } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import FirmwareUploadDialog from "./FirmwareUploadDialog";
+
+const mockGetMinerModelGroups = vi.fn();
+const mockProcessFile = vi.fn();
+
+vi.mock("@/protoFleet/api/useMinerModelGroups", () => ({
+  default: () => ({ getMinerModelGroups: mockGetMinerModelGroups }),
+}));
+
+vi.mock("@/protoFleet/components/FirmwareUpload", () => ({
+  useFirmwareUpload: () => ({
+    state: "idle",
+    file: null,
+    uploadProgress: 0,
+    errorMessage: null,
+    serverConfig: { allowedExtensions: [".swu"] },
+    processFile: mockProcessFile,
+    reset: vi.fn(),
+    retry: vi.fn(),
+  }),
+  FileDropZone: ({ disabled }: { disabled?: boolean }) => (
+    <div data-testid="file-drop-zone" data-disabled={String(!!disabled)} />
+  ),
+  FileErrorStatus: vi.fn(() => null),
+  FileProcessingStatus: vi.fn(() => null),
+  FileReadyStatus: vi.fn(() => null),
+}));
+
+vi.mock("@/shared/components/Modal/Modal", () => ({
+  default: ({ children, open }: { children: ReactNode; open?: boolean }) => (open ? <div>{children}</div> : null),
+}));
+
+vi.mock("@/shared/components/Select", () => ({
+  default: ({ id, onChange, disabled }: { id: string; onChange: (value: string) => void; disabled?: boolean }) => (
+    <button
+      type="button"
+      data-testid={id}
+      disabled={disabled}
+      onClick={() => onChange(id.includes("manufacturer") ? "Proto" : "Rig")}
+    >
+      {id}
+    </button>
+  ),
+}));
+
+vi.mock("@/shared/components/Input", () => ({
+  default: ({ id, onChange }: { id: string; onChange: (value: string) => void }) => (
+    <input
+      data-testid={id}
+      onChange={(event: ChangeEvent<HTMLInputElement>) => onChange(event.target.value)}
+    />
+  ),
+}));
+
+describe("FirmwareUploadDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetMinerModelGroups.mockResolvedValue([{ manufacturer: "Proto", model: "Rig", count: 1 }]);
+  });
+
+  it("disables file selection until manufacturer, model, and version are complete", async () => {
+    render(<FirmwareUploadDialog open onSuccess={vi.fn()} onDismiss={vi.fn()} />);
+
+    const dropZone = await screen.findByTestId("file-drop-zone");
+    expect(dropZone).toHaveAttribute("data-disabled", "true");
+
+    fireEvent.click(screen.getByTestId("firmware-target-manufacturer"));
+    fireEvent.click(screen.getByTestId("firmware-target-model"));
+    fireEvent.change(screen.getByTestId("firmware-version"), { target: { value: "2.0.0" } });
+
+    expect(screen.getByTestId("file-drop-zone")).toHaveAttribute("data-disabled", "false");
+  });
+});

--- a/client/src/protoFleet/features/settings/components/FirmwareUploadDialog.test.tsx
+++ b/client/src/protoFleet/features/settings/components/FirmwareUploadDialog.test.tsx
@@ -1,43 +1,75 @@
 import type { ChangeEvent, ReactNode } from "react";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import FirmwareUploadDialog from "./FirmwareUploadDialog";
 
 const mockGetMinerModelGroups = vi.fn();
 const mockProcessFile = vi.fn();
+const mockUseFirmwareUpload = vi.fn();
+const mockUpdateFirmwareMetadata = vi.fn();
+
+vi.mock("@/protoFleet/api/useFirmwareApi", () => ({
+  useFirmwareApi: () => ({ updateFirmwareMetadata: mockUpdateFirmwareMetadata }),
+}));
 
 vi.mock("@/protoFleet/api/useMinerModelGroups", () => ({
   default: () => ({ getMinerModelGroups: mockGetMinerModelGroups }),
 }));
 
 vi.mock("@/protoFleet/components/FirmwareUpload", () => ({
-  useFirmwareUpload: () => ({
-    state: "idle",
-    file: null,
-    uploadProgress: 0,
-    errorMessage: null,
-    serverConfig: { allowedExtensions: [".swu"] },
-    processFile: mockProcessFile,
-    reset: vi.fn(),
-    retry: vi.fn(),
-  }),
-  FileDropZone: ({ disabled }: { disabled?: boolean }) => (
-    <div data-testid="file-drop-zone" data-disabled={String(!!disabled)} />
+  useFirmwareUpload: () => mockUseFirmwareUpload(),
+  FileDropZone: ({ disabled, onFileSelect }: { disabled?: boolean; onFileSelect: (file: File) => void }) => (
+    <button
+      type="button"
+      data-testid="file-drop-zone"
+      data-disabled={String(!!disabled)}
+      disabled={disabled}
+      onClick={() => onFileSelect(new File(["firmware"], "update.swu"))}
+    />
   ),
   FileErrorStatus: vi.fn(() => null),
   FileProcessingStatus: vi.fn(() => null),
-  FileReadyStatus: vi.fn(() => null),
+  FileReadyStatus: vi.fn(() => <div data-testid="file-ready-status" />),
 }));
 
 vi.mock("@/shared/components/Modal/Modal", () => ({
-  default: ({ children, open }: { children: ReactNode; open?: boolean }) => (open ? <div>{children}</div> : null),
+  default: ({
+    children,
+    open,
+    buttons,
+  }: {
+    children: ReactNode;
+    open?: boolean;
+    buttons?: Array<{ text: string; onClick?: () => void; disabled?: boolean }>;
+  }) =>
+    open ? (
+      <div>
+        {children}
+        {buttons?.map((button) => (
+          <button key={button.text} onClick={button.onClick} disabled={button.disabled}>
+            {button.text}
+          </button>
+        ))}
+      </div>
+    ) : null,
 }));
 
 vi.mock("@/shared/components/Select", () => ({
-  default: ({ id, onChange, disabled }: { id: string; onChange: (value: string) => void; disabled?: boolean }) => (
+  default: ({
+    id,
+    value,
+    onChange,
+    disabled,
+  }: {
+    id: string;
+    value: string;
+    onChange: (value: string) => void;
+    disabled?: boolean;
+  }) => (
     <button
       type="button"
       data-testid={id}
+      data-value={value}
       disabled={disabled}
       onClick={() => onChange(id.includes("manufacturer") ? "Proto" : "Rig")}
     >
@@ -47,9 +79,21 @@ vi.mock("@/shared/components/Select", () => ({
 }));
 
 vi.mock("@/shared/components/Input", () => ({
-  default: ({ id, onChange }: { id: string; onChange: (value: string) => void }) => (
+  default: ({
+    id,
+    initValue,
+    onChange,
+    disabled,
+  }: {
+    id: string;
+    initValue?: string;
+    onChange: (value: string) => void;
+    disabled?: boolean;
+  }) => (
     <input
       data-testid={id}
+      value={initValue ?? ""}
+      disabled={disabled}
       onChange={(event: ChangeEvent<HTMLInputElement>) => onChange(event.target.value)}
     />
   ),
@@ -58,7 +102,19 @@ vi.mock("@/shared/components/Input", () => ({
 describe("FirmwareUploadDialog", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUpdateFirmwareMetadata.mockResolvedValue(undefined);
     mockGetMinerModelGroups.mockResolvedValue([{ manufacturer: "Proto", model: "Rig", count: 1 }]);
+    mockUseFirmwareUpload.mockReturnValue({
+      state: "idle",
+      file: null,
+      firmwareFileId: null,
+      uploadProgress: 0,
+      errorMessage: null,
+      serverConfig: { allowedExtensions: [".swu"] },
+      processFile: mockProcessFile,
+      reset: vi.fn(),
+      retry: vi.fn(),
+    });
   });
 
   it("disables file selection until manufacturer, model, and version are complete", async () => {
@@ -72,5 +128,131 @@ describe("FirmwareUploadDialog", () => {
     fireEvent.change(screen.getByTestId("firmware-version"), { target: { value: "2.0.0" } });
 
     expect(screen.getByTestId("file-drop-zone")).toHaveAttribute("data-disabled", "false");
+  });
+
+  it("keeps uploaded firmware metadata visible and editable", async () => {
+    const view = render(<FirmwareUploadDialog open onSuccess={vi.fn()} onDismiss={vi.fn()} />);
+
+    await screen.findByTestId("firmware-target-manufacturer");
+    fireEvent.click(screen.getByTestId("firmware-target-manufacturer"));
+    fireEvent.click(screen.getByTestId("firmware-target-model"));
+    fireEvent.change(screen.getByTestId("firmware-version"), { target: { value: "2.0.0" } });
+    fireEvent.click(screen.getByTestId("file-drop-zone"));
+
+    mockUseFirmwareUpload.mockReturnValue({
+      state: "ready",
+      file: new File(["firmware"], "update.swu"),
+      firmwareFileId: "firmware-1",
+      uploadProgress: 100,
+      errorMessage: null,
+      serverConfig: { allowedExtensions: [".swu"] },
+      processFile: mockProcessFile,
+      reset: vi.fn(),
+      retry: vi.fn(),
+    });
+    view.rerender(<FirmwareUploadDialog open onSuccess={vi.fn()} onDismiss={vi.fn()} />);
+
+    expect(await screen.findByTestId("firmware-target-manufacturer")).not.toBeDisabled();
+    expect(screen.getByTestId("firmware-target-manufacturer")).toHaveAttribute("data-value", "Proto");
+    expect(screen.getByTestId("firmware-target-model")).not.toBeDisabled();
+    expect(screen.getByTestId("firmware-target-model")).toHaveAttribute("data-value", "Rig");
+    expect(screen.getByTestId("firmware-version")).not.toBeDisabled();
+    expect(screen.getByTestId("firmware-version")).toHaveValue("2.0.0");
+    expect(screen.getByTestId("file-ready-status")).toBeInTheDocument();
+    expect(screen.queryByTestId("file-drop-zone")).not.toBeInTheDocument();
+    expect(screen.queryByText("Edit metadata")).not.toBeInTheDocument();
+    expect(screen.getByText("Done")).toBeInTheDocument();
+  });
+
+  it("updates changed metadata when Done is selected", async () => {
+    const onSuccess = vi.fn();
+    const view = render(<FirmwareUploadDialog open onSuccess={onSuccess} onDismiss={vi.fn()} />);
+
+    await screen.findByTestId("firmware-target-manufacturer");
+    fireEvent.click(screen.getByTestId("firmware-target-manufacturer"));
+    fireEvent.click(screen.getByTestId("firmware-target-model"));
+    fireEvent.change(screen.getByTestId("firmware-version"), { target: { value: "2.0.0" } });
+    fireEvent.click(screen.getByTestId("file-drop-zone"));
+
+    mockUseFirmwareUpload.mockReturnValue({
+      state: "ready",
+      file: new File(["firmware"], "update.swu"),
+      firmwareFileId: "firmware-1",
+      uploadProgress: 100,
+      errorMessage: null,
+      serverConfig: { allowedExtensions: [".swu"] },
+      processFile: mockProcessFile,
+      reset: vi.fn(),
+      retry: vi.fn(),
+    });
+    view.rerender(<FirmwareUploadDialog open onSuccess={onSuccess} onDismiss={vi.fn()} />);
+
+    fireEvent.change(screen.getByTestId("firmware-version"), { target: { value: "2.1.0" } });
+    fireEvent.click(screen.getByText("Done"));
+
+    await waitFor(() => {
+      expect(mockUpdateFirmwareMetadata).toHaveBeenCalledWith("firmware-1", {
+        targetManufacturer: "Proto",
+        targetModel: "Rig",
+        firmwareVersion: "2.1.0",
+      });
+      expect(onSuccess).toHaveBeenCalledOnce();
+    });
+  });
+
+  it("closes without updating unchanged metadata when Done is selected", async () => {
+    const onSuccess = vi.fn();
+    const view = render(<FirmwareUploadDialog open onSuccess={onSuccess} onDismiss={vi.fn()} />);
+
+    await screen.findByTestId("firmware-target-manufacturer");
+    fireEvent.click(screen.getByTestId("firmware-target-manufacturer"));
+    fireEvent.click(screen.getByTestId("firmware-target-model"));
+    fireEvent.change(screen.getByTestId("firmware-version"), { target: { value: "2.0.0" } });
+    fireEvent.click(screen.getByTestId("file-drop-zone"));
+
+    mockUseFirmwareUpload.mockReturnValue({
+      state: "ready",
+      file: new File(["firmware"], "update.swu"),
+      firmwareFileId: "firmware-1",
+      uploadProgress: 100,
+      errorMessage: null,
+      serverConfig: { allowedExtensions: [".swu"] },
+      processFile: mockProcessFile,
+      reset: vi.fn(),
+      retry: vi.fn(),
+    });
+    view.rerender(<FirmwareUploadDialog open onSuccess={onSuccess} onDismiss={vi.fn()} />);
+
+    fireEvent.click(screen.getByText("Done"));
+
+    expect(mockUpdateFirmwareMetadata).not.toHaveBeenCalled();
+    expect(onSuccess).toHaveBeenCalledOnce();
+  });
+
+  it("keeps Done unavailable while changed metadata is incomplete", async () => {
+    const view = render(<FirmwareUploadDialog open onSuccess={vi.fn()} onDismiss={vi.fn()} />);
+
+    await screen.findByTestId("firmware-target-manufacturer");
+    fireEvent.click(screen.getByTestId("firmware-target-manufacturer"));
+    fireEvent.click(screen.getByTestId("firmware-target-model"));
+    fireEvent.change(screen.getByTestId("firmware-version"), { target: { value: "2.0.0" } });
+    fireEvent.click(screen.getByTestId("file-drop-zone"));
+
+    mockUseFirmwareUpload.mockReturnValue({
+      state: "ready",
+      file: new File(["firmware"], "update.swu"),
+      firmwareFileId: "firmware-1",
+      uploadProgress: 100,
+      errorMessage: null,
+      serverConfig: { allowedExtensions: [".swu"] },
+      processFile: mockProcessFile,
+      reset: vi.fn(),
+      retry: vi.fn(),
+    });
+    view.rerender(<FirmwareUploadDialog open onSuccess={vi.fn()} onDismiss={vi.fn()} />);
+
+    fireEvent.click(screen.getByTestId("firmware-target-manufacturer"));
+
+    expect(screen.getByText("Done")).toBeDisabled();
   });
 });

--- a/client/src/protoFleet/features/settings/components/FirmwareUploadDialog.test.tsx
+++ b/client/src/protoFleet/features/settings/components/FirmwareUploadDialog.test.tsx
@@ -6,11 +6,7 @@ import FirmwareUploadDialog from "./FirmwareUploadDialog";
 const mockGetMinerModelGroups = vi.fn();
 const mockProcessFile = vi.fn();
 const mockUseFirmwareUpload = vi.fn();
-const mockUpdateFirmwareMetadata = vi.fn();
-
-vi.mock("@/protoFleet/api/useFirmwareApi", () => ({
-  useFirmwareApi: () => ({ updateFirmwareMetadata: mockUpdateFirmwareMetadata }),
-}));
+let mockSelectedFile: File;
 
 vi.mock("@/protoFleet/api/useMinerModelGroups", () => ({
   default: () => ({ getMinerModelGroups: mockGetMinerModelGroups }),
@@ -24,12 +20,20 @@ vi.mock("@/protoFleet/components/FirmwareUpload", () => ({
       data-testid="file-drop-zone"
       data-disabled={String(!!disabled)}
       disabled={disabled}
-      onClick={() => onFileSelect(new File(["firmware"], "update.swu"))}
+      onClick={() => onFileSelect(mockSelectedFile)}
     />
   ),
+  FileSelectedStatus: ({ fileName, onRemove }: { fileName: string; fileSize: number; onRemove: () => void }) => (
+    <div data-testid="file-selected-status">
+      {fileName}
+      <button type="button" onClick={onRemove}>
+        Remove
+      </button>
+    </div>
+  ),
+  firmwareVersionFromFilename: (filename: string) => filename.match(/(\d+\.\d+\.\d+)/)?.[1] ?? null,
   FileErrorStatus: vi.fn(() => null),
   FileProcessingStatus: vi.fn(() => null),
-  FileReadyStatus: vi.fn(() => <div data-testid="file-ready-status" />),
 }));
 
 vi.mock("@/shared/components/Modal/Modal", () => ({
@@ -102,7 +106,7 @@ vi.mock("@/shared/components/Input", () => ({
 describe("FirmwareUploadDialog", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockUpdateFirmwareMetadata.mockResolvedValue(undefined);
+    mockSelectedFile = new File(["firmware"], "update-2.0.0.swu");
     mockGetMinerModelGroups.mockResolvedValue([{ manufacturer: "Proto", model: "Rig", count: 1 }]);
     mockUseFirmwareUpload.mockReturnValue({
       state: "idle",
@@ -117,142 +121,76 @@ describe("FirmwareUploadDialog", () => {
     });
   });
 
-  it("disables file selection until manufacturer, model, and version are complete", async () => {
+  it("selects a file before metadata is complete and infers its version", async () => {
     render(<FirmwareUploadDialog open onSuccess={vi.fn()} onDismiss={vi.fn()} />);
 
     const dropZone = await screen.findByTestId("file-drop-zone");
-    expect(dropZone).toHaveAttribute("data-disabled", "true");
+    expect(dropZone).toHaveAttribute("data-disabled", "false");
+    fireEvent.click(dropZone);
 
-    fireEvent.click(screen.getByTestId("firmware-target-manufacturer"));
-    fireEvent.click(screen.getByTestId("firmware-target-model"));
-    fireEvent.change(screen.getByTestId("firmware-version"), { target: { value: "2.0.0" } });
-
-    expect(screen.getByTestId("file-drop-zone")).toHaveAttribute("data-disabled", "false");
-  });
-
-  it("keeps uploaded firmware metadata visible and editable", async () => {
-    const view = render(<FirmwareUploadDialog open onSuccess={vi.fn()} onDismiss={vi.fn()} />);
-
-    await screen.findByTestId("firmware-target-manufacturer");
-    fireEvent.click(screen.getByTestId("firmware-target-manufacturer"));
-    fireEvent.click(screen.getByTestId("firmware-target-model"));
-    fireEvent.change(screen.getByTestId("firmware-version"), { target: { value: "2.0.0" } });
-    fireEvent.click(screen.getByTestId("file-drop-zone"));
-
-    mockUseFirmwareUpload.mockReturnValue({
-      state: "ready",
-      file: new File(["firmware"], "update.swu"),
-      firmwareFileId: "firmware-1",
-      uploadProgress: 100,
-      errorMessage: null,
-      serverConfig: { allowedExtensions: [".swu"] },
-      processFile: mockProcessFile,
-      reset: vi.fn(),
-      retry: vi.fn(),
-    });
-    view.rerender(<FirmwareUploadDialog open onSuccess={vi.fn()} onDismiss={vi.fn()} />);
-
-    expect(await screen.findByTestId("firmware-target-manufacturer")).not.toBeDisabled();
-    expect(screen.getByTestId("firmware-target-manufacturer")).toHaveAttribute("data-value", "Proto");
-    expect(screen.getByTestId("firmware-target-model")).not.toBeDisabled();
-    expect(screen.getByTestId("firmware-target-model")).toHaveAttribute("data-value", "Rig");
-    expect(screen.getByTestId("firmware-version")).not.toBeDisabled();
+    expect(screen.getByTestId("file-selected-status")).toHaveTextContent("update-2.0.0.swu");
     expect(screen.getByTestId("firmware-version")).toHaveValue("2.0.0");
-    expect(screen.getByTestId("file-ready-status")).toBeInTheDocument();
-    expect(screen.queryByTestId("file-drop-zone")).not.toBeInTheDocument();
-    expect(screen.queryByText("Edit metadata")).not.toBeInTheDocument();
-    expect(screen.getByText("Done")).toBeInTheDocument();
-  });
+    expect(screen.getByText("Upload")).toBeDisabled();
+    expect(mockProcessFile).not.toHaveBeenCalled();
 
-  it("updates changed metadata when Done is selected", async () => {
-    const onSuccess = vi.fn();
-    const view = render(<FirmwareUploadDialog open onSuccess={onSuccess} onDismiss={vi.fn()} />);
-
-    await screen.findByTestId("firmware-target-manufacturer");
     fireEvent.click(screen.getByTestId("firmware-target-manufacturer"));
     fireEvent.click(screen.getByTestId("firmware-target-model"));
-    fireEvent.change(screen.getByTestId("firmware-version"), { target: { value: "2.0.0" } });
-    fireEvent.click(screen.getByTestId("file-drop-zone"));
 
-    mockUseFirmwareUpload.mockReturnValue({
-      state: "ready",
-      file: new File(["firmware"], "update.swu"),
-      firmwareFileId: "firmware-1",
-      uploadProgress: 100,
-      errorMessage: null,
-      serverConfig: { allowedExtensions: [".swu"] },
-      processFile: mockProcessFile,
-      reset: vi.fn(),
-      retry: vi.fn(),
-    });
-    view.rerender(<FirmwareUploadDialog open onSuccess={onSuccess} onDismiss={vi.fn()} />);
+    expect(screen.getByText("Upload")).not.toBeDisabled();
+    fireEvent.click(screen.getByText("Upload"));
 
-    fireEvent.change(screen.getByTestId("firmware-version"), { target: { value: "2.1.0" } });
-    fireEvent.click(screen.getByText("Done"));
-
-    await waitFor(() => {
-      expect(mockUpdateFirmwareMetadata).toHaveBeenCalledWith("firmware-1", {
+    expect(mockProcessFile).toHaveBeenCalledWith(
+      mockSelectedFile,
+      {
         targetManufacturer: "Proto",
         targetModel: "Rig",
-        firmwareVersion: "2.1.0",
-      });
+        firmwareVersion: "2.0.0",
+      },
+      expect.any(Function),
+    );
+  });
+
+  it("does not replace a version entered before file selection", async () => {
+    render(<FirmwareUploadDialog open onSuccess={vi.fn()} onDismiss={vi.fn()} />);
+
+    await screen.findByTestId("file-drop-zone");
+    fireEvent.change(screen.getByTestId("firmware-version"), { target: { value: "9.0.0" } });
+    fireEvent.click(screen.getByTestId("file-drop-zone"));
+
+    expect(screen.getByTestId("firmware-version")).toHaveValue("9.0.0");
+  });
+
+  it("keeps upload unavailable when the filename has no version and metadata is incomplete", async () => {
+    mockSelectedFile = new File(["firmware"], "update.swu");
+    render(<FirmwareUploadDialog open onSuccess={vi.fn()} onDismiss={vi.fn()} />);
+
+    await screen.findByTestId("file-drop-zone");
+    fireEvent.click(screen.getByTestId("file-drop-zone"));
+    fireEvent.click(screen.getByTestId("firmware-target-manufacturer"));
+    fireEvent.click(screen.getByTestId("firmware-target-model"));
+
+    expect(screen.getByTestId("firmware-version")).toHaveValue("");
+    expect(screen.getByText("Upload")).toBeDisabled();
+    expect(mockProcessFile).not.toHaveBeenCalled();
+  });
+
+  it("closes and refreshes after the upload becomes ready", async () => {
+    const onSuccess = vi.fn();
+    render(<FirmwareUploadDialog open onSuccess={onSuccess} onDismiss={vi.fn()} />);
+
+    await screen.findByTestId("firmware-target-manufacturer");
+    fireEvent.click(screen.getByTestId("firmware-target-manufacturer"));
+    fireEvent.click(screen.getByTestId("firmware-target-model"));
+    fireEvent.change(screen.getByTestId("firmware-version"), { target: { value: "2.0.0" } });
+    fireEvent.click(screen.getByTestId("file-drop-zone"));
+    fireEvent.click(screen.getByText("Upload"));
+
+    const onReady = mockProcessFile.mock.calls[0]?.[2] as (() => void) | undefined;
+    onReady?.();
+
+    await waitFor(() => {
       expect(onSuccess).toHaveBeenCalledOnce();
     });
-  });
-
-  it("closes without updating unchanged metadata when Done is selected", async () => {
-    const onSuccess = vi.fn();
-    const view = render(<FirmwareUploadDialog open onSuccess={onSuccess} onDismiss={vi.fn()} />);
-
-    await screen.findByTestId("firmware-target-manufacturer");
-    fireEvent.click(screen.getByTestId("firmware-target-manufacturer"));
-    fireEvent.click(screen.getByTestId("firmware-target-model"));
-    fireEvent.change(screen.getByTestId("firmware-version"), { target: { value: "2.0.0" } });
-    fireEvent.click(screen.getByTestId("file-drop-zone"));
-
-    mockUseFirmwareUpload.mockReturnValue({
-      state: "ready",
-      file: new File(["firmware"], "update.swu"),
-      firmwareFileId: "firmware-1",
-      uploadProgress: 100,
-      errorMessage: null,
-      serverConfig: { allowedExtensions: [".swu"] },
-      processFile: mockProcessFile,
-      reset: vi.fn(),
-      retry: vi.fn(),
-    });
-    view.rerender(<FirmwareUploadDialog open onSuccess={onSuccess} onDismiss={vi.fn()} />);
-
-    fireEvent.click(screen.getByText("Done"));
-
-    expect(mockUpdateFirmwareMetadata).not.toHaveBeenCalled();
-    expect(onSuccess).toHaveBeenCalledOnce();
-  });
-
-  it("keeps Done unavailable while changed metadata is incomplete", async () => {
-    const view = render(<FirmwareUploadDialog open onSuccess={vi.fn()} onDismiss={vi.fn()} />);
-
-    await screen.findByTestId("firmware-target-manufacturer");
-    fireEvent.click(screen.getByTestId("firmware-target-manufacturer"));
-    fireEvent.click(screen.getByTestId("firmware-target-model"));
-    fireEvent.change(screen.getByTestId("firmware-version"), { target: { value: "2.0.0" } });
-    fireEvent.click(screen.getByTestId("file-drop-zone"));
-
-    mockUseFirmwareUpload.mockReturnValue({
-      state: "ready",
-      file: new File(["firmware"], "update.swu"),
-      firmwareFileId: "firmware-1",
-      uploadProgress: 100,
-      errorMessage: null,
-      serverConfig: { allowedExtensions: [".swu"] },
-      processFile: mockProcessFile,
-      reset: vi.fn(),
-      retry: vi.fn(),
-    });
-    view.rerender(<FirmwareUploadDialog open onSuccess={vi.fn()} onDismiss={vi.fn()} />);
-
-    fireEvent.click(screen.getByTestId("firmware-target-manufacturer"));
-
-    expect(screen.getByText("Done")).toBeDisabled();
+    expect(screen.queryByText("Done")).not.toBeInTheDocument();
   });
 });

--- a/client/src/protoFleet/features/settings/components/FirmwareUploadDialog.test.tsx
+++ b/client/src/protoFleet/features/settings/components/FirmwareUploadDialog.test.tsx
@@ -2,6 +2,7 @@ import type { ChangeEvent, ReactNode } from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import FirmwareUploadDialog from "./FirmwareUploadDialog";
+import { uploadHookState } from "@/protoFleet/components/FirmwareUpload/useFirmwareUpload.fixtures";
 
 const mockGetMinerModelGroups = vi.fn();
 const mockProcessFile = vi.fn();
@@ -103,25 +104,15 @@ vi.mock("@/shared/components/Input", () => ({
   ),
 }));
 
-const uploadHookState = (overrides: Record<string, unknown> = {}) => ({
-  state: "idle",
-  file: null,
-  firmwareFileId: null,
-  uploadProgress: 0,
-  errorMessage: null,
-  serverConfig: { allowedExtensions: [".swu"] },
-  processFile: mockProcessFile,
-  reset: vi.fn(),
-  retry: vi.fn(),
-  ...overrides,
-});
+const dialogUploadState = (overrides: Record<string, unknown> = {}) =>
+  uploadHookState({ serverConfig: { allowedExtensions: [".swu"] }, processFile: mockProcessFile, ...overrides });
 
 describe("FirmwareUploadDialog", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSelectedFile = new File(["firmware"], "update-2.0.0.swu");
     mockGetMinerModelGroups.mockResolvedValue([{ manufacturer: "Proto", model: "Rig", count: 1 }]);
-    mockUseFirmwareUpload.mockReturnValue(uploadHookState());
+    mockUseFirmwareUpload.mockReturnValue(dialogUploadState());
   });
 
   it("selects a file before metadata is complete and infers its version", async () => {
@@ -186,7 +177,7 @@ describe("FirmwareUploadDialog", () => {
     fireEvent.click(screen.getByText("Upload"));
     expect(mockProcessFile).toHaveBeenCalledOnce();
 
-    mockUseFirmwareUpload.mockReturnValue(uploadHookState({ state: "ready" }));
+    mockUseFirmwareUpload.mockReturnValue(dialogUploadState({ state: "ready" }));
     rerender(<FirmwareUploadDialog open onSuccess={onSuccess} onDismiss={onDismiss} />);
 
     await waitFor(() => {

--- a/client/src/protoFleet/features/settings/components/FirmwareUploadDialog.test.tsx
+++ b/client/src/protoFleet/features/settings/components/FirmwareUploadDialog.test.tsx
@@ -169,9 +169,13 @@ describe("FirmwareUploadDialog", () => {
 
     render(<FirmwareUploadDialog open onSuccess={vi.fn()} onDismiss={vi.fn()} />);
 
-    expect(
-      await screen.findByText("No paired miner models found. Pair at least one miner to populate firmware targets."),
-    ).toBeInTheDocument();
+    const targetAvailabilityCallout = await screen.findByText(
+      "No paired miner models found. Pair at least one miner to populate firmware targets.",
+    );
+    const manufacturerField = screen.getByTestId("firmware-target-manufacturer");
+
+    expect(targetAvailabilityCallout).toBeInTheDocument();
+    expect(targetAvailabilityCallout.compareDocumentPosition(manufacturerField)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
   });
 
   it("keeps the loading error authoritative when miner models cannot be loaded", async () => {

--- a/client/src/protoFleet/features/settings/components/FirmwareUploadDialog.test.tsx
+++ b/client/src/protoFleet/features/settings/components/FirmwareUploadDialog.test.tsx
@@ -164,6 +164,27 @@ describe("FirmwareUploadDialog", () => {
     expect(mockProcessFile).not.toHaveBeenCalled();
   });
 
+  it("explains why firmware targets are unavailable without paired miner models", async () => {
+    mockGetMinerModelGroups.mockResolvedValue([]);
+
+    render(<FirmwareUploadDialog open onSuccess={vi.fn()} onDismiss={vi.fn()} />);
+
+    expect(
+      await screen.findByText("No paired miner models found. Pair at least one miner to populate firmware targets."),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps the loading error authoritative when miner models cannot be loaded", async () => {
+    mockGetMinerModelGroups.mockRejectedValue(new Error("unavailable"));
+
+    render(<FirmwareUploadDialog open onSuccess={vi.fn()} onDismiss={vi.fn()} />);
+
+    expect(await screen.findByText("Couldn't load fleet miner models.")).toBeInTheDocument();
+    expect(
+      screen.queryByText("No paired miner models found. Pair at least one miner to populate firmware targets."),
+    ).not.toBeInTheDocument();
+  });
+
   it("closes and refreshes after the upload becomes ready", async () => {
     const onSuccess = vi.fn();
     const onDismiss = vi.fn();

--- a/client/src/protoFleet/features/settings/components/FirmwareUploadDialog.tsx
+++ b/client/src/protoFleet/features/settings/components/FirmwareUploadDialog.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { MinerModelGroup } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
+import { type FirmwareMetadataInput, useFirmwareApi } from "@/protoFleet/api/useFirmwareApi";
 import useMinerModelGroups from "@/protoFleet/api/useMinerModelGroups";
 import {
   FileDropZone,
@@ -23,21 +24,26 @@ interface FirmwareUploadDialogProps {
 }
 
 const FirmwareUploadDialog = ({ open, onSuccess, onDismiss }: FirmwareUploadDialogProps) => {
-  const { state, file, uploadProgress, errorMessage, serverConfig, processFile, reset, retry } =
+  const { state, file, firmwareFileId, uploadProgress, errorMessage, serverConfig, processFile, reset, retry } =
     useFirmwareUpload(!!open);
+  const { updateFirmwareMetadata } = useFirmwareApi();
   const { getMinerModelGroups } = useMinerModelGroups();
   const [targetManufacturer, setTargetManufacturer] = useState("");
   const [targetModel, setTargetModel] = useState("");
   const [firmwareVersion, setFirmwareVersion] = useState("");
   const [modelGroups, setModelGroups] = useState<MinerModelGroup[] | null>(null);
   const [modelsError, setModelsError] = useState<string | null>(null);
+  const [isSavingMetadata, setIsSavingMetadata] = useState(false);
+  const [metadataSaveError, setMetadataSaveError] = useState<string | null>(null);
+  const [savedMetadata, setSavedMetadata] = useState<FirmwareMetadataInput | null>(null);
 
   const configLoaded = serverConfig !== null;
   const modelsLoading = open && modelGroups === null && modelsError === null;
   const modelsLoaded = !modelsLoading && modelsError === null;
   const isProcessing = state === "hashing" || state === "checking" || state === "uploading";
   const showLoadingSpinner = state === "idle" && (!configLoaded || modelsLoading);
-  const showDropZone = state === "idle" && configLoaded && modelsLoaded;
+  const showMetadataFields = configLoaded && modelsLoaded;
+  const metadataLocked = (state !== "idle" && state !== "ready") || isSavingMetadata;
   const showProcessingStatus = isProcessing && file != null;
   const showReadyStatus = state === "ready" && file != null;
   const showError = state === "error" && errorMessage != null;
@@ -95,36 +101,75 @@ const FirmwareUploadDialog = ({ open, onSuccess, onDismiss }: FirmwareUploadDial
   );
   const hasCompleteTarget =
     target.targetManufacturer !== "" && target.targetModel !== "" && target.firmwareVersion !== "";
+  const hasMetadataChanges =
+    state === "ready" &&
+    (savedMetadata === null ||
+      savedMetadata.targetManufacturer !== target.targetManufacturer ||
+      savedMetadata.targetModel !== target.targetModel ||
+      savedMetadata.firmwareVersion !== target.firmwareVersion);
 
-  const handleDismiss = useCallback(() => {
-    const uploaded = state === "ready";
+  const resetDialogState = useCallback((): void => {
     reset();
     setTargetManufacturer("");
     setTargetModel("");
     setFirmwareVersion("");
     setModelGroups(null);
     setModelsError(null);
+    setIsSavingMetadata(false);
+    setMetadataSaveError(null);
+    setSavedMetadata(null);
+  }, [reset]);
+
+  const handleDismiss = useCallback(() => {
+    const uploaded = state === "ready";
+    resetDialogState();
     if (uploaded) {
       onSuccess();
     } else {
       onDismiss();
     }
-  }, [state, onDismiss, onSuccess, reset]);
+  }, [state, onDismiss, onSuccess, resetDialogState]);
 
-  const handleDone = useCallback(() => {
-    reset();
-    setTargetManufacturer("");
-    setTargetModel("");
-    setFirmwareVersion("");
-    setModelGroups(null);
-    setModelsError(null);
+  const handleDone = useCallback(async (): Promise<void> => {
+    if (hasMetadataChanges) {
+      if (!firmwareFileId || !hasCompleteTarget) return;
+      setIsSavingMetadata(true);
+      setMetadataSaveError(null);
+      try {
+        await updateFirmwareMetadata(firmwareFileId, target);
+      } catch (error) {
+        setMetadataSaveError(error instanceof Error ? error.message : "We couldn't update the metadata. Try again.");
+        setIsSavingMetadata(false);
+        return;
+      }
+    }
+
+    resetDialogState();
     onSuccess();
-  }, [onSuccess, reset]);
+  }, [
+    firmwareFileId,
+    hasCompleteTarget,
+    hasMetadataChanges,
+    onSuccess,
+    resetDialogState,
+    target,
+    updateFirmwareMetadata,
+  ]);
 
-  const buttons =
-    state === "ready"
-      ? [{ text: "Done", variant: variants.primary, onClick: handleDone, dismissModalOnClick: false }]
-      : undefined;
+  const buttons = useMemo(() => {
+    if (state !== "ready") return undefined;
+    return [
+      {
+        text: isSavingMetadata ? "Saving…" : "Done",
+        variant: variants.primary,
+        onClick: (): void => {
+          void handleDone();
+        },
+        dismissModalOnClick: false,
+        disabled: isSavingMetadata || (hasMetadataChanges && (!hasCompleteTarget || !firmwareFileId)),
+      },
+    ];
+  }, [firmwareFileId, handleDone, hasCompleteTarget, hasMetadataChanges, isSavingMetadata, state]);
 
   return (
     <Modal open={open} title="Upload firmware" onDismiss={handleDismiss} buttons={buttons} divider={false}>
@@ -138,7 +183,7 @@ const FirmwareUploadDialog = ({ open, onSuccess, onDismiss }: FirmwareUploadDial
           </div>
         ) : null}
 
-        {showDropZone ? (
+        {showMetadataFields ? (
           <>
             <div className="grid gap-4 tablet:grid-cols-2">
               <Select
@@ -147,9 +192,11 @@ const FirmwareUploadDialog = ({ open, onSuccess, onDismiss }: FirmwareUploadDial
                 options={manufacturerOptions}
                 value={targetManufacturer}
                 onChange={(value) => {
+                  setMetadataSaveError(null);
                   setTargetManufacturer(value);
                   setTargetModel("");
                 }}
+                disabled={metadataLocked}
                 forceBelow
               />
               <Select
@@ -157,8 +204,11 @@ const FirmwareUploadDialog = ({ open, onSuccess, onDismiss }: FirmwareUploadDial
                 label="Model"
                 options={modelOptions}
                 value={selectedTargetModel}
-                onChange={setTargetModel}
-                disabled={!targetManufacturer}
+                onChange={(value) => {
+                  setMetadataSaveError(null);
+                  setTargetModel(value);
+                }}
+                disabled={metadataLocked || !targetManufacturer}
                 forceBelow
               />
             </div>
@@ -166,18 +216,29 @@ const FirmwareUploadDialog = ({ open, onSuccess, onDismiss }: FirmwareUploadDial
               id="firmware-version"
               label="Firmware version"
               initValue={firmwareVersion}
-              onChange={setFirmwareVersion}
+              onChange={(value) => {
+                setMetadataSaveError(null);
+                setFirmwareVersion(value);
+              }}
+              disabled={metadataLocked}
               required
             />
-            <FileDropZone
-              extensions={serverConfig.allowedExtensions}
-              onFileSelect={(selectedFile) => processFile(selectedFile, target)}
-              disabled={!hasCompleteTarget}
-            />
+            {state === "idle" ? (
+              <FileDropZone
+                extensions={serverConfig.allowedExtensions}
+                onFileSelect={(selectedFile) => {
+                  setSavedMetadata(target);
+                  processFile(selectedFile, target);
+                }}
+                disabled={!hasCompleteTarget}
+              />
+            ) : null}
           </>
         ) : null}
 
         {modelsError ? <Callout intent="danger" prefixIcon={<Alert />} title={modelsError} /> : null}
+
+        {metadataSaveError ? <Callout intent="danger" prefixIcon={<Alert />} title={metadataSaveError} /> : null}
 
         {showProcessingStatus ? (
           <FileProcessingStatus

--- a/client/src/protoFleet/features/settings/components/FirmwareUploadDialog.tsx
+++ b/client/src/protoFleet/features/settings/components/FirmwareUploadDialog.tsx
@@ -13,6 +13,7 @@ import { variants } from "@/shared/components/Button";
 import Callout from "@/shared/components/Callout";
 import Modal from "@/shared/components/Modal/Modal";
 import ProgressCircular from "@/shared/components/ProgressCircular/ProgressCircular";
+import Input from "@/shared/components/Input";
 import Select from "@/shared/components/Select";
 
 interface FirmwareUploadDialogProps {
@@ -27,6 +28,7 @@ const FirmwareUploadDialog = ({ open, onSuccess, onDismiss }: FirmwareUploadDial
   const { getMinerModelGroups } = useMinerModelGroups();
   const [targetManufacturer, setTargetManufacturer] = useState("");
   const [targetModel, setTargetModel] = useState("");
+  const [firmwareVersion, setFirmwareVersion] = useState("");
   const [modelGroups, setModelGroups] = useState<MinerModelGroup[] | null>(null);
   const [modelsError, setModelsError] = useState<string | null>(null);
 
@@ -84,16 +86,20 @@ const FirmwareUploadDialog = ({ open, onSuccess, onDismiss }: FirmwareUploadDial
 
   const selectedTargetModel = modelOptions.some((option) => option.value === targetModel) ? targetModel : "";
   const target = useMemo(
-    () => ({ targetManufacturer: targetManufacturer.trim(), targetModel: selectedTargetModel.trim() }),
-    [targetManufacturer, selectedTargetModel],
+    () => ({
+      targetManufacturer: targetManufacturer.trim(),
+      targetModel: selectedTargetModel.trim(),
+      firmwareVersion: firmwareVersion.trim(),
+    }),
+    [firmwareVersion, targetManufacturer, selectedTargetModel],
   );
-  const hasTarget = target.targetManufacturer !== "" && target.targetModel !== "";
 
   const handleDismiss = useCallback(() => {
     const uploaded = state === "ready";
     reset();
     setTargetManufacturer("");
     setTargetModel("");
+    setFirmwareVersion("");
     setModelGroups(null);
     setModelsError(null);
     if (uploaded) {
@@ -107,6 +113,7 @@ const FirmwareUploadDialog = ({ open, onSuccess, onDismiss }: FirmwareUploadDial
     reset();
     setTargetManufacturer("");
     setTargetModel("");
+    setFirmwareVersion("");
     setModelGroups(null);
     setModelsError(null);
     onSuccess();
@@ -153,10 +160,15 @@ const FirmwareUploadDialog = ({ open, onSuccess, onDismiss }: FirmwareUploadDial
                 forceBelow
               />
             </div>
+            <Input
+              id="firmware-version"
+              label="Firmware version"
+              initValue={firmwareVersion}
+              onChange={setFirmwareVersion}
+            />
             <FileDropZone
               extensions={serverConfig.allowedExtensions}
               onFileSelect={(selectedFile) => processFile(selectedFile, target)}
-              disabled={!hasTarget}
             />
           </>
         ) : null}

--- a/client/src/protoFleet/features/settings/components/FirmwareUploadDialog.tsx
+++ b/client/src/protoFleet/features/settings/components/FirmwareUploadDialog.tsx
@@ -1,4 +1,6 @@
-import { useCallback } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { MinerModelGroup } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
+import useMinerModelGroups from "@/protoFleet/api/useMinerModelGroups";
 import {
   FileDropZone,
   FileErrorStatus,
@@ -6,9 +8,12 @@ import {
   FileReadyStatus,
   useFirmwareUpload,
 } from "@/protoFleet/components/FirmwareUpload";
+import { Alert } from "@/shared/assets/icons";
 import { variants } from "@/shared/components/Button";
+import Callout from "@/shared/components/Callout";
 import Modal from "@/shared/components/Modal/Modal";
 import ProgressCircular from "@/shared/components/ProgressCircular/ProgressCircular";
+import Select from "@/shared/components/Select";
 
 interface FirmwareUploadDialogProps {
   open?: boolean;
@@ -19,18 +24,78 @@ interface FirmwareUploadDialogProps {
 const FirmwareUploadDialog = ({ open, onSuccess, onDismiss }: FirmwareUploadDialogProps) => {
   const { state, file, uploadProgress, errorMessage, serverConfig, processFile, reset, retry } =
     useFirmwareUpload(!!open);
+  const { getMinerModelGroups } = useMinerModelGroups();
+  const [targetManufacturer, setTargetManufacturer] = useState("");
+  const [targetModel, setTargetModel] = useState("");
+  const [modelGroups, setModelGroups] = useState<MinerModelGroup[] | null>(null);
+  const [modelsError, setModelsError] = useState<string | null>(null);
 
   const configLoaded = serverConfig !== null;
+  const modelsLoading = open && modelGroups === null && modelsError === null;
+  const modelsLoaded = !modelsLoading && modelsError === null;
   const isProcessing = state === "hashing" || state === "checking" || state === "uploading";
-  const showLoadingSpinner = state === "idle" && !configLoaded;
-  const showDropZone = state === "idle" && configLoaded;
+  const showLoadingSpinner = state === "idle" && (!configLoaded || modelsLoading);
+  const showDropZone = state === "idle" && configLoaded && modelsLoaded;
   const showProcessingStatus = isProcessing && file != null;
   const showReadyStatus = state === "ready" && file != null;
   const showError = state === "error" && errorMessage != null;
 
+  useEffect(() => {
+    if (!open || modelGroups !== null || modelsError !== null) return;
+
+    let cancelled = false;
+    void getMinerModelGroups(null)
+      .then((groups) => {
+        if (!cancelled) setModelGroups(groups);
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setModelGroups([]);
+          setModelsError("Couldn't load fleet miner models.");
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [getMinerModelGroups, modelGroups, modelsError, open]);
+
+  const manufacturerOptions = useMemo(() => {
+    const manufacturers = [
+      ...new Set((modelGroups ?? []).map((group) => group.manufacturer.trim()).filter(Boolean)),
+    ].sort();
+    return [
+      { value: "", label: "Select manufacturer" },
+      ...manufacturers.map((manufacturer) => ({ value: manufacturer, label: manufacturer })),
+    ];
+  }, [modelGroups]);
+
+  const modelOptions = useMemo(() => {
+    const models = (modelGroups ?? [])
+      .filter((group) => group.manufacturer === targetManufacturer)
+      .map((group) => group.model.trim())
+      .filter(Boolean)
+      .sort();
+    return [
+      { value: "", label: "Select model" },
+      ...models.map((modelName) => ({ value: modelName, label: modelName })),
+    ];
+  }, [modelGroups, targetManufacturer]);
+
+  const selectedTargetModel = modelOptions.some((option) => option.value === targetModel) ? targetModel : "";
+  const target = useMemo(
+    () => ({ targetManufacturer: targetManufacturer.trim(), targetModel: selectedTargetModel.trim() }),
+    [targetManufacturer, selectedTargetModel],
+  );
+  const hasTarget = target.targetManufacturer !== "" && target.targetModel !== "";
+
   const handleDismiss = useCallback(() => {
     const uploaded = state === "ready";
     reset();
+    setTargetManufacturer("");
+    setTargetModel("");
+    setModelGroups(null);
+    setModelsError(null);
     if (uploaded) {
       onSuccess();
     } else {
@@ -40,6 +105,10 @@ const FirmwareUploadDialog = ({ open, onSuccess, onDismiss }: FirmwareUploadDial
 
   const handleDone = useCallback(() => {
     reset();
+    setTargetManufacturer("");
+    setTargetModel("");
+    setModelGroups(null);
+    setModelsError(null);
     onSuccess();
   }, [onSuccess, reset]);
 
@@ -60,7 +129,39 @@ const FirmwareUploadDialog = ({ open, onSuccess, onDismiss }: FirmwareUploadDial
           </div>
         ) : null}
 
-        {showDropZone ? <FileDropZone extensions={serverConfig.allowedExtensions} onFileSelect={processFile} /> : null}
+        {showDropZone ? (
+          <>
+            <div className="grid gap-4 tablet:grid-cols-2">
+              <Select
+                id="firmware-target-manufacturer"
+                label="Manufacturer"
+                options={manufacturerOptions}
+                value={targetManufacturer}
+                onChange={(value) => {
+                  setTargetManufacturer(value);
+                  setTargetModel("");
+                }}
+                forceBelow
+              />
+              <Select
+                id="firmware-target-model"
+                label="Model"
+                options={modelOptions}
+                value={selectedTargetModel}
+                onChange={setTargetModel}
+                disabled={!targetManufacturer}
+                forceBelow
+              />
+            </div>
+            <FileDropZone
+              extensions={serverConfig.allowedExtensions}
+              onFileSelect={(selectedFile) => processFile(selectedFile, target)}
+              disabled={!hasTarget}
+            />
+          </>
+        ) : null}
+
+        {modelsError ? <Callout intent="danger" prefixIcon={<Alert />} title={modelsError} /> : null}
 
         {showProcessingStatus ? (
           <FileProcessingStatus

--- a/client/src/protoFleet/features/settings/components/FirmwareUploadDialog.tsx
+++ b/client/src/protoFleet/features/settings/components/FirmwareUploadDialog.tsx
@@ -11,9 +11,9 @@ import {
 import { Alert } from "@/shared/assets/icons";
 import { variants } from "@/shared/components/Button";
 import Callout from "@/shared/components/Callout";
+import Input from "@/shared/components/Input";
 import Modal from "@/shared/components/Modal/Modal";
 import ProgressCircular from "@/shared/components/ProgressCircular/ProgressCircular";
-import Input from "@/shared/components/Input";
 import Select from "@/shared/components/Select";
 
 interface FirmwareUploadDialogProps {
@@ -165,6 +165,7 @@ const FirmwareUploadDialog = ({ open, onSuccess, onDismiss }: FirmwareUploadDial
               label="Firmware version"
               initValue={firmwareVersion}
               onChange={setFirmwareVersion}
+              required
             />
             <FileDropZone
               extensions={serverConfig.allowedExtensions}

--- a/client/src/protoFleet/features/settings/components/FirmwareUploadDialog.tsx
+++ b/client/src/protoFleet/features/settings/components/FirmwareUploadDialog.tsx
@@ -93,6 +93,8 @@ const FirmwareUploadDialog = ({ open, onSuccess, onDismiss }: FirmwareUploadDial
     }),
     [firmwareVersion, targetManufacturer, selectedTargetModel],
   );
+  const hasCompleteTarget =
+    target.targetManufacturer !== "" && target.targetModel !== "" && target.firmwareVersion !== "";
 
   const handleDismiss = useCallback(() => {
     const uploaded = state === "ready";
@@ -170,6 +172,7 @@ const FirmwareUploadDialog = ({ open, onSuccess, onDismiss }: FirmwareUploadDial
             <FileDropZone
               extensions={serverConfig.allowedExtensions}
               onFileSelect={(selectedFile) => processFile(selectedFile, target)}
+              disabled={!hasCompleteTarget}
             />
           </>
         ) : null}

--- a/client/src/protoFleet/features/settings/components/FirmwareUploadDialog.tsx
+++ b/client/src/protoFleet/features/settings/components/FirmwareUploadDialog.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import type { MinerModelGroup } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
-import useMinerModelGroups from "@/protoFleet/api/useMinerModelGroups";
+import { hasCompleteFirmwareTarget } from "@/protoFleet/api/useFirmwareApi";
 import {
   FileDropZone,
   FileErrorStatus,
@@ -9,13 +8,13 @@ import {
   firmwareVersionFromFilename,
   useFirmwareUpload,
 } from "@/protoFleet/components/FirmwareUpload";
+import FirmwareTargetFields from "@/protoFleet/features/settings/components/FirmwareTargetFields";
+import { useMinerTargetOptions } from "@/protoFleet/features/settings/components/useMinerTargetOptions";
 import { Alert } from "@/shared/assets/icons";
 import { variants } from "@/shared/components/Button";
 import Callout from "@/shared/components/Callout";
-import Input from "@/shared/components/Input";
 import Modal from "@/shared/components/Modal/Modal";
 import ProgressCircular from "@/shared/components/ProgressCircular/ProgressCircular";
-import Select from "@/shared/components/Select";
 
 interface FirmwareUploadDialogProps {
   open?: boolean;
@@ -26,87 +25,42 @@ interface FirmwareUploadDialogProps {
 const FirmwareUploadDialog = ({ open, onSuccess, onDismiss }: FirmwareUploadDialogProps) => {
   const { state, file, uploadProgress, errorMessage, serverConfig, processFile, reset, retry } =
     useFirmwareUpload(!!open);
-  const { getMinerModelGroups } = useMinerModelGroups();
   const [targetManufacturer, setTargetManufacturer] = useState("");
   const [targetModel, setTargetModel] = useState("");
   const [firmwareVersion, setFirmwareVersion] = useState("");
-  const [modelGroups, setModelGroups] = useState<MinerModelGroup[] | null>(null);
-  const [modelsError, setModelsError] = useState<string | null>(null);
   const [pendingFile, setPendingFile] = useState<File | null>(null);
+  const {
+    modelGroups,
+    modelsError,
+    manufacturerOptions,
+    modelOptions,
+    reset: resetModelOptions,
+  } = useMinerTargetOptions({ active: !!open, selectedManufacturer: targetManufacturer });
 
   const configLoaded = serverConfig !== null;
   const modelsLoading = open && modelGroups === null && modelsError === null;
-  const modelsLoaded = !modelsLoading && modelsError === null;
   const isProcessing = state === "hashing" || state === "checking" || state === "uploading";
   const showLoadingSpinner = state === "idle" && (!configLoaded || modelsLoading);
-  const showMetadataFields = configLoaded && modelsLoaded;
+  const showMetadataFields = configLoaded && !modelsLoading && modelsError === null;
   const metadataLocked = state !== "idle";
   const showProcessingStatus = isProcessing && file != null;
   const showError = state === "error" && errorMessage != null;
 
-  useEffect(() => {
-    if (!open || modelGroups !== null || modelsError !== null) return;
-
-    let cancelled = false;
-    void getMinerModelGroups(null)
-      .then((groups) => {
-        if (!cancelled) setModelGroups(groups);
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setModelGroups([]);
-          setModelsError("Couldn't load fleet miner models.");
-        }
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [getMinerModelGroups, modelGroups, modelsError, open]);
-
-  const manufacturerOptions = useMemo(() => {
-    const manufacturers = [
-      ...new Set((modelGroups ?? []).map((group) => group.manufacturer.trim()).filter(Boolean)),
-    ].sort();
-    return [
-      { value: "", label: "Select manufacturer" },
-      ...manufacturers.map((manufacturer) => ({ value: manufacturer, label: manufacturer })),
-    ];
-  }, [modelGroups]);
-
-  const modelOptions = useMemo(() => {
-    const models = (modelGroups ?? [])
-      .filter((group) => group.manufacturer === targetManufacturer)
-      .map((group) => group.model.trim())
-      .filter(Boolean)
-      .sort();
-    return [
-      { value: "", label: "Select model" },
-      ...models.map((modelName) => ({ value: modelName, label: modelName })),
-    ];
-  }, [modelGroups, targetManufacturer]);
-
   const selectedTargetModel = modelOptions.some((option) => option.value === targetModel) ? targetModel : "";
   const target = useMemo(
-    () => ({
-      targetManufacturer: targetManufacturer.trim(),
-      targetModel: selectedTargetModel.trim(),
-      firmwareVersion: firmwareVersion.trim(),
-    }),
+    () => ({ targetManufacturer, targetModel: selectedTargetModel, firmwareVersion }),
     [firmwareVersion, targetManufacturer, selectedTargetModel],
   );
-  const hasCompleteTarget =
-    target.targetManufacturer !== "" && target.targetModel !== "" && target.firmwareVersion !== "";
+  const hasCompleteTarget = hasCompleteFirmwareTarget(target);
 
   const resetDialogState = useCallback((): void => {
     reset();
     setTargetManufacturer("");
     setTargetModel("");
     setFirmwareVersion("");
-    setModelGroups(null);
-    setModelsError(null);
+    resetModelOptions();
     setPendingFile(null);
-  }, [reset]);
+  }, [reset, resetModelOptions]);
 
   const handleDismiss = useCallback(() => {
     resetDialogState();
@@ -115,12 +69,16 @@ const FirmwareUploadDialog = ({ open, onSuccess, onDismiss }: FirmwareUploadDial
 
   const handleUpload = useCallback((): void => {
     if (!pendingFile || !hasCompleteTarget) return;
-    processFile(pendingFile, target, () => {
-      resetDialogState();
-      onSuccess();
-    });
+    processFile(pendingFile, target);
     setPendingFile(null);
-  }, [hasCompleteTarget, onSuccess, pendingFile, processFile, resetDialogState, target]);
+  }, [hasCompleteTarget, pendingFile, processFile, target]);
+
+  useEffect(() => {
+    if (state !== "ready") return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- one-shot reset synchronizing dialog state with the upload hook's async completion
+    resetDialogState();
+    onSuccess();
+  }, [onSuccess, resetDialogState, state]);
 
   const buttons = useMemo(() => {
     if (state === "idle" && pendingFile) {
@@ -151,36 +109,17 @@ const FirmwareUploadDialog = ({ open, onSuccess, onDismiss }: FirmwareUploadDial
 
         {showMetadataFields ? (
           <>
-            <div className="grid gap-4 tablet:grid-cols-2">
-              <Select
-                id="firmware-target-manufacturer"
-                label="Manufacturer"
-                options={manufacturerOptions}
-                value={targetManufacturer}
-                onChange={(value) => {
-                  setTargetManufacturer(value);
-                  setTargetModel("");
-                }}
-                disabled={metadataLocked}
-                forceBelow
-              />
-              <Select
-                id="firmware-target-model"
-                label="Model"
-                options={modelOptions}
-                value={selectedTargetModel}
-                onChange={setTargetModel}
-                disabled={metadataLocked || !targetManufacturer}
-                forceBelow
-              />
-            </div>
-            <Input
-              id="firmware-version"
-              label="Firmware version"
-              initValue={firmwareVersion}
-              onChange={setFirmwareVersion}
+            <FirmwareTargetFields
+              idPrefix="firmware"
+              manufacturerOptions={manufacturerOptions}
+              modelOptions={modelOptions}
+              manufacturer={targetManufacturer}
+              model={selectedTargetModel}
+              version={firmwareVersion}
               disabled={metadataLocked}
-              required
+              onManufacturerChange={setTargetManufacturer}
+              onModelChange={setTargetModel}
+              onVersionChange={setFirmwareVersion}
             />
             {state === "idle" ? (
               pendingFile ? (

--- a/client/src/protoFleet/features/settings/components/FirmwareUploadDialog.tsx
+++ b/client/src/protoFleet/features/settings/components/FirmwareUploadDialog.tsx
@@ -1,12 +1,12 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { MinerModelGroup } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
-import { type FirmwareMetadataInput, useFirmwareApi } from "@/protoFleet/api/useFirmwareApi";
 import useMinerModelGroups from "@/protoFleet/api/useMinerModelGroups";
 import {
   FileDropZone,
   FileErrorStatus,
   FileProcessingStatus,
-  FileReadyStatus,
+  FileSelectedStatus,
+  firmwareVersionFromFilename,
   useFirmwareUpload,
 } from "@/protoFleet/components/FirmwareUpload";
 import { Alert } from "@/shared/assets/icons";
@@ -24,18 +24,15 @@ interface FirmwareUploadDialogProps {
 }
 
 const FirmwareUploadDialog = ({ open, onSuccess, onDismiss }: FirmwareUploadDialogProps) => {
-  const { state, file, firmwareFileId, uploadProgress, errorMessage, serverConfig, processFile, reset, retry } =
+  const { state, file, uploadProgress, errorMessage, serverConfig, processFile, reset, retry } =
     useFirmwareUpload(!!open);
-  const { updateFirmwareMetadata } = useFirmwareApi();
   const { getMinerModelGroups } = useMinerModelGroups();
   const [targetManufacturer, setTargetManufacturer] = useState("");
   const [targetModel, setTargetModel] = useState("");
   const [firmwareVersion, setFirmwareVersion] = useState("");
   const [modelGroups, setModelGroups] = useState<MinerModelGroup[] | null>(null);
   const [modelsError, setModelsError] = useState<string | null>(null);
-  const [isSavingMetadata, setIsSavingMetadata] = useState(false);
-  const [metadataSaveError, setMetadataSaveError] = useState<string | null>(null);
-  const [savedMetadata, setSavedMetadata] = useState<FirmwareMetadataInput | null>(null);
+  const [pendingFile, setPendingFile] = useState<File | null>(null);
 
   const configLoaded = serverConfig !== null;
   const modelsLoading = open && modelGroups === null && modelsError === null;
@@ -43,9 +40,8 @@ const FirmwareUploadDialog = ({ open, onSuccess, onDismiss }: FirmwareUploadDial
   const isProcessing = state === "hashing" || state === "checking" || state === "uploading";
   const showLoadingSpinner = state === "idle" && (!configLoaded || modelsLoading);
   const showMetadataFields = configLoaded && modelsLoaded;
-  const metadataLocked = (state !== "idle" && state !== "ready") || isSavingMetadata;
+  const metadataLocked = state !== "idle";
   const showProcessingStatus = isProcessing && file != null;
-  const showReadyStatus = state === "ready" && file != null;
   const showError = state === "error" && errorMessage != null;
 
   useEffect(() => {
@@ -101,12 +97,6 @@ const FirmwareUploadDialog = ({ open, onSuccess, onDismiss }: FirmwareUploadDial
   );
   const hasCompleteTarget =
     target.targetManufacturer !== "" && target.targetModel !== "" && target.firmwareVersion !== "";
-  const hasMetadataChanges =
-    state === "ready" &&
-    (savedMetadata === null ||
-      savedMetadata.targetManufacturer !== target.targetManufacturer ||
-      savedMetadata.targetModel !== target.targetModel ||
-      savedMetadata.firmwareVersion !== target.firmwareVersion);
 
   const resetDialogState = useCallback((): void => {
     reset();
@@ -115,61 +105,37 @@ const FirmwareUploadDialog = ({ open, onSuccess, onDismiss }: FirmwareUploadDial
     setFirmwareVersion("");
     setModelGroups(null);
     setModelsError(null);
-    setIsSavingMetadata(false);
-    setMetadataSaveError(null);
-    setSavedMetadata(null);
+    setPendingFile(null);
   }, [reset]);
 
   const handleDismiss = useCallback(() => {
-    const uploaded = state === "ready";
     resetDialogState();
-    if (uploaded) {
+    onDismiss();
+  }, [onDismiss, resetDialogState]);
+
+  const handleUpload = useCallback((): void => {
+    if (!pendingFile || !hasCompleteTarget) return;
+    processFile(pendingFile, target, () => {
+      resetDialogState();
       onSuccess();
-    } else {
-      onDismiss();
-    }
-  }, [state, onDismiss, onSuccess, resetDialogState]);
-
-  const handleDone = useCallback(async (): Promise<void> => {
-    if (hasMetadataChanges) {
-      if (!firmwareFileId || !hasCompleteTarget) return;
-      setIsSavingMetadata(true);
-      setMetadataSaveError(null);
-      try {
-        await updateFirmwareMetadata(firmwareFileId, target);
-      } catch (error) {
-        setMetadataSaveError(error instanceof Error ? error.message : "We couldn't update the metadata. Try again.");
-        setIsSavingMetadata(false);
-        return;
-      }
-    }
-
-    resetDialogState();
-    onSuccess();
-  }, [
-    firmwareFileId,
-    hasCompleteTarget,
-    hasMetadataChanges,
-    onSuccess,
-    resetDialogState,
-    target,
-    updateFirmwareMetadata,
-  ]);
+    });
+    setPendingFile(null);
+  }, [hasCompleteTarget, onSuccess, pendingFile, processFile, resetDialogState, target]);
 
   const buttons = useMemo(() => {
-    if (state !== "ready") return undefined;
-    return [
-      {
-        text: isSavingMetadata ? "Saving…" : "Done",
-        variant: variants.primary,
-        onClick: (): void => {
-          void handleDone();
+    if (state === "idle" && pendingFile) {
+      return [
+        {
+          text: "Upload",
+          variant: variants.primary,
+          onClick: handleUpload,
+          dismissModalOnClick: false,
+          disabled: !hasCompleteTarget,
         },
-        dismissModalOnClick: false,
-        disabled: isSavingMetadata || (hasMetadataChanges && (!hasCompleteTarget || !firmwareFileId)),
-      },
-    ];
-  }, [firmwareFileId, handleDone, hasCompleteTarget, hasMetadataChanges, isSavingMetadata, state]);
+      ];
+    }
+    return undefined;
+  }, [handleUpload, hasCompleteTarget, pendingFile, state]);
 
   return (
     <Modal open={open} title="Upload firmware" onDismiss={handleDismiss} buttons={buttons} divider={false}>
@@ -192,7 +158,6 @@ const FirmwareUploadDialog = ({ open, onSuccess, onDismiss }: FirmwareUploadDial
                 options={manufacturerOptions}
                 value={targetManufacturer}
                 onChange={(value) => {
-                  setMetadataSaveError(null);
                   setTargetManufacturer(value);
                   setTargetModel("");
                 }}
@@ -204,10 +169,7 @@ const FirmwareUploadDialog = ({ open, onSuccess, onDismiss }: FirmwareUploadDial
                 label="Model"
                 options={modelOptions}
                 value={selectedTargetModel}
-                onChange={(value) => {
-                  setMetadataSaveError(null);
-                  setTargetModel(value);
-                }}
+                onChange={setTargetModel}
                 disabled={metadataLocked || !targetManufacturer}
                 forceBelow
               />
@@ -216,29 +178,34 @@ const FirmwareUploadDialog = ({ open, onSuccess, onDismiss }: FirmwareUploadDial
               id="firmware-version"
               label="Firmware version"
               initValue={firmwareVersion}
-              onChange={(value) => {
-                setMetadataSaveError(null);
-                setFirmwareVersion(value);
-              }}
+              onChange={setFirmwareVersion}
               disabled={metadataLocked}
               required
             />
             {state === "idle" ? (
-              <FileDropZone
-                extensions={serverConfig.allowedExtensions}
-                onFileSelect={(selectedFile) => {
-                  setSavedMetadata(target);
-                  processFile(selectedFile, target);
-                }}
-                disabled={!hasCompleteTarget}
-              />
+              pendingFile ? (
+                <FileSelectedStatus
+                  fileName={pendingFile.name}
+                  fileSize={pendingFile.size}
+                  onRemove={() => setPendingFile(null)}
+                />
+              ) : (
+                <FileDropZone
+                  extensions={serverConfig.allowedExtensions}
+                  onFileSelect={(selectedFile) => {
+                    setPendingFile(selectedFile);
+                    setFirmwareVersion((currentVersion) => {
+                      if (currentVersion.trim()) return currentVersion;
+                      return firmwareVersionFromFilename(selectedFile.name) ?? currentVersion;
+                    });
+                  }}
+                />
+              )
             ) : null}
           </>
         ) : null}
 
         {modelsError ? <Callout intent="danger" prefixIcon={<Alert />} title={modelsError} /> : null}
-
-        {metadataSaveError ? <Callout intent="danger" prefixIcon={<Alert />} title={metadataSaveError} /> : null}
 
         {showProcessingStatus ? (
           <FileProcessingStatus
@@ -248,8 +215,6 @@ const FirmwareUploadDialog = ({ open, onSuccess, onDismiss }: FirmwareUploadDial
             uploadProgress={uploadProgress}
           />
         ) : null}
-
-        {showReadyStatus ? <FileReadyStatus fileName={file.name} fileSize={file.size} /> : null}
 
         {showError ? <FileErrorStatus message={errorMessage} onRetry={retry} /> : null}
       </div>

--- a/client/src/protoFleet/features/settings/components/FirmwareUploadDialog.tsx
+++ b/client/src/protoFleet/features/settings/components/FirmwareUploadDialog.tsx
@@ -115,6 +115,16 @@ const FirmwareUploadDialog = ({ open, onSuccess, onDismiss }: FirmwareUploadDial
           </div>
         ) : null}
 
+        {showNoMinerModels ? (
+          <Callout
+            intent="information"
+            prefixIcon={<Info />}
+            title="No paired miner models found. Pair at least one miner to populate firmware targets."
+          />
+        ) : null}
+
+        {modelsError ? <Callout intent="danger" prefixIcon={<Alert />} title={modelsError} /> : null}
+
         {showMetadataFields ? (
           <>
             <FirmwareTargetFields
@@ -151,16 +161,6 @@ const FirmwareUploadDialog = ({ open, onSuccess, onDismiss }: FirmwareUploadDial
             ) : null}
           </>
         ) : null}
-
-        {showNoMinerModels ? (
-          <Callout
-            intent="information"
-            prefixIcon={<Info />}
-            title="No paired miner models found. Pair at least one miner to populate firmware targets."
-          />
-        ) : null}
-
-        {modelsError ? <Callout intent="danger" prefixIcon={<Alert />} title={modelsError} /> : null}
 
         {showProcessingStatus ? (
           <FileProcessingStatus

--- a/client/src/protoFleet/features/settings/components/FirmwareUploadDialog.tsx
+++ b/client/src/protoFleet/features/settings/components/FirmwareUploadDialog.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/protoFleet/components/FirmwareUpload";
 import FirmwareTargetFields from "@/protoFleet/features/settings/components/FirmwareTargetFields";
 import { useMinerTargetOptions } from "@/protoFleet/features/settings/components/useMinerTargetOptions";
-import { Alert } from "@/shared/assets/icons";
+import { Alert, Info } from "@/shared/assets/icons";
 import { variants } from "@/shared/components/Button";
 import Callout from "@/shared/components/Callout";
 import Modal from "@/shared/components/Modal/Modal";
@@ -44,6 +44,10 @@ const FirmwareUploadDialog = ({ open, onSuccess, onDismiss }: FirmwareUploadDial
 
   const configLoaded = serverConfig !== null;
   const modelsLoading = open && modelGroups === null && modelsError === null;
+  const showNoMinerModels =
+    modelGroups !== null &&
+    modelsError === null &&
+    !modelGroups.some((group) => group.manufacturer.trim() && group.model.trim());
   const isProcessing = state === "hashing" || state === "checking" || state === "uploading";
   const showLoadingSpinner = state === "idle" && (!configLoaded || modelsLoading);
   const showMetadataFields = configLoaded && !modelsLoading && modelsError === null;
@@ -146,6 +150,14 @@ const FirmwareUploadDialog = ({ open, onSuccess, onDismiss }: FirmwareUploadDial
               )
             ) : null}
           </>
+        ) : null}
+
+        {showNoMinerModels ? (
+          <Callout
+            intent="information"
+            prefixIcon={<Info />}
+            title="No paired miner models found. Pair at least one miner to populate firmware targets."
+          />
         ) : null}
 
         {modelsError ? <Callout intent="danger" prefixIcon={<Alert />} title={modelsError} /> : null}

--- a/client/src/protoFleet/features/settings/components/FirmwareUploadDialog.tsx
+++ b/client/src/protoFleet/features/settings/components/FirmwareUploadDialog.tsx
@@ -34,8 +34,13 @@ const FirmwareUploadDialog = ({ open, onSuccess, onDismiss }: FirmwareUploadDial
     modelsError,
     manufacturerOptions,
     modelOptions,
+    resolvedModel,
     reset: resetModelOptions,
-  } = useMinerTargetOptions({ active: !!open, selectedManufacturer: targetManufacturer });
+  } = useMinerTargetOptions({
+    active: !!open,
+    selectedManufacturer: targetManufacturer,
+    selectedModel: targetModel,
+  });
 
   const configLoaded = serverConfig !== null;
   const modelsLoading = open && modelGroups === null && modelsError === null;
@@ -46,10 +51,9 @@ const FirmwareUploadDialog = ({ open, onSuccess, onDismiss }: FirmwareUploadDial
   const showProcessingStatus = isProcessing && file != null;
   const showError = state === "error" && errorMessage != null;
 
-  const selectedTargetModel = modelOptions.some((option) => option.value === targetModel) ? targetModel : "";
   const target = useMemo(
-    () => ({ targetManufacturer, targetModel: selectedTargetModel, firmwareVersion }),
-    [firmwareVersion, targetManufacturer, selectedTargetModel],
+    () => ({ targetManufacturer, targetModel: resolvedModel, firmwareVersion }),
+    [firmwareVersion, targetManufacturer, resolvedModel],
   );
   const hasCompleteTarget = hasCompleteFirmwareTarget(target);
 
@@ -114,7 +118,7 @@ const FirmwareUploadDialog = ({ open, onSuccess, onDismiss }: FirmwareUploadDial
               manufacturerOptions={manufacturerOptions}
               modelOptions={modelOptions}
               manufacturer={targetManufacturer}
-              model={selectedTargetModel}
+              model={resolvedModel}
               version={firmwareVersion}
               disabled={metadataLocked}
               onManufacturerChange={setTargetManufacturer}

--- a/client/src/protoFleet/features/settings/components/useMinerTargetOptions.ts
+++ b/client/src/protoFleet/features/settings/components/useMinerTargetOptions.ts
@@ -1,0 +1,79 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { MinerModelGroup } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
+import useMinerModelGroups from "@/protoFleet/api/useMinerModelGroups";
+
+const MINER_MODELS_ERROR_MESSAGE = "Couldn't load fleet miner models.";
+
+interface UseMinerTargetOptionsArgs {
+  /** Fetch model groups while true (typically the dialog's open state). */
+  active: boolean;
+  /** Currently selected manufacturer; model options are limited to it. */
+  selectedManufacturer: string;
+  /** Existing values kept selectable even when absent from the fleet. */
+  seedManufacturer?: string;
+  seedModel?: string;
+}
+
+/**
+ * Loads the fleet's miner model groups and builds the Manufacturer/Model
+ * select options shared by the firmware metadata dialogs. `reset` clears the
+ * fetched groups so the next activation refetches.
+ */
+export function useMinerTargetOptions({
+  active,
+  selectedManufacturer,
+  seedManufacturer = "",
+  seedModel = "",
+}: UseMinerTargetOptionsArgs) {
+  const { getMinerModelGroups } = useMinerModelGroups();
+  const [modelGroups, setModelGroups] = useState<MinerModelGroup[] | null>(null);
+  const [modelsError, setModelsError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!active || modelGroups !== null || modelsError !== null) return;
+    let cancelled = false;
+    void getMinerModelGroups(null)
+      .then((groups) => {
+        if (!cancelled) setModelGroups(groups);
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setModelGroups([]);
+          setModelsError(MINER_MODELS_ERROR_MESSAGE);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [active, getMinerModelGroups, modelGroups, modelsError]);
+
+  const reset = useCallback(() => {
+    setModelGroups(null);
+    setModelsError(null);
+  }, []);
+
+  const manufacturerOptions = useMemo(() => {
+    const manufacturers = new Set((modelGroups ?? []).map((group) => group.manufacturer.trim()).filter(Boolean));
+    if (seedManufacturer.trim()) manufacturers.add(seedManufacturer.trim());
+    return [
+      { value: "", label: "Select manufacturer" },
+      ...[...manufacturers].sort().map((manufacturer) => ({ value: manufacturer, label: manufacturer })),
+    ];
+  }, [modelGroups, seedManufacturer]);
+
+  const modelOptions = useMemo(() => {
+    const models = new Set(
+      (modelGroups ?? [])
+        .filter((group) => group.manufacturer.trim() === selectedManufacturer.trim())
+        .map((group) => group.model.trim())
+        .filter(Boolean),
+    );
+    if (seedModel.trim()) models.add(seedModel.trim());
+    return [
+      { value: "", label: "Select model" },
+      ...[...models].sort().map((model) => ({ value: model, label: model })),
+    ];
+  }, [modelGroups, selectedManufacturer, seedModel]);
+
+  return { modelGroups, modelsError, manufacturerOptions, modelOptions, reset };
+}

--- a/client/src/protoFleet/features/settings/components/useMinerTargetOptions.ts
+++ b/client/src/protoFleet/features/settings/components/useMinerTargetOptions.ts
@@ -9,6 +9,8 @@ interface UseMinerTargetOptionsArgs {
   active: boolean;
   /** Currently selected manufacturer; model options are limited to it. */
   selectedManufacturer: string;
+  /** Currently selected model, reconciled against the options as `resolvedModel`. */
+  selectedModel: string;
   /** Existing values kept selectable even when absent from the fleet. */
   seedManufacturer?: string;
   seedModel?: string;
@@ -18,10 +20,16 @@ interface UseMinerTargetOptionsArgs {
  * Loads the fleet's miner model groups and builds the Manufacturer/Model
  * select options shared by the firmware metadata dialogs. `reset` clears the
  * fetched groups so the next activation refetches.
+ *
+ * Because `modelOptions` narrows to the selected manufacturer and arrives
+ * asynchronously, `selectedModel` can fall out of the list. This hook owns that
+ * invariant: use `resolvedModel` rather than the raw selection so a stale model
+ * is never submitted or rendered as a phantom option.
  */
 export function useMinerTargetOptions({
   active,
   selectedManufacturer,
+  selectedModel,
   seedManufacturer = "",
   seedModel = "",
 }: UseMinerTargetOptionsArgs) {
@@ -75,5 +83,10 @@ export function useMinerTargetOptions({
     ];
   }, [modelGroups, selectedManufacturer, seedModel]);
 
-  return { modelGroups, modelsError, manufacturerOptions, modelOptions, reset };
+  const resolvedModel = useMemo(
+    () => (modelOptions.some((option) => option.value === selectedModel) ? selectedModel : ""),
+    [modelOptions, selectedModel],
+  );
+
+  return { modelGroups, modelsError, manufacturerOptions, modelOptions, resolvedModel, reset };
 }

--- a/client/src/protoFleet/features/settings/components/useMinerTargetOptions.ts
+++ b/client/src/protoFleet/features/settings/components/useMinerTargetOptions.ts
@@ -76,12 +76,14 @@ export function useMinerTargetOptions({
         .map((group) => group.model.trim())
         .filter(Boolean),
     );
-    if (seedModel.trim()) models.add(seedModel.trim());
+    const selectedManufacturerKey = selectedManufacturer.trim().toLowerCase();
+    const seedManufacturerKey = seedManufacturer.trim().toLowerCase();
+    if (seedModel.trim() && selectedManufacturerKey === seedManufacturerKey) models.add(seedModel.trim());
     return [
       { value: "", label: "Select model" },
       ...[...models].sort().map((model) => ({ value: model, label: model })),
     ];
-  }, [modelGroups, selectedManufacturer, seedModel]);
+  }, [modelGroups, seedManufacturer, seedModel, selectedManufacturer]);
 
   const resolvedModel = useMemo(
     () => (modelOptions.some((option) => option.value === selectedModel) ? selectedModel : ""),

--- a/plugin/proto/internal/device/device.go
+++ b/plugin/proto/internal/device/device.go
@@ -305,13 +305,13 @@ func (d *Device) refreshFirmwareVersion(ctx context.Context, metrics *sdk.Device
 	if time.Since(d.lastFirmwareCheckAt) < firmwareRefreshInterval {
 		return
 	}
-	d.lastFirmwareCheckAt = time.Now()
 	fwVersion, err := d.client.GetFirmwareVersion(ctx)
 	if err != nil {
 		slog.Debug("failed to get firmware version during Status", "error", err)
 		return
 	}
 	if fwVersion != "" {
+		d.lastFirmwareCheckAt = time.Now()
 		d.deviceInfo.FirmwareVersion = fwVersion
 		metrics.FirmwareVersion = fwVersion
 	}

--- a/plugin/proto/internal/device/device.go
+++ b/plugin/proto/internal/device/device.go
@@ -306,12 +306,12 @@ func (d *Device) refreshFirmwareVersion(ctx context.Context, metrics *sdk.Device
 		return
 	}
 	fwVersion, err := d.client.GetFirmwareVersion(ctx)
+	d.lastFirmwareCheckAt = time.Now()
 	if err != nil {
 		slog.Debug("failed to get firmware version during Status", "error", err)
 		return
 	}
 	if fwVersion != "" {
-		d.lastFirmwareCheckAt = time.Now()
 		d.deviceInfo.FirmwareVersion = fwVersion
 		metrics.FirmwareVersion = fwVersion
 	}

--- a/plugin/proto/internal/device/device.go
+++ b/plugin/proto/internal/device/device.go
@@ -760,6 +760,13 @@ func (d *Device) invalidateStatusCache() {
 	d.clearStatusCacheLocked()
 }
 
+func (d *Device) invalidateStatusAndFirmwareCaches() {
+	d.mutex.Lock()
+	defer d.mutex.Unlock()
+	d.clearStatusCacheLocked()
+	d.lastFirmwareCheckAt = time.Time{}
+}
+
 func (d *Device) clearStatusCacheLocked() {
 	d.lastStatus = nil
 	d.lastStatusAt = time.Time{}
@@ -904,7 +911,7 @@ func (d *Device) Reboot(ctx context.Context) error {
 		return fmt.Errorf("failed to reboot device: %w", err)
 	}
 
-	d.invalidateStatusCache()
+	d.invalidateStatusAndFirmwareCaches()
 
 	return nil
 }

--- a/plugin/proto/internal/device/device_test.go
+++ b/plugin/proto/internal/device/device_test.go
@@ -281,6 +281,68 @@ func TestUpdateMinerPasswordClearsDefaultPasswordStatusCache(t *testing.T) {
 	assert.Equal(t, 1, systemStatusCalls, "post-change status should not need an immediate extra probe")
 }
 
+func TestRebootRefreshesFirmwareVersionOnNextStatus(t *testing.T) {
+	firmwareVersion := "1.0.0"
+	var firmwareVersionCalls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v1/auth/login":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"test-token","refresh_token":"r"}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/mining":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"mining-status":{"status":"Mining"}}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/pools":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"pools":[{"id":0,"url":"stratum+tcp://pool.example:3333","user":"worker"}]}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/telemetry":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/system/status":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"default_password_active":false}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/system/reboot":
+			firmwareVersion = "2.0.0"
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/system":
+			firmwareVersionCalls++
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{"system-info":{"os":{"name":"Proto OS","version":%q}}}`, firmwareVersion)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	parsed, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	host, portStr, err := net.SplitHostPort(parsed.Host)
+	require.NoError(t, err)
+	port, err := strconv.ParseInt(portStr, 10, 32)
+	require.NoError(t, err)
+
+	dev, err := New("device-firmware-reboot", sdk.DeviceInfo{
+		Host:            host,
+		Port:            int32(port),
+		URLScheme:       "http",
+		FirmwareVersion: firmwareVersion,
+	}, sdk.UsernamePassword{Username: "admin", Password: "proto"}, SetStatusTTL(time.Hour))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = dev.Close(context.Background()) })
+
+	cached, err := dev.Status(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "1.0.0", cached.FirmwareVersion)
+	require.Equal(t, 0, firmwareVersionCalls, "known firmware should remain throttled before reboot")
+
+	require.NoError(t, dev.Reboot(context.Background()))
+
+	refreshed, err := dev.Status(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "2.0.0", refreshed.FirmwareVersion)
+	assert.Equal(t, 1, firmwareVersionCalls, "first post-reboot status should refresh activated firmware")
+}
+
 func TestDevice_CurtailFullWrapsDispatchFailureAsTransient(t *testing.T) {
 	dev := newMiningControlTestDevice(t, http.StatusInternalServerError)
 

--- a/plugin/proto/internal/device/device_test.go
+++ b/plugin/proto/internal/device/device_test.go
@@ -343,6 +343,75 @@ func TestRebootRefreshesFirmwareVersionOnNextStatus(t *testing.T) {
 	assert.Equal(t, 1, firmwareVersionCalls, "first post-reboot status should refresh activated firmware")
 }
 
+func TestRebootRetriesFirmwareVersionAfterFailedProbe(t *testing.T) {
+	firmwareVersion := "1.0.0"
+	failFirmwareVersionProbe := false
+	var firmwareVersionCalls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v1/auth/login":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"test-token","refresh_token":"r"}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/mining":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"mining-status":{"status":"Mining"}}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/pools":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"pools":[{"id":0,"url":"stratum+tcp://pool.example:3333","user":"worker"}]}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/telemetry":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{}`))
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/system/status":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"default_password_active":false}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/api/v1/system/reboot":
+			firmwareVersion = "2.0.0"
+			failFirmwareVersionProbe = true
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodGet && r.URL.Path == "/api/v1/system":
+			firmwareVersionCalls++
+			if failFirmwareVersionProbe {
+				failFirmwareVersionProbe = false
+				w.WriteHeader(http.StatusServiceUnavailable)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{"system-info":{"os":{"name":"Proto OS","version":%q}}}`, firmwareVersion)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	parsed, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	host, portStr, err := net.SplitHostPort(parsed.Host)
+	require.NoError(t, err)
+	port, err := strconv.ParseInt(portStr, 10, 32)
+	require.NoError(t, err)
+
+	dev, err := New("device-firmware-reboot-retry", sdk.DeviceInfo{
+		Host:            host,
+		Port:            int32(port),
+		URLScheme:       "http",
+		FirmwareVersion: firmwareVersion,
+	}, sdk.UsernamePassword{Username: "admin", Password: "proto"}, SetStatusTTL(0))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = dev.Close(context.Background()) })
+
+	require.NoError(t, dev.Reboot(context.Background()))
+
+	stale, err := dev.Status(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "1.0.0", stale.FirmwareVersion)
+	require.Equal(t, 1, firmwareVersionCalls, "first post-reboot firmware probe should fail")
+
+	refreshed, err := dev.Status(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "2.0.0", refreshed.FirmwareVersion)
+	assert.Equal(t, 2, firmwareVersionCalls, "failed probe should not suppress the next firmware refresh")
+}
+
 func TestDevice_CurtailFullWrapsDispatchFailureAsTransient(t *testing.T) {
 	dev := newMiningControlTestDevice(t, http.StatusInternalServerError)
 

--- a/plugin/proto/internal/device/device_test.go
+++ b/plugin/proto/internal/device/device_test.go
@@ -343,7 +343,7 @@ func TestRebootRefreshesFirmwareVersionOnNextStatus(t *testing.T) {
 	assert.Equal(t, 1, firmwareVersionCalls, "first post-reboot status should refresh activated firmware")
 }
 
-func TestRebootRetriesFirmwareVersionAfterFailedProbe(t *testing.T) {
+func TestRebootThrottlesFirmwareVersionRetryAfterFailedProbe(t *testing.T) {
 	firmwareVersion := "1.0.0"
 	failFirmwareVersionProbe := false
 	var firmwareVersionCalls int
@@ -406,10 +406,16 @@ func TestRebootRetriesFirmwareVersionAfterFailedProbe(t *testing.T) {
 	require.Equal(t, "1.0.0", stale.FirmwareVersion)
 	require.Equal(t, 1, firmwareVersionCalls, "first post-reboot firmware probe should fail")
 
+	stillStale, err := dev.Status(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "1.0.0", stillStale.FirmwareVersion)
+	require.Equal(t, 1, firmwareVersionCalls, "failed firmware probe should throttle immediate retries")
+
+	dev.lastFirmwareCheckAt = time.Now().Add(-firmwareRefreshInterval)
 	refreshed, err := dev.Status(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, "2.0.0", refreshed.FirmwareVersion)
-	assert.Equal(t, 2, firmwareVersionCalls, "failed probe should not suppress the next firmware refresh")
+	assert.Equal(t, 2, firmwareVersionCalls, "firmware refresh should retry after the throttle interval")
 }
 
 func TestDevice_CurtailFullWrapsDispatchFailureAsTransient(t *testing.T) {

--- a/server/cmd/fleetcli/firmware.go
+++ b/server/cmd/fleetcli/firmware.go
@@ -67,7 +67,7 @@ func firmwareCheckCommand() *cli.Command {
 			if err != nil {
 				return err
 			}
-			target, err := firmwareTargetFromCommandStrict(cmd)
+			target, err := firmwareTargetFromCommand(cmd)
 			if err != nil {
 				return err
 			}
@@ -105,7 +105,7 @@ func firmwareUploadCommand() *cli.Command {
 			if err != nil {
 				return err
 			}
-			target, err := firmwareTargetFromCommandStrict(cmd)
+			target, err := firmwareTargetFromCommand(cmd)
 			if err != nil {
 				return err
 			}
@@ -120,11 +120,11 @@ func firmwareUploadCommand() *cli.Command {
 			if !cmd.Bool("quiet") {
 				progress = os.Stderr
 			}
-			result, reused, err := runFirmwareUpload(ctx, client, path, target, cmd.Bool("force"), progress)
+			result, err := runFirmwareUpload(ctx, client, path, target, cmd.Bool("force"), progress)
 			if err != nil {
 				return err
 			}
-			if reused && progress != nil {
+			if result.Reused && progress != nil {
 				_, _ = fmt.Fprintln(progress, "file with identical sha256 already on server; skipped upload (use --force to re-upload)")
 			}
 			return printJSON(result)
@@ -309,24 +309,18 @@ func firmwareTargetFlags() []cli.Flag {
 	}
 }
 
-func firmwareTargetFromCommandStrict(cmd *cli.Command) (firmwareTarget, error) {
-	target := firmwareTargetFromCommand(cmd)
-	if err := target.validate(); err != nil {
-		return firmwareTarget{}, err
-	}
-	return target, nil
-}
-
-func firmwareTargetFromCommand(cmd *cli.Command) firmwareTarget {
-	return firmwareTarget{
+// firmwareTargetFromCommand reads the firmware target flags and validates that
+// all required fields are present.
+func firmwareTargetFromCommand(cmd *cli.Command) (firmwareTarget, error) {
+	target := firmwareTarget{
 		Manufacturer: strings.TrimSpace(cmd.String("target-manufacturer")),
 		Model:        strings.TrimSpace(cmd.String("target-model")),
 		Version:      strings.TrimSpace(cmd.String("firmware-version")),
 	}
-}
-
-func (t firmwareTarget) complete() bool {
-	return t.Manufacturer != "" && t.Model != "" && t.Version != ""
+	if err := target.validate(); err != nil {
+		return firmwareTarget{}, err
+	}
+	return target, nil
 }
 
 // validate reports the first missing required firmware target field.
@@ -347,31 +341,31 @@ func (t firmwareTarget) validate() error {
 // local file, hash it, reuse the server copy on a checksum hit (unless force),
 // and otherwise stream a direct or chunked upload depending on size. A nil
 // progress writer suppresses all progress output.
-func runFirmwareUpload(ctx context.Context, client *Client, path string, target firmwareTarget, force bool, progress io.Writer) (firmwareUploadResult, bool, error) {
+func runFirmwareUpload(ctx context.Context, client *Client, path string, target firmwareTarget, force bool, progress io.Writer) (firmwareUploadResult, error) {
 	var result firmwareUploadResult
 
 	f, err := os.Open(path)
 	if err != nil {
-		return result, false, fmt.Errorf("open %s: %w", path, err)
+		return result, fmt.Errorf("open %s: %w", path, err)
 	}
 	defer func() { _ = f.Close() }()
 
 	info, err := f.Stat()
 	if err != nil {
-		return result, false, fmt.Errorf("stat %s: %w", path, err)
+		return result, fmt.Errorf("stat %s: %w", path, err)
 	}
 	if info.IsDir() {
-		return result, false, fmt.Errorf("%s is a directory", path)
+		return result, fmt.Errorf("%s is a directory", path)
 	}
 	filename := filepath.Base(path)
 	size := info.Size()
 
 	cfg, err := client.FirmwareConfig(ctx)
 	if err != nil {
-		return result, false, err
+		return result, err
 	}
 	if err := validateFirmwareFile(filename, size, cfg); err != nil {
-		return result, false, err
+		return result, err
 	}
 
 	if progress != nil {
@@ -379,22 +373,20 @@ func runFirmwareUpload(ctx context.Context, client *Client, path string, target 
 	}
 	digest, err := sha256Hex(f)
 	if err != nil {
-		return result, false, fmt.Errorf("hash %s: %w", path, err)
+		return result, fmt.Errorf("hash %s: %w", path, err)
 	}
 	if _, err := f.Seek(0, io.SeekStart); err != nil {
-		return result, false, fmt.Errorf("rewind %s: %w", path, err)
+		return result, fmt.Errorf("rewind %s: %w", path, err)
 	}
 
-	if target.complete() {
-		check, err := client.FirmwareCheck(ctx, digest, target)
-		if err != nil {
-			return result, false, err
-		}
-		if check.Exists && check.FirmwareFileID != "" && !force {
-			result.FirmwareFileID = check.FirmwareFileID
-			result.Reused = true
-			return result, true, nil
-		}
+	check, err := client.FirmwareCheck(ctx, digest, target)
+	if err != nil {
+		return result, err
+	}
+	if check.Exists && check.FirmwareFileID != "" && !force {
+		result.FirmwareFileID = check.FirmwareFileID
+		result.Reused = true
+		return result, nil
 	}
 
 	reporter := newProgressPrinter(progress, size)
@@ -408,11 +400,11 @@ func runFirmwareUpload(ctx context.Context, client *Client, path string, target 
 		_, _ = fmt.Fprintln(progress)
 	}
 	if err != nil {
-		return result, false, err
+		return result, err
 	}
 	result.FirmwareFileID = uploadResp.FirmwareFileID
 	result.Reused = uploadResp.Reused
-	return result, uploadResp.Reused, nil
+	return result, nil
 }
 
 // validateFirmwareFile applies the same local checks as the web client before

--- a/server/cmd/fleetcli/firmware.go
+++ b/server/cmd/fleetcli/firmware.go
@@ -105,6 +105,10 @@ func firmwareUploadCommand() *cli.Command {
 			if err != nil {
 				return err
 			}
+			target, err := firmwareTargetFromCommandStrict(cmd)
+			if err != nil {
+				return err
+			}
 
 			client, err := openClient(ctx, cmd)
 			if err != nil {
@@ -115,10 +119,6 @@ func firmwareUploadCommand() *cli.Command {
 			var progress io.Writer
 			if !cmd.Bool("quiet") {
 				progress = os.Stderr
-			}
-			target := firmwareTargetFromCommand(cmd)
-			if err := validateFirmwareUploadTarget(path, target); err != nil {
-				return err
 			}
 			result, reused, err := runFirmwareUpload(ctx, client, path, target, cmd.Bool("force"), progress)
 			if err != nil {
@@ -341,15 +341,6 @@ func (t firmwareTarget) validate() error {
 		return fmt.Errorf("--firmware-version is required")
 	}
 	return nil
-}
-
-// validateFirmwareUploadTarget requires full target metadata for non-.swu
-// uploads; .swu images carry their target inside the file itself.
-func validateFirmwareUploadTarget(path string, target firmwareTarget) error {
-	if strings.HasSuffix(strings.ToLower(filepath.Base(path)), ".swu") {
-		return nil
-	}
-	return target.validate()
 }
 
 // runFirmwareUpload drives the full upload flow: fetch config, validate the

--- a/server/cmd/fleetcli/firmware.go
+++ b/server/cmd/fleetcli/firmware.go
@@ -61,8 +61,13 @@ func firmwareCheckCommand() *cli.Command {
 		Name:      "check",
 		Usage:     "Check whether a firmware file with the same SHA-256 already exists on the server",
 		ArgsUsage: "<path>",
+		Flags:     firmwareTargetFlags(),
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			path, err := singleArg(cmd, "<path>")
+			if err != nil {
+				return err
+			}
+			target, err := firmwareTargetFromCommand(cmd)
 			if err != nil {
 				return err
 			}
@@ -77,7 +82,7 @@ func firmwareCheckCommand() *cli.Command {
 			}
 			defer func() { _ = client.Close() }()
 
-			resp, err := client.FirmwareCheck(ctx, digest)
+			resp, err := client.FirmwareCheck(ctx, digest, target)
 			if err != nil {
 				return err
 			}
@@ -92,6 +97,8 @@ func firmwareUploadCommand() *cli.Command {
 		Usage:     "Upload a firmware file, reusing the server copy when checksums match",
 		ArgsUsage: "<path>",
 		Flags: []cli.Flag{
+			&cli.StringFlag{Name: "target-manufacturer", Usage: "Firmware target manufacturer/product"},
+			&cli.StringFlag{Name: "target-model", Usage: "Firmware target miner model"},
 			&cli.BoolFlag{Name: "force", Usage: "Upload even when a file with the same checksum already exists on the server"},
 			&cli.BoolFlag{Name: "quiet", Usage: "Suppress progress output on stderr"},
 		},
@@ -111,7 +118,11 @@ func firmwareUploadCommand() *cli.Command {
 			if !cmd.Bool("quiet") {
 				progress = os.Stderr
 			}
-			result, reused, err := runFirmwareUpload(ctx, client, path, cmd.Bool("force"), progress)
+			target, err := firmwareTargetFromCommand(cmd)
+			if err != nil {
+				return err
+			}
+			result, reused, err := runFirmwareUpload(ctx, client, path, target, cmd.Bool("force"), progress)
 			if err != nil {
 				return err
 			}
@@ -285,11 +296,37 @@ type firmwareUploadResult struct {
 	FirmwareFileID string `json:"firmware_file_id"`
 }
 
+type firmwareTarget struct {
+	Manufacturer string
+	Model        string
+}
+
+func firmwareTargetFlags() []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{Name: "target-manufacturer", Usage: "Firmware target manufacturer/product"},
+		&cli.StringFlag{Name: "target-model", Usage: "Firmware target miner model"},
+	}
+}
+
+func firmwareTargetFromCommand(cmd *cli.Command) (firmwareTarget, error) {
+	target := firmwareTarget{
+		Manufacturer: strings.TrimSpace(cmd.String("target-manufacturer")),
+		Model:        strings.TrimSpace(cmd.String("target-model")),
+	}
+	if target.Manufacturer == "" {
+		return firmwareTarget{}, fmt.Errorf("--target-manufacturer is required")
+	}
+	if target.Model == "" {
+		return firmwareTarget{}, fmt.Errorf("--target-model is required")
+	}
+	return target, nil
+}
+
 // runFirmwareUpload drives the full upload flow: fetch config, validate the
 // local file, hash it, reuse the server copy on a checksum hit (unless force),
 // and otherwise stream a direct or chunked upload depending on size. A nil
 // progress writer suppresses all progress output.
-func runFirmwareUpload(ctx context.Context, client *Client, path string, force bool, progress io.Writer) (firmwareUploadResult, bool, error) {
+func runFirmwareUpload(ctx context.Context, client *Client, path string, target firmwareTarget, force bool, progress io.Writer) (firmwareUploadResult, bool, error) {
 	var result firmwareUploadResult
 
 	f, err := os.Open(path)
@@ -327,7 +364,7 @@ func runFirmwareUpload(ctx context.Context, client *Client, path string, force b
 		return result, false, fmt.Errorf("rewind %s: %w", path, err)
 	}
 
-	check, err := client.FirmwareCheck(ctx, digest)
+	check, err := client.FirmwareCheck(ctx, digest, target)
 	if err != nil {
 		return result, false, err
 	}
@@ -339,9 +376,9 @@ func runFirmwareUpload(ctx context.Context, client *Client, path string, force b
 	reporter := newProgressPrinter(progress, size)
 	var fileID string
 	if size <= cfg.ChunkSizeBytes {
-		fileID, err = client.FirmwareUploadDirect(ctx, filename, f, reporter)
+		fileID, err = client.FirmwareUploadDirect(ctx, filename, f, target, reporter)
 	} else {
-		fileID, err = client.FirmwareUploadChunked(ctx, filename, f, size, cfg.ChunkSizeBytes, reporter)
+		fileID, err = client.FirmwareUploadChunked(ctx, filename, f, size, cfg.ChunkSizeBytes, target, reporter)
 	}
 	if reporter != nil {
 		_, _ = fmt.Fprintln(progress)

--- a/server/cmd/fleetcli/firmware.go
+++ b/server/cmd/fleetcli/firmware.go
@@ -67,7 +67,7 @@ func firmwareCheckCommand() *cli.Command {
 			if err != nil {
 				return err
 			}
-			target, err := firmwareTargetFromCommand(cmd)
+			target, err := firmwareTargetFromCommandStrict(cmd)
 			if err != nil {
 				return err
 			}
@@ -96,12 +96,10 @@ func firmwareUploadCommand() *cli.Command {
 		Name:      "upload",
 		Usage:     "Upload a firmware file, reusing the server copy when checksums match",
 		ArgsUsage: "<path>",
-		Flags: []cli.Flag{
-			&cli.StringFlag{Name: "target-manufacturer", Usage: "Firmware target manufacturer/product"},
-			&cli.StringFlag{Name: "target-model", Usage: "Firmware target miner model"},
+		Flags: append(firmwareTargetFlags(),
 			&cli.BoolFlag{Name: "force", Usage: "Upload even when a file with the same checksum already exists on the server"},
 			&cli.BoolFlag{Name: "quiet", Usage: "Suppress progress output on stderr"},
-		},
+		),
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			path, err := singleArg(cmd, "<path>")
 			if err != nil {
@@ -118,8 +116,8 @@ func firmwareUploadCommand() *cli.Command {
 			if !cmd.Bool("quiet") {
 				progress = os.Stderr
 			}
-			target, err := firmwareTargetFromCommand(cmd)
-			if err != nil {
+			target := firmwareTargetFromCommand(cmd)
+			if err := validateFirmwareUploadTarget(path, target); err != nil {
 				return err
 			}
 			result, reused, err := runFirmwareUpload(ctx, client, path, target, cmd.Bool("force"), progress)
@@ -294,32 +292,64 @@ func buildFirmwareDeployRequest(ctx context.Context, cmd *cli.Command, client *C
 
 type firmwareUploadResult struct {
 	FirmwareFileID string `json:"firmware_file_id"`
+	Reused         bool   `json:"reused,omitempty"`
 }
 
 type firmwareTarget struct {
 	Manufacturer string
 	Model        string
+	Version      string
 }
 
 func firmwareTargetFlags() []cli.Flag {
 	return []cli.Flag{
 		&cli.StringFlag{Name: "target-manufacturer", Usage: "Firmware target manufacturer/product"},
 		&cli.StringFlag{Name: "target-model", Usage: "Firmware target miner model"},
+		&cli.StringFlag{Name: "firmware-version", Usage: "Firmware version reported after a successful install"},
 	}
 }
 
-func firmwareTargetFromCommand(cmd *cli.Command) (firmwareTarget, error) {
-	target := firmwareTarget{
-		Manufacturer: strings.TrimSpace(cmd.String("target-manufacturer")),
-		Model:        strings.TrimSpace(cmd.String("target-model")),
-	}
-	if target.Manufacturer == "" {
-		return firmwareTarget{}, fmt.Errorf("--target-manufacturer is required")
-	}
-	if target.Model == "" {
-		return firmwareTarget{}, fmt.Errorf("--target-model is required")
+func firmwareTargetFromCommandStrict(cmd *cli.Command) (firmwareTarget, error) {
+	target := firmwareTargetFromCommand(cmd)
+	if err := target.validate(); err != nil {
+		return firmwareTarget{}, err
 	}
 	return target, nil
+}
+
+func firmwareTargetFromCommand(cmd *cli.Command) firmwareTarget {
+	return firmwareTarget{
+		Manufacturer: strings.TrimSpace(cmd.String("target-manufacturer")),
+		Model:        strings.TrimSpace(cmd.String("target-model")),
+		Version:      strings.TrimSpace(cmd.String("firmware-version")),
+	}
+}
+
+func (t firmwareTarget) complete() bool {
+	return t.Manufacturer != "" && t.Model != "" && t.Version != ""
+}
+
+// validate reports the first missing required firmware target field.
+func (t firmwareTarget) validate() error {
+	if t.Manufacturer == "" {
+		return fmt.Errorf("--target-manufacturer is required")
+	}
+	if t.Model == "" {
+		return fmt.Errorf("--target-model is required")
+	}
+	if t.Version == "" {
+		return fmt.Errorf("--firmware-version is required")
+	}
+	return nil
+}
+
+// validateFirmwareUploadTarget requires full target metadata for non-.swu
+// uploads; .swu images carry their target inside the file itself.
+func validateFirmwareUploadTarget(path string, target firmwareTarget) error {
+	if strings.HasSuffix(strings.ToLower(filepath.Base(path)), ".swu") {
+		return nil
+	}
+	return target.validate()
 }
 
 // runFirmwareUpload drives the full upload flow: fetch config, validate the
@@ -364,21 +394,24 @@ func runFirmwareUpload(ctx context.Context, client *Client, path string, target 
 		return result, false, fmt.Errorf("rewind %s: %w", path, err)
 	}
 
-	check, err := client.FirmwareCheck(ctx, digest, target)
-	if err != nil {
-		return result, false, err
-	}
-	if check.Exists && check.FirmwareFileID != "" && !force {
-		result.FirmwareFileID = check.FirmwareFileID
-		return result, true, nil
+	if target.complete() {
+		check, err := client.FirmwareCheck(ctx, digest, target)
+		if err != nil {
+			return result, false, err
+		}
+		if check.Exists && check.FirmwareFileID != "" && !force {
+			result.FirmwareFileID = check.FirmwareFileID
+			result.Reused = true
+			return result, true, nil
+		}
 	}
 
 	reporter := newProgressPrinter(progress, size)
-	var fileID string
+	var uploadResp *firmwareUploadResponse
 	if size <= cfg.ChunkSizeBytes {
-		fileID, err = client.FirmwareUploadDirect(ctx, filename, f, target, reporter)
+		uploadResp, err = client.FirmwareUploadDirect(ctx, filename, f, target, force, reporter)
 	} else {
-		fileID, err = client.FirmwareUploadChunked(ctx, filename, f, size, cfg.ChunkSizeBytes, target, reporter)
+		uploadResp, err = client.FirmwareUploadChunked(ctx, filename, f, size, cfg.ChunkSizeBytes, target, force, reporter)
 	}
 	if reporter != nil {
 		_, _ = fmt.Fprintln(progress)
@@ -386,8 +419,9 @@ func runFirmwareUpload(ctx context.Context, client *Client, path string, target 
 	if err != nil {
 		return result, false, err
 	}
-	result.FirmwareFileID = fileID
-	return result, false, nil
+	result.FirmwareFileID = uploadResp.FirmwareFileID
+	result.Reused = uploadResp.Reused
+	return result, uploadResp.Reused, nil
 }
 
 // validateFirmwareFile applies the same local checks as the web client before

--- a/server/cmd/fleetcli/firmware.go
+++ b/server/cmd/fleetcli/firmware.go
@@ -29,6 +29,7 @@ func firmwareCommand() *cli.Command {
 			firmwareCheckCommand(),
 			firmwareUploadCommand(),
 			firmwareListCommand(),
+			firmwareEditMetadataCommand(),
 			firmwareDeleteCommand(),
 			firmwareDeleteAllCommand(),
 			firmwareDeployCommand(),
@@ -148,6 +149,44 @@ func firmwareListCommand() *cli.Command {
 				return err
 			}
 			return printJSON(resp)
+		},
+	}
+}
+
+func firmwareEditMetadataCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "edit-metadata",
+		Usage: "Update a stored firmware file's target metadata",
+		Flags: append([]cli.Flag{
+			&cli.StringFlag{Name: "firmware-file-id", Usage: "Uploaded firmware file id", Required: true},
+		}, firmwareTargetFlags()...),
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			fileID := strings.TrimSpace(cmd.String("firmware-file-id"))
+			if fileID == "" {
+				return fmt.Errorf("--firmware-file-id is required")
+			}
+			target, err := firmwareTargetFromCommand(cmd)
+			if err != nil {
+				return err
+			}
+
+			client, err := openClient(ctx, cmd)
+			if err != nil {
+				return err
+			}
+			defer func() { _ = client.Close() }()
+
+			if err := client.FirmwareUpdateMetadata(ctx, fileID, target); err != nil {
+				return err
+			}
+			// The server replies 204 with no body; echo the updated values so
+			// the command still prints a useful JSON result.
+			return printJSON(firmwareMetadataUpdateResult{
+				FirmwareFileID:     fileID,
+				TargetManufacturer: target.Manufacturer,
+				TargetModel:        target.Model,
+				FirmwareVersion:    target.Version,
+			})
 		},
 	}
 }
@@ -293,6 +332,13 @@ func buildFirmwareDeployRequest(ctx context.Context, cmd *cli.Command, client *C
 type firmwareUploadResult struct {
 	FirmwareFileID string `json:"firmware_file_id"`
 	Reused         bool   `json:"reused,omitempty"`
+}
+
+type firmwareMetadataUpdateResult struct {
+	FirmwareFileID     string `json:"firmware_file_id"`
+	TargetManufacturer string `json:"target_manufacturer"`
+	TargetModel        string `json:"target_model"`
+	FirmwareVersion    string `json:"firmware_version"`
 }
 
 type firmwareTarget struct {

--- a/server/cmd/fleetcli/firmware_client.go
+++ b/server/cmd/fleetcli/firmware_client.go
@@ -38,6 +38,7 @@ type firmwareCheckRequest struct {
 	SHA256             string `json:"sha256"`
 	TargetManufacturer string `json:"target_manufacturer"`
 	TargetModel        string `json:"target_model"`
+	FirmwareVersion    string `json:"firmware_version"`
 }
 
 type firmwareCheckResponse struct {
@@ -52,6 +53,7 @@ type firmwareFileInfo struct {
 	UploadedAt         string `json:"uploaded_at"`
 	TargetManufacturer string `json:"target_manufacturer"`
 	TargetModel        string `json:"target_model"`
+	FirmwareVersion    string `json:"firmware_version,omitempty"`
 }
 
 type firmwareListResponse struct {
@@ -67,6 +69,8 @@ type firmwareInitiateRequest struct {
 	FileSize           int64  `json:"file_size"`
 	TargetManufacturer string `json:"target_manufacturer"`
 	TargetModel        string `json:"target_model"`
+	FirmwareVersion    string `json:"firmware_version"`
+	Force              bool   `json:"force,omitempty"`
 }
 
 type firmwareInitiateResponse struct {
@@ -75,6 +79,7 @@ type firmwareInitiateResponse struct {
 
 type firmwareUploadResponse struct {
 	FirmwareFileID string `json:"firmware_file_id"`
+	Reused         bool   `json:"reused,omitempty"`
 }
 
 // firmwareURL builds an endpoint URL under the firmware HTTP API. Firmware
@@ -211,6 +216,7 @@ func (c *Client) FirmwareCheck(ctx context.Context, sha256Hex string, target fir
 		SHA256:             sha256Hex,
 		TargetManufacturer: target.Manufacturer,
 		TargetModel:        target.Model,
+		FirmwareVersion:    target.Version,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("marshal firmware check request: %w", err)
@@ -262,17 +268,29 @@ func (c *Client) FirmwareDeleteAll(ctx context.Context) (*firmwareDeleteAllRespo
 // FirmwareUploadDirect streams the file as a single multipart request. The
 // body is piped so the file is never buffered in memory, which means the
 // request goes out with chunked transfer encoding instead of a Content-Length.
-func (c *Client) FirmwareUploadDirect(ctx context.Context, filename string, file io.Reader, target firmwareTarget, progress progressFunc) (string, error) {
+func (c *Client) FirmwareUploadDirect(ctx context.Context, filename string, file io.Reader, target firmwareTarget, force bool, progress progressFunc) (*firmwareUploadResponse, error) {
 	pr, pw := io.Pipe()
 	mw := multipart.NewWriter(pw)
 	go func() {
-		if err := mw.WriteField("target_manufacturer", target.Manufacturer); err != nil {
-			_ = pw.CloseWithError(err)
-			return
+		fields := map[string]string{
+			"target_manufacturer": target.Manufacturer,
+			"target_model":        target.Model,
+			"firmware_version":    target.Version,
 		}
-		if err := mw.WriteField("target_model", target.Model); err != nil {
-			_ = pw.CloseWithError(err)
-			return
+		for name, value := range fields {
+			if value == "" {
+				continue
+			}
+			if err := mw.WriteField(name, value); err != nil {
+				_ = pw.CloseWithError(err)
+				return
+			}
+		}
+		if force {
+			if err := mw.WriteField("force", "true"); err != nil {
+				_ = pw.CloseWithError(err)
+				return
+			}
 		}
 		part, err := mw.CreateFormFile("file", filename)
 		if err != nil {
@@ -295,23 +313,25 @@ func (c *Client) FirmwareUploadDirect(ctx context.Context, filename string, file
 		transfer:    true,
 		out:         resp,
 	}); err != nil {
-		return "", err
+		return nil, err
 	}
-	return resp.FirmwareFileID, nil
+	return resp, nil
 }
 
 // FirmwareUploadChunked uploads the file through the initiate/chunk/complete
 // flow. Chunks are sent sequentially because the server rejects out-of-order
 // ranges.
-func (c *Client) FirmwareUploadChunked(ctx context.Context, filename string, file io.ReaderAt, size, chunkSize int64, target firmwareTarget, progress progressFunc) (string, error) {
+func (c *Client) FirmwareUploadChunked(ctx context.Context, filename string, file io.ReaderAt, size, chunkSize int64, target firmwareTarget, force bool, progress progressFunc) (*firmwareUploadResponse, error) {
 	body, err := json.Marshal(firmwareInitiateRequest{
 		Filename:           filename,
 		FileSize:           size,
 		TargetManufacturer: target.Manufacturer,
 		TargetModel:        target.Model,
+		FirmwareVersion:    target.Version,
+		Force:              force,
 	})
 	if err != nil {
-		return "", fmt.Errorf("marshal chunked upload initiate request: %w", err)
+		return nil, fmt.Errorf("marshal chunked upload initiate request: %w", err)
 	}
 	initiate := &firmwareInitiateResponse{}
 	if err := c.doFirmware(ctx, firmwareRequest{
@@ -321,10 +341,10 @@ func (c *Client) FirmwareUploadChunked(ctx context.Context, filename string, fil
 		contentType: contentTypeJSON,
 		out:         initiate,
 	}); err != nil {
-		return "", err
+		return nil, err
 	}
 	if initiate.UploadID == "" {
-		return "", fmt.Errorf("chunked upload initiate did not return an upload id")
+		return nil, fmt.Errorf("chunked upload initiate did not return an upload id")
 	}
 
 	for start := int64(0); start < size; start += chunkSize {
@@ -339,7 +359,7 @@ func (c *Client) FirmwareUploadChunked(ctx context.Context, filename string, fil
 			contentRange:  fmt.Sprintf("bytes %d-%d/%d", start, end-1, size),
 			transfer:      true,
 		}); err != nil {
-			return "", err
+			return nil, err
 		}
 	}
 
@@ -350,7 +370,7 @@ func (c *Client) FirmwareUploadChunked(ctx context.Context, filename string, fil
 		transfer: true,
 		out:      resp,
 	}); err != nil {
-		return "", err
+		return nil, err
 	}
-	return resp.FirmwareFileID, nil
+	return resp, nil
 }

--- a/server/cmd/fleetcli/firmware_client.go
+++ b/server/cmd/fleetcli/firmware_client.go
@@ -35,7 +35,9 @@ type firmwareConfig struct {
 }
 
 type firmwareCheckRequest struct {
-	SHA256 string `json:"sha256"`
+	SHA256             string `json:"sha256"`
+	TargetManufacturer string `json:"target_manufacturer"`
+	TargetModel        string `json:"target_model"`
 }
 
 type firmwareCheckResponse struct {
@@ -44,10 +46,12 @@ type firmwareCheckResponse struct {
 }
 
 type firmwareFileInfo struct {
-	ID         string `json:"id"`
-	Filename   string `json:"filename"`
-	Size       int64  `json:"size"`
-	UploadedAt string `json:"uploaded_at"`
+	ID                 string `json:"id"`
+	Filename           string `json:"filename"`
+	Size               int64  `json:"size"`
+	UploadedAt         string `json:"uploaded_at"`
+	TargetManufacturer string `json:"target_manufacturer"`
+	TargetModel        string `json:"target_model"`
 }
 
 type firmwareListResponse struct {
@@ -59,8 +63,10 @@ type firmwareDeleteAllResponse struct {
 }
 
 type firmwareInitiateRequest struct {
-	Filename string `json:"filename"`
-	FileSize int64  `json:"file_size"`
+	Filename           string `json:"filename"`
+	FileSize           int64  `json:"file_size"`
+	TargetManufacturer string `json:"target_manufacturer"`
+	TargetModel        string `json:"target_model"`
 }
 
 type firmwareInitiateResponse struct {
@@ -200,8 +206,12 @@ func (c *Client) FirmwareConfig(ctx context.Context) (*firmwareConfig, error) {
 
 // FirmwareCheck asks the server whether a firmware file with the given
 // SHA-256 hex digest already exists.
-func (c *Client) FirmwareCheck(ctx context.Context, sha256Hex string) (*firmwareCheckResponse, error) {
-	body, err := json.Marshal(firmwareCheckRequest{SHA256: sha256Hex})
+func (c *Client) FirmwareCheck(ctx context.Context, sha256Hex string, target firmwareTarget) (*firmwareCheckResponse, error) {
+	body, err := json.Marshal(firmwareCheckRequest{
+		SHA256:             sha256Hex,
+		TargetManufacturer: target.Manufacturer,
+		TargetModel:        target.Model,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("marshal firmware check request: %w", err)
 	}
@@ -252,10 +262,18 @@ func (c *Client) FirmwareDeleteAll(ctx context.Context) (*firmwareDeleteAllRespo
 // FirmwareUploadDirect streams the file as a single multipart request. The
 // body is piped so the file is never buffered in memory, which means the
 // request goes out with chunked transfer encoding instead of a Content-Length.
-func (c *Client) FirmwareUploadDirect(ctx context.Context, filename string, file io.Reader, progress progressFunc) (string, error) {
+func (c *Client) FirmwareUploadDirect(ctx context.Context, filename string, file io.Reader, target firmwareTarget, progress progressFunc) (string, error) {
 	pr, pw := io.Pipe()
 	mw := multipart.NewWriter(pw)
 	go func() {
+		if err := mw.WriteField("target_manufacturer", target.Manufacturer); err != nil {
+			_ = pw.CloseWithError(err)
+			return
+		}
+		if err := mw.WriteField("target_model", target.Model); err != nil {
+			_ = pw.CloseWithError(err)
+			return
+		}
 		part, err := mw.CreateFormFile("file", filename)
 		if err != nil {
 			_ = pw.CloseWithError(err)
@@ -285,8 +303,13 @@ func (c *Client) FirmwareUploadDirect(ctx context.Context, filename string, file
 // FirmwareUploadChunked uploads the file through the initiate/chunk/complete
 // flow. Chunks are sent sequentially because the server rejects out-of-order
 // ranges.
-func (c *Client) FirmwareUploadChunked(ctx context.Context, filename string, file io.ReaderAt, size, chunkSize int64, progress progressFunc) (string, error) {
-	body, err := json.Marshal(firmwareInitiateRequest{Filename: filename, FileSize: size})
+func (c *Client) FirmwareUploadChunked(ctx context.Context, filename string, file io.ReaderAt, size, chunkSize int64, target firmwareTarget, progress progressFunc) (string, error) {
+	body, err := json.Marshal(firmwareInitiateRequest{
+		Filename:           filename,
+		FileSize:           size,
+		TargetManufacturer: target.Manufacturer,
+		TargetModel:        target.Model,
+	})
 	if err != nil {
 		return "", fmt.Errorf("marshal chunked upload initiate request: %w", err)
 	}

--- a/server/cmd/fleetcli/firmware_client.go
+++ b/server/cmd/fleetcli/firmware_client.go
@@ -272,16 +272,15 @@ func (c *Client) FirmwareUploadDirect(ctx context.Context, filename string, file
 	pr, pw := io.Pipe()
 	mw := multipart.NewWriter(pw)
 	go func() {
-		fields := map[string]string{
-			"target_manufacturer": target.Manufacturer,
-			"target_model":        target.Model,
-			"firmware_version":    target.Version,
+		// Ordered so the request body is byte-for-byte reproducible; the
+		// target fields are already required to be non-empty by validate.
+		fields := []struct{ name, value string }{
+			{"target_manufacturer", target.Manufacturer},
+			{"target_model", target.Model},
+			{"firmware_version", target.Version},
 		}
-		for name, value := range fields {
-			if value == "" {
-				continue
-			}
-			if err := mw.WriteField(name, value); err != nil {
+		for _, field := range fields {
+			if err := mw.WriteField(field.name, field.value); err != nil {
 				_ = pw.CloseWithError(err)
 				return
 			}

--- a/server/cmd/fleetcli/firmware_client.go
+++ b/server/cmd/fleetcli/firmware_client.go
@@ -41,6 +41,12 @@ type firmwareCheckRequest struct {
 	FirmwareVersion    string `json:"firmware_version"`
 }
 
+type firmwareMetadataUpdateRequest struct {
+	TargetManufacturer string `json:"target_manufacturer"`
+	TargetModel        string `json:"target_model"`
+	FirmwareVersion    string `json:"firmware_version"`
+}
+
 type firmwareCheckResponse struct {
 	Exists         bool   `json:"exists"`
 	FirmwareFileID string `json:"firmware_file_id,omitempty"`
@@ -244,6 +250,23 @@ func (c *Client) FirmwareList(ctx context.Context) (*firmwareListResponse, error
 		return nil, err
 	}
 	return resp, nil
+}
+
+func (c *Client) FirmwareUpdateMetadata(ctx context.Context, fileID string, target firmwareTarget) error {
+	body, err := json.Marshal(firmwareMetadataUpdateRequest{
+		TargetManufacturer: target.Manufacturer,
+		TargetModel:        target.Model,
+		FirmwareVersion:    target.Version,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal firmware metadata update request: %w", err)
+	}
+	return c.doFirmware(ctx, firmwareRequest{
+		method:      http.MethodPatch,
+		url:         c.firmwareURL("files", fileID),
+		body:        bytes.NewReader(body),
+		contentType: contentTypeJSON,
+	})
 }
 
 func (c *Client) FirmwareDelete(ctx context.Context, fileID string) error {

--- a/server/cmd/fleetcli/firmware_test.go
+++ b/server/cmd/fleetcli/firmware_test.go
@@ -437,42 +437,24 @@ func TestFirmwareUploadChunkedSequence(t *testing.T) {
 	}
 }
 
-func TestFirmwareUploadSWUWithoutMetadataSkipsPrecheck(t *testing.T) {
-	path := writeTempFirmwareFile(t, "proto-rig.swu", []byte("firmware"))
-
-	mux := http.NewServeMux()
-	serveFirmwareConfig(t, mux, firmwareConfig{AllowedExtensions: []string{".swu"}, MaxFileSizeBytes: 1 << 20, ChunkSizeBytes: 1024})
-	forbidFirmwareEndpoint(t, mux, "POST /api/v1/firmware/check")
-	mux.HandleFunc("POST /api/v1/firmware/upload", func(w http.ResponseWriter, r *http.Request) {
-		if got := r.FormValue("target_manufacturer"); got != "" {
-			t.Errorf("target_manufacturer = %q, want empty", got)
-		}
-		if got := r.FormValue("target_model"); got != "" {
-			t.Errorf("target_model = %q, want empty", got)
-		}
-		if got := r.FormValue("firmware_version"); got != "" {
-			t.Errorf("firmware_version = %q, want empty", got)
-		}
-		writeFirmwareJSON(t, w, firmwareUploadResponse{FirmwareFileID: "parsed-id", Reused: true})
-	})
-	client := newFirmwareTestServer(t, mux)
-
-	result, reused, err := runFirmwareUpload(context.Background(), client, path, firmwareTarget{}, false, nil)
-	if err != nil {
-		t.Fatalf("runFirmwareUpload() error = %v", err)
+func TestFirmwareTargetValidateRequiresAllMetadata(t *testing.T) {
+	tests := []struct {
+		name    string
+		target  firmwareTarget
+		wantErr string
+	}{
+		{name: "manufacturer", target: firmwareTarget{}, wantErr: "--target-manufacturer is required"},
+		{name: "model", target: firmwareTarget{Manufacturer: "Proto"}, wantErr: "--target-model is required"},
+		{name: "version", target: firmwareTarget{Manufacturer: "Proto", Model: "S21"}, wantErr: "--firmware-version is required"},
 	}
-	if !reused || !result.Reused {
-		t.Fatalf("reused = %v result.Reused = %v, want true/true", reused, result.Reused)
-	}
-	if result.FirmwareFileID != "parsed-id" {
-		t.Errorf("FirmwareFileID = %q, want parsed-id", result.FirmwareFileID)
-	}
-}
 
-func TestValidateFirmwareUploadTargetRequiresMetadataForNonSWU(t *testing.T) {
-	err := validateFirmwareUploadTarget("firmware.zip", firmwareTarget{})
-	if err == nil || !strings.Contains(err.Error(), "--target-manufacturer is required") {
-		t.Fatalf("validateFirmwareUploadTarget() error = %v, want target-manufacturer requirement", err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.target.validate()
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("validate() error = %v, want containing %q", err, tt.wantErr)
+			}
+		})
 	}
 }
 

--- a/server/cmd/fleetcli/firmware_test.go
+++ b/server/cmd/fleetcli/firmware_test.go
@@ -90,7 +90,7 @@ func writeTempFirmwareFile(t *testing.T, name string, content []byte) string {
 }
 
 func testFirmwareTarget() firmwareTarget {
-	return firmwareTarget{Manufacturer: "Proto", Model: "S21"}
+	return firmwareTarget{Manufacturer: "Proto", Model: "S21", Version: "v2.0.0"}
 }
 
 func TestFileSHA256(t *testing.T) {
@@ -199,7 +199,7 @@ func TestFirmwareCheckSendsSHA256(t *testing.T) {
 	if gotContentType != contentTypeJSON {
 		t.Errorf("check Content-Type = %q, want %q", gotContentType, contentTypeJSON)
 	}
-	wantBody := fmt.Sprintf(`{"sha256":%q,"target_manufacturer":"Proto","target_model":"S21"}`, digest)
+	wantBody := fmt.Sprintf(`{"sha256":%q,"target_manufacturer":"Proto","target_model":"S21","firmware_version":"v2.0.0"}`, digest)
 	if string(gotBody) != wantBody {
 		t.Errorf("check body = %s, want %s", gotBody, wantBody)
 	}
@@ -256,6 +256,9 @@ func TestFirmwareUploadReusesExistingFile(t *testing.T) {
 	}
 	if result.FirmwareFileID != "existing-id" {
 		t.Errorf("FirmwareFileID = %q, want %q", result.FirmwareFileID, "existing-id")
+	}
+	if !result.Reused {
+		t.Error("result.Reused = false, want true")
 	}
 }
 
@@ -324,6 +327,12 @@ func TestFirmwareUploadDirectUsesMultipart(t *testing.T) {
 				}
 				if got := r.FormValue("target_model"); got != "S21" {
 					t.Errorf("target_model = %q, want S21", got)
+				}
+				if got := r.FormValue("firmware_version"); got != "v2.0.0" {
+					t.Errorf("firmware_version = %q, want v2.0.0", got)
+				}
+				if got := r.FormValue("force"); got != "" {
+					t.Errorf("force = %q, want empty", got)
 				}
 				gotBytes, err = io.ReadAll(file)
 				if err != nil {
@@ -408,6 +417,9 @@ func TestFirmwareUploadChunkedSequence(t *testing.T) {
 	if initiateBody.TargetManufacturer != "Proto" || initiateBody.TargetModel != "S21" {
 		t.Errorf("initiate target = %s %s, want Proto S21", initiateBody.TargetManufacturer, initiateBody.TargetModel)
 	}
+	if initiateBody.Force {
+		t.Error("initiate force = true, want false")
+	}
 	wantRanges := []string{"bytes 0-7/20", "bytes 8-15/20", "bytes 16-19/20"}
 	if len(gotRanges) != len(wantRanges) {
 		t.Fatalf("chunk count = %d (%v), want %d", len(gotRanges), gotRanges, len(wantRanges))
@@ -422,6 +434,45 @@ func TestFirmwareUploadChunkedSequence(t *testing.T) {
 	}
 	if !bytes.Equal(reassembled, content) {
 		t.Errorf("reassembled chunks do not match the source file (got %q, want %q)", reassembled, content)
+	}
+}
+
+func TestFirmwareUploadSWUWithoutMetadataSkipsPrecheck(t *testing.T) {
+	path := writeTempFirmwareFile(t, "proto-rig.swu", []byte("firmware"))
+
+	mux := http.NewServeMux()
+	serveFirmwareConfig(t, mux, firmwareConfig{AllowedExtensions: []string{".swu"}, MaxFileSizeBytes: 1 << 20, ChunkSizeBytes: 1024})
+	forbidFirmwareEndpoint(t, mux, "POST /api/v1/firmware/check")
+	mux.HandleFunc("POST /api/v1/firmware/upload", func(w http.ResponseWriter, r *http.Request) {
+		if got := r.FormValue("target_manufacturer"); got != "" {
+			t.Errorf("target_manufacturer = %q, want empty", got)
+		}
+		if got := r.FormValue("target_model"); got != "" {
+			t.Errorf("target_model = %q, want empty", got)
+		}
+		if got := r.FormValue("firmware_version"); got != "" {
+			t.Errorf("firmware_version = %q, want empty", got)
+		}
+		writeFirmwareJSON(t, w, firmwareUploadResponse{FirmwareFileID: "parsed-id", Reused: true})
+	})
+	client := newFirmwareTestServer(t, mux)
+
+	result, reused, err := runFirmwareUpload(context.Background(), client, path, firmwareTarget{}, false, nil)
+	if err != nil {
+		t.Fatalf("runFirmwareUpload() error = %v", err)
+	}
+	if !reused || !result.Reused {
+		t.Fatalf("reused = %v result.Reused = %v, want true/true", reused, result.Reused)
+	}
+	if result.FirmwareFileID != "parsed-id" {
+		t.Errorf("FirmwareFileID = %q, want parsed-id", result.FirmwareFileID)
+	}
+}
+
+func TestValidateFirmwareUploadTargetRequiresMetadataForNonSWU(t *testing.T) {
+	err := validateFirmwareUploadTarget("firmware.zip", firmwareTarget{})
+	if err == nil || !strings.Contains(err.Error(), "--target-manufacturer is required") {
+		t.Fatalf("validateFirmwareUploadTarget() error = %v, want target-manufacturer requirement", err)
 	}
 }
 

--- a/server/cmd/fleetcli/firmware_test.go
+++ b/server/cmd/fleetcli/firmware_test.go
@@ -89,6 +89,10 @@ func writeTempFirmwareFile(t *testing.T, name string, content []byte) string {
 	return path
 }
 
+func testFirmwareTarget() firmwareTarget {
+	return firmwareTarget{Manufacturer: "Proto", Model: "S21"}
+}
+
 func TestFileSHA256(t *testing.T) {
 	content := []byte("fleet firmware payload")
 	path := writeTempFirmwareFile(t, "fw.swu", content)
@@ -187,7 +191,7 @@ func TestFirmwareCheckSendsSHA256(t *testing.T) {
 	client := newFirmwareTestServer(t, mux)
 
 	digest := strings.Repeat("ab", 32)
-	resp, err := client.FirmwareCheck(context.Background(), digest)
+	resp, err := client.FirmwareCheck(context.Background(), digest, testFirmwareTarget())
 	if err != nil {
 		t.Fatalf("FirmwareCheck() error = %v", err)
 	}
@@ -195,7 +199,7 @@ func TestFirmwareCheckSendsSHA256(t *testing.T) {
 	if gotContentType != contentTypeJSON {
 		t.Errorf("check Content-Type = %q, want %q", gotContentType, contentTypeJSON)
 	}
-	wantBody := fmt.Sprintf(`{"sha256":%q}`, digest)
+	wantBody := fmt.Sprintf(`{"sha256":%q,"target_manufacturer":"Proto","target_model":"S21"}`, digest)
 	if string(gotBody) != wantBody {
 		t.Errorf("check body = %s, want %s", gotBody, wantBody)
 	}
@@ -243,7 +247,7 @@ func TestFirmwareUploadReusesExistingFile(t *testing.T) {
 	forbidFirmwareEndpoint(t, mux, "POST /api/v1/firmware/upload/chunked")
 	client := newFirmwareTestServer(t, mux)
 
-	result, reused, err := runFirmwareUpload(context.Background(), client, path, false, nil)
+	result, reused, err := runFirmwareUpload(context.Background(), client, path, testFirmwareTarget(), false, nil)
 	if err != nil {
 		t.Fatalf("runFirmwareUpload() error = %v", err)
 	}
@@ -268,7 +272,7 @@ func TestFirmwareUploadForceUploadsDespiteCheckHit(t *testing.T) {
 	})
 	client := newFirmwareTestServer(t, mux)
 
-	result, reused, err := runFirmwareUpload(context.Background(), client, path, true, nil)
+	result, reused, err := runFirmwareUpload(context.Background(), client, path, testFirmwareTarget(), true, nil)
 	if err != nil {
 		t.Fatalf("runFirmwareUpload() error = %v", err)
 	}
@@ -315,6 +319,12 @@ func TestFirmwareUploadDirectUsesMultipart(t *testing.T) {
 				}
 				defer func() { _ = file.Close() }()
 				gotFilename = header.Filename
+				if got := r.FormValue("target_manufacturer"); got != "Proto" {
+					t.Errorf("target_manufacturer = %q, want Proto", got)
+				}
+				if got := r.FormValue("target_model"); got != "S21" {
+					t.Errorf("target_model = %q, want S21", got)
+				}
 				gotBytes, err = io.ReadAll(file)
 				if err != nil {
 					t.Errorf("read multipart file: %v", err)
@@ -323,7 +333,7 @@ func TestFirmwareUploadDirectUsesMultipart(t *testing.T) {
 			})
 			client := newFirmwareTestServer(t, mux)
 
-			result, reused, err := runFirmwareUpload(context.Background(), client, path, false, nil)
+			result, reused, err := runFirmwareUpload(context.Background(), client, path, testFirmwareTarget(), false, nil)
 			if err != nil {
 				t.Fatalf("runFirmwareUpload() error = %v", err)
 			}
@@ -382,7 +392,7 @@ func TestFirmwareUploadChunkedSequence(t *testing.T) {
 	})
 	client := newFirmwareTestServer(t, mux)
 
-	result, reused, err := runFirmwareUpload(context.Background(), client, path, false, nil)
+	result, reused, err := runFirmwareUpload(context.Background(), client, path, testFirmwareTarget(), false, nil)
 	if err != nil {
 		t.Fatalf("runFirmwareUpload() error = %v", err)
 	}
@@ -394,6 +404,9 @@ func TestFirmwareUploadChunkedSequence(t *testing.T) {
 	}
 	if initiateBody.Filename != "big-firmware.swu" || initiateBody.FileSize != int64(len(content)) {
 		t.Errorf("initiate body = %+v, want filename big-firmware.swu and file_size %d", initiateBody, len(content))
+	}
+	if initiateBody.TargetManufacturer != "Proto" || initiateBody.TargetModel != "S21" {
+		t.Errorf("initiate target = %s %s, want Proto S21", initiateBody.TargetManufacturer, initiateBody.TargetModel)
 	}
 	wantRanges := []string{"bytes 0-7/20", "bytes 8-15/20", "bytes 16-19/20"}
 	if len(gotRanges) != len(wantRanges) {
@@ -448,7 +461,7 @@ func TestFirmwareUploadValidationRejectsLocally(t *testing.T) {
 			forbidFirmwareEndpoint(t, mux, "POST /api/v1/firmware/upload/chunked")
 			client := newFirmwareTestServer(t, mux)
 
-			_, _, err := runFirmwareUpload(context.Background(), client, tt.path(t), false, nil)
+			_, _, err := runFirmwareUpload(context.Background(), client, tt.path(t), testFirmwareTarget(), false, nil)
 			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
 				t.Fatalf("runFirmwareUpload() error = %v, want containing %q", err, tt.wantErr)
 			}

--- a/server/cmd/fleetcli/firmware_test.go
+++ b/server/cmd/fleetcli/firmware_test.go
@@ -247,12 +247,9 @@ func TestFirmwareUploadReusesExistingFile(t *testing.T) {
 	forbidFirmwareEndpoint(t, mux, "POST /api/v1/firmware/upload/chunked")
 	client := newFirmwareTestServer(t, mux)
 
-	result, reused, err := runFirmwareUpload(context.Background(), client, path, testFirmwareTarget(), false, nil)
+	result, err := runFirmwareUpload(context.Background(), client, path, testFirmwareTarget(), false, nil)
 	if err != nil {
 		t.Fatalf("runFirmwareUpload() error = %v", err)
-	}
-	if !reused {
-		t.Error("runFirmwareUpload() reused = false, want true")
 	}
 	if result.FirmwareFileID != "existing-id" {
 		t.Errorf("FirmwareFileID = %q, want %q", result.FirmwareFileID, "existing-id")
@@ -275,15 +272,15 @@ func TestFirmwareUploadForceUploadsDespiteCheckHit(t *testing.T) {
 	})
 	client := newFirmwareTestServer(t, mux)
 
-	result, reused, err := runFirmwareUpload(context.Background(), client, path, testFirmwareTarget(), true, nil)
+	result, err := runFirmwareUpload(context.Background(), client, path, testFirmwareTarget(), true, nil)
 	if err != nil {
 		t.Fatalf("runFirmwareUpload() error = %v", err)
 	}
 	if !uploadHit {
 		t.Error("direct upload endpoint was not called despite --force")
 	}
-	if reused {
-		t.Error("runFirmwareUpload() reused = true, want false")
+	if result.Reused {
+		t.Error("result.Reused = true, want false")
 	}
 	if result.FirmwareFileID != "fresh-id" {
 		t.Errorf("FirmwareFileID = %q, want %q", result.FirmwareFileID, "fresh-id")
@@ -342,12 +339,12 @@ func TestFirmwareUploadDirectUsesMultipart(t *testing.T) {
 			})
 			client := newFirmwareTestServer(t, mux)
 
-			result, reused, err := runFirmwareUpload(context.Background(), client, path, testFirmwareTarget(), false, nil)
+			result, err := runFirmwareUpload(context.Background(), client, path, testFirmwareTarget(), false, nil)
 			if err != nil {
 				t.Fatalf("runFirmwareUpload() error = %v", err)
 			}
-			if reused {
-				t.Error("runFirmwareUpload() reused = true, want false")
+			if result.Reused {
+				t.Error("result.Reused = true, want false")
 			}
 			if result.FirmwareFileID != "direct-id" {
 				t.Errorf("FirmwareFileID = %q, want %q", result.FirmwareFileID, "direct-id")
@@ -401,12 +398,12 @@ func TestFirmwareUploadChunkedSequence(t *testing.T) {
 	})
 	client := newFirmwareTestServer(t, mux)
 
-	result, reused, err := runFirmwareUpload(context.Background(), client, path, testFirmwareTarget(), false, nil)
+	result, err := runFirmwareUpload(context.Background(), client, path, testFirmwareTarget(), false, nil)
 	if err != nil {
 		t.Fatalf("runFirmwareUpload() error = %v", err)
 	}
-	if reused {
-		t.Error("runFirmwareUpload() reused = true, want false")
+	if result.Reused {
+		t.Error("result.Reused = true, want false")
 	}
 	if result.FirmwareFileID != "chunked-id" {
 		t.Errorf("FirmwareFileID = %q, want %q", result.FirmwareFileID, "chunked-id")
@@ -494,7 +491,7 @@ func TestFirmwareUploadValidationRejectsLocally(t *testing.T) {
 			forbidFirmwareEndpoint(t, mux, "POST /api/v1/firmware/upload/chunked")
 			client := newFirmwareTestServer(t, mux)
 
-			_, _, err := runFirmwareUpload(context.Background(), client, tt.path(t), testFirmwareTarget(), false, nil)
+			_, err := runFirmwareUpload(context.Background(), client, tt.path(t), testFirmwareTarget(), false, nil)
 			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
 				t.Fatalf("runFirmwareUpload() error = %v, want containing %q", err, tt.wantErr)
 			}

--- a/server/cmd/fleetcli/firmware_test.go
+++ b/server/cmd/fleetcli/firmware_test.go
@@ -90,7 +90,7 @@ func writeTempFirmwareFile(t *testing.T, name string, content []byte) string {
 }
 
 func testFirmwareTarget() firmwareTarget {
-	return firmwareTarget{Manufacturer: "Proto", Model: "S21", Version: "v2.0.0"}
+	return firmwareTarget{Manufacturer: "Proto", Model: "Rig", Version: "v2.0.0"}
 }
 
 func TestFileSHA256(t *testing.T) {
@@ -199,7 +199,7 @@ func TestFirmwareCheckSendsSHA256(t *testing.T) {
 	if gotContentType != contentTypeJSON {
 		t.Errorf("check Content-Type = %q, want %q", gotContentType, contentTypeJSON)
 	}
-	wantBody := fmt.Sprintf(`{"sha256":%q,"target_manufacturer":"Proto","target_model":"S21","firmware_version":"v2.0.0"}`, digest)
+	wantBody := fmt.Sprintf(`{"sha256":%q,"target_manufacturer":"Proto","target_model":"Rig","firmware_version":"v2.0.0"}`, digest)
 	if string(gotBody) != wantBody {
 		t.Errorf("check body = %s, want %s", gotBody, wantBody)
 	}
@@ -322,8 +322,8 @@ func TestFirmwareUploadDirectUsesMultipart(t *testing.T) {
 				if got := r.FormValue("target_manufacturer"); got != "Proto" {
 					t.Errorf("target_manufacturer = %q, want Proto", got)
 				}
-				if got := r.FormValue("target_model"); got != "S21" {
-					t.Errorf("target_model = %q, want S21", got)
+				if got := r.FormValue("target_model"); got != "Rig" {
+					t.Errorf("target_model = %q, want Rig", got)
 				}
 				if got := r.FormValue("firmware_version"); got != "v2.0.0" {
 					t.Errorf("firmware_version = %q, want v2.0.0", got)
@@ -411,8 +411,8 @@ func TestFirmwareUploadChunkedSequence(t *testing.T) {
 	if initiateBody.Filename != "big-firmware.swu" || initiateBody.FileSize != int64(len(content)) {
 		t.Errorf("initiate body = %+v, want filename big-firmware.swu and file_size %d", initiateBody, len(content))
 	}
-	if initiateBody.TargetManufacturer != "Proto" || initiateBody.TargetModel != "S21" {
-		t.Errorf("initiate target = %s %s, want Proto S21", initiateBody.TargetManufacturer, initiateBody.TargetModel)
+	if initiateBody.TargetManufacturer != "Proto" || initiateBody.TargetModel != "Rig" {
+		t.Errorf("initiate target = %s %s, want Proto Rig", initiateBody.TargetManufacturer, initiateBody.TargetModel)
 	}
 	if initiateBody.Force {
 		t.Error("initiate force = true, want false")
@@ -442,7 +442,7 @@ func TestFirmwareTargetValidateRequiresAllMetadata(t *testing.T) {
 	}{
 		{name: "manufacturer", target: firmwareTarget{}, wantErr: "--target-manufacturer is required"},
 		{name: "model", target: firmwareTarget{Manufacturer: "Proto"}, wantErr: "--target-model is required"},
-		{name: "version", target: firmwareTarget{Manufacturer: "Proto", Model: "S21"}, wantErr: "--firmware-version is required"},
+		{name: "version", target: firmwareTarget{Manufacturer: "Proto", Model: "Rig"}, wantErr: "--firmware-version is required"},
 	}
 
 	for _, tt := range tests {

--- a/server/cmd/fleetcli/firmware_test.go
+++ b/server/cmd/fleetcli/firmware_test.go
@@ -521,6 +521,44 @@ func TestFirmwareListDecodesFiles(t *testing.T) {
 	}
 }
 
+func TestFirmwareUpdateMetadataPatchesEscapedFileEndpoint(t *testing.T) {
+	fileID := "abc/def %"
+	target := testFirmwareTarget()
+	var gotEscapedPath, gotContentType, gotAccept, gotBody string
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("PATCH /api/v1/firmware/files/", func(w http.ResponseWriter, r *http.Request) {
+		gotEscapedPath = r.URL.EscapedPath()
+		gotContentType = r.Header.Get("Content-Type")
+		gotAccept = r.Header.Get("Accept")
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read metadata update body: %v", err)
+		}
+		gotBody = string(body)
+		w.WriteHeader(http.StatusNoContent)
+	})
+	client := newFirmwareTestServer(t, mux)
+
+	if err := client.FirmwareUpdateMetadata(context.Background(), fileID, target); err != nil {
+		t.Fatalf("FirmwareUpdateMetadata() error = %v", err)
+	}
+	wantPath := "/api/v1/firmware/files/" + url.PathEscape(fileID)
+	if gotEscapedPath != wantPath {
+		t.Errorf("request path = %q, want %q", gotEscapedPath, wantPath)
+	}
+	if gotContentType != contentTypeJSON {
+		t.Errorf("Content-Type = %q, want %q", gotContentType, contentTypeJSON)
+	}
+	if gotAccept != contentTypeJSON {
+		t.Errorf("Accept = %q, want %q", gotAccept, contentTypeJSON)
+	}
+	wantBody := `{"target_manufacturer":"Proto","target_model":"Rig","firmware_version":"v2.0.0"}`
+	if gotBody != wantBody {
+		t.Errorf("request body = %q, want %q", gotBody, wantBody)
+	}
+}
+
 func TestFirmwareDeleteHitsFileEndpoint(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -685,6 +723,54 @@ func TestFirmwareDeleteAllCommandDeletesAfterYes(t *testing.T) {
 				t.Fatalf("deleted_count = %d, want 3", decoded.DeletedCount)
 			}
 		})
+	}
+}
+
+func TestFirmwareEditMetadataCommandPrintsConfirmation(t *testing.T) {
+	pinFleetAuthEnv(t, map[string]string{envFleetPassword: "proto"})
+	oldNoColor := color.NoColor
+	color.NoColor = true
+	t.Cleanup(func() { color.NoColor = oldNoColor })
+
+	fileID := "550e8400-e29b-41d4-a716-446655440000"
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /auth.v1.AuthService/Authenticate", func(w http.ResponseWriter, _ *http.Request) {
+		http.SetCookie(w, &http.Cookie{Name: "fleet_session", Value: "test-session", Path: "/", Secure: true})
+		w.Header().Set("Content-Type", contentTypeJSON)
+		_, _ = w.Write([]byte(`{}`))
+	})
+	mux.HandleFunc("PATCH /api/v1/firmware/files/"+fileID, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	output := captureStdout(t, func() {
+		err := newRootCommand().Run(context.Background(), []string{
+			"fleetcli", "--server", srv.URL + "/", "--username", "admin",
+			"firmware", "edit-metadata",
+			"--firmware-file-id", fileID,
+			"--target-manufacturer", "Proto",
+			"--target-model", "Rig",
+			"--firmware-version", "v2.0.0",
+		})
+		if err != nil {
+			t.Fatalf("firmware edit-metadata error = %v", err)
+		}
+	})
+
+	var decoded firmwareMetadataUpdateResult
+	if err := json.Unmarshal([]byte(output), &decoded); err != nil {
+		t.Fatalf("output is not JSON: %s", output)
+	}
+	want := firmwareMetadataUpdateResult{
+		FirmwareFileID:     fileID,
+		TargetManufacturer: "Proto",
+		TargetModel:        "Rig",
+		FirmwareVersion:    "v2.0.0",
+	}
+	if decoded != want {
+		t.Errorf("edit-metadata output = %+v, want %+v", decoded, want)
 	}
 }
 
@@ -1073,6 +1159,64 @@ func TestFirmwareSingleArgValidation(t *testing.T) {
 			err := firmwareCheckCommand().Run(context.Background(), tt.args)
 			if err == nil || !strings.Contains(err.Error(), "expected exactly one argument") {
 				t.Fatalf("check %v error = %v, want single-argument usage error", tt.args, err)
+			}
+		})
+	}
+}
+
+func TestFirmwareEditMetadataCommandRequiresIDAndTarget(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name: "file id",
+			args: []string{
+				"edit-metadata",
+				"--target-manufacturer", "Proto",
+				"--target-model", "Rig",
+				"--firmware-version", "v2.0.0",
+			},
+			wantErr: "firmware-file-id",
+		},
+		{
+			name: "manufacturer",
+			args: []string{
+				"edit-metadata",
+				"--firmware-file-id", "firmware-id",
+				"--target-model", "Rig",
+				"--firmware-version", "v2.0.0",
+			},
+			wantErr: "--target-manufacturer is required",
+		},
+		{
+			name: "model",
+			args: []string{
+				"edit-metadata",
+				"--firmware-file-id", "firmware-id",
+				"--target-manufacturer", "Proto",
+				"--firmware-version", "v2.0.0",
+			},
+			wantErr: "--target-model is required",
+		},
+		{
+			name: "version",
+			args: []string{
+				"edit-metadata",
+				"--firmware-file-id", "firmware-id",
+				"--target-manufacturer", "Proto",
+				"--target-model", "Rig",
+			},
+			wantErr: "--firmware-version is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := firmwareEditMetadataCommand().Run(context.Background(), tt.args)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("edit-metadata error = %v, want containing %q", err, tt.wantErr)
 			}
 		})
 	}

--- a/server/cmd/fleetcli/main_test.go
+++ b/server/cmd/fleetcli/main_test.go
@@ -100,8 +100,8 @@ func TestGeneratedLeafCommandsMatchManifest(t *testing.T) {
 			t.Errorf("generated command %q missing from manifest", path)
 		}
 	}
-	if gotAll := leafCommandPaths(allCommands()); len(gotAll) != 131 {
-		t.Fatalf("all command leaves = %d, want 131", len(gotAll))
+	if gotAll := leafCommandPaths(allCommands()); len(gotAll) != 132 {
+		t.Fatalf("all command leaves = %d, want 132", len(gotAll))
 	}
 }
 

--- a/server/cmd/fleetd/main.go
+++ b/server/cmd/fleetd/main.go
@@ -626,15 +626,16 @@ func start(config *Config) error {
 		orgQueries := db.NewFailoverResettingQuerier(db.NewRetryDB(conn))
 		mux.Handle("POST "+alertmanagerwebhook.Path, alertmanagerwebhook.NewHandler(notificationHistoryStore, config.Metrics.WebhookToken, orgQueries, alertsDeliverer))
 	}
-	mux.Handle("/api/v1/firmware/upload", firmwareHandler.NewUploadHandler(filesService, sessionSvc, userStore, filesService.MaxFirmwareFileSize()))
+	mux.Handle("/api/v1/firmware/upload", firmwareHandler.NewUploadHandler(filesService, sessionSvc, userStore, activitySvc, filesService.MaxFirmwareFileSize()))
 	mux.Handle("/api/v1/firmware/check", firmwareHandler.NewCheckHandler(filesService, sessionSvc, userStore))
 	mux.Handle("GET /api/v1/firmware/config", firmwareHandler.NewConfigHandler(filesService, sessionSvc, userStore, config.Files))
 
 	chunkedMgr := firmwareHandler.NewChunkedUploadManager()
 	mux.Handle("POST /api/v1/firmware/upload/chunked", firmwareHandler.NewInitiateHandler(chunkedMgr, filesService, sessionSvc, userStore))
 	mux.Handle("PUT /api/v1/firmware/upload/chunked/{uploadId}", firmwareHandler.NewChunkHandler(chunkedMgr, sessionSvc, userStore))
-	mux.Handle("POST /api/v1/firmware/upload/chunked/{uploadId}/complete", firmwareHandler.NewCompleteHandler(chunkedMgr, filesService, sessionSvc, userStore))
+	mux.Handle("POST /api/v1/firmware/upload/chunked/{uploadId}/complete", firmwareHandler.NewCompleteHandler(chunkedMgr, filesService, sessionSvc, userStore, activitySvc))
 	mux.Handle("GET /api/v1/firmware/files", firmwareHandler.NewListFilesHandler(filesService, sessionSvc, userStore))
+	mux.Handle("PATCH /api/v1/firmware/files/{fileId}", firmwareHandler.NewUpdateMetadataHandler(filesService, sessionSvc, userStore))
 	mux.Handle("DELETE /api/v1/firmware/files/{fileId}", firmwareHandler.NewDeleteFileHandler(filesService, sessionSvc, userStore))
 	mux.Handle("DELETE /api/v1/firmware/files", firmwareHandler.NewDeleteAllFilesHandler(filesService, sessionSvc, userStore))
 	mux.Handle("/miners/{deviceIdentifier}/api/v1/{rest...}", minerProxyHandler.NewHandler(conn, sessionSvc, userStore, permissionResolver, encryptSvc))

--- a/server/cmd/fleetd/main.go
+++ b/server/cmd/fleetd/main.go
@@ -635,7 +635,7 @@ func start(config *Config) error {
 	mux.Handle("PUT /api/v1/firmware/upload/chunked/{uploadId}", firmwareHandler.NewChunkHandler(chunkedMgr, sessionSvc, userStore, permissionResolver))
 	mux.Handle("POST /api/v1/firmware/upload/chunked/{uploadId}/complete", firmwareHandler.NewCompleteHandler(chunkedMgr, filesService, sessionSvc, userStore, activitySvc, permissionResolver))
 	mux.Handle("GET /api/v1/firmware/files", firmwareHandler.NewListFilesHandler(filesService, sessionSvc, userStore))
-	mux.Handle("PATCH /api/v1/firmware/files/{fileId}", firmwareHandler.NewUpdateMetadataHandler(filesService, sessionSvc, userStore, permissionResolver))
+	mux.Handle("PATCH /api/v1/firmware/files/{fileId}", firmwareHandler.NewUpdateMetadataHandler(filesService, sessionSvc, userStore, activitySvc, permissionResolver))
 	mux.Handle("DELETE /api/v1/firmware/files/{fileId}", firmwareHandler.NewDeleteFileHandler(filesService, sessionSvc, userStore, permissionResolver))
 	mux.Handle("DELETE /api/v1/firmware/files", firmwareHandler.NewDeleteAllFilesHandler(filesService, sessionSvc, userStore, permissionResolver))
 	mux.Handle("/miners/{deviceIdentifier}/api/v1/{rest...}", minerProxyHandler.NewHandler(conn, sessionSvc, userStore, permissionResolver, encryptSvc))

--- a/server/cmd/fleetd/main.go
+++ b/server/cmd/fleetd/main.go
@@ -626,18 +626,18 @@ func start(config *Config) error {
 		orgQueries := db.NewFailoverResettingQuerier(db.NewRetryDB(conn))
 		mux.Handle("POST "+alertmanagerwebhook.Path, alertmanagerwebhook.NewHandler(notificationHistoryStore, config.Metrics.WebhookToken, orgQueries, alertsDeliverer))
 	}
-	mux.Handle("/api/v1/firmware/upload", firmwareHandler.NewUploadHandler(filesService, sessionSvc, userStore, activitySvc, filesService.MaxFirmwareFileSize()))
+	mux.Handle("/api/v1/firmware/upload", firmwareHandler.NewUploadHandler(filesService, sessionSvc, userStore, activitySvc, permissionResolver))
 	mux.Handle("/api/v1/firmware/check", firmwareHandler.NewCheckHandler(filesService, sessionSvc, userStore))
 	mux.Handle("GET /api/v1/firmware/config", firmwareHandler.NewConfigHandler(filesService, sessionSvc, userStore, config.Files))
 
 	chunkedMgr := firmwareHandler.NewChunkedUploadManager()
-	mux.Handle("POST /api/v1/firmware/upload/chunked", firmwareHandler.NewInitiateHandler(chunkedMgr, filesService, sessionSvc, userStore))
-	mux.Handle("PUT /api/v1/firmware/upload/chunked/{uploadId}", firmwareHandler.NewChunkHandler(chunkedMgr, sessionSvc, userStore))
-	mux.Handle("POST /api/v1/firmware/upload/chunked/{uploadId}/complete", firmwareHandler.NewCompleteHandler(chunkedMgr, filesService, sessionSvc, userStore, activitySvc))
+	mux.Handle("POST /api/v1/firmware/upload/chunked", firmwareHandler.NewInitiateHandler(chunkedMgr, filesService, sessionSvc, userStore, permissionResolver))
+	mux.Handle("PUT /api/v1/firmware/upload/chunked/{uploadId}", firmwareHandler.NewChunkHandler(chunkedMgr, sessionSvc, userStore, permissionResolver))
+	mux.Handle("POST /api/v1/firmware/upload/chunked/{uploadId}/complete", firmwareHandler.NewCompleteHandler(chunkedMgr, filesService, sessionSvc, userStore, activitySvc, permissionResolver))
 	mux.Handle("GET /api/v1/firmware/files", firmwareHandler.NewListFilesHandler(filesService, sessionSvc, userStore))
-	mux.Handle("PATCH /api/v1/firmware/files/{fileId}", firmwareHandler.NewUpdateMetadataHandler(filesService, sessionSvc, userStore))
-	mux.Handle("DELETE /api/v1/firmware/files/{fileId}", firmwareHandler.NewDeleteFileHandler(filesService, sessionSvc, userStore))
-	mux.Handle("DELETE /api/v1/firmware/files", firmwareHandler.NewDeleteAllFilesHandler(filesService, sessionSvc, userStore))
+	mux.Handle("PATCH /api/v1/firmware/files/{fileId}", firmwareHandler.NewUpdateMetadataHandler(filesService, sessionSvc, userStore, permissionResolver))
+	mux.Handle("DELETE /api/v1/firmware/files/{fileId}", firmwareHandler.NewDeleteFileHandler(filesService, sessionSvc, userStore, permissionResolver))
+	mux.Handle("DELETE /api/v1/firmware/files", firmwareHandler.NewDeleteAllFilesHandler(filesService, sessionSvc, userStore, permissionResolver))
 	mux.Handle("/miners/{deviceIdentifier}/api/v1/{rest...}", minerProxyHandler.NewHandler(conn, sessionSvc, userStore, permissionResolver, encryptSvc))
 
 	chunkedUploadCleanup := newBackgroundLoop(func(ctx context.Context) {

--- a/server/docker-compose.fleetnode-ui-test.yaml
+++ b/server/docker-compose.fleetnode-ui-test.yaml
@@ -54,7 +54,7 @@ services:
       MINER_TYPE: "Antminer S19 UI Test"
       SERIAL_NUMBER: "UI-TEST-ANTMINER-001"
       MAC_ADDRESS: "02:42:0a:5a:00:20"
-      FIRMWARE_VERSION: "Antminer S19 XP 140Th 15/01/2023 10:30:25"
+      FIRMWARE_VERSION: "2.0.0"
       IP_ADDRESS: "10.90.0.20"
       GATEWAY: "10.90.0.1"
       DNS_SERVERS: ""

--- a/server/docker-compose.yaml
+++ b/server/docker-compose.yaml
@@ -137,7 +137,7 @@ services:
       dockerfile: Dockerfile
     environment:
       MINER_TYPE: "Antminer S19 XP"
-      FIRMWARE_VERSION: "Antminer S19 XP 140Th 15/01/2023 10:30:25"
+      FIRMWARE_VERSION: "2.0.0"
       USERNAME: "root19"
       PASSWORD: "root19"
     healthcheck:
@@ -167,7 +167,7 @@ services:
       dockerfile: Dockerfile
     environment:
       MINER_TYPE: "Antminer S17"
-      FIRMWARE_VERSION: "Antminer S19 XP 140Th 15/01/2023 10:30:25"
+      FIRMWARE_VERSION: "2.0.0"
       ERROR_BOARD_TEMP: "96.0"
     healthcheck:
       test: [ "CMD", "wget", "-qO-", "http://localhost:80/health" ]
@@ -188,7 +188,7 @@ services:
       dockerfile: Dockerfile
     environment:
       MINER_TYPE: "Antminer S21"
-      FIRMWARE_VERSION: "Antminer S19 XP 140Th 15/01/2023 10:30:25"
+      FIRMWARE_VERSION: "2.0.0"
       ERROR_HW_PERCENT: "6.5"
       ERROR_HW_COUNT: "1500"
     healthcheck:
@@ -210,7 +210,7 @@ services:
       dockerfile: Dockerfile
     environment:
       MINER_TYPE: "Antminer S21 XP"
-      FIRMWARE_VERSION: "Antminer S19 XP 140Th 15/01/2023 10:30:25"
+      FIRMWARE_VERSION: "2.0.0"
       USERNAME: "root21"
       PASSWORD: "root21"
       ERROR_BOARD_NOT_ALIVE: "true"
@@ -233,7 +233,7 @@ services:
       dockerfile: Dockerfile
     environment:
       MINER_TYPE: "Antminer S17 XP"
-      FIRMWARE_VERSION: "Antminer S19 XP 140Th 15/01/2023 10:30:25"
+      FIRMWARE_VERSION: "2.0.0"
       USERNAME: "root17"
       PASSWORD: "root17"
       ERROR_POOL_NOT_ALIVE: "true"
@@ -260,7 +260,7 @@ services:
       dockerfile: Dockerfile
     environment:
       MINER_TYPE: "Antminer S18"
-      FIRMWARE_VERSION: "Antminer S19 XP 140Th 15/01/2023 10:30:25"
+      FIRMWARE_VERSION: "2.0.0"
       ERROR_REJECTED_PERCENT: "12.0"
       ERROR_STALE_COUNT: "150"
     healthcheck:
@@ -309,7 +309,7 @@ services:
       dockerfile: Dockerfile
     environment:
       MINER_TYPE: "Antminer S19"
-      FIRMWARE_VERSION: "Antminer S19 XP 140Th 15/01/2023 10:30:25"
+      FIRMWARE_VERSION: "2.0.0"
     healthcheck:
       test: [ "CMD", "wget", "-qO-", "http://localhost:80/health" ]
       interval: 10s

--- a/server/e2e/fleetcli_firmware_e2e_test.go
+++ b/server/e2e/fleetcli_firmware_e2e_test.go
@@ -16,6 +16,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	firmwareE2ETargetManufacturer = "Proto"
+	firmwareE2ETargetModel        = "Rig"
+)
+
 // TestFleetCLIFirmwareWorkflow drives the firmware file lifecycle through the
 // fleetcli binary: config -> check -> upload (direct and chunked) -> list ->
 // delete -> delete-all.
@@ -81,7 +86,7 @@ func TestFleetCLIFirmwareWorkflow(t *testing.T) {
 	var smallFileID string
 
 	t.Run("UploadDirect", func(t *testing.T) {
-		output, err := runFleetCLI(ctx, env, "firmware", "upload", "--quiet", smallPath)
+		output, err := runFleetCLI(ctx, env, "firmware", "upload", "--quiet", "--target-manufacturer", firmwareE2ETargetManufacturer, "--target-model", firmwareE2ETargetModel, smallPath)
 		require.NoError(t, err, "direct upload should succeed")
 		smallFileID = decodeFirmwareFileID(t, output)
 		t.Logf("✓ Direct upload stored firmware file %s", smallFileID)
@@ -99,7 +104,7 @@ func TestFleetCLIFirmwareWorkflow(t *testing.T) {
 	t.Run("UploadReusesExisting", func(t *testing.T) {
 		require.NotEmpty(t, smallFileID, "smallFileID must be set from the direct upload step")
 
-		output, err := runFleetCLI(ctx, env, "firmware", "upload", "--quiet", smallPath)
+		output, err := runFleetCLI(ctx, env, "firmware", "upload", "--quiet", "--target-manufacturer", firmwareE2ETargetManufacturer, "--target-model", firmwareE2ETargetModel, smallPath)
 		require.NoError(t, err, "re-upload should succeed")
 		assert.Equal(t, smallFileID, decodeFirmwareFileID(t, output),
 			"re-uploading identical content should return the existing file id")
@@ -117,7 +122,7 @@ func TestFleetCLIFirmwareWorkflow(t *testing.T) {
 			"chunked test file must fit within the server's max file size")
 		chunkedPath := writeRandomFirmwareFile(t, workDir, "e2e-firmware-chunked.swu", chunkedSize)
 
-		output, err := runFleetCLI(ctx, env, "firmware", "upload", "--quiet", chunkedPath)
+		output, err := runFleetCLI(ctx, env, "firmware", "upload", "--quiet", "--target-manufacturer", firmwareE2ETargetManufacturer, "--target-model", firmwareE2ETargetModel, chunkedPath)
 		require.NoError(t, err, "chunked upload should succeed")
 		chunkedFileID = decodeFirmwareFileID(t, output)
 		assert.NotEqual(t, smallFileID, chunkedFileID, "chunked upload should store a distinct file")
@@ -184,9 +189,11 @@ func TestFleetCLIFirmwareWorkflow(t *testing.T) {
 }
 
 type firmwareE2EFile struct {
-	ID       string `json:"id"`
-	Filename string `json:"filename"`
-	Size     int64  `json:"size"`
+	ID                 string `json:"id"`
+	Filename           string `json:"filename"`
+	Size               int64  `json:"size"`
+	TargetManufacturer string `json:"target_manufacturer"`
+	TargetModel        string `json:"target_model"`
 }
 
 type firmwareE2ECheck struct {
@@ -211,7 +218,7 @@ func writeRandomFirmwareFile(t *testing.T, dir, name string, size int64) string 
 func checkFirmwareFile(t *testing.T, ctx context.Context, env []string, path string) firmwareE2ECheck {
 	t.Helper()
 
-	output, err := runFleetCLI(ctx, env, "firmware", "check", path)
+	output, err := runFleetCLI(ctx, env, "firmware", "check", "--target-manufacturer", firmwareE2ETargetManufacturer, "--target-model", firmwareE2ETargetModel, path)
 	require.NoError(t, err, "firmware check should succeed")
 
 	var resp firmwareE2ECheck

--- a/server/e2e/fleetcli_firmware_e2e_test.go
+++ b/server/e2e/fleetcli_firmware_e2e_test.go
@@ -19,6 +19,7 @@ import (
 const (
 	firmwareE2ETargetManufacturer = "Proto"
 	firmwareE2ETargetModel        = "Rig"
+	firmwareE2EVersion            = "2.4.6"
 )
 
 // TestFleetCLIFirmwareWorkflow drives the firmware file lifecycle through the
@@ -86,7 +87,11 @@ func TestFleetCLIFirmwareWorkflow(t *testing.T) {
 	var smallFileID string
 
 	t.Run("UploadDirect", func(t *testing.T) {
-		output, err := runFleetCLI(ctx, env, "firmware", "upload", "--quiet", "--target-manufacturer", firmwareE2ETargetManufacturer, "--target-model", firmwareE2ETargetModel, smallPath)
+		output, err := runFleetCLI(ctx, env, "firmware", "upload", "--quiet",
+			"--target-manufacturer", firmwareE2ETargetManufacturer,
+			"--target-model", firmwareE2ETargetModel,
+			"--firmware-version", firmwareE2EVersion,
+			smallPath)
 		require.NoError(t, err, "direct upload should succeed")
 		smallFileID = decodeFirmwareFileID(t, output)
 		t.Logf("✓ Direct upload stored firmware file %s", smallFileID)
@@ -104,7 +109,11 @@ func TestFleetCLIFirmwareWorkflow(t *testing.T) {
 	t.Run("UploadReusesExisting", func(t *testing.T) {
 		require.NotEmpty(t, smallFileID, "smallFileID must be set from the direct upload step")
 
-		output, err := runFleetCLI(ctx, env, "firmware", "upload", "--quiet", "--target-manufacturer", firmwareE2ETargetManufacturer, "--target-model", firmwareE2ETargetModel, smallPath)
+		output, err := runFleetCLI(ctx, env, "firmware", "upload", "--quiet",
+			"--target-manufacturer", firmwareE2ETargetManufacturer,
+			"--target-model", firmwareE2ETargetModel,
+			"--firmware-version", firmwareE2EVersion,
+			smallPath)
 		require.NoError(t, err, "re-upload should succeed")
 		assert.Equal(t, smallFileID, decodeFirmwareFileID(t, output),
 			"re-uploading identical content should return the existing file id")
@@ -122,7 +131,11 @@ func TestFleetCLIFirmwareWorkflow(t *testing.T) {
 			"chunked test file must fit within the server's max file size")
 		chunkedPath := writeRandomFirmwareFile(t, workDir, "e2e-firmware-chunked.swu", chunkedSize)
 
-		output, err := runFleetCLI(ctx, env, "firmware", "upload", "--quiet", "--target-manufacturer", firmwareE2ETargetManufacturer, "--target-model", firmwareE2ETargetModel, chunkedPath)
+		output, err := runFleetCLI(ctx, env, "firmware", "upload", "--quiet",
+			"--target-manufacturer", firmwareE2ETargetManufacturer,
+			"--target-model", firmwareE2ETargetModel,
+			"--firmware-version", firmwareE2EVersion,
+			chunkedPath)
 		require.NoError(t, err, "chunked upload should succeed")
 		chunkedFileID = decodeFirmwareFileID(t, output)
 		assert.NotEqual(t, smallFileID, chunkedFileID, "chunked upload should store a distinct file")
@@ -146,11 +159,17 @@ func TestFleetCLIFirmwareWorkflow(t *testing.T) {
 		require.NotNil(t, small, "list should include the direct upload")
 		assert.Equal(t, "e2e-firmware-small.swu", small.Filename)
 		assert.Equal(t, int64(64*1024), small.Size)
+		assert.Equal(t, firmwareE2ETargetManufacturer, small.TargetManufacturer)
+		assert.Equal(t, firmwareE2ETargetModel, small.TargetModel)
+		assert.Equal(t, firmwareE2EVersion, small.FirmwareVersion)
 
 		chunked := findFirmwareFile(files, chunkedFileID)
 		require.NotNil(t, chunked, "list should include the chunked upload")
 		assert.Equal(t, "e2e-firmware-chunked.swu", chunked.Filename)
 		assert.Equal(t, chunkedSize, chunked.Size, "stored size should match the full chunked file")
+		assert.Equal(t, firmwareE2ETargetManufacturer, chunked.TargetManufacturer)
+		assert.Equal(t, firmwareE2ETargetModel, chunked.TargetModel)
+		assert.Equal(t, firmwareE2EVersion, chunked.FirmwareVersion)
 		t.Logf("✓ List contains both uploads (%d file(s) total)", len(files))
 	})
 
@@ -194,6 +213,7 @@ type firmwareE2EFile struct {
 	Size               int64  `json:"size"`
 	TargetManufacturer string `json:"target_manufacturer"`
 	TargetModel        string `json:"target_model"`
+	FirmwareVersion    string `json:"firmware_version"`
 }
 
 type firmwareE2ECheck struct {
@@ -218,7 +238,11 @@ func writeRandomFirmwareFile(t *testing.T, dir, name string, size int64) string 
 func checkFirmwareFile(t *testing.T, ctx context.Context, env []string, path string) firmwareE2ECheck {
 	t.Helper()
 
-	output, err := runFleetCLI(ctx, env, "firmware", "check", "--target-manufacturer", firmwareE2ETargetManufacturer, "--target-model", firmwareE2ETargetModel, path)
+	output, err := runFleetCLI(ctx, env, "firmware", "check",
+		"--target-manufacturer", firmwareE2ETargetManufacturer,
+		"--target-model", firmwareE2ETargetModel,
+		"--firmware-version", firmwareE2EVersion,
+		path)
 	require.NoError(t, err, "firmware check should succeed")
 
 	var resp firmwareE2ECheck

--- a/server/e2e/fleetcli_firmware_e2e_test.go
+++ b/server/e2e/fleetcli_firmware_e2e_test.go
@@ -20,11 +20,14 @@ const (
 	firmwareE2ETargetManufacturer = "Proto"
 	firmwareE2ETargetModel        = "Rig"
 	firmwareE2EVersion            = "2.4.6"
+	firmwareE2EEditedManufacturer = "Proto Industries"
+	firmwareE2EEditedModel        = "Rig Pro"
+	firmwareE2EEditedVersion      = "2.4.7"
 )
 
 // TestFleetCLIFirmwareWorkflow drives the firmware file lifecycle through the
-// fleetcli binary: config -> check -> upload (direct and chunked) -> list ->
-// delete -> delete-all.
+// fleetcli binary: config -> check -> upload (direct and chunked) -> edit
+// metadata -> list -> delete -> delete-all.
 //
 // Prerequisites: the docker-compose stack must be running with fleet-api on
 // localhost:4000 (e.g. `just dev`). The final delete-all step removes every
@@ -149,6 +152,30 @@ func TestFleetCLIFirmwareWorkflow(t *testing.T) {
 		t.Logf("✓ Chunked upload stored firmware file %s (%d bytes)", chunkedFileID, chunkedSize)
 	})
 
+	t.Run("EditMetadata", func(t *testing.T) {
+		require.NotEmpty(t, smallFileID, "smallFileID must be set from the direct upload step")
+
+		output, err := runFleetCLI(ctx, env, "firmware", "edit-metadata",
+			"--firmware-file-id", smallFileID,
+			"--target-manufacturer", firmwareE2EEditedManufacturer,
+			"--target-model", firmwareE2EEditedModel,
+			"--firmware-version", firmwareE2EEditedVersion)
+		require.NoError(t, err, "firmware metadata edit should succeed")
+
+		var resp struct {
+			FirmwareFileID     string `json:"firmware_file_id"`
+			TargetManufacturer string `json:"target_manufacturer"`
+			TargetModel        string `json:"target_model"`
+			FirmwareVersion    string `json:"firmware_version"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(output), &resp), "edit-metadata output should be JSON: %s", output)
+		assert.Equal(t, smallFileID, resp.FirmwareFileID, "edit-metadata should echo the updated file id")
+		assert.Equal(t, firmwareE2EEditedManufacturer, resp.TargetManufacturer)
+		assert.Equal(t, firmwareE2EEditedModel, resp.TargetModel)
+		assert.Equal(t, firmwareE2EEditedVersion, resp.FirmwareVersion)
+		t.Logf("✓ Updated metadata for firmware file %s", smallFileID)
+	})
+
 	t.Run("List", func(t *testing.T) {
 		require.NotEmpty(t, smallFileID, "smallFileID must be set from the direct upload step")
 		require.NotEmpty(t, chunkedFileID, "chunkedFileID must be set from the chunked upload step")
@@ -159,9 +186,9 @@ func TestFleetCLIFirmwareWorkflow(t *testing.T) {
 		require.NotNil(t, small, "list should include the direct upload")
 		assert.Equal(t, "e2e-firmware-small.swu", small.Filename)
 		assert.Equal(t, int64(64*1024), small.Size)
-		assert.Equal(t, firmwareE2ETargetManufacturer, small.TargetManufacturer)
-		assert.Equal(t, firmwareE2ETargetModel, small.TargetModel)
-		assert.Equal(t, firmwareE2EVersion, small.FirmwareVersion)
+		assert.Equal(t, firmwareE2EEditedManufacturer, small.TargetManufacturer)
+		assert.Equal(t, firmwareE2EEditedModel, small.TargetModel)
+		assert.Equal(t, firmwareE2EEditedVersion, small.FirmwareVersion)
 
 		chunked := findFirmwareFile(files, chunkedFileID)
 		require.NotNil(t, chunked, "list should include the chunked upload")

--- a/server/e2e/fleetcli_subcommands_e2e_test.go
+++ b/server/e2e/fleetcli_subcommands_e2e_test.go
@@ -331,7 +331,13 @@ func TestFleetCLISubcommands(t *testing.T) {
 		require.NotEmpty(t, deviceIdentifier, "deviceIdentifier must be set")
 
 		firmwarePath := writeRandomFirmwareFile(t, t.TempDir(), "fleetcli-destructive.swu", 64*1024)
-		uploaded := runFleetCLIJSON(t, ctx, env, "firmware", "upload", "--quiet", firmwarePath)
+		uploaded := runFleetCLIJSON(t, ctx, env,
+			"firmware", "upload", "--quiet",
+			"--target-manufacturer", firmwareE2ETargetManufacturer,
+			"--target-model", firmwareE2ETargetModel,
+			"--firmware-version", firmwareE2EVersion,
+			firmwarePath,
+		)
 		firmwareFileID := jsonString(t, uploaded, "firmware_file_id")
 		require.NotEmpty(t, firmwareFileID, "firmware upload should return firmware_file_id")
 		t.Cleanup(func() {

--- a/server/fake-antminer/firmware_update_test.go
+++ b/server/fake-antminer/firmware_update_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func firmwareUploadRequest(t *testing.T, filename string) *http.Request {
+	t.Helper()
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, err := writer.CreateFormFile("file", filename)
+	if err != nil {
+		t.Fatalf("create firmware form file: %v", err)
+	}
+	if _, err := part.Write([]byte("fake firmware")); err != nil {
+		t.Fatalf("write firmware form file: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close multipart writer: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/cgi-bin/upgrade.cgi", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	return req
+}
+
+func TestFirmwareVersionFromFilename(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		want     string
+		wantOK   bool
+	}{
+		{name: "release filename", filename: "miner-image-release-c3-p1-1.3.5.swu", want: "1.3.5", wantOK: true},
+		{name: "v prefix", filename: "antminer-s19-v2.1.0.tar.gz", want: "2.1.0", wantOK: true},
+		{name: "no version", filename: "antminer-firmware.tar.gz", wantOK: false},
+		{name: "partial version", filename: "antminer-2.1.tar.gz", wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := firmwareVersionFromFilename(tt.filename)
+			if got != tt.want || ok != tt.wantOK {
+				t.Fatalf("firmwareVersionFromFilename(%q) = %q, %v; want %q, %v", tt.filename, got, ok, tt.want, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestFirmwareUploadPromotesFilenameVersionOnReboot(t *testing.T) {
+	state := &MinerState{FirmwareVersion: "2.0.0"}
+	uploadRecorder := httptest.NewRecorder()
+
+	createUpgradeHandler(state).ServeHTTP(uploadRecorder, firmwareUploadRequest(t, "antminer-s19-v2.1.0.tar.gz"))
+
+	if uploadRecorder.Code != http.StatusOK {
+		t.Fatalf("expected upload status %d, got %d", http.StatusOK, uploadRecorder.Code)
+	}
+	if state.FirmwareVersion != "2.0.0" {
+		t.Fatalf("expected current firmware to remain 2.0.0 before reboot, got %q", state.FirmwareVersion)
+	}
+	if state.PendingFirmwareVersion != "2.1.0" {
+		t.Fatalf("expected pending firmware 2.1.0, got %q", state.PendingFirmwareVersion)
+	}
+
+	rebootRecorder := httptest.NewRecorder()
+	createRebootHandler(state).ServeHTTP(
+		rebootRecorder,
+		httptest.NewRequest(http.MethodPost, "/cgi-bin/reboot.cgi", nil),
+	)
+
+	if rebootRecorder.Code != http.StatusOK {
+		t.Fatalf("expected reboot status %d, got %d", http.StatusOK, rebootRecorder.Code)
+	}
+	if state.FirmwareVersion != "2.1.0" {
+		t.Fatalf("expected current firmware 2.1.0 after reboot, got %q", state.FirmwareVersion)
+	}
+	if state.PendingFirmwareVersion != "" {
+		t.Fatalf("expected pending firmware to be cleared, got %q", state.PendingFirmwareVersion)
+	}
+	if got := generateVersionResponse(state).Version[0].BMMiner; got != "2.1.0" {
+		t.Fatalf("expected RPC firmware version 2.1.0, got %q", got)
+	}
+}
+
+func TestFirmwareUploadWithoutFilenameVersionPreservesCurrentVersion(t *testing.T) {
+	state := &MinerState{FirmwareVersion: "2.0.0"}
+	uploadRecorder := httptest.NewRecorder()
+
+	createUpgradeHandler(state).ServeHTTP(uploadRecorder, firmwareUploadRequest(t, "antminer-firmware.tar.gz"))
+
+	if uploadRecorder.Code != http.StatusOK {
+		t.Fatalf("expected upload status %d, got %d", http.StatusOK, uploadRecorder.Code)
+	}
+	if state.PendingFirmwareVersion != "" {
+		t.Fatalf("expected no pending firmware version, got %q", state.PendingFirmwareVersion)
+	}
+
+	rebootRecorder := httptest.NewRecorder()
+	createRebootHandler(state).ServeHTTP(
+		rebootRecorder,
+		httptest.NewRequest(http.MethodPost, "/cgi-bin/reboot.cgi", nil),
+	)
+
+	if state.FirmwareVersion != "2.0.0" {
+		t.Fatalf("expected current firmware to remain 2.0.0, got %q", state.FirmwareVersion)
+	}
+}

--- a/server/fake-antminer/http_handlers.go
+++ b/server/fake-antminer/http_handlers.go
@@ -15,7 +15,17 @@ import (
 	"github.com/google/uuid"
 )
 
+var firmwareFilenameVersionRE = regexp.MustCompile(`(?:^|[^0-9.])v?([0-9]+\.[0-9]+\.[0-9]+)(?:$|[^0-9.]|\.[A-Za-z])`)
+
 // HTTP handler functions
+
+func firmwareVersionFromFilename(filename string) (string, bool) {
+	matches := firmwareFilenameVersionRE.FindStringSubmatch(filename)
+	if len(matches) != 2 {
+		return "", false
+	}
+	return matches[1], true
+}
 
 func createSystemInfoHandler(state *MinerState) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -341,6 +351,13 @@ func createRebootHandler(state *MinerState) http.HandlerFunc {
 
 		log.Println("Received reboot request")
 
+		state.mu.Lock()
+		if state.PendingFirmwareVersion != "" {
+			state.FirmwareVersion = state.PendingFirmwareVersion
+			state.PendingFirmwareVersion = ""
+		}
+		state.mu.Unlock()
+
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintf(w, `{"success": true, "message": "Reboot initiated"}`)
@@ -591,7 +608,7 @@ func createKernelLogHandler(state *MinerState) http.HandlerFunc {
 	}
 }
 
-func createUpgradeHandler(_ *MinerState) http.HandlerFunc {
+func createUpgradeHandler(state *MinerState) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -605,7 +622,16 @@ func createUpgradeHandler(_ *MinerState) http.HandlerFunc {
 		}
 		defer file.Close()
 
-		log.Printf("Firmware upgrade received: filename=%s, size=%d", header.Filename, header.Size)
+		version, hasVersion := firmwareVersionFromFilename(header.Filename)
+		state.mu.Lock()
+		state.PendingFirmwareVersion = version
+		state.mu.Unlock()
+
+		if hasVersion {
+			log.Printf("Firmware upgrade received: filename=%s, size=%d, staged_version=%s", header.Filename, header.Size, version)
+		} else {
+			log.Printf("Firmware upgrade received: filename=%s, size=%d", header.Filename, header.Size)
+		}
 
 		w.Header().Set("Content-Type", "text/html")
 		w.WriteHeader(http.StatusOK)

--- a/server/fake-antminer/main.go
+++ b/server/fake-antminer/main.go
@@ -19,7 +19,7 @@ func main() {
 	minerType := getEnv("MINER_TYPE", "Antminer S19j Pro")
 	serialNumber := getEnv("SERIAL_NUMBER", "fake-antminer-1")
 	macAddress := getEnv("MAC_ADDRESS", "00:11:22:33:44:55")
-	firmwareVersion := getEnv("FIRMWARE_VERSION", "Antminer S19j Pro 110Th 28/11/2022 16:51:53")
+	firmwareVersion := getEnv("FIRMWARE_VERSION", "2.0.0")
 
 	// Validate required environment variables
 	if err := validateConfig(minerType, serialNumber, macAddress); err != nil {

--- a/server/fake-antminer/models.go
+++ b/server/fake-antminer/models.go
@@ -79,24 +79,25 @@ type DeviceInfo struct {
 
 // MinerState holds the state data of the fake miner
 type MinerState struct {
-	mu              sync.RWMutex
-	MinerType       string
-	SerialNumber    string
-	MacAddress      string
-	FirmwareVersion string
-	IPAddress       string
-	Hostname        string
-	NetMask         string
-	Gateway         string
-	DNSServers      string
-	HashRate        float64
-	Temperature     float64
-	Pools           []Pool
-	MinerMode       string
-	BitmainWorkMode string
-	Username        string
-	Password        string
-	IsBlinking      bool
+	mu                     sync.RWMutex
+	MinerType              string
+	SerialNumber           string
+	MacAddress             string
+	FirmwareVersion        string
+	PendingFirmwareVersion string
+	IPAddress              string
+	Hostname               string
+	NetMask                string
+	Gateway                string
+	DNSServers             string
+	HashRate               float64
+	Temperature            float64
+	Pools                  []Pool
+	MinerMode              string
+	BitmainWorkMode        string
+	Username               string
+	Password               string
+	IsBlinking             bool
 	// Error simulation fields
 	ErrorConfig ErrorConfig
 }

--- a/server/fake-antminer/rpc_handlers.go
+++ b/server/fake-antminer/rpc_handlers.go
@@ -98,6 +98,10 @@ func generateVersionResponse(state *MinerState) VersionResponse {
 	defer state.mu.RUnlock()
 
 	now := time.Now().Unix()
+	firmwareVersion := state.FirmwareVersion
+	if firmwareVersion == "" {
+		firmwareVersion = "2.0.0"
+	}
 	return VersionResponse{
 		RPCResponse: RPCResponse{
 			Status: []StatusInfo{
@@ -111,7 +115,7 @@ func generateVersionResponse(state *MinerState) VersionResponse {
 		},
 		Version: []VersionInfo{
 			{
-				BMMiner:     "2.0.0",
+				BMMiner:     firmwareVersion,
 				API:         "3.1",
 				Miner:       state.MinerType,
 				CompileTime: "2023-05-01",

--- a/server/fake-proto-rig/rest_api_handler.go
+++ b/server/fake-proto-rig/rest_api_handler.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -20,6 +21,8 @@ const (
 	minPasswordLength      = 8
 	maxLocateLEDOnTimeSecs = 300
 )
+
+var firmwareFilenameVersionRE = regexp.MustCompile(`(?:^|[^0-9.])v?([0-9]+\.[0-9]+\.[0-9]+)(?:$|[^0-9.]|\.[A-Za-z])`)
 
 // REST API JSON types matching the OpenAPI spec (MDK-API.json)
 
@@ -169,6 +172,21 @@ func nextFirmwareVersion(currentVersion string) string {
 	}
 
 	return fmt.Sprintf("%d.%d.%d", major, minor, patch+1)
+}
+
+func firmwareVersionFromFilename(filename string) (string, bool) {
+	matches := firmwareFilenameVersionRE.FindStringSubmatch(filename)
+	if len(matches) != 2 {
+		return "", false
+	}
+	return matches[1], true
+}
+
+func stagedFirmwareVersion(filename, currentVersion string) string {
+	if version, ok := firmwareVersionFromFilename(filename); ok {
+		return version
+	}
+	return nextFirmwareVersion(currentVersion)
 }
 
 func buildSystemUpdateStatus(status, currentVersion, previousVersion, newVersion string) UpdateStatus {
@@ -1785,24 +1803,29 @@ func (h *RESTApiHandler) handleUpdate(w http.ResponseWriter, r *http.Request) {
 			h.writeJSON(w, http.StatusConflict, MessageResponse{Message: "System update is already in progress."})
 			return
 		}
+		h.state.mu.Unlock()
+
+		file, header, err := r.FormFile("file")
+		if err != nil {
+			h.writeError(w, http.StatusBadRequest, "BAD_REQUEST", "Missing or invalid 'file' field in multipart form")
+			return
+		}
+		defer file.Close()
+
+		h.state.mu.Lock()
+		switch h.state.FWUpdateStatus {
+		case "downloading", "downloaded", "installing", "installed":
+			h.state.mu.Unlock()
+			h.writeJSON(w, http.StatusConflict, MessageResponse{Message: "System update is already in progress."})
+			return
+		}
 		currentVersion := h.state.FWCurrentVersion
 		if currentVersion == "" {
 			currentVersion = defaultFirmwareVersion
 		}
 		h.state.FWUpdateStatus = "downloading"
-		h.state.FWNewVersion = nextFirmwareVersion(currentVersion)
+		h.state.FWNewVersion = stagedFirmwareVersion(header.Filename, currentVersion)
 		h.state.mu.Unlock()
-
-		file, header, err := r.FormFile("file")
-		if err != nil {
-			h.state.mu.Lock()
-			h.state.FWUpdateStatus = ""
-			h.state.FWNewVersion = ""
-			h.state.mu.Unlock()
-			h.writeError(w, http.StatusBadRequest, "BAD_REQUEST", "Missing or invalid 'file' field in multipart form")
-			return
-		}
-		defer file.Close()
 
 		log.Printf("Firmware upload received: filename=%s, size=%d", header.Filename, header.Size)
 		h.startFirmwareOTALifecycle()

--- a/server/fake-proto-rig/rest_api_handler_test.go
+++ b/server/fake-proto-rig/rest_api_handler_test.go
@@ -2473,6 +2473,54 @@ func TestHandleSystem_SwUpdateStatusUsesSpecFieldNames(t *testing.T) {
 	}
 }
 
+func TestStagedFirmwareVersion_UsesFilenameVersionWhenPresent(t *testing.T) {
+	tests := []struct {
+		name           string
+		filename       string
+		currentVersion string
+		want           string
+	}{
+		{
+			name:           "plain semantic version",
+			filename:       "protoos-1.9.0.swu",
+			currentVersion: "1.8.0",
+			want:           "1.9.0",
+		},
+		{
+			name:           "v-prefixed semantic version",
+			filename:       "firmware-update-v2.0.2.swu",
+			currentVersion: "1.8.0",
+			want:           "2.0.2",
+		},
+		{
+			name:           "fallback when filename has no version",
+			filename:       "protoos-update.swu",
+			currentVersion: "1.8.0",
+			want:           defaultNextFirmwareVersion,
+		},
+		{
+			name:           "fallback increments non-default current version",
+			filename:       "protoos-update.swu",
+			currentVersion: "2.3.4",
+			want:           "2.3.5",
+		},
+		{
+			name:           "does not extract partial four-part version",
+			filename:       "protoos-1.2.3.4.swu",
+			currentVersion: "1.8.0",
+			want:           defaultNextFirmwareVersion,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := stagedFirmwareVersion(tt.filename, tt.currentVersion); got != tt.want {
+				t.Fatalf("expected staged version %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
 func TestHandleSystem_PreviousVersionSetAfterInstallReboot(t *testing.T) {
 	state := NewMinerState("SN12345678", "00:11:22:33:44:55")
 	h := NewRESTApiHandler(state)
@@ -2622,10 +2670,11 @@ func TestHandleUpdate_PutWhileInstalled_RejectsAndPreservesStagedVersion(t *test
 func TestHandleUpdate_PutProgressesToInstalled(t *testing.T) {
 	state := NewMinerState("SN12345678", "00:11:22:33:44:55")
 	h := NewRESTApiHandler(state)
+	const uploadedVersion = "2.4.6"
 
 	var body bytes.Buffer
 	writer := multipart.NewWriter(&body)
-	part, err := writer.CreateFormFile("file", "protoos-update.swu")
+	part, err := writer.CreateFormFile("file", "protoos-"+uploadedVersion+".swu")
 	if err != nil {
 		t.Fatalf("failed to create multipart file: %v", err)
 	}
@@ -2653,11 +2702,34 @@ func TestHandleUpdate_PutProgressesToInstalled(t *testing.T) {
 			t.Fatalf("expected sw_update_status object, got: %v", info["sw_update_status"])
 		}
 
-		if got := swUpdate["new_version"]; got != defaultNextFirmwareVersion {
-			t.Fatalf("expected new_version %q after upload, got %v", defaultNextFirmwareVersion, got)
+		if got := swUpdate["new_version"]; got != uploadedVersion {
+			t.Fatalf("expected new_version %q after upload, got %v", uploadedVersion, got)
 		}
 
 		if swUpdate["status"] == "installed" {
+			rebootRR := httptest.NewRecorder()
+			rebootReq := httptest.NewRequest(http.MethodPost, "/api/v1/system/reboot", nil)
+			h.handleReboot(rebootRR, rebootReq)
+
+			if rebootRR.Code != http.StatusAccepted {
+				t.Fatalf("expected %d from reboot, got %d; body=%s", http.StatusAccepted, rebootRR.Code, rebootRR.Body.String())
+			}
+
+			state.mu.Lock()
+			state.Rebooting = false
+			state.mu.Unlock()
+
+			info = getSystemInfo(t, h)
+			swUpdate, ok = info["sw_update_status"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected sw_update_status object after reboot, got: %v", info["sw_update_status"])
+			}
+			if got := swUpdate["current_version"]; got != uploadedVersion {
+				t.Fatalf("expected current_version %q after reboot, got %v", uploadedVersion, got)
+			}
+			if got := swUpdate["previous_version"]; got != defaultFirmwareVersion {
+				t.Fatalf("expected previous_version %q after reboot, got %v", defaultFirmwareVersion, got)
+			}
 			return
 		}
 

--- a/server/internal/domain/command/execution_service_test.go
+++ b/server/internal/domain/command/execution_service_test.go
@@ -865,7 +865,10 @@ func TestExecuteCommandOnDevice_FirmwareUpdatePassesFileMetadata(t *testing.T) {
 	filesService, err := files.NewService(files.Config{})
 	require.NoError(t, err)
 	content := "firmware image"
-	fileID, err := filesService.SaveFirmwareFile("update.swu", strings.NewReader(content))
+	fileID, err := filesService.SaveFirmwareFile("update.swu", strings.NewReader(content), files.FirmwareMetadata{
+		TargetManufacturer: "Proto",
+		TargetModel:        "S21",
+	})
 	require.NoError(t, err)
 
 	mockQueue := mocks.NewMockMessageQueue(ctrl)

--- a/server/internal/domain/command/execution_service_test.go
+++ b/server/internal/domain/command/execution_service_test.go
@@ -868,6 +868,7 @@ func TestExecuteCommandOnDevice_FirmwareUpdatePassesFileMetadata(t *testing.T) {
 	fileID, err := filesService.SaveFirmwareFile("update.swu", strings.NewReader(content), files.FirmwareMetadata{
 		TargetManufacturer: "Proto",
 		TargetModel:        "S21",
+		FirmwareVersion:    "1.2.3",
 	})
 	require.NoError(t, err)
 

--- a/server/internal/domain/command/execution_service_test.go
+++ b/server/internal/domain/command/execution_service_test.go
@@ -867,7 +867,7 @@ func TestExecuteCommandOnDevice_FirmwareUpdatePassesFileMetadata(t *testing.T) {
 	content := "firmware image"
 	fileID, err := filesService.SaveFirmwareFile("update.swu", strings.NewReader(content), files.FirmwareMetadata{
 		TargetManufacturer: "Proto",
-		TargetModel:        "S21",
+		TargetModel:        "Rig",
 		FirmwareVersion:    "1.2.3",
 	})
 	require.NoError(t, err)

--- a/server/internal/domain/command/service.go
+++ b/server/internal/domain/command/service.go
@@ -1568,10 +1568,10 @@ func (s *Service) validateFirmwareUpdateTargets(
 ) error {
 	metadata, err := s.filesService.GetFirmwareMetadata(firmwareFileID)
 	if err != nil {
-		return fleeterror.NewFailedPreconditionError("firmware target metadata is unavailable; re-upload the firmware before deploying it")
+		return err
 	}
 	if err := files.ValidateFirmwareMetadata(metadata); err != nil {
-		return fleeterror.NewFailedPreconditionError("firmware target metadata is unknown; re-upload the firmware before deploying it")
+		return fleeterror.NewFailedPreconditionError("firmware target metadata is unknown; repair its metadata before deploying it")
 	}
 
 	identifiers := make([]string, 0, len(devices))

--- a/server/internal/domain/command/service.go
+++ b/server/internal/domain/command/service.go
@@ -1590,9 +1590,7 @@ func (s *Service) validateFirmwareUpdateTargets(
 	mismatchCount := 0
 	for _, identifier := range identifiers {
 		property, ok := propertiesByIdentifier[identifier]
-		if !ok || strings.TrimSpace(property.Manufacturer) == "" || strings.TrimSpace(property.Model) == "" ||
-			!strings.EqualFold(strings.TrimSpace(property.Manufacturer), metadata.TargetManufacturer) ||
-			!strings.EqualFold(strings.TrimSpace(property.Model), metadata.TargetModel) {
+		if !ok || !metadata.MatchesTarget(property.Manufacturer, property.Model) {
 			mismatchCount++
 		}
 	}

--- a/server/internal/domain/command/service.go
+++ b/server/internal/domain/command/service.go
@@ -913,7 +913,12 @@ func (s *Service) processCommand(ctx context.Context, command *Command) (*Comman
 		if !ok {
 			return nil, fleeterror.NewInternalError("invalid firmware update payload")
 		}
-		if err := s.validateFirmwareUpdateTargets(ctx, info.OrganizationID, resolvedDevices, firmwarePayload.FirmwareFileID); err != nil {
+		metadata, release, err := s.filesService.LeaseFirmwareMetadata(firmwarePayload.FirmwareFileID)
+		if err != nil {
+			return nil, err
+		}
+		defer release()
+		if err := s.validateFirmwareUpdateTargets(ctx, info.OrganizationID, resolvedDevices, metadata); err != nil {
 			return nil, err
 		}
 	}
@@ -1564,12 +1569,8 @@ func (s *Service) validateFirmwareUpdateTargets(
 	ctx context.Context,
 	organizationID int64,
 	devices []resolvedDevice,
-	firmwareFileID string,
+	metadata files.FirmwareMetadata,
 ) error {
-	metadata, err := s.filesService.GetFirmwareMetadata(firmwareFileID)
-	if err != nil {
-		return err
-	}
 	if err := files.ValidateFirmwareMetadata(metadata); err != nil {
 		return fleeterror.NewFailedPreconditionError("firmware target metadata is unknown; repair its metadata before deploying it")
 	}

--- a/server/internal/domain/command/service.go
+++ b/server/internal/domain/command/service.go
@@ -908,6 +908,15 @@ func (s *Service) processCommand(ctx context.Context, command *Command) (*Comman
 	if err != nil {
 		return nil, fleeterror.NewInternalErrorf("error resolving identifiers to device IDs: %v", err)
 	}
+	if command.commandType == commandtype.FirmwareUpdate {
+		firmwarePayload, ok := command.payload.(dto.FirmwareUpdatePayload)
+		if !ok {
+			return nil, fleeterror.NewInternalError("invalid firmware update payload")
+		}
+		if err := s.validateFirmwareUpdateTargets(ctx, info.OrganizationID, resolvedDevices, firmwarePayload.FirmwareFileID); err != nil {
+			return nil, err
+		}
+	}
 
 	logPayload := command.payload
 	queuePayloads := []queue.EnqueueMessage{}
@@ -1549,6 +1558,54 @@ func (s *Service) FirmwareUpdate(ctx context.Context, deviceSelector *pb.DeviceS
 	}
 	s.finalizeDispatch(ctx, result, "firmware_update", "Update firmware")
 	return result, nil
+}
+
+func (s *Service) validateFirmwareUpdateTargets(
+	ctx context.Context,
+	organizationID int64,
+	devices []resolvedDevice,
+	firmwareFileID string,
+) error {
+	metadata, err := s.filesService.GetFirmwareMetadata(firmwareFileID)
+	if err != nil {
+		return fleeterror.NewFailedPreconditionError("firmware target metadata is unavailable; re-upload the firmware before deploying it")
+	}
+	if err := files.ValidateFirmwareMetadata(metadata); err != nil {
+		return fleeterror.NewFailedPreconditionError("firmware target metadata is unknown; re-upload the firmware before deploying it")
+	}
+
+	identifiers := make([]string, 0, len(devices))
+	for _, device := range devices {
+		identifiers = append(identifiers, device.identifier)
+	}
+	properties, err := s.deviceStore.GetDevicePropertiesForRename(ctx, organizationID, identifiers, false)
+	if err != nil {
+		return fleeterror.NewInternalErrorf("failed to load device targets for firmware compatibility validation: %v", err)
+	}
+	propertiesByIdentifier := make(map[string]stores.DeviceRenameProperties, len(properties))
+	for _, property := range properties {
+		propertiesByIdentifier[property.DeviceIdentifier] = property
+	}
+
+	mismatchCount := 0
+	for _, identifier := range identifiers {
+		property, ok := propertiesByIdentifier[identifier]
+		if !ok || strings.TrimSpace(property.Manufacturer) == "" || strings.TrimSpace(property.Model) == "" ||
+			!strings.EqualFold(strings.TrimSpace(property.Manufacturer), metadata.TargetManufacturer) ||
+			!strings.EqualFold(strings.TrimSpace(property.Model), metadata.TargetModel) {
+			mismatchCount++
+		}
+	}
+	if mismatchCount > 0 {
+		return fleeterror.NewFailedPreconditionErrorf(
+			"firmware targets %s %s, but %d of %d selected device(s) have a different or unknown target",
+			metadata.TargetManufacturer,
+			metadata.TargetModel,
+			mismatchCount,
+			len(identifiers),
+		)
+	}
+	return nil
 }
 
 func (s *Service) Unpair(ctx context.Context, deviceSelector *pb.DeviceSelector) (*CommandResult, error) {

--- a/server/internal/domain/command/service_firmware_test.go
+++ b/server/internal/domain/command/service_firmware_test.go
@@ -1,0 +1,203 @@
+package command
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/block/proto-fleet/server/internal/domain/commandtype"
+	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
+	"github.com/block/proto-fleet/server/internal/domain/miner/dto"
+	stores "github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
+	storeMocks "github.com/block/proto-fleet/server/internal/domain/stores/interfaces/mocks"
+	"github.com/block/proto-fleet/server/internal/infrastructure/files"
+	queueMocks "github.com/block/proto-fleet/server/internal/infrastructure/queue/mocks"
+)
+
+func setupFirmwareTargetValidationService(t *testing.T) (*Service, *storeMocks.MockDeviceStore, *files.Service) {
+	t.Helper()
+	t.Chdir(t.TempDir())
+	filesService, err := files.NewService(files.Config{})
+	require.NoError(t, err)
+	deviceStore := storeMocks.NewMockDeviceStore(gomock.NewController(t))
+	return &Service{filesService: filesService, deviceStore: deviceStore}, deviceStore, filesService
+}
+
+func TestValidateFirmwareUpdateTargets_AcceptsMatchingTargetsCaseInsensitively(t *testing.T) {
+	svc, deviceStore, filesService := setupFirmwareTargetValidationService(t)
+	fileID, err := filesService.SaveFirmwareFile("update.swu", strings.NewReader("firmware"), files.FirmwareMetadata{
+		TargetManufacturer: "Proto",
+		TargetModel:        "Rig",
+		FirmwareVersion:    "2.0.0",
+	})
+	require.NoError(t, err)
+	devices := []resolvedDevice{{id: 1, identifier: "device-1"}, {id: 2, identifier: "device-2"}}
+	deviceStore.EXPECT().GetDevicePropertiesForRename(gomock.Any(), int64(7), []string{"device-1", "device-2"}, false).Return(
+		[]stores.DeviceRenameProperties{
+			{DeviceIdentifier: "device-1", Manufacturer: " proto ", Model: "RIG"},
+			{DeviceIdentifier: "device-2", Manufacturer: "Proto", Model: "Rig"},
+		}, nil,
+	)
+
+	assert.NoError(t, svc.validateFirmwareUpdateTargets(t.Context(), 7, devices, fileID))
+}
+
+func TestValidateFirmwareUpdateTargets_RejectsMismatchedOrUnknownTargets(t *testing.T) {
+	svc, deviceStore, filesService := setupFirmwareTargetValidationService(t)
+	fileID, err := filesService.SaveFirmwareFile("update.swu", strings.NewReader("firmware"), files.FirmwareMetadata{
+		TargetManufacturer: "Proto",
+		TargetModel:        "Rig",
+		FirmwareVersion:    "2.0.0",
+	})
+	require.NoError(t, err)
+	devices := []resolvedDevice{{id: 1, identifier: "device-1"}, {id: 2, identifier: "device-2"}}
+	deviceStore.EXPECT().GetDevicePropertiesForRename(gomock.Any(), int64(7), []string{"device-1", "device-2"}, false).Return(
+		[]stores.DeviceRenameProperties{
+			{DeviceIdentifier: "device-1", Manufacturer: "Bitmain", Model: "Rig"},
+			{DeviceIdentifier: "device-2", Manufacturer: "Proto", Model: ""},
+		}, nil,
+	)
+
+	err = svc.validateFirmwareUpdateTargets(t.Context(), 7, devices, fileID)
+	require.Error(t, err)
+	assert.True(t, fleeterror.IsFailedPreconditionError(err))
+	assert.Contains(t, err.Error(), "2 of 2")
+}
+
+func TestValidateFirmwareUpdateTargets_RejectsLegacyFirmware(t *testing.T) {
+	svc, _, _ := setupFirmwareTargetValidationService(t)
+	const fileID = "11111111-1111-1111-1111-111111111111"
+	legacyDir := filepath.Join("firmware", fileID)
+	require.NoError(t, os.MkdirAll(legacyDir, 0750))
+	require.NoError(t, os.WriteFile(filepath.Join(legacyDir, "legacy.swu"), []byte("legacy"), 0600))
+
+	err := svc.validateFirmwareUpdateTargets(t.Context(), 7, []resolvedDevice{{id: 1, identifier: "device-1"}}, fileID)
+	require.Error(t, err)
+	assert.True(t, fleeterror.IsFailedPreconditionError(err))
+	assert.Contains(t, err.Error(), "metadata is unknown")
+}
+
+func TestProcessCommand_FirmwareUpdateValidatesBeforeDispatch(t *testing.T) {
+	tests := []struct {
+		name       string
+		legacy     bool
+		properties []stores.DeviceRenameProperties
+		wantError  bool
+	}{
+		{
+			name: "matching targets dispatch",
+			properties: []stores.DeviceRenameProperties{
+				{DeviceIdentifier: "device-1", Manufacturer: " proto ", Model: "RIG"},
+				{DeviceIdentifier: "device-2", Manufacturer: "Proto", Model: "Rig"},
+			},
+		},
+		{
+			name: "mixed targets fail",
+			properties: []stores.DeviceRenameProperties{
+				{DeviceIdentifier: "device-1", Manufacturer: "Proto", Model: "Rig"},
+				{DeviceIdentifier: "device-2", Manufacturer: "Bitmain", Model: "S19"},
+			},
+			wantError: true,
+		},
+		{
+			name: "missing device target fails",
+			properties: []stores.DeviceRenameProperties{
+				{DeviceIdentifier: "device-1", Manufacturer: "Proto", Model: "Rig"},
+				{DeviceIdentifier: "device-2", Manufacturer: "", Model: ""},
+			},
+			wantError: true,
+		},
+		{
+			name: "missing device row fails",
+			properties: []stores.DeviceRenameProperties{
+				{DeviceIdentifier: "device-1", Manufacturer: "Proto", Model: "Rig"},
+			},
+			wantError: true,
+		},
+		{
+			name:      "legacy firmware fails",
+			legacy:    true,
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Chdir(t.TempDir())
+			filesService, err := files.NewService(files.Config{})
+			require.NoError(t, err)
+			var fileID string
+			if tt.legacy {
+				fileID = "11111111-1111-1111-1111-111111111111"
+				legacyDir := filepath.Join("firmware", fileID)
+				require.NoError(t, os.MkdirAll(legacyDir, 0750))
+				require.NoError(t, os.WriteFile(filepath.Join(legacyDir, "legacy.swu"), []byte("legacy"), 0600))
+			} else {
+				fileID, err = filesService.SaveFirmwareFile("update.swu", strings.NewReader("firmware"), files.FirmwareMetadata{
+					TargetManufacturer: "Proto",
+					TargetModel:        "Rig",
+					FirmwareVersion:    "2.0.0",
+				})
+				require.NoError(t, err)
+			}
+
+			ctrl := gomock.NewController(t)
+			deviceStore := storeMocks.NewMockDeviceStore(ctrl)
+			messageQueue := queueMocks.NewMockMessageQueue(ctrl)
+			if !tt.legacy {
+				deviceStore.EXPECT().GetDevicePropertiesForRename(
+					gomock.Any(), int64(7), []string{"device-1", "device-2"}, false,
+				).Return(tt.properties, nil)
+			}
+
+			batchCreated := false
+			svc := &Service{
+				config:           &Config{},
+				executionService: &ExecutionService{queueProcessorRunning: true},
+				messageQueue:     messageQueue,
+				filesService:     filesService,
+				deviceStore:      deviceStore,
+				resolveDevicesOverride: func(_ context.Context, identifiers []string) ([]resolvedDevice, error) {
+					return []resolvedDevice{
+						{id: 101, identifier: identifiers[0]},
+						{id: 102, identifier: identifiers[1]},
+					}, nil
+				},
+				saveCommandBatchLogOverride: func(context.Context, int64, int64, *Command, []byte, int) (string, error) {
+					batchCreated = true
+					return "batch-1", nil
+				},
+			}
+			payload := dto.FirmwareUpdatePayload{FirmwareFileID: fileID}
+			if !tt.wantError {
+				messageQueue.EXPECT().Enqueue(
+					gomock.Any(), "batch-1", commandtype.FirmwareUpdate, []int64{101, 102}, payload,
+				).Return(nil)
+			}
+
+			result, err := svc.processCommand(manualSessionCtx(7), &Command{
+				commandType:    commandtype.FirmwareUpdate,
+				deviceSelector: includeSelector("device-1", "device-2"),
+				payload:        payload,
+			})
+			if tt.wantError {
+				require.Error(t, err)
+				assert.True(t, fleeterror.IsFailedPreconditionError(err))
+				assert.False(t, batchCreated)
+				assert.Nil(t, result)
+				return
+			}
+			require.NoError(t, err)
+			assert.True(t, batchCreated)
+			require.NotNil(t, result)
+			assert.Equal(t, "batch-1", result.BatchIdentifier)
+			assert.Equal(t, 2, result.DispatchedCount)
+		})
+	}
+}

--- a/server/internal/domain/command/service_firmware_test.go
+++ b/server/internal/domain/command/service_firmware_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"connectrpc.com/connect"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -81,6 +82,68 @@ func TestValidateFirmwareUpdateTargets_RejectsLegacyFirmware(t *testing.T) {
 	require.Error(t, err)
 	assert.True(t, fleeterror.IsFailedPreconditionError(err))
 	assert.Contains(t, err.Error(), "metadata is unknown")
+	assert.Contains(t, err.Error(), "repair its metadata")
+}
+
+func TestValidateFirmwareUpdateTargets_PreservesMetadataLookupErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		fileID     string
+		setup      func(t *testing.T)
+		assertCode func(t *testing.T, err error)
+	}{
+		{
+			name:   "invalid file ID",
+			fileID: "not-a-uuid",
+			assertCode: func(t *testing.T, err error) {
+				t.Helper()
+				assert.True(t, fleeterror.IsInvalidArgumentError(err))
+			},
+		},
+		{
+			name:   "missing firmware",
+			fileID: "11111111-1111-1111-1111-111111111111",
+			assertCode: func(t *testing.T, err error) {
+				t.Helper()
+				assert.True(t, fleeterror.IsNotFoundError(err))
+			},
+		},
+		{
+			name:   "corrupt metadata",
+			fileID: "22222222-2222-2222-2222-222222222222",
+			setup: func(t *testing.T) {
+				t.Helper()
+				dir := filepath.Join("firmware", "22222222-2222-2222-2222-222222222222")
+				require.NoError(t, os.MkdirAll(dir, 0750))
+				require.NoError(t, os.WriteFile(filepath.Join(dir, "metadata.json"), []byte("{"), 0600))
+			},
+			assertCode: func(t *testing.T, err error) {
+				t.Helper()
+				var fleetErr fleeterror.FleetError
+				require.ErrorAs(t, err, &fleetErr)
+				assert.Equal(t, connect.CodeInternal, fleetErr.GRPCCode)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, _, _ := setupFirmwareTargetValidationService(t)
+			if tt.setup != nil {
+				tt.setup(t)
+			}
+
+			err := svc.validateFirmwareUpdateTargets(
+				t.Context(),
+				7,
+				[]resolvedDevice{{id: 1, identifier: "device-1"}},
+				tt.fileID,
+			)
+
+			require.Error(t, err)
+			tt.assertCode(t, err)
+		})
+	}
 }
 
 func TestProcessCommand_FirmwareUpdateValidatesBeforeDispatch(t *testing.T) {

--- a/server/internal/domain/command/service_firmware_test.go
+++ b/server/internal/domain/command/service_firmware_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"connectrpc.com/connect"
 	"github.com/stretchr/testify/assert"
@@ -46,7 +47,9 @@ func TestValidateFirmwareUpdateTargets_AcceptsMatchingTargetsCaseInsensitively(t
 		}, nil,
 	)
 
-	assert.NoError(t, svc.validateFirmwareUpdateTargets(t.Context(), 7, devices, fileID))
+	metadata, err := filesService.GetFirmwareMetadata(fileID)
+	require.NoError(t, err)
+	assert.NoError(t, svc.validateFirmwareUpdateTargets(t.Context(), 7, devices, metadata))
 }
 
 func TestValidateFirmwareUpdateTargets_RejectsMismatchedOrUnknownTargets(t *testing.T) {
@@ -65,7 +68,9 @@ func TestValidateFirmwareUpdateTargets_RejectsMismatchedOrUnknownTargets(t *test
 		}, nil,
 	)
 
-	err = svc.validateFirmwareUpdateTargets(t.Context(), 7, devices, fileID)
+	metadata, err := filesService.GetFirmwareMetadata(fileID)
+	require.NoError(t, err)
+	err = svc.validateFirmwareUpdateTargets(t.Context(), 7, devices, metadata)
 	require.Error(t, err)
 	assert.True(t, fleeterror.IsFailedPreconditionError(err))
 	assert.Contains(t, err.Error(), "2 of 2")
@@ -78,14 +83,16 @@ func TestValidateFirmwareUpdateTargets_RejectsLegacyFirmware(t *testing.T) {
 	require.NoError(t, os.MkdirAll(legacyDir, 0750))
 	require.NoError(t, os.WriteFile(filepath.Join(legacyDir, "legacy.swu"), []byte("legacy"), 0600))
 
-	err := svc.validateFirmwareUpdateTargets(t.Context(), 7, []resolvedDevice{{id: 1, identifier: "device-1"}}, fileID)
+	metadata, err := svc.filesService.GetFirmwareMetadata(fileID)
+	require.NoError(t, err)
+	err = svc.validateFirmwareUpdateTargets(t.Context(), 7, []resolvedDevice{{id: 1, identifier: "device-1"}}, metadata)
 	require.Error(t, err)
 	assert.True(t, fleeterror.IsFailedPreconditionError(err))
 	assert.Contains(t, err.Error(), "metadata is unknown")
 	assert.Contains(t, err.Error(), "repair its metadata")
 }
 
-func TestValidateFirmwareUpdateTargets_PreservesMetadataLookupErrors(t *testing.T) {
+func TestLeaseFirmwareMetadata_PreservesMetadataLookupErrors(t *testing.T) {
 	tests := []struct {
 		name       string
 		fileID     string
@@ -128,19 +135,15 @@ func TestValidateFirmwareUpdateTargets_PreservesMetadataLookupErrors(t *testing.
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			svc, _, _ := setupFirmwareTargetValidationService(t)
+			_, _, filesService := setupFirmwareTargetValidationService(t)
 			if tt.setup != nil {
 				tt.setup(t)
 			}
 
-			err := svc.validateFirmwareUpdateTargets(
-				t.Context(),
-				7,
-				[]resolvedDevice{{id: 1, identifier: "device-1"}},
-				tt.fileID,
-			)
+			_, release, err := filesService.LeaseFirmwareMetadata(tt.fileID)
 
 			require.Error(t, err)
+			assert.Nil(t, release)
 			tt.assertCode(t, err)
 		})
 	}
@@ -263,4 +266,109 @@ func TestProcessCommand_FirmwareUpdateValidatesBeforeDispatch(t *testing.T) {
 			assert.Equal(t, 2, result.DispatchedCount)
 		})
 	}
+}
+
+func TestProcessCommand_FirmwareUpdateHoldsMetadataLeaseThroughDispatch(t *testing.T) {
+	t.Chdir(t.TempDir())
+	filesService, err := files.NewService(files.Config{})
+	require.NoError(t, err)
+	fileID, err := filesService.SaveFirmwareFile("update.swu", strings.NewReader("firmware"), files.FirmwareMetadata{
+		TargetManufacturer: "Proto",
+		TargetModel:        "Rig",
+		FirmwareVersion:    "2.0.0",
+	})
+	require.NoError(t, err)
+
+	ctrl := gomock.NewController(t)
+	deviceStore := storeMocks.NewMockDeviceStore(ctrl)
+	messageQueue := queueMocks.NewMockMessageQueue(ctrl)
+	validationStarted := make(chan struct{})
+	allowValidation := make(chan struct{})
+	deviceStore.EXPECT().GetDevicePropertiesForRename(
+		gomock.Any(), int64(7), []string{"device-1"}, false,
+	).DoAndReturn(func(context.Context, int64, []string, bool) ([]stores.DeviceRenameProperties, error) {
+		close(validationStarted)
+		<-allowValidation
+		return []stores.DeviceRenameProperties{{
+			DeviceIdentifier: "device-1",
+			Manufacturer:     "Proto",
+			Model:            "Rig",
+		}}, nil
+	})
+
+	enqueueStarted := make(chan struct{})
+	allowEnqueue := make(chan struct{})
+	payload := dto.FirmwareUpdatePayload{FirmwareFileID: fileID}
+	messageQueue.EXPECT().Enqueue(
+		gomock.Any(), "batch-1", commandtype.FirmwareUpdate, []int64{101}, payload,
+	).DoAndReturn(func(context.Context, string, commandtype.Type, []int64, any) error {
+		close(enqueueStarted)
+		<-allowEnqueue
+		return nil
+	})
+
+	svc := &Service{
+		config:           &Config{},
+		executionService: &ExecutionService{run: newExecutionRun(context.Background())},
+		messageQueue:     messageQueue,
+		filesService:     filesService,
+		deviceStore:      deviceStore,
+		resolveDevicesOverride: func(_ context.Context, identifiers []string) ([]resolvedDevice, error) {
+			return []resolvedDevice{{id: 101, identifier: identifiers[0]}}, nil
+		},
+		saveCommandBatchLogOverride: func(context.Context, int64, int64, *Command, []byte, int) (string, error) {
+			return "batch-1", nil
+		},
+	}
+
+	type commandOutcome struct {
+		result *CommandResult
+		err    error
+	}
+	commandDone := make(chan commandOutcome, 1)
+	go func() {
+		result, err := svc.processCommand(manualSessionCtx(7), &Command{
+			commandType:    commandtype.FirmwareUpdate,
+			deviceSelector: includeSelector("device-1"),
+			payload:        payload,
+		})
+		commandDone <- commandOutcome{result: result, err: err}
+	}()
+	<-validationStarted
+
+	updateStarted := make(chan struct{})
+	updateDone := make(chan error, 1)
+	go func() {
+		close(updateStarted)
+		_, err := filesService.UpdateFirmwareMetadata(fileID, files.FirmwareMetadata{
+			TargetManufacturer: "Bitmain",
+			TargetModel:        "S19",
+			FirmwareVersion:    "3.0.0",
+		})
+		updateDone <- err
+	}()
+	<-updateStarted
+
+	select {
+	case err := <-updateDone:
+		close(allowValidation)
+		t.Fatalf("metadata update completed during target validation: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(allowValidation)
+	<-enqueueStarted
+	select {
+	case err := <-updateDone:
+		close(allowEnqueue)
+		t.Fatalf("metadata update completed before firmware dispatch: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(allowEnqueue)
+	outcome := <-commandDone
+	require.NoError(t, outcome.err)
+	require.NotNil(t, outcome.result)
+	assert.Equal(t, "batch-1", outcome.result.BatchIdentifier)
+	require.NoError(t, <-updateDone)
 }

--- a/server/internal/domain/command/service_firmware_test.go
+++ b/server/internal/domain/command/service_firmware_test.go
@@ -159,7 +159,7 @@ func TestProcessCommand_FirmwareUpdateValidatesBeforeDispatch(t *testing.T) {
 			batchCreated := false
 			svc := &Service{
 				config:           &Config{},
-				executionService: &ExecutionService{queueProcessorRunning: true},
+				executionService: &ExecutionService{run: newExecutionRun(context.Background())},
 				messageQueue:     messageQueue,
 				filesService:     filesService,
 				deviceStore:      deviceStore,

--- a/server/internal/handlers/firmware/activity.go
+++ b/server/internal/handlers/firmware/activity.go
@@ -1,0 +1,37 @@
+package firmware
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/block/proto-fleet/server/internal/domain/activity"
+	activitymodels "github.com/block/proto-fleet/server/internal/domain/activity/models"
+	"github.com/block/proto-fleet/server/internal/infrastructure/files"
+)
+
+const firmwareUploadedEventType = "firmware_uploaded"
+
+func logFirmwareUploadActivity(
+	ctx context.Context,
+	activitySvc *activity.Service,
+	filename string,
+	result files.FirmwareUploadSaveResult,
+) {
+	if result.Reused {
+		return
+	}
+	event := activitymodels.Event{
+		Category:    activitymodels.CategorySystem,
+		Type:        firmwareUploadedEventType,
+		Description: fmt.Sprintf("Uploaded firmware file: %s", filename),
+		Metadata: map[string]any{
+			"firmware_file_id":    result.FirmwareFileID,
+			"filename":            filename,
+			"target_manufacturer": result.Metadata.TargetManufacturer,
+			"target_model":        result.Metadata.TargetModel,
+			"firmware_version":    result.Metadata.FirmwareVersion,
+		},
+	}
+	activity.StampActor(ctx, &event)
+	activitySvc.Log(ctx, event)
+}

--- a/server/internal/handlers/firmware/activity.go
+++ b/server/internal/handlers/firmware/activity.go
@@ -9,7 +9,10 @@ import (
 	"github.com/block/proto-fleet/server/internal/infrastructure/files"
 )
 
-const firmwareUploadedEventType = "firmware_uploaded"
+const (
+	firmwareUploadedEventType        = "firmware_uploaded"
+	firmwareMetadataUpdatedEventType = "firmware_metadata_updated"
+)
 
 func logFirmwareUploadActivity(
 	ctx context.Context,
@@ -31,6 +34,35 @@ func logFirmwareUploadActivity(
 			"target_model":        result.Metadata.TargetModel,
 			"firmware_version":    result.Metadata.FirmwareVersion,
 		},
+	}
+	activity.StampActor(ctx, &event)
+	activitySvc.Log(ctx, event)
+}
+
+func logFirmwareMetadataUpdatedActivity(
+	ctx context.Context,
+	activitySvc *activity.Service,
+	fileID string,
+	previous *files.FirmwareMetadata,
+	current files.FirmwareMetadata,
+) {
+	metadata := map[string]any{
+		"firmware_file_id":            fileID,
+		"current_target_manufacturer": current.TargetManufacturer,
+		"current_target_model":        current.TargetModel,
+		"current_firmware_version":    current.FirmwareVersion,
+	}
+	if previous != nil {
+		metadata["previous_target_manufacturer"] = previous.TargetManufacturer
+		metadata["previous_target_model"] = previous.TargetModel
+		metadata["previous_firmware_version"] = previous.FirmwareVersion
+	}
+
+	event := activitymodels.Event{
+		Category:    activitymodels.CategorySystem,
+		Type:        firmwareMetadataUpdatedEventType,
+		Description: fmt.Sprintf("Updated firmware metadata: %s", fileID),
+		Metadata:    metadata,
 	}
 	activity.StampActor(ctx, &event)
 	activitySvc.Log(ctx, event)

--- a/server/internal/handlers/firmware/authorization.go
+++ b/server/internal/handlers/firmware/authorization.go
@@ -1,0 +1,90 @@
+package firmware
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+
+	"github.com/block/proto-fleet/server/internal/domain/authz"
+	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
+	"github.com/block/proto-fleet/server/internal/domain/session"
+	"github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
+	"github.com/block/proto-fleet/server/internal/handlers/middleware"
+)
+
+// effectivePermissionResolver is the request-scoped subset of the authz
+// resolver used by firmware's raw HTTP handlers.
+type effectivePermissionResolver interface {
+	LoadEffective(ctx context.Context, userID, organizationID int64) (*authz.EffectivePermissions, error)
+}
+
+// authorizeMutation applies the same effective-permission lookup and canonical
+// permission gate used by Connect handlers. Firmware routes are registered
+// directly on net/http, so they do not pass through the Connect auth
+// interceptor that normally populates this context.
+func authorizeMutation(
+	r *http.Request,
+	sessionService *session.Service,
+	userStore interfaces.UserStore,
+	permissionResolver effectivePermissionResolver,
+) (context.Context, error) {
+	ctx, err := authenticate(r, sessionService, userStore)
+	if err != nil {
+		return r.Context(), err
+	}
+
+	info, err := session.GetInfo(ctx)
+	if err != nil {
+		return r.Context(), fleeterror.NewUnauthenticatedError("authentication required")
+	}
+	if permissionResolver == nil {
+		return r.Context(), fleeterror.NewInternalError(
+			"authz: permission resolver not wired into firmware handler",
+		)
+	}
+
+	effectivePermissions, err := permissionResolver.LoadEffective(ctx, info.UserID, info.OrganizationID)
+	if err != nil {
+		return r.Context(), fleeterror.NewInternalErrorf(
+			"authz: effective permissions lookup failed: %v",
+			err,
+		)
+	}
+
+	ctx = middleware.WithEffectivePermissions(ctx, effectivePermissions)
+	if _, err := middleware.RequirePermission(
+		ctx,
+		authz.PermMinerFirmwareUpdate,
+		authz.ResourceContext{},
+	); err != nil {
+		return r.Context(), err
+	}
+	return ctx, nil
+}
+
+func requireMutationPermission(
+	w http.ResponseWriter,
+	r *http.Request,
+	sessionService *session.Service,
+	userStore interfaces.UserStore,
+	permissionResolver effectivePermissionResolver,
+	operation string,
+) (context.Context, bool) {
+	ctx, err := authorizeMutation(r, sessionService, userStore, permissionResolver)
+	if err == nil {
+		return ctx, true
+	}
+
+	switch {
+	case fleeterror.IsAuthenticationError(err):
+		slog.Warn("firmware mutation authentication failed", "operation", operation, "error", err)
+		writeError(w, http.StatusUnauthorized, "authentication required")
+	case fleeterror.IsForbiddenError(err):
+		slog.Warn("firmware mutation authorization denied", "operation", operation)
+		writeError(w, http.StatusForbidden, "permission denied")
+	default:
+		slog.Error("firmware mutation authorization failed", "operation", operation, "error", err)
+		writeError(w, http.StatusInternalServerError, "authorization failed")
+	}
+	return r.Context(), false
+}

--- a/server/internal/handlers/firmware/authorization_test.go
+++ b/server/internal/handlers/firmware/authorization_test.go
@@ -109,8 +109,7 @@ func TestFirmwareMutationHandlers_RejectUserWithoutFirmwareUpdatePermission(t *t
 
 			tt.handler(env).ServeHTTP(rr, req)
 
-			assert.Equal(t, http.StatusForbidden, rr.Code)
-			assert.JSONEq(t, `{"error":"permission denied"}`, rr.Body.String())
+			assertJSONErrorResponse(t, rr, http.StatusForbidden, "permission denied")
 		})
 	}
 }

--- a/server/internal/handlers/firmware/authorization_test.go
+++ b/server/internal/handlers/firmware/authorization_test.go
@@ -1,0 +1,148 @@
+package firmware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/proto-fleet/server/internal/domain/authz"
+	"github.com/block/proto-fleet/server/internal/infrastructure/files"
+)
+
+func TestFirmwareMutationHandlers_RejectUserWithoutFirmwareUpdatePermission(t *testing.T) {
+	tests := []struct {
+		name    string
+		method  string
+		path    string
+		handler func(*testEnv) http.Handler
+	}{
+		{
+			name:   "direct upload",
+			method: http.MethodPost,
+			path:   "/api/v1/firmware/upload",
+			handler: func(env *testEnv) http.Handler {
+				return env.uploadHandler()
+			},
+		},
+		{
+			name:   "initiate chunked upload",
+			method: http.MethodPost,
+			path:   "/api/v1/firmware/upload/chunked",
+			handler: func(env *testEnv) http.Handler {
+				return &initiateHandler{
+					mgr:                NewChunkedUploadManager(),
+					filesService:       env.fileSvc,
+					sessionService:     env.sessionSvc,
+					userStore:          env.userStoreMock,
+					permissionResolver: env.permissionResolver,
+				}
+			},
+		},
+		{
+			name:   "upload chunk",
+			method: http.MethodPut,
+			path:   "/api/v1/firmware/upload/chunked/upload-id",
+			handler: func(env *testEnv) http.Handler {
+				return &chunkHandler{
+					mgr:                NewChunkedUploadManager(),
+					sessionService:     env.sessionSvc,
+					userStore:          env.userStoreMock,
+					permissionResolver: env.permissionResolver,
+				}
+			},
+		},
+		{
+			name:   "complete chunked upload",
+			method: http.MethodPost,
+			path:   "/api/v1/firmware/upload/chunked/upload-id/complete",
+			handler: func(env *testEnv) http.Handler {
+				return &completeHandler{
+					mgr:                NewChunkedUploadManager(),
+					filesService:       env.fileSvc,
+					sessionService:     env.sessionSvc,
+					userStore:          env.userStoreMock,
+					permissionResolver: env.permissionResolver,
+				}
+			},
+		},
+		{
+			name:   "update metadata",
+			method: http.MethodPatch,
+			path:   "/api/v1/firmware/files/file-id",
+			handler: func(env *testEnv) http.Handler {
+				return env.updateMetadataHandler()
+			},
+		},
+		{
+			name:   "delete file",
+			method: http.MethodDelete,
+			path:   "/api/v1/firmware/files/file-id",
+			handler: func(env *testEnv) http.Handler {
+				return env.deleteFileHandler()
+			},
+		},
+		{
+			name:   "delete all files",
+			method: http.MethodDelete,
+			path:   "/api/v1/firmware/files",
+			handler: func(env *testEnv) http.Handler {
+				return env.deleteAllFilesHandler()
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := newTestEnv(t)
+			env.permissionResolver = staticPermissionResolver{
+				permissions: []string{authz.PermFleetRead},
+			}
+			env.expectAuth()
+
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			req.AddCookie(validSessionCookie(env.sessionID))
+			rr := httptest.NewRecorder()
+
+			tt.handler(env).ServeHTTP(rr, req)
+
+			assert.Equal(t, http.StatusForbidden, rr.Code)
+			assert.JSONEq(t, `{"error":"permission denied"}`, rr.Body.String())
+		})
+	}
+}
+
+func TestUpdateMetadataHandler_DenialPreservesStoredTarget(t *testing.T) {
+	env := newTestEnv(t)
+	fileID, err := env.fileSvc.SaveFirmwareFile(
+		"firmware.swu",
+		strings.NewReader("firmware payload"),
+		testFirmwareMetadata(),
+	)
+	require.NoError(t, err)
+
+	env.permissionResolver = staticPermissionResolver{
+		permissions: []string{authz.PermFleetRead},
+	}
+	env.expectAuth()
+
+	body := `{"target_manufacturer":"Bitmain","target_model":"S19","firmware_version":"v3.0.0"}`
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/firmware/files/"+fileID, strings.NewReader(body))
+	req.SetPathValue("fileId", fileID)
+	req.AddCookie(validSessionCookie(env.sessionID))
+	rr := httptest.NewRecorder()
+
+	env.updateMetadataHandler().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusForbidden, rr.Code)
+	metadata, err := env.fileSvc.GetFirmwareMetadata(fileID)
+	require.NoError(t, err)
+	assert.Equal(t, files.FirmwareMetadata{
+		TargetManufacturer: "Proto",
+		TargetModel:        "Rig",
+		FirmwareVersion:    "v2.0.0",
+	}, metadata)
+}

--- a/server/internal/handlers/firmware/chunked.go
+++ b/server/internal/handlers/firmware/chunked.go
@@ -30,6 +30,7 @@ type uploadSession struct {
 	expectedSize  int64
 	receivedBytes int64
 	tempFilePath  string
+	force         bool
 	createdAt     time.Time
 	lastActivity  time.Time
 }
@@ -39,6 +40,8 @@ type initiateRequest struct {
 	FileSize           int64  `json:"file_size"`
 	TargetManufacturer string `json:"target_manufacturer"`
 	TargetModel        string `json:"target_model"`
+	FirmwareVersion    string `json:"firmware_version"`
+	Force              bool   `json:"force,omitempty"`
 }
 
 type initiateResponse struct {
@@ -146,10 +149,7 @@ func (h *initiateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	metadata := files.FirmwareMetadata{
 		TargetManufacturer: req.TargetManufacturer,
 		TargetModel:        req.TargetModel,
-	}
-	if err := files.ValidateFirmwareMetadata(metadata); err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
-		return
+		FirmwareVersion:    req.FirmwareVersion,
 	}
 
 	if req.FileSize <= 0 {
@@ -185,6 +185,7 @@ func (h *initiateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		metadata:     metadata,
 		expectedSize: req.FileSize,
 		tempFilePath: tempPath,
+		force:        req.Force,
 		createdAt:    now,
 		lastActivity: now,
 	}
@@ -341,7 +342,7 @@ func (h *completeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fileID, err := h.filesService.SaveFirmwareFileFromPath(sess.filename, sess.tempFilePath, sess.metadata)
+	saveResult, err := h.filesService.SaveFirmwareUploadFromPath(sess.filename, sess.tempFilePath, sess.metadata, sess.force, "")
 	if err != nil {
 		os.Remove(sess.tempFilePath)
 		if isClientError(err) {
@@ -353,11 +354,11 @@ func (h *completeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	slog.Info("chunked upload completed", "upload_id", uploadID, "firmware_file_id", fileID)
+	slog.Info("chunked upload completed", "upload_id", uploadID, "firmware_file_id", saveResult.FirmwareFileID, "reused", saveResult.Reused)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	if err := json.NewEncoder(w).Encode(uploadResponse{FirmwareFileID: fileID}); err != nil {
+	if err := json.NewEncoder(w).Encode(uploadResponse{FirmwareFileID: saveResult.FirmwareFileID, Reused: saveResult.Reused}); err != nil {
 		slog.Error("failed to encode chunked upload response", "error", err)
 	}
 }

--- a/server/internal/handlers/firmware/chunked.go
+++ b/server/internal/handlers/firmware/chunked.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	activityDomain "github.com/block/proto-fleet/server/internal/domain/activity"
 	"github.com/block/proto-fleet/server/internal/domain/session"
 	"github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
 	"github.com/block/proto-fleet/server/internal/infrastructure/files"
@@ -291,8 +292,9 @@ func NewCompleteHandler(
 	filesService *files.Service,
 	sessionService *session.Service,
 	userStore interfaces.UserStore,
+	activitySvc *activityDomain.Service,
 ) http.Handler {
-	return &completeHandler{mgr: mgr, filesService: filesService, sessionService: sessionService, userStore: userStore}
+	return &completeHandler{mgr: mgr, filesService: filesService, sessionService: sessionService, userStore: userStore, activitySvc: activitySvc}
 }
 
 type completeHandler struct {
@@ -300,10 +302,12 @@ type completeHandler struct {
 	filesService   *files.Service
 	sessionService *session.Service
 	userStore      interfaces.UserStore
+	activitySvc    *activityDomain.Service
 }
 
 func (h *completeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if _, err := authenticate(r, h.sessionService, h.userStore); err != nil {
+	ctx, err := authenticate(r, h.sessionService, h.userStore)
+	if err != nil {
 		writeError(w, http.StatusUnauthorized, "authentication required")
 		return
 	}
@@ -359,6 +363,7 @@ func (h *completeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	slog.Info("chunked upload completed", "upload_id", uploadID, "firmware_file_id", saveResult.FirmwareFileID, "reused", saveResult.Reused)
+	logFirmwareUploadActivity(ctx, h.activitySvc, sess.filename, saveResult)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)

--- a/server/internal/handlers/firmware/chunked.go
+++ b/server/internal/handlers/firmware/chunked.go
@@ -26,6 +26,7 @@ type uploadSession struct {
 	mu            sync.Mutex
 	uploadID      string
 	filename      string
+	metadata      files.FirmwareMetadata
 	expectedSize  int64
 	receivedBytes int64
 	tempFilePath  string
@@ -34,8 +35,10 @@ type uploadSession struct {
 }
 
 type initiateRequest struct {
-	Filename string `json:"filename"`
-	FileSize int64  `json:"file_size"`
+	Filename           string `json:"filename"`
+	FileSize           int64  `json:"file_size"`
+	TargetManufacturer string `json:"target_manufacturer"`
+	TargetModel        string `json:"target_model"`
 }
 
 type initiateResponse struct {
@@ -140,6 +143,14 @@ func (h *initiateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	metadata := files.FirmwareMetadata{
+		TargetManufacturer: req.TargetManufacturer,
+		TargetModel:        req.TargetModel,
+	}
+	if err := files.ValidateFirmwareMetadata(metadata); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 
 	if req.FileSize <= 0 {
 		writeError(w, http.StatusBadRequest, "file_size must be greater than zero")
@@ -171,6 +182,7 @@ func (h *initiateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.mgr.sessions[uploadID] = &uploadSession{
 		uploadID:     uploadID,
 		filename:     req.Filename,
+		metadata:     metadata,
 		expectedSize: req.FileSize,
 		tempFilePath: tempPath,
 		createdAt:    now,
@@ -329,7 +341,7 @@ func (h *completeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fileID, err := h.filesService.SaveFirmwareFileFromPath(sess.filename, sess.tempFilePath)
+	fileID, err := h.filesService.SaveFirmwareFileFromPath(sess.filename, sess.tempFilePath, sess.metadata)
 	if err != nil {
 		os.Remove(sess.tempFilePath)
 		if isClientError(err) {

--- a/server/internal/handlers/firmware/chunked.go
+++ b/server/internal/handlers/firmware/chunked.go
@@ -10,7 +10,6 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -110,20 +109,34 @@ func NewInitiateHandler(
 	filesService *files.Service,
 	sessionService *session.Service,
 	userStore interfaces.UserStore,
+	permissionResolver effectivePermissionResolver,
 ) http.Handler {
-	return &initiateHandler{mgr: mgr, filesService: filesService, sessionService: sessionService, userStore: userStore}
+	return &initiateHandler{
+		mgr:                mgr,
+		filesService:       filesService,
+		sessionService:     sessionService,
+		userStore:          userStore,
+		permissionResolver: permissionResolver,
+	}
 }
 
 type initiateHandler struct {
-	mgr            *ChunkedUploadManager
-	filesService   *files.Service
-	sessionService *session.Service
-	userStore      interfaces.UserStore
+	mgr                *ChunkedUploadManager
+	filesService       *files.Service
+	sessionService     *session.Service
+	userStore          interfaces.UserStore
+	permissionResolver effectivePermissionResolver
 }
 
 func (h *initiateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if _, err := authenticate(r, h.sessionService, h.userStore); err != nil {
-		writeError(w, http.StatusUnauthorized, "authentication required")
+	if _, ok := requireMutationPermission(
+		w,
+		r,
+		h.sessionService,
+		h.userStore,
+		h.permissionResolver,
+		"initiate chunked upload",
+	); !ok {
 		return
 	}
 
@@ -166,14 +179,12 @@ func (h *initiateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	uploadID := hex.EncodeToString(b)
-	tempPath := filepath.Join(files.StagingDir(), uploadID)
-	tempFile, err := os.OpenFile(tempPath, os.O_CREATE|os.O_RDWR, 0600)
+	tempPath, err := files.NewChunkedStagingPath(uploadID)
 	if err != nil {
 		slog.Error("failed to create temp file for chunked upload", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to initiate upload")
 		return
 	}
-	tempFile.Close()
 
 	now := time.Now()
 	h.mgr.mu.Lock()
@@ -203,19 +214,32 @@ func NewChunkHandler(
 	mgr *ChunkedUploadManager,
 	sessionService *session.Service,
 	userStore interfaces.UserStore,
+	permissionResolver effectivePermissionResolver,
 ) http.Handler {
-	return &chunkHandler{mgr: mgr, sessionService: sessionService, userStore: userStore}
+	return &chunkHandler{
+		mgr:                mgr,
+		sessionService:     sessionService,
+		userStore:          userStore,
+		permissionResolver: permissionResolver,
+	}
 }
 
 type chunkHandler struct {
-	mgr            *ChunkedUploadManager
-	sessionService *session.Service
-	userStore      interfaces.UserStore
+	mgr                *ChunkedUploadManager
+	sessionService     *session.Service
+	userStore          interfaces.UserStore
+	permissionResolver effectivePermissionResolver
 }
 
 func (h *chunkHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if _, err := authenticate(r, h.sessionService, h.userStore); err != nil {
-		writeError(w, http.StatusUnauthorized, "authentication required")
+	if _, ok := requireMutationPermission(
+		w,
+		r,
+		h.sessionService,
+		h.userStore,
+		h.permissionResolver,
+		"upload chunk",
+	); !ok {
 		return
 	}
 
@@ -286,22 +310,37 @@ func NewCompleteHandler(
 	sessionService *session.Service,
 	userStore interfaces.UserStore,
 	activitySvc *activityDomain.Service,
+	permissionResolver effectivePermissionResolver,
 ) http.Handler {
-	return &completeHandler{mgr: mgr, filesService: filesService, sessionService: sessionService, userStore: userStore, activitySvc: activitySvc}
+	return &completeHandler{
+		mgr:                mgr,
+		filesService:       filesService,
+		sessionService:     sessionService,
+		userStore:          userStore,
+		activitySvc:        activitySvc,
+		permissionResolver: permissionResolver,
+	}
 }
 
 type completeHandler struct {
-	mgr            *ChunkedUploadManager
-	filesService   *files.Service
-	sessionService *session.Service
-	userStore      interfaces.UserStore
-	activitySvc    *activityDomain.Service
+	mgr                *ChunkedUploadManager
+	filesService       *files.Service
+	sessionService     *session.Service
+	userStore          interfaces.UserStore
+	activitySvc        *activityDomain.Service
+	permissionResolver effectivePermissionResolver
 }
 
 func (h *completeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	ctx, err := authenticate(r, h.sessionService, h.userStore)
-	if err != nil {
-		writeError(w, http.StatusUnauthorized, "authentication required")
+	ctx, ok := requireMutationPermission(
+		w,
+		r,
+		h.sessionService,
+		h.userStore,
+		h.permissionResolver,
+		"complete chunked upload",
+	)
+	if !ok {
 		return
 	}
 
@@ -323,6 +362,13 @@ func (h *completeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// The session is out of the map, so no further chunk can arrive and the
+	// staged file is ours to publish or discard on every path below.
+	// Checksum is empty: the chunks were written across many requests, so it
+	// is computed once here by SaveFirmwareUploadFromPath.
+	staged := &files.StagedFirmwareUpload{Path: sess.tempFilePath}
+	defer staged.Discard()
+
 	// Wait for any in-flight chunk write to finish. After removing the
 	// session from the map no new chunk requests can find it, so once we
 	// acquire sess.mu the receivedBytes value is final.
@@ -331,21 +377,18 @@ func (h *completeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	sess.mu.Unlock()
 
 	if receivedBytes != sess.expectedSize {
-		os.Remove(sess.tempFilePath)
 		writeError(w, http.StatusBadRequest, fmt.Sprintf("received %d bytes but expected %d", receivedBytes, sess.expectedSize))
 		return
 	}
 
-	info, statErr := os.Stat(sess.tempFilePath)
+	info, statErr := os.Stat(staged.Path)
 	if statErr != nil || info.Size() != sess.expectedSize {
-		os.Remove(sess.tempFilePath)
 		writeError(w, http.StatusInternalServerError, "uploaded file size mismatch on disk")
 		return
 	}
 
-	saveResult, err := h.filesService.SaveFirmwareUploadFromPath(sess.filename, sess.tempFilePath, sess.metadata, sess.force, "")
+	saveResult, err := h.filesService.SaveFirmwareUploadFromPath(sess.filename, staged.Path, sess.metadata, sess.force, staged.Checksum)
 	if err != nil {
-		os.Remove(sess.tempFilePath)
 		if isClientError(err) {
 			writeError(w, http.StatusBadRequest, err.Error())
 			return

--- a/server/internal/handlers/firmware/chunked.go
+++ b/server/internal/handlers/firmware/chunked.go
@@ -151,6 +151,10 @@ func (h *initiateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		TargetModel:        req.TargetModel,
 		FirmwareVersion:    req.FirmwareVersion,
 	}
+	if err := files.ValidateFirmwareUploadMetadata(metadata); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
 
 	if req.FileSize <= 0 {
 		writeError(w, http.StatusBadRequest, "file_size must be greater than zero")

--- a/server/internal/handlers/firmware/chunked.go
+++ b/server/internal/handlers/firmware/chunked.go
@@ -37,12 +37,10 @@ type uploadSession struct {
 }
 
 type initiateRequest struct {
-	Filename           string `json:"filename"`
-	FileSize           int64  `json:"file_size"`
-	TargetManufacturer string `json:"target_manufacturer"`
-	TargetModel        string `json:"target_model"`
-	FirmwareVersion    string `json:"firmware_version"`
-	Force              bool   `json:"force,omitempty"`
+	Filename string `json:"filename"`
+	FileSize int64  `json:"file_size"`
+	files.FirmwareMetadata
+	Force bool `json:"force,omitempty"`
 }
 
 type initiateResponse struct {
@@ -147,12 +145,7 @@ func (h *initiateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	metadata := files.FirmwareMetadata{
-		TargetManufacturer: req.TargetManufacturer,
-		TargetModel:        req.TargetModel,
-		FirmwareVersion:    req.FirmwareVersion,
-	}
-	if err := files.ValidateFirmwareUploadMetadata(metadata); err != nil {
+	if err := files.ValidateFirmwareUploadMetadata(req.FirmwareMetadata); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -187,7 +180,7 @@ func (h *initiateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.mgr.sessions[uploadID] = &uploadSession{
 		uploadID:     uploadID,
 		filename:     req.Filename,
-		metadata:     metadata,
+		metadata:     req.FirmwareMetadata,
 		expectedSize: req.FileSize,
 		tempFilePath: tempPath,
 		force:        req.Force,

--- a/server/internal/handlers/firmware/chunked_test.go
+++ b/server/internal/handlers/firmware/chunked_test.go
@@ -54,10 +54,14 @@ func TestParseContentRange(t *testing.T) {
 
 func chunkedInitiateBody(filename string, size int) string {
 	return fmt.Sprintf(
-		`{"filename":%q,"file_size":%d,"target_manufacturer":"Proto","target_model":"S21"}`,
+		`{"filename":%q,"file_size":%d,"target_manufacturer":"Proto","target_model":"S21","firmware_version":"v2.0.0"}`,
 		filename,
 		size,
 	)
+}
+
+func chunkedInitiateBodyWithoutMetadata(filename string, size int) string {
+	return fmt.Sprintf(`{"filename":%q,"file_size":%d}`, filename, size)
 }
 
 func TestChunkedUpload_FullLifecycle(t *testing.T) {
@@ -136,18 +140,42 @@ func TestChunkedUpload_InitiateRejectsInvalidExtension(t *testing.T) {
 	assert.Contains(t, rr.Body.String(), "unsupported firmware file type")
 }
 
-func TestChunkedUpload_InitiateRejectsMissingTargetMetadata(t *testing.T) {
+func TestChunkedUpload_CompleteRejectsMissingTargetMetadata(t *testing.T) {
 	env := newTestEnv(t)
-	env.expectAuth()
 	mgr := NewChunkedUploadManager()
 
-	h := &initiateHandler{mgr: mgr, filesService: env.fileSvc, sessionService: env.sessionSvc, userStore: env.userStoreMock}
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload/chunked", strings.NewReader(`{"filename":"firmware.swu","file_size":100}`))
+	initHandler := &initiateHandler{mgr: mgr, filesService: env.fileSvc, sessionService: env.sessionSvc, userStore: env.userStoreMock}
+	chunkH := &chunkHandler{mgr: mgr, sessionService: env.sessionSvc, userStore: env.userStoreMock}
+	completeH := &completeHandler{mgr: mgr, filesService: env.fileSvc, sessionService: env.sessionSvc, userStore: env.userStoreMock}
+	content := "missing metadata firmware"
+
+	env.expectAuth()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload/chunked", strings.NewReader(chunkedInitiateBodyWithoutMetadata("firmware.swu", len(content))))
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(validSessionCookie(env.sessionID))
 	rr := httptest.NewRecorder()
+	initHandler.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
 
-	h.ServeHTTP(rr, req)
+	var initResp initiateResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &initResp))
+
+	env.expectAuth()
+	req = httptest.NewRequest(http.MethodPut, "/api/v1/firmware/upload/chunked/"+initResp.UploadID, strings.NewReader(content))
+	req.Header.Set("Content-Range", fmt.Sprintf("bytes 0-%d/%d", len(content)-1, len(content)))
+	req.AddCookie(validSessionCookie(env.sessionID))
+	req.SetPathValue("uploadId", initResp.UploadID)
+	rr = httptest.NewRecorder()
+	chunkH.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	env.expectAuth()
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload/chunked/"+initResp.UploadID+"/complete", nil)
+	req.AddCookie(validSessionCookie(env.sessionID))
+	req.SetPathValue("uploadId", initResp.UploadID)
+	rr = httptest.NewRecorder()
+	completeH.ServeHTTP(rr, req)
+
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
 	assert.Contains(t, rr.Body.String(), "target_manufacturer")
 }

--- a/server/internal/handlers/firmware/chunked_test.go
+++ b/server/internal/handlers/firmware/chunked_test.go
@@ -140,44 +140,39 @@ func TestChunkedUpload_InitiateRejectsInvalidExtension(t *testing.T) {
 	assert.Contains(t, rr.Body.String(), "unsupported firmware file type")
 }
 
-func TestChunkedUpload_CompleteRejectsMissingTargetMetadata(t *testing.T) {
-	env := newTestEnv(t)
-	mgr := NewChunkedUploadManager()
+func TestChunkedUpload_InitiateRejectsMissingTargetMetadata(t *testing.T) {
+	tests := []struct {
+		name      string
+		body      string
+		wantError string
+	}{
+		{name: "all metadata", body: chunkedInitiateBodyWithoutMetadata("firmware.swu", 10), wantError: "target_manufacturer"},
+		{name: "manufacturer", body: `{"filename":"firmware.swu","file_size":10,"target_model":"S21","firmware_version":"v2.0.0"}`, wantError: "target_manufacturer"},
+		{name: "model", body: `{"filename":"firmware.swu","file_size":10,"target_manufacturer":"Proto","firmware_version":"v2.0.0"}`, wantError: "target_model"},
+		{name: "version", body: `{"filename":"firmware.swu","file_size":10,"target_manufacturer":"Proto","target_model":"S21"}`, wantError: "firmware_version"},
+	}
 
-	initHandler := &initiateHandler{mgr: mgr, filesService: env.fileSvc, sessionService: env.sessionSvc, userStore: env.userStoreMock}
-	chunkH := &chunkHandler{mgr: mgr, sessionService: env.sessionSvc, userStore: env.userStoreMock}
-	completeH := &completeHandler{mgr: mgr, filesService: env.fileSvc, sessionService: env.sessionSvc, userStore: env.userStoreMock}
-	content := "missing metadata firmware"
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := newTestEnv(t)
+			mgr := NewChunkedUploadManager()
+			h := &initiateHandler{mgr: mgr, filesService: env.fileSvc, sessionService: env.sessionSvc, userStore: env.userStoreMock}
 
-	env.expectAuth()
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload/chunked", strings.NewReader(chunkedInitiateBodyWithoutMetadata("firmware.swu", len(content))))
-	req.Header.Set("Content-Type", "application/json")
-	req.AddCookie(validSessionCookie(env.sessionID))
-	rr := httptest.NewRecorder()
-	initHandler.ServeHTTP(rr, req)
-	require.Equal(t, http.StatusOK, rr.Code)
+			env.expectAuth()
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload/chunked", strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			req.AddCookie(validSessionCookie(env.sessionID))
+			rr := httptest.NewRecorder()
+			h.ServeHTTP(rr, req)
 
-	var initResp initiateResponse
-	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &initResp))
-
-	env.expectAuth()
-	req = httptest.NewRequest(http.MethodPut, "/api/v1/firmware/upload/chunked/"+initResp.UploadID, strings.NewReader(content))
-	req.Header.Set("Content-Range", fmt.Sprintf("bytes 0-%d/%d", len(content)-1, len(content)))
-	req.AddCookie(validSessionCookie(env.sessionID))
-	req.SetPathValue("uploadId", initResp.UploadID)
-	rr = httptest.NewRecorder()
-	chunkH.ServeHTTP(rr, req)
-	require.Equal(t, http.StatusOK, rr.Code)
-
-	env.expectAuth()
-	req = httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload/chunked/"+initResp.UploadID+"/complete", nil)
-	req.AddCookie(validSessionCookie(env.sessionID))
-	req.SetPathValue("uploadId", initResp.UploadID)
-	rr = httptest.NewRecorder()
-	completeH.ServeHTTP(rr, req)
-
-	assert.Equal(t, http.StatusBadRequest, rr.Code)
-	assert.Contains(t, rr.Body.String(), "target_manufacturer")
+			assert.Equal(t, http.StatusBadRequest, rr.Code)
+			assert.Contains(t, rr.Body.String(), tt.wantError)
+			assert.Empty(t, mgr.sessions)
+			entries, err := os.ReadDir(files.StagingDir())
+			require.NoError(t, err)
+			assert.Empty(t, entries)
+		})
+	}
 }
 
 func TestChunkedUpload_InitiateRejectsOversizedFile(t *testing.T) {

--- a/server/internal/handlers/firmware/chunked_test.go
+++ b/server/internal/handlers/firmware/chunked_test.go
@@ -52,6 +52,14 @@ func TestParseContentRange(t *testing.T) {
 	}
 }
 
+func chunkedInitiateBody(filename string, size int) string {
+	return fmt.Sprintf(
+		`{"filename":%q,"file_size":%d,"target_manufacturer":"Proto","target_model":"S21"}`,
+		filename,
+		size,
+	)
+}
+
 func TestChunkedUpload_FullLifecycle(t *testing.T) {
 	env := newTestEnv(t)
 	mgr := NewChunkedUploadManager()
@@ -64,7 +72,7 @@ func TestChunkedUpload_FullLifecycle(t *testing.T) {
 
 	// Initiate
 	env.expectAuth()
-	body := fmt.Sprintf(`{"filename":"firmware.swu","file_size":%d}`, len(content))
+	body := chunkedInitiateBody("firmware.swu", len(content))
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload/chunked", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(validSessionCookie(env.sessionID))
@@ -118,7 +126,7 @@ func TestChunkedUpload_InitiateRejectsInvalidExtension(t *testing.T) {
 	mgr := NewChunkedUploadManager()
 
 	h := &initiateHandler{mgr: mgr, filesService: env.fileSvc, sessionService: env.sessionSvc, userStore: env.userStoreMock}
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload/chunked", strings.NewReader(`{"filename":"bad.bin","file_size":100}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload/chunked", strings.NewReader(chunkedInitiateBody("bad.bin", 100)))
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(validSessionCookie(env.sessionID))
 	rr := httptest.NewRecorder()
@@ -128,6 +136,22 @@ func TestChunkedUpload_InitiateRejectsInvalidExtension(t *testing.T) {
 	assert.Contains(t, rr.Body.String(), "unsupported firmware file type")
 }
 
+func TestChunkedUpload_InitiateRejectsMissingTargetMetadata(t *testing.T) {
+	env := newTestEnv(t)
+	env.expectAuth()
+	mgr := NewChunkedUploadManager()
+
+	h := &initiateHandler{mgr: mgr, filesService: env.fileSvc, sessionService: env.sessionSvc, userStore: env.userStoreMock}
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload/chunked", strings.NewReader(`{"filename":"firmware.swu","file_size":100}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(validSessionCookie(env.sessionID))
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "target_manufacturer")
+}
+
 func TestChunkedUpload_InitiateRejectsOversizedFile(t *testing.T) {
 	env := newTestEnv(t)
 	env.expectAuth()
@@ -135,7 +159,7 @@ func TestChunkedUpload_InitiateRejectsOversizedFile(t *testing.T) {
 	mgr := NewChunkedUploadManager()
 
 	h := &initiateHandler{mgr: mgr, filesService: env.fileSvc, sessionService: env.sessionSvc, userStore: env.userStoreMock}
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload/chunked", strings.NewReader(`{"filename":"firmware.swu","file_size":200}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload/chunked", strings.NewReader(chunkedInitiateBody("firmware.swu", 200)))
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(validSessionCookie(env.sessionID))
 	rr := httptest.NewRecorder()
@@ -150,7 +174,7 @@ func TestChunkedUpload_InitiateRejectsAuth(t *testing.T) {
 	mgr := NewChunkedUploadManager()
 
 	h := &initiateHandler{mgr: mgr, filesService: env.fileSvc, sessionService: env.sessionSvc, userStore: env.userStoreMock}
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload/chunked", strings.NewReader(`{"filename":"firmware.swu","file_size":100}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload/chunked", strings.NewReader(chunkedInitiateBody("firmware.swu", 100)))
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 
@@ -183,7 +207,7 @@ func TestChunkedUpload_ChunkRejectsOutOfOrder(t *testing.T) {
 
 	// Initiate
 	env.expectAuth()
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload/chunked", strings.NewReader(`{"filename":"firmware.swu","file_size":10}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload/chunked", strings.NewReader(chunkedInitiateBody("firmware.swu", 10)))
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(validSessionCookie(env.sessionID))
 	rr := httptest.NewRecorder()
@@ -216,7 +240,7 @@ func TestChunkedUpload_CompleteRejectsSizeMismatch(t *testing.T) {
 
 	// Initiate with file_size=10
 	env.expectAuth()
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload/chunked", strings.NewReader(`{"filename":"firmware.swu","file_size":10}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload/chunked", strings.NewReader(chunkedInitiateBody("firmware.swu", 10)))
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(validSessionCookie(env.sessionID))
 	rr := httptest.NewRecorder()
@@ -257,7 +281,7 @@ func TestChunkedUpload_DuplicateChunkRejected(t *testing.T) {
 
 	// Initiate
 	env.expectAuth()
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload/chunked", strings.NewReader(`{"filename":"firmware.swu","file_size":10}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload/chunked", strings.NewReader(chunkedInitiateBody("firmware.swu", 10)))
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(validSessionCookie(env.sessionID))
 	rr := httptest.NewRecorder()

--- a/server/internal/handlers/firmware/chunked_test.go
+++ b/server/internal/handlers/firmware/chunked_test.go
@@ -1,6 +1,7 @@
 package firmware
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -13,7 +14,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 
+	activityDomain "github.com/block/proto-fleet/server/internal/domain/activity"
+	activityModels "github.com/block/proto-fleet/server/internal/domain/activity/models"
+	storeMocks "github.com/block/proto-fleet/server/internal/domain/stores/interfaces/mocks"
 	"github.com/block/proto-fleet/server/internal/infrastructure/files"
 )
 
@@ -70,7 +75,18 @@ func TestChunkedUpload_FullLifecycle(t *testing.T) {
 
 	initHandler := &initiateHandler{mgr: mgr, filesService: env.fileSvc, sessionService: env.sessionSvc, userStore: env.userStoreMock}
 	chunkH := &chunkHandler{mgr: mgr, sessionService: env.sessionSvc, userStore: env.userStoreMock}
-	completeH := &completeHandler{mgr: mgr, filesService: env.fileSvc, sessionService: env.sessionSvc, userStore: env.userStoreMock}
+	activityStore := storeMocks.NewMockActivityStore(env.ctrl)
+	activityStore.EXPECT().Insert(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, event *activityModels.Event) error {
+			assert.Equal(t, firmwareUploadedEventType, event.Type)
+			assert.Equal(t, "firmware.swu", event.Metadata["filename"])
+			return nil
+		},
+	)
+	completeH := &completeHandler{
+		mgr: mgr, filesService: env.fileSvc, sessionService: env.sessionSvc,
+		userStore: env.userStoreMock, activitySvc: activityDomain.NewService(activityStore),
+	}
 
 	content := "abcdefghij" // 10 bytes, 2 chunks of 5
 

--- a/server/internal/handlers/firmware/chunked_test.go
+++ b/server/internal/handlers/firmware/chunked_test.go
@@ -59,7 +59,7 @@ func TestParseContentRange(t *testing.T) {
 
 func chunkedInitiateBody(filename string, size int) string {
 	return fmt.Sprintf(
-		`{"filename":%q,"file_size":%d,"target_manufacturer":"Proto","target_model":"S21","firmware_version":"v2.0.0"}`,
+		`{"filename":%q,"file_size":%d,"target_manufacturer":"Proto","target_model":"Rig","firmware_version":"v2.0.0"}`,
 		filename,
 		size,
 	)
@@ -163,9 +163,9 @@ func TestChunkedUpload_InitiateRejectsMissingTargetMetadata(t *testing.T) {
 		wantError string
 	}{
 		{name: "all metadata", body: chunkedInitiateBodyWithoutMetadata("firmware.swu", 10), wantError: "target_manufacturer"},
-		{name: "manufacturer", body: `{"filename":"firmware.swu","file_size":10,"target_model":"S21","firmware_version":"v2.0.0"}`, wantError: "target_manufacturer"},
+		{name: "manufacturer", body: `{"filename":"firmware.swu","file_size":10,"target_model":"Rig","firmware_version":"v2.0.0"}`, wantError: "target_manufacturer"},
 		{name: "model", body: `{"filename":"firmware.swu","file_size":10,"target_manufacturer":"Proto","firmware_version":"v2.0.0"}`, wantError: "target_model"},
-		{name: "version", body: `{"filename":"firmware.swu","file_size":10,"target_manufacturer":"Proto","target_model":"S21"}`, wantError: "firmware_version"},
+		{name: "version", body: `{"filename":"firmware.swu","file_size":10,"target_manufacturer":"Proto","target_model":"Rig"}`, wantError: "firmware_version"},
 	}
 
 	for _, tt := range tests {

--- a/server/internal/handlers/firmware/chunked_test.go
+++ b/server/internal/handlers/firmware/chunked_test.go
@@ -73,8 +73,14 @@ func TestChunkedUpload_FullLifecycle(t *testing.T) {
 	env := newTestEnv(t)
 	mgr := NewChunkedUploadManager()
 
-	initHandler := &initiateHandler{mgr: mgr, filesService: env.fileSvc, sessionService: env.sessionSvc, userStore: env.userStoreMock}
-	chunkH := &chunkHandler{mgr: mgr, sessionService: env.sessionSvc, userStore: env.userStoreMock}
+	initHandler := &initiateHandler{
+		mgr: mgr, filesService: env.fileSvc, sessionService: env.sessionSvc,
+		userStore: env.userStoreMock, permissionResolver: env.permissionResolver,
+	}
+	chunkH := &chunkHandler{
+		mgr: mgr, sessionService: env.sessionSvc, userStore: env.userStoreMock,
+		permissionResolver: env.permissionResolver,
+	}
 	activityStore := storeMocks.NewMockActivityStore(env.ctrl)
 	activityStore.EXPECT().Insert(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, event *activityModels.Event) error {
@@ -86,6 +92,7 @@ func TestChunkedUpload_FullLifecycle(t *testing.T) {
 	completeH := &completeHandler{
 		mgr: mgr, filesService: env.fileSvc, sessionService: env.sessionSvc,
 		userStore: env.userStoreMock, activitySvc: activityDomain.NewService(activityStore),
+		permissionResolver: env.permissionResolver,
 	}
 
 	content := "abcdefghij" // 10 bytes, 2 chunks of 5
@@ -145,7 +152,10 @@ func TestChunkedUpload_InitiateRejectsInvalidExtension(t *testing.T) {
 	env.expectAuth()
 	mgr := NewChunkedUploadManager()
 
-	h := &initiateHandler{mgr: mgr, filesService: env.fileSvc, sessionService: env.sessionSvc, userStore: env.userStoreMock}
+	h := &initiateHandler{
+		mgr: mgr, filesService: env.fileSvc, sessionService: env.sessionSvc,
+		userStore: env.userStoreMock, permissionResolver: env.permissionResolver,
+	}
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload/chunked", strings.NewReader(chunkedInitiateBody("bad.bin", 100)))
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(validSessionCookie(env.sessionID))
@@ -172,7 +182,10 @@ func TestChunkedUpload_InitiateRejectsMissingTargetMetadata(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			env := newTestEnv(t)
 			mgr := NewChunkedUploadManager()
-			h := &initiateHandler{mgr: mgr, filesService: env.fileSvc, sessionService: env.sessionSvc, userStore: env.userStoreMock}
+			h := &initiateHandler{
+				mgr: mgr, filesService: env.fileSvc, sessionService: env.sessionSvc,
+				userStore: env.userStoreMock, permissionResolver: env.permissionResolver,
+			}
 
 			env.expectAuth()
 			req := httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload/chunked", strings.NewReader(tt.body))
@@ -184,9 +197,9 @@ func TestChunkedUpload_InitiateRejectsMissingTargetMetadata(t *testing.T) {
 			assert.Equal(t, http.StatusBadRequest, rr.Code)
 			assert.Contains(t, rr.Body.String(), tt.wantError)
 			assert.Empty(t, mgr.sessions)
-			entries, err := os.ReadDir(files.StagingDir())
+			staged, err := files.StagedFirmwareUploadCount()
 			require.NoError(t, err)
-			assert.Empty(t, entries)
+			assert.Zero(t, staged)
 		})
 	}
 }
@@ -197,7 +210,10 @@ func TestChunkedUpload_InitiateRejectsOversizedFile(t *testing.T) {
 	env.fileSvc, _ = files.NewService(files.Config{MaxFirmwareFileSize: 100})
 	mgr := NewChunkedUploadManager()
 
-	h := &initiateHandler{mgr: mgr, filesService: env.fileSvc, sessionService: env.sessionSvc, userStore: env.userStoreMock}
+	h := &initiateHandler{
+		mgr: mgr, filesService: env.fileSvc, sessionService: env.sessionSvc,
+		userStore: env.userStoreMock, permissionResolver: env.permissionResolver,
+	}
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload/chunked", strings.NewReader(chunkedInitiateBody("firmware.swu", 200)))
 	req.Header.Set("Content-Type", "application/json")
 	req.AddCookie(validSessionCookie(env.sessionID))
@@ -212,7 +228,10 @@ func TestChunkedUpload_InitiateRejectsAuth(t *testing.T) {
 	env := newTestEnv(t)
 	mgr := NewChunkedUploadManager()
 
-	h := &initiateHandler{mgr: mgr, filesService: env.fileSvc, sessionService: env.sessionSvc, userStore: env.userStoreMock}
+	h := &initiateHandler{
+		mgr: mgr, filesService: env.fileSvc, sessionService: env.sessionSvc,
+		userStore: env.userStoreMock, permissionResolver: env.permissionResolver,
+	}
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload/chunked", strings.NewReader(chunkedInitiateBody("firmware.swu", 100)))
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
@@ -226,7 +245,10 @@ func TestChunkedUpload_ChunkRejectsUnknownSession(t *testing.T) {
 	env.expectAuth()
 	mgr := NewChunkedUploadManager()
 
-	h := &chunkHandler{mgr: mgr, sessionService: env.sessionSvc, userStore: env.userStoreMock}
+	h := &chunkHandler{
+		mgr: mgr, sessionService: env.sessionSvc, userStore: env.userStoreMock,
+		permissionResolver: env.permissionResolver,
+	}
 	req := httptest.NewRequest(http.MethodPut, "/api/v1/firmware/upload/chunked/nonexistent", strings.NewReader("data"))
 	req.Header.Set("Content-Range", "bytes 0-3/10")
 	req.AddCookie(validSessionCookie(env.sessionID))
@@ -241,8 +263,14 @@ func TestChunkedUpload_ChunkRejectsOutOfOrder(t *testing.T) {
 	env := newTestEnv(t)
 	mgr := NewChunkedUploadManager()
 
-	initHandler := &initiateHandler{mgr: mgr, filesService: env.fileSvc, sessionService: env.sessionSvc, userStore: env.userStoreMock}
-	chunkH := &chunkHandler{mgr: mgr, sessionService: env.sessionSvc, userStore: env.userStoreMock}
+	initHandler := &initiateHandler{
+		mgr: mgr, filesService: env.fileSvc, sessionService: env.sessionSvc,
+		userStore: env.userStoreMock, permissionResolver: env.permissionResolver,
+	}
+	chunkH := &chunkHandler{
+		mgr: mgr, sessionService: env.sessionSvc, userStore: env.userStoreMock,
+		permissionResolver: env.permissionResolver,
+	}
 
 	// Initiate
 	env.expectAuth()
@@ -273,9 +301,18 @@ func TestChunkedUpload_CompleteRejectsSizeMismatch(t *testing.T) {
 	env := newTestEnv(t)
 	mgr := NewChunkedUploadManager()
 
-	initHandler := &initiateHandler{mgr: mgr, filesService: env.fileSvc, sessionService: env.sessionSvc, userStore: env.userStoreMock}
-	chunkH := &chunkHandler{mgr: mgr, sessionService: env.sessionSvc, userStore: env.userStoreMock}
-	completeH := &completeHandler{mgr: mgr, filesService: env.fileSvc, sessionService: env.sessionSvc, userStore: env.userStoreMock}
+	initHandler := &initiateHandler{
+		mgr: mgr, filesService: env.fileSvc, sessionService: env.sessionSvc,
+		userStore: env.userStoreMock, permissionResolver: env.permissionResolver,
+	}
+	chunkH := &chunkHandler{
+		mgr: mgr, sessionService: env.sessionSvc, userStore: env.userStoreMock,
+		permissionResolver: env.permissionResolver,
+	}
+	completeH := &completeHandler{
+		mgr: mgr, filesService: env.fileSvc, sessionService: env.sessionSvc,
+		userStore: env.userStoreMock, permissionResolver: env.permissionResolver,
+	}
 
 	// Initiate with file_size=10
 	env.expectAuth()
@@ -315,8 +352,14 @@ func TestChunkedUpload_DuplicateChunkRejected(t *testing.T) {
 	env := newTestEnv(t)
 	mgr := NewChunkedUploadManager()
 
-	initHandler := &initiateHandler{mgr: mgr, filesService: env.fileSvc, sessionService: env.sessionSvc, userStore: env.userStoreMock}
-	chunkH := &chunkHandler{mgr: mgr, sessionService: env.sessionSvc, userStore: env.userStoreMock}
+	initHandler := &initiateHandler{
+		mgr: mgr, filesService: env.fileSvc, sessionService: env.sessionSvc,
+		userStore: env.userStoreMock, permissionResolver: env.permissionResolver,
+	}
+	chunkH := &chunkHandler{
+		mgr: mgr, sessionService: env.sessionSvc, userStore: env.userStoreMock,
+		permissionResolver: env.permissionResolver,
+	}
 
 	// Initiate
 	env.expectAuth()

--- a/server/internal/handlers/firmware/handler.go
+++ b/server/internal/handlers/firmware/handler.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"connectrpc.com/authn"
+	activityDomain "github.com/block/proto-fleet/server/internal/domain/activity"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 	"github.com/block/proto-fleet/server/internal/domain/session"
 	"github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
@@ -94,11 +95,12 @@ func (h *configHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // NewUploadHandler returns an http.Handler that accepts multipart firmware file uploads.
 // The handler validates the file, streams it to disk, and returns a firmware_file_id.
 // The request body is capped at maxUploadBytes to reject oversized uploads early.
-func NewUploadHandler(filesService *files.Service, sessionService *session.Service, userStore interfaces.UserStore, maxUploadBytes int64) http.Handler {
+func NewUploadHandler(filesService *files.Service, sessionService *session.Service, userStore interfaces.UserStore, activitySvc *activityDomain.Service, maxUploadBytes int64) http.Handler {
 	return &uploadHandler{
 		filesService:   filesService,
 		sessionService: sessionService,
 		userStore:      userStore,
+		activitySvc:    activitySvc,
 		maxUploadBytes: maxUploadBytes,
 	}
 }
@@ -181,6 +183,7 @@ type uploadHandler struct {
 	filesService   *files.Service
 	sessionService *session.Service
 	userStore      interfaces.UserStore
+	activitySvc    *activityDomain.Service
 	maxUploadBytes int64
 }
 
@@ -239,6 +242,7 @@ func (h *uploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	slog.Info("firmware file uploaded successfully", "file_id", saveResult.FirmwareFileID, "filename", filename, "reused", saveResult.Reused)
+	logFirmwareUploadActivity(ctx, h.activitySvc, filename, saveResult)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
@@ -367,6 +371,12 @@ type deleteAllFilesResponse struct {
 	Error        string `json:"error,omitempty"`
 }
 
+type updateMetadataRequest struct {
+	TargetManufacturer string `json:"target_manufacturer"`
+	TargetModel        string `json:"target_model"`
+	FirmwareVersion    string `json:"firmware_version"`
+}
+
 // NewListFilesHandler returns an http.Handler that lists all uploaded firmware files.
 func NewListFilesHandler(filesService *files.Service, sessionService *session.Service, userStore interfaces.UserStore) http.Handler {
 	return &listFilesHandler{
@@ -405,6 +415,70 @@ func (h *listFilesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewEncoder(w).Encode(listFilesResponse{Files: fileList}); err != nil {
 		slog.Error("failed to encode list files response", "error", err)
 	}
+}
+
+// NewUpdateMetadataHandler returns an http.Handler that updates a stored
+// firmware file's deployment metadata.
+func NewUpdateMetadataHandler(filesService *files.Service, sessionService *session.Service, userStore interfaces.UserStore) http.Handler {
+	return &updateMetadataHandler{
+		filesService:   filesService,
+		sessionService: sessionService,
+		userStore:      userStore,
+	}
+}
+
+type updateMetadataHandler struct {
+	filesService   *files.Service
+	sessionService *session.Service
+	userStore      interfaces.UserStore
+}
+
+func (h *updateMetadataHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if _, err := authenticate(r, h.sessionService, h.userStore); err != nil {
+		slog.Warn("firmware metadata update authentication failed", "error", err)
+		writeError(w, http.StatusUnauthorized, "authentication required")
+		return
+	}
+
+	fileID := r.PathValue("fileId")
+	if fileID == "" {
+		writeError(w, http.StatusBadRequest, "file ID is required")
+		return
+	}
+
+	const maxBodyBytes = 4096
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	var req updateMetadataRequest
+	if err := decoder.Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+
+	metadata := files.FirmwareMetadata{
+		TargetManufacturer: req.TargetManufacturer,
+		TargetModel:        req.TargetModel,
+		FirmwareVersion:    req.FirmwareVersion,
+	}
+	if err := h.filesService.UpdateFirmwareMetadata(fileID, metadata); err != nil {
+		switch {
+		case fleeterror.IsNotFoundError(err):
+			writeError(w, http.StatusNotFound, err.Error())
+		case fleeterror.IsInvalidArgumentError(err):
+			writeError(w, http.StatusBadRequest, err.Error())
+		default:
+			slog.Error("failed to update firmware metadata", "file_id", fileID, "error", err)
+			writeError(w, http.StatusInternalServerError, "failed to update firmware metadata")
+		}
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // NewDeleteFileHandler returns an http.Handler that deletes a single firmware file by ID.

--- a/server/internal/handlers/firmware/handler.go
+++ b/server/internal/handlers/firmware/handler.go
@@ -27,10 +27,8 @@ type uploadResponse struct {
 }
 
 type checkRequest struct {
-	SHA256             string `json:"sha256"`
-	TargetManufacturer string `json:"target_manufacturer"`
-	TargetModel        string `json:"target_model"`
-	FirmwareVersion    string `json:"firmware_version"`
+	SHA256 string `json:"sha256"`
+	files.FirmwareMetadata
 }
 
 type checkResponse struct {
@@ -154,17 +152,12 @@ func (h *checkHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	metadata := files.FirmwareMetadata{
-		TargetManufacturer: req.TargetManufacturer,
-		TargetModel:        req.TargetModel,
-		FirmwareVersion:    req.FirmwareVersion,
-	}
-	if err := files.ValidateFirmwareUploadMetadata(metadata); err != nil {
+	if err := files.ValidateFirmwareUploadMetadata(req.FirmwareMetadata); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
-	fileID, ok := h.filesService.FindFirmwareFileByChecksum(strings.ToLower(req.SHA256), metadata)
+	fileID, ok := h.filesService.FindFirmwareFileByChecksum(strings.ToLower(req.SHA256), req.FirmwareMetadata)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
@@ -266,8 +259,11 @@ func extractMultipartFile(r *http.Request) (filename string, reader io.ReadClose
 	}
 
 	mr := multipart.NewReader(r.Body, boundary)
-	var filePart io.ReadCloser
-	var fileName string
+	metadataFields := map[string]*string{
+		"target_manufacturer": &metadata.TargetManufacturer,
+		"target_model":        &metadata.TargetModel,
+		"firmware_version":    &metadata.FirmwareVersion,
+	}
 	for {
 		part, err := mr.NextPart()
 		if err == io.EOF {
@@ -277,44 +273,38 @@ func extractMultipartFile(r *http.Request) (filename string, reader io.ReadClose
 			return "", nil, files.FirmwareMetadata{}, false, fmt.Errorf("failed to read multipart form: %w", err)
 		}
 
-		switch part.FormName() {
-		case "file":
-			filePart = part
-			fileName = part.FileName()
-			return fileName, filePart, metadata, force, nil
-		case "target_manufacturer":
-			value, readErr := io.ReadAll(io.LimitReader(part, 1024))
-			part.Close()
+		name := part.FormName()
+		switch {
+		case name == "file":
+			return part.FileName(), part, metadata, force, nil
+		case metadataFields[name] != nil:
+			value, readErr := readPartValue(part, 1024, name)
 			if readErr != nil {
-				return "", nil, files.FirmwareMetadata{}, false, fmt.Errorf("failed to read target_manufacturer: %w", readErr)
+				return "", nil, files.FirmwareMetadata{}, false, readErr
 			}
-			metadata.TargetManufacturer = string(value)
-		case "target_model":
-			value, readErr := io.ReadAll(io.LimitReader(part, 1024))
-			part.Close()
+			*metadataFields[name] = value
+		case name == "force":
+			value, readErr := readPartValue(part, 16, name)
 			if readErr != nil {
-				return "", nil, files.FirmwareMetadata{}, false, fmt.Errorf("failed to read target_model: %w", readErr)
+				return "", nil, files.FirmwareMetadata{}, false, readErr
 			}
-			metadata.TargetModel = string(value)
-		case "firmware_version":
-			value, readErr := io.ReadAll(io.LimitReader(part, 1024))
-			part.Close()
-			if readErr != nil {
-				return "", nil, files.FirmwareMetadata{}, false, fmt.Errorf("failed to read firmware_version: %w", readErr)
-			}
-			metadata.FirmwareVersion = string(value)
-		case "force":
-			value, readErr := io.ReadAll(io.LimitReader(part, 16))
-			part.Close()
-			if readErr != nil {
-				return "", nil, files.FirmwareMetadata{}, false, fmt.Errorf("failed to read force: %w", readErr)
-			}
-			force = strings.EqualFold(strings.TrimSpace(string(value)), "true") || strings.TrimSpace(string(value)) == "1"
+			value = strings.TrimSpace(value)
+			force = strings.EqualFold(value, "true") || value == "1"
 		default:
 			part.Close()
 		}
 	}
 	return "", nil, files.FirmwareMetadata{}, false, fmt.Errorf("missing 'file' field in multipart form")
+}
+
+// readPartValue reads a small text form field up to limit bytes and closes the part.
+func readPartValue(part *multipart.Part, limit int64, name string) (string, error) {
+	value, err := io.ReadAll(io.LimitReader(part, limit))
+	part.Close()
+	if err != nil {
+		return "", fmt.Errorf("failed to read %s: %w", name, err)
+	}
+	return string(value), nil
 }
 
 // authenticate extracts and validates the session cookie from the HTTP request,
@@ -369,12 +359,6 @@ type listFilesResponse struct {
 type deleteAllFilesResponse struct {
 	DeletedCount int    `json:"deleted_count"`
 	Error        string `json:"error,omitempty"`
-}
-
-type updateMetadataRequest struct {
-	TargetManufacturer string `json:"target_manufacturer"`
-	TargetModel        string `json:"target_model"`
-	FirmwareVersion    string `json:"firmware_version"`
 }
 
 // NewListFilesHandler returns an http.Handler that lists all uploaded firmware files.
@@ -450,8 +434,8 @@ func (h *updateMetadataHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
 	decoder := json.NewDecoder(r.Body)
 	decoder.DisallowUnknownFields()
-	var req updateMetadataRequest
-	if err := decoder.Decode(&req); err != nil {
+	var metadata files.FirmwareMetadata
+	if err := decoder.Decode(&metadata); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
 		return
 	}
@@ -460,11 +444,6 @@ func (h *updateMetadataHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	metadata := files.FirmwareMetadata{
-		TargetManufacturer: req.TargetManufacturer,
-		TargetModel:        req.TargetModel,
-		FirmwareVersion:    req.FirmwareVersion,
-	}
 	if err := h.filesService.UpdateFirmwareMetadata(fileID, metadata); err != nil {
 		switch {
 		case fleeterror.IsNotFoundError(err):

--- a/server/internal/handlers/firmware/handler.go
+++ b/server/internal/handlers/firmware/handler.go
@@ -25,7 +25,9 @@ type uploadResponse struct {
 }
 
 type checkRequest struct {
-	SHA256 string `json:"sha256"`
+	SHA256             string `json:"sha256"`
+	TargetManufacturer string `json:"target_manufacturer"`
+	TargetModel        string `json:"target_model"`
 }
 
 type checkResponse struct {
@@ -148,7 +150,16 @@ func (h *checkHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fileID, ok := h.filesService.FindFirmwareFileByChecksum(strings.ToLower(req.SHA256))
+	metadata := files.FirmwareMetadata{
+		TargetManufacturer: req.TargetManufacturer,
+		TargetModel:        req.TargetModel,
+	}
+	if err := files.ValidateFirmwareMetadata(metadata); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	fileID, ok := h.filesService.FindFirmwareFileByChecksum(strings.ToLower(req.SHA256), metadata)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
@@ -195,7 +206,7 @@ func (h *uploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	const multipartOverhead int64 = 1 * 1024 * 1024 // 1 MB
 	r.Body = http.MaxBytesReader(w, r.Body, h.maxUploadBytes+multipartOverhead)
 
-	filename, fileReader, err := extractMultipartFile(r)
+	filename, fileReader, metadata, err := extractMultipartFile(r)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
@@ -207,7 +218,7 @@ func (h *uploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fileID, err := h.filesService.SaveFirmwareFile(filename, fileReader)
+	fileID, err := h.filesService.SaveFirmwareFile(filename, fileReader, metadata)
 	if err != nil {
 		if isClientError(err) {
 			writeError(w, http.StatusBadRequest, err.Error())
@@ -229,33 +240,57 @@ func (h *uploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // extractMultipartFile streams the multipart body to find the "file" part
 // without buffering the entire body in memory or spilling to temp files.
-func extractMultipartFile(r *http.Request) (filename string, reader io.ReadCloser, err error) {
+func extractMultipartFile(r *http.Request) (filename string, reader io.ReadCloser, metadata files.FirmwareMetadata, err error) {
 	contentType := r.Header.Get("Content-Type")
 	mediaType, params, err := mime.ParseMediaType(contentType)
 	if err != nil || !strings.HasPrefix(mediaType, "multipart/") {
-		return "", nil, fmt.Errorf("expected multipart/form-data content type")
+		return "", nil, files.FirmwareMetadata{}, fmt.Errorf("expected multipart/form-data content type")
 	}
 
 	boundary := params["boundary"]
 	if boundary == "" {
-		return "", nil, fmt.Errorf("missing multipart boundary")
+		return "", nil, files.FirmwareMetadata{}, fmt.Errorf("missing multipart boundary")
 	}
 
 	mr := multipart.NewReader(r.Body, boundary)
+	var filePart io.ReadCloser
+	var fileName string
 	for {
 		part, err := mr.NextPart()
 		if err == io.EOF {
-			return "", nil, fmt.Errorf("missing 'file' field in multipart form")
+			break
 		}
 		if err != nil {
-			return "", nil, fmt.Errorf("failed to read multipart form: %w", err)
+			return "", nil, files.FirmwareMetadata{}, fmt.Errorf("failed to read multipart form: %w", err)
 		}
 
-		if part.FormName() == "file" {
-			return part.FileName(), part, nil
+		switch part.FormName() {
+		case "file":
+			filePart = part
+			fileName = part.FileName()
+			if err := files.ValidateFirmwareMetadata(metadata); err != nil {
+				return "", nil, files.FirmwareMetadata{}, err
+			}
+			return fileName, filePart, metadata, nil
+		case "target_manufacturer":
+			value, readErr := io.ReadAll(io.LimitReader(part, 1024))
+			part.Close()
+			if readErr != nil {
+				return "", nil, files.FirmwareMetadata{}, fmt.Errorf("failed to read target_manufacturer: %w", readErr)
+			}
+			metadata.TargetManufacturer = string(value)
+		case "target_model":
+			value, readErr := io.ReadAll(io.LimitReader(part, 1024))
+			part.Close()
+			if readErr != nil {
+				return "", nil, files.FirmwareMetadata{}, fmt.Errorf("failed to read target_model: %w", readErr)
+			}
+			metadata.TargetModel = string(value)
+		default:
+			part.Close()
 		}
-		part.Close()
 	}
+	return "", nil, files.FirmwareMetadata{}, fmt.Errorf("missing 'file' field in multipart form")
 }
 
 // authenticate extracts and validates the session cookie from the HTTP request,

--- a/server/internal/handlers/firmware/handler.go
+++ b/server/internal/handlers/firmware/handler.go
@@ -214,12 +214,18 @@ func (h *uploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	defer fileReader.Close()
-
-	if err := h.filesService.ValidateFirmwareFilename(filename); err != nil {
+	if err := files.ValidateFirmwareUploadMetadata(metadata); err != nil {
+		_ = r.Body.Close()
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
+
+	if err := h.filesService.ValidateFirmwareFilename(filename); err != nil {
+		_ = r.Body.Close()
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	defer fileReader.Close()
 
 	saveResult, err := h.filesService.SaveFirmwareUpload(filename, fileReader, metadata, force)
 	if err != nil {

--- a/server/internal/handlers/firmware/handler.go
+++ b/server/internal/handlers/firmware/handler.go
@@ -22,12 +22,14 @@ import (
 
 type uploadResponse struct {
 	FirmwareFileID string `json:"firmware_file_id"`
+	Reused         bool   `json:"reused,omitempty"`
 }
 
 type checkRequest struct {
 	SHA256             string `json:"sha256"`
 	TargetManufacturer string `json:"target_manufacturer"`
 	TargetModel        string `json:"target_model"`
+	FirmwareVersion    string `json:"firmware_version"`
 }
 
 type checkResponse struct {
@@ -153,8 +155,9 @@ func (h *checkHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	metadata := files.FirmwareMetadata{
 		TargetManufacturer: req.TargetManufacturer,
 		TargetModel:        req.TargetModel,
+		FirmwareVersion:    req.FirmwareVersion,
 	}
-	if err := files.ValidateFirmwareMetadata(metadata); err != nil {
+	if err := files.ValidateFirmwareUploadMetadata(metadata); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -206,7 +209,7 @@ func (h *uploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	const multipartOverhead int64 = 1 * 1024 * 1024 // 1 MB
 	r.Body = http.MaxBytesReader(w, r.Body, h.maxUploadBytes+multipartOverhead)
 
-	filename, fileReader, metadata, err := extractMultipartFile(r)
+	filename, fileReader, metadata, force, err := extractMultipartFile(r)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
@@ -218,7 +221,7 @@ func (h *uploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fileID, err := h.filesService.SaveFirmwareFile(filename, fileReader, metadata)
+	saveResult, err := h.filesService.SaveFirmwareUpload(filename, fileReader, metadata, force)
 	if err != nil {
 		if isClientError(err) {
 			writeError(w, http.StatusBadRequest, err.Error())
@@ -229,27 +232,27 @@ func (h *uploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	slog.Info("firmware file uploaded successfully", "file_id", fileID, "filename", filename)
+	slog.Info("firmware file uploaded successfully", "file_id", saveResult.FirmwareFileID, "filename", filename, "reused", saveResult.Reused)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	if err := json.NewEncoder(w).Encode(uploadResponse{FirmwareFileID: fileID}); err != nil {
+	if err := json.NewEncoder(w).Encode(uploadResponse{FirmwareFileID: saveResult.FirmwareFileID, Reused: saveResult.Reused}); err != nil {
 		slog.Error("failed to encode upload response", "error", err)
 	}
 }
 
 // extractMultipartFile streams the multipart body to find the "file" part
 // without buffering the entire body in memory or spilling to temp files.
-func extractMultipartFile(r *http.Request) (filename string, reader io.ReadCloser, metadata files.FirmwareMetadata, err error) {
+func extractMultipartFile(r *http.Request) (filename string, reader io.ReadCloser, metadata files.FirmwareMetadata, force bool, err error) {
 	contentType := r.Header.Get("Content-Type")
 	mediaType, params, err := mime.ParseMediaType(contentType)
 	if err != nil || !strings.HasPrefix(mediaType, "multipart/") {
-		return "", nil, files.FirmwareMetadata{}, fmt.Errorf("expected multipart/form-data content type")
+		return "", nil, files.FirmwareMetadata{}, false, fmt.Errorf("expected multipart/form-data content type")
 	}
 
 	boundary := params["boundary"]
 	if boundary == "" {
-		return "", nil, files.FirmwareMetadata{}, fmt.Errorf("missing multipart boundary")
+		return "", nil, files.FirmwareMetadata{}, false, fmt.Errorf("missing multipart boundary")
 	}
 
 	mr := multipart.NewReader(r.Body, boundary)
@@ -261,36 +264,47 @@ func extractMultipartFile(r *http.Request) (filename string, reader io.ReadClose
 			break
 		}
 		if err != nil {
-			return "", nil, files.FirmwareMetadata{}, fmt.Errorf("failed to read multipart form: %w", err)
+			return "", nil, files.FirmwareMetadata{}, false, fmt.Errorf("failed to read multipart form: %w", err)
 		}
 
 		switch part.FormName() {
 		case "file":
 			filePart = part
 			fileName = part.FileName()
-			if err := files.ValidateFirmwareMetadata(metadata); err != nil {
-				return "", nil, files.FirmwareMetadata{}, err
-			}
-			return fileName, filePart, metadata, nil
+			return fileName, filePart, metadata, force, nil
 		case "target_manufacturer":
 			value, readErr := io.ReadAll(io.LimitReader(part, 1024))
 			part.Close()
 			if readErr != nil {
-				return "", nil, files.FirmwareMetadata{}, fmt.Errorf("failed to read target_manufacturer: %w", readErr)
+				return "", nil, files.FirmwareMetadata{}, false, fmt.Errorf("failed to read target_manufacturer: %w", readErr)
 			}
 			metadata.TargetManufacturer = string(value)
 		case "target_model":
 			value, readErr := io.ReadAll(io.LimitReader(part, 1024))
 			part.Close()
 			if readErr != nil {
-				return "", nil, files.FirmwareMetadata{}, fmt.Errorf("failed to read target_model: %w", readErr)
+				return "", nil, files.FirmwareMetadata{}, false, fmt.Errorf("failed to read target_model: %w", readErr)
 			}
 			metadata.TargetModel = string(value)
+		case "firmware_version":
+			value, readErr := io.ReadAll(io.LimitReader(part, 1024))
+			part.Close()
+			if readErr != nil {
+				return "", nil, files.FirmwareMetadata{}, false, fmt.Errorf("failed to read firmware_version: %w", readErr)
+			}
+			metadata.FirmwareVersion = string(value)
+		case "force":
+			value, readErr := io.ReadAll(io.LimitReader(part, 16))
+			part.Close()
+			if readErr != nil {
+				return "", nil, files.FirmwareMetadata{}, false, fmt.Errorf("failed to read force: %w", readErr)
+			}
+			force = strings.EqualFold(strings.TrimSpace(string(value)), "true") || strings.TrimSpace(string(value)) == "1"
 		default:
 			part.Close()
 		}
 	}
-	return "", nil, files.FirmwareMetadata{}, fmt.Errorf("missing 'file' field in multipart form")
+	return "", nil, files.FirmwareMetadata{}, false, fmt.Errorf("missing 'file' field in multipart form")
 }
 
 // authenticate extracts and validates the session cookie from the HTTP request,

--- a/server/internal/handlers/firmware/handler.go
+++ b/server/internal/handlers/firmware/handler.go
@@ -226,7 +226,12 @@ func (h *uploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	upload, err := extractMultipartFile(r, h.filesService)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
+		if isClientError(err) {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		slog.Error("failed to stage firmware upload", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to stage firmware upload")
 		return
 	}
 	defer upload.staged.Discard()
@@ -271,12 +276,12 @@ func extractMultipartFile(r *http.Request, filesService *files.Service) (extract
 	contentType := r.Header.Get("Content-Type")
 	mediaType, params, err := mime.ParseMediaType(contentType)
 	if err != nil || !strings.HasPrefix(mediaType, "multipart/") {
-		return extractedMultipartUpload{}, fmt.Errorf("expected multipart/form-data content type")
+		return extractedMultipartUpload{}, fleeterror.NewInvalidArgumentError("expected multipart/form-data content type")
 	}
 
 	boundary := params["boundary"]
 	if boundary == "" {
-		return extractedMultipartUpload{}, fmt.Errorf("missing multipart boundary")
+		return extractedMultipartUpload{}, fleeterror.NewInvalidArgumentError("missing multipart boundary")
 	}
 
 	completed := false
@@ -298,7 +303,11 @@ func extractMultipartFile(r *http.Request, filesService *files.Service) (extract
 			break
 		}
 		if err != nil {
-			return extractedMultipartUpload{}, fmt.Errorf("failed to read multipart form: %w", err)
+			var maxBytesErr *http.MaxBytesError
+			if errors.As(err, &maxBytesErr) {
+				return extractedMultipartUpload{}, fmt.Errorf("failed to read multipart form: %w", err)
+			}
+			return extractedMultipartUpload{}, fleeterror.NewInvalidArgumentErrorf("failed to read multipart form: %v", err)
 		}
 
 		name := part.FormName()
@@ -306,7 +315,7 @@ func extractMultipartFile(r *http.Request, filesService *files.Service) (extract
 		case name == "file":
 			if upload.staged != nil {
 				_ = part.Close()
-				return extractedMultipartUpload{}, fmt.Errorf("multiple 'file' fields are not supported")
+				return extractedMultipartUpload{}, fleeterror.NewInvalidArgumentError("multiple 'file' fields are not supported")
 			}
 			upload.filename = part.FileName()
 			staged, stageErr := filesService.StageFirmwareUpload(part)
@@ -333,7 +342,7 @@ func extractMultipartFile(r *http.Request, filesService *files.Service) (extract
 		}
 	}
 	if upload.staged == nil {
-		return extractedMultipartUpload{}, fmt.Errorf("missing 'file' field in multipart form")
+		return extractedMultipartUpload{}, fleeterror.NewInvalidArgumentError("missing 'file' field in multipart form")
 	}
 	completed = true
 	return upload, nil
@@ -344,7 +353,7 @@ func readPartValue(part *multipart.Part, limit int64, name string) (string, erro
 	value, err := io.ReadAll(io.LimitReader(part, limit))
 	part.Close()
 	if err != nil {
-		return "", fmt.Errorf("failed to read %s: %w", name, err)
+		return "", fleeterror.NewInvalidArgumentErrorf("failed to read %s: %v", name, err)
 	}
 	return string(value), nil
 }
@@ -449,12 +458,14 @@ func NewUpdateMetadataHandler(
 	filesService *files.Service,
 	sessionService *session.Service,
 	userStore interfaces.UserStore,
+	activitySvc *activityDomain.Service,
 	permissionResolver effectivePermissionResolver,
 ) http.Handler {
 	return &updateMetadataHandler{
 		filesService:       filesService,
 		sessionService:     sessionService,
 		userStore:          userStore,
+		activitySvc:        activitySvc,
 		permissionResolver: permissionResolver,
 	}
 }
@@ -463,18 +474,20 @@ type updateMetadataHandler struct {
 	filesService       *files.Service
 	sessionService     *session.Service
 	userStore          interfaces.UserStore
+	activitySvc        *activityDomain.Service
 	permissionResolver effectivePermissionResolver
 }
 
 func (h *updateMetadataHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if _, ok := requireMutationPermission(
+	ctx, ok := requireMutationPermission(
 		w,
 		r,
 		h.sessionService,
 		h.userStore,
 		h.permissionResolver,
 		"update metadata",
-	); !ok {
+	)
+	if !ok {
 		return
 	}
 
@@ -498,6 +511,14 @@ func (h *updateMetadataHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	var previousMetadata *files.FirmwareMetadata
+	previous, err := h.filesService.GetFirmwareMetadata(fileID)
+	if err != nil {
+		slog.Warn("failed to read previous firmware metadata for activity", "file_id", fileID, "error", err)
+	} else {
+		previousMetadata = &previous
+	}
+
 	if err := h.filesService.UpdateFirmwareMetadata(fileID, metadata); err != nil {
 		switch {
 		case fleeterror.IsNotFoundError(err):
@@ -510,6 +531,13 @@ func (h *updateMetadataHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		}
 		return
 	}
+
+	currentMetadata, err := h.filesService.GetFirmwareMetadata(fileID)
+	if err != nil {
+		slog.Warn("failed to read updated firmware metadata for activity", "file_id", fileID, "error", err)
+		currentMetadata = metadata
+	}
+	logFirmwareMetadataUpdatedActivity(ctx, h.activitySvc, fileID, previousMetadata, currentMetadata)
 
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/server/internal/handlers/firmware/handler.go
+++ b/server/internal/handlers/firmware/handler.go
@@ -236,11 +236,6 @@ func (h *uploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	defer upload.staged.Discard()
 
-	if err := h.filesService.ValidateFirmwareFilename(upload.filename); err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
-		return
-	}
-
 	saveResult, err := h.filesService.SaveFirmwareUploadFromPath(
 		upload.filename,
 		upload.staged.Path,
@@ -297,6 +292,7 @@ func extractMultipartFile(r *http.Request, filesService *files.Service) (extract
 		"target_model":        &upload.metadata.TargetModel,
 		"firmware_version":    &upload.metadata.FirmwareVersion,
 	}
+	metadataFieldsRead := make(map[string]bool, len(metadataFields))
 	for {
 		part, err := mr.NextPart()
 		if err == io.EOF {
@@ -318,6 +314,16 @@ func extractMultipartFile(r *http.Request, filesService *files.Service) (extract
 				return extractedMultipartUpload{}, fleeterror.NewInvalidArgumentError("multiple 'file' fields are not supported")
 			}
 			upload.filename = part.FileName()
+			if validationErr := filesService.ValidateFirmwareFilename(upload.filename); validationErr != nil {
+				_ = part.Close()
+				return extractedMultipartUpload{}, validationErr
+			}
+			if len(metadataFieldsRead) == len(metadataFields) {
+				if validationErr := files.ValidateFirmwareUploadMetadata(upload.metadata); validationErr != nil {
+					_ = part.Close()
+					return extractedMultipartUpload{}, validationErr
+				}
+			}
 			staged, stageErr := filesService.StageFirmwareUpload(part)
 			_ = part.Close()
 			if stageErr != nil {
@@ -330,6 +336,7 @@ func extractMultipartFile(r *http.Request, filesService *files.Service) (extract
 				return extractedMultipartUpload{}, readErr
 			}
 			*metadataFields[name] = value
+			metadataFieldsRead[name] = true
 		case name == "force":
 			value, readErr := readPartValue(part, 16, name)
 			if readErr != nil {
@@ -511,15 +518,8 @@ func (h *updateMetadataHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	var previousMetadata *files.FirmwareMetadata
-	previous, err := h.filesService.GetFirmwareMetadata(fileID)
+	result, err := h.filesService.UpdateFirmwareMetadata(fileID, metadata)
 	if err != nil {
-		slog.Warn("failed to read previous firmware metadata for activity", "file_id", fileID, "error", err)
-	} else {
-		previousMetadata = &previous
-	}
-
-	if err := h.filesService.UpdateFirmwareMetadata(fileID, metadata); err != nil {
 		switch {
 		case fleeterror.IsNotFoundError(err):
 			writeError(w, http.StatusNotFound, err.Error())
@@ -532,12 +532,7 @@ func (h *updateMetadataHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	currentMetadata, err := h.filesService.GetFirmwareMetadata(fileID)
-	if err != nil {
-		slog.Warn("failed to read updated firmware metadata for activity", "file_id", fileID, "error", err)
-		currentMetadata = metadata
-	}
-	logFirmwareMetadataUpdatedActivity(ctx, h.activitySvc, fileID, previousMetadata, currentMetadata)
+	logFirmwareMetadataUpdatedActivity(ctx, h.activitySvc, fileID, result.Previous, result.Current)
 
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/server/internal/handlers/firmware/handler.go
+++ b/server/internal/handlers/firmware/handler.go
@@ -2,6 +2,7 @@ package firmware
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -11,6 +12,7 @@ import (
 	"mime"
 	"mime/multipart"
 	"net/http"
+	"os"
 	"strings"
 
 	"connectrpc.com/authn"
@@ -24,6 +26,14 @@ import (
 type uploadResponse struct {
 	FirmwareFileID string `json:"firmware_file_id"`
 	Reused         bool   `json:"reused,omitempty"`
+}
+
+type extractedMultipartUpload struct {
+	filename   string
+	stagedPath string
+	checksum   string
+	metadata   files.FirmwareMetadata
+	force      bool
 }
 
 type checkRequest struct {
@@ -205,25 +215,29 @@ func (h *uploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	const multipartOverhead int64 = 1 * 1024 * 1024 // 1 MB
 	r.Body = http.MaxBytesReader(w, r.Body, h.maxUploadBytes+multipartOverhead)
 
-	filename, fileReader, metadata, force, err := extractMultipartFile(r)
+	upload, err := extractMultipartFile(r, h.filesService.MaxFirmwareFileSize())
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	if err := files.ValidateFirmwareUploadMetadata(metadata); err != nil {
-		_ = r.Body.Close()
+	defer func() { _ = os.Remove(upload.stagedPath) }()
+	if err := files.ValidateFirmwareUploadMetadata(upload.metadata); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
-	if err := h.filesService.ValidateFirmwareFilename(filename); err != nil {
-		_ = r.Body.Close()
+	if err := h.filesService.ValidateFirmwareFilename(upload.filename); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	defer fileReader.Close()
 
-	saveResult, err := h.filesService.SaveFirmwareUpload(filename, fileReader, metadata, force)
+	saveResult, err := h.filesService.SaveFirmwareUploadFromPath(
+		upload.filename,
+		upload.stagedPath,
+		upload.metadata,
+		upload.force,
+		upload.checksum,
+	)
 	if err != nil {
 		if isClientError(err) {
 			writeError(w, http.StatusBadRequest, err.Error())
@@ -234,8 +248,8 @@ func (h *uploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	slog.Info("firmware file uploaded successfully", "file_id", saveResult.FirmwareFileID, "filename", filename, "reused", saveResult.Reused)
-	logFirmwareUploadActivity(ctx, h.activitySvc, filename, saveResult)
+	slog.Info("firmware file uploaded successfully", "file_id", saveResult.FirmwareFileID, "filename", upload.filename, "reused", saveResult.Reused)
+	logFirmwareUploadActivity(ctx, h.activitySvc, upload.filename, saveResult)
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
@@ -244,25 +258,34 @@ func (h *uploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// extractMultipartFile streams the multipart body to find the "file" part
-// without buffering the entire body in memory or spilling to temp files.
-func extractMultipartFile(r *http.Request) (filename string, reader io.ReadCloser, metadata files.FirmwareMetadata, force bool, err error) {
+// extractMultipartFile stages the file while reading the complete multipart
+// body, so metadata fields are accepted regardless of whether they appear
+// before or after the file part.
+func extractMultipartFile(r *http.Request, maxFileBytes int64) (extractedMultipartUpload, error) {
+	var upload extractedMultipartUpload
 	contentType := r.Header.Get("Content-Type")
 	mediaType, params, err := mime.ParseMediaType(contentType)
 	if err != nil || !strings.HasPrefix(mediaType, "multipart/") {
-		return "", nil, files.FirmwareMetadata{}, false, fmt.Errorf("expected multipart/form-data content type")
+		return extractedMultipartUpload{}, fmt.Errorf("expected multipart/form-data content type")
 	}
 
 	boundary := params["boundary"]
 	if boundary == "" {
-		return "", nil, files.FirmwareMetadata{}, false, fmt.Errorf("missing multipart boundary")
+		return extractedMultipartUpload{}, fmt.Errorf("missing multipart boundary")
 	}
+
+	completed := false
+	defer func() {
+		if !completed && upload.stagedPath != "" {
+			_ = os.Remove(upload.stagedPath)
+		}
+	}()
 
 	mr := multipart.NewReader(r.Body, boundary)
 	metadataFields := map[string]*string{
-		"target_manufacturer": &metadata.TargetManufacturer,
-		"target_model":        &metadata.TargetModel,
-		"firmware_version":    &metadata.FirmwareVersion,
+		"target_manufacturer": &upload.metadata.TargetManufacturer,
+		"target_model":        &upload.metadata.TargetModel,
+		"firmware_version":    &upload.metadata.FirmwareVersion,
 	}
 	for {
 		part, err := mr.NextPart()
@@ -270,31 +293,59 @@ func extractMultipartFile(r *http.Request) (filename string, reader io.ReadClose
 			break
 		}
 		if err != nil {
-			return "", nil, files.FirmwareMetadata{}, false, fmt.Errorf("failed to read multipart form: %w", err)
+			return extractedMultipartUpload{}, fmt.Errorf("failed to read multipart form: %w", err)
 		}
 
 		name := part.FormName()
 		switch {
 		case name == "file":
-			return part.FileName(), part, metadata, force, nil
+			if upload.stagedPath != "" {
+				_ = part.Close()
+				return extractedMultipartUpload{}, fmt.Errorf("multiple 'file' fields are not supported")
+			}
+			upload.filename = part.FileName()
+			tempFile, createErr := os.CreateTemp(files.StagingDir(), "multipart-*")
+			if createErr != nil {
+				_ = part.Close()
+				return extractedMultipartUpload{}, fmt.Errorf("failed to stage firmware file: %w", createErr)
+			}
+			upload.stagedPath = tempFile.Name()
+			hasher := sha256.New()
+			written, copyErr := io.Copy(io.MultiWriter(tempFile, hasher), io.LimitReader(part, maxFileBytes+1))
+			closeErr := tempFile.Close()
+			_ = part.Close()
+			if copyErr != nil {
+				return extractedMultipartUpload{}, fmt.Errorf("failed to read firmware file: %w", copyErr)
+			}
+			if closeErr != nil {
+				return extractedMultipartUpload{}, fmt.Errorf("failed to close staged firmware file: %w", closeErr)
+			}
+			if written > maxFileBytes {
+				return extractedMultipartUpload{}, fmt.Errorf("firmware file too large: exceeded %d byte limit during upload", maxFileBytes)
+			}
+			upload.checksum = hex.EncodeToString(hasher.Sum(nil))
 		case metadataFields[name] != nil:
 			value, readErr := readPartValue(part, 1024, name)
 			if readErr != nil {
-				return "", nil, files.FirmwareMetadata{}, false, readErr
+				return extractedMultipartUpload{}, readErr
 			}
 			*metadataFields[name] = value
 		case name == "force":
 			value, readErr := readPartValue(part, 16, name)
 			if readErr != nil {
-				return "", nil, files.FirmwareMetadata{}, false, readErr
+				return extractedMultipartUpload{}, readErr
 			}
 			value = strings.TrimSpace(value)
-			force = strings.EqualFold(value, "true") || value == "1"
+			upload.force = strings.EqualFold(value, "true") || value == "1"
 		default:
 			part.Close()
 		}
 	}
-	return "", nil, files.FirmwareMetadata{}, false, fmt.Errorf("missing 'file' field in multipart form")
+	if upload.stagedPath == "" {
+		return extractedMultipartUpload{}, fmt.Errorf("missing 'file' field in multipart form")
+	}
+	completed = true
+	return upload, nil
 }
 
 // readPartValue reads a small text form field up to limit bytes and closes the part.

--- a/server/internal/handlers/firmware/handler.go
+++ b/server/internal/handlers/firmware/handler.go
@@ -2,7 +2,6 @@ package firmware
 
 import (
 	"context"
-	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -12,7 +11,6 @@ import (
 	"mime"
 	"mime/multipart"
 	"net/http"
-	"os"
 	"strings"
 
 	"connectrpc.com/authn"
@@ -29,11 +27,10 @@ type uploadResponse struct {
 }
 
 type extractedMultipartUpload struct {
-	filename   string
-	stagedPath string
-	checksum   string
-	metadata   files.FirmwareMetadata
-	force      bool
+	filename string
+	staged   *files.StagedFirmwareUpload
+	metadata files.FirmwareMetadata
+	force    bool
 }
 
 type checkRequest struct {
@@ -102,14 +99,21 @@ func (h *configHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // NewUploadHandler returns an http.Handler that accepts multipart firmware file uploads.
 // The handler validates the file, streams it to disk, and returns a firmware_file_id.
-// The request body is capped at maxUploadBytes to reject oversized uploads early.
-func NewUploadHandler(filesService *files.Service, sessionService *session.Service, userStore interfaces.UserStore, activitySvc *activityDomain.Service, maxUploadBytes int64) http.Handler {
+// The request body is capped at the files service's firmware size limit to reject
+// oversized uploads early.
+func NewUploadHandler(
+	filesService *files.Service,
+	sessionService *session.Service,
+	userStore interfaces.UserStore,
+	activitySvc *activityDomain.Service,
+	permissionResolver effectivePermissionResolver,
+) http.Handler {
 	return &uploadHandler{
-		filesService:   filesService,
-		sessionService: sessionService,
-		userStore:      userStore,
-		activitySvc:    activitySvc,
-		maxUploadBytes: maxUploadBytes,
+		filesService:       filesService,
+		sessionService:     sessionService,
+		userStore:          userStore,
+		activitySvc:        activitySvc,
+		permissionResolver: permissionResolver,
 	}
 }
 
@@ -183,11 +187,11 @@ func (h *checkHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 type uploadHandler struct {
-	filesService   *files.Service
-	sessionService *session.Service
-	userStore      interfaces.UserStore
-	activitySvc    *activityDomain.Service
-	maxUploadBytes int64
+	filesService       *files.Service
+	sessionService     *session.Service
+	userStore          interfaces.UserStore
+	activitySvc        *activityDomain.Service
+	permissionResolver effectivePermissionResolver
 }
 
 func (h *uploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -197,10 +201,15 @@ func (h *uploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctx, err := authenticate(r, h.sessionService, h.userStore)
-	if err != nil {
-		slog.Warn("firmware upload authentication failed", "error", err)
-		writeError(w, http.StatusUnauthorized, "authentication required")
+	ctx, ok := requireMutationPermission(
+		w,
+		r,
+		h.sessionService,
+		h.userStore,
+		h.permissionResolver,
+		"upload",
+	)
+	if !ok {
 		return
 	}
 
@@ -213,18 +222,14 @@ func (h *uploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Pad the body limit to account for multipart boundaries and part headers.
 	const multipartOverhead int64 = 1 * 1024 * 1024 // 1 MB
-	r.Body = http.MaxBytesReader(w, r.Body, h.maxUploadBytes+multipartOverhead)
+	r.Body = http.MaxBytesReader(w, r.Body, h.filesService.MaxFirmwareFileSize()+multipartOverhead)
 
-	upload, err := extractMultipartFile(r, h.filesService.MaxFirmwareFileSize())
+	upload, err := extractMultipartFile(r, h.filesService)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	defer func() { _ = os.Remove(upload.stagedPath) }()
-	if err := files.ValidateFirmwareUploadMetadata(upload.metadata); err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
-		return
-	}
+	defer upload.staged.Discard()
 
 	if err := h.filesService.ValidateFirmwareFilename(upload.filename); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
@@ -233,10 +238,10 @@ func (h *uploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	saveResult, err := h.filesService.SaveFirmwareUploadFromPath(
 		upload.filename,
-		upload.stagedPath,
+		upload.staged.Path,
 		upload.metadata,
 		upload.force,
-		upload.checksum,
+		upload.staged.Checksum,
 	)
 	if err != nil {
 		if isClientError(err) {
@@ -261,7 +266,7 @@ func (h *uploadHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // extractMultipartFile stages the file while reading the complete multipart
 // body, so metadata fields are accepted regardless of whether they appear
 // before or after the file part.
-func extractMultipartFile(r *http.Request, maxFileBytes int64) (extractedMultipartUpload, error) {
+func extractMultipartFile(r *http.Request, filesService *files.Service) (extractedMultipartUpload, error) {
 	var upload extractedMultipartUpload
 	contentType := r.Header.Get("Content-Type")
 	mediaType, params, err := mime.ParseMediaType(contentType)
@@ -276,8 +281,8 @@ func extractMultipartFile(r *http.Request, maxFileBytes int64) (extractedMultipa
 
 	completed := false
 	defer func() {
-		if !completed && upload.stagedPath != "" {
-			_ = os.Remove(upload.stagedPath)
+		if !completed {
+			upload.staged.Discard()
 		}
 	}()
 
@@ -299,31 +304,17 @@ func extractMultipartFile(r *http.Request, maxFileBytes int64) (extractedMultipa
 		name := part.FormName()
 		switch {
 		case name == "file":
-			if upload.stagedPath != "" {
+			if upload.staged != nil {
 				_ = part.Close()
 				return extractedMultipartUpload{}, fmt.Errorf("multiple 'file' fields are not supported")
 			}
 			upload.filename = part.FileName()
-			tempFile, createErr := os.CreateTemp(files.StagingDir(), "multipart-*")
-			if createErr != nil {
-				_ = part.Close()
-				return extractedMultipartUpload{}, fmt.Errorf("failed to stage firmware file: %w", createErr)
-			}
-			upload.stagedPath = tempFile.Name()
-			hasher := sha256.New()
-			written, copyErr := io.Copy(io.MultiWriter(tempFile, hasher), io.LimitReader(part, maxFileBytes+1))
-			closeErr := tempFile.Close()
+			staged, stageErr := filesService.StageFirmwareUpload(part)
 			_ = part.Close()
-			if copyErr != nil {
-				return extractedMultipartUpload{}, fmt.Errorf("failed to read firmware file: %w", copyErr)
+			if stageErr != nil {
+				return extractedMultipartUpload{}, stageErr
 			}
-			if closeErr != nil {
-				return extractedMultipartUpload{}, fmt.Errorf("failed to close staged firmware file: %w", closeErr)
-			}
-			if written > maxFileBytes {
-				return extractedMultipartUpload{}, fmt.Errorf("firmware file too large: exceeded %d byte limit during upload", maxFileBytes)
-			}
-			upload.checksum = hex.EncodeToString(hasher.Sum(nil))
+			upload.staged = staged
 		case metadataFields[name] != nil:
 			value, readErr := readPartValue(part, 1024, name)
 			if readErr != nil {
@@ -341,7 +332,7 @@ func extractMultipartFile(r *http.Request, maxFileBytes int64) (extractedMultipa
 			part.Close()
 		}
 	}
-	if upload.stagedPath == "" {
+	if upload.staged == nil {
 		return extractedMultipartUpload{}, fmt.Errorf("missing 'file' field in multipart form")
 	}
 	completed = true
@@ -454,24 +445,36 @@ func (h *listFilesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // NewUpdateMetadataHandler returns an http.Handler that updates a stored
 // firmware file's deployment metadata.
-func NewUpdateMetadataHandler(filesService *files.Service, sessionService *session.Service, userStore interfaces.UserStore) http.Handler {
+func NewUpdateMetadataHandler(
+	filesService *files.Service,
+	sessionService *session.Service,
+	userStore interfaces.UserStore,
+	permissionResolver effectivePermissionResolver,
+) http.Handler {
 	return &updateMetadataHandler{
-		filesService:   filesService,
-		sessionService: sessionService,
-		userStore:      userStore,
+		filesService:       filesService,
+		sessionService:     sessionService,
+		userStore:          userStore,
+		permissionResolver: permissionResolver,
 	}
 }
 
 type updateMetadataHandler struct {
-	filesService   *files.Service
-	sessionService *session.Service
-	userStore      interfaces.UserStore
+	filesService       *files.Service
+	sessionService     *session.Service
+	userStore          interfaces.UserStore
+	permissionResolver effectivePermissionResolver
 }
 
 func (h *updateMetadataHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if _, err := authenticate(r, h.sessionService, h.userStore); err != nil {
-		slog.Warn("firmware metadata update authentication failed", "error", err)
-		writeError(w, http.StatusUnauthorized, "authentication required")
+	if _, ok := requireMutationPermission(
+		w,
+		r,
+		h.sessionService,
+		h.userStore,
+		h.permissionResolver,
+		"update metadata",
+	); !ok {
 		return
 	}
 
@@ -512,24 +515,36 @@ func (h *updateMetadataHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 }
 
 // NewDeleteFileHandler returns an http.Handler that deletes a single firmware file by ID.
-func NewDeleteFileHandler(filesService *files.Service, sessionService *session.Service, userStore interfaces.UserStore) http.Handler {
+func NewDeleteFileHandler(
+	filesService *files.Service,
+	sessionService *session.Service,
+	userStore interfaces.UserStore,
+	permissionResolver effectivePermissionResolver,
+) http.Handler {
 	return &deleteFileHandler{
-		filesService:   filesService,
-		sessionService: sessionService,
-		userStore:      userStore,
+		filesService:       filesService,
+		sessionService:     sessionService,
+		userStore:          userStore,
+		permissionResolver: permissionResolver,
 	}
 }
 
 type deleteFileHandler struct {
-	filesService   *files.Service
-	sessionService *session.Service
-	userStore      interfaces.UserStore
+	filesService       *files.Service
+	sessionService     *session.Service
+	userStore          interfaces.UserStore
+	permissionResolver effectivePermissionResolver
 }
 
 func (h *deleteFileHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if _, err := authenticate(r, h.sessionService, h.userStore); err != nil {
-		slog.Warn("firmware delete authentication failed", "error", err)
-		writeError(w, http.StatusUnauthorized, "authentication required")
+	if _, ok := requireMutationPermission(
+		w,
+		r,
+		h.sessionService,
+		h.userStore,
+		h.permissionResolver,
+		"delete file",
+	); !ok {
 		return
 	}
 
@@ -557,24 +572,36 @@ func (h *deleteFileHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 // NewDeleteAllFilesHandler returns an http.Handler that deletes all firmware files.
-func NewDeleteAllFilesHandler(filesService *files.Service, sessionService *session.Service, userStore interfaces.UserStore) http.Handler {
+func NewDeleteAllFilesHandler(
+	filesService *files.Service,
+	sessionService *session.Service,
+	userStore interfaces.UserStore,
+	permissionResolver effectivePermissionResolver,
+) http.Handler {
 	return &deleteAllFilesHandler{
-		filesService:   filesService,
-		sessionService: sessionService,
-		userStore:      userStore,
+		filesService:       filesService,
+		sessionService:     sessionService,
+		userStore:          userStore,
+		permissionResolver: permissionResolver,
 	}
 }
 
 type deleteAllFilesHandler struct {
-	filesService   *files.Service
-	sessionService *session.Service
-	userStore      interfaces.UserStore
+	filesService       *files.Service
+	sessionService     *session.Service
+	userStore          interfaces.UserStore
+	permissionResolver effectivePermissionResolver
 }
 
 func (h *deleteAllFilesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	if _, err := authenticate(r, h.sessionService, h.userStore); err != nil {
-		slog.Warn("firmware delete-all authentication failed", "error", err)
-		writeError(w, http.StatusUnauthorized, "authentication required")
+	if _, ok := requireMutationPermission(
+		w,
+		r,
+		h.sessionService,
+		h.userStore,
+		h.permissionResolver,
+		"delete all files",
+	); !ok {
 		return
 	}
 

--- a/server/internal/handlers/firmware/handler_test.go
+++ b/server/internal/handlers/firmware/handler_test.go
@@ -9,6 +9,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -166,11 +167,20 @@ func createMultipartRequest(t *testing.T, filename string, content []byte, cooki
 	return req
 }
 
-func createMultipartRequestWithoutMetadata(t *testing.T, filename string, content []byte, cookie *http.Cookie) *http.Request {
+func createMultipartRequestWithFields(
+	t *testing.T,
+	filename string,
+	content []byte,
+	cookie *http.Cookie,
+	fields map[string]string,
+) *http.Request {
 	t.Helper()
 
 	var buf bytes.Buffer
 	writer := multipart.NewWriter(&buf)
+	for name, value := range fields {
+		require.NoError(t, writer.WriteField(name, value))
+	}
 	part, err := writer.CreateFormFile("file", filename)
 	require.NoError(t, err)
 	_, err = part.Write(content)
@@ -273,15 +283,33 @@ func TestUploadHandler_RejectsInvalidExtension(t *testing.T) {
 }
 
 func TestUploadHandler_RejectsMissingTargetMetadata(t *testing.T) {
-	env := newTestEnv(t)
-	env.expectAuth()
-	req := createMultipartRequestWithoutMetadata(t, "firmware.swu", []byte("data"), validSessionCookie(env.sessionID))
-	rr := httptest.NewRecorder()
+	tests := []struct {
+		name      string
+		fields    map[string]string
+		wantError string
+	}{
+		{name: "all metadata", wantError: "target_manufacturer"},
+		{name: "manufacturer", fields: map[string]string{"target_model": "S21", "firmware_version": "v2.0.0"}, wantError: "target_manufacturer"},
+		{name: "model", fields: map[string]string{"target_manufacturer": "Proto", "firmware_version": "v2.0.0"}, wantError: "target_model"},
+		{name: "version", fields: map[string]string{"target_manufacturer": "Proto", "target_model": "S21"}, wantError: "firmware_version"},
+	}
 
-	env.uploadHandler().ServeHTTP(rr, req)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := newTestEnv(t)
+			env.expectAuth()
+			req := createMultipartRequestWithFields(t, "firmware.swu", []byte("data"), validSessionCookie(env.sessionID), tt.fields)
+			rr := httptest.NewRecorder()
 
-	assert.Equal(t, http.StatusBadRequest, rr.Code)
-	assert.Contains(t, rr.Body.String(), "target_manufacturer")
+			env.uploadHandler().ServeHTTP(rr, req)
+
+			assert.Equal(t, http.StatusBadRequest, rr.Code)
+			assert.Contains(t, rr.Body.String(), tt.wantError)
+			entries, err := os.ReadDir(files.StagingDir())
+			require.NoError(t, err)
+			assert.Empty(t, entries)
+		})
+	}
 }
 
 func TestUploadHandler_RejectsMissingFileField(t *testing.T) {

--- a/server/internal/handlers/firmware/handler_test.go
+++ b/server/internal/handlers/firmware/handler_test.go
@@ -149,6 +149,8 @@ func createMultipartRequest(t *testing.T, filename string, content []byte, cooki
 
 	var buf bytes.Buffer
 	writer := multipart.NewWriter(&buf)
+	require.NoError(t, writer.WriteField("target_manufacturer", "Proto"))
+	require.NoError(t, writer.WriteField("target_model", "S21"))
 	part, err := writer.CreateFormFile("file", filename)
 	require.NoError(t, err)
 	_, err = part.Write(content)
@@ -161,6 +163,33 @@ func createMultipartRequest(t *testing.T, filename string, content []byte, cooki
 		req.AddCookie(cookie)
 	}
 	return req
+}
+
+func createMultipartRequestWithoutMetadata(t *testing.T, filename string, content []byte, cookie *http.Cookie) *http.Request {
+	t.Helper()
+
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	part, err := writer.CreateFormFile("file", filename)
+	require.NoError(t, err)
+	_, err = part.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload", &buf)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	if cookie != nil {
+		req.AddCookie(cookie)
+	}
+	return req
+}
+
+func testFirmwareMetadata() files.FirmwareMetadata {
+	return files.FirmwareMetadata{TargetManufacturer: "Proto", TargetModel: "S21"}
+}
+
+func firmwareCheckBody(checksum string) string {
+	return fmt.Sprintf(`{"sha256":%q,"target_manufacturer":"Proto","target_model":"S21"}`, checksum)
 }
 
 func createCheckRequest(t *testing.T, body string, cookie *http.Cookie) *http.Request {
@@ -240,6 +269,18 @@ func TestUploadHandler_RejectsInvalidExtension(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
 	assert.Contains(t, rr.Body.String(), "unsupported firmware file type")
+}
+
+func TestUploadHandler_RejectsMissingTargetMetadata(t *testing.T) {
+	env := newTestEnv(t)
+	env.expectAuth()
+	req := createMultipartRequestWithoutMetadata(t, "firmware.swu", []byte("data"), validSessionCookie(env.sessionID))
+	rr := httptest.NewRecorder()
+
+	env.uploadHandler().ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "target_manufacturer")
 }
 
 func TestUploadHandler_RejectsMissingFileField(t *testing.T) {
@@ -349,7 +390,7 @@ func TestCheckHandler_RejectsNonHexChecksum(t *testing.T) {
 	env := newTestEnv(t)
 	env.expectAuth()
 	nonHex := strings.Repeat("zz", 32) // 64 chars but not valid hex
-	req := createCheckRequest(t, `{"sha256":"`+nonHex+`"}`, validSessionCookie(env.sessionID))
+	req := createCheckRequest(t, firmwareCheckBody(nonHex), validSessionCookie(env.sessionID))
 	rr := httptest.NewRecorder()
 
 	env.checkHandler().ServeHTTP(rr, req)
@@ -362,7 +403,7 @@ func TestCheckHandler_ReturnsFalseForUnknownChecksum(t *testing.T) {
 	env := newTestEnv(t)
 	env.expectAuth()
 	checksum := strings.Repeat("a", 64)
-	req := createCheckRequest(t, `{"sha256":"`+checksum+`"}`, validSessionCookie(env.sessionID))
+	req := createCheckRequest(t, firmwareCheckBody(checksum), validSessionCookie(env.sessionID))
 	rr := httptest.NewRecorder()
 
 	env.checkHandler().ServeHTTP(rr, req)
@@ -372,16 +413,35 @@ func TestCheckHandler_ReturnsFalseForUnknownChecksum(t *testing.T) {
 	assert.NotContains(t, rr.Body.String(), "firmware_file_id")
 }
 
+func TestCheckHandler_RequiresMatchingTargetMetadata(t *testing.T) {
+	env := newTestEnv(t)
+	env.expectAuth()
+
+	content := "firmware content for target mismatch"
+	fileID, err := env.fileSvc.SaveFirmwareFile("firmware.swu", strings.NewReader(content), testFirmwareMetadata())
+	require.NoError(t, err)
+
+	body := fmt.Sprintf(`{"sha256":%q,"target_manufacturer":"Proto","target_model":"S19"}`, sha256Hex(content))
+	req := createCheckRequest(t, body, validSessionCookie(env.sessionID))
+	rr := httptest.NewRecorder()
+
+	env.checkHandler().ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Contains(t, rr.Body.String(), `"exists":false`)
+	assert.NotContains(t, rr.Body.String(), fileID)
+}
+
 func TestCheckHandler_ReturnsTrueForKnownChecksum(t *testing.T) {
 	env := newTestEnv(t)
 	env.expectAuth()
 
 	content := "firmware content for check test"
-	fileID, err := env.fileSvc.SaveFirmwareFile("firmware.swu", strings.NewReader(content))
+	fileID, err := env.fileSvc.SaveFirmwareFile("firmware.swu", strings.NewReader(content), testFirmwareMetadata())
 	require.NoError(t, err)
 
 	checksum := sha256Hex(content)
-	req := createCheckRequest(t, `{"sha256":"`+checksum+`"}`, validSessionCookie(env.sessionID))
+	req := createCheckRequest(t, firmwareCheckBody(checksum), validSessionCookie(env.sessionID))
 	rr := httptest.NewRecorder()
 
 	env.checkHandler().ServeHTTP(rr, req)
@@ -396,11 +456,11 @@ func TestCheckHandler_AcceptsUppercaseChecksum(t *testing.T) {
 	env.expectAuth()
 
 	content := "firmware for uppercase check"
-	fileID, err := env.fileSvc.SaveFirmwareFile("firmware.swu", strings.NewReader(content))
+	fileID, err := env.fileSvc.SaveFirmwareFile("firmware.swu", strings.NewReader(content), testFirmwareMetadata())
 	require.NoError(t, err)
 
 	checksum := strings.ToUpper(sha256Hex(content))
-	req := createCheckRequest(t, `{"sha256":"`+checksum+`"}`, validSessionCookie(env.sessionID))
+	req := createCheckRequest(t, firmwareCheckBody(checksum), validSessionCookie(env.sessionID))
 	rr := httptest.NewRecorder()
 
 	env.checkHandler().ServeHTTP(rr, req)
@@ -552,9 +612,9 @@ func TestListFilesHandler_ReturnsSavedFiles(t *testing.T) {
 	env := newTestEnv(t)
 	env.expectAuth()
 
-	_, err := env.fileSvc.SaveFirmwareFile("alpha.swu", strings.NewReader("alpha"))
+	_, err := env.fileSvc.SaveFirmwareFile("alpha.swu", strings.NewReader("alpha"), testFirmwareMetadata())
 	require.NoError(t, err)
-	_, err = env.fileSvc.SaveFirmwareFile("beta.tar.gz", strings.NewReader("beta content"))
+	_, err = env.fileSvc.SaveFirmwareFile("beta.tar.gz", strings.NewReader("beta content"), testFirmwareMetadata())
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/firmware/files", nil)
@@ -569,6 +629,10 @@ func TestListFilesHandler_ReturnsSavedFiles(t *testing.T) {
 	err = json.Unmarshal(rr.Body.Bytes(), &resp)
 	require.NoError(t, err)
 	assert.Len(t, resp.Files, 2)
+	for _, file := range resp.Files {
+		assert.Equal(t, "Proto", file.TargetManufacturer)
+		assert.Equal(t, "S21", file.TargetModel)
+	}
 }
 
 // --- Delete file handler tests ---
@@ -587,7 +651,7 @@ func TestDeleteFileHandler_DeletesExistingFile(t *testing.T) {
 	env := newTestEnv(t)
 	env.expectAuth()
 
-	fileID, err := env.fileSvc.SaveFirmwareFile("firmware.swu", strings.NewReader("data"))
+	fileID, err := env.fileSvc.SaveFirmwareFile("firmware.swu", strings.NewReader("data"), testFirmwareMetadata())
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(http.MethodDelete, "/api/v1/firmware/files/"+fileID, nil)
@@ -650,9 +714,9 @@ func TestDeleteAllFilesHandler_DeletesAllFiles(t *testing.T) {
 	env := newTestEnv(t)
 	env.expectAuth()
 
-	_, err := env.fileSvc.SaveFirmwareFile("one.swu", strings.NewReader("one"))
+	_, err := env.fileSvc.SaveFirmwareFile("one.swu", strings.NewReader("one"), testFirmwareMetadata())
 	require.NoError(t, err)
-	_, err = env.fileSvc.SaveFirmwareFile("two.swu", strings.NewReader("two"))
+	_, err = env.fileSvc.SaveFirmwareFile("two.swu", strings.NewReader("two"), testFirmwareMetadata())
 	require.NoError(t, err)
 
 	req := httptest.NewRequest(http.MethodDelete, "/api/v1/firmware/files", nil)

--- a/server/internal/handlers/firmware/handler_test.go
+++ b/server/internal/handlers/firmware/handler_test.go
@@ -2,6 +2,7 @@ package firmware
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -18,6 +19,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	activityDomain "github.com/block/proto-fleet/server/internal/domain/activity"
+	activityModels "github.com/block/proto-fleet/server/internal/domain/activity/models"
 	"github.com/block/proto-fleet/server/internal/domain/session"
 	sessionMocks "github.com/block/proto-fleet/server/internal/domain/session/mocks"
 	"github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
@@ -130,6 +133,14 @@ func (e *testEnv) uploadHandler() *uploadHandler {
 
 func (e *testEnv) checkHandler() *checkHandler {
 	return &checkHandler{
+		filesService:   e.fileSvc,
+		sessionService: e.sessionSvc,
+		userStore:      e.userStoreMock,
+	}
+}
+
+func (e *testEnv) updateMetadataHandler() *updateMetadataHandler {
+	return &updateMetadataHandler{
 		filesService:   e.fileSvc,
 		sessionService: e.sessionSvc,
 		userStore:      e.userStoreMock,
@@ -337,6 +348,34 @@ func TestUploadHandler_SuccessfulUpload(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Code)
 	assert.Contains(t, rr.Body.String(), "firmware_file_id")
 	assert.Contains(t, rr.Header().Get("Content-Type"), "application/json")
+}
+
+func TestUploadHandler_LogsNewFirmwareActivity(t *testing.T) {
+	env := newTestEnv(t)
+	env.expectAuth()
+	activityStore := storeMocks.NewMockActivityStore(env.ctrl)
+	activityStore.EXPECT().Insert(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, event *activityModels.Event) error {
+			assert.Equal(t, activityModels.CategorySystem, event.Category)
+			assert.Equal(t, firmwareUploadedEventType, event.Type)
+			assert.Equal(t, "Uploaded firmware file: firmware-v2.0.swu", event.Description)
+			assert.Equal(t, "testuser", *event.Username)
+			assert.Equal(t, int64(1), *event.OrganizationID)
+			assert.Equal(t, "Proto", event.Metadata["target_manufacturer"])
+			assert.Equal(t, "S21", event.Metadata["target_model"])
+			assert.Equal(t, "v2.0.0", event.Metadata["firmware_version"])
+			return nil
+		},
+	)
+
+	h := env.uploadHandler()
+	h.activitySvc = activityDomain.NewService(activityStore)
+	req := createMultipartRequest(t, "firmware-v2.0.swu", []byte("activity firmware"), validSessionCookie(env.sessionID))
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
 }
 
 func TestUploadHandler_SuccessfulUploadTarGz(t *testing.T) {
@@ -662,6 +701,64 @@ func TestListFilesHandler_ReturnsSavedFiles(t *testing.T) {
 		assert.Equal(t, "Proto", file.TargetManufacturer)
 		assert.Equal(t, "S21", file.TargetModel)
 	}
+}
+
+// --- Update metadata handler tests ---
+
+func TestUpdateMetadataHandler_UpdatesStoredFirmware(t *testing.T) {
+	env := newTestEnv(t)
+	env.expectAuth()
+	fileID, err := env.fileSvc.SaveFirmwareFile("firmware.swu", strings.NewReader("data"), testFirmwareMetadata())
+	require.NoError(t, err)
+
+	body := `{"target_manufacturer":"Bitmain","target_model":"S19","firmware_version":"v3.0.0"}`
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/firmware/files/"+fileID, strings.NewReader(body))
+	req.SetPathValue("fileId", fileID)
+	req.AddCookie(validSessionCookie(env.sessionID))
+	rr := httptest.NewRecorder()
+
+	env.updateMetadataHandler().ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusNoContent, rr.Code)
+	metadata, err := env.fileSvc.GetFirmwareMetadata(fileID)
+	require.NoError(t, err)
+	assert.Equal(t, files.FirmwareMetadata{
+		TargetManufacturer: "Bitmain",
+		TargetModel:        "S19",
+		FirmwareVersion:    "v3.0.0",
+	}, metadata)
+}
+
+func TestUpdateMetadataHandler_RejectsIncompleteMetadata(t *testing.T) {
+	env := newTestEnv(t)
+	env.expectAuth()
+	fileID, err := env.fileSvc.SaveFirmwareFile("firmware.swu", strings.NewReader("data"), testFirmwareMetadata())
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/firmware/files/"+fileID, strings.NewReader(`{"target_manufacturer":"Proto"}`))
+	req.SetPathValue("fileId", fileID)
+	req.AddCookie(validSessionCookie(env.sessionID))
+	rr := httptest.NewRecorder()
+
+	env.updateMetadataHandler().ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	assert.Contains(t, rr.Body.String(), "target_model")
+}
+
+func TestUpdateMetadataHandler_Returns404ForMissingFile(t *testing.T) {
+	env := newTestEnv(t)
+	env.expectAuth()
+	fileID := "00000000-0000-0000-0000-000000000000"
+	body := `{"target_manufacturer":"Proto","target_model":"S21","firmware_version":"v2.0.0"}`
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/firmware/files/"+fileID, strings.NewReader(body))
+	req.SetPathValue("fileId", fileID)
+	req.AddCookie(validSessionCookie(env.sessionID))
+	rr := httptest.NewRecorder()
+
+	env.updateMetadataHandler().ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
 }
 
 // --- Delete file handler tests ---

--- a/server/internal/handlers/firmware/handler_test.go
+++ b/server/internal/handlers/firmware/handler_test.go
@@ -151,6 +151,7 @@ func createMultipartRequest(t *testing.T, filename string, content []byte, cooki
 	writer := multipart.NewWriter(&buf)
 	require.NoError(t, writer.WriteField("target_manufacturer", "Proto"))
 	require.NoError(t, writer.WriteField("target_model", "S21"))
+	require.NoError(t, writer.WriteField("firmware_version", "v2.0.0"))
 	part, err := writer.CreateFormFile("file", filename)
 	require.NoError(t, err)
 	_, err = part.Write(content)
@@ -185,11 +186,11 @@ func createMultipartRequestWithoutMetadata(t *testing.T, filename string, conten
 }
 
 func testFirmwareMetadata() files.FirmwareMetadata {
-	return files.FirmwareMetadata{TargetManufacturer: "Proto", TargetModel: "S21"}
+	return files.FirmwareMetadata{TargetManufacturer: "Proto", TargetModel: "S21", FirmwareVersion: "v2.0.0"}
 }
 
 func firmwareCheckBody(checksum string) string {
-	return fmt.Sprintf(`{"sha256":%q,"target_manufacturer":"Proto","target_model":"S21"}`, checksum)
+	return fmt.Sprintf(`{"sha256":%q,"target_manufacturer":"Proto","target_model":"S21","firmware_version":"v2.0.0"}`, checksum)
 }
 
 func createCheckRequest(t *testing.T, body string, cookie *http.Cookie) *http.Request {
@@ -421,7 +422,7 @@ func TestCheckHandler_RequiresMatchingTargetMetadata(t *testing.T) {
 	fileID, err := env.fileSvc.SaveFirmwareFile("firmware.swu", strings.NewReader(content), testFirmwareMetadata())
 	require.NoError(t, err)
 
-	body := fmt.Sprintf(`{"sha256":%q,"target_manufacturer":"Proto","target_model":"S19"}`, sha256Hex(content))
+	body := fmt.Sprintf(`{"sha256":%q,"target_manufacturer":"Proto","target_model":"S19","firmware_version":"v2.0.0"}`, sha256Hex(content))
 	req := createCheckRequest(t, body, validSessionCookie(env.sessionID))
 	rr := httptest.NewRecorder()
 

--- a/server/internal/handlers/firmware/handler_test.go
+++ b/server/internal/handlers/firmware/handler_test.go
@@ -351,6 +351,50 @@ func TestUploadHandler_RejectsInvalidExtension(t *testing.T) {
 	assert.Contains(t, rr.Body.String(), "unsupported firmware file type")
 }
 
+func TestUploadHandler_RejectsInvalidExtensionBeforeOversizedFile(t *testing.T) {
+	env := newTestEnv(t)
+	env.expectAuth()
+	var err error
+	env.fileSvc, err = files.NewService(files.Config{MaxFirmwareFileSize: 50})
+	require.NoError(t, err)
+	req := createMultipartRequest(
+		t,
+		"firmware.bin",
+		[]byte(strings.Repeat("x", 200)),
+		validSessionCookie(env.sessionID),
+	)
+	rr := httptest.NewRecorder()
+
+	env.uploadHandler().ServeHTTP(rr, req)
+
+	assertJSONErrorResponse(t, rr, http.StatusBadRequest,
+		`FleetError: invalid_argument (Common: 0) unsupported firmware file type "firmware.bin" (allowed: .swu, .tar.gz, .zip)`)
+}
+
+func TestUploadHandler_RejectsCompleteInvalidMetadataBeforeStaging(t *testing.T) {
+	env := newTestEnv(t)
+	env.expectAuth()
+	require.NoError(t, os.RemoveAll("firmware/staging"))
+	require.NoError(t, os.WriteFile("firmware/staging", []byte("not a directory"), 0600))
+	req := createMultipartRequestWithFields(
+		t,
+		"firmware.swu",
+		[]byte("data"),
+		validSessionCookie(env.sessionID),
+		map[string]string{
+			"target_manufacturer": "Proto",
+			"target_model":        " ",
+			"firmware_version":    "v2.0.0",
+		},
+	)
+	rr := httptest.NewRecorder()
+
+	env.uploadHandler().ServeHTTP(rr, req)
+
+	assertJSONErrorResponse(t, rr, http.StatusBadRequest,
+		"FleetError: invalid_argument (Common: 0) target_model is required")
+}
+
 func TestUploadHandler_RejectsMissingTargetMetadata(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -804,7 +848,7 @@ func TestUpdateMetadataHandler_UpdatesStoredFirmware(t *testing.T) {
 	fileID, err := env.fileSvc.SaveFirmwareFile("firmware.swu", strings.NewReader("data"), testFirmwareMetadata())
 	require.NoError(t, err)
 
-	body := `{"target_manufacturer":"Bitmain","target_model":"S19","firmware_version":"v3.0.0"}`
+	body := `{"target_manufacturer":" Bitmain ","target_model":" S19 ","firmware_version":" v3.0.0 "}`
 	req := httptest.NewRequest(http.MethodPatch, "/api/v1/firmware/files/"+fileID, strings.NewReader(body))
 	req.SetPathValue("fileId", fileID)
 	req.AddCookie(validSessionCookie(env.sessionID))
@@ -848,7 +892,7 @@ func TestUpdateMetadataHandler_LogsMetadataUpdateActivity(t *testing.T) {
 	h := env.updateMetadataHandler()
 	h.activitySvc = activityDomain.NewService(activityStore)
 
-	body := `{"target_manufacturer":"Bitmain","target_model":"S19","firmware_version":"v3.0.0"}`
+	body := `{"target_manufacturer":" Bitmain ","target_model":" S19 ","firmware_version":" v3.0.0 "}`
 	req := httptest.NewRequest(http.MethodPatch, "/api/v1/firmware/files/"+fileID, strings.NewReader(body))
 	req.SetPathValue("fileId", fileID)
 	req.AddCookie(validSessionCookie(env.sessionID))

--- a/server/internal/handlers/firmware/handler_test.go
+++ b/server/internal/handlers/firmware/handler_test.go
@@ -178,6 +178,28 @@ func createMultipartRequest(t *testing.T, filename string, content []byte, cooki
 	return req
 }
 
+func createFileFirstMultipartRequest(t *testing.T, filename string, content []byte, cookie *http.Cookie) *http.Request {
+	t.Helper()
+
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	part, err := writer.CreateFormFile("file", filename)
+	require.NoError(t, err)
+	_, err = part.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, writer.WriteField("target_manufacturer", "Proto"))
+	require.NoError(t, writer.WriteField("target_model", "Rig"))
+	require.NoError(t, writer.WriteField("firmware_version", "v2.0.0"))
+	require.NoError(t, writer.Close())
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload", &buf)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	if cookie != nil {
+		req.AddCookie(cookie)
+	}
+	return req
+}
+
 func createMultipartRequestWithFields(
 	t *testing.T,
 	filename string,
@@ -348,6 +370,26 @@ func TestUploadHandler_SuccessfulUpload(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Code)
 	assert.Contains(t, rr.Body.String(), "firmware_file_id")
 	assert.Contains(t, rr.Header().Get("Content-Type"), "application/json")
+}
+
+func TestUploadHandler_AcceptsMetadataAfterFile(t *testing.T) {
+	env := newTestEnv(t)
+	env.expectAuth()
+	req := createFileFirstMultipartRequest(t, "firmware-v2.0.swu", []byte("file-first firmware"), validSessionCookie(env.sessionID))
+	rr := httptest.NewRecorder()
+
+	env.uploadHandler().ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	stored, err := env.fileSvc.ListFirmwareFiles()
+	require.NoError(t, err)
+	require.Len(t, stored, 1)
+	assert.Equal(t, "Proto", stored[0].TargetManufacturer)
+	assert.Equal(t, "Rig", stored[0].TargetModel)
+	assert.Equal(t, "v2.0.0", stored[0].FirmwareVersion)
+	stagingEntries, err := os.ReadDir(files.StagingDir())
+	require.NoError(t, err)
+	assert.Empty(t, stagingEntries)
 }
 
 func TestUploadHandler_LogsNewFirmwareActivity(t *testing.T) {

--- a/server/internal/handlers/firmware/handler_test.go
+++ b/server/internal/handlers/firmware/handler_test.go
@@ -43,6 +43,16 @@ type staticPermissionResolver struct {
 	err         error
 }
 
+func assertJSONErrorResponse(t *testing.T, rr *httptest.ResponseRecorder, status int, message string) {
+	t.Helper()
+	require.Equal(t, status, rr.Code)
+	assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+
+	var response errorResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &response))
+	assert.Equal(t, message, response.Error)
+}
+
 func (r staticPermissionResolver) LoadEffective(
 	_ context.Context,
 	_,
@@ -809,8 +819,7 @@ func TestUpdateMetadataHandler_RejectsIncompleteMetadata(t *testing.T) {
 
 	env.updateMetadataHandler().ServeHTTP(rr, req)
 
-	assert.Equal(t, http.StatusBadRequest, rr.Code)
-	assert.Contains(t, rr.Body.String(), "target_model")
+	assertJSONErrorResponse(t, rr, http.StatusBadRequest, "FleetError: invalid_argument (Common: 0) target_model is required")
 }
 
 func TestUpdateMetadataHandler_Returns404ForMissingFile(t *testing.T) {
@@ -825,7 +834,7 @@ func TestUpdateMetadataHandler_Returns404ForMissingFile(t *testing.T) {
 
 	env.updateMetadataHandler().ServeHTTP(rr, req)
 
-	assert.Equal(t, http.StatusNotFound, rr.Code)
+	assertJSONErrorResponse(t, rr, http.StatusNotFound, "FleetError: not_found (Common: 0) firmware file not found: "+fileID)
 }
 
 // --- Delete file handler tests ---
@@ -837,7 +846,7 @@ func TestDeleteFileHandler_RejectsNoCookie(t *testing.T) {
 
 	env.deleteFileHandler().ServeHTTP(rr, req)
 
-	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	assertJSONErrorResponse(t, rr, http.StatusUnauthorized, "authentication required")
 }
 
 func TestDeleteFileHandler_DeletesExistingFile(t *testing.T) {
@@ -871,8 +880,7 @@ func TestDeleteFileHandler_Returns400ForInvalidID(t *testing.T) {
 
 	env.deleteFileHandler().ServeHTTP(rr, req)
 
-	assert.Equal(t, http.StatusBadRequest, rr.Code)
-	assert.Contains(t, rr.Body.String(), "invalid firmware file ID")
+	assertJSONErrorResponse(t, rr, http.StatusBadRequest, "FleetError: invalid_argument (Common: 0) invalid firmware file ID: not-a-uuid")
 }
 
 func TestDeleteFileHandler_Returns404ForMissingFile(t *testing.T) {
@@ -887,8 +895,7 @@ func TestDeleteFileHandler_Returns404ForMissingFile(t *testing.T) {
 
 	env.deleteFileHandler().ServeHTTP(rr, req)
 
-	assert.Equal(t, http.StatusNotFound, rr.Code)
-	assert.Contains(t, rr.Body.String(), "firmware file not found")
+	assertJSONErrorResponse(t, rr, http.StatusNotFound, "FleetError: not_found (Common: 0) firmware file not found: "+missingID)
 }
 
 // --- Delete all files handler tests ---
@@ -900,7 +907,7 @@ func TestDeleteAllFilesHandler_RejectsNoCookie(t *testing.T) {
 
 	env.deleteAllFilesHandler().ServeHTTP(rr, req)
 
-	assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	assertJSONErrorResponse(t, rr, http.StatusUnauthorized, "authentication required")
 }
 
 func TestDeleteAllFilesHandler_DeletesAllFiles(t *testing.T) {

--- a/server/internal/handlers/firmware/handler_test.go
+++ b/server/internal/handlers/firmware/handler_test.go
@@ -10,7 +10,6 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -21,6 +20,7 @@ import (
 
 	activityDomain "github.com/block/proto-fleet/server/internal/domain/activity"
 	activityModels "github.com/block/proto-fleet/server/internal/domain/activity/models"
+	"github.com/block/proto-fleet/server/internal/domain/authz"
 	"github.com/block/proto-fleet/server/internal/domain/session"
 	sessionMocks "github.com/block/proto-fleet/server/internal/domain/session/mocks"
 	"github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
@@ -28,15 +28,34 @@ import (
 	"github.com/block/proto-fleet/server/internal/infrastructure/files"
 )
 
-const testMaxUploadBytes int64 = 10 * 1024 * 1024 // 10 MB for tests
-
 type testEnv struct {
-	ctrl             *gomock.Controller
-	sessionStoreMock *sessionMocks.MockStore
-	userStoreMock    *storeMocks.MockUserStore
-	fileSvc          *files.Service
-	sessionSvc       *session.Service
-	sessionID        string
+	ctrl               *gomock.Controller
+	sessionStoreMock   *sessionMocks.MockStore
+	userStoreMock      *storeMocks.MockUserStore
+	fileSvc            *files.Service
+	sessionSvc         *session.Service
+	sessionID          string
+	permissionResolver effectivePermissionResolver
+}
+
+type staticPermissionResolver struct {
+	permissions []string
+	err         error
+}
+
+func (r staticPermissionResolver) LoadEffective(
+	_ context.Context,
+	_,
+	_ int64,
+) (*authz.EffectivePermissions, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	return authz.NewEffectivePermissions([]authz.Assignment{{
+		AssignmentID: 1,
+		ScopeType:    authz.ScopeOrg,
+		Permissions:  r.permissions,
+	}}), nil
 }
 
 func newTestEnv(t *testing.T) *testEnv {
@@ -66,6 +85,9 @@ func newTestEnv(t *testing.T) *testEnv {
 		fileSvc:          fileSvc,
 		sessionSvc:       sessionSvc,
 		sessionID:        "test-session-id",
+		permissionResolver: staticPermissionResolver{
+			permissions: []string{authz.PermMinerFirmwareUpdate},
+		},
 	}
 }
 
@@ -124,10 +146,10 @@ func TestAuthenticate_PopulatesSessionInfo(t *testing.T) {
 
 func (e *testEnv) uploadHandler() *uploadHandler {
 	return &uploadHandler{
-		filesService:   e.fileSvc,
-		sessionService: e.sessionSvc,
-		userStore:      e.userStoreMock,
-		maxUploadBytes: testMaxUploadBytes,
+		filesService:       e.fileSvc,
+		sessionService:     e.sessionSvc,
+		userStore:          e.userStoreMock,
+		permissionResolver: e.permissionResolver,
 	}
 }
 
@@ -141,9 +163,10 @@ func (e *testEnv) checkHandler() *checkHandler {
 
 func (e *testEnv) updateMetadataHandler() *updateMetadataHandler {
 	return &updateMetadataHandler{
-		filesService:   e.fileSvc,
-		sessionService: e.sessionSvc,
-		userStore:      e.userStoreMock,
+		filesService:       e.fileSvc,
+		sessionService:     e.sessionSvc,
+		userStore:          e.userStoreMock,
+		permissionResolver: e.permissionResolver,
 	}
 }
 
@@ -156,18 +179,48 @@ func (e *testEnv) configHandler() *configHandler {
 	}
 }
 
-func createMultipartRequest(t *testing.T, filename string, content []byte, cookie *http.Cookie) *http.Request {
+func defaultFirmwareFields() map[string]string {
+	return map[string]string{
+		"target_manufacturer": "Proto",
+		"target_model":        "Rig",
+		"firmware_version":    "v2.0.0",
+	}
+}
+
+// buildMultipartRequest assembles a firmware upload body from fields plus the
+// file part. fileFirst puts the file ahead of the metadata fields, which the
+// handler must accept just the same.
+func buildMultipartRequest(
+	t *testing.T,
+	filename string,
+	content []byte,
+	cookie *http.Cookie,
+	fields map[string]string,
+	fileFirst bool,
+) *http.Request {
 	t.Helper()
 
 	var buf bytes.Buffer
 	writer := multipart.NewWriter(&buf)
-	require.NoError(t, writer.WriteField("target_manufacturer", "Proto"))
-	require.NoError(t, writer.WriteField("target_model", "Rig"))
-	require.NoError(t, writer.WriteField("firmware_version", "v2.0.0"))
-	part, err := writer.CreateFormFile("file", filename)
-	require.NoError(t, err)
-	_, err = part.Write(content)
-	require.NoError(t, err)
+	writeFile := func() {
+		part, err := writer.CreateFormFile("file", filename)
+		require.NoError(t, err)
+		_, err = part.Write(content)
+		require.NoError(t, err)
+	}
+	writeFields := func() {
+		for name, value := range fields {
+			require.NoError(t, writer.WriteField(name, value))
+		}
+	}
+
+	if fileFirst {
+		writeFile()
+		writeFields()
+	} else {
+		writeFields()
+		writeFile()
+	}
 	require.NoError(t, writer.Close())
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload", &buf)
@@ -178,26 +231,14 @@ func createMultipartRequest(t *testing.T, filename string, content []byte, cooki
 	return req
 }
 
+func createMultipartRequest(t *testing.T, filename string, content []byte, cookie *http.Cookie) *http.Request {
+	t.Helper()
+	return buildMultipartRequest(t, filename, content, cookie, defaultFirmwareFields(), false)
+}
+
 func createFileFirstMultipartRequest(t *testing.T, filename string, content []byte, cookie *http.Cookie) *http.Request {
 	t.Helper()
-
-	var buf bytes.Buffer
-	writer := multipart.NewWriter(&buf)
-	part, err := writer.CreateFormFile("file", filename)
-	require.NoError(t, err)
-	_, err = part.Write(content)
-	require.NoError(t, err)
-	require.NoError(t, writer.WriteField("target_manufacturer", "Proto"))
-	require.NoError(t, writer.WriteField("target_model", "Rig"))
-	require.NoError(t, writer.WriteField("firmware_version", "v2.0.0"))
-	require.NoError(t, writer.Close())
-
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload", &buf)
-	req.Header.Set("Content-Type", writer.FormDataContentType())
-	if cookie != nil {
-		req.AddCookie(cookie)
-	}
-	return req
+	return buildMultipartRequest(t, filename, content, cookie, defaultFirmwareFields(), true)
 }
 
 func createMultipartRequestWithFields(
@@ -208,24 +249,7 @@ func createMultipartRequestWithFields(
 	fields map[string]string,
 ) *http.Request {
 	t.Helper()
-
-	var buf bytes.Buffer
-	writer := multipart.NewWriter(&buf)
-	for name, value := range fields {
-		require.NoError(t, writer.WriteField(name, value))
-	}
-	part, err := writer.CreateFormFile("file", filename)
-	require.NoError(t, err)
-	_, err = part.Write(content)
-	require.NoError(t, err)
-	require.NoError(t, writer.Close())
-
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/firmware/upload", &buf)
-	req.Header.Set("Content-Type", writer.FormDataContentType())
-	if cookie != nil {
-		req.AddCookie(cookie)
-	}
-	return req
+	return buildMultipartRequest(t, filename, content, cookie, fields, false)
 }
 
 func testFirmwareMetadata() files.FirmwareMetadata {
@@ -338,9 +362,9 @@ func TestUploadHandler_RejectsMissingTargetMetadata(t *testing.T) {
 
 			assert.Equal(t, http.StatusBadRequest, rr.Code)
 			assert.Contains(t, rr.Body.String(), tt.wantError)
-			entries, err := os.ReadDir(files.StagingDir())
+			staged, err := files.StagedFirmwareUploadCount()
 			require.NoError(t, err)
-			assert.Empty(t, entries)
+			assert.Zero(t, staged)
 		})
 	}
 }
@@ -387,9 +411,9 @@ func TestUploadHandler_AcceptsMetadataAfterFile(t *testing.T) {
 	assert.Equal(t, "Proto", stored[0].TargetManufacturer)
 	assert.Equal(t, "Rig", stored[0].TargetModel)
 	assert.Equal(t, "v2.0.0", stored[0].FirmwareVersion)
-	stagingEntries, err := os.ReadDir(files.StagingDir())
+	staged, err := files.StagedFirmwareUploadCount()
 	require.NoError(t, err)
-	assert.Empty(t, stagingEntries)
+	assert.Zero(t, staged)
 }
 
 func TestUploadHandler_LogsNewFirmwareActivity(t *testing.T) {
@@ -439,7 +463,6 @@ func TestUploadHandler_RejectsOversizedBody(t *testing.T) {
 	env.fileSvc, _ = files.NewService(files.Config{MaxFirmwareFileSize: 50})
 
 	h := env.uploadHandler()
-	h.maxUploadBytes = 50
 
 	oversized := []byte(strings.Repeat("x", 200))
 	req := createMultipartRequest(t, "firmware.swu", oversized, validSessionCookie(env.sessionID))
@@ -675,17 +698,19 @@ func (e *testEnv) listFilesHandler() *listFilesHandler {
 
 func (e *testEnv) deleteFileHandler() *deleteFileHandler {
 	return &deleteFileHandler{
-		filesService:   e.fileSvc,
-		sessionService: e.sessionSvc,
-		userStore:      e.userStoreMock,
+		filesService:       e.fileSvc,
+		sessionService:     e.sessionSvc,
+		userStore:          e.userStoreMock,
+		permissionResolver: e.permissionResolver,
 	}
 }
 
 func (e *testEnv) deleteAllFilesHandler() *deleteAllFilesHandler {
 	return &deleteAllFilesHandler{
-		filesService:   e.fileSvc,
-		sessionService: e.sessionSvc,
-		userStore:      e.userStoreMock,
+		filesService:       e.fileSvc,
+		sessionService:     e.sessionSvc,
+		userStore:          e.userStoreMock,
+		permissionResolver: e.permissionResolver,
 	}
 }
 

--- a/server/internal/handlers/firmware/handler_test.go
+++ b/server/internal/handlers/firmware/handler_test.go
@@ -10,6 +10,8 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -390,6 +392,20 @@ func TestUploadHandler_RejectsMissingFileField(t *testing.T) {
 	env.uploadHandler().ServeHTTP(rr, req)
 
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestUploadHandler_Returns500WhenStagingFails(t *testing.T) {
+	env := newTestEnv(t)
+	env.expectAuth()
+	require.NoError(t, os.RemoveAll("firmware/staging"))
+	require.NoError(t, os.WriteFile("firmware/staging", []byte("not a directory"), 0600))
+	req := createMultipartRequest(t, "firmware.swu", []byte("data"), validSessionCookie(env.sessionID))
+	rr := httptest.NewRecorder()
+
+	env.uploadHandler().ServeHTTP(rr, req)
+
+	assertJSONErrorResponse(t, rr, http.StatusInternalServerError, "failed to stage firmware upload")
+	assert.NotContains(t, rr.Body.String(), "failed to create firmware staging file")
 }
 
 func TestUploadHandler_SuccessfulUpload(t *testing.T) {
@@ -795,6 +811,104 @@ func TestUpdateMetadataHandler_UpdatesStoredFirmware(t *testing.T) {
 	rr := httptest.NewRecorder()
 
 	env.updateMetadataHandler().ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusNoContent, rr.Code)
+	metadata, err := env.fileSvc.GetFirmwareMetadata(fileID)
+	require.NoError(t, err)
+	assert.Equal(t, files.FirmwareMetadata{
+		TargetManufacturer: "Bitmain",
+		TargetModel:        "S19",
+		FirmwareVersion:    "v3.0.0",
+	}, metadata)
+}
+
+func TestUpdateMetadataHandler_LogsMetadataUpdateActivity(t *testing.T) {
+	env := newTestEnv(t)
+	env.expectAuth()
+	fileID, err := env.fileSvc.SaveFirmwareFile("firmware.swu", strings.NewReader("data"), testFirmwareMetadata())
+	require.NoError(t, err)
+	activityStore := storeMocks.NewMockActivityStore(env.ctrl)
+	activityStore.EXPECT().Insert(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, event *activityModels.Event) error {
+			assert.Equal(t, activityModels.CategorySystem, event.Category)
+			assert.Equal(t, firmwareMetadataUpdatedEventType, event.Type)
+			assert.Equal(t, "Updated firmware metadata: "+fileID, event.Description)
+			assert.Equal(t, "testuser", *event.Username)
+			assert.Equal(t, int64(1), *event.OrganizationID)
+			assert.Equal(t, fileID, event.Metadata["firmware_file_id"])
+			assert.Equal(t, "Proto", event.Metadata["previous_target_manufacturer"])
+			assert.Equal(t, "Rig", event.Metadata["previous_target_model"])
+			assert.Equal(t, "v2.0.0", event.Metadata["previous_firmware_version"])
+			assert.Equal(t, "Bitmain", event.Metadata["current_target_manufacturer"])
+			assert.Equal(t, "S19", event.Metadata["current_target_model"])
+			assert.Equal(t, "v3.0.0", event.Metadata["current_firmware_version"])
+			return nil
+		},
+	)
+	h := env.updateMetadataHandler()
+	h.activitySvc = activityDomain.NewService(activityStore)
+
+	body := `{"target_manufacturer":"Bitmain","target_model":"S19","firmware_version":"v3.0.0"}`
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/firmware/files/"+fileID, strings.NewReader(body))
+	req.SetPathValue("fileId", fileID)
+	req.AddCookie(validSessionCookie(env.sessionID))
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusNoContent, rr.Code)
+}
+
+func TestUpdateMetadataHandler_DoesNotLogActivityForFailedUpdate(t *testing.T) {
+	env := newTestEnv(t)
+	env.expectAuth()
+	activityStore := storeMocks.NewMockActivityStore(env.ctrl)
+	h := env.updateMetadataHandler()
+	h.activitySvc = activityDomain.NewService(activityStore)
+	fileID := "00000000-0000-0000-0000-000000000000"
+
+	body := `{"target_manufacturer":"Proto","target_model":"Rig","firmware_version":"v2.0.0"}`
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/firmware/files/"+fileID, strings.NewReader(body))
+	req.SetPathValue("fileId", fileID)
+	req.AddCookie(validSessionCookie(env.sessionID))
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+func TestUpdateMetadataHandler_RepairsCorruptMetadataAndLogsCurrentState(t *testing.T) {
+	env := newTestEnv(t)
+	env.expectAuth()
+	fileID, err := env.fileSvc.SaveFirmwareFile("firmware.swu", strings.NewReader("data"), testFirmwareMetadata())
+	require.NoError(t, err)
+	payloadPath, err := env.fileSvc.GetFirmwareFilePath(fileID)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(filepath.Dir(payloadPath), "metadata.json"), []byte(`not json`), 0600))
+
+	activityStore := storeMocks.NewMockActivityStore(env.ctrl)
+	activityStore.EXPECT().Insert(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, event *activityModels.Event) error {
+			assert.Equal(t, "Bitmain", event.Metadata["current_target_manufacturer"])
+			assert.Equal(t, "S19", event.Metadata["current_target_model"])
+			assert.Equal(t, "v3.0.0", event.Metadata["current_firmware_version"])
+			assert.NotContains(t, event.Metadata, "previous_target_manufacturer")
+			assert.NotContains(t, event.Metadata, "previous_target_model")
+			assert.NotContains(t, event.Metadata, "previous_firmware_version")
+			return nil
+		},
+	)
+	h := env.updateMetadataHandler()
+	h.activitySvc = activityDomain.NewService(activityStore)
+
+	body := `{"target_manufacturer":"Bitmain","target_model":"S19","firmware_version":"v3.0.0"}`
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/firmware/files/"+fileID, strings.NewReader(body))
+	req.SetPathValue("fileId", fileID)
+	req.AddCookie(validSessionCookie(env.sessionID))
+	rr := httptest.NewRecorder()
+
+	h.ServeHTTP(rr, req)
 
 	assert.Equal(t, http.StatusNoContent, rr.Code)
 	metadata, err := env.fileSvc.GetFirmwareMetadata(fileID)

--- a/server/internal/handlers/firmware/handler_test.go
+++ b/server/internal/handlers/firmware/handler_test.go
@@ -162,7 +162,7 @@ func createMultipartRequest(t *testing.T, filename string, content []byte, cooki
 	var buf bytes.Buffer
 	writer := multipart.NewWriter(&buf)
 	require.NoError(t, writer.WriteField("target_manufacturer", "Proto"))
-	require.NoError(t, writer.WriteField("target_model", "S21"))
+	require.NoError(t, writer.WriteField("target_model", "Rig"))
 	require.NoError(t, writer.WriteField("firmware_version", "v2.0.0"))
 	part, err := writer.CreateFormFile("file", filename)
 	require.NoError(t, err)
@@ -207,11 +207,11 @@ func createMultipartRequestWithFields(
 }
 
 func testFirmwareMetadata() files.FirmwareMetadata {
-	return files.FirmwareMetadata{TargetManufacturer: "Proto", TargetModel: "S21", FirmwareVersion: "v2.0.0"}
+	return files.FirmwareMetadata{TargetManufacturer: "Proto", TargetModel: "Rig", FirmwareVersion: "v2.0.0"}
 }
 
 func firmwareCheckBody(checksum string) string {
-	return fmt.Sprintf(`{"sha256":%q,"target_manufacturer":"Proto","target_model":"S21","firmware_version":"v2.0.0"}`, checksum)
+	return fmt.Sprintf(`{"sha256":%q,"target_manufacturer":"Proto","target_model":"Rig","firmware_version":"v2.0.0"}`, checksum)
 }
 
 func createCheckRequest(t *testing.T, body string, cookie *http.Cookie) *http.Request {
@@ -300,9 +300,9 @@ func TestUploadHandler_RejectsMissingTargetMetadata(t *testing.T) {
 		wantError string
 	}{
 		{name: "all metadata", wantError: "target_manufacturer"},
-		{name: "manufacturer", fields: map[string]string{"target_model": "S21", "firmware_version": "v2.0.0"}, wantError: "target_manufacturer"},
+		{name: "manufacturer", fields: map[string]string{"target_model": "Rig", "firmware_version": "v2.0.0"}, wantError: "target_manufacturer"},
 		{name: "model", fields: map[string]string{"target_manufacturer": "Proto", "firmware_version": "v2.0.0"}, wantError: "target_model"},
-		{name: "version", fields: map[string]string{"target_manufacturer": "Proto", "target_model": "S21"}, wantError: "firmware_version"},
+		{name: "version", fields: map[string]string{"target_manufacturer": "Proto", "target_model": "Rig"}, wantError: "firmware_version"},
 	}
 
 	for _, tt := range tests {
@@ -362,7 +362,7 @@ func TestUploadHandler_LogsNewFirmwareActivity(t *testing.T) {
 			assert.Equal(t, "testuser", *event.Username)
 			assert.Equal(t, int64(1), *event.OrganizationID)
 			assert.Equal(t, "Proto", event.Metadata["target_manufacturer"])
-			assert.Equal(t, "S21", event.Metadata["target_model"])
+			assert.Equal(t, "Rig", event.Metadata["target_model"])
 			assert.Equal(t, "v2.0.0", event.Metadata["firmware_version"])
 			return nil
 		},
@@ -699,7 +699,7 @@ func TestListFilesHandler_ReturnsSavedFiles(t *testing.T) {
 	assert.Len(t, resp.Files, 2)
 	for _, file := range resp.Files {
 		assert.Equal(t, "Proto", file.TargetManufacturer)
-		assert.Equal(t, "S21", file.TargetModel)
+		assert.Equal(t, "Rig", file.TargetModel)
 	}
 }
 
@@ -750,7 +750,7 @@ func TestUpdateMetadataHandler_Returns404ForMissingFile(t *testing.T) {
 	env := newTestEnv(t)
 	env.expectAuth()
 	fileID := "00000000-0000-0000-0000-000000000000"
-	body := `{"target_manufacturer":"Proto","target_model":"S21","firmware_version":"v2.0.0"}`
+	body := `{"target_manufacturer":"Proto","target_model":"Rig","firmware_version":"v2.0.0"}`
 	req := httptest.NewRequest(http.MethodPatch, "/api/v1/firmware/files/"+fileID, strings.NewReader(body))
 	req.SetPathValue("fileId", fileID)
 	req.AddCookie(validSessionCookie(env.sessionID))

--- a/server/internal/handlers/fleetnode/gateway/handler_artifact_test.go
+++ b/server/internal/handlers/fleetnode/gateway/handler_artifact_test.go
@@ -240,7 +240,10 @@ func TestCommandArtifactUploadAndDownloadRequireInFlightExpectation(t *testing.T
 func TestDownloadCommandArtifactServesFirmwarePayload(t *testing.T) {
 	h, client := newArtifactTestClient(t)
 	payload := []byte("firmware image bytes")
-	fileID, err := h.files.SaveFirmwareFile("update.swu", bytes.NewReader(payload))
+	fileID, err := h.files.SaveFirmwareFile("update.swu", bytes.NewReader(payload), files.FirmwareMetadata{
+		TargetManufacturer: "Proto",
+		TargetModel:        "S21",
+	})
 	require.NoError(t, err)
 	_, info, err := h.files.OpenFirmwareFileWithInfo(fileID)
 	require.NoError(t, err)

--- a/server/internal/handlers/fleetnode/gateway/handler_artifact_test.go
+++ b/server/internal/handlers/fleetnode/gateway/handler_artifact_test.go
@@ -243,6 +243,7 @@ func TestDownloadCommandArtifactServesFirmwarePayload(t *testing.T) {
 	fileID, err := h.files.SaveFirmwareFile("update.swu", bytes.NewReader(payload), files.FirmwareMetadata{
 		TargetManufacturer: "Proto",
 		TargetModel:        "S21",
+		FirmwareVersion:    "1.2.3",
 	})
 	require.NoError(t, err)
 	_, info, err := h.files.OpenFirmwareFileWithInfo(fileID)

--- a/server/internal/handlers/fleetnode/gateway/handler_artifact_test.go
+++ b/server/internal/handlers/fleetnode/gateway/handler_artifact_test.go
@@ -242,7 +242,7 @@ func TestDownloadCommandArtifactServesFirmwarePayload(t *testing.T) {
 	payload := []byte("firmware image bytes")
 	fileID, err := h.files.SaveFirmwareFile("update.swu", bytes.NewReader(payload), files.FirmwareMetadata{
 		TargetManufacturer: "Proto",
-		TargetModel:        "S21",
+		TargetModel:        "Rig",
 		FirmwareVersion:    "1.2.3",
 	})
 	require.NoError(t, err)

--- a/server/internal/infrastructure/files/command_artifact_test.go
+++ b/server/internal/infrastructure/files/command_artifact_test.go
@@ -46,6 +46,20 @@ func TestSaveCommandArtifactValidatesAndOpens(t *testing.T) {
 	assert.Empty(t, commandArtifactStagingEntries(t))
 }
 
+func TestSaveCommandArtifactPreservesDotPrefixedFilename(t *testing.T) {
+	svc := setupService(t)
+	content := "hidden artifact payload"
+
+	info, err := svc.SaveCommandArtifact(".miner-logs.zip", int64(len(content)), checksumOf(content), strings.NewReader(content))
+	require.NoError(t, err)
+	assert.Equal(t, ".miner-logs.zip", info.Filename)
+
+	reader, opened, err := svc.OpenCommandArtifact(info.ID)
+	require.NoError(t, err)
+	defer reader.Close()
+	assert.Equal(t, ".miner-logs.zip", opened.Filename)
+}
+
 func TestSaveCommandArtifactReservesMetadataFilename(t *testing.T) {
 	svc := setupService(t)
 	content := "miner log bundle bytes"

--- a/server/internal/infrastructure/files/firmware.go
+++ b/server/internal/infrastructure/files/firmware.go
@@ -3,6 +3,7 @@ package files
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
@@ -18,16 +19,25 @@ import (
 
 // FirmwareFileInfo holds metadata about a stored firmware file.
 type FirmwareFileInfo struct {
-	ID         string    `json:"id"`
-	Filename   string    `json:"filename"`
-	Size       int64     `json:"size"`
-	SHA256     string    `json:"sha256,omitempty"`
-	FilePath   string    `json:"-"`
-	UploadedAt time.Time `json:"uploaded_at"`
+	ID                 string    `json:"id"`
+	Filename           string    `json:"filename"`
+	Size               int64     `json:"size"`
+	SHA256             string    `json:"sha256,omitempty"`
+	FilePath           string    `json:"-"`
+	UploadedAt         time.Time `json:"uploaded_at"`
+	TargetManufacturer string    `json:"target_manufacturer"`
+	TargetModel        string    `json:"target_model"`
+}
+
+// FirmwareMetadata describes the single miner type a firmware file targets.
+type FirmwareMetadata struct {
+	TargetManufacturer string `json:"target_manufacturer"`
+	TargetModel        string `json:"target_model"`
 }
 
 const firmwareDir = "firmware"
 const firmwareStagingDir = "firmware/staging"
+const firmwareMetadataFilename = "metadata.json"
 
 const defaultMaxFirmwareFileSize int64 = 500 * 1024 * 1024 // 500 MB
 
@@ -45,6 +55,36 @@ func AllowedFirmwareExtensions() []string {
 
 func getFirmwareDirPath(fileID string) string {
 	return filepath.Join(firmwareDir, fileID)
+}
+
+type firmwareChecksumEntry struct {
+	fileID   string
+	metadata FirmwareMetadata
+}
+
+func (m FirmwareMetadata) normalized() FirmwareMetadata {
+	return FirmwareMetadata{
+		TargetManufacturer: strings.TrimSpace(m.TargetManufacturer),
+		TargetModel:        strings.TrimSpace(m.TargetModel),
+	}
+}
+
+func (m FirmwareMetadata) matches(other FirmwareMetadata) bool {
+	m = m.normalized()
+	other = other.normalized()
+	return m.TargetManufacturer == other.TargetManufacturer && m.TargetModel == other.TargetModel
+}
+
+// ValidateFirmwareMetadata checks that target metadata is complete.
+func ValidateFirmwareMetadata(metadata FirmwareMetadata) error {
+	metadata = metadata.normalized()
+	if metadata.TargetManufacturer == "" {
+		return fleeterror.NewInvalidArgumentError("target_manufacturer is required")
+	}
+	if metadata.TargetModel == "" {
+		return fleeterror.NewInvalidArgumentError("target_model is required")
+	}
+	return nil
 }
 
 // canonicalizeFirmwareFileID validates and normalizes a firmware file ID.
@@ -136,7 +176,12 @@ func (s *Service) ValidateFirmwareFile(filename string, size int64) error {
 //
 // Callers should call ValidateFirmwareFile or ValidateFirmwareFilename before
 // saving to ensure the filename extension is acceptable.
-func (s *Service) SaveFirmwareFile(filename string, reader io.Reader) (string, error) {
+func (s *Service) SaveFirmwareFile(filename string, reader io.Reader, metadata FirmwareMetadata) (string, error) {
+	metadata = metadata.normalized()
+	if err := ValidateFirmwareMetadata(metadata); err != nil {
+		return "", err
+	}
+
 	fileID := id.GenerateID()
 	dir := getFirmwareDirPath(fileID)
 
@@ -182,9 +227,14 @@ func (s *Service) SaveFirmwareFile(filename string, reader io.Reader) (string, e
 		return "", fleeterror.NewInternalErrorf("failed to sync firmware file to disk: %v", err)
 	}
 
+	if err := writeFirmwareMetadata(dir, metadata); err != nil {
+		_ = os.RemoveAll(dir)
+		return "", err
+	}
+
 	checksum := hex.EncodeToString(hasher.Sum(nil))
 
-	s.rememberFirmwareChecksum(checksum, fileID)
+	s.rememberFirmwareChecksum(checksum, fileID, metadata)
 
 	slog.Info("firmware file saved", "file_id", fileID, "filename", sanitized, "checksum", checksum)
 	return fileID, nil
@@ -194,7 +244,12 @@ func (s *Service) SaveFirmwareFile(filename string, reader io.Reader) (string, e
 // into the standard firmware directory, computes its SHA-256 checksum, and registers
 // it in the checksum index. Uses os.Rename for efficiency — both paths must be on
 // the same filesystem. Used by the chunked upload complete handler.
-func (s *Service) SaveFirmwareFileFromPath(filename string, srcPath string) (string, error) {
+func (s *Service) SaveFirmwareFileFromPath(filename string, srcPath string, metadata FirmwareMetadata) (string, error) {
+	metadata = metadata.normalized()
+	if err := ValidateFirmwareMetadata(metadata); err != nil {
+		return "", err
+	}
+
 	fileID := id.GenerateID()
 	dir := getFirmwareDirPath(fileID)
 
@@ -226,7 +281,12 @@ func (s *Service) SaveFirmwareFileFromPath(filename string, srcPath string) (str
 		return "", fleeterror.NewInvalidArgumentError("firmware file is empty")
 	}
 
-	s.rememberFirmwareChecksum(checksum, fileID)
+	if err := writeFirmwareMetadata(dir, metadata); err != nil {
+		_ = os.RemoveAll(dir)
+		return "", err
+	}
+
+	s.rememberFirmwareChecksum(checksum, fileID, metadata)
 
 	slog.Info("firmware file saved from path", "file_id", fileID, "filename", sanitized, "checksum", checksum)
 	return fileID, nil
@@ -242,9 +302,29 @@ func (s *Service) GetFirmwareFilePath(fileID string) (string, error) {
 	return getFirmwareFilePathForCanonicalID(canonical)
 }
 
+// GetFirmwareMetadata returns the target metadata for a stored firmware file.
+func (s *Service) GetFirmwareMetadata(fileID string) (FirmwareMetadata, error) {
+	canonical, err := canonicalizeFirmwareFileID(fileID)
+	if err != nil {
+		return FirmwareMetadata{}, err
+	}
+	dir := getFirmwareDirPath(canonical)
+	if _, err := os.Stat(dir); err != nil {
+		if os.IsNotExist(err) {
+			return FirmwareMetadata{}, fleeterror.NewNotFoundErrorf("firmware file not found: %s", canonical)
+		}
+		return FirmwareMetadata{}, fleeterror.NewInternalErrorf("failed to stat firmware dir %s: %v", canonical, err)
+	}
+	metadata, err := readFirmwareMetadata(dir)
+	if err != nil {
+		return FirmwareMetadata{}, fleeterror.NewInternalErrorf("failed to read firmware metadata: %v", err)
+	}
+	return metadata, nil
+}
+
 func getFirmwareFilePathForCanonicalID(canonical string) (string, error) {
 	dir := getFirmwareDirPath(canonical)
-	path, err := findSingleFileInDir(dir)
+	path, err := findSingleFirmwarePayloadInDir(dir)
 	if err != nil {
 		return "", fleeterror.NewNotFoundErrorf("firmware file not found: %s", canonical)
 	}
@@ -288,13 +368,20 @@ func (s *Service) OpenFirmwareFileWithInfo(fileID string) (io.ReadCloser, Firmwa
 		file.Close()
 		return nil, FirmwareFileInfo{}, err
 	}
+	metadata, err := readFirmwareMetadata(getFirmwareDirPath(canonical))
+	if err != nil {
+		file.Close()
+		return nil, FirmwareFileInfo{}, fleeterror.NewInternalErrorf("failed to read firmware metadata: %v", err)
+	}
 
 	return file, FirmwareFileInfo{
-		ID:       canonical,
-		Filename: filepath.Base(filePath),
-		Size:     info.Size(),
-		SHA256:   checksum,
-		FilePath: filePath,
+		ID:                 canonical,
+		Filename:           filepath.Base(filePath),
+		Size:               info.Size(),
+		SHA256:             checksum,
+		FilePath:           filePath,
+		TargetManufacturer: metadata.TargetManufacturer,
+		TargetModel:        metadata.TargetModel,
 	}, nil
 }
 
@@ -306,7 +393,11 @@ func (s *Service) firmwareChecksum(canonicalID, filePath string) (string, error)
 	if err != nil {
 		return "", fleeterror.NewInternalErrorf("failed to compute firmware checksum: %v", err)
 	}
-	s.rememberFirmwareChecksum(checksum, canonicalID)
+	metadata, err := readFirmwareMetadata(getFirmwareDirPath(canonicalID))
+	if err != nil {
+		return "", fleeterror.NewInternalErrorf("failed to read firmware metadata: %v", err)
+	}
+	s.rememberFirmwareChecksum(checksum, canonicalID, metadata)
 	return checksum, nil
 }
 
@@ -317,29 +408,47 @@ func (s *Service) lookupFirmwareChecksum(canonicalID string) (string, bool) {
 	return checksum, ok
 }
 
-func (s *Service) rememberFirmwareChecksum(checksum, canonicalID string) {
+func (s *Service) rememberFirmwareChecksum(checksum, canonicalID string, metadata FirmwareMetadata) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.firmwareChecksumByID[canonicalID] = checksum
-	for _, id := range s.checksumIndex[checksum] {
-		if id == canonicalID {
+	metadata = metadata.normalized()
+	for i, entry := range s.checksumIndex[checksum] {
+		if entry.fileID == canonicalID {
+			s.checksumIndex[checksum][i].metadata = metadata
 			return
 		}
 	}
-	s.checksumIndex[checksum] = append(s.checksumIndex[checksum], canonicalID)
+	s.checksumIndex[checksum] = append(s.checksumIndex[checksum], firmwareChecksumEntry{
+		fileID:   canonicalID,
+		metadata: metadata,
+	})
 }
 
 // FindFirmwareFileByChecksum looks up a firmware file by its SHA-256 hex digest.
 // Returns the file ID and true if found, or empty string and false otherwise.
 // Used by the pre-upload check endpoint to let clients skip redundant uploads.
-func (s *Service) FindFirmwareFileByChecksum(sha256Hex string) (string, bool) {
+func (s *Service) FindFirmwareFileByChecksum(sha256Hex string, metadata FirmwareMetadata) (string, bool) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-	ids := s.checksumIndex[sha256Hex]
-	if len(ids) == 0 {
-		return "", false
+	entries := append([]firmwareChecksumEntry(nil), s.checksumIndex[sha256Hex]...)
+	s.mu.Unlock()
+
+	metadata = metadata.normalized()
+	for _, entry := range entries {
+		storedMetadata, err := readFirmwareMetadata(getFirmwareDirPath(entry.fileID))
+		if err != nil {
+			slog.Warn("deleting invalid firmware dir during checksum lookup", "file_id", entry.fileID, "error", err)
+			_ = os.RemoveAll(getFirmwareDirPath(entry.fileID))
+			s.mu.Lock()
+			s.removeFirmwareChecksumLocked(sha256Hex, entry.fileID)
+			s.mu.Unlock()
+			continue
+		}
+		if storedMetadata.matches(metadata) {
+			return entry.fileID, true
+		}
 	}
-	return ids[0], true
+	return "", false
 }
 
 // DeleteFirmwareFile removes a firmware file from disk and the checksum index.
@@ -378,8 +487,8 @@ func (s *Service) DeleteFirmwareFile(fileID string) error {
 func (s *Service) removeFirmwareChecksumLocked(checksum, canonicalID string) {
 	delete(s.firmwareChecksumByID, canonicalID)
 	ids := s.checksumIndex[checksum]
-	for i, id := range ids {
-		if id != canonicalID {
+	for i, entry := range ids {
+		if entry.fileID != canonicalID {
 			continue
 		}
 		ids = append(ids[:i], ids[i+1:]...)
@@ -394,8 +503,8 @@ func (s *Service) removeFirmwareChecksumLocked(checksum, canonicalID string) {
 
 func (s *Service) removeFirmwareChecksumByScanLocked(canonicalID string) {
 	for checksum, ids := range s.checksumIndex {
-		for i, id := range ids {
-			if id != canonicalID {
+		for i, entry := range ids {
+			if entry.fileID != canonicalID {
 				continue
 			}
 			ids = append(ids[:i], ids[i+1:]...)
@@ -428,7 +537,17 @@ func (s *Service) ListFirmwareFiles() ([]FirmwareFileInfo, error) {
 		}
 
 		dir := getFirmwareDirPath(fileID)
-		filePath, err := findSingleFileInDir(dir)
+		metadata, err := readFirmwareMetadata(dir)
+		if err != nil {
+			slog.Warn("deleting invalid firmware dir during list", "file_id", fileID, "error", err)
+			_ = os.RemoveAll(dir)
+			s.mu.Lock()
+			s.removeFirmwareChecksumByScanLocked(fileID)
+			s.mu.Unlock()
+			continue
+		}
+
+		filePath, err := findSingleFirmwarePayloadInDir(dir)
 		if err != nil {
 			slog.Warn("skipping firmware dir during list", "file_id", fileID, "error", err)
 			continue
@@ -447,10 +566,12 @@ func (s *Service) ListFirmwareFiles() ([]FirmwareFileInfo, error) {
 		}
 
 		result = append(result, FirmwareFileInfo{
-			ID:         fileID,
-			Filename:   filepath.Base(filePath),
-			Size:       fileInfo.Size(),
-			UploadedAt: dirInfo.ModTime(),
+			ID:                 fileID,
+			Filename:           filepath.Base(filePath),
+			Size:               fileInfo.Size(),
+			UploadedAt:         dirInfo.ModTime(),
+			TargetManufacturer: metadata.TargetManufacturer,
+			TargetModel:        metadata.TargetModel,
 		})
 	}
 
@@ -514,7 +635,13 @@ func (s *Service) initChecksumIndex() error {
 			continue
 		}
 		dir := getFirmwareDirPath(fileID)
-		filePath, err := findSingleFileInDir(dir)
+		metadata, err := readFirmwareMetadata(dir)
+		if err != nil {
+			slog.Warn("deleting invalid firmware dir during checksum rebuild", "file_id", fileID, "error", err)
+			_ = os.RemoveAll(dir)
+			continue
+		}
+		filePath, err := findSingleFirmwarePayloadInDir(dir)
 		if err != nil {
 			continue
 		}
@@ -524,7 +651,7 @@ func (s *Service) initChecksumIndex() error {
 			continue
 		}
 
-		s.rememberFirmwareChecksum(checksum, fileID)
+		s.rememberFirmwareChecksum(checksum, fileID, metadata)
 	}
 
 	count := 0
@@ -549,6 +676,67 @@ func computeFileChecksum(filePath string) (string, error) {
 		return "", fmt.Errorf("failed to compute checksum: %w", err)
 	}
 	return hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
+func writeFirmwareMetadata(dir string, metadata FirmwareMetadata) error {
+	file, err := os.OpenFile(filepath.Join(dir, firmwareMetadataFilename), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+	if err != nil {
+		return fleeterror.NewInternalErrorf("failed to create firmware metadata: %v", err)
+	}
+	defer file.Close()
+
+	if err := json.NewEncoder(file).Encode(metadata.normalized()); err != nil {
+		return fleeterror.NewInternalErrorf("failed to write firmware metadata: %v", err)
+	}
+	if err := file.Sync(); err != nil {
+		return fleeterror.NewInternalErrorf("failed to sync firmware metadata to disk: %v", err)
+	}
+	return nil
+}
+
+func readFirmwareMetadata(dir string) (FirmwareMetadata, error) {
+	file, err := os.Open(filepath.Join(dir, firmwareMetadataFilename))
+	if err != nil {
+		return FirmwareMetadata{}, err
+	}
+	defer file.Close()
+
+	decoder := json.NewDecoder(file)
+	var metadata FirmwareMetadata
+	if err := decoder.Decode(&metadata); err != nil {
+		return FirmwareMetadata{}, err
+	}
+	metadata = metadata.normalized()
+	if err := ValidateFirmwareMetadata(metadata); err != nil {
+		return FirmwareMetadata{}, err
+	}
+	return metadata, nil
+}
+
+// findSingleFirmwarePayloadInDir returns the path to the single non-directory
+// payload entry inside a directory. metadata.json is ignored.
+func findSingleFirmwarePayloadInDir(dir string) (string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "", fmt.Errorf("failed to read firmware dir %s: %w", dir, err)
+	}
+	var foundPath string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if e.Name() == firmwareMetadataFilename {
+			continue
+		}
+		if foundPath != "" {
+			return "", fmt.Errorf("multiple files found in %s", dir)
+		}
+		foundPath = filepath.Join(dir, e.Name())
+	}
+	if foundPath == "" {
+		return "", fmt.Errorf("no file found in %s", dir)
+	}
+	return foundPath, nil
 }
 
 func hasAllowedFirmwareExtension(filename string) bool {

--- a/server/internal/infrastructure/files/firmware.go
+++ b/server/internal/infrastructure/files/firmware.go
@@ -820,14 +820,14 @@ func writeFirmwareMetadata(dir string, metadata FirmwareMetadata) error {
 func readFirmwareMetadata(dir string) (FirmwareMetadata, error) {
 	file, err := os.Open(filepath.Join(dir, firmwareMetadataFilename))
 	if err != nil {
-		return FirmwareMetadata{}, err
+		return FirmwareMetadata{}, fmt.Errorf("open firmware metadata: %w", err)
 	}
 	defer file.Close()
 
 	decoder := json.NewDecoder(file)
 	var metadata FirmwareMetadata
 	if err := decoder.Decode(&metadata); err != nil {
-		return FirmwareMetadata{}, err
+		return FirmwareMetadata{}, fmt.Errorf("decode firmware metadata: %w", err)
 	}
 	metadata = metadata.normalized()
 	if err := ValidateFirmwareMetadata(metadata); err != nil {

--- a/server/internal/infrastructure/files/firmware.go
+++ b/server/internal/infrastructure/files/firmware.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -48,6 +49,8 @@ type FirmwareUploadSaveResult struct {
 const firmwareDir = "firmware"
 const firmwareStagingDir = "firmware/staging"
 const firmwareMetadataFilename = "metadata.json"
+
+var errFirmwareMetadataNotFound = errors.New("firmware metadata not found")
 
 const defaultMaxFirmwareFileSize int64 = 500 * 1024 * 1024 // 500 MB
 
@@ -144,7 +147,18 @@ func initFirmwareDir() error {
 // sessions are in-memory only, any files in the staging directory at startup
 // are orphans from interrupted uploads.
 func cleanStagingDir() {
-	cleanStorageStagingDir(firmwareStagingDir, "failed to remove orphaned staging file", "removed orphaned staging file")
+	entries, err := os.ReadDir(firmwareStagingDir)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		path := filepath.Join(firmwareStagingDir, entry.Name())
+		if err := os.RemoveAll(path); err != nil {
+			slog.Warn("failed to remove orphaned staging entry", "path", path, "error", err)
+		} else {
+			slog.Info("removed orphaned staging entry", "path", path)
+		}
+	}
 }
 
 // StagingDir returns the path to the firmware staging directory for chunked uploads.
@@ -203,73 +217,21 @@ func (s *Service) ValidateFirmwareFile(filename string, size int64) error {
 // Callers should call ValidateFirmwareFile or ValidateFirmwareFilename before
 // saving to ensure the filename extension is acceptable.
 func (s *Service) SaveFirmwareFile(filename string, reader io.Reader, metadata FirmwareMetadata) (string, error) {
-	metadata = metadata.normalized()
-	if err := ValidateFirmwareUploadMetadata(metadata); err != nil {
+	result, err := s.SaveFirmwareUpload(filename, reader, metadata, true)
+	if err != nil {
 		return "", err
 	}
-
-	fileID := id.GenerateID()
-	dir := getFirmwareDirPath(fileID)
-
-	if err := os.MkdirAll(dir, 0750); err != nil {
-		return "", fleeterror.NewInternalErrorf("failed to create firmware file dir: %v", err)
-	}
-
-	sanitized := sanitizeFirmwareFilename(filename)
-	filePath := filepath.Join(dir, sanitized)
-
-	file, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
-	if err != nil {
-		_ = os.RemoveAll(dir)
-		return "", fleeterror.NewInternalErrorf("failed to create firmware file: %v", err)
-	}
-	defer file.Close()
-
-	maxSize := s.maxFirmwareFileSize
-	if maxSize <= 0 {
-		maxSize = defaultMaxFirmwareFileSize
-	}
-	limitedReader := io.LimitReader(reader, maxSize+1)
-
-	hasher := sha256.New()
-	teeReader := io.TeeReader(limitedReader, hasher)
-
-	written, err := io.Copy(file, teeReader)
-	if err != nil {
-		_ = os.RemoveAll(dir)
-		return "", fleeterror.NewInternalErrorf("failed to write firmware file: %v", err)
-	}
-	if written > maxSize {
-		_ = os.RemoveAll(dir)
-		return "", fleeterror.NewInvalidArgumentErrorf("firmware file too large: exceeded %d byte limit during upload", maxSize)
-	}
-	if written == 0 {
-		_ = os.RemoveAll(dir)
-		return "", fleeterror.NewInvalidArgumentError("firmware file is empty")
-	}
-
-	if err := file.Sync(); err != nil {
-		_ = os.RemoveAll(dir)
-		return "", fleeterror.NewInternalErrorf("failed to sync firmware file to disk: %v", err)
-	}
-
-	if err := writeFirmwareMetadata(dir, metadata); err != nil {
-		_ = os.RemoveAll(dir)
-		return "", err
-	}
-
-	checksum := hex.EncodeToString(hasher.Sum(nil))
-
-	s.rememberFirmwareChecksum(checksum, fileID, metadata)
-
-	slog.Info("firmware file saved", "file_id", fileID, "filename", sanitized, "checksum", checksum)
-	return fileID, nil
+	return result.FirmwareFileID, nil
 }
 
 // SaveFirmwareUpload stages a streamed upload and reuses an existing file with
 // the same checksum plus metadata unless force is true.
 func (s *Service) SaveFirmwareUpload(filename string, reader io.Reader, manualMetadata FirmwareMetadata, force bool) (FirmwareUploadSaveResult, error) {
 	var result FirmwareUploadSaveResult
+	metadata := manualMetadata.normalized()
+	if err := ValidateFirmwareUploadMetadata(metadata); err != nil {
+		return result, err
+	}
 
 	tempFile, err := os.CreateTemp(firmwareStagingDir, "direct-*")
 	if err != nil {
@@ -308,7 +270,7 @@ func (s *Service) SaveFirmwareUpload(filename string, reader io.Reader, manualMe
 	}
 
 	checksum := hex.EncodeToString(hasher.Sum(nil))
-	result, err = s.SaveFirmwareUploadFromPath(filename, tempPath, manualMetadata, force, checksum)
+	result, err = s.SaveFirmwareUploadFromPath(filename, tempPath, metadata, force, checksum)
 	if err != nil {
 		return FirmwareUploadSaveResult{}, err
 	}
@@ -378,33 +340,57 @@ func (s *Service) SaveFirmwareFileFromPath(filename string, srcPath string, meta
 
 func (s *Service) saveFirmwareFileFromPathWithChecksum(filename string, srcPath string, metadata FirmwareMetadata, checksum string) (string, error) {
 	fileID := id.GenerateID()
-	dir := getFirmwareDirPath(fileID)
-
-	if err := os.MkdirAll(dir, 0750); err != nil {
-		return "", fleeterror.NewInternalErrorf("failed to create firmware file dir: %v", err)
+	finalDir := getFirmwareDirPath(fileID)
+	stagingDir, err := os.MkdirTemp(firmwareStagingDir, "publish-*")
+	if err != nil {
+		return "", fleeterror.NewInternalErrorf("failed to create firmware publish staging dir: %v", err)
 	}
+	removeStaging := true
+	defer func() {
+		if removeStaging {
+			_ = os.RemoveAll(stagingDir)
+		}
+	}()
 
 	sanitized := sanitizeFirmwareFilename(filename)
-	destPath := filepath.Join(dir, sanitized)
+	destPath := filepath.Join(stagingDir, sanitized)
 
 	if err := os.Rename(srcPath, destPath); err != nil {
-		_ = os.RemoveAll(dir)
 		return "", fleeterror.NewInternalErrorf("failed to move firmware file: %v", err)
 	}
 
 	info, err := os.Stat(destPath)
 	if err != nil {
-		_ = os.RemoveAll(dir)
 		return "", fleeterror.NewInternalErrorf("failed to stat firmware file: %v", err)
 	}
 	if info.Size() == 0 {
-		_ = os.RemoveAll(dir)
 		return "", fleeterror.NewInvalidArgumentError("firmware file is empty")
 	}
 
-	if err := writeFirmwareMetadata(dir, metadata); err != nil {
-		_ = os.RemoveAll(dir)
+	payload, err := os.OpenFile(destPath, os.O_RDWR, 0)
+	if err != nil {
+		return "", fleeterror.NewInternalErrorf("failed to open staged firmware file for sync: %v", err)
+	}
+	if err := payload.Sync(); err != nil {
+		_ = payload.Close()
+		return "", fleeterror.NewInternalErrorf("failed to sync staged firmware file: %v", err)
+	}
+	if err := payload.Close(); err != nil {
+		return "", fleeterror.NewInternalErrorf("failed to close staged firmware file: %v", err)
+	}
+
+	if err := writeFirmwareMetadata(stagingDir, metadata); err != nil {
 		return "", err
+	}
+	if err := syncFirmwareDirectory(stagingDir); err != nil {
+		return "", fleeterror.NewInternalErrorf("failed to sync firmware staging directory: %v", err)
+	}
+	if err := os.Rename(stagingDir, finalDir); err != nil {
+		return "", fleeterror.NewInternalErrorf("failed to publish firmware directory: %v", err)
+	}
+	removeStaging = false
+	if err := syncFirmwareDirectory(firmwareDir); err != nil {
+		return "", fleeterror.NewInternalErrorf("failed to sync firmware directory: %v", err)
 	}
 
 	s.rememberFirmwareChecksum(checksum, fileID, metadata)
@@ -438,6 +424,9 @@ func (s *Service) GetFirmwareMetadata(fileID string) (FirmwareMetadata, error) {
 	}
 	metadata, err := readFirmwareMetadata(dir)
 	if err != nil {
+		if errors.Is(err, errFirmwareMetadataNotFound) {
+			return FirmwareMetadata{}, nil
+		}
 		return FirmwareMetadata{}, fleeterror.NewInternalErrorf("failed to read firmware metadata: %v", err)
 	}
 	return metadata, nil
@@ -491,8 +480,11 @@ func (s *Service) OpenFirmwareFileWithInfo(fileID string) (io.ReadCloser, Firmwa
 	}
 	metadata, err := readFirmwareMetadata(getFirmwareDirPath(canonical))
 	if err != nil {
-		file.Close()
-		return nil, FirmwareFileInfo{}, fleeterror.NewInternalErrorf("failed to read firmware metadata: %v", err)
+		if !errors.Is(err, errFirmwareMetadataNotFound) {
+			file.Close()
+			return nil, FirmwareFileInfo{}, fleeterror.NewInternalErrorf("failed to read firmware metadata: %v", err)
+		}
+		metadata = FirmwareMetadata{}
 	}
 
 	return file, FirmwareFileInfo{
@@ -517,7 +509,11 @@ func (s *Service) firmwareChecksum(canonicalID, filePath string) (string, error)
 	}
 	metadata, err := readFirmwareMetadata(getFirmwareDirPath(canonicalID))
 	if err != nil {
-		return "", fleeterror.NewInternalErrorf("failed to read firmware metadata: %v", err)
+		if !errors.Is(err, errFirmwareMetadataNotFound) {
+			return "", fleeterror.NewInternalErrorf("failed to read firmware metadata: %v", err)
+		}
+		s.rememberFirmwareChecksumByID(checksum, canonicalID)
+		return checksum, nil
 	}
 	s.rememberFirmwareChecksum(checksum, canonicalID, metadata)
 	return checksum, nil
@@ -547,6 +543,12 @@ func (s *Service) rememberFirmwareChecksum(checksum, canonicalID string, metadat
 	})
 }
 
+func (s *Service) rememberFirmwareChecksumByID(checksum, canonicalID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.firmwareChecksumByID[canonicalID] = checksum
+}
+
 // FindFirmwareFileByChecksum looks up a firmware file by its SHA-256 hex digest.
 // Returns the file ID and true if found, or empty string and false otherwise.
 // Used by the pre-upload check endpoint to let clients skip redundant uploads.
@@ -559,8 +561,10 @@ func (s *Service) FindFirmwareFileByChecksum(sha256Hex string, metadata Firmware
 	for _, entry := range entries {
 		storedMetadata, err := readFirmwareMetadata(getFirmwareDirPath(entry.fileID))
 		if err != nil {
-			slog.Warn("deleting invalid firmware dir during checksum lookup", "file_id", entry.fileID, "error", err)
-			_ = os.RemoveAll(getFirmwareDirPath(entry.fileID))
+			if errors.Is(err, errFirmwareMetadataNotFound) {
+				continue
+			}
+			slog.Warn("skipping firmware with invalid metadata during checksum lookup", "file_id", entry.fileID, "error", err)
 			s.mu.Lock()
 			s.removeFirmwareChecksumLocked(sha256Hex, entry.fileID)
 			s.mu.Unlock()
@@ -661,12 +665,12 @@ func (s *Service) ListFirmwareFiles() ([]FirmwareFileInfo, error) {
 		dir := getFirmwareDirPath(fileID)
 		metadata, err := readFirmwareMetadata(dir)
 		if err != nil {
-			slog.Warn("deleting invalid firmware dir during list", "file_id", fileID, "error", err)
-			_ = os.RemoveAll(dir)
-			s.mu.Lock()
-			s.removeFirmwareChecksumByScanLocked(fileID)
-			s.mu.Unlock()
-			continue
+			if errors.Is(err, errFirmwareMetadataNotFound) {
+				metadata = FirmwareMetadata{}
+			} else {
+				slog.Warn("skipping firmware with invalid metadata during list", "file_id", fileID, "error", err)
+				continue
+			}
 		}
 
 		filePath, err := findSingleFirmwarePayloadInDir(dir)
@@ -760,9 +764,12 @@ func (s *Service) initChecksumIndex() error {
 		dir := getFirmwareDirPath(fileID)
 		metadata, err := readFirmwareMetadata(dir)
 		if err != nil {
-			slog.Warn("deleting invalid firmware dir during checksum rebuild", "file_id", fileID, "error", err)
-			_ = os.RemoveAll(dir)
-			continue
+			if errors.Is(err, errFirmwareMetadataNotFound) {
+				continue
+			} else {
+				slog.Warn("skipping firmware with invalid metadata during checksum rebuild", "file_id", fileID, "error", err)
+				continue
+			}
 		}
 		filePath, err := findSingleFirmwarePayloadInDir(dir)
 		if err != nil {
@@ -820,6 +827,9 @@ func writeFirmwareMetadata(dir string, metadata FirmwareMetadata) error {
 func readFirmwareMetadata(dir string) (FirmwareMetadata, error) {
 	file, err := os.Open(filepath.Join(dir, firmwareMetadataFilename))
 	if err != nil {
+		if os.IsNotExist(err) {
+			return FirmwareMetadata{}, fmt.Errorf("%w: %s", errFirmwareMetadataNotFound, dir)
+		}
 		return FirmwareMetadata{}, fmt.Errorf("open firmware metadata: %w", err)
 	}
 	defer file.Close()
@@ -834,6 +844,15 @@ func readFirmwareMetadata(dir string) (FirmwareMetadata, error) {
 		return FirmwareMetadata{}, err
 	}
 	return metadata, nil
+}
+
+func syncFirmwareDirectory(dir string) error {
+	file, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	return file.Sync()
 }
 
 // findSingleFirmwarePayloadInDir returns the path to the single non-directory

--- a/server/internal/infrastructure/files/firmware.go
+++ b/server/internal/infrastructure/files/firmware.go
@@ -27,12 +27,22 @@ type FirmwareFileInfo struct {
 	UploadedAt         time.Time `json:"uploaded_at"`
 	TargetManufacturer string    `json:"target_manufacturer"`
 	TargetModel        string    `json:"target_model"`
+	FirmwareVersion    string    `json:"firmware_version,omitempty"`
 }
 
 // FirmwareMetadata describes the single miner type a firmware file targets.
 type FirmwareMetadata struct {
 	TargetManufacturer string `json:"target_manufacturer"`
 	TargetModel        string `json:"target_model"`
+	FirmwareVersion    string `json:"firmware_version,omitempty"`
+}
+
+// FirmwareUploadSaveResult describes the stored or reused firmware file after
+// upload metadata has been resolved.
+type FirmwareUploadSaveResult struct {
+	FirmwareFileID string
+	Reused         bool
+	Metadata       FirmwareMetadata
 }
 
 const firmwareDir = "firmware"
@@ -66,13 +76,16 @@ func (m FirmwareMetadata) normalized() FirmwareMetadata {
 	return FirmwareMetadata{
 		TargetManufacturer: strings.TrimSpace(m.TargetManufacturer),
 		TargetModel:        strings.TrimSpace(m.TargetModel),
+		FirmwareVersion:    strings.TrimSpace(m.FirmwareVersion),
 	}
 }
 
 func (m FirmwareMetadata) matches(other FirmwareMetadata) bool {
 	m = m.normalized()
 	other = other.normalized()
-	return m.TargetManufacturer == other.TargetManufacturer && m.TargetModel == other.TargetModel
+	return m.TargetManufacturer == other.TargetManufacturer &&
+		m.TargetModel == other.TargetModel &&
+		m.FirmwareVersion == other.FirmwareVersion
 }
 
 // ValidateFirmwareMetadata checks that target metadata is complete.
@@ -83,6 +96,19 @@ func ValidateFirmwareMetadata(metadata FirmwareMetadata) error {
 	}
 	if metadata.TargetModel == "" {
 		return fleeterror.NewInvalidArgumentError("target_model is required")
+	}
+	return nil
+}
+
+// ValidateFirmwareUploadMetadata checks metadata required for new uploads and
+// checksum reuse. Existing files may predate firmware_version metadata.
+func ValidateFirmwareUploadMetadata(metadata FirmwareMetadata) error {
+	metadata = metadata.normalized()
+	if err := ValidateFirmwareMetadata(metadata); err != nil {
+		return err
+	}
+	if metadata.FirmwareVersion == "" {
+		return fleeterror.NewInvalidArgumentError("firmware_version is required")
 	}
 	return nil
 }
@@ -178,7 +204,7 @@ func (s *Service) ValidateFirmwareFile(filename string, size int64) error {
 // saving to ensure the filename extension is acceptable.
 func (s *Service) SaveFirmwareFile(filename string, reader io.Reader, metadata FirmwareMetadata) (string, error) {
 	metadata = metadata.normalized()
-	if err := ValidateFirmwareMetadata(metadata); err != nil {
+	if err := ValidateFirmwareUploadMetadata(metadata); err != nil {
 		return "", err
 	}
 
@@ -240,16 +266,117 @@ func (s *Service) SaveFirmwareFile(filename string, reader io.Reader, metadata F
 	return fileID, nil
 }
 
+// SaveFirmwareUpload stages a streamed upload and reuses an existing file with
+// the same checksum plus metadata unless force is true.
+func (s *Service) SaveFirmwareUpload(filename string, reader io.Reader, manualMetadata FirmwareMetadata, force bool) (FirmwareUploadSaveResult, error) {
+	var result FirmwareUploadSaveResult
+
+	tempFile, err := os.CreateTemp(firmwareStagingDir, "direct-*")
+	if err != nil {
+		return result, fleeterror.NewInternalErrorf("failed to create firmware staging file: %v", err)
+	}
+	tempPath := tempFile.Name()
+	removeTemp := true
+	defer func() {
+		_ = tempFile.Close()
+		if removeTemp {
+			_ = os.Remove(tempPath)
+		}
+	}()
+
+	maxSize := s.maxFirmwareFileSize
+	if maxSize <= 0 {
+		maxSize = defaultMaxFirmwareFileSize
+	}
+	limitedReader := io.LimitReader(reader, maxSize+1)
+	hasher := sha256.New()
+	written, err := io.Copy(tempFile, io.TeeReader(limitedReader, hasher))
+	if err != nil {
+		return result, fleeterror.NewInternalErrorf("failed to write firmware staging file: %v", err)
+	}
+	if written > maxSize {
+		return result, fleeterror.NewInvalidArgumentErrorf("firmware file too large: exceeded %d byte limit during upload", maxSize)
+	}
+	if written == 0 {
+		return result, fleeterror.NewInvalidArgumentError("firmware file is empty")
+	}
+	if err := tempFile.Sync(); err != nil {
+		return result, fleeterror.NewInternalErrorf("failed to sync firmware staging file: %v", err)
+	}
+	if err := tempFile.Close(); err != nil {
+		return result, fleeterror.NewInternalErrorf("failed to close firmware staging file: %v", err)
+	}
+
+	checksum := hex.EncodeToString(hasher.Sum(nil))
+	result, err = s.SaveFirmwareUploadFromPath(filename, tempPath, manualMetadata, force, checksum)
+	if err != nil {
+		return FirmwareUploadSaveResult{}, err
+	}
+	removeTemp = false
+	return result, nil
+}
+
+// SaveFirmwareUploadFromPath consumes a staged upload path. On success it either
+// removes the staged file and returns an existing matching firmware_file_id, or
+// moves the staged file into permanent firmware storage.
+func (s *Service) SaveFirmwareUploadFromPath(filename string, srcPath string, manualMetadata FirmwareMetadata, force bool, checksum string) (FirmwareUploadSaveResult, error) {
+	var result FirmwareUploadSaveResult
+
+	metadata := manualMetadata.normalized()
+	if err := ValidateFirmwareUploadMetadata(metadata); err != nil {
+		return result, err
+	}
+
+	if checksum == "" {
+		var err error
+		checksum, err = computeFileChecksum(srcPath)
+		if err != nil {
+			return result, fleeterror.NewInternalErrorf("failed to compute firmware checksum: %v", err)
+		}
+	}
+
+	if !force {
+		if existingID, ok := s.FindFirmwareFileByChecksum(checksum, metadata); ok {
+			if err := os.Remove(srcPath); err != nil && !os.IsNotExist(err) {
+				return result, fleeterror.NewInternalErrorf("failed to remove reused firmware staging file: %v", err)
+			}
+			return FirmwareUploadSaveResult{
+				FirmwareFileID: existingID,
+				Reused:         true,
+				Metadata:       metadata,
+			}, nil
+		}
+	}
+
+	fileID, err := s.saveFirmwareFileFromPathWithChecksum(filename, srcPath, metadata, checksum)
+	if err != nil {
+		return result, err
+	}
+	return FirmwareUploadSaveResult{
+		FirmwareFileID: fileID,
+		Metadata:       metadata,
+	}, nil
+}
+
 // SaveFirmwareFileFromPath moves an existing file (e.g. from the staging directory)
 // into the standard firmware directory, computes its SHA-256 checksum, and registers
 // it in the checksum index. Uses os.Rename for efficiency — both paths must be on
 // the same filesystem. Used by the chunked upload complete handler.
 func (s *Service) SaveFirmwareFileFromPath(filename string, srcPath string, metadata FirmwareMetadata) (string, error) {
 	metadata = metadata.normalized()
-	if err := ValidateFirmwareMetadata(metadata); err != nil {
+	if err := ValidateFirmwareUploadMetadata(metadata); err != nil {
 		return "", err
 	}
 
+	checksum, err := computeFileChecksum(srcPath)
+	if err != nil {
+		return "", fleeterror.NewInternalErrorf("failed to compute checksum before move: %v", err)
+	}
+
+	return s.saveFirmwareFileFromPathWithChecksum(filename, srcPath, metadata, checksum)
+}
+
+func (s *Service) saveFirmwareFileFromPathWithChecksum(filename string, srcPath string, metadata FirmwareMetadata, checksum string) (string, error) {
 	fileID := id.GenerateID()
 	dir := getFirmwareDirPath(fileID)
 
@@ -263,12 +390,6 @@ func (s *Service) SaveFirmwareFileFromPath(filename string, srcPath string, meta
 	if err := os.Rename(srcPath, destPath); err != nil {
 		_ = os.RemoveAll(dir)
 		return "", fleeterror.NewInternalErrorf("failed to move firmware file: %v", err)
-	}
-
-	checksum, err := computeFileChecksum(destPath)
-	if err != nil {
-		_ = os.RemoveAll(dir)
-		return "", fleeterror.NewInternalErrorf("failed to compute checksum after move: %v", err)
 	}
 
 	info, err := os.Stat(destPath)
@@ -382,6 +503,7 @@ func (s *Service) OpenFirmwareFileWithInfo(fileID string) (io.ReadCloser, Firmwa
 		FilePath:           filePath,
 		TargetManufacturer: metadata.TargetManufacturer,
 		TargetModel:        metadata.TargetModel,
+		FirmwareVersion:    metadata.FirmwareVersion,
 	}, nil
 }
 
@@ -572,6 +694,7 @@ func (s *Service) ListFirmwareFiles() ([]FirmwareFileInfo, error) {
 			UploadedAt:         dirInfo.ModTime(),
 			TargetManufacturer: metadata.TargetManufacturer,
 			TargetModel:        metadata.TargetModel,
+			FirmwareVersion:    metadata.FirmwareVersion,
 		})
 	}
 

--- a/server/internal/infrastructure/files/firmware.go
+++ b/server/internal/infrastructure/files/firmware.go
@@ -432,6 +432,46 @@ func (s *Service) GetFirmwareMetadata(fileID string) (FirmwareMetadata, error) {
 	return metadata, nil
 }
 
+// UpdateFirmwareMetadata atomically replaces the target metadata for a stored
+// firmware file and refreshes its checksum reuse entry. This also allows a
+// legacy payload without a sidecar to become eligible for new deployments once
+// complete metadata has been supplied.
+func (s *Service) UpdateFirmwareMetadata(fileID string, metadata FirmwareMetadata) error {
+	canonical, err := canonicalizeFirmwareFileID(fileID)
+	if err != nil {
+		return err
+	}
+	metadata = metadata.normalized()
+	if err := ValidateFirmwareUploadMetadata(metadata); err != nil {
+		return err
+	}
+
+	dir := getFirmwareDirPath(canonical)
+	if _, err := os.Stat(dir); err != nil {
+		if os.IsNotExist(err) {
+			return fleeterror.NewNotFoundErrorf("firmware file not found: %s", canonical)
+		}
+		return fleeterror.NewInternalErrorf("failed to stat firmware dir %s: %v", canonical, err)
+	}
+	filePath, err := findSingleFirmwarePayloadInDir(dir)
+	if err != nil {
+		return fleeterror.NewNotFoundErrorf("firmware file not found: %s", canonical)
+	}
+	checksum, err := computeFileChecksum(filePath)
+	if err != nil {
+		return fleeterror.NewInternalErrorf("failed to compute firmware checksum: %v", err)
+	}
+
+	if err := writeFirmwareMetadataAtomic(dir, metadata); err != nil {
+		return err
+	}
+	s.rememberFirmwareChecksum(checksum, canonical, metadata)
+	if err := syncFirmwareDirectory(dir); err != nil {
+		return fleeterror.NewInternalErrorf("failed to sync firmware directory: %v", err)
+	}
+	return nil
+}
+
 func getFirmwareFilePathForCanonicalID(canonical string) (string, error) {
 	dir := getFirmwareDirPath(canonical)
 	path, err := findSingleFirmwarePayloadInDir(dir)
@@ -824,6 +864,39 @@ func writeFirmwareMetadata(dir string, metadata FirmwareMetadata) error {
 	return nil
 }
 
+func writeFirmwareMetadataAtomic(dir string, metadata FirmwareMetadata) error {
+	tempFile, err := os.CreateTemp(dir, ".metadata-*.tmp")
+	if err != nil {
+		return fleeterror.NewInternalErrorf("failed to create firmware metadata staging file: %v", err)
+	}
+	tempPath := tempFile.Name()
+	removeTemp := true
+	defer func() {
+		_ = tempFile.Close()
+		if removeTemp {
+			_ = os.Remove(tempPath)
+		}
+	}()
+
+	if err := tempFile.Chmod(0600); err != nil {
+		return fleeterror.NewInternalErrorf("failed to set firmware metadata permissions: %v", err)
+	}
+	if err := json.NewEncoder(tempFile).Encode(metadata.normalized()); err != nil {
+		return fleeterror.NewInternalErrorf("failed to write firmware metadata: %v", err)
+	}
+	if err := tempFile.Sync(); err != nil {
+		return fleeterror.NewInternalErrorf("failed to sync firmware metadata to disk: %v", err)
+	}
+	if err := tempFile.Close(); err != nil {
+		return fleeterror.NewInternalErrorf("failed to close firmware metadata staging file: %v", err)
+	}
+	if err := os.Rename(tempPath, filepath.Join(dir, firmwareMetadataFilename)); err != nil {
+		return fleeterror.NewInternalErrorf("failed to publish firmware metadata: %v", err)
+	}
+	removeTemp = false
+	return nil
+}
+
 func readFirmwareMetadata(dir string) (FirmwareMetadata, error) {
 	file, err := os.Open(filepath.Join(dir, firmwareMetadataFilename))
 	if err != nil {
@@ -867,7 +940,7 @@ func findSingleFirmwarePayloadInDir(dir string) (string, error) {
 		if e.IsDir() {
 			continue
 		}
-		if e.Name() == firmwareMetadataFilename {
+		if e.Name() == firmwareMetadataFilename || strings.HasPrefix(e.Name(), ".metadata-") {
 			continue
 		}
 		if foundPath != "" {

--- a/server/internal/infrastructure/files/firmware.go
+++ b/server/internal/infrastructure/files/firmware.go
@@ -70,11 +70,6 @@ func getFirmwareDirPath(fileID string) string {
 	return filepath.Join(firmwareDir, fileID)
 }
 
-type firmwareChecksumEntry struct {
-	fileID   string
-	metadata FirmwareMetadata
-}
-
 func (m FirmwareMetadata) normalized() FirmwareMetadata {
 	return FirmwareMetadata{
 		TargetManufacturer: strings.TrimSpace(m.TargetManufacturer),
@@ -89,6 +84,19 @@ func (m FirmwareMetadata) matches(other FirmwareMetadata) bool {
 	return m.TargetManufacturer == other.TargetManufacturer &&
 		m.TargetModel == other.TargetModel &&
 		m.FirmwareVersion == other.FirmwareVersion
+}
+
+// MatchesTarget reports whether the firmware applies to a device with the
+// given manufacturer and model. Unlike matches (exact comparison, used for
+// upload dedup), deployment compatibility is case-insensitive, and a device
+// with unknown manufacturer or model never matches.
+func (m FirmwareMetadata) MatchesTarget(manufacturer, model string) bool {
+	m = m.normalized()
+	manufacturer = strings.TrimSpace(manufacturer)
+	model = strings.TrimSpace(model)
+	return manufacturer != "" && model != "" &&
+		strings.EqualFold(manufacturer, m.TargetManufacturer) &&
+		strings.EqualFold(model, m.TargetModel)
 }
 
 // ValidateFirmwareMetadata checks that target metadata is complete.
@@ -143,22 +151,13 @@ func initFirmwareDir() error {
 	return nil
 }
 
-// cleanStagingDir removes leftover temp files from previous runs. Since upload
-// sessions are in-memory only, any files in the staging directory at startup
-// are orphans from interrupted uploads.
+// cleanStagingDir removes leftover temp files and publish dirs from previous
+// runs. Since upload sessions are in-memory only, anything in the staging
+// directory at startup is an orphan from an interrupted upload.
 func cleanStagingDir() {
-	entries, err := os.ReadDir(firmwareStagingDir)
-	if err != nil {
-		return
-	}
-	for _, entry := range entries {
-		path := filepath.Join(firmwareStagingDir, entry.Name())
-		if err := os.RemoveAll(path); err != nil {
-			slog.Warn("failed to remove orphaned staging entry", "path", path, "error", err)
-		} else {
-			slog.Info("removed orphaned staging entry", "path", path)
-		}
-	}
+	cleanStorageStagingDir(firmwareStagingDir,
+		"failed to remove orphaned staging entry",
+		"removed orphaned staging entry")
 }
 
 // StagingDir returns the path to the firmware staging directory for chunked uploads.
@@ -262,9 +261,8 @@ func (s *Service) SaveFirmwareUpload(filename string, reader io.Reader, manualMe
 	if written == 0 {
 		return result, fleeterror.NewInvalidArgumentError("firmware file is empty")
 	}
-	if err := tempFile.Sync(); err != nil {
-		return result, fleeterror.NewInternalErrorf("failed to sync firmware staging file: %v", err)
-	}
+	// No fsync here: the staging file is throwaway, and the publish path syncs
+	// the payload before the rename that makes it visible.
 	if err := tempFile.Close(); err != nil {
 		return result, fleeterror.NewInternalErrorf("failed to close firmware staging file: %v", err)
 	}
@@ -318,24 +316,6 @@ func (s *Service) SaveFirmwareUploadFromPath(filename string, srcPath string, ma
 		FirmwareFileID: fileID,
 		Metadata:       metadata,
 	}, nil
-}
-
-// SaveFirmwareFileFromPath moves an existing file (e.g. from the staging directory)
-// into the standard firmware directory, computes its SHA-256 checksum, and registers
-// it in the checksum index. Uses os.Rename for efficiency — both paths must be on
-// the same filesystem. Used by the chunked upload complete handler.
-func (s *Service) SaveFirmwareFileFromPath(filename string, srcPath string, metadata FirmwareMetadata) (string, error) {
-	metadata = metadata.normalized()
-	if err := ValidateFirmwareUploadMetadata(metadata); err != nil {
-		return "", err
-	}
-
-	checksum, err := computeFileChecksum(srcPath)
-	if err != nil {
-		return "", fleeterror.NewInternalErrorf("failed to compute checksum before move: %v", err)
-	}
-
-	return s.saveFirmwareFileFromPathWithChecksum(filename, srcPath, metadata, checksum)
 }
 
 func (s *Service) saveFirmwareFileFromPathWithChecksum(filename string, srcPath string, metadata FirmwareMetadata, checksum string) (string, error) {
@@ -393,7 +373,7 @@ func (s *Service) saveFirmwareFileFromPathWithChecksum(filename string, srcPath 
 		return "", fleeterror.NewInternalErrorf("failed to sync firmware directory: %v", err)
 	}
 
-	s.rememberFirmwareChecksum(checksum, fileID, metadata)
+	s.rememberFirmwareChecksum(checksum, fileID)
 
 	slog.Info("firmware file saved from path", "file_id", fileID, "filename", sanitized, "checksum", checksum)
 	return fileID, nil
@@ -453,19 +433,24 @@ func (s *Service) UpdateFirmwareMetadata(fileID string, metadata FirmwareMetadat
 		}
 		return fleeterror.NewInternalErrorf("failed to stat firmware dir %s: %v", canonical, err)
 	}
-	filePath, err := findSingleFirmwarePayloadInDir(dir)
+	filePath, err := findSingleFileInDir(dir, firmwareMetadataFilename)
 	if err != nil {
 		return fleeterror.NewNotFoundErrorf("firmware file not found: %s", canonical)
 	}
-	checksum, err := computeFileChecksum(filePath)
-	if err != nil {
-		return fleeterror.NewInternalErrorf("failed to compute firmware checksum: %v", err)
+	// The payload is immutable after publish, so a cached checksum is trusted;
+	// only legacy files that were never indexed need a fresh hash.
+	checksum, ok := s.lookupFirmwareChecksum(canonical)
+	if !ok {
+		checksum, err = computeFileChecksum(filePath)
+		if err != nil {
+			return fleeterror.NewInternalErrorf("failed to compute firmware checksum: %v", err)
+		}
 	}
 
-	if err := writeFirmwareMetadataAtomic(dir, metadata); err != nil {
+	if err := writeFirmwareMetadata(dir, metadata); err != nil {
 		return err
 	}
-	s.rememberFirmwareChecksum(checksum, canonical, metadata)
+	s.rememberFirmwareChecksum(checksum, canonical)
 	if err := syncFirmwareDirectory(dir); err != nil {
 		return fleeterror.NewInternalErrorf("failed to sync firmware directory: %v", err)
 	}
@@ -474,7 +459,7 @@ func (s *Service) UpdateFirmwareMetadata(fileID string, metadata FirmwareMetadat
 
 func getFirmwareFilePathForCanonicalID(canonical string) (string, error) {
 	dir := getFirmwareDirPath(canonical)
-	path, err := findSingleFirmwarePayloadInDir(dir)
+	path, err := findSingleFileInDir(dir, firmwareMetadataFilename)
 	if err != nil {
 		return "", fleeterror.NewNotFoundErrorf("firmware file not found: %s", canonical)
 	}
@@ -513,18 +498,21 @@ func (s *Service) OpenFirmwareFileWithInfo(fileID string) (io.ReadCloser, Firmwa
 		return nil, FirmwareFileInfo{}, fleeterror.NewInternalErrorf("failed to stat firmware file: %v", err)
 	}
 
-	checksum, err := s.firmwareChecksum(canonical, filePath)
-	if err != nil {
-		file.Close()
-		return nil, FirmwareFileInfo{}, err
-	}
-	metadata, err := readFirmwareMetadata(getFirmwareDirPath(canonical))
-	if err != nil {
+	metadata, hasMetadata := FirmwareMetadata{}, true
+	if m, err := readFirmwareMetadata(getFirmwareDirPath(canonical)); err != nil {
 		if !errors.Is(err, errFirmwareMetadataNotFound) {
 			file.Close()
 			return nil, FirmwareFileInfo{}, fleeterror.NewInternalErrorf("failed to read firmware metadata: %v", err)
 		}
-		metadata = FirmwareMetadata{}
+		hasMetadata = false
+	} else {
+		metadata = m
+	}
+
+	checksum, err := s.firmwareChecksum(canonical, filePath, hasMetadata)
+	if err != nil {
+		file.Close()
+		return nil, FirmwareFileInfo{}, err
 	}
 
 	return file, FirmwareFileInfo{
@@ -539,7 +527,10 @@ func (s *Service) OpenFirmwareFileWithInfo(fileID string) (io.ReadCloser, Firmwa
 	}, nil
 }
 
-func (s *Service) firmwareChecksum(canonicalID, filePath string) (string, error) {
+// firmwareChecksum returns the file's cached checksum, computing it on a miss.
+// hasValidMetadata decides how a computed checksum is cached: only files with a
+// valid metadata sidecar become eligible for checksum-reuse lookups.
+func (s *Service) firmwareChecksum(canonicalID, filePath string, hasValidMetadata bool) (string, error) {
 	if checksum, ok := s.lookupFirmwareChecksum(canonicalID); ok {
 		return checksum, nil
 	}
@@ -547,15 +538,11 @@ func (s *Service) firmwareChecksum(canonicalID, filePath string) (string, error)
 	if err != nil {
 		return "", fleeterror.NewInternalErrorf("failed to compute firmware checksum: %v", err)
 	}
-	metadata, err := readFirmwareMetadata(getFirmwareDirPath(canonicalID))
-	if err != nil {
-		if !errors.Is(err, errFirmwareMetadataNotFound) {
-			return "", fleeterror.NewInternalErrorf("failed to read firmware metadata: %v", err)
-		}
+	if hasValidMetadata {
+		s.rememberFirmwareChecksum(checksum, canonicalID)
+	} else {
 		s.rememberFirmwareChecksumByID(checksum, canonicalID)
-		return checksum, nil
 	}
-	s.rememberFirmwareChecksum(checksum, canonicalID, metadata)
 	return checksum, nil
 }
 
@@ -566,21 +553,19 @@ func (s *Service) lookupFirmwareChecksum(canonicalID string) (string, bool) {
 	return checksum, ok
 }
 
-func (s *Service) rememberFirmwareChecksum(checksum, canonicalID string, metadata FirmwareMetadata) {
+// rememberFirmwareChecksum caches a file's checksum and makes it eligible for
+// checksum reuse. Files without valid metadata must use
+// rememberFirmwareChecksumByID instead so they never satisfy a reuse lookup.
+func (s *Service) rememberFirmwareChecksum(checksum, canonicalID string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.firmwareChecksumByID[canonicalID] = checksum
-	metadata = metadata.normalized()
-	for i, entry := range s.checksumIndex[checksum] {
-		if entry.fileID == canonicalID {
-			s.checksumIndex[checksum][i].metadata = metadata
+	for _, id := range s.checksumIndex[checksum] {
+		if id == canonicalID {
 			return
 		}
 	}
-	s.checksumIndex[checksum] = append(s.checksumIndex[checksum], firmwareChecksumEntry{
-		fileID:   canonicalID,
-		metadata: metadata,
-	})
+	s.checksumIndex[checksum] = append(s.checksumIndex[checksum], canonicalID)
 }
 
 func (s *Service) rememberFirmwareChecksumByID(checksum, canonicalID string) {
@@ -594,24 +579,24 @@ func (s *Service) rememberFirmwareChecksumByID(checksum, canonicalID string) {
 // Used by the pre-upload check endpoint to let clients skip redundant uploads.
 func (s *Service) FindFirmwareFileByChecksum(sha256Hex string, metadata FirmwareMetadata) (string, bool) {
 	s.mu.Lock()
-	entries := append([]firmwareChecksumEntry(nil), s.checksumIndex[sha256Hex]...)
+	fileIDs := append([]string(nil), s.checksumIndex[sha256Hex]...)
 	s.mu.Unlock()
 
 	metadata = metadata.normalized()
-	for _, entry := range entries {
-		storedMetadata, err := readFirmwareMetadata(getFirmwareDirPath(entry.fileID))
+	for _, fileID := range fileIDs {
+		storedMetadata, err := readFirmwareMetadata(getFirmwareDirPath(fileID))
 		if err != nil {
 			if errors.Is(err, errFirmwareMetadataNotFound) {
 				continue
 			}
-			slog.Warn("skipping firmware with invalid metadata during checksum lookup", "file_id", entry.fileID, "error", err)
+			slog.Warn("skipping firmware with invalid metadata during checksum lookup", "file_id", fileID, "error", err)
 			s.mu.Lock()
-			s.removeFirmwareChecksumLocked(sha256Hex, entry.fileID)
+			s.removeFirmwareChecksumLocked(sha256Hex, fileID)
 			s.mu.Unlock()
 			continue
 		}
 		if storedMetadata.matches(metadata) {
-			return entry.fileID, true
+			return fileID, true
 		}
 	}
 	return "", false
@@ -653,8 +638,8 @@ func (s *Service) DeleteFirmwareFile(fileID string) error {
 func (s *Service) removeFirmwareChecksumLocked(checksum, canonicalID string) {
 	delete(s.firmwareChecksumByID, canonicalID)
 	ids := s.checksumIndex[checksum]
-	for i, entry := range ids {
-		if entry.fileID != canonicalID {
+	for i, id := range ids {
+		if id != canonicalID {
 			continue
 		}
 		ids = append(ids[:i], ids[i+1:]...)
@@ -669,8 +654,8 @@ func (s *Service) removeFirmwareChecksumLocked(checksum, canonicalID string) {
 
 func (s *Service) removeFirmwareChecksumByScanLocked(canonicalID string) {
 	for checksum, ids := range s.checksumIndex {
-		for i, entry := range ids {
-			if entry.fileID != canonicalID {
+		for i, id := range ids {
+			if id != canonicalID {
 				continue
 			}
 			ids = append(ids[:i], ids[i+1:]...)
@@ -713,7 +698,7 @@ func (s *Service) ListFirmwareFiles() ([]FirmwareFileInfo, error) {
 			}
 		}
 
-		filePath, err := findSingleFirmwarePayloadInDir(dir)
+		filePath, err := findSingleFileInDir(dir, firmwareMetadataFilename)
 		if err != nil {
 			slog.Warn("skipping firmware dir during list", "file_id", fileID, "error", err)
 			continue
@@ -802,16 +787,13 @@ func (s *Service) initChecksumIndex() error {
 			continue
 		}
 		dir := getFirmwareDirPath(fileID)
-		metadata, err := readFirmwareMetadata(dir)
-		if err != nil {
-			if errors.Is(err, errFirmwareMetadataNotFound) {
-				continue
-			} else {
+		if _, err := readFirmwareMetadata(dir); err != nil {
+			if !errors.Is(err, errFirmwareMetadataNotFound) {
 				slog.Warn("skipping firmware with invalid metadata during checksum rebuild", "file_id", fileID, "error", err)
-				continue
 			}
+			continue
 		}
-		filePath, err := findSingleFirmwarePayloadInDir(dir)
+		filePath, err := findSingleFileInDir(dir, firmwareMetadataFilename)
 		if err != nil {
 			continue
 		}
@@ -821,7 +803,7 @@ func (s *Service) initChecksumIndex() error {
 			continue
 		}
 
-		s.rememberFirmwareChecksum(checksum, fileID, metadata)
+		s.rememberFirmwareChecksum(checksum, fileID)
 	}
 
 	count := 0
@@ -848,23 +830,9 @@ func computeFileChecksum(filePath string) (string, error) {
 	return hex.EncodeToString(hasher.Sum(nil)), nil
 }
 
+// writeFirmwareMetadata atomically publishes the metadata sidecar via a
+// temp-file-and-rename, so readers never observe a partially written sidecar.
 func writeFirmwareMetadata(dir string, metadata FirmwareMetadata) error {
-	file, err := os.OpenFile(filepath.Join(dir, firmwareMetadataFilename), os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
-	if err != nil {
-		return fleeterror.NewInternalErrorf("failed to create firmware metadata: %v", err)
-	}
-	defer file.Close()
-
-	if err := json.NewEncoder(file).Encode(metadata.normalized()); err != nil {
-		return fleeterror.NewInternalErrorf("failed to write firmware metadata: %v", err)
-	}
-	if err := file.Sync(); err != nil {
-		return fleeterror.NewInternalErrorf("failed to sync firmware metadata to disk: %v", err)
-	}
-	return nil
-}
-
-func writeFirmwareMetadataAtomic(dir string, metadata FirmwareMetadata) error {
 	tempFile, err := os.CreateTemp(dir, ".metadata-*.tmp")
 	if err != nil {
 		return fleeterror.NewInternalErrorf("failed to create firmware metadata staging file: %v", err)
@@ -922,36 +890,13 @@ func readFirmwareMetadata(dir string) (FirmwareMetadata, error) {
 func syncFirmwareDirectory(dir string) error {
 	file, err := os.Open(dir)
 	if err != nil {
-		return err
+		return fmt.Errorf("open firmware directory for sync: %w", err)
 	}
 	defer file.Close()
-	return file.Sync()
-}
-
-// findSingleFirmwarePayloadInDir returns the path to the single non-directory
-// payload entry inside a directory. metadata.json is ignored.
-func findSingleFirmwarePayloadInDir(dir string) (string, error) {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return "", fmt.Errorf("failed to read firmware dir %s: %w", dir, err)
+	if err := file.Sync(); err != nil {
+		return fmt.Errorf("sync firmware directory: %w", err)
 	}
-	var foundPath string
-	for _, e := range entries {
-		if e.IsDir() {
-			continue
-		}
-		if e.Name() == firmwareMetadataFilename || strings.HasPrefix(e.Name(), ".metadata-") {
-			continue
-		}
-		if foundPath != "" {
-			return "", fmt.Errorf("multiple files found in %s", dir)
-		}
-		foundPath = filepath.Join(dir, e.Name())
-	}
-	if foundPath == "" {
-		return "", fmt.Errorf("no file found in %s", dir)
-	}
-	return foundPath, nil
+	return nil
 }
 
 func hasAllowedFirmwareExtension(filename string) bool {

--- a/server/internal/infrastructure/files/firmware.go
+++ b/server/internal/infrastructure/files/firmware.go
@@ -456,14 +456,14 @@ func (s *Service) saveFirmwareFileFromPathWithChecksum(filename string, srcPath 
 	if err := writeFirmwareMetadata(stagingDir, metadata, time.Now().UTC()); err != nil {
 		return "", err
 	}
-	if err := syncFirmwareDirectory(stagingDir); err != nil {
+	if err := s.syncFirmwareDir(stagingDir); err != nil {
 		return "", fleeterror.NewInternalErrorf("failed to sync firmware staging directory: %v", err)
 	}
 	if err := os.Rename(stagingDir, finalDir); err != nil {
 		return "", fleeterror.NewInternalErrorf("failed to publish firmware directory: %v", err)
 	}
 	removeStaging = false
-	if err := syncFirmwareDirectory(firmwareDir); err != nil {
+	if err := s.syncFirmwareDir(firmwareDir); err != nil {
 		return "", fleeterror.NewInternalErrorf("failed to sync firmware directory: %v", err)
 	}
 
@@ -532,9 +532,9 @@ func (s *Service) UpdateFirmwareMetadata(fileID string, metadata FirmwareMetadat
 	if record, readErr := readFirmwareMetadataRecord(dir); readErr == nil && !record.UploadedAt.IsZero() {
 		uploadedAt = record.UploadedAt
 	}
-	filePath, err := findSingleFileInDir(dir, firmwareMetadataFilename)
+	filePath, err := getFirmwareFilePathForCanonicalID(canonical)
 	if err != nil {
-		return fleeterror.NewNotFoundErrorf("firmware file not found: %s", canonical)
+		return err
 	}
 	// The payload is immutable after publish, so a cached checksum is trusted;
 	// only legacy files that were never indexed need a fresh hash.
@@ -546,23 +546,29 @@ func (s *Service) UpdateFirmwareMetadata(fileID string, metadata FirmwareMetadat
 		}
 	}
 
+	// Keep the cached checksum, but stop advertising this file for reuse while
+	// its replacement metadata is not yet durable.
+	s.removeFirmwareChecksumEligibility(checksum, canonical)
 	if err := writeFirmwareMetadata(dir, metadata, uploadedAt); err != nil {
 		return err
 	}
-	s.rememberFirmwareChecksum(checksum, canonical)
-	if err := syncFirmwareDirectory(dir); err != nil {
+	if err := s.syncFirmwareDir(dir); err != nil {
 		return fleeterror.NewInternalErrorf("failed to sync firmware directory: %v", err)
 	}
+	s.rememberFirmwareChecksum(checksum, canonical)
 	return nil
 }
 
 func getFirmwareFilePathForCanonicalID(canonical string) (string, error) {
 	dir := getFirmwareDirPath(canonical)
 	path, err := findSingleFileInDir(dir, firmwareMetadataFilename)
-	if err != nil {
+	if err == nil {
+		return path, nil
+	}
+	if errors.Is(err, errStorageDirNoFile) || errors.Is(err, os.ErrNotExist) {
 		return "", fleeterror.NewNotFoundErrorf("firmware file not found: %s", canonical)
 	}
-	return path, nil
+	return "", fleeterror.NewInternalErrorf("failed to inspect firmware directory %s: %v", canonical, err)
 }
 
 // OpenFirmwareFile opens the firmware file for reading and returns the reader,
@@ -671,6 +677,24 @@ func (s *Service) rememberFirmwareChecksumByID(checksum, canonicalID string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.firmwareChecksumByID[canonicalID] = checksum
+}
+
+func (s *Service) removeFirmwareChecksumEligibility(checksum, canonicalID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	ids := s.checksumIndex[checksum]
+	for i, id := range ids {
+		if id != canonicalID {
+			continue
+		}
+		ids = append(ids[:i], ids[i+1:]...)
+		if len(ids) == 0 {
+			delete(s.checksumIndex, checksum)
+		} else {
+			s.checksumIndex[checksum] = ids
+		}
+		return
+	}
 }
 
 // FindFirmwareFileByChecksum looks up a firmware file by its SHA-256 hex digest.

--- a/server/internal/infrastructure/files/firmware.go
+++ b/server/internal/infrastructure/files/firmware.go
@@ -534,6 +534,12 @@ func (s *Service) UpdateFirmwareMetadata(fileID string, metadata FirmwareMetadat
 		return err
 	}
 
+	// Serialize metadata replacement with checksum reuse lookups so a lookup
+	// observes either the complete pre-edit state or the complete post-edit
+	// state, never a sidecar that disagrees with its index snapshot.
+	s.firmwareMetadataReuseMu.Lock()
+	defer s.firmwareMetadataReuseMu.Unlock()
+
 	dir := getFirmwareDirPath(canonical)
 	dirInfo, err := os.Stat(dir)
 	if err != nil {
@@ -721,6 +727,9 @@ func (s *Service) removeFirmwareChecksumEligibility(checksum, canonicalID string
 // Returns the file ID and true if found, or empty string and false otherwise.
 // Used by the pre-upload check endpoint to let clients skip redundant uploads.
 func (s *Service) FindFirmwareFileByChecksum(sha256Hex string, metadata FirmwareMetadata) (string, bool) {
+	s.firmwareMetadataReuseMu.RLock()
+	defer s.firmwareMetadataReuseMu.RUnlock()
+
 	s.mu.Lock()
 	fileIDs := append([]string(nil), s.checksumIndex[sha256Hex]...)
 	s.mu.Unlock()

--- a/server/internal/infrastructure/files/firmware.go
+++ b/server/internal/infrastructure/files/firmware.go
@@ -383,6 +383,13 @@ func (s *Service) SaveFirmwareUploadFromPath(filename string, srcPath string, ma
 		}
 	}
 
+	// Keep deletion and metadata replacement from observing a newly published
+	// directory until its checksum index entry and result are complete. Acquire
+	// this only after the reuse lookup to avoid recursively taking an RLock
+	// while a writer is pending.
+	s.firmwareMetadataReuseMu.RLock()
+	defer s.firmwareMetadataReuseMu.RUnlock()
+
 	fileID, err := s.saveFirmwareFileFromPathWithChecksum(filename, srcPath, metadata, checksum)
 	if err != nil {
 		return result, err
@@ -506,6 +513,26 @@ func (s *Service) GetFirmwareFilePath(fileID string) (string, error) {
 
 // GetFirmwareMetadata returns the target metadata for a stored firmware file.
 func (s *Service) GetFirmwareMetadata(fileID string) (FirmwareMetadata, error) {
+	s.firmwareMetadataReuseMu.RLock()
+	defer s.firmwareMetadataReuseMu.RUnlock()
+
+	return s.getFirmwareMetadataUnlocked(fileID)
+}
+
+// LeaseFirmwareMetadata returns target metadata while holding the firmware
+// lifecycle read lock. The caller must invoke release when it no longer relies
+// on that metadata remaining current.
+func (s *Service) LeaseFirmwareMetadata(fileID string) (metadata FirmwareMetadata, release func(), err error) {
+	s.firmwareMetadataReuseMu.RLock()
+	metadata, err = s.getFirmwareMetadataUnlocked(fileID)
+	if err != nil {
+		s.firmwareMetadataReuseMu.RUnlock()
+		return FirmwareMetadata{}, nil, err
+	}
+	return metadata, s.firmwareMetadataReuseMu.RUnlock, nil
+}
+
+func (s *Service) getFirmwareMetadataUnlocked(fileID string) (FirmwareMetadata, error) {
 	canonical, err := canonicalizeFirmwareFileID(fileID)
 	if err != nil {
 		return FirmwareMetadata{}, err

--- a/server/internal/infrastructure/files/firmware.go
+++ b/server/internal/infrastructure/files/firmware.go
@@ -54,7 +54,6 @@ type FirmwareUploadSaveResult struct {
 const firmwareDir = "firmware"
 const firmwareStagingDir = "firmware/staging"
 const firmwareMetadataFilename = "metadata.json"
-const firmwareMetadataStagingDirname = ".metadata-staging"
 
 var errFirmwareMetadataNotFound = errors.New("firmware metadata not found")
 
@@ -166,9 +165,38 @@ func cleanStagingDir() {
 		"removed orphaned staging entry")
 }
 
-// StagingDir returns the path to the firmware staging directory for chunked uploads.
-func StagingDir() string {
-	return firmwareStagingDir
+// StagedFirmwareUploadCount reports how many entries are currently in the
+// firmware staging area. Every upload path discards its staged file, so a
+// non-zero count with no upload in flight means one leaked.
+func StagedFirmwareUploadCount() (int, error) {
+	entries, err := os.ReadDir(firmwareStagingDir)
+	if err != nil {
+		return 0, fleeterror.NewInternalErrorf("failed to read firmware staging dir: %v", err)
+	}
+	return len(entries), nil
+}
+
+// NewChunkedStagingPath reserves a staging file for a chunked upload session and
+// returns its path. Unlike StageFirmwareUpload the payload arrives later, over
+// many requests, so the path is derived from the caller's upload ID rather than
+// randomly generated. Anything left behind is reclaimed by cleanStagingDir on
+// the next start.
+func NewChunkedStagingPath(uploadID string) (string, error) {
+	if uploadID == "" {
+		return "", fleeterror.NewInvalidArgumentError("upload ID is required")
+	}
+	if uploadID != filepath.Base(uploadID) {
+		return "", fleeterror.NewInvalidArgumentErrorf("invalid upload ID %q", uploadID)
+	}
+	path := filepath.Join(firmwareStagingDir, uploadID)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return "", fleeterror.NewInternalErrorf("failed to create firmware staging file: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		return "", fleeterror.NewInternalErrorf("failed to close firmware staging file: %v", err)
+	}
+	return path, nil
 }
 
 // ValidateFirmwareFilename checks that the filename is non-empty and has an
@@ -229,25 +257,42 @@ func (s *Service) SaveFirmwareFile(filename string, reader io.Reader, metadata F
 	return result.FirmwareFileID, nil
 }
 
-// SaveFirmwareUpload stages a streamed upload and reuses an existing file with
-// the same checksum plus metadata unless force is true.
-func (s *Service) SaveFirmwareUpload(filename string, reader io.Reader, manualMetadata FirmwareMetadata, force bool) (FirmwareUploadSaveResult, error) {
-	var result FirmwareUploadSaveResult
-	metadata := manualMetadata.normalized()
-	if err := ValidateFirmwareUploadMetadata(metadata); err != nil {
-		return result, err
-	}
+// StagedFirmwareUpload is a firmware payload written to the staging area, held
+// there until SaveFirmwareUploadFromPath either publishes it or discards it in
+// favour of an existing copy.
+type StagedFirmwareUpload struct {
+	Path     string
+	Checksum string
+	Size     int64
+}
 
-	tempFile, err := os.CreateTemp(firmwareStagingDir, "direct-*")
-	if err != nil {
-		return result, fleeterror.NewInternalErrorf("failed to create firmware staging file: %v", err)
+// Discard removes the staged file. It is safe to call more than once, and after
+// the file has already been consumed, so callers can defer it unconditionally.
+func (u *StagedFirmwareUpload) Discard() {
+	if u == nil || u.Path == "" {
+		return
 	}
-	tempPath := tempFile.Name()
-	removeTemp := true
+	if err := os.Remove(u.Path); err != nil && !os.IsNotExist(err) {
+		slog.Warn("failed to remove firmware staging file", "path", u.Path, "error", err)
+	}
+}
+
+// StageFirmwareUpload streams reader into the firmware staging area, hashing as
+// it goes, and enforces the configured size limit. It owns every rule about how
+// an in-flight upload reaches disk, so the HTTP handlers and SaveFirmwareUpload
+// share one implementation. The caller owns the returned upload and must call
+// Discard unless it is consumed by SaveFirmwareUploadFromPath.
+func (s *Service) StageFirmwareUpload(reader io.Reader) (*StagedFirmwareUpload, error) {
+	tempFile, err := os.CreateTemp(firmwareStagingDir, "upload-*")
+	if err != nil {
+		return nil, fleeterror.NewInternalErrorf("failed to create firmware staging file: %v", err)
+	}
+	staged := &StagedFirmwareUpload{Path: tempFile.Name()}
+	published := false
 	defer func() {
 		_ = tempFile.Close()
-		if removeTemp {
-			_ = os.Remove(tempPath)
+		if !published {
+			staged.Discard()
 		}
 	}()
 
@@ -255,36 +300,48 @@ func (s *Service) SaveFirmwareUpload(filename string, reader io.Reader, manualMe
 	if maxSize <= 0 {
 		maxSize = defaultMaxFirmwareFileSize
 	}
-	limitedReader := io.LimitReader(reader, maxSize+1)
 	hasher := sha256.New()
-	written, err := io.Copy(tempFile, io.TeeReader(limitedReader, hasher))
+	written, err := io.Copy(io.MultiWriter(tempFile, hasher), io.LimitReader(reader, maxSize+1))
 	if err != nil {
-		return result, fleeterror.NewInternalErrorf("failed to write firmware staging file: %v", err)
+		return nil, fleeterror.NewInternalErrorf("failed to write firmware staging file: %v", err)
 	}
 	if written > maxSize {
-		return result, fleeterror.NewInvalidArgumentErrorf("firmware file too large: exceeded %d byte limit during upload", maxSize)
+		return nil, fleeterror.NewInvalidArgumentErrorf("firmware file too large: exceeded %d byte limit during upload", maxSize)
 	}
 	if written == 0 {
-		return result, fleeterror.NewInvalidArgumentError("firmware file is empty")
+		return nil, fleeterror.NewInvalidArgumentError("firmware file is empty")
 	}
 	// No fsync here: the staging file is throwaway, and the publish path syncs
 	// the payload before the rename that makes it visible.
 	if err := tempFile.Close(); err != nil {
-		return result, fleeterror.NewInternalErrorf("failed to close firmware staging file: %v", err)
+		return nil, fleeterror.NewInternalErrorf("failed to close firmware staging file: %v", err)
 	}
 
-	checksum := hex.EncodeToString(hasher.Sum(nil))
-	result, err = s.SaveFirmwareUploadFromPath(filename, tempPath, metadata, force, checksum)
+	staged.Checksum = hex.EncodeToString(hasher.Sum(nil))
+	staged.Size = written
+	published = true
+	return staged, nil
+}
+
+// SaveFirmwareUpload stages a streamed upload and reuses an existing file with
+// the same checksum plus metadata unless force is true.
+func (s *Service) SaveFirmwareUpload(filename string, reader io.Reader, manualMetadata FirmwareMetadata, force bool) (FirmwareUploadSaveResult, error) {
+	staged, err := s.StageFirmwareUpload(reader)
 	if err != nil {
 		return FirmwareUploadSaveResult{}, err
 	}
-	removeTemp = false
-	return result, nil
+	defer staged.Discard()
+
+	return s.SaveFirmwareUploadFromPath(filename, staged.Path, manualMetadata, force, staged.Checksum)
 }
 
-// SaveFirmwareUploadFromPath consumes a staged upload path. On success it either
-// removes the staged file and returns an existing matching firmware_file_id, or
-// moves the staged file into permanent firmware storage.
+// SaveFirmwareUploadFromPath publishes a staged upload: it either moves the
+// staged file into permanent firmware storage, or leaves it in place and
+// returns an existing matching firmware_file_id.
+//
+// srcPath stays owned by the caller, which must discard it on every outcome —
+// see StagedFirmwareUpload.Discard, which is a no-op once the file has been
+// moved into storage.
 func (s *Service) SaveFirmwareUploadFromPath(filename string, srcPath string, manualMetadata FirmwareMetadata, force bool, checksum string) (FirmwareUploadSaveResult, error) {
 	var result FirmwareUploadSaveResult
 
@@ -311,9 +368,6 @@ func (s *Service) SaveFirmwareUploadFromPath(filename string, srcPath string, ma
 
 	if !force {
 		if existingID, ok := s.FindFirmwareFileByChecksum(checksum, metadata); ok {
-			if err := os.Remove(srcPath); err != nil && !os.IsNotExist(err) {
-				return result, fleeterror.NewInternalErrorf("failed to remove reused firmware staging file: %v", err)
-			}
 			return FirmwareUploadSaveResult{
 				FirmwareFileID: existingID,
 				Reused:         true,
@@ -757,12 +811,14 @@ func (s *Service) ListFirmwareFiles() ([]FirmwareFileInfo, error) {
 			continue
 		}
 
-		dirInfo, err := os.Stat(dir)
-		if err != nil {
-			slog.Warn("failed to stat firmware dir during list", "file_id", fileID, "error", err)
-			continue
-		}
+		// Files predating the metadata sidecar's uploaded_at fall back to the
+		// directory mtime; everything else already knows when it was uploaded.
 		if uploadedAt.IsZero() {
+			dirInfo, err := os.Stat(dir)
+			if err != nil {
+				slog.Warn("failed to stat firmware dir during list", "file_id", fileID, "error", err)
+				continue
+			}
 			uploadedAt = dirInfo.ModTime()
 		}
 
@@ -883,17 +939,11 @@ func computeFileChecksum(filePath string) (string, error) {
 // writeFirmwareMetadata atomically publishes the metadata sidecar via a
 // temp-file-and-rename, so readers never observe a partially written sidecar.
 func writeFirmwareMetadata(dir string, metadata FirmwareMetadata, uploadedAt time.Time) error {
-	stagingDir := filepath.Join(dir, firmwareMetadataStagingDirname)
-	if err := os.MkdirAll(stagingDir, 0700); err != nil {
-		return fleeterror.NewInternalErrorf("failed to create firmware metadata staging directory: %v", err)
-	}
-	defer func() {
-		// Remove only an empty staging directory so concurrent metadata writers
-		// cannot delete one another's temporary files.
-		_ = os.Remove(stagingDir)
-	}()
-
-	tempFile, err := os.CreateTemp(stagingDir, "metadata-*.tmp")
+	// Stage in the shared firmware staging dir rather than inside dir: it is on
+	// the same filesystem (so the publish rename stays atomic), it keeps
+	// temporary files out of the payload namespace, and cleanStagingDir already
+	// reclaims anything a crash leaves behind.
+	tempFile, err := os.CreateTemp(firmwareStagingDir, "metadata-*.tmp")
 	if err != nil {
 		return fleeterror.NewInternalErrorf("failed to create firmware metadata staging file: %v", err)
 	}

--- a/server/internal/infrastructure/files/firmware.go
+++ b/server/internal/infrastructure/files/firmware.go
@@ -54,6 +54,7 @@ type FirmwareUploadSaveResult struct {
 const firmwareDir = "firmware"
 const firmwareStagingDir = "firmware/staging"
 const firmwareMetadataFilename = "metadata.json"
+const firmwareMetadataStagingDirname = ".metadata-staging"
 
 var errFirmwareMetadataNotFound = errors.New("firmware metadata not found")
 
@@ -882,7 +883,17 @@ func computeFileChecksum(filePath string) (string, error) {
 // writeFirmwareMetadata atomically publishes the metadata sidecar via a
 // temp-file-and-rename, so readers never observe a partially written sidecar.
 func writeFirmwareMetadata(dir string, metadata FirmwareMetadata, uploadedAt time.Time) error {
-	tempFile, err := os.CreateTemp(dir, ".metadata-*.tmp")
+	stagingDir := filepath.Join(dir, firmwareMetadataStagingDirname)
+	if err := os.MkdirAll(stagingDir, 0700); err != nil {
+		return fleeterror.NewInternalErrorf("failed to create firmware metadata staging directory: %v", err)
+	}
+	defer func() {
+		// Remove only an empty staging directory so concurrent metadata writers
+		// cannot delete one another's temporary files.
+		_ = os.Remove(stagingDir)
+	}()
+
+	tempFile, err := os.CreateTemp(stagingDir, "metadata-*.tmp")
 	if err != nil {
 		return fleeterror.NewInternalErrorf("failed to create firmware metadata staging file: %v", err)
 	}

--- a/server/internal/infrastructure/files/firmware.go
+++ b/server/internal/infrastructure/files/firmware.go
@@ -562,8 +562,13 @@ func (s *Service) UpdateFirmwareMetadata(fileID string, metadata FirmwareMetadat
 
 	// Keep the cached checksum, but stop advertising this file for reuse while
 	// its replacement metadata is not yet durable.
-	s.removeFirmwareChecksumEligibility(checksum, canonical)
+	wasEligible := s.removeFirmwareChecksumEligibility(checksum, canonical)
 	if err := writeFirmwareMetadata(dir, metadata, uploadedAt); err != nil {
+		// The atomic metadata publish did not complete, so the previous sidecar
+		// remains authoritative and can safely be advertised again.
+		if wasEligible {
+			s.rememberFirmwareChecksum(checksum, canonical)
+		}
 		return err
 	}
 	if err := s.syncFirmwareDir(dir); err != nil {
@@ -693,7 +698,7 @@ func (s *Service) rememberFirmwareChecksumByID(checksum, canonicalID string) {
 	s.firmwareChecksumByID[canonicalID] = checksum
 }
 
-func (s *Service) removeFirmwareChecksumEligibility(checksum, canonicalID string) {
+func (s *Service) removeFirmwareChecksumEligibility(checksum, canonicalID string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	ids := s.checksumIndex[checksum]
@@ -707,8 +712,9 @@ func (s *Service) removeFirmwareChecksumEligibility(checksum, canonicalID string
 		} else {
 			s.checksumIndex[checksum] = ids
 		}
-		return
+		return true
 	}
+	return false
 }
 
 // FindFirmwareFileByChecksum looks up a firmware file by its SHA-256 hex digest.

--- a/server/internal/infrastructure/files/firmware.go
+++ b/server/internal/infrastructure/files/firmware.go
@@ -464,6 +464,20 @@ func (s *Service) saveFirmwareFileFromPathWithChecksum(filename string, srcPath 
 	}
 	removeStaging = false
 	if err := s.syncFirmwareDir(firmwareDir); err != nil {
+		if rollbackErr := os.RemoveAll(finalDir); rollbackErr != nil {
+			return "", fleeterror.NewInternalErrorf(
+				"failed to sync firmware directory: %v; failed to remove published firmware directory during rollback: %v",
+				err,
+				rollbackErr,
+			)
+		}
+		if rollbackSyncErr := s.syncFirmwareDir(firmwareDir); rollbackSyncErr != nil {
+			return "", fleeterror.NewInternalErrorf(
+				"failed to sync firmware directory: %v; failed to sync firmware directory after rollback: %v",
+				err,
+				rollbackSyncErr,
+			)
+		}
 		return "", fleeterror.NewInternalErrorf("failed to sync firmware directory: %v", err)
 	}
 

--- a/server/internal/infrastructure/files/firmware.go
+++ b/server/internal/infrastructure/files/firmware.go
@@ -51,6 +51,13 @@ type FirmwareUploadSaveResult struct {
 	Metadata       FirmwareMetadata
 }
 
+// FirmwareMetadataUpdateResult captures the metadata transition committed by
+// an update. Previous is nil when the existing sidecar was missing or corrupt.
+type FirmwareMetadataUpdateResult struct {
+	Previous *FirmwareMetadata
+	Current  FirmwareMetadata
+}
+
 const firmwareDir = "firmware"
 const firmwareStagingDir = "firmware/staging"
 const firmwareMetadataFilename = "metadata.json"
@@ -521,17 +528,17 @@ func (s *Service) GetFirmwareMetadata(fileID string) (FirmwareMetadata, error) {
 }
 
 // UpdateFirmwareMetadata atomically replaces the target metadata for a stored
-// firmware file and refreshes its checksum reuse entry. This also allows a
-// legacy payload without a sidecar to become eligible for new deployments once
-// complete metadata has been supplied.
-func (s *Service) UpdateFirmwareMetadata(fileID string, metadata FirmwareMetadata) error {
+// firmware file, refreshes its checksum reuse entry, and returns the committed
+// metadata transition. This also allows a legacy payload without a sidecar to
+// become eligible for new deployments once complete metadata has been supplied.
+func (s *Service) UpdateFirmwareMetadata(fileID string, metadata FirmwareMetadata) (FirmwareMetadataUpdateResult, error) {
 	canonical, err := canonicalizeFirmwareFileID(fileID)
 	if err != nil {
-		return err
+		return FirmwareMetadataUpdateResult{}, err
 	}
 	metadata = metadata.normalized()
 	if err := ValidateFirmwareUploadMetadata(metadata); err != nil {
-		return err
+		return FirmwareMetadataUpdateResult{}, err
 	}
 
 	// Serialize metadata replacement with checksum reuse lookups so a lookup
@@ -544,17 +551,22 @@ func (s *Service) UpdateFirmwareMetadata(fileID string, metadata FirmwareMetadat
 	dirInfo, err := os.Stat(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return fleeterror.NewNotFoundErrorf("firmware file not found: %s", canonical)
+			return FirmwareMetadataUpdateResult{}, fleeterror.NewNotFoundErrorf("firmware file not found: %s", canonical)
 		}
-		return fleeterror.NewInternalErrorf("failed to stat firmware dir %s: %v", canonical, err)
+		return FirmwareMetadataUpdateResult{}, fleeterror.NewInternalErrorf("failed to stat firmware dir %s: %v", canonical, err)
 	}
 	uploadedAt := dirInfo.ModTime()
-	if record, readErr := readFirmwareMetadataRecord(dir); readErr == nil && !record.UploadedAt.IsZero() {
-		uploadedAt = record.UploadedAt
+	var previous *FirmwareMetadata
+	if record, readErr := readFirmwareMetadataRecord(dir); readErr == nil {
+		previousMetadata := record.FirmwareMetadata
+		previous = &previousMetadata
+		if !record.UploadedAt.IsZero() {
+			uploadedAt = record.UploadedAt
+		}
 	}
 	filePath, err := getFirmwareFilePathForCanonicalID(canonical)
 	if err != nil {
-		return err
+		return FirmwareMetadataUpdateResult{}, err
 	}
 	// The payload is immutable after publish, so a cached checksum is trusted;
 	// only legacy files that were never indexed need a fresh hash.
@@ -562,7 +574,7 @@ func (s *Service) UpdateFirmwareMetadata(fileID string, metadata FirmwareMetadat
 	if !ok {
 		checksum, err = computeFileChecksum(filePath)
 		if err != nil {
-			return fleeterror.NewInternalErrorf("failed to compute firmware checksum: %v", err)
+			return FirmwareMetadataUpdateResult{}, fleeterror.NewInternalErrorf("failed to compute firmware checksum: %v", err)
 		}
 	}
 
@@ -575,13 +587,16 @@ func (s *Service) UpdateFirmwareMetadata(fileID string, metadata FirmwareMetadat
 		if wasEligible {
 			s.rememberFirmwareChecksum(checksum, canonical)
 		}
-		return err
+		return FirmwareMetadataUpdateResult{}, err
 	}
 	if err := s.syncFirmwareDir(dir); err != nil {
-		return fleeterror.NewInternalErrorf("failed to sync firmware directory: %v", err)
+		return FirmwareMetadataUpdateResult{}, fleeterror.NewInternalErrorf("failed to sync firmware directory: %v", err)
 	}
 	s.rememberFirmwareChecksum(checksum, canonical)
-	return nil
+	return FirmwareMetadataUpdateResult{
+		Previous: previous,
+		Current:  metadata,
+	}, nil
 }
 
 func getFirmwareFilePathForCanonicalID(canonical string) (string, error) {

--- a/server/internal/infrastructure/files/firmware.go
+++ b/server/internal/infrastructure/files/firmware.go
@@ -762,6 +762,11 @@ func (s *Service) DeleteFirmwareFile(fileID string) error {
 		return err
 	}
 
+	// Serialize deletion with checksum reuse lookups so a lookup either returns
+	// an existing artifact or observes its completed removal.
+	s.firmwareMetadataReuseMu.Lock()
+	defer s.firmwareMetadataReuseMu.Unlock()
+
 	dir := getFirmwareDirPath(canonical)
 	if _, err := os.Stat(dir); err != nil {
 		if os.IsNotExist(err) {

--- a/server/internal/infrastructure/files/firmware.go
+++ b/server/internal/infrastructure/files/firmware.go
@@ -38,6 +38,11 @@ type FirmwareMetadata struct {
 	FirmwareVersion    string `json:"firmware_version,omitempty"`
 }
 
+type firmwareMetadataRecord struct {
+	FirmwareMetadata
+	UploadedAt time.Time `json:"uploaded_at,omitempty"`
+}
+
 // FirmwareUploadSaveResult describes the stored or reused firmware file after
 // upload metadata has been resolved.
 type FirmwareUploadSaveResult struct {
@@ -295,6 +300,14 @@ func (s *Service) SaveFirmwareUploadFromPath(filename string, srcPath string, ma
 		}
 	}
 
+	release := s.acquireFirmwareUploadLock(firmwareUploadKey{
+		checksum:     checksum,
+		manufacturer: metadata.TargetManufacturer,
+		model:        metadata.TargetModel,
+		version:      metadata.FirmwareVersion,
+	})
+	defer release()
+
 	if !force {
 		if existingID, ok := s.FindFirmwareFileByChecksum(checksum, metadata); ok {
 			if err := os.Remove(srcPath); err != nil && !os.IsNotExist(err) {
@@ -316,6 +329,32 @@ func (s *Service) SaveFirmwareUploadFromPath(filename string, srcPath string, ma
 		FirmwareFileID: fileID,
 		Metadata:       metadata,
 	}, nil
+}
+
+func (s *Service) acquireFirmwareUploadLock(key firmwareUploadKey) func() {
+	s.mu.Lock()
+	if s.firmwareUploadLocks == nil {
+		s.firmwareUploadLocks = make(map[firmwareUploadKey]*firmwareUploadLock)
+	}
+	lock := s.firmwareUploadLocks[key]
+	if lock == nil {
+		lock = &firmwareUploadLock{}
+		s.firmwareUploadLocks[key] = lock
+	}
+	lock.refs++
+	s.mu.Unlock()
+
+	lock.mu.Lock()
+	return func() {
+		lock.mu.Unlock()
+
+		s.mu.Lock()
+		lock.refs--
+		if lock.refs == 0 && s.firmwareUploadLocks[key] == lock {
+			delete(s.firmwareUploadLocks, key)
+		}
+		s.mu.Unlock()
+	}
 }
 
 func (s *Service) saveFirmwareFileFromPathWithChecksum(filename string, srcPath string, metadata FirmwareMetadata, checksum string) (string, error) {
@@ -359,7 +398,7 @@ func (s *Service) saveFirmwareFileFromPathWithChecksum(filename string, srcPath 
 		return "", fleeterror.NewInternalErrorf("failed to close staged firmware file: %v", err)
 	}
 
-	if err := writeFirmwareMetadata(stagingDir, metadata); err != nil {
+	if err := writeFirmwareMetadata(stagingDir, metadata, time.Now().UTC()); err != nil {
 		return "", err
 	}
 	if err := syncFirmwareDirectory(stagingDir); err != nil {
@@ -427,11 +466,16 @@ func (s *Service) UpdateFirmwareMetadata(fileID string, metadata FirmwareMetadat
 	}
 
 	dir := getFirmwareDirPath(canonical)
-	if _, err := os.Stat(dir); err != nil {
+	dirInfo, err := os.Stat(dir)
+	if err != nil {
 		if os.IsNotExist(err) {
 			return fleeterror.NewNotFoundErrorf("firmware file not found: %s", canonical)
 		}
 		return fleeterror.NewInternalErrorf("failed to stat firmware dir %s: %v", canonical, err)
+	}
+	uploadedAt := dirInfo.ModTime()
+	if record, readErr := readFirmwareMetadataRecord(dir); readErr == nil && !record.UploadedAt.IsZero() {
+		uploadedAt = record.UploadedAt
 	}
 	filePath, err := findSingleFileInDir(dir, firmwareMetadataFilename)
 	if err != nil {
@@ -447,7 +491,7 @@ func (s *Service) UpdateFirmwareMetadata(fileID string, metadata FirmwareMetadat
 		}
 	}
 
-	if err := writeFirmwareMetadata(dir, metadata); err != nil {
+	if err := writeFirmwareMetadata(dir, metadata, uploadedAt); err != nil {
 		return err
 	}
 	s.rememberFirmwareChecksum(checksum, canonical)
@@ -688,7 +732,9 @@ func (s *Service) ListFirmwareFiles() ([]FirmwareFileInfo, error) {
 		}
 
 		dir := getFirmwareDirPath(fileID)
-		metadata, err := readFirmwareMetadata(dir)
+		record, err := readFirmwareMetadataRecord(dir)
+		metadata := record.FirmwareMetadata
+		uploadedAt := record.UploadedAt
 		if err != nil {
 			if errors.Is(err, errFirmwareMetadataNotFound) {
 				metadata = FirmwareMetadata{}
@@ -715,12 +761,15 @@ func (s *Service) ListFirmwareFiles() ([]FirmwareFileInfo, error) {
 			slog.Warn("failed to stat firmware dir during list", "file_id", fileID, "error", err)
 			continue
 		}
+		if uploadedAt.IsZero() {
+			uploadedAt = dirInfo.ModTime()
+		}
 
 		result = append(result, FirmwareFileInfo{
 			ID:                 fileID,
 			Filename:           filepath.Base(filePath),
 			Size:               fileInfo.Size(),
-			UploadedAt:         dirInfo.ModTime(),
+			UploadedAt:         uploadedAt,
 			TargetManufacturer: metadata.TargetManufacturer,
 			TargetModel:        metadata.TargetModel,
 			FirmwareVersion:    metadata.FirmwareVersion,
@@ -832,7 +881,7 @@ func computeFileChecksum(filePath string) (string, error) {
 
 // writeFirmwareMetadata atomically publishes the metadata sidecar via a
 // temp-file-and-rename, so readers never observe a partially written sidecar.
-func writeFirmwareMetadata(dir string, metadata FirmwareMetadata) error {
+func writeFirmwareMetadata(dir string, metadata FirmwareMetadata, uploadedAt time.Time) error {
 	tempFile, err := os.CreateTemp(dir, ".metadata-*.tmp")
 	if err != nil {
 		return fleeterror.NewInternalErrorf("failed to create firmware metadata staging file: %v", err)
@@ -849,7 +898,11 @@ func writeFirmwareMetadata(dir string, metadata FirmwareMetadata) error {
 	if err := tempFile.Chmod(0600); err != nil {
 		return fleeterror.NewInternalErrorf("failed to set firmware metadata permissions: %v", err)
 	}
-	if err := json.NewEncoder(tempFile).Encode(metadata.normalized()); err != nil {
+	record := firmwareMetadataRecord{
+		FirmwareMetadata: metadata.normalized(),
+		UploadedAt:       uploadedAt,
+	}
+	if err := json.NewEncoder(tempFile).Encode(record); err != nil {
 		return fleeterror.NewInternalErrorf("failed to write firmware metadata: %v", err)
 	}
 	if err := tempFile.Sync(); err != nil {
@@ -866,25 +919,30 @@ func writeFirmwareMetadata(dir string, metadata FirmwareMetadata) error {
 }
 
 func readFirmwareMetadata(dir string) (FirmwareMetadata, error) {
+	record, err := readFirmwareMetadataRecord(dir)
+	return record.FirmwareMetadata, err
+}
+
+func readFirmwareMetadataRecord(dir string) (firmwareMetadataRecord, error) {
 	file, err := os.Open(filepath.Join(dir, firmwareMetadataFilename))
 	if err != nil {
 		if os.IsNotExist(err) {
-			return FirmwareMetadata{}, fmt.Errorf("%w: %s", errFirmwareMetadataNotFound, dir)
+			return firmwareMetadataRecord{}, fmt.Errorf("%w: %s", errFirmwareMetadataNotFound, dir)
 		}
-		return FirmwareMetadata{}, fmt.Errorf("open firmware metadata: %w", err)
+		return firmwareMetadataRecord{}, fmt.Errorf("open firmware metadata: %w", err)
 	}
 	defer file.Close()
 
 	decoder := json.NewDecoder(file)
-	var metadata FirmwareMetadata
-	if err := decoder.Decode(&metadata); err != nil {
-		return FirmwareMetadata{}, fmt.Errorf("decode firmware metadata: %w", err)
+	var record firmwareMetadataRecord
+	if err := decoder.Decode(&record); err != nil {
+		return firmwareMetadataRecord{}, fmt.Errorf("decode firmware metadata: %w", err)
 	}
-	metadata = metadata.normalized()
-	if err := ValidateFirmwareMetadata(metadata); err != nil {
-		return FirmwareMetadata{}, err
+	record.FirmwareMetadata = record.FirmwareMetadata.normalized()
+	if err := ValidateFirmwareMetadata(record.FirmwareMetadata); err != nil {
+		return firmwareMetadataRecord{}, err
 	}
-	return metadata, nil
+	return record, nil
 }
 
 func syncFirmwareDirectory(dir string) error {

--- a/server/internal/infrastructure/files/firmware_test.go
+++ b/server/internal/infrastructure/files/firmware_test.go
@@ -19,6 +19,10 @@ func checksumOf(content string) string {
 	return hex.EncodeToString(h[:])
 }
 
+func testFirmwareMetadata() FirmwareMetadata {
+	return FirmwareMetadata{TargetManufacturer: "Proto", TargetModel: "S21"}
+}
+
 func storageDirEntries(t *testing.T, dir string) []os.DirEntry {
 	t.Helper()
 	entries, err := os.ReadDir(dir)
@@ -39,6 +43,7 @@ func storageDirEntriesExcept(t *testing.T, dir, ignoredName string) []os.DirEntr
 }
 
 func firmwareFileEntries(t *testing.T) []os.DirEntry {
+	t.Helper()
 	return storageDirEntriesExcept(t, firmwareDir, "staging")
 }
 
@@ -110,7 +115,7 @@ func TestSaveFirmwareFile_StreamsToDisk(t *testing.T) {
 	content := "fake firmware content"
 	reader := strings.NewReader(content)
 
-	fileID, err := svc.SaveFirmwareFile("firmware-v2.0.swu", reader)
+	fileID, err := svc.SaveFirmwareFile("firmware-v2.0.swu", reader, testFirmwareMetadata())
 
 	require.NoError(t, err)
 	assert.NotEmpty(t, fileID)
@@ -124,10 +129,37 @@ func TestSaveFirmwareFile_StreamsToDisk(t *testing.T) {
 	assert.Equal(t, "firmware-v2.0.swu", filepath.Base(filePath))
 }
 
+func TestSaveFirmwareFile_WritesTargetMetadata(t *testing.T) {
+	svc := setupService(t)
+
+	fileID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader("data"), testFirmwareMetadata())
+	require.NoError(t, err)
+
+	metadata, err := svc.GetFirmwareMetadata(fileID)
+	require.NoError(t, err)
+	assert.Equal(t, testFirmwareMetadata(), metadata)
+
+	files, err := svc.ListFirmwareFiles()
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	assert.Equal(t, "Proto", files[0].TargetManufacturer)
+	assert.Equal(t, "S21", files[0].TargetModel)
+}
+
+func TestSaveFirmwareFile_RejectsMissingTargetMetadata(t *testing.T) {
+	svc := setupService(t)
+
+	_, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader("data"), FirmwareMetadata{})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "target_manufacturer")
+	assert.Empty(t, firmwareFileEntries(t), "invalid upload should not leave files behind")
+}
+
 func TestSaveFirmwareFile_SanitizesFilename(t *testing.T) {
 	svc := setupService(t)
 
-	fileID, err := svc.SaveFirmwareFile("../../etc/passwd", strings.NewReader("data"))
+	fileID, err := svc.SaveFirmwareFile("../../etc/passwd", strings.NewReader("data"), testFirmwareMetadata())
 
 	require.NoError(t, err)
 
@@ -141,7 +173,7 @@ func TestSaveFirmwareFile_RejectsOversizedStream(t *testing.T) {
 	svc.maxFirmwareFileSize = 10
 
 	oversizedData := strings.Repeat("x", 20)
-	_, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(oversizedData))
+	_, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(oversizedData), testFirmwareMetadata())
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "too large")
@@ -153,10 +185,10 @@ func TestSaveFirmwareFile_IdenticalContentGetsDifferentIDs(t *testing.T) {
 	svc := setupService(t)
 
 	content := "identical firmware content"
-	id1, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content))
+	id1, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content), testFirmwareMetadata())
 	require.NoError(t, err)
 
-	id2, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content))
+	id2, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content), testFirmwareMetadata())
 	require.NoError(t, err)
 
 	assert.NotEqual(t, id1, id2, "each save should produce a unique fileID even for identical content")
@@ -165,10 +197,10 @@ func TestSaveFirmwareFile_IdenticalContentGetsDifferentIDs(t *testing.T) {
 func TestSaveFirmwareFile_DifferentContentGetsDifferentID(t *testing.T) {
 	svc := setupService(t)
 
-	id1, err := svc.SaveFirmwareFile("firmware-a.swu", strings.NewReader("content A"))
+	id1, err := svc.SaveFirmwareFile("firmware-a.swu", strings.NewReader("content A"), testFirmwareMetadata())
 	require.NoError(t, err)
 
-	id2, err := svc.SaveFirmwareFile("firmware-b.swu", strings.NewReader("content B"))
+	id2, err := svc.SaveFirmwareFile("firmware-b.swu", strings.NewReader("content B"), testFirmwareMetadata())
 	require.NoError(t, err)
 
 	assert.NotEqual(t, id1, id2, "different content should produce different fileIDs")
@@ -178,10 +210,10 @@ func TestSaveFirmwareFile_EachSaveCreatesOwnDirectory(t *testing.T) {
 	svc := setupService(t)
 
 	content := "same content twice"
-	_, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content))
+	_, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content), testFirmwareMetadata())
 	require.NoError(t, err)
 
-	_, err = svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content))
+	_, err = svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content), testFirmwareMetadata())
 	require.NoError(t, err)
 
 	assert.Len(t, firmwareFileEntries(t), 2, "each save should create its own directory on disk")
@@ -216,7 +248,7 @@ func TestOpenFirmwareFile_ReturnsReaderAndMetadata(t *testing.T) {
 	svc := setupService(t)
 
 	content := "firmware binary data here"
-	fileID, err := svc.SaveFirmwareFile("update.swu", strings.NewReader(content))
+	fileID, err := svc.SaveFirmwareFile("update.swu", strings.NewReader(content), testFirmwareMetadata())
 	require.NoError(t, err)
 
 	reader, filename, size, err := svc.OpenFirmwareFile(fileID)
@@ -231,44 +263,22 @@ func TestOpenFirmwareFile_ReturnsReaderAndMetadata(t *testing.T) {
 	assert.Equal(t, content, string(data))
 }
 
-func TestOpenFirmwareFileWithInfo_ReturnsReaderAndChecksum(t *testing.T) {
+func TestOpenFirmwareFile_IgnoresMetadataSidecar(t *testing.T) {
 	svc := setupService(t)
 
-	content := "firmware binary data here"
-	fileID, err := svc.SaveFirmwareFile("update.swu", strings.NewReader(content))
+	content := "firmware payload"
+	fileID, err := svc.SaveFirmwareFile("update.swu", strings.NewReader(content), testFirmwareMetadata())
 	require.NoError(t, err)
 
-	reader, info, err := svc.OpenFirmwareFileWithInfo(fileID)
+	reader, filename, size, err := svc.OpenFirmwareFile(fileID)
 	require.NoError(t, err)
 	defer reader.Close()
-
-	assert.Equal(t, fileID, info.ID)
-	assert.Equal(t, "update.swu", info.Filename)
-	assert.Equal(t, int64(len(content)), info.Size)
-	assert.Equal(t, checksumOf(content), info.SHA256)
-	assert.Equal(t, filepath.Join(firmwareDir, fileID, "update.swu"), info.FilePath)
 
 	data, err := io.ReadAll(reader)
 	require.NoError(t, err)
+	assert.Equal(t, "update.swu", filename)
+	assert.Equal(t, int64(len(content)), size)
 	assert.Equal(t, content, string(data))
-}
-
-func TestOpenFirmwareFileWithInfo_RebuildsMissingChecksumIndexEntry(t *testing.T) {
-	svc := setupService(t)
-
-	content := "firmware binary data here"
-	fileID, err := svc.SaveFirmwareFile("update.swu", strings.NewReader(content))
-	require.NoError(t, err)
-	svc.checksumIndex = make(map[string][]string)
-	svc.firmwareChecksumByID = make(map[string]string)
-
-	reader, info, err := svc.OpenFirmwareFileWithInfo(fileID)
-	require.NoError(t, err)
-	defer reader.Close()
-
-	assert.Equal(t, checksumOf(content), info.SHA256)
-	assert.Equal(t, []string{fileID}, svc.checksumIndex[checksumOf(content)])
-	assert.Equal(t, checksumOf(content), svc.firmwareChecksumByID[fileID])
 }
 
 func TestOpenFirmwareFile_ReturnsErrorForMissing(t *testing.T) {
@@ -288,26 +298,14 @@ func TestOpenFirmwareFile_RejectsPathTraversal(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid firmware file ID")
 }
 
-func TestOpenFirmwareFileWithInfo_RejectsInvalidOrMissingID(t *testing.T) {
-	svc := setupService(t)
-
-	_, _, err := svc.OpenFirmwareFileWithInfo("../logs/tmp")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid firmware file ID")
-
-	_, _, err = svc.OpenFirmwareFileWithInfo("00000000-0000-0000-0000-000000000000")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "firmware file not found")
-}
-
 func TestFindFirmwareFileByChecksum_ReturnsTrueForExistingFile(t *testing.T) {
 	svc := setupService(t)
 
 	content := "findable firmware content"
-	fileID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content))
+	fileID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content), testFirmwareMetadata())
 	require.NoError(t, err)
 
-	foundID, ok := svc.FindFirmwareFileByChecksum(checksumOf(content))
+	foundID, ok := svc.FindFirmwareFileByChecksum(checksumOf(content), testFirmwareMetadata())
 	assert.True(t, ok)
 	assert.Equal(t, fileID, foundID)
 }
@@ -315,29 +313,60 @@ func TestFindFirmwareFileByChecksum_ReturnsTrueForExistingFile(t *testing.T) {
 func TestFindFirmwareFileByChecksum_ReturnsFalseForUnknownChecksum(t *testing.T) {
 	svc := setupService(t)
 
-	foundID, ok := svc.FindFirmwareFileByChecksum("0000000000000000000000000000000000000000000000000000000000000000")
+	foundID, ok := svc.FindFirmwareFileByChecksum("0000000000000000000000000000000000000000000000000000000000000000", testFirmwareMetadata())
 	assert.False(t, ok)
 	assert.Empty(t, foundID)
+}
+
+func TestFindFirmwareFileByChecksum_RequiresMatchingTargetMetadata(t *testing.T) {
+	svc := setupService(t)
+
+	content := "same firmware content"
+	fileID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content), testFirmwareMetadata())
+	require.NoError(t, err)
+
+	foundID, ok := svc.FindFirmwareFileByChecksum(checksumOf(content), FirmwareMetadata{TargetManufacturer: "Proto", TargetModel: "S19"})
+	assert.False(t, ok)
+	assert.Empty(t, foundID)
+
+	foundID, ok = svc.FindFirmwareFileByChecksum(checksumOf(content), testFirmwareMetadata())
+	assert.True(t, ok)
+	assert.Equal(t, fileID, foundID)
+}
+
+func TestFindFirmwareFileByChecksum_DeletesInvalidMetadataDirectory(t *testing.T) {
+	svc := setupService(t)
+
+	content := "firmware with corrupted metadata"
+	fileID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content), testFirmwareMetadata())
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(getFirmwareDirPath(fileID), firmwareMetadataFilename), []byte(`not json`), 0600))
+
+	foundID, ok := svc.FindFirmwareFileByChecksum(checksumOf(content), testFirmwareMetadata())
+
+	assert.False(t, ok)
+	assert.Empty(t, foundID)
+	assert.NoDirExists(t, getFirmwareDirPath(fileID))
 }
 
 func TestFindFirmwareFileByChecksum_ReturnsFalseAfterDelete(t *testing.T) {
 	svc := setupService(t)
 
 	content := "firmware to find then delete"
-	fileID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content))
+	fileID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content), testFirmwareMetadata())
 	require.NoError(t, err)
 
 	err = svc.DeleteFirmwareFile(fileID)
 	require.NoError(t, err)
 
-	_, ok := svc.FindFirmwareFileByChecksum(checksumOf(content))
+	_, ok := svc.FindFirmwareFileByChecksum(checksumOf(content), testFirmwareMetadata())
 	assert.False(t, ok)
 }
 
 func TestDeleteFirmwareFile_RemovesDirectory(t *testing.T) {
 	svc := setupService(t)
 
-	fileID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader("data"))
+	fileID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader("data"), testFirmwareMetadata())
 	require.NoError(t, err)
 
 	dir := getFirmwareDirPath(fileID)
@@ -353,16 +382,15 @@ func TestDeleteFirmwareFile_RemovesFromChecksumIndex(t *testing.T) {
 	svc := setupService(t)
 
 	content := "firmware to delete and re-upload"
-	fileID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content))
+	fileID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content), testFirmwareMetadata())
 	require.NoError(t, err)
 
 	err = svc.DeleteFirmwareFile(fileID)
 	require.NoError(t, err)
 
 	assert.Empty(t, svc.checksumIndex, "checksumIndex should be empty after delete")
-	assert.Empty(t, svc.firmwareChecksumByID, "firmwareChecksumByID should be empty after delete")
 
-	newID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content))
+	newID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content), testFirmwareMetadata())
 	require.NoError(t, err)
 	assert.NotEqual(t, fileID, newID, "re-upload after delete should get a new fileID")
 }
@@ -413,7 +441,7 @@ func TestNewService_PreservesExistingFirmwareFilesAcrossRestart(t *testing.T) {
 	require.NoError(t, err)
 
 	content := "persisted firmware data"
-	fileID, err := svc.SaveFirmwareFile("persisted.swu", strings.NewReader(content))
+	fileID, err := svc.SaveFirmwareFile("persisted.swu", strings.NewReader(content), testFirmwareMetadata())
 	require.NoError(t, err)
 
 	restartedSvc, err := NewService(Config{})
@@ -431,6 +459,32 @@ func TestNewService_PreservesExistingFirmwareFilesAcrossRestart(t *testing.T) {
 	assert.Equal(t, content, string(data))
 }
 
+func TestNewService_DeletesLegacyFirmwareDirectoriesWithoutMetadata(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+
+	require.NoError(t, os.MkdirAll(filepath.Join(firmwareDir, "11111111-1111-1111-1111-111111111111"), 0750))
+	require.NoError(t, os.WriteFile(filepath.Join(firmwareDir, "11111111-1111-1111-1111-111111111111", "legacy.swu"), []byte("legacy"), 0600))
+
+	_, err := NewService(Config{})
+	require.NoError(t, err)
+
+	assert.NoDirExists(t, filepath.Join(firmwareDir, "11111111-1111-1111-1111-111111111111"))
+}
+
+func TestListFirmwareFiles_DeletesInvalidMetadataDirectories(t *testing.T) {
+	svc := setupService(t)
+
+	fileID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader("data"), testFirmwareMetadata())
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(getFirmwareDirPath(fileID), firmwareMetadataFilename), []byte(`{"target_manufacturer":"","target_model":"S21"}`), 0600))
+
+	files, err := svc.ListFirmwareFiles()
+	require.NoError(t, err)
+	assert.Empty(t, files)
+	assert.NoDirExists(t, getFirmwareDirPath(fileID))
+}
+
 func TestInitChecksumIndex_RebuildsOnRestart(t *testing.T) {
 	tmp := t.TempDir()
 	t.Chdir(tmp)
@@ -439,13 +493,13 @@ func TestInitChecksumIndex_RebuildsOnRestart(t *testing.T) {
 	require.NoError(t, err)
 
 	content := "firmware for restart test"
-	fileID, err := svc1.SaveFirmwareFile("firmware.swu", strings.NewReader(content))
+	fileID, err := svc1.SaveFirmwareFile("firmware.swu", strings.NewReader(content), testFirmwareMetadata())
 	require.NoError(t, err)
 
 	svc2, err := NewService(Config{})
 	require.NoError(t, err)
 
-	foundID, ok := svc2.FindFirmwareFileByChecksum(checksumOf(content))
+	foundID, ok := svc2.FindFirmwareFileByChecksum(checksumOf(content), testFirmwareMetadata())
 	assert.True(t, ok, "after restart, checksum index should contain the existing file")
 	assert.Equal(t, fileID, foundID)
 }
@@ -453,7 +507,7 @@ func TestInitChecksumIndex_RebuildsOnRestart(t *testing.T) {
 func TestSaveFirmwareFile_RejectsEmptyStream(t *testing.T) {
 	svc := setupService(t)
 
-	_, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(""))
+	_, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(""), testFirmwareMetadata())
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "empty")
@@ -465,10 +519,10 @@ func TestSaveFirmwareFile_IndependentDeletion(t *testing.T) {
 	svc := setupService(t)
 
 	content := "shared firmware content"
-	id1, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content))
+	id1, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content), testFirmwareMetadata())
 	require.NoError(t, err)
 
-	id2, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content))
+	id2, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content), testFirmwareMetadata())
 	require.NoError(t, err)
 
 	err = svc.DeleteFirmwareFile(id1)
@@ -486,16 +540,16 @@ func TestFindFirmwareFileByChecksum_SurvivesPartialDeletion(t *testing.T) {
 	svc := setupService(t)
 
 	content := "firmware uploaded by two batches"
-	id1, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content))
+	id1, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content), testFirmwareMetadata())
 	require.NoError(t, err)
 
-	id2, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content))
+	id2, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content), testFirmwareMetadata())
 	require.NoError(t, err)
 
 	err = svc.DeleteFirmwareFile(id2)
 	require.NoError(t, err)
 
-	foundID, ok := svc.FindFirmwareFileByChecksum(checksumOf(content))
+	foundID, ok := svc.FindFirmwareFileByChecksum(checksumOf(content), testFirmwareMetadata())
 	assert.True(t, ok, "checksum lookup should still succeed after deleting one of two identical uploads")
 	assert.Equal(t, id1, foundID)
 }
@@ -551,7 +605,7 @@ func TestSaveFirmwareFileFromPath_MovesAndRegistersChecksum(t *testing.T) {
 	srcPath := filepath.Join(firmwareStagingDir, "test-upload")
 	require.NoError(t, os.WriteFile(srcPath, []byte(content), 0600))
 
-	fileID, err := svc.SaveFirmwareFileFromPath("chunked.swu", srcPath)
+	fileID, err := svc.SaveFirmwareFileFromPath("chunked.swu", srcPath, testFirmwareMetadata())
 	require.NoError(t, err)
 	assert.NotEmpty(t, fileID)
 
@@ -563,7 +617,7 @@ func TestSaveFirmwareFileFromPath_MovesAndRegistersChecksum(t *testing.T) {
 	assert.Equal(t, content, string(data))
 	assert.Equal(t, "chunked.swu", filepath.Base(filePath))
 
-	foundID, ok := svc.FindFirmwareFileByChecksum(checksumOf(content))
+	foundID, ok := svc.FindFirmwareFileByChecksum(checksumOf(content), testFirmwareMetadata())
 	assert.True(t, ok, "checksum index should contain the file after SaveFirmwareFileFromPath")
 	assert.Equal(t, fileID, foundID)
 
@@ -577,7 +631,7 @@ func TestSaveFirmwareFileFromPath_RejectsEmptyFile(t *testing.T) {
 	srcPath := filepath.Join(firmwareStagingDir, "empty-upload")
 	require.NoError(t, os.WriteFile(srcPath, []byte{}, 0600))
 
-	_, err := svc.SaveFirmwareFileFromPath("empty.swu", srcPath)
+	_, err := svc.SaveFirmwareFileFromPath("empty.swu", srcPath, testFirmwareMetadata())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "empty")
 }
@@ -594,10 +648,10 @@ func TestListFirmwareFiles_EmptyReturnsEmptySlice(t *testing.T) {
 func TestListFirmwareFiles_ReturnsSavedFiles(t *testing.T) {
 	svc := setupService(t)
 
-	id1, err := svc.SaveFirmwareFile("alpha.swu", strings.NewReader("alpha content"))
+	id1, err := svc.SaveFirmwareFile("alpha.swu", strings.NewReader("alpha content"), testFirmwareMetadata())
 	require.NoError(t, err)
 
-	id2, err := svc.SaveFirmwareFile("beta.tar.gz", strings.NewReader("beta content here"))
+	id2, err := svc.SaveFirmwareFile("beta.tar.gz", strings.NewReader("beta content here"), testFirmwareMetadata())
 	require.NoError(t, err)
 
 	files, err := svc.ListFirmwareFiles()
@@ -626,7 +680,7 @@ func TestListFirmwareFiles_SkipsStagingDir(t *testing.T) {
 	// Place a file in the staging dir
 	require.NoError(t, os.WriteFile(filepath.Join(firmwareStagingDir, "orphan"), []byte("data"), 0600))
 
-	_, err := svc.SaveFirmwareFile("real.swu", strings.NewReader("real content"))
+	_, err := svc.SaveFirmwareFile("real.swu", strings.NewReader("real content"), testFirmwareMetadata())
 	require.NoError(t, err)
 
 	files, err := svc.ListFirmwareFiles()
@@ -638,10 +692,10 @@ func TestListFirmwareFiles_SkipsStagingDir(t *testing.T) {
 func TestListFirmwareFiles_SortedByUploadTimeDescending(t *testing.T) {
 	svc := setupService(t)
 
-	_, err := svc.SaveFirmwareFile("first.swu", strings.NewReader("first"))
+	_, err := svc.SaveFirmwareFile("first.swu", strings.NewReader("first"), testFirmwareMetadata())
 	require.NoError(t, err)
 
-	_, err = svc.SaveFirmwareFile("second.swu", strings.NewReader("second"))
+	_, err = svc.SaveFirmwareFile("second.swu", strings.NewReader("second"), testFirmwareMetadata())
 	require.NoError(t, err)
 
 	files, err := svc.ListFirmwareFiles()
@@ -654,9 +708,9 @@ func TestListFirmwareFiles_SortedByUploadTimeDescending(t *testing.T) {
 func TestDeleteAllFirmwareFiles_RemovesAllFiles(t *testing.T) {
 	svc := setupService(t)
 
-	_, err := svc.SaveFirmwareFile("one.swu", strings.NewReader("one"))
+	_, err := svc.SaveFirmwareFile("one.swu", strings.NewReader("one"), testFirmwareMetadata())
 	require.NoError(t, err)
-	_, err = svc.SaveFirmwareFile("two.swu", strings.NewReader("two"))
+	_, err = svc.SaveFirmwareFile("two.swu", strings.NewReader("two"), testFirmwareMetadata())
 	require.NoError(t, err)
 
 	deleted, err := svc.DeleteAllFirmwareFiles()
@@ -680,15 +734,15 @@ func TestDeleteAllFirmwareFiles_CleansChecksumIndex(t *testing.T) {
 	svc := setupService(t)
 
 	content := "firmware for checksum cleanup test"
-	_, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content))
+	_, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content), testFirmwareMetadata())
 	require.NoError(t, err)
 
-	_, ok := svc.FindFirmwareFileByChecksum(checksumOf(content))
+	_, ok := svc.FindFirmwareFileByChecksum(checksumOf(content), testFirmwareMetadata())
 	require.True(t, ok, "checksum should be found before delete-all")
 
 	_, err = svc.DeleteAllFirmwareFiles()
 	require.NoError(t, err)
 
-	_, ok = svc.FindFirmwareFileByChecksum(checksumOf(content))
+	_, ok = svc.FindFirmwareFileByChecksum(checksumOf(content), testFirmwareMetadata())
 	assert.False(t, ok, "checksum should not be found after delete-all")
 }

--- a/server/internal/infrastructure/files/firmware_test.go
+++ b/server/internal/infrastructure/files/firmware_test.go
@@ -144,6 +144,10 @@ func TestSaveFirmwareFile_WritesTargetMetadata(t *testing.T) {
 	require.Len(t, files, 1)
 	assert.Equal(t, "Proto", files[0].TargetManufacturer)
 	assert.Equal(t, "S21", files[0].TargetModel)
+
+	publishedEntries := storageDirEntries(t, getFirmwareDirPath(fileID))
+	require.Len(t, publishedEntries, 2)
+	assert.Empty(t, storageDirEntries(t, firmwareStagingDir))
 }
 
 func TestSaveFirmwareFile_RejectsMissingTargetMetadata(t *testing.T) {
@@ -334,7 +338,7 @@ func TestFindFirmwareFileByChecksum_RequiresMatchingTargetMetadata(t *testing.T)
 	assert.Equal(t, fileID, foundID)
 }
 
-func TestFindFirmwareFileByChecksum_DeletesInvalidMetadataDirectory(t *testing.T) {
+func TestFindFirmwareFileByChecksum_PreservesInvalidMetadataDirectory(t *testing.T) {
 	svc := setupService(t)
 
 	content := "firmware with corrupted metadata"
@@ -346,7 +350,8 @@ func TestFindFirmwareFileByChecksum_DeletesInvalidMetadataDirectory(t *testing.T
 
 	assert.False(t, ok)
 	assert.Empty(t, foundID)
-	assert.NoDirExists(t, getFirmwareDirPath(fileID))
+	assert.DirExists(t, getFirmwareDirPath(fileID))
+	assert.NotContains(t, svc.firmwareChecksumByID, fileID)
 }
 
 func TestFindFirmwareFileByChecksum_ReturnsFalseAfterDelete(t *testing.T) {
@@ -459,20 +464,62 @@ func TestNewService_PreservesExistingFirmwareFilesAcrossRestart(t *testing.T) {
 	assert.Equal(t, content, string(data))
 }
 
-func TestNewService_DeletesLegacyFirmwareDirectoriesWithoutMetadata(t *testing.T) {
+func TestNewService_PreservesLegacyFirmwareDirectoriesWithoutMetadata(t *testing.T) {
 	tmp := t.TempDir()
 	t.Chdir(tmp)
 
 	require.NoError(t, os.MkdirAll(filepath.Join(firmwareDir, "11111111-1111-1111-1111-111111111111"), 0750))
 	require.NoError(t, os.WriteFile(filepath.Join(firmwareDir, "11111111-1111-1111-1111-111111111111", "legacy.swu"), []byte("legacy"), 0600))
 
-	_, err := NewService(Config{})
+	svc, err := NewService(Config{})
 	require.NoError(t, err)
 
-	assert.NoDirExists(t, filepath.Join(firmwareDir, "11111111-1111-1111-1111-111111111111"))
+	legacyDir := filepath.Join(firmwareDir, "11111111-1111-1111-1111-111111111111")
+	assert.DirExists(t, legacyDir)
+
+	listed, err := svc.ListFirmwareFiles()
+	require.NoError(t, err)
+	require.Len(t, listed, 1)
+	assert.Empty(t, listed[0].TargetManufacturer)
+	assert.Empty(t, listed[0].TargetModel)
+	assert.Empty(t, listed[0].FirmwareVersion)
+
+	reader, filename, _, err := svc.OpenFirmwareFile("11111111-1111-1111-1111-111111111111")
+	require.NoError(t, err)
+	defer reader.Close()
+	assert.Equal(t, "legacy.swu", filename)
+	assert.Empty(t, svc.checksumIndex, "legacy firmware must not enter the checksum reuse index")
+
+	foundID, ok := svc.FindFirmwareFileByChecksum(checksumOf("legacy"), testFirmwareMetadata())
+	assert.False(t, ok)
+	assert.Empty(t, foundID)
 }
 
-func TestListFirmwareFiles_DeletesInvalidMetadataDirectories(t *testing.T) {
+func TestNewService_PreservesCorruptFirmwareMetadataDirectories(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	const fileID = "11111111-1111-1111-1111-111111111111"
+	dir := getFirmwareDirPath(fileID)
+	require.NoError(t, os.MkdirAll(dir, 0750))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "corrupt.swu"), []byte("corrupt"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, firmwareMetadataFilename), []byte("not-json"), 0600))
+
+	svc, err := NewService(Config{})
+	require.NoError(t, err)
+	assert.FileExists(t, filepath.Join(dir, "corrupt.swu"))
+
+	listed, err := svc.ListFirmwareFiles()
+	require.NoError(t, err)
+	assert.Empty(t, listed)
+	assert.FileExists(t, filepath.Join(dir, "corrupt.swu"))
+
+	foundID, ok := svc.FindFirmwareFileByChecksum(checksumOf("corrupt"), testFirmwareMetadata())
+	assert.False(t, ok)
+	assert.Empty(t, foundID)
+	assert.FileExists(t, filepath.Join(dir, "corrupt.swu"))
+}
+
+func TestListFirmwareFiles_PreservesInvalidMetadataDirectories(t *testing.T) {
 	svc := setupService(t)
 
 	fileID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader("data"), testFirmwareMetadata())
@@ -482,7 +529,20 @@ func TestListFirmwareFiles_DeletesInvalidMetadataDirectories(t *testing.T) {
 	files, err := svc.ListFirmwareFiles()
 	require.NoError(t, err)
 	assert.Empty(t, files)
-	assert.NoDirExists(t, getFirmwareDirPath(fileID))
+	assert.DirExists(t, getFirmwareDirPath(fileID))
+}
+
+func TestNewService_CleansOrphanedFirmwareStagingFilesAndDirectories(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+
+	require.NoError(t, os.MkdirAll(filepath.Join(firmwareStagingDir, "publish-orphan"), 0750))
+	require.NoError(t, os.WriteFile(filepath.Join(firmwareStagingDir, "publish-orphan", "payload.swu"), []byte("data"), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(firmwareStagingDir, "upload-orphan"), []byte("data"), 0600))
+
+	_, err := NewService(Config{})
+	require.NoError(t, err)
+	assert.Empty(t, storageDirEntries(t, firmwareStagingDir))
 }
 
 func TestInitChecksumIndex_RebuildsOnRestart(t *testing.T) {

--- a/server/internal/infrastructure/files/firmware_test.go
+++ b/server/internal/infrastructure/files/firmware_test.go
@@ -723,15 +723,16 @@ func TestAllowedExtensionsList_IsDeterministic(t *testing.T) {
 	}
 }
 
-func TestSaveFirmwareFileFromPath_MovesAndRegistersChecksum(t *testing.T) {
+func TestSaveFirmwareUploadFromPath_MovesAndRegistersChecksum(t *testing.T) {
 	svc := setupService(t)
 
 	content := "firmware via chunked upload"
 	srcPath := filepath.Join(firmwareStagingDir, "test-upload")
 	require.NoError(t, os.WriteFile(srcPath, []byte(content), 0600))
 
-	fileID, err := svc.SaveFirmwareFileFromPath("chunked.swu", srcPath, testFirmwareMetadata())
+	result, err := svc.SaveFirmwareUploadFromPath("chunked.swu", srcPath, testFirmwareMetadata(), true, "")
 	require.NoError(t, err)
+	fileID := result.FirmwareFileID
 	assert.NotEmpty(t, fileID)
 
 	filePath, err := svc.GetFirmwareFilePath(fileID)
@@ -743,7 +744,7 @@ func TestSaveFirmwareFileFromPath_MovesAndRegistersChecksum(t *testing.T) {
 	assert.Equal(t, "chunked.swu", filepath.Base(filePath))
 
 	foundID, ok := svc.FindFirmwareFileByChecksum(checksumOf(content), testFirmwareMetadata())
-	assert.True(t, ok, "checksum index should contain the file after SaveFirmwareFileFromPath")
+	assert.True(t, ok, "checksum index should contain the file after SaveFirmwareUploadFromPath")
 	assert.Equal(t, fileID, foundID)
 
 	_, statErr := os.Stat(srcPath)
@@ -804,13 +805,13 @@ func TestSaveFirmwareUpload_ForceBypassesDedupe(t *testing.T) {
 	assert.Len(t, firmwareFileEntries(t), 2)
 }
 
-func TestSaveFirmwareFileFromPath_RejectsEmptyFile(t *testing.T) {
+func TestSaveFirmwareUploadFromPath_RejectsEmptyFile(t *testing.T) {
 	svc := setupService(t)
 
 	srcPath := filepath.Join(firmwareStagingDir, "empty-upload")
 	require.NoError(t, os.WriteFile(srcPath, []byte{}, 0600))
 
-	_, err := svc.SaveFirmwareFileFromPath("empty.swu", srcPath, testFirmwareMetadata())
+	_, err := svc.SaveFirmwareUploadFromPath("empty.swu", srcPath, testFirmwareMetadata(), true, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "empty")
 }

--- a/server/internal/infrastructure/files/firmware_test.go
+++ b/server/internal/infrastructure/files/firmware_test.go
@@ -20,7 +20,7 @@ func checksumOf(content string) string {
 }
 
 func testFirmwareMetadata() FirmwareMetadata {
-	return FirmwareMetadata{TargetManufacturer: "Proto", TargetModel: "S21"}
+	return FirmwareMetadata{TargetManufacturer: "Proto", TargetModel: "S21", FirmwareVersion: "v2.0.0"}
 }
 
 func storageDirEntries(t *testing.T, dir string) []os.DirEntry {
@@ -623,6 +623,60 @@ func TestSaveFirmwareFileFromPath_MovesAndRegistersChecksum(t *testing.T) {
 
 	_, statErr := os.Stat(srcPath)
 	assert.True(t, os.IsNotExist(statErr), "source file should be removed after rename")
+}
+
+func TestSaveFirmwareUpload_UsesManualMetadata(t *testing.T) {
+	svc := setupService(t)
+	content := "firmware content"
+
+	result, err := svc.SaveFirmwareUpload("proto-rig.swu", strings.NewReader(content), testFirmwareMetadata(), false)
+
+	require.NoError(t, err)
+	assert.False(t, result.Reused)
+	assert.Equal(t, testFirmwareMetadata(), result.Metadata)
+
+	metadata, err := svc.GetFirmwareMetadata(result.FirmwareFileID)
+	require.NoError(t, err)
+	assert.Equal(t, result.Metadata, metadata)
+}
+
+func TestSaveFirmwareUpload_RejectsMissingMetadata(t *testing.T) {
+	svc := setupService(t)
+
+	_, err := svc.SaveFirmwareUpload("vendor.swu", strings.NewReader("firmware content"), FirmwareMetadata{}, false)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "target_manufacturer")
+}
+
+func TestSaveFirmwareUpload_ReusesExistingWithSameMetadata(t *testing.T) {
+	svc := setupService(t)
+	content := "firmware content"
+
+	first, err := svc.SaveFirmwareUpload("proto-rig.swu", strings.NewReader(content), testFirmwareMetadata(), false)
+	require.NoError(t, err)
+
+	second, err := svc.SaveFirmwareUpload("proto-rig.swu", strings.NewReader(content), testFirmwareMetadata(), false)
+	require.NoError(t, err)
+
+	assert.True(t, second.Reused)
+	assert.Equal(t, first.FirmwareFileID, second.FirmwareFileID)
+	assert.Len(t, firmwareFileEntries(t), 1)
+}
+
+func TestSaveFirmwareUpload_ForceBypassesDedupe(t *testing.T) {
+	svc := setupService(t)
+	content := "firmware content"
+
+	first, err := svc.SaveFirmwareUpload("proto-rig.swu", strings.NewReader(content), testFirmwareMetadata(), false)
+	require.NoError(t, err)
+
+	second, err := svc.SaveFirmwareUpload("proto-rig.swu", strings.NewReader(content), testFirmwareMetadata(), true)
+	require.NoError(t, err)
+
+	assert.False(t, second.Reused)
+	assert.NotEqual(t, first.FirmwareFileID, second.FirmwareFileID)
+	assert.Len(t, firmwareFileEntries(t), 2)
 }
 
 func TestSaveFirmwareFileFromPath_RejectsEmptyFile(t *testing.T) {

--- a/server/internal/infrastructure/files/firmware_test.go
+++ b/server/internal/infrastructure/files/firmware_test.go
@@ -150,6 +150,71 @@ func TestSaveFirmwareFile_WritesTargetMetadata(t *testing.T) {
 	assert.Empty(t, storageDirEntries(t, firmwareStagingDir))
 }
 
+func TestUpdateFirmwareMetadata_ReplacesMetadataAndChecksumTarget(t *testing.T) {
+	svc := setupService(t)
+	content := "firmware metadata update"
+	fileID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content), testFirmwareMetadata())
+	require.NoError(t, err)
+
+	updated := FirmwareMetadata{
+		TargetManufacturer: " Bitmain ",
+		TargetModel:        " S19 ",
+		FirmwareVersion:    " v3.0.0 ",
+	}
+	require.NoError(t, svc.UpdateFirmwareMetadata(fileID, updated))
+
+	metadata, err := svc.GetFirmwareMetadata(fileID)
+	require.NoError(t, err)
+	assert.Equal(t, FirmwareMetadata{
+		TargetManufacturer: "Bitmain",
+		TargetModel:        "S19",
+		FirmwareVersion:    "v3.0.0",
+	}, metadata)
+
+	_, found := svc.FindFirmwareFileByChecksum(checksumOf(content), testFirmwareMetadata())
+	assert.False(t, found)
+	foundID, found := svc.FindFirmwareFileByChecksum(checksumOf(content), metadata)
+	assert.True(t, found)
+	assert.Equal(t, fileID, foundID)
+
+	entries := storageDirEntries(t, getFirmwareDirPath(fileID))
+	assert.Len(t, entries, 2, "atomic metadata replacement should not leave staging files")
+}
+
+func TestUpdateFirmwareMetadata_AddsMetadataToLegacyPayload(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+
+	const fileID = "11111111-1111-1111-1111-111111111111"
+	dir := getFirmwareDirPath(fileID)
+	require.NoError(t, os.MkdirAll(dir, 0750))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "legacy.swu"), []byte("legacy"), 0600))
+
+	svc, err := NewService(Config{})
+	require.NoError(t, err)
+	require.NoError(t, svc.UpdateFirmwareMetadata(fileID, testFirmwareMetadata()))
+
+	metadata, err := svc.GetFirmwareMetadata(fileID)
+	require.NoError(t, err)
+	assert.Equal(t, testFirmwareMetadata(), metadata)
+	foundID, found := svc.FindFirmwareFileByChecksum(checksumOf("legacy"), testFirmwareMetadata())
+	assert.True(t, found)
+	assert.Equal(t, fileID, foundID)
+}
+
+func TestUpdateFirmwareMetadata_RejectsIncompleteMetadataWithoutChangingSidecar(t *testing.T) {
+	svc := setupService(t)
+	fileID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader("data"), testFirmwareMetadata())
+	require.NoError(t, err)
+
+	err = svc.UpdateFirmwareMetadata(fileID, FirmwareMetadata{TargetManufacturer: "Proto"})
+	require.Error(t, err)
+
+	metadata, readErr := svc.GetFirmwareMetadata(fileID)
+	require.NoError(t, readErr)
+	assert.Equal(t, testFirmwareMetadata(), metadata)
+}
+
 func TestSaveFirmwareFile_RejectsMissingTargetMetadata(t *testing.T) {
 	svc := setupService(t)
 

--- a/server/internal/infrastructure/files/firmware_test.go
+++ b/server/internal/infrastructure/files/firmware_test.go
@@ -154,6 +154,32 @@ func TestSaveFirmwareFile_WritesTargetMetadata(t *testing.T) {
 	assert.Empty(t, storageDirEntries(t, firmwareStagingDir))
 }
 
+func TestSaveFirmwareFile_RollsBackPublishedDirectoryWhenParentSyncFails(t *testing.T) {
+	svc := setupService(t)
+	const content = "firmware whose publish sync fails"
+
+	var syncedDirs []string
+	svc.syncFirmwareDir = func(dir string) error {
+		syncedDirs = append(syncedDirs, dir)
+		if len(syncedDirs) == 2 {
+			return errors.New("injected firmware directory sync failure")
+		}
+		return nil
+	}
+
+	_, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content), testFirmwareMetadata())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "injected firmware directory sync failure")
+	require.Len(t, syncedDirs, 3)
+	assert.Equal(t, firmwareStagingDir, filepath.Dir(syncedDirs[0]))
+	assert.Equal(t, []string{firmwareDir, firmwareDir}, syncedDirs[1:],
+		"rollback should sync the parent directory after removing the published entry")
+	assert.Empty(t, firmwareFileEntries(t), "failed publish sync should not leave visible firmware behind")
+	_, found := svc.FindFirmwareFileByChecksum(checksumOf(content), testFirmwareMetadata())
+	assert.False(t, found, "failed publish sync should not leak into the checksum index")
+}
+
 func TestUpdateFirmwareMetadata_ReplacesMetadataAndChecksumTarget(t *testing.T) {
 	svc := setupService(t)
 	content := "firmware metadata update"

--- a/server/internal/infrastructure/files/firmware_test.go
+++ b/server/internal/infrastructure/files/firmware_test.go
@@ -287,6 +287,23 @@ func TestSaveFirmwareFile_SanitizesFilename(t *testing.T) {
 	assert.Equal(t, "passwd", filepath.Base(filePath))
 }
 
+func TestSaveFirmwareFile_PreservesDotPrefixedFilename(t *testing.T) {
+	svc := setupService(t)
+	require.NoError(t, svc.ValidateFirmwareFilename(".firmware.swu"))
+
+	fileID, err := svc.SaveFirmwareFile(".firmware.swu", strings.NewReader("data"), testFirmwareMetadata())
+	require.NoError(t, err)
+
+	filePath, err := svc.GetFirmwareFilePath(fileID)
+	require.NoError(t, err)
+	assert.Equal(t, ".firmware.swu", filepath.Base(filePath))
+
+	listed, err := svc.ListFirmwareFiles()
+	require.NoError(t, err)
+	require.Len(t, listed, 1)
+	assert.Equal(t, ".firmware.swu", listed[0].Filename)
+}
+
 func TestSaveFirmwareFile_RejectsOversizedStream(t *testing.T) {
 	svc := setupService(t)
 	svc.maxFirmwareFileSize = 10

--- a/server/internal/infrastructure/files/firmware_test.go
+++ b/server/internal/infrastructure/files/firmware_test.go
@@ -7,7 +7,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 	"github.com/stretchr/testify/assert"
@@ -179,6 +181,54 @@ func TestUpdateFirmwareMetadata_ReplacesMetadataAndChecksumTarget(t *testing.T) 
 
 	entries := storageDirEntries(t, getFirmwareDirPath(fileID))
 	assert.Len(t, entries, 2, "atomic metadata replacement should not leave staging files")
+}
+
+func TestUpdateFirmwareMetadata_PreservesUploadTime(t *testing.T) {
+	svc := setupService(t)
+	fileID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader("data"), testFirmwareMetadata())
+	require.NoError(t, err)
+
+	before, err := svc.ListFirmwareFiles()
+	require.NoError(t, err)
+	require.Len(t, before, 1)
+
+	time.Sleep(10 * time.Millisecond)
+	require.NoError(t, svc.UpdateFirmwareMetadata(fileID, FirmwareMetadata{
+		TargetManufacturer: "Bitmain",
+		TargetModel:        "S19",
+		FirmwareVersion:    "v3.0.0",
+	}))
+
+	after, err := svc.ListFirmwareFiles()
+	require.NoError(t, err)
+	require.Len(t, after, 1)
+	assert.Equal(t, before[0].UploadedAt, after[0].UploadedAt)
+}
+
+func TestUpdateFirmwareMetadata_PersistsLegacyUploadTimeFallback(t *testing.T) {
+	svc := setupService(t)
+	fileID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader("data"), testFirmwareMetadata())
+	require.NoError(t, err)
+
+	dir := getFirmwareDirPath(fileID)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, firmwareMetadataFilename),
+		[]byte(`{"target_manufacturer":"Proto","target_model":"Rig","firmware_version":"v2.0.0"}`),
+		0600,
+	))
+	fallbackTime := time.Date(2025, time.January, 2, 3, 4, 5, 0, time.UTC)
+	require.NoError(t, os.Chtimes(dir, fallbackTime, fallbackTime))
+
+	require.NoError(t, svc.UpdateFirmwareMetadata(fileID, FirmwareMetadata{
+		TargetManufacturer: "Bitmain",
+		TargetModel:        "S19",
+		FirmwareVersion:    "v3.0.0",
+	}))
+
+	files, err := svc.ListFirmwareFiles()
+	require.NoError(t, err)
+	require.Len(t, files, 1)
+	assert.True(t, fallbackTime.Equal(files[0].UploadedAt))
 }
 
 func TestUpdateFirmwareMetadata_AddsMetadataToLegacyPayload(t *testing.T) {
@@ -788,6 +838,57 @@ func TestSaveFirmwareUpload_ReusesExistingWithSameMetadata(t *testing.T) {
 	assert.True(t, second.Reused)
 	assert.Equal(t, first.FirmwareFileID, second.FirmwareFileID)
 	assert.Len(t, firmwareFileEntries(t), 1)
+}
+
+func TestSaveFirmwareUpload_ConcurrentIdenticalUploadsReuseOneFile(t *testing.T) {
+	svc := setupService(t)
+	const uploadCount = 16
+
+	type uploadOutcome struct {
+		result FirmwareUploadSaveResult
+		err    error
+	}
+	start := make(chan struct{})
+	outcomes := make(chan uploadOutcome, uploadCount)
+	var wg sync.WaitGroup
+	for range uploadCount {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			result, err := svc.SaveFirmwareUpload(
+				"proto-rig.swu",
+				strings.NewReader("firmware content"),
+				testFirmwareMetadata(),
+				false,
+			)
+			outcomes <- uploadOutcome{result: result, err: err}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(outcomes)
+
+	var fileID string
+	newCount := 0
+	reusedCount := 0
+	for outcome := range outcomes {
+		require.NoError(t, outcome.err)
+		if fileID == "" {
+			fileID = outcome.result.FirmwareFileID
+		}
+		assert.Equal(t, fileID, outcome.result.FirmwareFileID)
+		if outcome.result.Reused {
+			reusedCount++
+		} else {
+			newCount++
+		}
+	}
+
+	assert.Equal(t, 1, newCount)
+	assert.Equal(t, uploadCount-1, reusedCount)
+	assert.Len(t, firmwareFileEntries(t), 1)
+	assert.Empty(t, svc.firmwareUploadLocks)
 }
 
 func TestSaveFirmwareUpload_ForceBypassesDedupe(t *testing.T) {

--- a/server/internal/infrastructure/files/firmware_test.go
+++ b/server/internal/infrastructure/files/firmware_test.go
@@ -154,6 +154,17 @@ func TestSaveFirmwareFile_WritesTargetMetadata(t *testing.T) {
 	assert.Empty(t, storageDirEntries(t, firmwareStagingDir))
 }
 
+func TestLeaseFirmwareMetadata_ReleasesReadLockOnError(t *testing.T) {
+	svc := setupService(t)
+
+	_, release, err := svc.LeaseFirmwareMetadata("not-a-uuid")
+
+	require.Error(t, err)
+	assert.Nil(t, release)
+	require.True(t, svc.firmwareMetadataReuseMu.TryLock(), "metadata lease error must release the lifecycle read lock")
+	svc.firmwareMetadataReuseMu.Unlock()
+}
+
 func TestSaveFirmwareFile_RollsBackPublishedDirectoryWhenParentSyncFails(t *testing.T) {
 	svc := setupService(t)
 	const content = "firmware whose publish sync fails"
@@ -1081,6 +1092,76 @@ func TestSaveFirmwareUploadFromPath_MovesAndRegistersChecksum(t *testing.T) {
 
 	_, statErr := os.Stat(srcPath)
 	assert.True(t, os.IsNotExist(statErr), "source file should be removed after rename")
+}
+
+func TestSaveFirmwareUploadFromPath_BlocksDeletionUntilPublicationCompletes(t *testing.T) {
+	svc := setupService(t)
+
+	content := "firmware protected during publication"
+	srcPath := filepath.Join(firmwareStagingDir, "protected-upload")
+	require.NoError(t, os.WriteFile(srcPath, []byte(content), 0600))
+
+	publishedFileID := make(chan string, 1)
+	allowDirectorySync := make(chan struct{})
+	svc.syncFirmwareDir = func(dir string) error {
+		if dir != firmwareDir {
+			return nil
+		}
+		entries, err := os.ReadDir(firmwareDir)
+		if err != nil {
+			return err
+		}
+		for _, entry := range entries {
+			if entry.Name() == "staging" {
+				continue
+			}
+			publishedFileID <- entry.Name()
+			<-allowDirectorySync
+			return nil
+		}
+		return errors.New("published firmware directory not found")
+	}
+
+	type saveOutcome struct {
+		result FirmwareUploadSaveResult
+		err    error
+	}
+	saveDone := make(chan saveOutcome, 1)
+	go func() {
+		result, err := svc.SaveFirmwareUploadFromPath(
+			"protected.swu",
+			srcPath,
+			testFirmwareMetadata(),
+			true,
+			checksumOf(content),
+		)
+		saveDone <- saveOutcome{result: result, err: err}
+	}()
+
+	fileID := <-publishedFileID
+	assert.DirExists(t, getFirmwareDirPath(fileID))
+
+	deleteStarted := make(chan struct{})
+	deleteDone := make(chan error, 1)
+	go func() {
+		close(deleteStarted)
+		deleteDone <- svc.DeleteFirmwareFile(fileID)
+	}()
+	<-deleteStarted
+
+	select {
+	case err := <-deleteDone:
+		close(allowDirectorySync)
+		<-saveDone
+		t.Fatalf("firmware deletion completed before publication returned: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(allowDirectorySync)
+	outcome := <-saveDone
+	require.NoError(t, outcome.err)
+	assert.Equal(t, fileID, outcome.result.FirmwareFileID)
+	require.NoError(t, <-deleteDone)
 }
 
 func TestSaveFirmwareUpload_UsesManualMetadata(t *testing.T) {

--- a/server/internal/infrastructure/files/firmware_test.go
+++ b/server/internal/infrastructure/files/firmware_test.go
@@ -252,6 +252,27 @@ func TestUpdateFirmwareMetadata_DoesNotIndexMetadataBeforeDirectorySync(t *testi
 	assert.Equal(t, checksumOf(content), cachedChecksum)
 }
 
+func TestUpdateFirmwareMetadata_RestoresChecksumEligibilityWhenWriteFails(t *testing.T) {
+	svc := setupService(t)
+	const content = "firmware with failed metadata write"
+	fileID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content), testFirmwareMetadata())
+	require.NoError(t, err)
+
+	require.NoError(t, os.Remove(firmwareStagingDir))
+	require.NoError(t, os.WriteFile(firmwareStagingDir, []byte("not a directory"), 0600))
+
+	err = svc.UpdateFirmwareMetadata(fileID, FirmwareMetadata{
+		TargetManufacturer: "Bitmain",
+		TargetModel:        "S19",
+		FirmwareVersion:    "v3.0.0",
+	})
+
+	require.Error(t, err)
+	foundID, found := svc.FindFirmwareFileByChecksum(checksumOf(content), testFirmwareMetadata())
+	assert.True(t, found, "failed metadata write should restore reuse eligibility for the unchanged sidecar")
+	assert.Equal(t, fileID, foundID)
+}
+
 func TestUpdateFirmwareMetadata_PreservesUploadTime(t *testing.T) {
 	svc := setupService(t)
 	fileID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader("data"), testFirmwareMetadata())

--- a/server/internal/infrastructure/files/firmware_test.go
+++ b/server/internal/infrastructure/files/firmware_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -1109,7 +1110,7 @@ func TestSaveFirmwareUploadFromPath_BlocksDeletionUntilPublicationCompletes(t *t
 		}
 		entries, err := os.ReadDir(firmwareDir)
 		if err != nil {
-			return err
+			return fmt.Errorf("read firmware directory: %w", err)
 		}
 		for _, entry := range entries {
 			if entry.Name() == "staging" {

--- a/server/internal/infrastructure/files/firmware_test.go
+++ b/server/internal/infrastructure/files/firmware_test.go
@@ -3,6 +3,7 @@ package files
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -11,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"connectrpc.com/connect"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -183,6 +185,47 @@ func TestUpdateFirmwareMetadata_ReplacesMetadataAndChecksumTarget(t *testing.T) 
 	assert.Len(t, entries, 2, "atomic metadata replacement should not leave staging files")
 }
 
+func TestUpdateFirmwareMetadata_ClassifiesCorruptPayloadDirectoryAsInternal(t *testing.T) {
+	svc := setupService(t)
+	fileID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader("data"), testFirmwareMetadata())
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(getFirmwareDirPath(fileID), "extra.swu"), []byte("extra"), 0600))
+
+	err = svc.UpdateFirmwareMetadata(fileID, FirmwareMetadata{
+		TargetManufacturer: "Bitmain",
+		TargetModel:        "S19",
+		FirmwareVersion:    "v3.0.0",
+	})
+
+	var fleetErr fleeterror.FleetError
+	require.ErrorAs(t, err, &fleetErr)
+	assert.Equal(t, connect.CodeInternal, fleetErr.GRPCCode)
+}
+
+func TestUpdateFirmwareMetadata_DoesNotIndexMetadataBeforeDirectorySync(t *testing.T) {
+	svc := setupService(t)
+	const content = "indexed firmware"
+	fileID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content), testFirmwareMetadata())
+	require.NoError(t, err)
+	svc.syncFirmwareDir = func(string) error {
+		return errors.New("injected directory sync failure")
+	}
+
+	metadata := FirmwareMetadata{
+		TargetManufacturer: "Bitmain",
+		TargetModel:        "S19",
+		FirmwareVersion:    "v3.0.0",
+	}
+	err = svc.UpdateFirmwareMetadata(fileID, metadata)
+
+	require.Error(t, err)
+	_, found := svc.FindFirmwareFileByChecksum(checksumOf(content), metadata)
+	assert.False(t, found, "renamed metadata must not become reuse-eligible until its directory entry is durable")
+	cachedChecksum, cached := svc.lookupFirmwareChecksum(fileID)
+	assert.True(t, cached, "failed metadata sync should retain the immutable payload checksum")
+	assert.Equal(t, checksumOf(content), cachedChecksum)
+}
+
 func TestUpdateFirmwareMetadata_PreservesUploadTime(t *testing.T) {
 	svc := setupService(t)
 	fileID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader("data"), testFirmwareMetadata())
@@ -203,6 +246,19 @@ func TestUpdateFirmwareMetadata_PreservesUploadTime(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, after, 1)
 	assert.Equal(t, before[0].UploadedAt, after[0].UploadedAt)
+}
+
+func TestGetFirmwareFilePath_ClassifiesCorruptPayloadDirectoryAsInternal(t *testing.T) {
+	svc := setupService(t)
+	fileID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader("data"), testFirmwareMetadata())
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(getFirmwareDirPath(fileID), "extra.swu"), []byte("extra"), 0600))
+
+	_, err = svc.GetFirmwareFilePath(fileID)
+
+	var fleetErr fleeterror.FleetError
+	require.ErrorAs(t, err, &fleetErr)
+	assert.Equal(t, connect.CodeInternal, fleetErr.GRPCCode)
 }
 
 func TestUpdateFirmwareMetadata_PersistsLegacyUploadTimeFallback(t *testing.T) {

--- a/server/internal/infrastructure/files/firmware_test.go
+++ b/server/internal/infrastructure/files/firmware_test.go
@@ -20,7 +20,7 @@ func checksumOf(content string) string {
 }
 
 func testFirmwareMetadata() FirmwareMetadata {
-	return FirmwareMetadata{TargetManufacturer: "Proto", TargetModel: "S21", FirmwareVersion: "v2.0.0"}
+	return FirmwareMetadata{TargetManufacturer: "Proto", TargetModel: "Rig", FirmwareVersion: "v2.0.0"}
 }
 
 func storageDirEntries(t *testing.T, dir string) []os.DirEntry {
@@ -143,7 +143,7 @@ func TestSaveFirmwareFile_WritesTargetMetadata(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, files, 1)
 	assert.Equal(t, "Proto", files[0].TargetManufacturer)
-	assert.Equal(t, "S21", files[0].TargetModel)
+	assert.Equal(t, "Rig", files[0].TargetModel)
 
 	publishedEntries := storageDirEntries(t, getFirmwareDirPath(fileID))
 	require.Len(t, publishedEntries, 2)
@@ -589,7 +589,7 @@ func TestListFirmwareFiles_PreservesInvalidMetadataDirectories(t *testing.T) {
 
 	fileID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader("data"), testFirmwareMetadata())
 	require.NoError(t, err)
-	require.NoError(t, os.WriteFile(filepath.Join(getFirmwareDirPath(fileID), firmwareMetadataFilename), []byte(`{"target_manufacturer":"","target_model":"S21"}`), 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(getFirmwareDirPath(fileID), firmwareMetadataFilename), []byte(`{"target_manufacturer":"","target_model":"Rig"}`), 0600))
 
 	files, err := svc.ListFirmwareFiles()
 	require.NoError(t, err)

--- a/server/internal/infrastructure/files/firmware_test.go
+++ b/server/internal/infrastructure/files/firmware_test.go
@@ -695,6 +695,31 @@ func TestDeleteFirmwareFile_RemovesFromChecksumIndex(t *testing.T) {
 	assert.NotEqual(t, fileID, newID, "re-upload after delete should get a new fileID")
 }
 
+func TestDeleteFirmwareFile_SerializesWithChecksumLookup(t *testing.T) {
+	svc := setupService(t)
+
+	fileID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader("firmware under lookup"), testFirmwareMetadata())
+	require.NoError(t, err)
+
+	svc.firmwareMetadataReuseMu.RLock()
+	deleteDone := make(chan error, 1)
+	go func() {
+		deleteDone <- svc.DeleteFirmwareFile(fileID)
+	}()
+
+	select {
+	case err := <-deleteDone:
+		svc.firmwareMetadataReuseMu.RUnlock()
+		t.Fatalf("firmware deletion completed during checksum lookup: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	assert.DirExists(t, getFirmwareDirPath(fileID))
+
+	svc.firmwareMetadataReuseMu.RUnlock()
+	require.NoError(t, <-deleteDone)
+	assert.NoDirExists(t, getFirmwareDirPath(fileID))
+}
+
 func TestDeleteFirmwareFile_ReturnsNotFoundForMissingFile(t *testing.T) {
 	svc := setupService(t)
 

--- a/server/internal/infrastructure/files/firmware_test.go
+++ b/server/internal/infrastructure/files/firmware_test.go
@@ -273,6 +273,66 @@ func TestUpdateFirmwareMetadata_RestoresChecksumEligibilityWhenWriteFails(t *tes
 	assert.Equal(t, fileID, foundID)
 }
 
+func TestUpdateFirmwareMetadata_SerializesChecksumLookupWithMetadataReplacement(t *testing.T) {
+	svc := setupService(t)
+	const content = "firmware with concurrent metadata lookup"
+	fileID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader(content), testFirmwareMetadata())
+	require.NoError(t, err)
+
+	updated := FirmwareMetadata{
+		TargetManufacturer: "Bitmain",
+		TargetModel:        "S19",
+		FirmwareVersion:    "v3.0.0",
+	}
+	updateAtDirectorySync := make(chan struct{})
+	allowDirectorySync := make(chan struct{})
+	svc.syncFirmwareDir = func(dir string) error {
+		if dir == getFirmwareDirPath(fileID) {
+			close(updateAtDirectorySync)
+			<-allowDirectorySync
+		}
+		return nil
+	}
+
+	updateDone := make(chan error, 1)
+	go func() {
+		updateDone <- svc.UpdateFirmwareMetadata(fileID, updated)
+	}()
+	<-updateAtDirectorySync
+
+	type lookupResult struct {
+		fileID string
+		found  bool
+	}
+	lookupStarted := make(chan struct{})
+	lookupDone := make(chan lookupResult, 1)
+	go func() {
+		close(lookupStarted)
+		foundID, found := svc.FindFirmwareFileByChecksum(checksumOf(content), testFirmwareMetadata())
+		lookupDone <- lookupResult{fileID: foundID, found: found}
+	}()
+	<-lookupStarted
+
+	select {
+	case result := <-lookupDone:
+		close(allowDirectorySync)
+		require.NoError(t, <-updateDone)
+		t.Fatalf("checksum lookup returned during metadata replacement: %+v", result)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(allowDirectorySync)
+	require.NoError(t, <-updateDone)
+
+	result := <-lookupDone
+	assert.False(t, result.found, "lookup must not reuse the artifact for its old target after the edit")
+	assert.Empty(t, result.fileID)
+
+	foundID, found := svc.FindFirmwareFileByChecksum(checksumOf(content), updated)
+	assert.True(t, found, "lookup should reuse the artifact for its new target after the edit")
+	assert.Equal(t, fileID, foundID)
+}
+
 func TestUpdateFirmwareMetadata_PreservesUploadTime(t *testing.T) {
 	svc := setupService(t)
 	fileID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader("data"), testFirmwareMetadata())

--- a/server/internal/infrastructure/files/firmware_test.go
+++ b/server/internal/infrastructure/files/firmware_test.go
@@ -191,7 +191,15 @@ func TestUpdateFirmwareMetadata_ReplacesMetadataAndChecksumTarget(t *testing.T) 
 		TargetModel:        " S19 ",
 		FirmwareVersion:    " v3.0.0 ",
 	}
-	require.NoError(t, svc.UpdateFirmwareMetadata(fileID, updated))
+	result, err := svc.UpdateFirmwareMetadata(fileID, updated)
+	require.NoError(t, err)
+	require.NotNil(t, result.Previous)
+	assert.Equal(t, testFirmwareMetadata(), *result.Previous)
+	assert.Equal(t, FirmwareMetadata{
+		TargetManufacturer: "Bitmain",
+		TargetModel:        "S19",
+		FirmwareVersion:    "v3.0.0",
+	}, result.Current)
 
 	metadata, err := svc.GetFirmwareMetadata(fileID)
 	require.NoError(t, err)
@@ -217,7 +225,7 @@ func TestUpdateFirmwareMetadata_ClassifiesCorruptPayloadDirectoryAsInternal(t *t
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(filepath.Join(getFirmwareDirPath(fileID), "extra.swu"), []byte("extra"), 0600))
 
-	err = svc.UpdateFirmwareMetadata(fileID, FirmwareMetadata{
+	_, err = svc.UpdateFirmwareMetadata(fileID, FirmwareMetadata{
 		TargetManufacturer: "Bitmain",
 		TargetModel:        "S19",
 		FirmwareVersion:    "v3.0.0",
@@ -242,7 +250,7 @@ func TestUpdateFirmwareMetadata_DoesNotIndexMetadataBeforeDirectorySync(t *testi
 		TargetModel:        "S19",
 		FirmwareVersion:    "v3.0.0",
 	}
-	err = svc.UpdateFirmwareMetadata(fileID, metadata)
+	_, err = svc.UpdateFirmwareMetadata(fileID, metadata)
 
 	require.Error(t, err)
 	_, found := svc.FindFirmwareFileByChecksum(checksumOf(content), metadata)
@@ -261,7 +269,7 @@ func TestUpdateFirmwareMetadata_RestoresChecksumEligibilityWhenWriteFails(t *tes
 	require.NoError(t, os.Remove(firmwareStagingDir))
 	require.NoError(t, os.WriteFile(firmwareStagingDir, []byte("not a directory"), 0600))
 
-	err = svc.UpdateFirmwareMetadata(fileID, FirmwareMetadata{
+	_, err = svc.UpdateFirmwareMetadata(fileID, FirmwareMetadata{
 		TargetManufacturer: "Bitmain",
 		TargetModel:        "S19",
 		FirmwareVersion:    "v3.0.0",
@@ -296,7 +304,8 @@ func TestUpdateFirmwareMetadata_SerializesChecksumLookupWithMetadataReplacement(
 
 	updateDone := make(chan error, 1)
 	go func() {
-		updateDone <- svc.UpdateFirmwareMetadata(fileID, updated)
+		_, err := svc.UpdateFirmwareMetadata(fileID, updated)
+		updateDone <- err
 	}()
 	<-updateAtDirectorySync
 
@@ -333,6 +342,69 @@ func TestUpdateFirmwareMetadata_SerializesChecksumLookupWithMetadataReplacement(
 	assert.Equal(t, fileID, foundID)
 }
 
+func TestUpdateFirmwareMetadata_ReturnsAtomicTransitionsForConcurrentEdits(t *testing.T) {
+	svc := setupService(t)
+	fileID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader("data"), testFirmwareMetadata())
+	require.NoError(t, err)
+
+	firstUpdate := FirmwareMetadata{
+		TargetManufacturer: "Bitmain",
+		TargetModel:        "S19",
+		FirmwareVersion:    "v3.0.0",
+	}
+	secondUpdate := FirmwareMetadata{
+		TargetManufacturer: "MicroBT",
+		TargetModel:        "M60",
+		FirmwareVersion:    "v4.0.0",
+	}
+
+	firstAtDirectorySync := make(chan struct{})
+	allowFirstDirectorySync := make(chan struct{})
+	blockedFirstUpdate := false
+	svc.syncFirmwareDir = func(dir string) error {
+		if dir == getFirmwareDirPath(fileID) && !blockedFirstUpdate {
+			blockedFirstUpdate = true
+			close(firstAtDirectorySync)
+			<-allowFirstDirectorySync
+		}
+		return nil
+	}
+
+	type updateOutcome struct {
+		result FirmwareMetadataUpdateResult
+		err    error
+	}
+	firstDone := make(chan updateOutcome, 1)
+	go func() {
+		result, err := svc.UpdateFirmwareMetadata(fileID, firstUpdate)
+		firstDone <- updateOutcome{result: result, err: err}
+	}()
+	<-firstAtDirectorySync
+
+	secondStarted := make(chan struct{})
+	secondDone := make(chan updateOutcome, 1)
+	go func() {
+		close(secondStarted)
+		result, err := svc.UpdateFirmwareMetadata(fileID, secondUpdate)
+		secondDone <- updateOutcome{result: result, err: err}
+	}()
+	<-secondStarted
+
+	close(allowFirstDirectorySync)
+
+	first := <-firstDone
+	require.NoError(t, first.err)
+	require.NotNil(t, first.result.Previous)
+	assert.Equal(t, testFirmwareMetadata(), *first.result.Previous)
+	assert.Equal(t, firstUpdate, first.result.Current)
+
+	second := <-secondDone
+	require.NoError(t, second.err)
+	require.NotNil(t, second.result.Previous)
+	assert.Equal(t, firstUpdate, *second.result.Previous)
+	assert.Equal(t, secondUpdate, second.result.Current)
+}
+
 func TestUpdateFirmwareMetadata_PreservesUploadTime(t *testing.T) {
 	svc := setupService(t)
 	fileID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader("data"), testFirmwareMetadata())
@@ -343,11 +415,12 @@ func TestUpdateFirmwareMetadata_PreservesUploadTime(t *testing.T) {
 	require.Len(t, before, 1)
 
 	time.Sleep(10 * time.Millisecond)
-	require.NoError(t, svc.UpdateFirmwareMetadata(fileID, FirmwareMetadata{
+	_, err = svc.UpdateFirmwareMetadata(fileID, FirmwareMetadata{
 		TargetManufacturer: "Bitmain",
 		TargetModel:        "S19",
 		FirmwareVersion:    "v3.0.0",
-	}))
+	})
+	require.NoError(t, err)
 
 	after, err := svc.ListFirmwareFiles()
 	require.NoError(t, err)
@@ -382,11 +455,12 @@ func TestUpdateFirmwareMetadata_PersistsLegacyUploadTimeFallback(t *testing.T) {
 	fallbackTime := time.Date(2025, time.January, 2, 3, 4, 5, 0, time.UTC)
 	require.NoError(t, os.Chtimes(dir, fallbackTime, fallbackTime))
 
-	require.NoError(t, svc.UpdateFirmwareMetadata(fileID, FirmwareMetadata{
+	_, err = svc.UpdateFirmwareMetadata(fileID, FirmwareMetadata{
 		TargetManufacturer: "Bitmain",
 		TargetModel:        "S19",
 		FirmwareVersion:    "v3.0.0",
-	}))
+	})
+	require.NoError(t, err)
 
 	files, err := svc.ListFirmwareFiles()
 	require.NoError(t, err)
@@ -405,7 +479,10 @@ func TestUpdateFirmwareMetadata_AddsMetadataToLegacyPayload(t *testing.T) {
 
 	svc, err := NewService(Config{})
 	require.NoError(t, err)
-	require.NoError(t, svc.UpdateFirmwareMetadata(fileID, testFirmwareMetadata()))
+	result, err := svc.UpdateFirmwareMetadata(fileID, testFirmwareMetadata())
+	require.NoError(t, err)
+	assert.Nil(t, result.Previous)
+	assert.Equal(t, testFirmwareMetadata(), result.Current)
 
 	metadata, err := svc.GetFirmwareMetadata(fileID)
 	require.NoError(t, err)
@@ -420,7 +497,7 @@ func TestUpdateFirmwareMetadata_RejectsIncompleteMetadataWithoutChangingSidecar(
 	fileID, err := svc.SaveFirmwareFile("firmware.swu", strings.NewReader("data"), testFirmwareMetadata())
 	require.NoError(t, err)
 
-	err = svc.UpdateFirmwareMetadata(fileID, FirmwareMetadata{TargetManufacturer: "Proto"})
+	_, err = svc.UpdateFirmwareMetadata(fileID, FirmwareMetadata{TargetManufacturer: "Proto"})
 	require.Error(t, err)
 
 	metadata, readErr := svc.GetFirmwareMetadata(fileID)

--- a/server/internal/infrastructure/files/service.go
+++ b/server/internal/infrastructure/files/service.go
@@ -83,8 +83,8 @@ type Service struct {
 	commandArtifactCleanupInterval time.Duration
 
 	mu                   sync.Mutex
-	checksumIndex        map[string][]firmwareChecksumEntry // SHA-256 hex -> matching file metadata
-	firmwareChecksumByID map[string]string                  // fileID -> SHA-256 hex
+	checksumIndex        map[string][]string // SHA-256 hex -> reuse-eligible file IDs
+	firmwareChecksumByID map[string]string   // fileID -> SHA-256 hex
 }
 
 // MaxFirmwareFileSize returns the configured maximum firmware file size in bytes.
@@ -155,7 +155,7 @@ func NewService(cfg Config) (*Service, error) {
 		maxCommandArtifactSize:         maxArtifactSize,
 		commandArtifactRetentionTTL:    retentionTTL,
 		commandArtifactCleanupInterval: cleanupInterval,
-		checksumIndex:                  make(map[string][]firmwareChecksumEntry),
+		checksumIndex:                  make(map[string][]string),
 		firmwareChecksumByID:           make(map[string]string),
 	}
 

--- a/server/internal/infrastructure/files/service.go
+++ b/server/internal/infrastructure/files/service.go
@@ -83,8 +83,8 @@ type Service struct {
 	commandArtifactCleanupInterval time.Duration
 
 	mu                   sync.Mutex
-	checksumIndex        map[string][]string // SHA-256 hex -> fileIDs
-	firmwareChecksumByID map[string]string   // fileID -> SHA-256 hex
+	checksumIndex        map[string][]firmwareChecksumEntry // SHA-256 hex -> matching file metadata
+	firmwareChecksumByID map[string]string                  // fileID -> SHA-256 hex
 }
 
 // MaxFirmwareFileSize returns the configured maximum firmware file size in bytes.
@@ -155,7 +155,7 @@ func NewService(cfg Config) (*Service, error) {
 		maxCommandArtifactSize:         maxArtifactSize,
 		commandArtifactRetentionTTL:    retentionTTL,
 		commandArtifactCleanupInterval: cleanupInterval,
-		checksumIndex:                  make(map[string][]string),
+		checksumIndex:                  make(map[string][]firmwareChecksumEntry),
 		firmwareChecksumByID:           make(map[string]string),
 	}
 

--- a/server/internal/infrastructure/files/service.go
+++ b/server/internal/infrastructure/files/service.go
@@ -98,6 +98,7 @@ type Service struct {
 	checksumIndex        map[string][]string // SHA-256 hex -> reuse-eligible file IDs
 	firmwareChecksumByID map[string]string   // fileID -> SHA-256 hex
 	firmwareUploadLocks  map[firmwareUploadKey]*firmwareUploadLock
+	syncFirmwareDir      func(string) error
 }
 
 // MaxFirmwareFileSize returns the configured maximum firmware file size in bytes.
@@ -171,6 +172,7 @@ func NewService(cfg Config) (*Service, error) {
 		checksumIndex:                  make(map[string][]string),
 		firmwareChecksumByID:           make(map[string]string),
 		firmwareUploadLocks:            make(map[firmwareUploadKey]*firmwareUploadLock),
+		syncFirmwareDir:                syncFirmwareDirectory,
 	}
 
 	if err := svc.initChecksumIndex(); err != nil {

--- a/server/internal/infrastructure/files/service.go
+++ b/server/internal/infrastructure/files/service.go
@@ -49,6 +49,18 @@ type FSFile struct {
 	Data     []byte
 }
 
+type firmwareUploadKey struct {
+	checksum     string
+	manufacturer string
+	model        string
+	version      string
+}
+
+type firmwareUploadLock struct {
+	mu   sync.Mutex
+	refs int
+}
+
 func getBatchLogsZipFilePath(batchLogUUID string) string {
 	return filepath.Join(tempDir, fmt.Sprintf("logs_batch_%s.zip", batchLogUUID))
 }
@@ -85,6 +97,7 @@ type Service struct {
 	mu                   sync.Mutex
 	checksumIndex        map[string][]string // SHA-256 hex -> reuse-eligible file IDs
 	firmwareChecksumByID map[string]string   // fileID -> SHA-256 hex
+	firmwareUploadLocks  map[firmwareUploadKey]*firmwareUploadLock
 }
 
 // MaxFirmwareFileSize returns the configured maximum firmware file size in bytes.
@@ -157,6 +170,7 @@ func NewService(cfg Config) (*Service, error) {
 		commandArtifactCleanupInterval: cleanupInterval,
 		checksumIndex:                  make(map[string][]string),
 		firmwareChecksumByID:           make(map[string]string),
+		firmwareUploadLocks:            make(map[firmwareUploadKey]*firmwareUploadLock),
 	}
 
 	if err := svc.initChecksumIndex(); err != nil {

--- a/server/internal/infrastructure/files/service.go
+++ b/server/internal/infrastructure/files/service.go
@@ -94,11 +94,12 @@ type Service struct {
 	commandArtifactRetentionTTL    time.Duration
 	commandArtifactCleanupInterval time.Duration
 
-	mu                   sync.Mutex
-	checksumIndex        map[string][]string // SHA-256 hex -> reuse-eligible file IDs
-	firmwareChecksumByID map[string]string   // fileID -> SHA-256 hex
-	firmwareUploadLocks  map[firmwareUploadKey]*firmwareUploadLock
-	syncFirmwareDir      func(string) error
+	mu                      sync.Mutex
+	firmwareMetadataReuseMu sync.RWMutex
+	checksumIndex           map[string][]string // SHA-256 hex -> reuse-eligible file IDs
+	firmwareChecksumByID    map[string]string   // fileID -> SHA-256 hex
+	firmwareUploadLocks     map[firmwareUploadKey]*firmwareUploadLock
+	syncFirmwareDir         func(string) error
 }
 
 // MaxFirmwareFileSize returns the configured maximum firmware file size in bytes.

--- a/server/internal/infrastructure/files/storage_helpers.go
+++ b/server/internal/infrastructure/files/storage_helpers.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/google/uuid"
 )
@@ -24,8 +25,10 @@ func canonicalizeStorageUUID(kind, value string) (string, error) {
 }
 
 // findSingleFileInDir returns the path to the single non-directory entry inside
-// a directory, ignoring any named sidecars. It returns an error if zero or more
-// than one data file exists, so callers fail fast on corrupted storage dirs.
+// a directory, ignoring any named sidecars and dot-prefixed entries (temp files
+// from atomic sidecar writes are never payloads). It returns an error if zero
+// or more than one data file exists, so callers fail fast on corrupted storage
+// dirs.
 func findSingleFileInDir(dir string, ignoredNames ...string) (string, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -38,7 +41,7 @@ func findSingleFileInDir(dir string, ignoredNames ...string) (string, error) {
 
 	var foundPath string
 	for _, e := range entries {
-		if e.IsDir() {
+		if e.IsDir() || strings.HasPrefix(e.Name(), ".") {
 			continue
 		}
 		if _, ok := ignored[e.Name()]; ok {
@@ -55,17 +58,16 @@ func findSingleFileInDir(dir string, ignoredNames ...string) (string, error) {
 	return foundPath, nil
 }
 
+// cleanStorageStagingDir removes every entry (files and directories) left in a
+// staging dir by interrupted operations from previous runs.
 func cleanStorageStagingDir(dir, failureMessage, successMessage string) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return
 	}
 	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
 		path := filepath.Join(dir, entry.Name())
-		if err := os.Remove(path); err != nil {
+		if err := os.RemoveAll(path); err != nil {
 			slog.Warn(failureMessage, "path", path, "error", err)
 		} else if successMessage != "" {
 			slog.Info(successMessage, "path", path)

--- a/server/internal/infrastructure/files/storage_helpers.go
+++ b/server/internal/infrastructure/files/storage_helpers.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/google/uuid"
 )
@@ -25,10 +24,8 @@ func canonicalizeStorageUUID(kind, value string) (string, error) {
 }
 
 // findSingleFileInDir returns the path to the single non-directory entry inside
-// a directory, ignoring any named sidecars and dot-prefixed entries (temp files
-// from atomic sidecar writes are never payloads). It returns an error if zero
-// or more than one data file exists, so callers fail fast on corrupted storage
-// dirs.
+// a directory, ignoring any named sidecars. It returns an error if zero or more
+// than one data file exists, so callers fail fast on corrupted storage dirs.
 func findSingleFileInDir(dir string, ignoredNames ...string) (string, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -41,7 +38,7 @@ func findSingleFileInDir(dir string, ignoredNames ...string) (string, error) {
 
 	var foundPath string
 	for _, e := range entries {
-		if e.IsDir() || strings.HasPrefix(e.Name(), ".") {
+		if e.IsDir() {
 			continue
 		}
 		if _, ok := ignored[e.Name()]; ok {


### PR DESCRIPTION
Reviewable diff: +2169/-346 across 36 files (excludes generated, test, and story files).

## Summary

Firmware payloads now carry a manufacturer, model, and firmware version from upload through deployment, and updates are rejected unless every selected miner matches that target. Operators can upload, inspect, repair, reuse, and deploy target-scoped firmware from ProtoFleet or the Fleet CLI, while server-side authorization, durable metadata indexing, and post-reboot version refresh keep those workflows safe and observable.

## How it works

1. ProtoFleet derives manufacturer/model choices from fleet model groups and requires a firmware version; the Fleet CLI requires equivalent target flags.
2. Every raw HTTP mutation first checks the canonical firmware-update permission, then direct and chunked uploads validate the complete target and compute SHA-256 while staging.
3. The file service publishes each payload beside an atomic `metadata.json` sidecar. Checksum reuse becomes eligible only after the directory entry is durable; metadata edits temporarily withdraw the artifact from reuse until the replacement sidecar is synced.
4. Preflight checks and saves reuse only an exact checksum-plus-metadata match. Keyed upload locks make concurrent identical uploads converge on one artifact, while `force` creates a new copy.
5. Inventory APIs return target metadata and support metadata repair without changing the original upload timestamp. Missing artifacts return not-found errors, while malformed storage layouts surface as internal errors.
6. ProtoFleet filters saved firmware to the selected miner target, and the server independently validates every resolved device before dispatch. After a Proto device reboots, its cached status and firmware-check timestamp are cleared so the next status reports the activated version immediately.

```mermaid
flowchart LR
    U["ProtoFleet or Fleet CLI"] --> A["Authorize firmware mutation"]
    A --> H["Validate target and stage upload"]
    H --> S["Firmware file service"]
    S --> D["Durable payload plus metadata.json"]
    D --> I["Checksum plus normalized target index"]
    I --> R["Exact-match reuse or forced copy"]
    D --> L["Inventory and metadata repair"]
    L --> P["Target-filtered firmware picker"]
    P --> V["Server-side device compatibility check"]
    V --> C["Firmware command dispatch"]
    C --> B["Miner reboot and activation"]
    B --> F["Fresh firmware version on next status"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/internal/infrastructure/files/` | Persists target metadata and upload time, maintains metadata-aware checksum indexes, atomically edits sidecars, classifies storage failures, and serializes identical uploads | Core durability, legacy compatibility, error semantics, and deduplication behavior |
| `server/internal/handlers/firmware/` | Validates upload/check metadata, exposes metadata editing, applies firmware-update authorization to every mutation, and records new-upload activity | HTTP validation, authorization, audit, and error-response boundary |
| `server/internal/domain/command/` | Validates resolved device manufacturer/model before firmware dispatch | Final safety boundary against incompatible deployment |
| `server/cmd/fleetcli/` | Requires target flags and carries them through direct and chunked requests | CLI contract and upload-mode parity |
| `client/src/protoFleet/api/` and `components/FirmwareUpload/` | Makes target metadata mandatory at the typed upload boundary and shares upload/version handling | Prevents incomplete first-party upload calls |
| `client/src/protoFleet/features/settings/` | Adds fleet-derived target fields, version inference, metadata columns, and metadata editing | Operator inventory and repair workflow |
| `client/src/protoFleet/features/fleetManagement/` | Restricts firmware actions to one known target and filters reusable payloads | Prevents mixed-target selections in the UI |
| `plugin/proto/internal/device/` | Invalidates both status and firmware-check caches after reboot | Ensures activation is visible without waiting for the normal firmware refresh interval |
| `server/fake-antminer/` and `server/fake-proto-rig/` | Models staged firmware activation and filename-derived version changes | End-to-end simulator fidelity |
| Test and E2E files | Cover storage durability, authorization responses, compatibility, concurrent deduplication, upload workflows, and activated-version reporting | Regression coverage; review with the corresponding production area |

## Key technical decisions & trade-offs

- Store metadata beside filesystem-owned payloads instead of introducing a database or protobuf migration; sidecar integrity remains part of artifact validity.
- Require complete metadata for new uploads but keep legacy files readable and editable; deployment stays blocked until target metadata is repaired.
- Use exact normalized metadata for deduplication and case-insensitive manufacturer/model matching for deployment; storage identity remains precise while device compatibility tolerates casing differences.
- Remove an artifact from checksum reuse before replacing metadata and restore it only after directory sync; a failed edit may be temporarily unavailable for reuse rather than advertise state that is not durable.
- Preserve `uploaded_at` in the sidecar and fall back to the legacy directory timestamp; metadata edits do not reorder inventory.
- Serialize only identical checksum-and-target uploads with reference-counted keyed locks; unrelated uploads remain concurrent.
- Clear the firmware refresh throttle only after a successful reboot; routine status polling keeps its existing cache behavior.

## Testing & validation

- `just lint`
- `go test -race ./internal/infrastructure/files ./internal/handlers/firmware -count=1`
- `(cd plugin/proto && go test ./internal/device -count=1)`
- Targeted firmware handler, command-domain, Fleet CLI, FleetNode artifact, and simulator tests
- Targeted Vitest coverage, including `useFirmwareApi.test.ts` (35 tests passed after rebase)
- `npx tsc --noEmit`
- Playwright firmware spec discovery passed and now asserts the activated version; the full Docker-backed browser flow was not rerun because the frontend stack was unavailable
- `git diff --check`

There are no database migrations, protobuf changes, or generated files in this PR.

## Screenshots
<img width="676" height="500" alt="Add firmware payload" src="https://github.com/user-attachments/assets/27cf2007-4e40-4ff4-b85e-31d145f18f1d" />
<img width="662" height="413" alt="Add firmware payload" src="https://github.com/user-attachments/assets/4205e0a3-660c-4d35-a3cd-b573eb4cc177" />
<img width="667" height="647" alt="Add firmware payload" src="https://github.com/user-attachments/assets/b3aab650-b6d0-492a-bf45-8363513b436e" />
<img width="1317" height="394" alt="hamware" src="https://github.com/user-attachments/assets/6e6b5d39-4bd2-4c9f-a464-b514c9bcc2fc" />
<img width="429" height="141" alt="Firmware update requires miners from the" src="https://github.com/user-attachments/assets/e90ec01b-8671-45ca-af5d-e57dac5f24f4" />
<img width="666" height="706" alt="image" src="https://github.com/user-attachments/assets/c24556fe-1bc3-49cc-9a3d-22a62ca3c1e7" />


