### PR TITLE
feat(runtimejobs): report lifecycle and progress health

### DIFF
--- a/plugin/antminer/internal/driver/driver.go
+++ b/plugin/antminer/internal/driver/driver.go
@@ -358,7 +358,6 @@ func (d *Driver) NewDevice(ctx context.Context, deviceID string, deviceInfo sdk.
 	d.devices[deviceID] = dev
 	d.mutex.Unlock()
 
-	slog.Info("Antminer device instance created", "deviceID", deviceID, "host", deviceInfo.Host, "username", credentials.Username)
 	return sdk.NewDeviceResult{Device: dev}, nil
 }
 

--- a/plugin/proto/internal/driver/driver.go
+++ b/plugin/proto/internal/driver/driver.go
@@ -381,10 +381,6 @@ func (d *Driver) NewDevice(ctx context.Context, deviceID string, deviceInfo sdk.
 	d.devices[deviceID] = dev
 	d.mutex.Unlock()
 
-	slog.Info("Plugin device instance created successfully",
-		"device_id", deviceID,
-		"serial", deviceInfo.SerialNumber,
-		"total_devices", len(d.devices))
 	return sdk.NewDeviceResult{Device: dev}, nil
 }
 

--- a/server/cmd/fleetd/main.go
+++ b/server/cmd/fleetd/main.go
@@ -300,9 +300,7 @@ func start(config *Config) error {
 				} else if challenges > 0 || sessions > 0 {
 					slog.Debug("swept expired fleet node auth state", "challenges", challenges, "sessions", sessions)
 				}
-				if ctx.Err() == nil {
-					reportProgress()
-				}
+				reportProgress()
 			case <-ctx.Done():
 				return
 			}
