### PR TITLE
test(ha): prove Patroni writer generation contract

### DIFF
--- a/deployment-files/ha/generation-fixture/README.md
+++ b/deployment-files/ha/generation-fixture/README.md
@@ -1,0 +1,94 @@
+# HA writer-generation proof fixture
+
+This disposable, local-only fixture proves the writer-generation contract needed
+before Proto Fleet adds its database lease. It is the HA-07 slice of the active/
+passive implementation plan, not a production deployment template.
+
+## Contract
+
+A pair of linearizable etcd prefix reads of `/service/proto-fleet-ha07/`
+brackets the runtime identity checks:
+
+1. The first `leader` key value names the Patroni member that owns the DCS lock.
+2. The `leader` key's etcd `create_revision` is the writer generation. It is
+   stable while that leader key exists and strictly increases when an expired or
+   deleted lock is recreated for a later leadership term.
+3. The matching `members/<leader>` value supplies Patroni's PostgreSQL and REST
+   endpoints at that first DCS snapshot revision.
+4. A connection through the multi-host, `target_session_attrs=read-write` DSN
+   must select the address advertised by that member.
+5. Patroni's `/primary` check must pass, and its timeline must equal
+   `pg_control_checkpoint().timeline_id` on the connected writable PostgreSQL.
+6. A second linearizable prefix read must still report the same leader name and
+   `create_revision`; otherwise leadership changed during validation and the
+   observation fails closed.
+
+The observation also reads the current leader lease TTL. The proof observes the
+same lease's TTL decrease and then increase, demonstrating a keepalive refresh
+without requiring Patroni to rewrite the leader key. The observation fails
+closed if any part is absent, expired, stale, or inconsistent.
+`leader.mod_revision` is retained only for diagnostics; it is not the generation
+because Patroni may update the leader key while preserving the same leadership
+term.
+
+The full serialized Fleet ownership token will additionally contain the cluster
+incarnation and lease epoch. Restoring etcd can roll revisions backward, so a
+restore must rotate the cluster incarnation as specified by the later HA restore
+work.
+
+## What the proof runs
+
+`scripts/prove.sh` creates a unique Compose project containing:
+
+- two PostgreSQL 18 + TimescaleDB + Patroni 4.1.4 members;
+- a three-member etcd 3.6.11 quorum; and
+- no Fleet process, keepalived, installer, production network policy, or
+  production image lifecycle.
+
+The script proves:
+
+- the generation is stable across Patroni lease renewal;
+- repeated primary promotions strictly increase it;
+- an acknowledged write can be lost during asynchronous promotion while the
+  generation still increases;
+- isolating the old primary from the DCS/replication network promotes the peer
+  with a higher generation; and
+- reconnecting the old primary makes it rejoin as a replica without changing
+  the new writer term.
+
+The fixture intentionally uses test-only credentials and an isolated Docker
+network. Do not reuse it as an installer or production configuration.
+
+## Run it
+
+Docker with Compose is required. From the repository root:
+
+```bash
+deployment-files/ha/generation-fixture/scripts/prove.sh unit
+deployment-files/ha/generation-fixture/scripts/prove.sh config >/dev/null
+deployment-files/ha/generation-fixture/scripts/prove.sh run
+```
+
+The full run rebuilds the repository's TimescaleDB image, creates a uniquely
+named project, prints each observed generation transition, emits the final
+validated observation as JSON, and removes its containers and volumes. A
+teardown failure makes the command fail instead of silently leaking resources.
+
+Set `HA_GENERATION_KEEP_STACK=1` to retain a failed fixture for inspection.
+Use `HA_GENERATION_CLEAN_PROMOTIONS=<n>` to increase the repeated-promotion
+count; the default is two before the separate write-loss and partition trials.
+`HA_GENERATION_WAIT_SECONDS` bounds each wait, while
+`HA_GENERATION_PROBE_TIMEOUT_SECONDS` bounds individual Docker, PostgreSQL, and
+Patroni probes.
+
+## Upstream basis
+
+- [Patroni 4.1.4](https://github.com/patroni/patroni/tree/v4.1.4) creates the
+  etcd leader key only when its create revision is zero and attaches the
+  current Patroni lease to that key.
+- [etcd's v3 key-value API](https://etcd.io/docs/v3.6/learning/api/) defines
+  `create_revision` as the key's creation revision and makes range reads
+  linearizable unless `serializable` is explicitly requested.
+- [Patroni's REST API](https://patroni.readthedocs.io/en/latest/rest_api.html)
+  returns success from `/primary` only for the PostgreSQL primary that owns the
+  leader lock.

--- a/deployment-files/ha/generation-fixture/compose.yaml
+++ b/deployment-files/ha/generation-fixture/compose.yaml
@@ -1,0 +1,131 @@
+x-etcd-common: &etcd-common
+  image: gcr.io/etcd-development/etcd:v3.6.11
+  networks:
+    - ha-generation
+  healthcheck:
+    test:
+      - CMD
+      - /usr/local/bin/etcdctl
+      - --endpoints=http://127.0.0.1:2379
+      - endpoint
+      - health
+    interval: 2s
+    timeout: 2s
+    retries: 30
+  stop_grace_period: 5s
+
+x-patroni-common: &patroni-common
+  image: proto-fleet-ha07-patroni:local
+  build:
+    context: .
+    dockerfile: patroni.Dockerfile
+    args:
+      BASE_IMAGE: proto-fleet-timescaledb:ha07
+      PATRONI_VERSION: 4.1.4
+  networks:
+    - ha-generation
+  depends_on:
+    etcd-a:
+      condition: service_healthy
+    etcd-b:
+      condition: service_healthy
+    etcd-witness:
+      condition: service_healthy
+  environment: &patroni-environment
+    HA_GENERATION_CLUSTER_PATH: /service/proto-fleet-ha07
+    HA_GENERATION_DB_DSN: postgresql://postgres:ha07-postgres@patroni-a:5432,patroni-b:5432/postgres?target_session_attrs=read-write&connect_timeout=2
+    HA_GENERATION_DCS_ENDPOINT: http://etcd-a:2379
+    HA_GENERATION_SCOPE: proto-fleet-ha07
+    PATRONI_REPLICATION_PASSWORD: ha07-replication
+    PATRONI_REPLICATION_USERNAME: replicator
+    PATRONI_REWIND_PASSWORD: ha07-postgres
+    PATRONI_REWIND_USERNAME: postgres
+    PATRONI_SUPERUSER_PASSWORD: ha07-postgres
+  healthcheck:
+    test:
+      - CMD
+      - curl
+      - --fail
+      - --silent
+      - --show-error
+      - http://127.0.0.1:8008/patroni
+    interval: 2s
+    timeout: 2s
+    retries: 60
+  stop_grace_period: 10s
+
+services:
+  etcd-a:
+    <<: *etcd-common
+    command:
+      - /usr/local/bin/etcd
+      - --name=etcd-a
+      - --data-dir=/etcd-data
+      - --listen-client-urls=http://0.0.0.0:2379
+      - --advertise-client-urls=http://etcd-a:2379
+      - --listen-peer-urls=http://0.0.0.0:2380
+      - --initial-advertise-peer-urls=http://etcd-a:2380
+      - --initial-cluster=etcd-a=http://etcd-a:2380,etcd-b=http://etcd-b:2380,etcd-witness=http://etcd-witness:2380
+      - --initial-cluster-state=new
+      - --initial-cluster-token=proto-fleet-ha07
+    volumes:
+      - etcd-a-data:/etcd-data
+
+  etcd-b:
+    <<: *etcd-common
+    command:
+      - /usr/local/bin/etcd
+      - --name=etcd-b
+      - --data-dir=/etcd-data
+      - --listen-client-urls=http://0.0.0.0:2379
+      - --advertise-client-urls=http://etcd-b:2379
+      - --listen-peer-urls=http://0.0.0.0:2380
+      - --initial-advertise-peer-urls=http://etcd-b:2380
+      - --initial-cluster=etcd-a=http://etcd-a:2380,etcd-b=http://etcd-b:2380,etcd-witness=http://etcd-witness:2380
+      - --initial-cluster-state=new
+      - --initial-cluster-token=proto-fleet-ha07
+    volumes:
+      - etcd-b-data:/etcd-data
+
+  etcd-witness:
+    <<: *etcd-common
+    command:
+      - /usr/local/bin/etcd
+      - --name=etcd-witness
+      - --data-dir=/etcd-data
+      - --listen-client-urls=http://0.0.0.0:2379
+      - --advertise-client-urls=http://etcd-witness:2379
+      - --listen-peer-urls=http://0.0.0.0:2380
+      - --initial-advertise-peer-urls=http://etcd-witness:2380
+      - --initial-cluster=etcd-a=http://etcd-a:2380,etcd-b=http://etcd-b:2380,etcd-witness=http://etcd-witness:2380
+      - --initial-cluster-state=new
+      - --initial-cluster-token=proto-fleet-ha07
+    volumes:
+      - etcd-witness-data:/etcd-data
+
+  patroni-a:
+    <<: *patroni-common
+    environment:
+      <<: *patroni-environment
+      PATRONI_NAME: patroni-a
+    volumes:
+      - patroni-a-data:/home/postgres/pgdata/data
+
+  patroni-b:
+    <<: *patroni-common
+    environment:
+      <<: *patroni-environment
+      PATRONI_NAME: patroni-b
+    volumes:
+      - patroni-b-data:/home/postgres/pgdata/data
+
+networks:
+  ha-generation:
+    name: ${HA_GENERATION_PROJECT_NAME:-proto-fleet-ha07}-network
+
+volumes:
+  etcd-a-data:
+  etcd-b-data:
+  etcd-witness-data:
+  patroni-a-data:
+  patroni-b-data:

--- a/deployment-files/ha/generation-fixture/patroni.Dockerfile
+++ b/deployment-files/ha/generation-fixture/patroni.Dockerfile
@@ -1,0 +1,28 @@
+ARG BASE_IMAGE=proto-fleet-timescaledb:ha07
+FROM ${BASE_IMAGE}
+
+ARG PATRONI_VERSION=4.1.4
+
+USER root
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        gettext-base \
+        python3 \
+        python3-venv \
+    && python3 -m venv /opt/patroni \
+    && /opt/patroni/bin/pip install --no-cache-dir \
+        "patroni[etcd3,psycopg2-binary]==${PATRONI_VERSION}" \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/opt/patroni/bin:${PATH}"
+
+COPY patroni.template.yml /etc/patroni/patroni.template.yml
+COPY scripts/patroni-entrypoint.sh /usr/local/bin/patroni-entrypoint
+COPY scripts/observe_generation.py /opt/ha07/observe_generation.py
+
+RUN chmod +x /usr/local/bin/patroni-entrypoint /opt/ha07/observe_generation.py \
+    && mkdir -p /etc/patroni /opt/ha07 \
+    && chown -R postgres:postgres /etc/patroni /opt/ha07 /home/postgres
+
+ENTRYPOINT ["/usr/local/bin/patroni-entrypoint"]

--- a/deployment-files/ha/generation-fixture/patroni.template.yml
+++ b/deployment-files/ha/generation-fixture/patroni.template.yml
@@ -1,0 +1,67 @@
+scope: ${HA_GENERATION_SCOPE}
+namespace: /service/
+name: ${PATRONI_NAME}
+
+restapi:
+  listen: 0.0.0.0:8008
+  connect_address: ${PATRONI_NAME}:8008
+
+etcd3:
+  hosts:
+    - etcd-a:2379
+    - etcd-b:2379
+    - etcd-witness:2379
+
+bootstrap:
+  dcs:
+    ttl: 20
+    loop_wait: 2
+    retry_timeout: 3
+    maximum_lag_on_failover: 1073741824
+    postgresql:
+      use_pg_rewind: true
+      use_slots: true
+      parameters:
+        hot_standby: "on"
+        max_replication_slots: 10
+        max_wal_senders: 10
+        synchronous_commit: "on"
+        wal_level: replica
+  initdb:
+    - encoding: UTF8
+    - data-checksums
+  pg_hba:
+    - host all all 0.0.0.0/0 scram-sha-256
+    - host replication ${PATRONI_REPLICATION_USERNAME} 0.0.0.0/0 scram-sha-256
+postgresql:
+  listen: 0.0.0.0:5432
+  connect_address: ${PATRONI_NAME}:5432
+  data_dir: /home/postgres/pgdata/data
+  bin_dir: /usr/lib/postgresql/18/bin
+  authentication:
+    superuser:
+      username: postgres
+      password: ${PATRONI_SUPERUSER_PASSWORD}
+    replication:
+      username: ${PATRONI_REPLICATION_USERNAME}
+      password: ${PATRONI_REPLICATION_PASSWORD}
+    rewind:
+      username: ${PATRONI_REWIND_USERNAME}
+      password: ${PATRONI_REWIND_PASSWORD}
+  parameters:
+    hot_standby: "on"
+    max_replication_slots: 10
+    max_wal_senders: 10
+    synchronous_commit: "on"
+    unix_socket_directories: /var/run/postgresql
+    wal_level: replica
+  pg_hba:
+    - local all all trust
+    - host all all 0.0.0.0/0 scram-sha-256
+    - host replication ${PATRONI_REPLICATION_USERNAME} 0.0.0.0/0 scram-sha-256
+
+tags:
+  clonefrom: false
+  nofailover: false
+  noloadbalance: false
+  nosync: false

--- a/deployment-files/ha/generation-fixture/scripts/observe_generation.py
+++ b/deployment-files/ha/generation-fixture/scripts/observe_generation.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""Observe and validate the HA-07 writer-generation contract."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import socket
+import sys
+from typing import Any, Callable
+from urllib import error, parse, request
+
+
+DEFAULT_CLUSTER_PATH = "/service/proto-fleet-ha07"
+
+
+def prefix_range_end(prefix: bytes) -> bytes:
+    """Return etcd's exclusive range end for a byte prefix."""
+    value = bytearray(prefix)
+    for index in range(len(value) - 1, -1, -1):
+        if value[index] < 0xFF:
+            value[index] += 1
+            return bytes(value[: index + 1])
+    return b"\0"
+
+
+def _decode(value: str) -> str:
+    return base64.b64decode(value, validate=True).decode()
+
+
+def extract_dcs_observation(snapshot: dict[str, Any], cluster_path: str) -> dict[str, Any]:
+    """Extract one Patroni leader term from a single etcd prefix snapshot."""
+    normalized_path = cluster_path.rstrip("/")
+    leader_path = f"{normalized_path}/leader"
+    nodes: dict[str, dict[str, Any]] = {}
+
+    for node in snapshot.get("kvs", []):
+        key = _decode(node["key"])
+        if key in nodes:
+            raise ValueError(f"duplicate DCS key in snapshot: {key}")
+        nodes[key] = node
+
+    leader_node = nodes.get(leader_path)
+    if leader_node is None:
+        raise ValueError(f"leader key is absent: {leader_path}")
+
+    leader_name = _decode(leader_node["value"])
+    if not leader_name:
+        raise ValueError("leader key has an empty member name")
+
+    try:
+        writer_generation = int(leader_node["create_revision"])
+        leader_lease_id = int(leader_node["lease"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError("leader create_revision or lease is missing or invalid") from exc
+    if writer_generation <= 0:
+        raise ValueError("leader create_revision must be positive")
+    if leader_lease_id <= 0:
+        raise ValueError("leader lease must be positive")
+
+    member_path = f"{normalized_path}/members/{leader_name}"
+    member_node = nodes.get(member_path)
+    if member_node is None:
+        raise ValueError(f"matching member key is absent: {member_path}")
+
+    try:
+        member = json.loads(_decode(member_node["value"]))
+    except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+        raise ValueError(f"member key is not valid JSON: {member_path}") from exc
+    if not isinstance(member, dict):
+        raise ValueError(f"member key must contain an object: {member_path}")
+    for required_field in ("api_url", "conn_url"):
+        if not isinstance(member.get(required_field), str) or not member[required_field]:
+            raise ValueError(f"member key is missing {required_field}: {member_path}")
+
+    try:
+        dcs_revision = int(snapshot["header"]["revision"])
+        leader_mod_revision = int(leader_node["mod_revision"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise ValueError("DCS revision metadata is missing or invalid") from exc
+
+    return {
+        "dcs_revision": dcs_revision,
+        "leader_mod_revision": leader_mod_revision,
+        "leader_lease_id": leader_lease_id,
+        "leader_name": leader_name,
+        "member": member,
+        "writer_generation": writer_generation,
+    }
+
+
+def read_linearizable_snapshot(
+    endpoint: str, cluster_path: str, timeout_seconds: float
+) -> dict[str, Any]:
+    """Read all Patroni keys at one linearizable etcd revision."""
+    prefix = f"{cluster_path.rstrip('/')}/".encode()
+    payload = json.dumps(
+        {
+            "key": base64.b64encode(prefix).decode(),
+            "range_end": base64.b64encode(prefix_range_end(prefix)).decode(),
+            "serializable": False,
+        }
+    ).encode()
+    range_request = request.Request(
+        f"{endpoint.rstrip('/')}/v3/kv/range",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with request.urlopen(range_request, timeout=timeout_seconds) as response:
+            return json.load(response)
+    except (error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"linearizable DCS read failed via {endpoint}") from exc
+
+
+def read_lease_ttl(
+    endpoint: str, lease_id: int, timeout_seconds: float
+) -> dict[str, int]:
+    """Read the remaining lifetime of the Patroni leader lease."""
+    payload = json.dumps({"ID": str(lease_id), "keys": False}).encode()
+    ttl_request = request.Request(
+        f"{endpoint.rstrip('/')}/v3/lease/timetolive",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with request.urlopen(ttl_request, timeout=timeout_seconds) as response:
+            lease = json.load(response)
+        returned_lease_id = int(lease["ID"])
+        ttl = int(lease["TTL"])
+        granted_ttl = int(lease["grantedTTL"])
+    except (
+        error.URLError,
+        TimeoutError,
+        json.JSONDecodeError,
+        KeyError,
+        TypeError,
+        ValueError,
+    ) as exc:
+        raise RuntimeError(f"leader lease TTL read failed via {endpoint}") from exc
+
+    if returned_lease_id != lease_id:
+        raise RuntimeError("leader lease TTL response returned a different lease")
+    if ttl <= 0 or granted_ttl <= 0:
+        raise RuntimeError("leader lease is expired or has an invalid TTL")
+    return {"granted_ttl": granted_ttl, "ttl": ttl}
+
+
+def writer_address_matches(
+    server_address: str,
+    server_port: int,
+    member_conn_url: str,
+    *,
+    resolver: Callable[..., list[Any]] = socket.getaddrinfo,
+) -> bool:
+    """Return whether Patroni's leader member resolves to the SQL server."""
+    member_url = parse.urlparse(member_conn_url)
+    if not member_url.hostname:
+        raise ValueError("leader member conn_url has no hostname")
+    member_port = member_url.port or 5432
+    if member_port != server_port:
+        return False
+
+    resolved_addresses = {
+        result[4][0]
+        for result in resolver(member_url.hostname, member_port, type=socket.SOCK_STREAM)
+    }
+    return server_address in resolved_addresses
+
+
+def query_writable_postgres(dsn: str) -> dict[str, Any]:
+    """Connect through the multi-host DSN and identify its writable server."""
+    try:
+        import psycopg2
+    except ImportError as exc:  # pragma: no cover - exercised in the fixture image
+        raise RuntimeError("psycopg2 is required inside the fixture image") from exc
+
+    with psycopg2.connect(dsn) as connection:
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT
+                    host(inet_server_addr()),
+                    inet_server_port(),
+                    pg_is_in_recovery(),
+                    (pg_control_checkpoint()).timeline_id
+                """
+            )
+            row = cursor.fetchone()
+
+    if row is None:
+        raise RuntimeError("writable Postgres identity query returned no row")
+    server_address, server_port, in_recovery, timeline = row
+    if in_recovery:
+        raise RuntimeError("multi-host DSN selected a Postgres replica")
+    return {
+        "server_address": str(server_address),
+        "server_port": int(server_port),
+        "timeline": int(timeline),
+    }
+
+
+def query_patroni(member_api_url: str, timeout_seconds: float) -> dict[str, Any]:
+    """Verify the DCS leader's REST identity still owns the primary lock."""
+    patroni_url = member_api_url.rstrip("/")
+    if not patroni_url.endswith("/patroni"):
+        patroni_url = f"{patroni_url}/patroni"
+    primary_url = f"{patroni_url.removesuffix('/patroni')}/primary"
+
+    try:
+        with request.urlopen(primary_url, timeout=timeout_seconds) as response:
+            if response.status != 200:
+                raise RuntimeError(f"Patroni primary check returned {response.status}")
+            state = json.load(response)
+    except (error.URLError, TimeoutError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"Patroni leader validation failed via {patroni_url}") from exc
+
+    if state.get("role") not in ("primary", "master"):
+        raise RuntimeError(f"DCS leader reports non-primary role: {state.get('role')}")
+    try:
+        timeline = int(state["timeline"])
+    except (KeyError, TypeError, ValueError) as exc:
+        raise RuntimeError("Patroni leader response has no valid timeline") from exc
+    return {"role": state["role"], "timeline": timeline}
+
+
+def observe(
+    *,
+    dcs_endpoint: str,
+    db_dsn: str,
+    cluster_path: str,
+    timeout_seconds: float,
+) -> dict[str, Any]:
+    """Build a fail-closed writer-generation observation."""
+    snapshot = read_linearizable_snapshot(dcs_endpoint, cluster_path, timeout_seconds)
+    dcs = extract_dcs_observation(snapshot, cluster_path)
+    writer = query_writable_postgres(db_dsn)
+    member = dcs["member"]
+    patroni = query_patroni(member["api_url"], timeout_seconds)
+
+    address_matches = writer_address_matches(
+        writer["server_address"], writer["server_port"], member["conn_url"]
+    )
+    timeline_matches = writer["timeline"] == patroni["timeline"]
+    if not address_matches:
+        raise RuntimeError(
+            "DCS leader member does not match the writable Postgres server address: "
+            f"SQL selected {writer['server_address']}:{writer['server_port']}, "
+            f"DCS advertised {member['conn_url']}"
+        )
+    if not timeline_matches:
+        raise RuntimeError(
+            "DCS leader Patroni timeline does not match writable Postgres timeline"
+        )
+
+    verified_snapshot = read_linearizable_snapshot(
+        dcs_endpoint, cluster_path, timeout_seconds
+    )
+    verified_dcs = extract_dcs_observation(verified_snapshot, cluster_path)
+    if (
+        verified_dcs["leader_name"] != dcs["leader_name"]
+        or verified_dcs["writer_generation"] != dcs["writer_generation"]
+    ):
+        raise RuntimeError(
+            "DCS leader term changed during writer validation: "
+            f"started with {dcs['leader_name']}@{dcs['writer_generation']}, "
+            "finished with "
+            f"{verified_dcs['leader_name']}@{verified_dcs['writer_generation']}"
+        )
+    dcs = verified_dcs
+    lease_ttl = read_lease_ttl(
+        dcs_endpoint, dcs["leader_lease_id"], timeout_seconds
+    )
+
+    return {
+        "binding": {
+            "address_matches": address_matches,
+            "patroni_primary": True,
+            "timeline_matches": timeline_matches,
+        },
+        "contract_version": 1,
+        "dcs": {
+            "cluster_path": cluster_path.rstrip("/"),
+            "leader_create_revision": dcs["writer_generation"],
+            "leader_lease_granted_ttl": lease_ttl["granted_ttl"],
+            "leader_lease_id": dcs["leader_lease_id"],
+            "leader_lease_ttl": lease_ttl["ttl"],
+            "leader_mod_revision": dcs["leader_mod_revision"],
+            "read_consistency": "linearizable",
+            "revision": dcs["dcs_revision"],
+        },
+        "writer": {
+            "name": dcs["leader_name"],
+            **writer,
+        },
+        "writer_generation": dcs["writer_generation"],
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Observe the HA-07 Patroni writer-generation contract"
+    )
+    parser.add_argument(
+        "--dcs-endpoint",
+        default=os.environ.get("HA_GENERATION_DCS_ENDPOINT", "http://etcd-a:2379"),
+    )
+    parser.add_argument(
+        "--db-dsn",
+        default=os.environ.get("HA_GENERATION_DB_DSN"),
+        required=os.environ.get("HA_GENERATION_DB_DSN") is None,
+    )
+    parser.add_argument(
+        "--cluster-path",
+        default=os.environ.get("HA_GENERATION_CLUSTER_PATH", DEFAULT_CLUSTER_PATH),
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=float(os.environ.get("HA_GENERATION_TIMEOUT_SECONDS", "3")),
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        observation = observe(
+            dcs_endpoint=args.dcs_endpoint,
+            db_dsn=args.db_dsn,
+            cluster_path=args.cluster_path,
+            timeout_seconds=args.timeout_seconds,
+        )
+    except Exception as exc:
+        print(f"writer-generation observation failed: {exc}", file=sys.stderr)
+        return 1
+
+    json.dump(observation, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/deployment-files/ha/generation-fixture/scripts/patroni-entrypoint.sh
+++ b/deployment-files/ha/generation-fixture/scripts/patroni-entrypoint.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+required=(
+  HA_GENERATION_SCOPE
+  PATRONI_NAME
+  PATRONI_REPLICATION_PASSWORD
+  PATRONI_REPLICATION_USERNAME
+  PATRONI_REWIND_PASSWORD
+  PATRONI_REWIND_USERNAME
+  PATRONI_SUPERUSER_PASSWORD
+)
+
+for name in "${required[@]}"; do
+  if [[ -z "${!name:-}" ]]; then
+    echo "missing required environment variable: ${name}" >&2
+    exit 2
+  fi
+done
+
+export PGDATA="${PGDATA:-/home/postgres/pgdata/data}"
+mkdir -p "${PGDATA}" /var/run/postgresql
+
+if [[ "$(id -u)" -eq 0 ]]; then
+  chown -R postgres:postgres "${PGDATA}" /var/run/postgresql
+  chmod 700 "${PGDATA}"
+fi
+
+envsubst < /etc/patroni/patroni.template.yml > /tmp/patroni.yml
+
+if [[ "$(id -u)" -eq 0 ]]; then
+  exec gosu postgres patroni /tmp/patroni.yml
+fi
+
+exec patroni /tmp/patroni.yml

--- a/deployment-files/ha/generation-fixture/scripts/prove.sh
+++ b/deployment-files/ha/generation-fixture/scripts/prove.sh
@@ -1,0 +1,450 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIXTURE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${FIXTURE_DIR}/../../.." && pwd)"
+COMPOSE_FILE="${FIXTURE_DIR}/compose.yaml"
+PROJECT_NAME="${HA_GENERATION_PROJECT_NAME:-proto-fleet-ha07-$$}"
+NETWORK_NAME="${PROJECT_NAME}-network"
+WAIT_SECONDS="${HA_GENERATION_WAIT_SECONDS:-180}"
+PROBE_TIMEOUT_SECONDS="${HA_GENERATION_PROBE_TIMEOUT_SECONDS:-5}"
+CLEAN_PROMOTIONS="${HA_GENERATION_CLEAN_PROMOTIONS:-2}"
+KEEP_STACK="${HA_GENERATION_KEEP_STACK:-0}"
+POSTGRES_PASSWORD="ha07-postgres"
+
+for timeout_value in "${WAIT_SECONDS}" "${PROBE_TIMEOUT_SECONDS}"; do
+  if [[ ! "${timeout_value}" =~ ^[1-9][0-9]*$ ]]; then
+    echo "HA generation timeout values must be positive integers" >&2
+    exit 2
+  fi
+done
+
+case "${PROJECT_NAME}" in
+  proto-fleet-ha07-*) ;;
+  *)
+    echo "HA_GENERATION_PROJECT_NAME must start with proto-fleet-ha07-" >&2
+    exit 2
+    ;;
+esac
+
+compose() {
+  HA_GENERATION_PROJECT_NAME="${PROJECT_NAME}" \
+    docker compose -p "${PROJECT_NAME}" -f "${COMPOSE_FILE}" "$@"
+}
+
+run_with_timeout() {
+  local timeout_seconds="$1"
+  shift
+  python3 -c '
+import subprocess
+import sys
+
+try:
+    result = subprocess.run(sys.argv[2:], timeout=float(sys.argv[1]), check=False)
+except subprocess.TimeoutExpired:
+    raise SystemExit(124)
+raise SystemExit(result.returncode)
+' "${timeout_seconds}" "$@"
+}
+
+compose_timed() {
+  local timeout_seconds="$1"
+  shift
+  run_with_timeout \
+    "${timeout_seconds}" \
+    env "HA_GENERATION_PROJECT_NAME=${PROJECT_NAME}" \
+    docker compose -p "${PROJECT_NAME}" -f "${COMPOSE_FILE}" "$@"
+}
+
+probe_timeout_for_deadline() {
+  local deadline="$1"
+  local remaining=$((deadline - SECONDS))
+
+  if ((remaining <= 0)); then
+    return 1
+  fi
+  if ((remaining > PROBE_TIMEOUT_SECONDS)); then
+    remaining="${PROBE_TIMEOUT_SECONDS}"
+  fi
+  printf '%s\n' "${remaining}"
+}
+
+log() {
+  printf '[ha-07] %s\n' "$*" >&2
+}
+
+json_field() {
+  local document="$1"
+  local path="$2"
+  printf '%s' "${document}" | python3 -c '
+import json
+import sys
+
+value = json.load(sys.stdin)
+for component in sys.argv[1].split("."):
+    value = value[component]
+print(value)
+' "${path}"
+}
+
+other_patroni() {
+  case "$1" in
+    patroni-a) printf 'patroni-b\n' ;;
+    patroni-b) printf 'patroni-a\n' ;;
+    *)
+      echo "unexpected Patroni member: $1" >&2
+      return 1
+      ;;
+  esac
+}
+
+observe_from() {
+  local service="$1"
+  local timeout_seconds="${2:-${PROBE_TIMEOUT_SECONDS}}"
+  local statement_timeout_ms=$((timeout_seconds * 1000))
+  compose_timed \
+    "${timeout_seconds}" \
+    exec -T \
+    -e "PGCONNECT_TIMEOUT=${timeout_seconds}" \
+    -e "PGOPTIONS=-c statement_timeout=${statement_timeout_ms}" \
+    "${service}" \
+    /opt/ha07/observe_generation.py --timeout-seconds "${timeout_seconds}"
+}
+
+wait_for_observation() {
+  local minimum_generation="${1:-0}"
+  local expected_writer="${2:-}"
+  local deadline=$((SECONDS + WAIT_SECONDS))
+  local service observation generation writer probe_timeout last_error=""
+  local services=(patroni-a patroni-b)
+
+  if [[ -n "${expected_writer}" ]]; then
+    services=("${expected_writer}")
+  fi
+
+  while ((SECONDS < deadline)); do
+    for service in "${services[@]}"; do
+      if ! probe_timeout="$(probe_timeout_for_deadline "${deadline}")"; then
+        break 2
+      fi
+      if ! compose_timed \
+        "${probe_timeout}" ps --status running -q "${service}" | grep -q .; then
+        continue
+      fi
+      if ! probe_timeout="$(probe_timeout_for_deadline "${deadline}")"; then
+        break 2
+      fi
+      if ! observation="$(observe_from "${service}" "${probe_timeout}" 2>&1)"; then
+        last_error="${service}: ${observation}"
+        continue
+      fi
+      generation="$(json_field "${observation}" writer_generation)"
+      writer="$(json_field "${observation}" writer.name)"
+      if ((generation <= minimum_generation)); then
+        continue
+      fi
+      if [[ -n "${expected_writer}" && "${writer}" != "${expected_writer}" ]]; then
+        continue
+      fi
+      printf '%s\n' "${observation}"
+      return 0
+    done
+    sleep 1
+  done
+
+  log "timed out waiting for writer generation > ${minimum_generation}"
+  if [[ -n "${last_error}" ]]; then
+    log "last observer rejection: ${last_error}"
+  fi
+  compose_timed "${PROBE_TIMEOUT_SECONDS}" ps >&2 || true
+  compose_timed \
+    "${PROBE_TIMEOUT_SECONDS}" logs --tail=80 patroni-a patroni-b >&2 || true
+  return 1
+}
+
+member_role() {
+  local service="$1"
+  local timeout_seconds="${2:-${PROBE_TIMEOUT_SECONDS}}"
+  compose_timed "${timeout_seconds}" exec -T "${service}" \
+    curl \
+      --fail \
+      --silent \
+      --show-error \
+      --connect-timeout "${timeout_seconds}" \
+      --max-time "${timeout_seconds}" \
+      http://127.0.0.1:8008/patroni \
+    | python3 -c 'import json, sys; print(json.load(sys.stdin)["role"])'
+}
+
+wait_for_role() {
+  local service="$1"
+  local expected_role="$2"
+  local deadline=$((SECONDS + WAIT_SECONDS))
+  local role probe_timeout
+
+  while ((SECONDS < deadline)); do
+    if ! probe_timeout="$(probe_timeout_for_deadline "${deadline}")"; then
+      break
+    fi
+    if role="$(member_role "${service}" "${probe_timeout}" 2>/dev/null)" \
+      && [[ "${role}" == "${expected_role}" ]]; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  log "timed out waiting for ${service} to report role ${expected_role}"
+  compose_timed "${PROBE_TIMEOUT_SECONDS}" logs --tail=80 "${service}" >&2 || true
+  return 1
+}
+
+sql() {
+  local service="$1"
+  local query="$2"
+  local timeout_seconds="${3:-${PROBE_TIMEOUT_SECONDS}}"
+  local statement_timeout_ms=$((timeout_seconds * 1000))
+  compose_timed \
+    "${timeout_seconds}" \
+    exec -T \
+    -e "PGPASSWORD=${POSTGRES_PASSWORD}" \
+    -e "PGCONNECT_TIMEOUT=${timeout_seconds}" \
+    -e "PGOPTIONS=-c statement_timeout=${statement_timeout_ms}" \
+    "${service}" \
+    psql -h 127.0.0.1 -U postgres -d postgres -Atq -v ON_ERROR_STOP=1 -c "${query}"
+}
+
+wait_for_sql_value() {
+  local service="$1"
+  local query="$2"
+  local expected="$3"
+  local deadline=$((SECONDS + WAIT_SECONDS))
+  local value probe_timeout
+
+  while ((SECONDS < deadline)); do
+    if ! probe_timeout="$(probe_timeout_for_deadline "${deadline}")"; then
+      break
+    fi
+    if value="$(sql "${service}" "${query}" "${probe_timeout}" 2>/dev/null)" \
+      && [[ "${value}" == "${expected}" ]]; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  log "timed out waiting for SQL value ${expected} on ${service}"
+  return 1
+}
+
+wait_for_lease_renewal() {
+  local initial_observation="$1"
+  local writer generation lease_id minimum_ttl deadline
+  local observation current_writer current_generation current_lease_id current_ttl
+  local probe_timeout last_error=""
+
+  writer="$(json_field "${initial_observation}" writer.name)"
+  generation="$(json_field "${initial_observation}" writer_generation)"
+  lease_id="$(json_field "${initial_observation}" dcs.leader_lease_id)"
+  minimum_ttl="$(json_field "${initial_observation}" dcs.leader_lease_ttl)"
+  deadline=$((SECONDS + WAIT_SECONDS))
+
+  while ((SECONDS < deadline)); do
+    if ! probe_timeout="$(probe_timeout_for_deadline "${deadline}")"; then
+      break
+    fi
+    if ! observation="$(observe_from "${writer}" "${probe_timeout}" 2>&1)"; then
+      last_error="${observation}"
+      sleep 1
+      continue
+    fi
+
+    current_writer="$(json_field "${observation}" writer.name)"
+    current_generation="$(json_field "${observation}" writer_generation)"
+    current_lease_id="$(json_field "${observation}" dcs.leader_lease_id)"
+    current_ttl="$(json_field "${observation}" dcs.leader_lease_ttl)"
+    if [[ "${current_writer}" != "${writer}" || "${current_generation}" != "${generation}" ]]; then
+      log "writer or generation changed while waiting for lease renewal"
+      return 1
+    fi
+    if [[ "${current_lease_id}" != "${lease_id}" ]]; then
+      log "leader lease changed while waiting for renewal"
+      return 1
+    fi
+    if ((current_ttl > minimum_ttl)); then
+      log \
+        "leader generation ${generation} stayed stable while lease ${lease_id}" \
+        "TTL refreshed ${minimum_ttl} -> ${current_ttl}"
+      printf '%s\n' "${observation}"
+      return 0
+    fi
+    if ((current_ttl < minimum_ttl)); then
+      minimum_ttl="${current_ttl}"
+    fi
+    sleep 1
+  done
+
+  log \
+    "timed out waiting for ${writer} generation ${generation} lease ${lease_id}" \
+    "TTL to refresh above ${minimum_ttl}"
+  if [[ -n "${last_error}" ]]; then
+    log "last observer rejection: ${last_error}"
+  fi
+  return 1
+}
+
+restore_as_replica() {
+  local former_primary="$1"
+  compose start "${former_primary}" >/dev/null
+  wait_for_role "${former_primary}" replica
+}
+
+clean_promotion() {
+  local observation="$1"
+  local previous_generation primary replica next_observation next_generation
+  previous_generation="$(json_field "${observation}" writer_generation)"
+  primary="$(json_field "${observation}" writer.name)"
+  replica="$(other_patroni "${primary}")"
+
+  log "stopping ${primary} to promote ${replica}"
+  compose stop "${primary}" >/dev/null
+  next_observation="$(wait_for_observation "${previous_generation}" "${replica}")"
+  next_generation="$(json_field "${next_observation}" writer_generation)"
+  log "writer generation advanced ${previous_generation} -> ${next_generation}"
+  restore_as_replica "${primary}"
+  printf '%s\n' "${next_observation}"
+}
+
+prove_async_write_loss() {
+  local observation="$1"
+  local previous_generation primary replica next_observation next_generation marker_count
+  previous_generation="$(json_field "${observation}" writer_generation)"
+  primary="$(json_field "${observation}" writer.name)"
+  replica="$(other_patroni "${primary}")"
+
+  log "preparing an acknowledged write that cannot reach ${replica}"
+  sql "${primary}" \
+    "CREATE TABLE IF NOT EXISTS ha07_async_loss_probe (marker text PRIMARY KEY); TRUNCATE ha07_async_loss_probe; SELECT pg_switch_wal();" \
+    >/dev/null
+  wait_for_sql_value \
+    "${replica}" \
+    "SELECT (to_regclass('public.ha07_async_loss_probe') IS NOT NULL)::text;" \
+    "true"
+
+  compose stop "${replica}" >/dev/null
+  sql "${primary}" "INSERT INTO ha07_async_loss_probe(marker) VALUES ('acknowledged-lost-write');" >/dev/null
+  wait_for_sql_value \
+    "${primary}" \
+    "SELECT count(*)::text FROM ha07_async_loss_probe WHERE marker = 'acknowledged-lost-write';" \
+    "1"
+
+  log "stopping ${primary}; ${replica} must promote without the acknowledged row"
+  compose stop "${primary}" >/dev/null
+  compose start "${replica}" >/dev/null
+  next_observation="$(wait_for_observation "${previous_generation}" "${replica}")"
+  next_generation="$(json_field "${next_observation}" writer_generation)"
+  marker_count="$(sql "${replica}" \
+    "SELECT count(*)::text FROM ha07_async_loss_probe WHERE marker = 'acknowledged-lost-write';")"
+  if [[ "${marker_count}" != "0" ]]; then
+    log "the acknowledged marker unexpectedly replicated; write-loss proof is invalid"
+    return 1
+  fi
+  log "write was lost while generation advanced ${previous_generation} -> ${next_generation}"
+
+  restore_as_replica "${primary}"
+  wait_for_sql_value \
+    "${primary}" \
+    "SELECT count(*)::text FROM ha07_async_loss_probe WHERE marker = 'acknowledged-lost-write';" \
+    "0"
+  printf '%s\n' "${next_observation}"
+}
+
+prove_partition_and_rejoin() {
+  local observation="$1"
+  local previous_generation primary replica container_id next_observation next_generation
+  previous_generation="$(json_field "${observation}" writer_generation)"
+  primary="$(json_field "${observation}" writer.name)"
+  replica="$(other_patroni "${primary}")"
+  container_id="$(compose ps -q "${primary}")"
+
+  log "disconnecting ${primary} from ${NETWORK_NAME}"
+  docker network disconnect --force "${NETWORK_NAME}" "${container_id}"
+  next_observation="$(wait_for_observation "${previous_generation}" "${replica}")"
+  next_generation="$(json_field "${next_observation}" writer_generation)"
+  log "partition promoted ${replica}; generation advanced ${previous_generation} -> ${next_generation}"
+
+  docker network connect --alias "${primary}" "${NETWORK_NAME}" "${container_id}"
+  wait_for_role "${primary}" replica
+
+  local stable_observation stable_generation stable_writer
+  stable_observation="$(observe_from "${replica}")"
+  stable_generation="$(json_field "${stable_observation}" writer_generation)"
+  stable_writer="$(json_field "${stable_observation}" writer.name)"
+  if [[ "${stable_generation}" != "${next_generation}" || "${stable_writer}" != "${replica}" ]]; then
+    log "old primary rejoin changed the authoritative writer term"
+    return 1
+  fi
+  printf '%s\n' "${stable_observation}"
+}
+
+cleanup() {
+  local exit_code=$?
+  trap - EXIT
+
+  if [[ "${KEEP_STACK}" == "1" && "${exit_code}" -ne 0 ]]; then
+    log "retaining ${PROJECT_NAME} for inspection"
+  else
+    if ! compose_timed \
+      "${WAIT_SECONDS}" down --volumes --remove-orphans >/dev/null; then
+      log "failed to tear down disposable fixture ${PROJECT_NAME}"
+      if [[ "${exit_code}" -eq 0 ]]; then
+        exit_code=1
+      fi
+    fi
+  fi
+  exit "${exit_code}"
+}
+
+run_proof() {
+  local observation initial_generation iteration
+
+  trap cleanup EXIT
+
+  log "building the repository TimescaleDB base"
+  docker build -t proto-fleet-timescaledb:ha07 "${REPO_ROOT}/server/timescaledb"
+  compose build patroni-a
+
+  log "starting the disposable two-Postgres, three-etcd fixture"
+  compose up -d --wait --wait-timeout "${WAIT_SECONDS}"
+  observation="$(wait_for_observation)"
+  initial_generation="$(json_field "${observation}" writer_generation)"
+  log "initial writer $(json_field "${observation}" writer.name) uses generation ${initial_generation}"
+
+  observation="$(wait_for_lease_renewal "${observation}")"
+
+  for ((iteration = 1; iteration <= CLEAN_PROMOTIONS; iteration++)); do
+    log "clean promotion ${iteration}/${CLEAN_PROMOTIONS}"
+    observation="$(clean_promotion "${observation}")"
+  done
+
+  observation="$(prove_async_write_loss "${observation}")"
+  observation="$(prove_partition_and_rejoin "${observation}")"
+
+  log "HA-07 PASS"
+  printf '%s\n' "${observation}"
+}
+
+case "${1:-run}" in
+  run)
+    run_proof
+    ;;
+  unit)
+    python3 -m unittest "${FIXTURE_DIR}/tests/test_observe_generation.py"
+    ;;
+  config)
+    compose config
+    ;;
+  *)
+    echo "usage: $0 [run|unit|config]" >&2
+    exit 2
+    ;;
+esac

--- a/deployment-files/ha/generation-fixture/tests/test_observe_generation.py
+++ b/deployment-files/ha/generation-fixture/tests/test_observe_generation.py
@@ -1,0 +1,222 @@
+import base64
+import importlib.util
+import json
+from pathlib import Path
+import unittest
+from unittest import mock
+
+
+MODULE_PATH = Path(__file__).parents[1] / "scripts" / "observe_generation.py"
+SPEC = importlib.util.spec_from_file_location("observe_generation", MODULE_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"unable to load observer from {MODULE_PATH}")
+observe_generation = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(observe_generation)
+
+
+def encoded(value: str) -> str:
+    return base64.b64encode(value.encode()).decode()
+
+
+def dcs_snapshot(
+    *,
+    leader: str = "patroni-a",
+    create_revision: str = "41",
+    lease: str = "998",
+    mod_revision: str = "47",
+    revision: str = "50",
+    include_member: bool = True,
+) -> dict:
+    cluster_path = "/service/proto-fleet-ha07"
+    key_values = [
+        {
+            "key": encoded(f"{cluster_path}/leader"),
+            "value": encoded(leader),
+            "create_revision": create_revision,
+            "mod_revision": mod_revision,
+            "lease": lease,
+        }
+    ]
+    if include_member:
+        key_values.append(
+            {
+                "key": encoded(f"{cluster_path}/members/{leader}"),
+                "value": encoded(
+                    json.dumps(
+                        {
+                            "api_url": f"http://{leader}:8008/patroni",
+                            "conn_url": f"postgres://{leader}:5432/postgres",
+                            "role": "primary",
+                            "state": "running",
+                        }
+                    )
+                ),
+                "create_revision": "13",
+                "mod_revision": "48",
+            }
+        )
+    return {"header": {"revision": revision}, "kvs": key_values}
+
+
+class ExtractDcsObservationTest(unittest.TestCase):
+    def test_extracts_stable_generation_and_leader_binding(self) -> None:
+        observation = observe_generation.extract_dcs_observation(
+            dcs_snapshot(), "/service/proto-fleet-ha07"
+        )
+
+        self.assertEqual(observation["writer_generation"], 41)
+        self.assertEqual(observation["leader_name"], "patroni-a")
+        self.assertEqual(
+            observation["member"]["conn_url"],
+            "postgres://patroni-a:5432/postgres",
+        )
+        self.assertEqual(observation["dcs_revision"], 50)
+        self.assertEqual(observation["leader_mod_revision"], 47)
+        self.assertEqual(observation["leader_lease_id"], 998)
+
+    def test_rejects_snapshot_without_leader(self) -> None:
+        with self.assertRaisesRegex(ValueError, "leader key"):
+            observe_generation.extract_dcs_observation(
+                {"header": {"revision": "50"}, "kvs": []},
+                "/service/proto-fleet-ha07",
+            )
+
+    def test_rejects_snapshot_without_matching_member(self) -> None:
+        with self.assertRaisesRegex(ValueError, "member key"):
+            observe_generation.extract_dcs_observation(
+                dcs_snapshot(include_member=False), "/service/proto-fleet-ha07"
+            )
+
+    def test_rejects_non_positive_generation(self) -> None:
+        with self.assertRaisesRegex(ValueError, "create_revision"):
+            observe_generation.extract_dcs_observation(
+                dcs_snapshot(create_revision="0"), "/service/proto-fleet-ha07"
+            )
+
+
+class PrefixRangeEndTest(unittest.TestCase):
+    def test_advances_the_last_prefix_byte(self) -> None:
+        self.assertEqual(
+            observe_generation.prefix_range_end(b"/service/proto-fleet-ha07/"),
+            b"/service/proto-fleet-ha070",
+        )
+
+
+class WriterAddressBindingTest(unittest.TestCase):
+    def test_accepts_the_member_connection_address(self) -> None:
+        def resolve(_host: str, _port: int, **_kwargs: object) -> list:
+            return [(None, None, None, None, ("172.30.0.12", 5432))]
+
+        self.assertTrue(
+            observe_generation.writer_address_matches(
+                "172.30.0.12",
+                5432,
+                "postgres://patroni-a:5432/postgres",
+                resolver=resolve,
+            )
+        )
+
+    def test_rejects_a_different_writable_server(self) -> None:
+        def resolve(_host: str, _port: int, **_kwargs: object) -> list:
+            return [(None, None, None, None, ("172.30.0.13", 5432))]
+
+        self.assertFalse(
+            observe_generation.writer_address_matches(
+                "172.30.0.12",
+                5432,
+                "postgres://patroni-a:5432/postgres",
+                resolver=resolve,
+            )
+        )
+
+
+class ObserveTest(unittest.TestCase):
+    def observe_with(
+        self,
+        snapshots: list[dict],
+        *,
+        address_matches: bool = True,
+        writer_timeline: int = 7,
+        patroni_timeline: int = 7,
+    ) -> dict:
+        with (
+            mock.patch.object(
+                observe_generation,
+                "read_linearizable_snapshot",
+                side_effect=snapshots,
+            ),
+            mock.patch.object(
+                observe_generation,
+                "query_writable_postgres",
+                return_value={
+                    "server_address": "172.30.0.12",
+                    "server_port": 5432,
+                    "timeline": writer_timeline,
+                },
+            ),
+            mock.patch.object(
+                observe_generation,
+                "query_patroni",
+                return_value={"role": "primary", "timeline": patroni_timeline},
+            ),
+            mock.patch.object(
+                observe_generation,
+                "writer_address_matches",
+                return_value=address_matches,
+            ),
+            mock.patch.object(
+                observe_generation,
+                "read_lease_ttl",
+                return_value={"granted_ttl": 20, "ttl": 18},
+            ),
+        ):
+            return observe_generation.observe(
+                dcs_endpoint="http://etcd-a:2379",
+                db_dsn="postgresql://patroni-a,patroni-b/postgres",
+                cluster_path="/service/proto-fleet-ha07",
+                timeout_seconds=1,
+            )
+
+    def test_rejects_writable_server_address_mismatch(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, "does not match"):
+            self.observe_with([dcs_snapshot()], address_matches=False)
+
+    def test_rejects_timeline_mismatch(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, "timeline does not match"):
+            self.observe_with(
+                [dcs_snapshot()],
+                writer_timeline=7,
+                patroni_timeline=8,
+            )
+
+    def test_rejects_leadership_change_during_validation(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, "leader term changed"):
+            self.observe_with(
+                [
+                    dcs_snapshot(),
+                    dcs_snapshot(
+                        leader="patroni-b",
+                        create_revision="51",
+                        mod_revision="53",
+                        revision="54",
+                    ),
+                ]
+            )
+
+    def test_reports_post_validation_revision_for_stable_term(self) -> None:
+        observation = self.observe_with(
+            [
+                dcs_snapshot(),
+                dcs_snapshot(mod_revision="58", revision="61"),
+            ]
+        )
+
+        self.assertEqual(observation["dcs"]["revision"], 61)
+        self.assertEqual(observation["dcs"]["leader_mod_revision"], 58)
+        self.assertEqual(observation["dcs"]["leader_lease_id"], 998)
+        self.assertEqual(observation["dcs"]["leader_lease_ttl"], 18)
+        self.assertEqual(observation["writer_generation"], 41)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Reviewable diff: +1153/-0 across 7 files (excludes generated, test, and story files).

## Summary

This PR establishes the writer-generation invariant that Proto Fleet's database lease fencing will consume: every Patroni promotion receives a strictly newer term, including when an acknowledged asynchronous write is lost. It adds a disposable local fixture that proves the invariant against real PostgreSQL 18, TimescaleDB, Patroni 4.1.4, and a three-member etcd 3.6.11 quorum so the lease design can depend on evidence rather than an assumption.

The fixture is contract evidence, not a production deployment template. Production image lifecycle, service identities, network hardening, TimescaleDB tuning parity, keepalived, installer UX, and broader fault coverage are intentionally out of scope.

## How it works

1. `prove.sh` builds the repository's TimescaleDB image, starts two Patroni-managed database members and three etcd members in a unique Compose project, and waits for a writable primary.
2. The observer takes a linearizable Patroni-prefix snapshot. The leader key's etcd `create_revision` is the writer generation; its value selects the matching Patroni member and its advertised SQL/REST endpoints.
3. A multi-host PostgreSQL connection must select that member as writable. Patroni's `/primary` response must agree on role and timeline.
4. A second linearizable DCS snapshot must still contain the same leader name and creation revision. Any missing key, changed term, address mismatch, expired lease, or timeline mismatch fails closed.
5. The harness proves a stable term across an actual lease refresh, performs repeated clean promotions, forces an acknowledged asynchronous write to be lost, partitions the old primary, and verifies that it rejoins as a replica without changing the new term.

```mermaid
flowchart TB
    Run["Writer-generation proof runner"] --> Compose["Disposable Compose project"]
    Compose --> Etcd["Three-member etcd quorum"]
    Compose --> A["Patroni A / PostgreSQL 18 / TimescaleDB"]
    Compose --> B["Patroni B / PostgreSQL 18 / TimescaleDB"]
    Run --> Observer["Fail-closed generation observer"]
    Observer --> Etcd
    Observer --> DSN["Multi-host read-write PostgreSQL DSN"]
    DSN --> A
    DSN --> B
    Observer --> Patroni["DCS-selected Patroni /primary endpoint"]
    Observer --> Result["Bound writer generation JSON"]
```

```mermaid
sequenceDiagram
    participant H as "Proof runner"
    participant O as "Generation observer"
    participant D as "etcd quorum"
    participant P as "Current PostgreSQL writer"
    participant R as "Patroni REST"
    H->>O: Observe current writer term
    O->>D: Linearizable prefix read
    O->>P: Connect with target_session_attrs=read-write
    O->>R: Validate /primary role and timeline
    O->>D: Re-read and require unchanged term
    O-->>H: Return bound create_revision
    H->>P: Stop or isolate current primary
    D-->>R: Expire old leader lease
    R->>D: Create new leader key
    H->>O: Require a strictly newer generation
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `deployment-files/ha/generation-fixture/compose.yaml` | Defines two Patroni database members and a three-member etcd quorum on an isolated network. | Confirms the proof uses quorum-backed leader election and the repository's PostgreSQL/TimescaleDB image rather than a mock. |
| `patroni.Dockerfile`, `patroni.template.yml`, `patroni-entrypoint.sh` | Builds Patroni 4.1.4 over the repository image and supplies the disposable cluster configuration. | Review the asynchronous failover settings, rewind path, DCS TTL, and intentionally test-only credentials. |
| `scripts/observe_generation.py` | Binds etcd leader creation revision to the actual writable PostgreSQL and Patroni primary, bracketing validation with linearizable reads. | This is the load-bearing generation contract; false positives must fail closed. |
| `scripts/prove.sh` | Orchestrates renewal, promotion, write-loss, partition, rejoin, bounded waits, diagnostics, and cleanup. | Review whether each reported pass demonstrates the claimed fault rather than merely surviving container churn. |
| `tests/test_observe_generation.py` | Covers DCS extraction, address binding, term-change rejection, and fail-closed mismatch paths. | Protects the observer's pure contract checks independently of Docker. |
| `README.md` | Defines the exact generation contract, evidence, run commands, and excluded production scope. | Keeps downstream HA work from treating this fixture as a supported deployment. |

## Key technical decisions & trade-offs

- Use the etcd leader key's `create_revision` as the generation, rather than `mod_revision`; lease keepalives can preserve the key without rewriting it, while recreation after promotion receives a newer cluster-wide revision.
- Bracket SQL and Patroni validation with two linearizable DCS reads, rather than trusting a single pre-validation snapshot across network calls.
- Prove renewal by observing the same lease TTL decrease and refresh while the generation remains fixed, rather than assuming a key rewrite that Patroni does not promise.
- Permit asynchronous write loss in this fixture and set a high failover-lag ceiling so the test demonstrates the exact rollback hazard the ownership fence must cover.
- Keep this artifact disposable and test-only. Production credentials, transport security, tuning, LAN policy, and image pin lifecycle are deliberately excluded.
- Bound every Docker, SQL, and REST probe and fail on teardown errors so a dependency hang or leaked project cannot masquerade as a passing proof.

## Testing & validation

- `deployment-files/ha/generation-fixture/scripts/prove.sh unit`: 11 tests pass.
- `prove.sh config`, `bash -n`, Python byte-compilation, and `git diff --check`: pass.
- Full Docker proof passes with real generation transitions `11 -> 23 -> 34 -> 51 -> 65`, including stable lease renewal, two clean promotions, acknowledged-write loss, partition promotion, and old-primary rejoin.
- The full `just lint` entrypoint was attempted, but the checkout has no installed client dependencies (`eslint: command not found`); the changed shell/Python/Compose paths passed their targeted checks.
- Not covered here: real-host network behavior, strict/auto-degrade standby policy, witness loss, production security, VIP movement, installer flows, or U9 qualification.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. This is an opt-in disposable local proof fixture and is not wired into Fleet runtime, deployment, or installer paths.

## New concepts

**Creation revision as a fencing term.** etcd assigns a monotonically increasing creation revision when a key is created. Patroni keeps its leader key alive through lease refreshes, so the revision is stable for that key lifetime; after expiry and promotion, recreating the key produces a newer value.

That makes `create_revision` useful for ordering database-writer eras without persisting the term in asynchronously replicated PostgreSQL. It must still be paired with a cluster incarnation because restoring or rebuilding etcd can reset the revision domain; do not use this technique as a globally durable counter across control-plane restores.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
