### PR TITLE
fix: deployment-host tracing port conflict and over-long Grafana rule UID

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,11 @@ These are the rules that recur in code review and that contributors most often m
    coordinated edits across `routePrefetch.ts` (factory plus tier) and
    `router.tsx` (`lazy()` wrapper). See the top-of-file runbook in either
    app's `routePrefetch.ts`.
+10. **Grafana alert rule UIDs: 40 characters max.** Grafana rejects longer
+    UIDs at provisioning time, and one bad UID aborts provisioning of *all*
+    alerting files at boot. Applies to every `uid:` under
+    `server/monitoring/grafana/` (keep the `proto_fleet_rule_uid` label equal
+    to the rule's UID).
 
 ## Git workflow
 

--- a/deployment-files/docker-compose.tracing.yaml
+++ b/deployment-files/docker-compose.tracing.yaml
@@ -10,11 +10,12 @@ services:
       # Parent server spans to the traceparent header Datadog RUM injects on
       # API calls (client observability), so RUM sessions link to APM traces.
       FLEET_TELEMETRY_TRUST_INCOMING_TRACES: "${FLEET_TELEMETRY_TRUST_INCOMING_TRACES:-true}"
+      # Overrides the base-compose 4318 endpoint; the collector is published on host port 4319 below.
+      FLEET_TELEMETRY_ENDPOINT: "http://otel-collector:4319"
     depends_on:
       otel-collector:
         condition: service_started
-    # Host-networked fleet-api inherits FLEET_TELEMETRY_ENDPOINT=http://otel-collector:4318
-    # from the base compose; resolve it to the loopback port published below.
+    # Host-networked fleet-api resolves otel-collector to the loopback port published below.
     extra_hosts:
       - "otel-collector:127.0.0.1"
 
@@ -29,8 +30,8 @@ services:
     volumes:
       - ./server/otel-collector-config.datadog.yaml:/etc/otelcol-contrib/config.yaml:ro
     ports:
-      # Loopback-only OTLP ingest for the host-networked fleet-api; not exposed on the LAN.
-      - "127.0.0.1:4318:4318"
+      # Loopback-only OTLP ingest for the host-networked fleet-api
+      - "127.0.0.1:4319:4318"
     logging:
       driver: "json-file"
       options:

--- a/server/monitoring/grafana/provisioning/alerting/proto-fleet-rules.yaml
+++ b/server/monitoring/grafana/provisioning/alerting/proto-fleet-rules.yaml
@@ -1,4 +1,5 @@
 # Proto Fleet alert rules — provisioned for Grafana's built-in alerting engine.
+# Rule UIDs are limited to 40 characters; one longer UID aborts provisioning of ALL alerting files at boot.
 
 apiVersion: 1
 
@@ -339,7 +340,7 @@ groups:
             cannot be received and miners can no longer be automatically
             curtailed or restored.
 
-      - uid: protofleet-curtailment-fan-restore-failed
+      - uid: protofleet-curtailment-fan-restore-fail
         title: Curtailment Fan Restore Failed
         condition: B
         data:
@@ -389,7 +390,7 @@ groups:
         for: 0s
         labels:
           # Primary rule identity for delivery routing (see ruleLabelRuleUID); must match this rule's uid.
-          proto_fleet_rule_uid: protofleet-curtailment-fan-restore-failed
+          proto_fleet_rule_uid: protofleet-curtailment-fan-restore-fail
           proto_fleet_scope: shared
           severity: critical
           rule_group: proto-fleet-curtailment

--- a/server/monitoring/grafana/system-monitoring/proto-fleet-system-rules.yaml
+++ b/server/monitoring/grafana/system-monitoring/proto-fleet-system-rules.yaml
@@ -4,6 +4,7 @@
 # metrics carry no org label (see docs/alerts-metrics.md), so every rule
 # CROSS JOINs fleet_active_organization to fan one host condition out to
 # per-org instances: delivery, pause, and history stay org-scoped.
+# Rule UIDs are limited to 40 characters; one longer UID aborts provisioning of ALL alerting files at boot.
 
 apiVersion: 1
 


### PR DESCRIPTION
Reviewable diff: +14/-6 across 4 files (excludes generated, test, and story files).

## Summary

Two operator-facing fixes found while rolling out the tracing overlay to the production-stl host, plus a guard note for future contributors. First, the Datadog tracing overlay published the OTel collector on host port 4318, which is already in use on the host — the collector is now published on loopback port 4319. Second, Grafana refused to boot its alert provisioning because one rule UID exceeded Grafana's 40-character limit, which aborts loading of **all** provisioned alert rules; the UID is shortened and the limit is documented in AGENTS.md and both rule-file headers.

## How it works

**Tracing port:** the host-networked fleet-api resolves `otel-collector` to `127.0.0.1` via `extra_hosts` and previously inherited `FLEET_TELEMETRY_ENDPOINT=http://otel-collector:4318` from the base compose. The overlay now overrides that endpoint to port 4319 and maps host `127.0.0.1:4319` to the collector's unchanged container port 4318. Nothing inside the container changes — the collector config and base compose are untouched, and the dev stack keeps using 4318 locally.

**Alert rule UID:** `protofleet-curtailment-fan-restore-failed` is 41 characters. Grafana validates UIDs at provisioning time and fails the whole alerting provisioner on the first invalid rule, so no alert rules loaded at boot (`Failed to provision alerting ... UID is longer than 40 symbols`). The rule is renamed to `protofleet-curtailment-fan-restore-fail` (39 chars) in both places it appears: the rule `uid` and the `proto_fleet_rule_uid` label the delivery router matches on.

## Diagrams

```mermaid
flowchart LR
    A["fleet-api (host network)"] -- "FLEET_TELEMETRY_ENDPOINT
http://otel-collector:4319" --> B["127.0.0.1:4319 (host loopback)"]
    B -- "port map 4319 -> 4318" --> C["otel-collector container :4318"]
    C --> D["Datadog APM"]
    E["other host process"] -- "already binds" --> F["127.0.0.1:4318"]
```

## Areas of the code involved

- `deployment-files/docker-compose.tracing.yaml` — host port mapping and fleet-api endpoint override.
- `server/monitoring/grafana/provisioning/alerting/proto-fleet-rules.yaml` — UID + routing-label rename, header note.
- `server/monitoring/grafana/system-monitoring/proto-fleet-system-rules.yaml` — header note.
- `AGENTS.md` — new "Rules that matter" entry for the 40-char UID limit.

## Key technical decisions & trade-offs

- **Remap the host port instead of changing the collector's listen port.** Keeps the change scoped to the overlay file; the container port, collector config, and dev stack stay on the standard OTLP 4318.
- **Renaming the rule UID is safe.** The old UID string appears nowhere else in the repo (no Go code, migrations, or client references — the delivery router reads the UID dynamically from labels), and no org routing rows can reference it because the rule never provisioned successfully.
- **UID, not title.** Grafana's 40-char limit applies to rule UIDs; titles are unaffected. The AGENTS.md note and file headers state this precisely, since one bad UID silently takes down every provisioned rule.

## Testing & validation

- `just lint` — 0 issues.
- `./deployment-files/tests/test-profiles.sh` (what the Deployment Config Checks CI workflow runs) — all profile/compose interpolation checks pass.
- Merged-compose validation with the base file staged the same way the artifact build lays it out: resolved config shows fleet-api pointed at `otel-collector:4319` and the collector published as `127.0.0.1:4319 -> 4318`.
- Grafana rule files: YAML parses cleanly; script-verified every rule UID is ≤40 chars (max is now 39) and every `proto_fleet_rule_uid` label equals its rule's UID.
- Both fixes were verified live on the production-stl host: spans reach Datadog APM through the 4319 mapping, and Grafana boots without the provisioning error after the UID rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)