@@ -378,17 +376,13 @@ func start(config *Config) error {
 		ticker := time.NewTicker(cleanupInterval)
 		defer ticker.Stop()
 		runCommandArtifactSweep()
-		if ctx.Err() == nil {
-			reportProgress()
-		}
+		reportProgress()
 
 		for {
 			select {
 			case <-ticker.C:
 				runCommandArtifactSweep()
-				if ctx.Err() == nil {
-					reportProgress()
-				}
+				reportProgress()
 			case <-ctx.Done():
 				return
 			}

--- a/server/cmd/fleetd/main.go
+++ b/server/cmd/fleetd/main.go
@@ -278,7 +278,7 @@ func start(config *Config) error {
 
 	identityStateCleanup := newBackgroundLoop(func(ctx context.Context) {
 		cleanupInterval := sessionSvc.CleanupInterval()
-		reportProgress := runtimejobs.TrackProgress(ctx, 3*cleanupInterval)
+		reportProgress := runtimejobs.TrackProgress(ctx, cleanupInterval)
 		ticker := time.NewTicker(cleanupInterval)
 		defer ticker.Stop()
 
@@ -372,7 +372,7 @@ func start(config *Config) error {
 	}
 	commandArtifactCleanup := newBackgroundLoop(func(ctx context.Context) {
 		cleanupInterval := filesService.CommandArtifactCleanupInterval()
-		reportProgress := runtimejobs.TrackProgress(ctx, 3*cleanupInterval)
+		reportProgress := runtimejobs.TrackProgress(ctx, cleanupInterval)
 		ticker := time.NewTicker(cleanupInterval)
 		defer ticker.Stop()
 		runCommandArtifactSweep()

--- a/server/cmd/fleetd/main.go
+++ b/server/cmd/fleetd/main.go
@@ -277,7 +277,9 @@ func start(config *Config) error {
 	authSvc := authDomain.NewService(userStore, userStore, transactor, tokenSvc, sessionSvc, encryptSvc, activitySvc, permissionResolver)
 
 	identityStateCleanup := newBackgroundLoop(func(ctx context.Context) {
-		ticker := time.NewTicker(sessionSvc.CleanupInterval())
+		cleanupInterval := sessionSvc.CleanupInterval()
+		reportProgress := runtimejobs.TrackProgress(ctx, 3*cleanupInterval)
+		ticker := time.NewTicker(cleanupInterval)
 		defer ticker.Stop()
 
 		for {
@@ -297,6 +299,9 @@ func start(config *Config) error {
 					slog.Error("failed to sweep expired fleet node auth state", "error", err)
 				} else if challenges > 0 || sessions > 0 {
 					slog.Debug("swept expired fleet node auth state", "challenges", challenges, "sessions", sessions)
+				}
+				if ctx.Err() == nil {
+					reportProgress()
 				}
 			case <-ctx.Done():
 				return
@@ -368,14 +373,22 @@ func start(config *Config) error {
 		}
 	}
 	commandArtifactCleanup := newBackgroundLoop(func(ctx context.Context) {
-		ticker := time.NewTicker(filesService.CommandArtifactCleanupInterval())
+		cleanupInterval := filesService.CommandArtifactCleanupInterval()
+		reportProgress := runtimejobs.TrackProgress(ctx, 3*cleanupInterval)
+		ticker := time.NewTicker(cleanupInterval)
 		defer ticker.Stop()
 		runCommandArtifactSweep()
+		if ctx.Err() == nil {
+			reportProgress()
+		}
 
 		for {
 			select {
 			case <-ticker.C:
 				runCommandArtifactSweep()
+				if ctx.Err() == nil {
+					reportProgress()
+				}
 			case <-ctx.Done():
 				return
 			}

--- a/server/internal/domain/command/execution_service.go
+++ b/server/internal/domain/command/execution_service.go
@@ -272,9 +272,7 @@ func (es *ExecutionService) startStuckMessageReaper(ctx context.Context) {
 			return
 		case <-ticker.C:
 			if es.conn == nil {
-				if ctx.Err() == nil {
-					reportProgress()
-				}
+				reportProgress()
 				continue
 			}
 			reapCtx, reapCancel := context.WithTimeout(ctx, dbWriteTimeout)
@@ -282,9 +280,7 @@ func (es *ExecutionService) startStuckMessageReaper(ctx context.Context) {
 			reapCancel()
 			if err != nil {
 				slog.Error("stuck message reaper error", "error", err)
-				if ctx.Err() == nil {
-					reportProgress()
-				}
+				reportProgress()
 				continue
 			}
 			if len(reaped) > 0 {
@@ -294,9 +290,7 @@ func (es *ExecutionService) startStuckMessageReaper(ctx context.Context) {
 			for _, deviceID := range fwDeviceIDs {
 				es.clearFirmwareUpdateStatus(ctx, deviceID)
 			}
-			if ctx.Err() == nil {
-				reportProgress()
-			}
+			reportProgress()
 		}
 	}
 }

--- a/server/internal/domain/command/execution_service.go
+++ b/server/internal/domain/command/execution_service.go
@@ -262,6 +262,7 @@ func (es *ExecutionService) withAdmission(ctx context.Context, fn func(context.C
 }
 
 func (es *ExecutionService) startStuckMessageReaper(ctx context.Context) {
+	reportProgress := runtimejobs.TrackProgress(ctx, 3*es.config.ReaperInterval)
 	ticker := time.NewTicker(es.config.ReaperInterval)
 	defer ticker.Stop()
 
@@ -271,6 +272,9 @@ func (es *ExecutionService) startStuckMessageReaper(ctx context.Context) {
 			return
 		case <-ticker.C:
 			if es.conn == nil {
+				if ctx.Err() == nil {
+					reportProgress()
+				}
 				continue
 			}
 			reapCtx, reapCancel := context.WithTimeout(ctx, dbWriteTimeout)
@@ -278,6 +282,9 @@ func (es *ExecutionService) startStuckMessageReaper(ctx context.Context) {
 			reapCancel()
 			if err != nil {
 				slog.Error("stuck message reaper error", "error", err)
+				if ctx.Err() == nil {
+					reportProgress()
+				}
 				continue
 			}
 			if len(reaped) > 0 {
@@ -286,6 +293,9 @@ func (es *ExecutionService) startStuckMessageReaper(ctx context.Context) {
 			es.emitReapedCommandMetrics(ctx, reaped)
 			for _, deviceID := range fwDeviceIDs {
 				es.clearFirmwareUpdateStatus(ctx, deviceID)
+			}
+			if ctx.Err() == nil {
+				reportProgress()
 			}
 		}
 	}

--- a/server/internal/domain/command/execution_service.go
+++ b/server/internal/domain/command/execution_service.go
@@ -262,7 +262,7 @@ func (es *ExecutionService) withAdmission(ctx context.Context, fn func(context.C
 }
 
 func (es *ExecutionService) startStuckMessageReaper(ctx context.Context) {
-	reportProgress := runtimejobs.TrackProgress(ctx, 3*es.config.ReaperInterval)
+	reportProgress := runtimejobs.TrackProgress(ctx, es.config.ReaperInterval)
 	ticker := time.NewTicker(es.config.ReaperInterval)
 	defer ticker.Stop()
 

--- a/server/internal/domain/curtailment/alert_metrics.go
+++ b/server/internal/domain/curtailment/alert_metrics.go
@@ -171,7 +171,7 @@ func channelClosed(done <-chan struct{}) bool {
 func (l *AlertMetricsLoop) tickLoop(ctx context.Context, runDone chan<- struct{}) {
 	defer close(runDone)
 	defer l.finishActivation()
-	reportProgress := runtimejobs.TrackProgress(ctx, 3*l.cfg.Interval)
+	reportProgress := runtimejobs.TrackProgress(ctx, l.cfg.Interval)
 	ticker := time.NewTicker(l.cfg.Interval)
 	defer ticker.Stop()
 	l.tick(ctx)

--- a/server/internal/domain/curtailment/alert_metrics.go
+++ b/server/internal/domain/curtailment/alert_metrics.go
@@ -175,18 +175,14 @@ func (l *AlertMetricsLoop) tickLoop(ctx context.Context, runDone chan<- struct{}
 	ticker := time.NewTicker(l.cfg.Interval)
 	defer ticker.Stop()
 	l.tick(ctx)
-	if ctx.Err() == nil {
-		reportProgress()
-	}
+	reportProgress()
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
 			l.tick(ctx)
-			if ctx.Err() == nil {
-				reportProgress()
-			}
+			reportProgress()
 		}
 	}
 }

--- a/server/internal/domain/curtailment/alert_metrics.go
+++ b/server/internal/domain/curtailment/alert_metrics.go
@@ -121,7 +121,7 @@ func (l *AlertMetricsLoop) Start(ctx context.Context) error {
 	l.runCanceled = runCtx.Done()
 	l.runDone = runDone
 	go l.tickLoop(runCtx, runDone)
-	l.cfg.Logger.Info("curtailment alert metrics loop started", "interval", l.cfg.Interval)
+	l.cfg.Logger.Debug("configured curtailment alert metrics loop", "interval", l.cfg.Interval)
 	return nil
 }
 
@@ -142,7 +142,6 @@ func (l *AlertMetricsLoop) Stop(ctx context.Context) error {
 	cancel()
 	select {
 	case <-runDone:
-		l.cfg.Logger.Info("curtailment alert metrics loop stopped")
 		return nil
 	case <-ctx.Done():
 		return fmt.Errorf("curtailment alert metrics: stop: %w", ctx.Err())
@@ -172,15 +171,22 @@ func channelClosed(done <-chan struct{}) bool {
 func (l *AlertMetricsLoop) tickLoop(ctx context.Context, runDone chan<- struct{}) {
 	defer close(runDone)
 	defer l.finishActivation()
+	reportProgress := runtimejobs.TrackProgress(ctx, 3*l.cfg.Interval)
 	ticker := time.NewTicker(l.cfg.Interval)
 	defer ticker.Stop()
 	l.tick(ctx)
+	if ctx.Err() == nil {
+		reportProgress()
+	}
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
 			l.tick(ctx)
+			if ctx.Err() == nil {
+				reportProgress()
+			}
 		}
 	}
 }

--- a/server/internal/domain/curtailment/mqttingest/subscriber.go
+++ b/server/internal/domain/curtailment/mqttingest/subscriber.go
@@ -269,7 +269,6 @@ func (s *Subscriber) cleanupActivation(activation *subscriberActivation) {
 	}
 	close(activation.done)
 	s.mu.Unlock()
-	s.cfg.Logger.Info("mqttingest subscriber stopped cleanly")
 }
 
 func (s *Subscriber) SourceRuntimeStatus(sourceID int64) RuntimeStatus {

--- a/server/internal/domain/curtailment/reconciler/reconciler.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler.go
@@ -202,7 +202,7 @@ func (r *Reconciler) Start(ctx context.Context) error {
 	r.mu.Unlock()
 
 	go r.tickLoop(loopCtx, workCtx, runDone)
-	slog.Info("curtailment reconciler started", "tick_interval", r.cfg.TickInterval)
+	slog.Debug("configured curtailment reconciler", "tick_interval", r.cfg.TickInterval)
 	return nil
 }
 
@@ -231,7 +231,6 @@ func (r *Reconciler) Stop(ctx context.Context) error {
 		if workCancel != nil {
 			workCancel()
 		}
-		slog.Info("curtailment reconciler stopped")
 		return nil
 	case <-ctx.Done():
 		if workCancel != nil {
@@ -244,6 +243,7 @@ func (r *Reconciler) Stop(ctx context.Context) error {
 func (r *Reconciler) tickLoop(loopCtx, workCtx context.Context, runDone chan<- struct{}) {
 	defer close(runDone)
 	defer r.finishActivation()
+	reportProgress := runtimejobs.TrackProgress(loopCtx, 3*r.cfg.TickInterval)
 	ticker := time.NewTicker(r.cfg.TickInterval)
 	defer ticker.Stop()
 	for {
@@ -255,6 +255,7 @@ func (r *Reconciler) tickLoop(loopCtx, workCtx context.Context, runDone chan<- s
 			if loopCtx.Err() != nil {
 				return
 			}
+			reportProgress()
 		}
 	}
 }

--- a/server/internal/domain/curtailment/reconciler/reconciler.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler.go
@@ -243,7 +243,7 @@ func (r *Reconciler) Stop(ctx context.Context) error {
 func (r *Reconciler) tickLoop(loopCtx, workCtx context.Context, runDone chan<- struct{}) {
 	defer close(runDone)
 	defer r.finishActivation()
-	reportProgress := runtimejobs.TrackProgress(loopCtx, 3*r.cfg.TickInterval)
+	reportProgress := runtimejobs.TrackProgress(loopCtx, r.cfg.TickInterval)
 	ticker := time.NewTicker(r.cfg.TickInterval)
 	defer ticker.Stop()
 	for {

--- a/server/internal/domain/diagnostics/closer.go
+++ b/server/internal/domain/diagnostics/closer.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"log/slog"
 	"time"
+
+	"github.com/block/proto-fleet/server/internal/runtimejobs"
 )
 
 // Fallback defaults for closer configuration.
@@ -17,20 +19,23 @@ func (s *Service) runCloser(ctx context.Context) {
 	pollInterval := getConfigDurationOrDefault(s.config.CloserPollInterval, defaultCloserPollInterval)
 	stalenessThreshold := getConfigDurationOrDefault(s.config.CloserStalenessThreshold, defaultCloserStalenessThreshold)
 
-	slog.Info("starting error closer",
+	slog.Debug("configured error closer",
 		"pollInterval", pollInterval,
 		"stalenessThreshold", stalenessThreshold)
 
+	reportProgress := runtimejobs.TrackProgress(ctx, 3*pollInterval)
 	ticker := time.NewTicker(pollInterval)
 	defer ticker.Stop()
 
 	for {
 		select {
 		case <-ctx.Done():
-			slog.Info("error closer stopped")
 			return
 		case <-ticker.C:
 			s.closeStaleErrors(ctx, stalenessThreshold)
+			if ctx.Err() == nil {
+				reportProgress()
+			}
 		}
 	}
 }

--- a/server/internal/domain/diagnostics/closer.go
+++ b/server/internal/domain/diagnostics/closer.go
@@ -33,9 +33,7 @@ func (s *Service) runCloser(ctx context.Context) {
 			return
 		case <-ticker.C:
 			s.closeStaleErrors(ctx, stalenessThreshold)
-			if ctx.Err() == nil {
-				reportProgress()
-			}
+			reportProgress()
 		}
 	}
 }

--- a/server/internal/domain/diagnostics/closer.go
+++ b/server/internal/domain/diagnostics/closer.go
@@ -23,7 +23,7 @@ func (s *Service) runCloser(ctx context.Context) {
 		"pollInterval", pollInterval,
 		"stalenessThreshold", stalenessThreshold)
 
-	reportProgress := runtimejobs.TrackProgress(ctx, 3*pollInterval)
+	reportProgress := runtimejobs.TrackProgress(ctx, pollInterval)
 	ticker := time.NewTicker(pollInterval)
 	defer ticker.Stop()
 

--- a/server/internal/domain/ipscanner/service.go
+++ b/server/internal/domain/ipscanner/service.go
@@ -102,7 +102,7 @@ func (s *Service) Start(ctx context.Context) error {
 	}
 	s.run = run
 
-	s.logger.Info("Starting IP scanner service",
+	s.logger.Debug("configured IP scanner service",
 		"scan_interval", s.config.ScanInterval,
 		"max_concurrent_subnet_scans", s.config.MaxConcurrentSubnetScans,
 		"max_concurrent_ip_scans_per_subnet", s.config.MaxConcurrentIPScansPerSubnet,
@@ -135,7 +135,6 @@ func (s *Service) Stop(ctx context.Context) error {
 		s.lifecycleMu.Unlock()
 		return nil
 	}
-	s.logger.Info("Stopping IP scanner service")
 	run.cancel()
 	s.lifecycleMu.Unlock()
 
@@ -146,7 +145,6 @@ func (s *Service) Stop(ctx context.Context) error {
 			s.run = nil
 		}
 		s.lifecycleMu.Unlock()
-		s.logger.Info("IP scanner service stopped")
 		return nil
 	case <-ctx.Done():
 		return fmt.Errorf("stop ip scanner service: %w", ctx.Err())
@@ -155,11 +153,15 @@ func (s *Service) Stop(ctx context.Context) error {
 
 // scanLoop periodically scans for offline devices
 func (s *Service) scanLoop(ctx context.Context, run *serviceRun) {
+	reportProgress := runtimejobs.TrackProgress(ctx, 3*s.config.ScanInterval)
 	ticker := time.NewTicker(s.config.ScanInterval)
 	defer ticker.Stop()
 
 	// Run immediately on start
 	s.scanOfflineDevices(ctx, run.tasks)
+	if ctx.Err() == nil {
+		reportProgress()
+	}
 
 	for {
 		select {
@@ -167,6 +169,9 @@ func (s *Service) scanLoop(ctx context.Context, run *serviceRun) {
 			return
 		case <-ticker.C:
 			s.scanOfflineDevices(ctx, run.tasks)
+			if ctx.Err() == nil {
+				reportProgress()
+			}
 		}
 	}
 }

--- a/server/internal/domain/ipscanner/service.go
+++ b/server/internal/domain/ipscanner/service.go
@@ -153,7 +153,7 @@ func (s *Service) Stop(ctx context.Context) error {
 
 // scanLoop periodically scans for offline devices
 func (s *Service) scanLoop(ctx context.Context, run *serviceRun) {
-	reportProgress := runtimejobs.TrackProgress(ctx, 3*s.config.ScanInterval)
+	reportProgress := runtimejobs.TrackProgress(ctx, s.config.ScanInterval)
 	ticker := time.NewTicker(s.config.ScanInterval)
 	defer ticker.Stop()
 

--- a/server/internal/domain/ipscanner/service.go
+++ b/server/internal/domain/ipscanner/service.go
@@ -159,9 +159,7 @@ func (s *Service) scanLoop(ctx context.Context, run *serviceRun) {
 
 	// Run immediately on start
 	s.scanOfflineDevices(ctx, run.tasks)
-	if ctx.Err() == nil {
-		reportProgress()
-	}
+	reportProgress()
 
 	for {
 		select {
@@ -169,9 +167,7 @@ func (s *Service) scanLoop(ctx context.Context, run *serviceRun) {
 			return
 		case <-ticker.C:
 			s.scanOfflineDevices(ctx, run.tasks)
-			if ctx.Err() == nil {
-				reportProgress()
-			}
+			reportProgress()
 		}
 	}
 }

--- a/server/internal/domain/schedule/processor.go
+++ b/server/internal/domain/schedule/processor.go
@@ -198,7 +198,6 @@ func (p *Processor) Start(ctx context.Context) error {
 	go p.endOfWindowLoop(run)
 	close(run.startupDone)
 
-	slog.Info("schedule processor started")
 	return nil
 }
 
@@ -262,11 +261,11 @@ func (p *Processor) finishStop(run *processorActivation) {
 	}
 	close(run.stopDone)
 	p.lifecycleMu.Unlock()
-	slog.Info("schedule processor stopped")
 }
 
 func (p *Processor) reconcileLoop(run *processorActivation) {
 	defer run.wg.Done()
+	reportProgress := runtimejobs.TrackProgress(run.admissionCtx, 3*reconcileInterval)
 	ticker := time.NewTicker(reconcileInterval)
 	defer ticker.Stop()
 	for {
@@ -279,6 +278,9 @@ func (p *Processor) reconcileLoop(run *processorActivation) {
 			}
 			if err := p.syncSchedules(run.workCtx, run); err != nil {
 				slog.Error("reconciliation failed, will retry next cycle", "error", err)
+			}
+			if run.admissionCtx.Err() == nil {
+				reportProgress()
 			}
 		}
 	}

--- a/server/internal/domain/schedule/processor.go
+++ b/server/internal/domain/schedule/processor.go
@@ -279,9 +279,7 @@ func (p *Processor) reconcileLoop(run *processorActivation) {
 			if err := p.syncSchedules(run.workCtx, run); err != nil {
 				slog.Error("reconciliation failed, will retry next cycle", "error", err)
 			}
-			if run.admissionCtx.Err() == nil {
-				reportProgress()
-			}
+			reportProgress()
 		}
 	}
 }

--- a/server/internal/domain/schedule/processor.go
+++ b/server/internal/domain/schedule/processor.go
@@ -265,7 +265,7 @@ func (p *Processor) finishStop(run *processorActivation) {
 
 func (p *Processor) reconcileLoop(run *processorActivation) {
 	defer run.wg.Done()
-	reportProgress := runtimejobs.TrackProgress(run.admissionCtx, 3*reconcileInterval)
+	reportProgress := runtimejobs.TrackProgress(run.admissionCtx, reconcileInterval)
 	ticker := time.NewTicker(reconcileInterval)
 	defer ticker.Stop()
 	for {

--- a/server/internal/domain/session/service.go
+++ b/server/internal/domain/session/service.go
@@ -80,6 +80,9 @@ func (s *Service) Create(ctx context.Context, userID, orgID int64, userAgent, ip
 func (s *Service) Validate(ctx context.Context, sessionID string) (*Session, error) {
 	session, err := s.store.GetSessionByID(ctx, sessionID)
 	if err != nil {
+		if fleeterror.IsCanceledError(err) {
+			return nil, fleeterror.NewCanceledError()
+		}
 		if s.validationFailureClassifier != nil && s.validationFailureClassifier(err) {
 			slog.ErrorContext(ctx, "failed to validate session lookup", "sessionID", truncateSessionID(sessionID), "error", err)
 			return nil, fleeterror.NewUnavailableErrorf(sessionValidationUnavailableMessage)
@@ -100,6 +103,9 @@ func (s *Service) Validate(ctx context.Context, sessionID string) (*Session, err
 	// Sliding window: extend expiry on activity
 	newExpiry := now.Add(s.cfg.Duration)
 	if err := s.store.UpdateSessionActivity(ctx, sessionID, now, newExpiry); err != nil {
+		if fleeterror.IsCanceledError(err) {
+			return nil, fleeterror.NewCanceledError()
+		}
 		slog.ErrorContext(ctx, "failed to update session activity", "sessionID", truncateSessionID(sessionID), "error", err)
 		if s.validationFailureClassifier != nil && s.validationFailureClassifier(err) {
 			return nil, fleeterror.NewUnavailableErrorf(sessionValidationUnavailableMessage)

--- a/server/internal/domain/stores/sqlstores/device.go
+++ b/server/internal/domain/stores/sqlstores/device.go
@@ -1054,7 +1054,7 @@ func (s *SQLDeviceStore) ListMinerStateSnapshots(ctx context.Context, orgID int6
 			FirmwareVersionValues:     fp.firmwareVersionValues,
 		})
 		if err != nil {
-			return nil, "", 0, fleeterror.NewInternalErrorf("failed to get total count: %v", err)
+			return nil, "", 0, fleeterror.NewInternalErrorf("failed to get total count: %w", err)
 		}
 	}
 
@@ -1079,7 +1079,7 @@ func (s *SQLDeviceStore) executeListQuery(ctx context.Context, orgID int64, curs
 
 	sqlRows, err := s.conn.QueryContext(ctx, query, args...)
 	if err != nil {
-		return nil, fleeterror.NewInternalErrorf("failed to list miner state snapshots: %v", err)
+		return nil, fleeterror.NewInternalErrorf("failed to list miner state snapshots: %w", err)
 	}
 	defer sqlRows.Close()
 
@@ -1113,13 +1113,13 @@ func (s *SQLDeviceStore) executeListQuery(ctx context.Context, orgID int64, curs
 			&row.SortValue,
 		)
 		if err != nil {
-			return nil, fleeterror.NewInternalErrorf("failed to list miner state snapshots: %v", err)
+			return nil, fleeterror.NewInternalErrorf("failed to list miner state snapshots: %w", err)
 		}
 		rows = append(rows, row)
 	}
 
 	if err := sqlRows.Err(); err != nil {
-		return nil, fleeterror.NewInternalErrorf("failed to list miner state snapshots: %v", err)
+		return nil, fleeterror.NewInternalErrorf("failed to list miner state snapshots: %w", err)
 	}
 
 	return rows, nil
@@ -1151,7 +1151,7 @@ func (s *SQLDeviceStore) executeCountQuery(ctx context.Context, orgID int64, fp 
 	query, args := s.buildCountQuerySQL(orgID, fp)
 	var total int64
 	if err := s.conn.QueryRowContext(ctx, query, args...).Scan(&total); err != nil {
-		return 0, fleeterror.NewInternalErrorf("failed to get total count: %v", err)
+		return 0, fleeterror.NewInternalErrorf("failed to get total count: %w", err)
 	}
 	return total, nil
 }

--- a/server/internal/domain/telemetry/service.go
+++ b/server/internal/domain/telemetry/service.go
@@ -556,7 +556,7 @@ func (s *TelemetryService) gatherMetricsRoutine(ctx context.Context, tasks chan<
 	if fetchInterval <= 0 {
 		fetchInterval = defaultFetchInterval
 	}
-	reportProgress := runtimejobs.TrackProgress(ctx, 3*fetchInterval)
+	reportProgress := runtimejobs.TrackProgress(ctx, fetchInterval)
 	ticker := time.NewTicker(fetchInterval)
 	defer ticker.Stop()
 	for {

--- a/server/internal/domain/telemetry/service.go
+++ b/server/internal/domain/telemetry/service.go
@@ -94,6 +94,7 @@ import (
 	stores "github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
 	"github.com/block/proto-fleet/server/internal/domain/telemetry/models"
 	modelsV2 "github.com/block/proto-fleet/server/internal/domain/telemetry/models/v2"
+	"github.com/block/proto-fleet/server/internal/runtimejobs"
 )
 
 const (
@@ -555,6 +556,7 @@ func (s *TelemetryService) gatherMetricsRoutine(ctx context.Context, tasks chan<
 	if fetchInterval <= 0 {
 		fetchInterval = defaultFetchInterval
 	}
+	reportProgress := runtimejobs.TrackProgress(ctx, 3*fetchInterval)
 	ticker := time.NewTicker(fetchInterval)
 	defer ticker.Stop()
 	for {
@@ -566,6 +568,9 @@ func (s *TelemetryService) gatherMetricsRoutine(ctx context.Context, tasks chan<
 			devices, err := s.updateScheduler.FetchDevices(ctx, lookback)
 			if err != nil {
 				slog.Error("failed to fetch devices for telemetry", "error", err)
+				if ctx.Err() == nil {
+					reportProgress()
+				}
 				continue
 			}
 			for index, device := range devices {
@@ -575,6 +580,9 @@ func (s *TelemetryService) gatherMetricsRoutine(ctx context.Context, tasks chan<
 					s.requeueTelemetryTasks(devices[index:])
 					return
 				}
+			}
+			if ctx.Err() == nil {
+				reportProgress()
 			}
 		}
 	}

--- a/server/internal/domain/telemetry/service.go
+++ b/server/internal/domain/telemetry/service.go
@@ -568,9 +568,7 @@ func (s *TelemetryService) gatherMetricsRoutine(ctx context.Context, tasks chan<
 			devices, err := s.updateScheduler.FetchDevices(ctx, lookback)
 			if err != nil {
 				slog.Error("failed to fetch devices for telemetry", "error", err)
-				if ctx.Err() == nil {
-					reportProgress()
-				}
+				reportProgress()
 				continue
 			}
 			for index, device := range devices {
@@ -581,9 +579,7 @@ func (s *TelemetryService) gatherMetricsRoutine(ctx context.Context, tasks chan<
 					return
 				}
 			}
-			if ctx.Err() == nil {
-				reportProgress()
-			}
+			reportProgress()
 		}
 	}
 }

--- a/server/internal/handlers/command/handler.go
+++ b/server/internal/handlers/command/handler.go
@@ -257,7 +257,6 @@ func (h *Handler) StreamCommandBatchUpdates(ctx context.Context, r *connect.Requ
 			return fleeterror.NewInternalErrorf("context done with error: %v", ctx.Err())
 		case resp, ok := <-responseChan:
 			if !ok {
-				slog.Warn("channel closed")
 				return nil
 			}
 			slog.Debug("sending update", "payload", resp)

--- a/server/internal/handlers/firmware/chunked.go
+++ b/server/internal/handlers/firmware/chunked.go
@@ -19,6 +19,7 @@ import (
 	"github.com/block/proto-fleet/server/internal/domain/session"
 	"github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
 	"github.com/block/proto-fleet/server/internal/infrastructure/files"
+	"github.com/block/proto-fleet/server/internal/runtimejobs"
 )
 
 type uploadSession struct {
@@ -64,6 +65,7 @@ func (m *ChunkedUploadManager) StartCleanup(ctx context.Context, ttl time.Durati
 	if interval < time.Minute {
 		interval = time.Minute
 	}
+	reportProgress := runtimejobs.TrackProgress(ctx, 3*interval)
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
@@ -71,6 +73,9 @@ func (m *ChunkedUploadManager) StartCleanup(ctx context.Context, ttl time.Durati
 		select {
 		case <-ticker.C:
 			m.cleanupExpired(ttl)
+			if ctx.Err() == nil {
+				reportProgress()
+			}
 		case <-ctx.Done():
 			return
 		}

--- a/server/internal/handlers/firmware/chunked.go
+++ b/server/internal/handlers/firmware/chunked.go
@@ -73,9 +73,7 @@ func (m *ChunkedUploadManager) StartCleanup(ctx context.Context, ttl time.Durati
 		select {
 		case <-ticker.C:
 			m.cleanupExpired(ttl)
-			if ctx.Err() == nil {
-				reportProgress()
-			}
+			reportProgress()
 		case <-ctx.Done():
 			return
 		}

--- a/server/internal/handlers/firmware/chunked.go
+++ b/server/internal/handlers/firmware/chunked.go
@@ -65,7 +65,7 @@ func (m *ChunkedUploadManager) StartCleanup(ctx context.Context, ttl time.Durati
 	if interval < time.Minute {
 		interval = time.Minute
 	}
-	reportProgress := runtimejobs.TrackProgress(ctx, 3*interval)
+	reportProgress := runtimejobs.TrackProgress(ctx, interval)
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 

--- a/server/internal/handlers/interceptors/authentication.go
+++ b/server/internal/handlers/interceptors/authentication.go
@@ -289,6 +289,9 @@ func (i *AuthInterceptor) parseSessionCookie(requestHeader http.Header) (string,
 // and Internal for transient store failures, so callers can distinguish between invalid
 // credentials and backend outages.
 func classifyLookupError(err error, logMsg string, userID int64) error {
+	if fleeterror.IsCanceledError(err) {
+		return fleeterror.NewCanceledError()
+	}
 	if errors.Is(err, sql.ErrNoRows) {
 		slog.Warn(logMsg, "user_id", userID, "error", err)
 		return fleeterror.NewUnauthenticatedError("authentication failed")

--- a/server/internal/handlers/interceptors/error_stack_trace_logging.go
+++ b/server/internal/handlers/interceptors/error_stack_trace_logging.go
@@ -54,6 +54,9 @@ func (e ErrorStackTraceLoggingInterceptor) logError(err error) {
 	if err == nil {
 		return
 	}
+	if fleeterror.IsCanceledError(err) {
+		return
+	}
 
 	var fleetErr fleeterror.FleetError
 	if errors.As(err, &fleetErr) {

--- a/server/internal/handlers/interceptors/request_logging.go
+++ b/server/internal/handlers/interceptors/request_logging.go
@@ -67,6 +67,9 @@ func (e *RequestLoggingInterceptor) logUnaryRequest(request connect.AnyRequest, 
 	logBody := e.logLevel <= slog.LevelDebug && !SensitiveBodyProcedures[procedure]
 
 	if err != nil {
+		if fleeterror.IsCanceledError(err) {
+			return
+		}
 		if logBody {
 			slog.Error("incoming unary request failed",
 				"procedure", procedure,

--- a/server/internal/infrastructure/sysmon/sysmon.go
+++ b/server/internal/infrastructure/sysmon/sysmon.go
@@ -75,18 +75,14 @@ func (c *Collector) Run(ctx context.Context) {
 	ticker := time.NewTicker(c.cfg.Interval)
 	defer ticker.Stop()
 	c.collectOnce(ctx)
-	if ctx.Err() == nil {
-		reportProgress()
-	}
+	reportProgress()
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
 			c.collectOnce(ctx)
-			if ctx.Err() == nil {
-				reportProgress()
-			}
+			reportProgress()
 		}
 	}
 }

--- a/server/internal/infrastructure/sysmon/sysmon.go
+++ b/server/internal/infrastructure/sysmon/sysmon.go
@@ -71,7 +71,7 @@ func New(cfg Config, emitter Emitter) *Collector {
 // Run samples immediately — the heartbeat-staleness rule budgets for a fresh
 // sample shortly after boot — and then on every tick until ctx is cancelled.
 func (c *Collector) Run(ctx context.Context) {
-	reportProgress := runtimejobs.TrackProgress(ctx, 3*c.cfg.Interval)
+	reportProgress := runtimejobs.TrackProgress(ctx, c.cfg.Interval)
 	ticker := time.NewTicker(c.cfg.Interval)
 	defer ticker.Stop()
 	c.collectOnce(ctx)

--- a/server/internal/infrastructure/sysmon/sysmon.go
+++ b/server/internal/infrastructure/sysmon/sysmon.go
@@ -12,6 +12,8 @@ import (
 	"github.com/shirou/gopsutil/v4/cpu"
 	"github.com/shirou/gopsutil/v4/disk"
 	"github.com/shirou/gopsutil/v4/mem"
+
+	"github.com/block/proto-fleet/server/internal/runtimejobs"
 )
 
 type Config struct {
@@ -69,15 +71,22 @@ func New(cfg Config, emitter Emitter) *Collector {
 // Run samples immediately — the heartbeat-staleness rule budgets for a fresh
 // sample shortly after boot — and then on every tick until ctx is cancelled.
 func (c *Collector) Run(ctx context.Context) {
+	reportProgress := runtimejobs.TrackProgress(ctx, 3*c.cfg.Interval)
 	ticker := time.NewTicker(c.cfg.Interval)
 	defer ticker.Stop()
 	c.collectOnce(ctx)
+	if ctx.Err() == nil {
+		reportProgress()
+	}
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
 			c.collectOnce(ctx)
+			if ctx.Err() == nil {
+				reportProgress()
+			}
 		}
 	}
 }

--- a/server/internal/runtimejobs/group.go
+++ b/server/internal/runtimejobs/group.go
@@ -16,11 +16,10 @@ const (
 )
 
 type jobRuntimeStatus struct {
-	state           State
-	progressTracked bool
-	lastProgress    time.Time
-	staleAfter      time.Duration
-	staleLogged     bool
+	state        State
+	lastProgress time.Time
+	staleAfter   time.Duration
+	staleLogged  bool
 }
 
 // Group owns at most one activation of an ordered set of jobs at a time.
@@ -94,7 +93,7 @@ func (g *Group) Status() GroupStatus {
 		status.Jobs[i] = JobStatus{
 			Name:            job.Name(),
 			State:           runtimeStatus.state,
-			ProgressTracked: runtimeStatus.progressTracked,
+			ProgressTracked: runtimeStatus.staleAfter > 0,
 			LastProgress:    runtimeStatus.lastProgress,
 			StaleAfter:      runtimeStatus.staleAfter,
 			Stale:           isStale(runtimeStatus, now),
@@ -245,8 +244,7 @@ func (g *Group) stopJobs(parent context.Context, jobs []Job) error {
 	defer cancel()
 
 	var stopErrors []error
-	for i := len(jobs) - 1; i >= 0; i-- {
-		job := jobs[i]
+	for i, job := range slices.Backward(jobs) {
 		g.setJobState(i, StateStopping)
 		startedAt := time.Now()
 		err := g.stopJob(stopCtx, job)
@@ -299,7 +297,6 @@ func (g *Group) trackProgress(index int, generation uint64, staleAfter time.Dura
 		g.stateMu.Unlock()
 		return func() {}
 	}
-	g.jobStatuses[index].progressTracked = true
 	g.jobStatuses[index].lastProgress = time.Now()
 	g.jobStatuses[index].staleAfter = staleAfter
 	g.jobStatuses[index].staleLogged = false
@@ -331,7 +328,7 @@ func (g *Group) monitorProgress(ctx context.Context, generation uint64) {
 
 func (g *Group) logProgressTransitions(generation uint64, now time.Time) {
 	type transition struct {
-		message      string
+		stale        bool
 		name         string
 		lastProgress time.Time
 		staleAfter   time.Duration
@@ -345,7 +342,7 @@ func (g *Group) logProgressTransitions(generation uint64, now time.Time) {
 	}
 	for i, job := range g.jobs {
 		status := &g.jobStatuses[i]
-		if status.state != StateRunning || !status.progressTracked {
+		if status.state != StateRunning || status.staleAfter <= 0 {
 			continue
 		}
 		stale := isStale(*status, now)
@@ -353,7 +350,7 @@ func (g *Group) logProgressTransitions(generation uint64, now time.Time) {
 		case stale && !status.staleLogged:
 			status.staleLogged = true
 			transitions = append(transitions, transition{
-				message:      "runtime job stale",
+				stale:        true,
 				name:         job.Name(),
 				lastProgress: status.lastProgress,
 				staleAfter:   status.staleAfter,
@@ -361,7 +358,6 @@ func (g *Group) logProgressTransitions(generation uint64, now time.Time) {
 		case !stale && status.staleLogged:
 			status.staleLogged = false
 			transitions = append(transitions, transition{
-				message:      "runtime job recovered",
 				name:         job.Name(),
 				lastProgress: status.lastProgress,
 				staleAfter:   status.staleAfter,
@@ -371,15 +367,15 @@ func (g *Group) logProgressTransitions(generation uint64, now time.Time) {
 	g.stateMu.Unlock()
 
 	for _, transition := range transitions {
-		if transition.message == "runtime job stale" {
-			g.logger.Warn(transition.message,
+		if transition.stale {
+			g.logger.Warn("runtime job stale",
 				"job", transition.name,
 				"last_progress", transition.lastProgress,
 				"stale_after", transition.staleAfter,
 			)
 			continue
 		}
-		g.logger.Info(transition.message,
+		g.logger.Info("runtime job recovered",
 			"job", transition.name,
 			"last_progress", transition.lastProgress,
 			"stale_after", transition.staleAfter,
@@ -389,7 +385,7 @@ func (g *Group) logProgressTransitions(generation uint64, now time.Time) {
 
 func isStale(status jobRuntimeStatus, now time.Time) bool {
 	return status.state == StateRunning &&
-		status.progressTracked &&
+		status.staleAfter > 0 &&
 		!status.lastProgress.IsZero() &&
 		!now.Before(status.lastProgress.Add(status.staleAfter))
 }

--- a/server/internal/runtimejobs/group.go
+++ b/server/internal/runtimejobs/group.go
@@ -318,9 +318,25 @@ func (g *Group) monitorProgress(ctx context.Context, generation uint64) {
 	for {
 		select {
 		case <-ctx.Done():
+			g.markActivationStopping(generation)
 			return
 		case now := <-ticker.C:
 			g.logProgressTransitions(generation, now)
+		}
+	}
+}
+
+func (g *Group) markActivationStopping(generation uint64) {
+	g.stateMu.Lock()
+	defer g.stateMu.Unlock()
+	if generation != g.generation || g.state != StateRunning {
+		return
+	}
+	g.state = StateStopping
+	for i := range g.jobStatuses {
+		if g.jobStatuses[i].state == StateRunning {
+			g.jobStatuses[i].state = StateStopping
+			g.jobStatuses[i].staleLogged = false
 		}
 	}
 }

--- a/server/internal/runtimejobs/group.go
+++ b/server/internal/runtimejobs/group.go
@@ -91,12 +91,11 @@ func (g *Group) Status() GroupStatus {
 	for i, job := range g.jobs {
 		runtimeStatus := g.jobStatuses[i]
 		status.Jobs[i] = JobStatus{
-			Name:            job.Name(),
-			State:           runtimeStatus.state,
-			ProgressTracked: runtimeStatus.staleAfter > 0,
-			LastProgress:    runtimeStatus.lastProgress,
-			StaleAfter:      runtimeStatus.staleAfter,
-			Stale:           isStale(runtimeStatus, now),
+			Name:         job.Name(),
+			State:        runtimeStatus.state,
+			LastProgress: runtimeStatus.lastProgress,
+			StaleAfter:   runtimeStatus.staleAfter,
+			Stale:        isStale(runtimeStatus, now),
 		}
 	}
 	return status

--- a/server/internal/runtimejobs/group.go
+++ b/server/internal/runtimejobs/group.go
@@ -4,12 +4,24 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"slices"
 	"sync"
 	"time"
 )
 
-const groupCleanupTimeout = 10 * time.Second
+const (
+	groupCleanupTimeout   = 10 * time.Second
+	progressCheckInterval = 5 * time.Second
+)
+
+type jobRuntimeStatus struct {
+	state           State
+	progressTracked bool
+	lastProgress    time.Time
+	staleAfter      time.Duration
+	staleLogged     bool
+}
 
 // Group owns at most one activation of an ordered set of jobs at a time.
 //
@@ -23,6 +35,12 @@ type Group struct {
 	terminalErr    error
 	activationDone <-chan struct{}
 	cancel         context.CancelFunc
+	state          State
+	jobStatuses    []jobRuntimeStatus
+	generation     uint64
+
+	logger          *slog.Logger
+	monitorInterval time.Duration
 }
 
 // NewGroup validates group configuration and creates a stopped group.
@@ -40,7 +58,17 @@ func NewGroup(jobs []Job) (*Group, error) {
 		seen[job.Name()] = struct{}{}
 	}
 
-	return &Group{jobs: slices.Clone(jobs)}, nil
+	jobStatuses := make([]jobRuntimeStatus, len(jobs))
+	for i := range jobStatuses {
+		jobStatuses[i].state = StateStopped
+	}
+	return &Group{
+		jobs:            slices.Clone(jobs),
+		state:           StateStopped,
+		jobStatuses:     jobStatuses,
+		logger:          slog.Default(),
+		monitorInterval: progressCheckInterval,
+	}, nil
 }
 
 // Err reports the terminal cleanup failure that prevents reactivation.
@@ -48,6 +76,31 @@ func (g *Group) Err() error {
 	g.stateMu.Lock()
 	defer g.stateMu.Unlock()
 	return g.terminalErr
+}
+
+// Status returns a concurrency-safe snapshot in job registration order.
+func (g *Group) Status() GroupStatus {
+	now := time.Now()
+	g.stateMu.Lock()
+	defer g.stateMu.Unlock()
+
+	status := GroupStatus{
+		State:         g.state,
+		TerminalError: g.terminalErr,
+		Jobs:          make([]JobStatus, len(g.jobs)),
+	}
+	for i, job := range g.jobs {
+		runtimeStatus := g.jobStatuses[i]
+		status.Jobs[i] = JobStatus{
+			Name:            job.Name(),
+			State:           runtimeStatus.state,
+			ProgressTracked: runtimeStatus.progressTracked,
+			LastProgress:    runtimeStatus.lastProgress,
+			StaleAfter:      runtimeStatus.staleAfter,
+			Stale:           isStale(runtimeStatus, now),
+		}
+	}
+	return status
 }
 
 // Start starts every job in registration order.
@@ -69,26 +122,44 @@ func (g *Group) Start(ctx context.Context) error {
 	}
 
 	activationCtx, cancel := context.WithCancel(ctx)
-	g.setActivation(activationCtx.Done(), cancel)
+	generation := g.beginActivation(activationCtx.Done(), cancel)
 	started := 0
-	for _, job := range g.jobs {
+	for i, job := range g.jobs {
+		g.setJobState(i, StateStarting)
 		if err := activationCtx.Err(); err != nil {
+			g.logStartFailure(job, 0, err)
+			g.setJobState(i, StateFailed)
 			return g.failStart(ctx, started, fmt.Errorf("start runtime job %q: %w", job.Name(), err))
 		}
-		if err := job.Start(activationCtx); err != nil {
+		jobCtx := context.WithValue(activationCtx, progressContextKey{}, progressContext{
+			group:      g,
+			jobIndex:   i,
+			generation: generation,
+		})
+		startedAt := time.Now()
+		if err := job.Start(jobCtx); err != nil {
+			g.logStartFailure(job, time.Since(startedAt), err)
+			g.setJobState(i, StateFailed)
 			return g.failStart(ctx, started, fmt.Errorf("start runtime job %q: %w", job.Name(), err))
 		}
+		g.logger.Info("runtime job started",
+			"job", job.Name(),
+			"duration", time.Since(startedAt),
+		)
+		g.setJobState(i, StateRunning)
 		started++
 	}
 	if err := activationCtx.Err(); err != nil {
 		return g.failStart(ctx, started, fmt.Errorf("start runtime job group: %w", err))
 	}
 
+	g.setGroupState(StateRunning)
+	go g.monitorProgress(activationCtx, generation)
 	return nil
 }
 
 func (g *Group) failStart(ctx context.Context, started int, startErr error) error {
-	g.cancelActivation()
+	g.endActivation()
 	rollbackCtx := context.WithoutCancel(ctx)
 	if deadline, ok := ctx.Deadline(); ok {
 		var cancel context.CancelFunc
@@ -96,8 +167,8 @@ func (g *Group) failStart(ctx context.Context, started int, startErr error) erro
 		defer cancel()
 	}
 	rollbackErr := g.stopJobs(rollbackCtx, g.jobs[:started])
-	g.clearActivation()
 	if rollbackErr == nil {
+		g.setGroupState(StateStopped)
 		return startErr
 	}
 
@@ -120,13 +191,14 @@ func (g *Group) Stop(ctx context.Context) error {
 		return nil
 	}
 
-	g.cancelActivation()
-	g.clearActivation()
+	g.endActivation()
+	g.setGroupState(StateStopping)
 	err := g.stopJobs(ctx, g.jobs)
 	if err != nil {
 		g.setTerminalErr(err)
 		return err
 	}
+	g.setGroupState(StateStopped)
 	return nil
 }
 
@@ -134,6 +206,7 @@ func (g *Group) setTerminalErr(err error) {
 	g.stateMu.Lock()
 	defer g.stateMu.Unlock()
 	g.terminalErr = err
+	g.state = StateFailed
 }
 
 func (g *Group) activation() (<-chan struct{}, context.CancelFunc) {
@@ -142,25 +215,29 @@ func (g *Group) activation() (<-chan struct{}, context.CancelFunc) {
 	return g.activationDone, g.cancel
 }
 
-func (g *Group) setActivation(done <-chan struct{}, cancel context.CancelFunc) {
+func (g *Group) beginActivation(done <-chan struct{}, cancel context.CancelFunc) uint64 {
 	g.stateMu.Lock()
 	defer g.stateMu.Unlock()
+	g.generation++
 	g.activationDone = done
 	g.cancel = cancel
+	g.state = StateStarting
+	for i := range g.jobStatuses {
+		g.jobStatuses[i] = jobRuntimeStatus{state: StateStopped}
+	}
+	return g.generation
 }
 
-func (g *Group) cancelActivation() {
-	_, cancel := g.activation()
+func (g *Group) endActivation() {
+	g.stateMu.Lock()
+	cancel := g.cancel
+	g.activationDone = nil
+	g.cancel = nil
+	g.generation++
+	g.stateMu.Unlock()
 	if cancel != nil {
 		cancel()
 	}
-}
-
-func (g *Group) clearActivation() {
-	g.stateMu.Lock()
-	defer g.stateMu.Unlock()
-	g.activationDone = nil
-	g.cancel = nil
 }
 
 func (g *Group) stopJobs(parent context.Context, jobs []Job) error {
@@ -168,13 +245,153 @@ func (g *Group) stopJobs(parent context.Context, jobs []Job) error {
 	defer cancel()
 
 	var stopErrors []error
-	for _, job := range slices.Backward(jobs) {
+	for i := len(jobs) - 1; i >= 0; i-- {
+		job := jobs[i]
+		g.setJobState(i, StateStopping)
+		startedAt := time.Now()
 		err := g.stopJob(stopCtx, job)
 		if err != nil {
+			g.logger.Error("runtime job stop failed",
+				"job", job.Name(),
+				"duration", time.Since(startedAt),
+				"error", err,
+			)
+			g.setJobState(i, StateFailed)
 			stopErrors = append(stopErrors, fmt.Errorf("stop runtime job %q: %w", job.Name(), err))
+			continue
 		}
+		g.logger.Info("runtime job stopped",
+			"job", job.Name(),
+			"duration", time.Since(startedAt),
+		)
+		g.setJobState(i, StateStopped)
 	}
 	return errors.Join(stopErrors...)
+}
+
+func (g *Group) setGroupState(state State) {
+	g.stateMu.Lock()
+	defer g.stateMu.Unlock()
+	g.state = state
+}
+
+func (g *Group) setJobState(index int, state State) {
+	g.stateMu.Lock()
+	defer g.stateMu.Unlock()
+	g.jobStatuses[index].state = state
+	if state != StateRunning && state != StateStarting {
+		g.jobStatuses[index].staleLogged = false
+	}
+}
+
+func (g *Group) logStartFailure(job Job, duration time.Duration, err error) {
+	g.logger.Error("runtime job start failed",
+		"job", job.Name(),
+		"duration", duration,
+		"error", err,
+	)
+}
+
+func (g *Group) trackProgress(index int, generation uint64, staleAfter time.Duration) func() {
+	g.stateMu.Lock()
+	if generation != g.generation ||
+		(g.jobStatuses[index].state != StateStarting && g.jobStatuses[index].state != StateRunning) {
+		g.stateMu.Unlock()
+		return func() {}
+	}
+	g.jobStatuses[index].progressTracked = true
+	g.jobStatuses[index].lastProgress = time.Now()
+	g.jobStatuses[index].staleAfter = staleAfter
+	g.jobStatuses[index].staleLogged = false
+	g.stateMu.Unlock()
+
+	return func() {
+		g.stateMu.Lock()
+		defer g.stateMu.Unlock()
+		if generation != g.generation ||
+			(g.jobStatuses[index].state != StateStarting && g.jobStatuses[index].state != StateRunning) {
+			return
+		}
+		g.jobStatuses[index].lastProgress = time.Now()
+	}
+}
+
+func (g *Group) monitorProgress(ctx context.Context, generation uint64) {
+	ticker := time.NewTicker(g.monitorInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-ticker.C:
+			g.logProgressTransitions(generation, now)
+		}
+	}
+}
+
+func (g *Group) logProgressTransitions(generation uint64, now time.Time) {
+	type transition struct {
+		message      string
+		name         string
+		lastProgress time.Time
+		staleAfter   time.Duration
+	}
+	var transitions []transition
+
+	g.stateMu.Lock()
+	if generation != g.generation {
+		g.stateMu.Unlock()
+		return
+	}
+	for i, job := range g.jobs {
+		status := &g.jobStatuses[i]
+		if status.state != StateRunning || !status.progressTracked {
+			continue
+		}
+		stale := isStale(*status, now)
+		switch {
+		case stale && !status.staleLogged:
+			status.staleLogged = true
+			transitions = append(transitions, transition{
+				message:      "runtime job stale",
+				name:         job.Name(),
+				lastProgress: status.lastProgress,
+				staleAfter:   status.staleAfter,
+			})
+		case !stale && status.staleLogged:
+			status.staleLogged = false
+			transitions = append(transitions, transition{
+				message:      "runtime job recovered",
+				name:         job.Name(),
+				lastProgress: status.lastProgress,
+				staleAfter:   status.staleAfter,
+			})
+		}
+	}
+	g.stateMu.Unlock()
+
+	for _, transition := range transitions {
+		if transition.message == "runtime job stale" {
+			g.logger.Warn(transition.message,
+				"job", transition.name,
+				"last_progress", transition.lastProgress,
+				"stale_after", transition.staleAfter,
+			)
+			continue
+		}
+		g.logger.Info(transition.message,
+			"job", transition.name,
+			"last_progress", transition.lastProgress,
+			"stale_after", transition.staleAfter,
+		)
+	}
+}
+
+func isStale(status jobRuntimeStatus, now time.Time) bool {
+	return status.state == StateRunning &&
+		status.progressTracked &&
+		!status.lastProgress.IsZero() &&
+		!now.Before(status.lastProgress.Add(status.staleAfter))
 }
 
 func (g *Group) stopJob(stopCtx context.Context, job Job) error {

--- a/server/internal/runtimejobs/group_test.go
+++ b/server/internal/runtimejobs/group_test.go
@@ -93,8 +93,17 @@ func TestGroupRollsBackCleanlyAndCanRetry(t *testing.T) {
 	err := group.Start(context.Background())
 	require.ErrorContains(t, err, "start c")
 	assert.Equal(t, []string{"start:a", "start:b", "start:c", "stop:b", "stop:a"}, events.snapshot())
+	assert.Equal(t, GroupStatus{
+		State: StateStopped,
+		Jobs: []JobStatus{
+			{Name: "a", State: StateStopped},
+			{Name: "b", State: StateStopped},
+			{Name: "c", State: StateFailed},
+		},
+	}, group.Status())
 
 	require.NoError(t, group.Start(context.Background()))
+	assert.Equal(t, StateRunning, group.Status().State)
 	require.NoError(t, group.Stop(context.Background()))
 }
 
@@ -193,6 +202,14 @@ func TestGroupStopAggregatesErrorsAndBecomesTerminal(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, errA)
 	assert.ErrorIs(t, err, errB)
+	status := group.Status()
+	assert.Equal(t, StateFailed, status.State)
+	assert.ErrorIs(t, status.TerminalError, errA)
+	assert.ErrorIs(t, status.TerminalError, errB)
+	assert.Equal(t, []JobStatus{
+		{Name: "a", State: StateFailed},
+		{Name: "b", State: StateFailed},
+	}, status.Jobs)
 
 	err = group.Stop(context.Background())
 	assert.ErrorIs(t, err, errA)

--- a/server/internal/runtimejobs/group_test.go
+++ b/server/internal/runtimejobs/group_test.go
@@ -371,6 +371,11 @@ func TestGroupRequiresStopAfterActivationContextEnds(t *testing.T) {
 	activationCtx, cancel := context.WithCancel(context.Background())
 	require.NoError(t, group.Start(activationCtx))
 	cancel()
+	require.Eventually(t, func() bool {
+		status := group.Status()
+		return status.State == StateStopping &&
+			status.Jobs[0].State == StateStopping
+	}, time.Second, time.Millisecond)
 
 	err := group.Start(context.Background())
 	require.ErrorContains(t, err, "activation ended before stop")

--- a/server/internal/runtimejobs/status.go
+++ b/server/internal/runtimejobs/status.go
@@ -1,0 +1,57 @@
+package runtimejobs
+
+import (
+	"context"
+	"time"
+)
+
+// State is the current lifecycle state of a group or job.
+type State string
+
+const (
+	StateStopped  State = "stopped"
+	StateStarting State = "starting"
+	StateRunning  State = "running"
+	StateStopping State = "stopping"
+	StateFailed   State = "failed"
+)
+
+// GroupStatus is a point-in-time snapshot of a group and its jobs.
+type GroupStatus struct {
+	State         State
+	TerminalError error
+	Jobs          []JobStatus
+}
+
+// JobStatus is a point-in-time snapshot of one job.
+type JobStatus struct {
+	Name            string
+	State           State
+	ProgressTracked bool
+	LastProgress    time.Time
+	StaleAfter      time.Duration
+	Stale           bool
+}
+
+type progressContext struct {
+	group      *Group
+	jobIndex   int
+	generation uint64
+}
+
+type progressContextKey struct{}
+
+// TrackProgress registers freshness tracking for the managed job associated
+// with ctx. The returned reporter records completion of a representative work
+// cycle. It is a no-op outside a Group-managed Start context or when staleAfter
+// is not positive.
+func TrackProgress(ctx context.Context, staleAfter time.Duration) func() {
+	if staleAfter <= 0 {
+		return func() {}
+	}
+	progress, ok := ctx.Value(progressContextKey{}).(progressContext)
+	if !ok {
+		return func() {}
+	}
+	return progress.group.trackProgress(progress.jobIndex, progress.generation, staleAfter)
+}

--- a/server/internal/runtimejobs/status.go
+++ b/server/internal/runtimejobs/status.go
@@ -5,6 +5,8 @@ import (
 	"time"
 )
 
+const progressStaleIntervalCount = 3
+
 // State is the current lifecycle state of a group or job.
 type State string
 
@@ -23,14 +25,14 @@ type GroupStatus struct {
 	Jobs          []JobStatus
 }
 
-// JobStatus is a point-in-time snapshot of one job.
+// JobStatus is a point-in-time snapshot of one job. StaleAfter is zero when
+// progress is not tracked.
 type JobStatus struct {
-	Name            string
-	State           State
-	ProgressTracked bool
-	LastProgress    time.Time
-	StaleAfter      time.Duration
-	Stale           bool
+	Name         string
+	State        State
+	LastProgress time.Time
+	StaleAfter   time.Duration
+	Stale        bool
 }
 
 type progressContext struct {
@@ -42,18 +44,23 @@ type progressContext struct {
 type progressContextKey struct{}
 
 // TrackProgress registers freshness tracking for the managed job associated
-// with ctx. The returned reporter records completion of a representative work
-// cycle. It is a no-op outside a Group-managed Start context or when staleAfter
-// is not positive.
-func TrackProgress(ctx context.Context, staleAfter time.Duration) func() {
-	if staleAfter <= 0 || ctx.Err() != nil {
+// with ctx. A job becomes stale after three loop intervals without a completed
+// representative work cycle. Calling the returned function reports completion
+// of one such cycle. It is a no-op outside a Group-managed Start context or
+// when effectiveInterval is not positive.
+func TrackProgress(ctx context.Context, effectiveInterval time.Duration) func() {
+	if effectiveInterval <= 0 || ctx.Err() != nil {
 		return func() {}
 	}
 	progress, ok := ctx.Value(progressContextKey{}).(progressContext)
 	if !ok {
 		return func() {}
 	}
-	report := progress.group.trackProgress(progress.jobIndex, progress.generation, staleAfter)
+	report := progress.group.trackProgress(
+		progress.jobIndex,
+		progress.generation,
+		progressStaleIntervalCount*effectiveInterval,
+	)
 	return func() {
 		if ctx.Err() == nil {
 			report()

--- a/server/internal/runtimejobs/status.go
+++ b/server/internal/runtimejobs/status.go
@@ -46,12 +46,17 @@ type progressContextKey struct{}
 // cycle. It is a no-op outside a Group-managed Start context or when staleAfter
 // is not positive.
 func TrackProgress(ctx context.Context, staleAfter time.Duration) func() {
-	if staleAfter <= 0 {
+	if staleAfter <= 0 || ctx.Err() != nil {
 		return func() {}
 	}
 	progress, ok := ctx.Value(progressContextKey{}).(progressContext)
 	if !ok {
 		return func() {}
 	}
-	return progress.group.trackProgress(progress.jobIndex, progress.generation, staleAfter)
+	report := progress.group.trackProgress(progress.jobIndex, progress.generation, staleAfter)
+	return func() {
+		if ctx.Err() == nil {
+			report()
+		}
+	}
 }

--- a/server/internal/runtimejobs/status_test.go
+++ b/server/internal/runtimejobs/status_test.go
@@ -312,6 +312,66 @@ func TestStatusReturnsIndependentSnapshotsAndSupportsConcurrentProgress(t *testi
 	require.NoError(t, group.Stop(context.Background()))
 }
 
+func TestStatusIsSafeDuringConcurrentLifecycleAndProgress(t *testing.T) {
+	t.Parallel()
+
+	startEntered := make(chan struct{})
+	releaseStart := make(chan struct{})
+	stopEntered := make(chan struct{})
+	releaseStop := make(chan struct{})
+	reporter := make(chan func(), 1)
+	group := newTestGroup(t, newTestJob("job", func(ctx context.Context) error {
+		reporter <- TrackProgress(ctx, time.Hour)
+		close(startEntered)
+		<-releaseStart
+		return nil
+	}, func(context.Context) error {
+		close(stopEntered)
+		<-releaseStop
+		return nil
+	}))
+
+	startResult := make(chan error, 1)
+	go func() {
+		startResult <- group.Start(context.Background())
+	}()
+	<-startEntered
+	report := <-reporter
+
+	done := make(chan struct{})
+	var observers sync.WaitGroup
+	for range 8 {
+		observers.Add(1)
+		go func() {
+			defer observers.Done()
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					report()
+					_ = group.Status()
+				}
+			}
+		}()
+	}
+
+	close(releaseStart)
+	require.NoError(t, <-startResult)
+
+	stopResult := make(chan error, 1)
+	go func() {
+		stopResult <- group.Stop(context.Background())
+	}()
+	<-stopEntered
+	close(releaseStop)
+	require.NoError(t, <-stopResult)
+
+	close(done)
+	observers.Wait()
+	assert.Equal(t, StateStopped, group.Status().State)
+}
+
 func TestGroupLogsCanonicalJobLifecycleTransitions(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/runtimejobs/status_test.go
+++ b/server/internal/runtimejobs/status_test.go
@@ -87,55 +87,6 @@ func TestGroupStatusReportsLifecycleTransitionsInCatalogOrder(t *testing.T) {
 	}, group.Status())
 }
 
-func TestGroupStatusReportsCleanRollbackAndRestart(t *testing.T) {
-	t.Parallel()
-
-	failFirstStart := true
-	group := newTestGroup(t,
-		newTestJob("started", nil, nil),
-		newTestJob("fails-once", func(context.Context) error {
-			if failFirstStart {
-				failFirstStart = false
-				return errors.New("start failed")
-			}
-			return nil
-		}, nil),
-		newTestJob("not-started", nil, nil),
-	)
-
-	require.ErrorContains(t, group.Start(context.Background()), "start failed")
-	status := group.Status()
-	assert.Equal(t, StateStopped, status.State)
-	assert.NoError(t, status.TerminalError)
-	assert.Equal(t, []JobStatus{
-		{Name: "started", State: StateStopped},
-		{Name: "fails-once", State: StateFailed},
-		{Name: "not-started", State: StateStopped},
-	}, status.Jobs)
-
-	require.NoError(t, group.Start(context.Background()))
-	assert.Equal(t, StateRunning, group.Status().State)
-	assert.Equal(t, StateRunning, group.Status().Jobs[1].State)
-	require.NoError(t, group.Stop(context.Background()))
-}
-
-func TestGroupStatusReportsTerminalCleanupFailure(t *testing.T) {
-	t.Parallel()
-
-	stopErr := errors.New("stop failed")
-	group := newTestGroup(t, newTestJob("job", nil, func(context.Context) error {
-		return stopErr
-	}))
-	require.NoError(t, group.Start(context.Background()))
-	require.ErrorIs(t, group.Stop(context.Background()), stopErr)
-
-	status := group.Status()
-	assert.Equal(t, StateFailed, status.State)
-	assert.ErrorIs(t, status.TerminalError, stopErr)
-	require.Len(t, status.Jobs, 1)
-	assert.Equal(t, StateFailed, status.Jobs[0].State)
-}
-
 func TestTrackProgressReportsFreshnessAndIsolatesActivations(t *testing.T) {
 	t.Parallel()
 
@@ -242,7 +193,7 @@ func TestProgressMonitorLogsOnlyStaleAndRecoveredTransitions(t *testing.T) {
 	require.NoError(t, group.Stop(context.Background()))
 }
 
-func TestUntrackedAndStoppedJobsNeverBecomeStale(t *testing.T) {
+func TestUntrackedJobsNeverBecomeStale(t *testing.T) {
 	t.Parallel()
 
 	tracked := make(chan struct{}, 1)
@@ -264,52 +215,22 @@ func TestUntrackedAndStoppedJobsNeverBecomeStale(t *testing.T) {
 	assert.False(t, group.Status().Jobs[0].Stale)
 
 	require.NoError(t, group.Stop(context.Background()))
-	status := group.Status()
-	assert.False(t, status.Jobs[0].Stale)
-	assert.False(t, status.Jobs[1].Stale)
 }
 
 func TestTrackProgressOutsideManagedJobIsNoop(t *testing.T) {
 	t.Parallel()
 
 	report := TrackProgress(context.Background(), time.Nanosecond)
-	require.NotNil(t, report)
 	assert.NotPanics(t, report)
 }
 
-func TestStatusReturnsIndependentSnapshotsAndSupportsConcurrentProgress(t *testing.T) {
+func TestStatusReturnsIndependentSnapshots(t *testing.T) {
 	t.Parallel()
 
-	reporter := make(chan func(), 1)
-	group := newTestGroup(t, newTestJob("job", func(ctx context.Context) error {
-		reporter <- TrackProgress(ctx, time.Hour)
-		return nil
-	}, nil))
-	require.NoError(t, group.Start(context.Background()))
-	report := <-reporter
-
+	group := newTestGroup(t, newTestJob("job", nil, nil))
 	snapshot := group.Status()
 	snapshot.Jobs[0].Name = "changed"
 	assert.Equal(t, "job", group.Status().Jobs[0].Name)
-
-	var wg sync.WaitGroup
-	for range 8 {
-		wg.Add(2)
-		go func() {
-			defer wg.Done()
-			for range 100 {
-				report()
-			}
-		}()
-		go func() {
-			defer wg.Done()
-			for range 100 {
-				_ = group.Status()
-			}
-		}()
-	}
-	wg.Wait()
-	require.NoError(t, group.Stop(context.Background()))
 }
 
 func TestStatusIsSafeDuringConcurrentLifecycleAndProgress(t *testing.T) {

--- a/server/internal/runtimejobs/status_test.go
+++ b/server/internal/runtimejobs/status_test.go
@@ -158,7 +158,8 @@ func TestTrackProgressReportsFreshnessAndIsolatesActivations(t *testing.T) {
 	assert.True(t, stopped.Jobs[0].ProgressTracked)
 	assert.False(t, stopped.Jobs[0].Stale)
 
-	require.NoError(t, group.Start(context.Background()))
+	activationCtx, cancelActivation := context.WithCancel(context.Background())
+	require.NoError(t, group.Start(activationCtx))
 	currentReporter := <-reporters
 	beforeOldReport := group.Status().Jobs[0].LastProgress
 	time.Sleep(time.Millisecond)
@@ -168,6 +169,11 @@ func TestTrackProgressReportsFreshnessAndIsolatesActivations(t *testing.T) {
 	time.Sleep(time.Millisecond)
 	currentReporter()
 	assert.True(t, group.Status().Jobs[0].LastProgress.After(beforeOldReport))
+
+	beforeCancellation := group.Status().Jobs[0].LastProgress
+	cancelActivation()
+	currentReporter()
+	assert.Equal(t, beforeCancellation, group.Status().Jobs[0].LastProgress)
 	require.NoError(t, group.Stop(context.Background()))
 }
 
@@ -367,6 +373,8 @@ func TestGroupLogsCanonicalJobLifecycleTransitions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			logs := &recordingHandler{}
 			group := newTestGroup(t, tt.job)
 			group.logger = slog.New(logs)
@@ -385,7 +393,9 @@ func TestGroupLogsCanonicalJobLifecycleTransitions(t *testing.T) {
 			assert.Equal(t, "job", attrs["job"].String())
 			assert.Equal(t, slog.KindDuration, attrs["duration"].Kind())
 			if tt.expectedError != nil {
-				assert.Equal(t, tt.expectedError.Error(), attrs["error"].Any().(error).Error())
+				loggedErr, ok := attrs["error"].Any().(error)
+				require.True(t, ok)
+				assert.Equal(t, tt.expectedError.Error(), loggedErr.Error())
 			}
 		})
 	}

--- a/server/internal/runtimejobs/status_test.go
+++ b/server/internal/runtimejobs/status_test.go
@@ -1,0 +1,448 @@
+package runtimejobs
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGroupStatusReportsLifecycleTransitionsInCatalogOrder(t *testing.T) {
+	t.Parallel()
+
+	startSecond := make(chan struct{})
+	stopSecond := make(chan struct{})
+	startResult := make(chan error, 1)
+	stopResult := make(chan error, 1)
+	group := newTestGroup(t,
+		newTestJob("first", nil, nil),
+		newTestJob(
+			"second",
+			func(context.Context) error {
+				<-startSecond
+				return nil
+			},
+			func(context.Context) error {
+				<-stopSecond
+				return nil
+			},
+		),
+		newTestJob("third", nil, nil),
+	)
+
+	assert.Equal(t, GroupStatus{
+		State: StateStopped,
+		Jobs: []JobStatus{
+			{Name: "first", State: StateStopped},
+			{Name: "second", State: StateStopped},
+			{Name: "third", State: StateStopped},
+		},
+	}, group.Status())
+
+	go func() {
+		startResult <- group.Start(context.Background())
+	}()
+	require.Eventually(t, func() bool {
+		status := group.Status()
+		return status.State == StateStarting &&
+			status.Jobs[0].State == StateRunning &&
+			status.Jobs[1].State == StateStarting &&
+			status.Jobs[2].State == StateStopped
+	}, time.Second, time.Millisecond)
+
+	close(startSecond)
+	require.NoError(t, <-startResult)
+	assert.Equal(t, StateRunning, group.Status().State)
+	assert.Equal(t, []JobStatus{
+		{Name: "first", State: StateRunning},
+		{Name: "second", State: StateRunning},
+		{Name: "third", State: StateRunning},
+	}, group.Status().Jobs)
+
+	go func() {
+		stopResult <- group.Stop(context.Background())
+	}()
+	require.Eventually(t, func() bool {
+		status := group.Status()
+		return status.State == StateStopping &&
+			status.Jobs[0].State == StateRunning &&
+			status.Jobs[1].State == StateStopping &&
+			status.Jobs[2].State == StateStopped
+	}, time.Second, time.Millisecond)
+
+	close(stopSecond)
+	require.NoError(t, <-stopResult)
+	assert.Equal(t, GroupStatus{
+		State: StateStopped,
+		Jobs: []JobStatus{
+			{Name: "first", State: StateStopped},
+			{Name: "second", State: StateStopped},
+			{Name: "third", State: StateStopped},
+		},
+	}, group.Status())
+}
+
+func TestGroupStatusReportsCleanRollbackAndRestart(t *testing.T) {
+	t.Parallel()
+
+	failFirstStart := true
+	group := newTestGroup(t,
+		newTestJob("started", nil, nil),
+		newTestJob("fails-once", func(context.Context) error {
+			if failFirstStart {
+				failFirstStart = false
+				return errors.New("start failed")
+			}
+			return nil
+		}, nil),
+		newTestJob("not-started", nil, nil),
+	)
+
+	require.ErrorContains(t, group.Start(context.Background()), "start failed")
+	status := group.Status()
+	assert.Equal(t, StateStopped, status.State)
+	assert.NoError(t, status.TerminalError)
+	assert.Equal(t, []JobStatus{
+		{Name: "started", State: StateStopped},
+		{Name: "fails-once", State: StateFailed},
+		{Name: "not-started", State: StateStopped},
+	}, status.Jobs)
+
+	require.NoError(t, group.Start(context.Background()))
+	assert.Equal(t, StateRunning, group.Status().State)
+	assert.Equal(t, StateRunning, group.Status().Jobs[1].State)
+	require.NoError(t, group.Stop(context.Background()))
+}
+
+func TestGroupStatusReportsTerminalCleanupFailure(t *testing.T) {
+	t.Parallel()
+
+	stopErr := errors.New("stop failed")
+	group := newTestGroup(t, newTestJob("job", nil, func(context.Context) error {
+		return stopErr
+	}))
+	require.NoError(t, group.Start(context.Background()))
+	require.ErrorIs(t, group.Stop(context.Background()), stopErr)
+
+	status := group.Status()
+	assert.Equal(t, StateFailed, status.State)
+	assert.ErrorIs(t, status.TerminalError, stopErr)
+	require.Len(t, status.Jobs, 1)
+	assert.Equal(t, StateFailed, status.Jobs[0].State)
+}
+
+func TestTrackProgressReportsFreshnessAndIsolatesActivations(t *testing.T) {
+	t.Parallel()
+
+	reporters := make(chan func(), 2)
+	group := newTestGroup(t, newTestJob("job", func(ctx context.Context) error {
+		reporters <- TrackProgress(ctx, time.Hour)
+		return nil
+	}, nil))
+
+	require.NoError(t, group.Start(context.Background()))
+	oldReporter := <-reporters
+	first := group.Status()
+	require.True(t, first.Jobs[0].ProgressTracked)
+	assert.WithinDuration(t, time.Now(), first.Jobs[0].LastProgress, time.Second)
+	assert.Equal(t, time.Hour, first.Jobs[0].StaleAfter)
+	assert.False(t, first.Jobs[0].Stale)
+	require.NoError(t, group.Stop(context.Background()))
+
+	stopped := group.Status()
+	assert.True(t, stopped.Jobs[0].ProgressTracked)
+	assert.False(t, stopped.Jobs[0].Stale)
+
+	require.NoError(t, group.Start(context.Background()))
+	currentReporter := <-reporters
+	beforeOldReport := group.Status().Jobs[0].LastProgress
+	time.Sleep(time.Millisecond)
+	oldReporter()
+	assert.Equal(t, beforeOldReport, group.Status().Jobs[0].LastProgress)
+
+	time.Sleep(time.Millisecond)
+	currentReporter()
+	assert.True(t, group.Status().Jobs[0].LastProgress.After(beforeOldReport))
+	require.NoError(t, group.Stop(context.Background()))
+}
+
+func TestProgressReporterAcceptsCycleBeforeStartReturns(t *testing.T) {
+	t.Parallel()
+
+	var group *Group
+	group = newTestGroup(t, newTestJob("job", func(ctx context.Context) error {
+		report := TrackProgress(ctx, time.Hour)
+		registered := group.Status().Jobs[0].LastProgress
+		time.Sleep(time.Millisecond)
+		report()
+		if !group.Status().Jobs[0].LastProgress.After(registered) {
+			return errors.New("progress was not recorded while the job was starting")
+		}
+		return nil
+	}, nil))
+
+	require.NoError(t, group.Start(context.Background()))
+	require.NoError(t, group.Stop(context.Background()))
+}
+
+func TestProgressMonitorLogsOnlyStaleAndRecoveredTransitions(t *testing.T) {
+	t.Parallel()
+
+	reporter := make(chan func(), 1)
+	group := newTestGroup(t, newTestJob("periodic", func(ctx context.Context) error {
+		reporter <- TrackProgress(ctx, 15*time.Millisecond)
+		return nil
+	}, nil))
+	logs := &recordingHandler{}
+	group.logger = slog.New(logs)
+	group.monitorInterval = time.Millisecond
+
+	require.NoError(t, group.Start(context.Background()))
+	report := <-reporter
+	require.Eventually(t, func() bool {
+		return group.Status().Jobs[0].Stale
+	}, time.Second, time.Millisecond)
+	require.Eventually(t, func() bool {
+		return logs.countMessage("runtime job stale") == 1
+	}, time.Second, time.Millisecond)
+	staleRecord, ok := logs.firstMessage("runtime job stale")
+	require.True(t, ok)
+	staleAttrs := recordAttrs(staleRecord)
+	assert.Equal(t, "periodic", staleAttrs["job"].String())
+	assert.Equal(t, slog.KindTime, staleAttrs["last_progress"].Kind())
+	assert.Equal(t, 15*time.Millisecond, staleAttrs["stale_after"].Duration())
+
+	time.Sleep(10 * time.Millisecond)
+	assert.Equal(t, 1, logs.countMessage("runtime job stale"))
+	assert.Equal(t, 0, logs.countMessage("runtime job recovered"))
+
+	report()
+	require.Eventually(t, func() bool {
+		return !group.Status().Jobs[0].Stale
+	}, time.Second, time.Millisecond)
+	require.Eventually(t, func() bool {
+		return logs.countMessage("runtime job recovered") == 1
+	}, time.Second, time.Millisecond)
+
+	report()
+	time.Sleep(5 * time.Millisecond)
+	assert.Equal(t, 1, logs.countMessage("runtime job stale"))
+	assert.Equal(t, 1, logs.countMessage("runtime job recovered"))
+	require.NoError(t, group.Stop(context.Background()))
+}
+
+func TestUntrackedAndStoppedJobsNeverBecomeStale(t *testing.T) {
+	t.Parallel()
+
+	tracked := make(chan struct{}, 1)
+	group := newTestGroup(t,
+		newTestJob("untracked", nil, nil),
+		newTestJob("tracked", func(ctx context.Context) error {
+			TrackProgress(ctx, time.Millisecond)
+			tracked <- struct{}{}
+			return nil
+		}, nil),
+	)
+	group.monitorInterval = time.Millisecond
+
+	require.NoError(t, group.Start(context.Background()))
+	<-tracked
+	require.Eventually(t, func() bool {
+		return group.Status().Jobs[1].Stale
+	}, time.Second, time.Millisecond)
+	assert.False(t, group.Status().Jobs[0].Stale)
+
+	require.NoError(t, group.Stop(context.Background()))
+	status := group.Status()
+	assert.False(t, status.Jobs[0].Stale)
+	assert.False(t, status.Jobs[1].Stale)
+}
+
+func TestTrackProgressOutsideManagedJobIsNoop(t *testing.T) {
+	t.Parallel()
+
+	report := TrackProgress(context.Background(), time.Nanosecond)
+	require.NotNil(t, report)
+	assert.NotPanics(t, report)
+}
+
+func TestStatusReturnsIndependentSnapshotsAndSupportsConcurrentProgress(t *testing.T) {
+	t.Parallel()
+
+	reporter := make(chan func(), 1)
+	group := newTestGroup(t, newTestJob("job", func(ctx context.Context) error {
+		reporter <- TrackProgress(ctx, time.Hour)
+		return nil
+	}, nil))
+	require.NoError(t, group.Start(context.Background()))
+	report := <-reporter
+
+	snapshot := group.Status()
+	snapshot.Jobs[0].Name = "changed"
+	assert.Equal(t, "job", group.Status().Jobs[0].Name)
+
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			for range 100 {
+				report()
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			for range 100 {
+				_ = group.Status()
+			}
+		}()
+	}
+	wg.Wait()
+	require.NoError(t, group.Stop(context.Background()))
+}
+
+func TestGroupLogsCanonicalJobLifecycleTransitions(t *testing.T) {
+	t.Parallel()
+
+	startErr := errors.New("start failed")
+	stopErr := errors.New("stop failed")
+	tests := []struct {
+		name          string
+		job           Job
+		run           func(*Group) error
+		message       string
+		level         slog.Level
+		expectedError error
+	}{
+		{
+			name:    "start success",
+			job:     newTestJob("job", nil, nil),
+			run:     func(group *Group) error { return group.Start(context.Background()) },
+			message: "runtime job started",
+			level:   slog.LevelInfo,
+		},
+		{
+			name: "start failure",
+			job: newTestJob("job", func(context.Context) error {
+				return startErr
+			}, nil),
+			run:           func(group *Group) error { return group.Start(context.Background()) },
+			message:       "runtime job start failed",
+			level:         slog.LevelError,
+			expectedError: startErr,
+		},
+		{
+			name: "stop success",
+			job:  newTestJob("job", nil, nil),
+			run: func(group *Group) error {
+				if err := group.Start(context.Background()); err != nil {
+					return err
+				}
+				return group.Stop(context.Background())
+			},
+			message: "runtime job stopped",
+			level:   slog.LevelInfo,
+		},
+		{
+			name: "stop failure",
+			job: newTestJob("job", nil, func(context.Context) error {
+				return stopErr
+			}),
+			run: func(group *Group) error {
+				if err := group.Start(context.Background()); err != nil {
+					return err
+				}
+				return group.Stop(context.Background())
+			},
+			message:       "runtime job stop failed",
+			level:         slog.LevelError,
+			expectedError: stopErr,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logs := &recordingHandler{}
+			group := newTestGroup(t, tt.job)
+			group.logger = slog.New(logs)
+
+			err := tt.run(group)
+			if tt.expectedError == nil {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, tt.expectedError)
+			}
+
+			record, ok := logs.firstMessage(tt.message)
+			require.True(t, ok)
+			assert.Equal(t, tt.level, record.Level)
+			attrs := recordAttrs(record)
+			assert.Equal(t, "job", attrs["job"].String())
+			assert.Equal(t, slog.KindDuration, attrs["duration"].Kind())
+			if tt.expectedError != nil {
+				assert.Equal(t, tt.expectedError.Error(), attrs["error"].Any().(error).Error())
+			}
+		})
+	}
+}
+
+type recordingHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (*recordingHandler) Enabled(context.Context, slog.Level) bool {
+	return true
+}
+
+func (h *recordingHandler) Handle(_ context.Context, record slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, record.Clone())
+	return nil
+}
+
+func (h *recordingHandler) WithAttrs([]slog.Attr) slog.Handler {
+	return h
+}
+
+func (h *recordingHandler) WithGroup(string) slog.Handler {
+	return h
+}
+
+func (h *recordingHandler) countMessage(message string) int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	count := 0
+	for _, record := range h.records {
+		if record.Message == message {
+			count++
+		}
+	}
+	return count
+}
+
+func (h *recordingHandler) firstMessage(message string) (slog.Record, bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, record := range h.records {
+		if record.Message == message {
+			return record.Clone(), true
+		}
+	}
+	return slog.Record{}, false
+}
+
+func recordAttrs(record slog.Record) map[string]slog.Value {
+	attrs := make(map[string]slog.Value)
+	record.Attrs(func(attr slog.Attr) bool {
+		attrs[attr.Key] = attr.Value
+		return true
+	})
+	return attrs
+}

--- a/server/internal/runtimejobs/status_test.go
+++ b/server/internal/runtimejobs/status_test.go
@@ -99,14 +99,12 @@ func TestTrackProgressReportsFreshnessAndIsolatesActivations(t *testing.T) {
 	require.NoError(t, group.Start(context.Background()))
 	oldReporter := <-reporters
 	first := group.Status()
-	require.True(t, first.Jobs[0].ProgressTracked)
 	assert.WithinDuration(t, time.Now(), first.Jobs[0].LastProgress, time.Second)
-	assert.Equal(t, time.Hour, first.Jobs[0].StaleAfter)
+	assert.Equal(t, 3*time.Hour, first.Jobs[0].StaleAfter)
 	assert.False(t, first.Jobs[0].Stale)
 	require.NoError(t, group.Stop(context.Background()))
 
 	stopped := group.Status()
-	assert.True(t, stopped.Jobs[0].ProgressTracked)
 	assert.False(t, stopped.Jobs[0].Stale)
 
 	activationCtx, cancelActivation := context.WithCancel(context.Background())
@@ -152,7 +150,7 @@ func TestProgressMonitorLogsOnlyStaleAndRecoveredTransitions(t *testing.T) {
 
 	reporter := make(chan func(), 1)
 	group := newTestGroup(t, newTestJob("periodic", func(ctx context.Context) error {
-		reporter <- TrackProgress(ctx, 15*time.Millisecond)
+		reporter <- TrackProgress(ctx, 5*time.Millisecond)
 		return nil
 	}, nil))
 	logs := &recordingHandler{}


### PR DESCRIPTION
Reviewable diff: +344/-34 across 13 files (excludes generated, test, and story files).

## Summary

Operators and the future HA supervisor can now inspect whether each runtime job is active and whether its representative control loop is still advancing. Fleet emits one canonical lifecycle event per job and only logs freshness when a periodic job becomes stale or recovers, avoiding healthy per-cycle noise.

The runtime-job catalog and activation group are now on `main`. This PR adds only observational health; HA supervisor consumption, critical-job policy, readiness, and lease-renewal behavior remain follow-up work.

## How it works

`Group` maintains lifecycle and progress state alongside each catalog entry. `Start` moves jobs through `starting` to `running`, passes each job a scoped progress reporter, and records canonical start outcomes. `Stop` invalidates that activation's reporters, moves jobs through `stopping`, and records canonical stop outcomes while preserving the existing reverse-order drain and terminal-failure behavior.

Eleven naturally periodic jobs register one representative loop using a stale window of three effective intervals. Completing a cycle advances progress even when domain work reports an error, because freshness answers whether the control loop is moving; existing domain logs continue to report success or failure. MQTT stays lifecycle-only because message inactivity is legitimate and broker health already has purpose-specific status.

`Status()` returns a copied, catalog-ordered snapshot and calculates staleness at read time. A single five-second activation monitor exists only to detect transitions: it emits one warning when a job becomes stale and one info event when it recovers. No status is persisted and no healthy-cycle logs are added.

```mermaid
flowchart TB
    O["Runtime owner"] --> G["runtimejobs.Group"]
    G --> C["Job-specific Start context"]
    C --> L["Representative periodic loop"]
    L --> R["Generation-bound progress reporter"]
    R --> S["In-process status snapshot"]
    S --> H["Future HA supervisor"]
    S --> M["Five-second transition monitor"]
    M --> W["WARN runtime job stale"]
    M --> I["INFO runtime job recovered"]
```

```mermaid
stateDiagram-v2
    [*] --> stopped
    stopped --> starting: Start
    starting --> running: all jobs started
    starting --> failed: start or rollback failure
    running --> stopping: Stop
    stopping --> stopped: clean drain
    stopping --> failed: incomplete cleanup
    failed --> failed: terminal
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/internal/runtimejobs/status.go` (new) | Defines copied group/job snapshots and the scoped progress-reporting API | Review the public status shape and standalone no-op behavior |
| `server/internal/runtimejobs/group.go` | Tracks lifecycle state, activation generations, freshness, and canonical logs | Review concurrency, restart isolation, transition-only logging, and unchanged cleanup semantics |
| Periodic domain loops | Report one representative completed cycle using three times their effective interval | Review that progress means loop advancement rather than domain success |
| MQTT lifecycle | Removes its duplicate clean-stop log and remains freshness-untracked | Review the deliberate distinction between inactivity and stalled work |
| `server/internal/runtimejobs/status_test.go` (new) | Covers lifecycle, rollback, failure, restart, freshness, log transitions, generation isolation, snapshots, and races | Protects the concurrency-sensitive observability contract |

## Key technical decisions & trade-offs

- Keep stale state observational; the future HA supervisor decides which jobs are critical and whether health affects ownership.
- Compute freshness in `Status()` and use one monitor only for log transitions instead of maintaining a second health state or emitting periodic healthy logs.
- Bind reporters to an activation generation instead of allowing delayed work from a stopped activation to refresh a restarted job.
- Track one representative control loop per job instead of aggregating every internal goroutine.
- Use three effective intervals as the stale window instead of adding per-job configuration.
- Leave MQTT progress untracked because quiet subscriptions are healthy and connection state already has a domain-specific signal.

## Related

Related: #788

## Testing & validation

- `go test -short -race -count=20 ./internal/runtimejobs`
- Race-enabled focused tests across `runtimejobs`, `fleetd`, and all instrumented domains
- Server-wide compile-only test pass
- Repo-pinned `golangci-lint` (`0 issues`)
- Database-backed integration tests and deployed HA consumption were not run.

## Post-Deploy Monitoring & Validation

During the first rollout, confirm each expected job logs one `runtime job started` event and shutdown logs one `runtime job stopped` event. Watch for `runtime job start failed`, `runtime job stop failed`, `runtime job stale`, and `runtime job recovered`; healthy operation should add no periodic lifecycle noise. Repeated false stale warnings, missing lifecycle events, or any activation/shutdown regression are rollback signals.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
