### PR TITLE
feat(telemetry): trace database queries as children of request spans

### DIFF
--- a/server/internal/domain/apikey/service_test.go
+++ b/server/internal/domain/apikey/service_test.go
@@ -40,7 +40,7 @@ func TestServiceExcludesAPIKeysForDeactivatedUsers(t *testing.T) {
 	assert.NotEqual(t, (*int64)(nil), validatedKey.UserID)
 	assert.Equal(t, testUser.DatabaseID, *validatedKey.UserID)
 
-	err = db2.WithTransactionNoResult(t.Context(), databaseService.DB, func(q *sqlc.Queries) error {
+	err = db2.WithTransactionNoResult(t.Context(), databaseService.DB, func(q sqlc.Querier) error {
 		return q.SoftDeleteUser(t.Context(), testUser.DatabaseID)
 	})
 	assert.NoError(t, err)

--- a/server/internal/domain/authz/reconcile.go
+++ b/server/internal/domain/authz/reconcile.go
@@ -52,7 +52,7 @@ import (
 // Callers must wrap their context with a deadline; without one a
 // stuck reconcile would block boot indefinitely.
 func Reconcile(ctx context.Context, conn *sql.DB) error {
-	return dbinfra.WithTransactionNoResult(ctx, conn, func(q *sqlc.Queries) error {
+	return dbinfra.WithTransactionNoResult(ctx, conn, func(q sqlc.Querier) error {
 		if err := q.AcquireReconcileLock(ctx); err != nil {
 			return fmt.Errorf("authz reconcile: acquire advisory lock: %w", err)
 		}
@@ -93,7 +93,7 @@ func SeedOrgBuiltins(ctx context.Context, q sqlc.Querier, orgID int64) (map[Buil
 	return seedOrgBuiltins(ctx, q, orgID)
 }
 
-func upsertCatalog(ctx context.Context, q *sqlc.Queries) error {
+func upsertCatalog(ctx context.Context, q sqlc.Querier) error {
 	for _, entry := range Catalog() {
 		if _, err := q.UpsertPermission(ctx, sqlc.UpsertPermissionParams{
 			Key:         entry.Key,

--- a/server/internal/domain/authz/resolver.go
+++ b/server/internal/domain/authz/resolver.go
@@ -58,7 +58,7 @@ func (r *PermissionResolver) LoadEffective(ctx context.Context, userID, organiza
 }
 
 // LoadEffectiveTx runs the same query against a caller-supplied
-// *sqlc.Queries handle so callers that already hold a transaction can
+// sqlc.Querier handle so callers that already hold a transaction can
 // re-load the effective set inside their own snapshot. The role-
 // management service uses this to re-check the caller's permissions
 // inside its mutation transactions, closing the TOCTOU window where a

--- a/server/internal/domain/authz/service.go
+++ b/server/internal/domain/authz/service.go
@@ -41,6 +41,7 @@ const (
 // permission edit can't slip in between the check and the persist.
 type Service struct {
 	conn        *sql.DB
+	queries     sqlc.Querier
 	activitySvc *activity.Service
 }
 
@@ -52,7 +53,11 @@ type Service struct {
 // activitySvc records role-management audit events; it may be nil (its
 // Log method is a no-op on a nil receiver), which tests rely on.
 func NewService(conn *sql.DB, activitySvc *activity.Service) *Service {
-	return &Service{conn: conn, activitySvc: activitySvc}
+	return &Service{
+		conn:        conn,
+		queries:     db.NewFailoverResettingQuerier(db.NewRetryDB(conn)),
+		activitySvc: activitySvc,
+	}
 }
 
 // auditWriteTimeout bounds the detached audit-log insert (see
@@ -103,7 +108,7 @@ type RoleView struct {
 // per-role hydrate-and-count pattern was O(roles * 2 queries) on a
 // listing hit by every role-management page open.
 func (s *Service) ListRoles(ctx context.Context, orgID int64) ([]RoleView, error) {
-	rows, err := sqlc.New(s.conn).ListRolesWithDetailsForOrg(ctx, sql.NullInt64{Int64: orgID, Valid: true})
+	rows, err := s.queries.ListRolesWithDetailsForOrg(ctx, sql.NullInt64{Int64: orgID, Valid: true})
 	if err != nil {
 		return nil, fleeterror.NewInternalErrorf("authz: list roles: %w", err)
 	}
@@ -177,7 +182,7 @@ func (s *Service) CreateCustomRole(ctx context.Context, callerID, orgID int64, n
 		return RoleView{}, err
 	}
 	trimmedDescription := strings.TrimSpace(description)
-	view, err := db.WithTransaction(ctx, s.conn, func(q *sqlc.Queries) (RoleView, error) {
+	view, err := db.WithTransaction(ctx, s.conn, func(q sqlc.Querier) (RoleView, error) {
 		if err := authorizeCallerCanGrant(ctx, q, callerID, orgID, normalized); err != nil {
 			return RoleView{}, err
 		}
@@ -223,7 +228,7 @@ func (s *Service) UpdateCustomRole(ctx context.Context, callerID, orgID, roleID 
 		return RoleView{}, err
 	}
 	trimmedDescription := strings.TrimSpace(description)
-	view, err := db.WithTransaction(ctx, s.conn, func(q *sqlc.Queries) (RoleView, error) {
+	view, err := db.WithTransaction(ctx, s.conn, func(q sqlc.Querier) (RoleView, error) {
 		existing, err := getRoleInOrg(ctx, q, orgID, roleID)
 		if err != nil {
 			return RoleView{}, err
@@ -295,7 +300,7 @@ func (s *Service) UpdateCustomRole(ctx context.Context, callerID, orgID, roleID 
 // count check and the soft delete.
 func (s *Service) DeleteCustomRole(ctx context.Context, callerID, orgID, roleID int64) error {
 	var deletedName string
-	err := db.WithTransactionNoResult(ctx, s.conn, func(q *sqlc.Queries) error {
+	err := db.WithTransactionNoResult(ctx, s.conn, func(q sqlc.Querier) error {
 		if err := authorizeCallerCanGrant(ctx, q, callerID, orgID, nil); err != nil {
 			return err
 		}
@@ -350,7 +355,7 @@ func (s *Service) DeleteCustomRole(ctx context.Context, callerID, orgID, roleID 
 // Pass an empty normalizedKeys to use this as a bare "caller still
 // holds role:manage" recheck — that's how DeleteCustomRole defends
 // against the middleware gate's window being too wide.
-func authorizeCallerCanGrant(ctx context.Context, q *sqlc.Queries, callerID, orgID int64, normalizedKeys []string) error {
+func authorizeCallerCanGrant(ctx context.Context, q sqlc.Querier, callerID, orgID int64, normalizedKeys []string) error {
 	callerEff, err := LoadEffectiveForUpdate(ctx, q, callerID, orgID)
 	if err != nil {
 		return fleeterror.NewInternalErrorf("authz: load caller permissions: %w", err)
@@ -462,7 +467,7 @@ func validateReadPairing(keys []string) error {
 // any prior rows first (UpdateCustomRole does this with
 // ClearRolePermissions). The permission table is reconciled at boot, so
 // every catalog key has a row.
-func setRolePermissions(ctx context.Context, q *sqlc.Queries, roleID int64, keys []string) error {
+func setRolePermissions(ctx context.Context, q sqlc.Querier, roleID int64, keys []string) error {
 	if len(keys) == 0 {
 		return nil
 	}
@@ -487,7 +492,7 @@ func setRolePermissions(ctx context.Context, q *sqlc.Queries, roleID int64, keys
 // hydrateRole loads the permission keys and live assignment count for a
 // role row and assembles a RoleView. Called per row inside ListRoles
 // and per-row after mutations.
-func hydrateRole(ctx context.Context, q *sqlc.Queries, r sqlc.Role) (RoleView, error) {
+func hydrateRole(ctx context.Context, q sqlc.Querier, r sqlc.Role) (RoleView, error) {
 	keys, err := q.ListRolePermissionKeys(ctx, r.ID)
 	if err != nil {
 		return RoleView{}, fleeterror.NewInternalErrorf("authz: list role permissions: %w", err)
@@ -520,7 +525,7 @@ func hydrateRole(ctx context.Context, q *sqlc.Queries, r sqlc.Role) (RoleView, e
 // InvalidArgument so an admin in org A cannot probe role ids belonging
 // to org B. NotFound is also masked as InvalidArgument for the same
 // existence-leak reason.
-func getRoleInOrg(ctx context.Context, q *sqlc.Queries, orgID, roleID int64) (sqlc.Role, error) {
+func getRoleInOrg(ctx context.Context, q sqlc.Querier, orgID, roleID int64) (sqlc.Role, error) {
 	role, err := q.GetRoleByID(ctx, roleID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -538,7 +543,7 @@ func getRoleInOrg(ctx context.Context, q *sqlc.Queries, orgID, roleID int64) (sq
 // Takes FOR UPDATE on the role row so DeleteCustomRole serializes
 // against resolveCreateUserRole (the only other code path that mutates
 // or depends on the role row's liveness during an assignment write).
-func getRoleInOrgForUpdate(ctx context.Context, q *sqlc.Queries, orgID, roleID int64) (sqlc.Role, error) {
+func getRoleInOrgForUpdate(ctx context.Context, q sqlc.Querier, orgID, roleID int64) (sqlc.Role, error) {
 	role, err := q.GetRoleByIDForUpdate(ctx, roleID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {

--- a/server/internal/domain/command/capability_checker.go
+++ b/server/internal/domain/command/capability_checker.go
@@ -119,7 +119,7 @@ func (c *CapabilityChecker) getDeviceInfo(
 
 // getAllDeviceInfo retrieves info for command-eligible devices in the organization.
 func (c *CapabilityChecker) getAllDeviceInfo(ctx context.Context, orgID int64) ([]deviceInfo, error) {
-	return db.WithTransaction(ctx, c.conn, func(q *sqlc.Queries) ([]deviceInfo, error) {
+	return db.WithTransaction(ctx, c.conn, func(q sqlc.Querier) ([]deviceInfo, error) {
 		rows, err := q.GetAllDeviceInfoForCapabilityCheck(ctx, orgID)
 		if err != nil {
 			return nil, fleeterror.NewInternalErrorf("error getting device info: %v", err)
@@ -143,7 +143,7 @@ func (c *CapabilityChecker) getDeviceInfoByDeviceIdentifiers(
 		return []deviceInfo{}, nil
 	}
 
-	return db.WithTransaction(ctx, c.conn, func(q *sqlc.Queries) ([]deviceInfo, error) {
+	return db.WithTransaction(ctx, c.conn, func(q sqlc.Querier) ([]deviceInfo, error) {
 		rows, err := q.GetDeviceInfoForCapabilityCheck(ctx, sqlc.GetDeviceInfoForCapabilityCheckParams{
 			DeviceIdentifiers: deviceIdentifiers,
 			OrgID:             orgID,

--- a/server/internal/domain/command/execution_service.go
+++ b/server/internal/domain/command/execution_service.go
@@ -309,7 +309,7 @@ func (es *ExecutionService) reapStuckMessages(ctx context.Context) ([]reapedComm
 	cutoff := time.Now().Add(-es.config.StuckMessageTimeout)
 	var reapedCmds []reapedCommand
 	var fwDeviceIDs []int64
-	err := db.WithTransactionNoResult(ctx, es.conn, func(q *sqlc.Queries) error {
+	err := db.WithTransactionNoResult(ctx, es.conn, func(q sqlc.Querier) error {
 		reaped, err := q.ReapStuckProcessingMessages(ctx, sqlc.ReapStuckProcessingMessagesParams{
 			Cutoff:    cutoff,
 			ReapLimit: 100,
@@ -517,7 +517,7 @@ func (es *ExecutionService) workerProcessCommand(ctx context.Context, message qu
 		queueUpdated  bool
 		queueTerminal bool
 	)
-	txErr := db.WithTransactionNoResult(dbCtx, es.conn, func(q *sqlc.Queries) error {
+	txErr := db.WithTransactionNoResult(dbCtx, es.conn, func(q sqlc.Querier) error {
 		// First: transition queue_message status (detects staleness via rowsAffected).
 		updated, terminal, err := es.markQueueMessageStatus(dbCtx, q, message, workerError)
 		if err != nil {
@@ -567,7 +567,7 @@ func (es *ExecutionService) workerProcessCommand(ctx context.Context, message qu
 //   - terminal is true when the resulting queue status is SUCCESS or FAILED
 //
 // (false, _, nil) means the row is no longer PROCESSING (stale/reaped)
-func (es *ExecutionService) markQueueMessageStatus(ctx context.Context, q *sqlc.Queries, message queue.Message, workerError error) (bool, bool, error) {
+func (es *ExecutionService) markQueueMessageStatus(ctx context.Context, q sqlc.Querier, message queue.Message, workerError error) (bool, bool, error) {
 	var (
 		result   sql.Result
 		err      error
@@ -1002,7 +1002,7 @@ func (es *ExecutionService) persistWorkerNameAfterPoolUpdate(
 		return es.deviceStore.UpdateWorkerName(ctx, deviceIdentifier, workerName)
 	}
 
-	return db.WithTransactionNoResult(ctx, es.conn, func(q *sqlc.Queries) error {
+	return db.WithTransactionNoResult(ctx, es.conn, func(q sqlc.Querier) error {
 		affected, err := q.UpdateDeviceWorkerName(ctx, sqlc.UpdateDeviceWorkerNameParams{
 			DeviceIdentifier: string(deviceIdentifier),
 			WorkerName:       sql.NullString{String: workerName, Valid: workerName != ""},
@@ -1121,7 +1121,7 @@ func normalizePoolUsernameBase(username string) string {
 
 // handleUnpairPostProcessing updates device pairing status and unregisters from telemetry after successful unpair
 func (es *ExecutionService) handleUnpairPostProcessing(ctx context.Context, deviceID int64) error {
-	deviceIdentifier, err := db.WithTransaction(ctx, es.conn, func(q *sqlc.Queries) (string, error) {
+	deviceIdentifier, err := db.WithTransaction(ctx, es.conn, func(q sqlc.Querier) (string, error) {
 		return q.GetDeviceIdentifierByID(ctx, deviceID)
 	})
 	if err != nil {
@@ -1168,7 +1168,7 @@ func (es *ExecutionService) clearFirmwareUpdateStatus(ctx context.Context, devic
 	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
 	defer cancel()
 
-	deviceIdentifier, err := db.WithTransaction(cleanupCtx, es.conn, func(q *sqlc.Queries) (string, error) {
+	deviceIdentifier, err := db.WithTransaction(cleanupCtx, es.conn, func(q sqlc.Querier) (string, error) {
 		return q.GetDeviceIdentifierByID(cleanupCtx, deviceID)
 	})
 	if err != nil {
@@ -1231,7 +1231,7 @@ func (es *ExecutionService) pollFirmwareInstallStatus(ctx context.Context, miner
 		return true, nil
 	}
 
-	deviceIdentifier, err := db.WithTransaction(ctx, es.conn, func(q *sqlc.Queries) (string, error) {
+	deviceIdentifier, err := db.WithTransaction(ctx, es.conn, func(q sqlc.Querier) (string, error) {
 		return q.GetDeviceIdentifierByID(ctx, deviceID)
 	})
 	if err != nil {
@@ -1256,7 +1256,7 @@ func (es *ExecutionService) markFirmwareRebootRequired(ctx context.Context, devi
 	if es.conn == nil || es.deviceStore == nil {
 		return
 	}
-	deviceIdentifier, err := db.WithTransaction(ctx, es.conn, func(q *sqlc.Queries) (string, error) {
+	deviceIdentifier, err := db.WithTransaction(ctx, es.conn, func(q sqlc.Querier) (string, error) {
 		return q.GetDeviceIdentifierByID(ctx, deviceID)
 	})
 	if err != nil {
@@ -1376,7 +1376,7 @@ func (es *ExecutionService) persistFleetNodeMinerCredentials(ctx context.Context
 	if err != nil {
 		return fleeterror.NewInternalErrorf("encode fleet node password update credentials: %v", err)
 	}
-	return db.WithTransactionNoResult(ctx, es.conn, func(q *sqlc.Queries) error {
+	return db.WithTransactionNoResult(ctx, es.conn, func(q sqlc.Querier) error {
 		return q.UpsertMinerCredentials(ctx, sqlc.UpsertMinerCredentialsParams{
 			DeviceID:    deviceID,
 			UsernameEnc: encodedUsername,
@@ -1403,7 +1403,7 @@ func (es *ExecutionService) insertProtoCredentials(ctx context.Context, deviceID
 		return fleeterror.NewInternalErrorf("failed to encrypt password: %v", err)
 	}
 
-	return db.WithTransactionNoResult(ctx, es.conn, func(q *sqlc.Queries) error {
+	return db.WithTransactionNoResult(ctx, es.conn, func(q sqlc.Querier) error {
 		return q.UpsertMinerCredentials(ctx, sqlc.UpsertMinerCredentialsParams{
 			DeviceID:    deviceID,
 			UsernameEnc: usernameEnc,
@@ -1421,7 +1421,7 @@ func (es *ExecutionService) updateMinerPasswordInDB(ctx context.Context, deviceI
 		return fleeterror.NewInternalErrorf("failed to encrypt password: %v", err)
 	}
 
-	rowsAffected, err := db.WithTransaction(ctx, es.conn, func(q *sqlc.Queries) (int64, error) {
+	rowsAffected, err := db.WithTransaction(ctx, es.conn, func(q sqlc.Querier) (int64, error) {
 		return q.UpdateMinerPassword(ctx, sqlc.UpdateMinerPasswordParams{
 			PasswordEnc: passwordEnc,
 			DeviceID:    deviceID,

--- a/server/internal/domain/command/integration_helpers_test.go
+++ b/server/internal/domain/command/integration_helpers_test.go
@@ -31,7 +31,7 @@ func setupRetentionTest(t *testing.T) (*sql.DB, *testutil.DatabaseService, *test
 func seedDeviceLog(t *testing.T, conn *sql.DB, batchUUID string, deviceID int64, status sqlc.DeviceCommandStatusEnum, updatedAt time.Time) {
 	t.Helper()
 	ctx := context.Background()
-	err := db2.WithTransactionNoResult(ctx, conn, func(q *sqlc.Queries) error {
+	err := db2.WithTransactionNoResult(ctx, conn, func(q sqlc.Querier) error {
 		return q.UpsertCommandOnDeviceLog(ctx, sqlc.UpsertCommandOnDeviceLogParams{
 			Uuid:      batchUUID,
 			DeviceID:  deviceID,

--- a/server/internal/domain/command/mark_status_integration_test.go
+++ b/server/internal/domain/command/mark_status_integration_test.go
@@ -25,7 +25,7 @@ func setupMarkStatusTest(t *testing.T) (*sql.DB, *testutil.DatabaseService, *tes
 
 func seedBatchLog(t *testing.T, conn *sql.DB, batchUUID string, userID int64, deviceCount int32) {
 	t.Helper()
-	err := db2.WithTransactionNoResult(context.Background(), conn, func(q *sqlc.Queries) error {
+	err := db2.WithTransactionNoResult(context.Background(), conn, func(q sqlc.Querier) error {
 		_, err := q.CreateCommandBatchLog(context.Background(), sqlc.CreateCommandBatchLogParams{
 			Uuid:         batchUUID,
 			Type:         "REBOOT",
@@ -43,7 +43,7 @@ func seedBatchLog(t *testing.T, conn *sql.DB, batchUUID string, userID int64, de
 func seedProcessingMessage(t *testing.T, conn *sql.DB, batchUUID string, deviceID int64) int64 {
 	t.Helper()
 	ctx := context.Background()
-	err := db2.WithTransactionNoResult(ctx, conn, func(q *sqlc.Queries) error {
+	err := db2.WithTransactionNoResult(ctx, conn, func(q sqlc.Querier) error {
 		return q.CreateQueueMessage(ctx, sqlc.CreateQueueMessageParams{
 			CommandBatchLogUuid: batchUUID,
 			CommandType:         "REBOOT",
@@ -100,7 +100,7 @@ func TestMarkQueueMessageStatusTransitions(t *testing.T) {
 		msgID := seedProcessingMessage(t, conn, batchUUID, device.DatabaseID)
 
 		// Act — same query as markQueueMessageStatus with nil workerError
-		result, err := db2.WithTransaction(context.Background(), conn, func(q *sqlc.Queries) (sql.Result, error) {
+		result, err := db2.WithTransaction(context.Background(), conn, func(q sqlc.Querier) (sql.Result, error) {
 			return q.UpdateMessageStatus(context.Background(), sqlc.UpdateMessageStatusParams{
 				ID:     msgID,
 				Status: sqlc.QueueStatusEnumSUCCESS,
@@ -123,7 +123,7 @@ func TestMarkQueueMessageStatusTransitions(t *testing.T) {
 		msgID := seedProcessingMessage(t, conn, batchUUID, device.DatabaseID)
 
 		// Act — same query as markQueueMessageStatus with retryable error
-		result, err := db2.WithTransaction(context.Background(), conn, func(q *sqlc.Queries) (sql.Result, error) {
+		result, err := db2.WithTransaction(context.Background(), conn, func(q sqlc.Querier) (sql.Result, error) {
 			return q.UpdateMessageAfterFailure(context.Background(), sqlc.UpdateMessageAfterFailureParams{
 				ID:         msgID,
 				RetryCount: 5, // MaxFailureRetries = 5, retry_count starts at 0
@@ -147,7 +147,7 @@ func TestMarkQueueMessageStatusTransitions(t *testing.T) {
 		msgID := seedProcessingMessage(t, conn, batchUUID, device.DatabaseID)
 
 		// Act — same query as markQueueMessageStatus with unimplemented error
-		result, err := db2.WithTransaction(context.Background(), conn, func(q *sqlc.Queries) (sql.Result, error) {
+		result, err := db2.WithTransaction(context.Background(), conn, func(q sqlc.Querier) (sql.Result, error) {
 			return q.UpdateMessagePermanentlyFailed(context.Background(), sqlc.UpdateMessagePermanentlyFailedParams{
 				ID:        msgID,
 				ErrorInfo: sql.NullString{String: "not supported", Valid: true},
@@ -170,7 +170,7 @@ func TestMarkQueueMessageStatusTransitions(t *testing.T) {
 
 		// Create message directly as FAILED (simulating reaper)
 		ctx := context.Background()
-		err := db2.WithTransactionNoResult(ctx, conn, func(q *sqlc.Queries) error {
+		err := db2.WithTransactionNoResult(ctx, conn, func(q sqlc.Querier) error {
 			return q.CreateQueueMessage(ctx, sqlc.CreateQueueMessageParams{
 				CommandBatchLogUuid: batchUUID,
 				CommandType:         "REBOOT",
@@ -189,7 +189,7 @@ func TestMarkQueueMessageStatusTransitions(t *testing.T) {
 		require.NoError(t, err)
 
 		// Act — try SUCCESS on already-FAILED message (WHERE status = 'PROCESSING' won't match)
-		result, err := db2.WithTransaction(ctx, conn, func(q *sqlc.Queries) (sql.Result, error) {
+		result, err := db2.WithTransaction(ctx, conn, func(q sqlc.Querier) (sql.Result, error) {
 			return q.UpdateMessageStatus(ctx, sqlc.UpdateMessageStatusParams{
 				ID:     msgID,
 				Status: sqlc.QueueStatusEnumSUCCESS,
@@ -222,7 +222,7 @@ func TestAtomicQueueStatusAndDeviceLog(t *testing.T) {
 		msgID := seedProcessingMessage(t, conn, batchUUID, device.DatabaseID)
 
 		// Act — single transaction: mark SUCCESS + write device log
-		err := db2.WithTransactionNoResult(context.Background(), conn, func(q *sqlc.Queries) error {
+		err := db2.WithTransactionNoResult(context.Background(), conn, func(q sqlc.Querier) error {
 			result, err := q.UpdateMessageStatus(context.Background(), sqlc.UpdateMessageStatusParams{
 				ID:     msgID,
 				Status: sqlc.QueueStatusEnumSUCCESS,
@@ -258,7 +258,7 @@ func TestAtomicQueueStatusAndDeviceLog(t *testing.T) {
 		failureReason := "plugin exploded: connection refused"
 
 		// Act — transition to FAILED and write the audit row with error_info.
-		err := db2.WithTransactionNoResult(context.Background(), conn, func(q *sqlc.Queries) error {
+		err := db2.WithTransactionNoResult(context.Background(), conn, func(q sqlc.Querier) error {
 			result, err := q.UpdateMessagePermanentlyFailed(context.Background(), sqlc.UpdateMessagePermanentlyFailedParams{
 				ID:        msgID,
 				ErrorInfo: sql.NullString{String: failureReason, Valid: true},
@@ -305,7 +305,7 @@ func TestAtomicQueueStatusAndDeviceLog(t *testing.T) {
 		seedBatchLog(t, conn, batchUUID, user.DatabaseID, 1)
 
 		// Act — write a SUCCESS device log without any error info.
-		err := db2.WithTransactionNoResult(context.Background(), conn, func(q *sqlc.Queries) error {
+		err := db2.WithTransactionNoResult(context.Background(), conn, func(q sqlc.Querier) error {
 			return q.UpsertCommandOnDeviceLog(context.Background(), sqlc.UpsertCommandOnDeviceLogParams{
 				Uuid:      batchUUID,
 				DeviceID:  device.DatabaseID,
@@ -335,7 +335,7 @@ func TestAtomicQueueStatusAndDeviceLog(t *testing.T) {
 
 		// Seed as FAILED (simulating reaper)
 		ctx := context.Background()
-		err := db2.WithTransactionNoResult(ctx, conn, func(q *sqlc.Queries) error {
+		err := db2.WithTransactionNoResult(ctx, conn, func(q sqlc.Querier) error {
 			return q.CreateQueueMessage(ctx, sqlc.CreateQueueMessageParams{
 				CommandBatchLogUuid: batchUUID,
 				CommandType:         "REBOOT",
@@ -354,7 +354,7 @@ func TestAtomicQueueStatusAndDeviceLog(t *testing.T) {
 		require.NoError(t, err)
 
 		// Act — same atomic transaction pattern; stale detection skips device log
-		err = db2.WithTransactionNoResult(ctx, conn, func(q *sqlc.Queries) error {
+		err = db2.WithTransactionNoResult(ctx, conn, func(q sqlc.Querier) error {
 			result, err := q.UpdateMessageStatus(ctx, sqlc.UpdateMessageStatusParams{
 				ID:     msgID,
 				Status: sqlc.QueueStatusEnumSUCCESS,

--- a/server/internal/domain/command/reaper_integration_test.go
+++ b/server/internal/domain/command/reaper_integration_test.go
@@ -29,7 +29,7 @@ func setupReaperTest(t *testing.T) (*sql.DB, *testutil.DatabaseService, *testuti
 
 func createBatchLog(t *testing.T, conn *sql.DB, batchUUID string, userID int64, deviceCount int32) {
 	t.Helper()
-	err := db2.WithTransactionNoResult(context.Background(), conn, func(q *sqlc.Queries) error {
+	err := db2.WithTransactionNoResult(context.Background(), conn, func(q sqlc.Querier) error {
 		_, err := q.CreateCommandBatchLog(context.Background(), sqlc.CreateCommandBatchLogParams{
 			Uuid:         batchUUID,
 			Type:         "REBOOT",
@@ -47,7 +47,7 @@ func createBatchLog(t *testing.T, conn *sql.DB, batchUUID string, userID int64, 
 func createStuckMessage(t *testing.T, conn *sql.DB, batchUUID string, deviceID int64, age time.Duration) {
 	t.Helper()
 	ctx := context.Background()
-	err := db2.WithTransactionNoResult(ctx, conn, func(q *sqlc.Queries) error {
+	err := db2.WithTransactionNoResult(ctx, conn, func(q sqlc.Querier) error {
 		return q.CreateQueueMessage(ctx, sqlc.CreateQueueMessageParams{
 			CommandBatchLogUuid: batchUUID,
 			CommandType:         "REBOOT",
@@ -219,7 +219,7 @@ func TestReaperIntegration(t *testing.T) {
 
 		// Create a message in SUCCESS state with an old timestamp
 		ctx := context.Background()
-		err := db2.WithTransactionNoResult(ctx, conn, func(q *sqlc.Queries) error {
+		err := db2.WithTransactionNoResult(ctx, conn, func(q sqlc.Querier) error {
 			return q.CreateQueueMessage(ctx, sqlc.CreateQueueMessageParams{
 				CommandBatchLogUuid: batchUUID,
 				CommandType:         "REBOOT",

--- a/server/internal/domain/command/results_integration_test.go
+++ b/server/internal/domain/command/results_integration_test.go
@@ -53,7 +53,7 @@ func newResultsTestService(conn *sql.DB) *command.Service {
 func seedBatchInState(t *testing.T, conn *sql.DB, batchUUID string, userID, orgID int64, deviceCount int32, status sqlc.BatchStatusEnum) {
 	t.Helper()
 	ctx := context.Background()
-	err := db2.WithTransactionNoResult(ctx, conn, func(q *sqlc.Queries) error {
+	err := db2.WithTransactionNoResult(ctx, conn, func(q sqlc.Querier) error {
 		_, err := q.CreateCommandBatchLog(ctx, sqlc.CreateCommandBatchLogParams{
 			Uuid:           batchUUID,
 			Type:           "REBOOT",
@@ -234,7 +234,7 @@ func TestGetCommandBatchDeviceResults_TruncatesLargeBatchesWithConsistentCounts(
 
 	// Bulk-insert codl rows in chunks so the test doesn't hammer sqlc one-by-one.
 	ctx := context.Background()
-	err := db2.WithTransactionNoResult(ctx, conn, func(q *sqlc.Queries) error {
+	err := db2.WithTransactionNoResult(ctx, conn, func(q sqlc.Querier) error {
 		for _, dev := range devs {
 			if err := q.UpsertCommandOnDeviceLog(ctx, sqlc.UpsertCommandOnDeviceLogParams{
 				Uuid:      batchUUID,
@@ -287,7 +287,7 @@ func TestGetCommandBatchDeviceResults_DeviceSnapshot(t *testing.T) {
 
 	ctx := context.Background()
 	upsert := func(status sqlc.DeviceCommandStatusEnum, errInfo sql.NullString) {
-		require.NoError(t, db2.WithTransactionNoResult(ctx, conn, func(q *sqlc.Queries) error {
+		require.NoError(t, db2.WithTransactionNoResult(ctx, conn, func(q sqlc.Querier) error {
 			return q.UpsertCommandOnDeviceLog(ctx, sqlc.UpsertCommandOnDeviceLogParams{
 				Uuid:      batchUUID,
 				DeviceID:  dev.DatabaseID,

--- a/server/internal/domain/command/service.go
+++ b/server/internal/domain/command/service.go
@@ -418,7 +418,7 @@ func (s *Service) buildActivityCompletedCallback(ctx context.Context, batchID, e
 	return func() error {
 		finCtx, cancel := context.WithTimeout(context.Background(), finalizerDBTimeout)
 		defer cancel()
-		counts, err := db.WithTransaction(finCtx, s.conn, func(q *sqlc.Queries) (sqlc.GetBatchStatusAndDeviceCountsRow, error) {
+		counts, err := db.WithTransaction(finCtx, s.conn, func(q sqlc.Querier) (sqlc.GetBatchStatusAndDeviceCountsRow, error) {
 			return q.GetBatchStatusAndDeviceCounts(finCtx, batchID)
 		})
 		if err != nil {
@@ -468,7 +468,7 @@ func (s *Service) saveCommandBatchLogToDB(ctx context.Context, userID, organizat
 		return "", fleeterror.NewInternalErrorf("cannot create command batch: session missing organization_id")
 	}
 
-	return db.WithTransaction(ctx, s.conn, func(q *sqlc.Queries) (string, error) {
+	return db.WithTransaction(ctx, s.conn, func(q sqlc.Querier) (string, error) {
 		timeNow := time.Now()
 		newUUID := id.GenerateID()
 
@@ -496,7 +496,7 @@ func (s *Service) statusUpdateIsProcessingBranch(ctx context.Context, commandBat
 		return false, fleeterror.NewInternalErrorf("error asking isProcessing: %v", err)
 	}
 	if isProcessing {
-		err = db.WithTransactionNoResult(ctx, s.conn, func(q *sqlc.Queries) error {
+		err = db.WithTransactionNoResult(ctx, s.conn, func(q sqlc.Querier) error {
 			return q.MarkCommandBatchProcessing(ctx, commandBatchLogUUID)
 		})
 		if err != nil {
@@ -509,7 +509,7 @@ func (s *Service) statusUpdateIsProcessingBranch(ctx context.Context, commandBat
 
 func (s *Service) getMarkFinishedBatchFunction(processingMarkedInDB bool) func(ctx context.Context, commandBatchLogUUID string) error {
 	return func(ctx context.Context, commandBatchLogUUID string) error {
-		return db.WithTransactionNoResult(ctx, s.conn, func(q *sqlc.Queries) error {
+		return db.WithTransactionNoResult(ctx, s.conn, func(q sqlc.Querier) error {
 			if processingMarkedInDB {
 				return q.MarkCommandBatchFinished(ctx, commandBatchLogUUID)
 			}
@@ -633,7 +633,7 @@ func (s *Service) resolveSelectorIdentifiers(ctx context.Context, selector *pb.D
 			filter = &pb.DeviceFilter{}
 		}
 
-		return db.WithTransaction(ctx, s.conn, func(q *sqlc.Queries) ([]string, error) {
+		return db.WithTransaction(ctx, s.conn, func(q sqlc.Querier) ([]string, error) {
 			var deviceStatus sql.NullString
 			var modelFilter sql.NullString
 			var manufacturerFilter sql.NullString
@@ -718,7 +718,7 @@ func (s *Service) resolveIdentifiersToDeviceIDs(ctx context.Context, identifiers
 	if s.resolveDeviceIDsOverride != nil {
 		return s.resolveDeviceIDsOverride(ctx, identifiers)
 	}
-	return db.WithTransaction(ctx, s.conn, func(q *sqlc.Queries) ([]int64, error) {
+	return db.WithTransaction(ctx, s.conn, func(q sqlc.Querier) ([]int64, error) {
 		return q.GetDeviceIDsByDeviceIdentifiers(ctx, identifiers)
 	})
 }
@@ -744,7 +744,7 @@ func (s *Service) resolveIdentifiersToDevices(ctx context.Context, identifiers [
 		}
 		return devices, nil
 	}
-	return db.WithTransaction(ctx, s.conn, func(q *sqlc.Queries) ([]resolvedDevice, error) {
+	return db.WithTransaction(ctx, s.conn, func(q sqlc.Querier) ([]resolvedDevice, error) {
 		rows, err := q.GetDeviceIDsWithIdentifiers(ctx, identifiers)
 		if err != nil {
 			return nil, err
@@ -778,7 +778,7 @@ func (s *Service) prepareUpdateMinerPasswordDispatch(ctx context.Context, orgID 
 	for _, device := range devices {
 		identifiers = append(identifiers, device.identifier)
 	}
-	rows, err := db.WithTransaction(ctx, s.conn, func(q *sqlc.Queries) ([]sqlc.GetDeviceCommandRoutesRow, error) {
+	rows, err := db.WithTransaction(ctx, s.conn, func(q sqlc.Querier) ([]sqlc.GetDeviceCommandRoutesRow, error) {
 		return q.GetDeviceCommandRoutes(ctx, sqlc.GetDeviceCommandRoutesParams{
 			OrgID:             orgID,
 			DeviceIdentifiers: identifiers,
@@ -1056,7 +1056,7 @@ func (s *Service) createMiningPoolDTO(ctx context.Context, poolID int64, priorit
 		return nil, fleeterror.NewInternalErrorf("error getting session info: %v", err)
 	}
 
-	pool, err := db.WithTransaction(ctx, s.conn, func(q *sqlc.Queries) (sqlc.Pool, error) {
+	pool, err := db.WithTransaction(ctx, s.conn, func(q sqlc.Querier) (sqlc.Pool, error) {
 		p, err := q.GetPool(ctx, sqlc.GetPoolParams{ID: poolID, OrgID: info.OrganizationID})
 		if err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
@@ -1195,7 +1195,7 @@ func (s *Service) preflightSV2Capabilities(ctx context.Context, selector *pb.Dev
 		return nil, nil, nil
 	}
 
-	rows, err := db.WithTransaction(ctx, s.conn, func(q *sqlc.Queries) ([]sqlc.GetDeviceInfoForCapabilityCheckRow, error) {
+	rows, err := db.WithTransaction(ctx, s.conn, func(q sqlc.Querier) ([]sqlc.GetDeviceInfoForCapabilityCheckRow, error) {
 		return q.GetDeviceInfoForCapabilityCheck(ctx, sqlc.GetDeviceInfoForCapabilityCheckParams{
 			DeviceIdentifiers: identifiers,
 			OrgID:             info.OrganizationID,
@@ -1452,7 +1452,7 @@ func (s *Service) ReapplyCurrentPoolsWithWorkerNames(
 }
 
 func (s *Service) getDeviceIDsWithIdentifiers(ctx context.Context, deviceIdentifiers []string) (map[string]int64, error) {
-	rows, err := db.WithTransaction(ctx, s.conn, func(q *sqlc.Queries) ([]sqlc.GetDeviceIDsWithIdentifiersRow, error) {
+	rows, err := db.WithTransaction(ctx, s.conn, func(q sqlc.Querier) ([]sqlc.GetDeviceIDsWithIdentifiersRow, error) {
 		return q.GetDeviceIDsWithIdentifiers(ctx, deviceIdentifiers)
 	})
 	if err != nil {
@@ -1476,7 +1476,7 @@ func (s *Service) enqueueWorkerNameReapplyMessages(
 	deviceIDsByIdentifier map[string]int64,
 	desiredWorkerNamesByDeviceIdentifier map[string]string,
 ) error {
-	return db.WithTransactionNoResult(ctx, s.conn, func(q *sqlc.Queries) error {
+	return db.WithTransactionNoResult(ctx, s.conn, func(q sqlc.Querier) error {
 		commandType := commandtype.UpdateMiningPools
 		for _, deviceIdentifier := range deviceIdentifiers {
 			payloadBytes, err := json.Marshal(dto.UpdateMiningPoolsPayload{
@@ -1763,7 +1763,7 @@ func (s *Service) GetCommandBatchDeviceResults(ctx context.Context, req *pb.GetC
 	// REPEATABLE READ + ReadOnly so header/counts/rows share one snapshot;
 	// the default READ COMMITTED would let concurrent worker writes to
 	// command_on_device_log produce inconsistent counts vs device_results.
-	bundle, err := db.WithTransaction(ctx, s.conn, func(q *sqlc.Queries) (resultsBundle, error) {
+	bundle, err := db.WithTransaction(ctx, s.conn, func(q sqlc.Querier) (resultsBundle, error) {
 		var b resultsBundle
 		header, hErr := q.GetBatchHeaderForOrg(ctx, sqlc.GetBatchHeaderForOrgParams{
 			Uuid:           req.BatchIdentifier,

--- a/server/internal/domain/command/status_service.go
+++ b/server/internal/domain/command/status_service.go
@@ -92,7 +92,7 @@ func (ss *StatusService) StreamCommandBatchUpdates(ctx context.Context, batchIde
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				statusAndCount, err := db.WithTransaction[sqlc.GetBatchStatusAndDeviceCountsRow](ctx, ss.conn, func(q *sqlc.Queries) (sqlc.GetBatchStatusAndDeviceCountsRow, error) {
+				statusAndCount, err := db.WithTransaction[sqlc.GetBatchStatusAndDeviceCountsRow](ctx, ss.conn, func(q sqlc.Querier) (sqlc.GetBatchStatusAndDeviceCountsRow, error) {
 					return q.GetBatchStatusAndDeviceCounts(ctx, batchIdentifier)
 				})
 				if err != nil {

--- a/server/internal/domain/stores/sqlstores/curtailment.go
+++ b/server/internal/domain/stores/sqlstores/curtailment.go
@@ -226,7 +226,7 @@ func (s *SQLCurtailmentStore) CreateResponseProfile(
 	profile models.ResponseProfile,
 	expectedInfrastructureDevices map[int64]models.ResponseProfileInfrastructureDevice,
 ) (*models.ResponseProfile, error) {
-	row, err := db.WithTransaction(ctx, s.conn.DB, func(q *sqlc.Queries) (sqlc.CurtailmentResponseProfile, error) {
+	row, err := db.WithTransaction(ctx, s.conn.DB, func(q sqlc.Querier) (sqlc.CurtailmentResponseProfile, error) {
 		if err := lockResponseProfileSitesForWrite(ctx, q, profile.OrgID, [][]byte{profile.ScopeJSON}, profile.SiteID); err != nil {
 			return sqlc.CurtailmentResponseProfile{}, err
 		}
@@ -250,7 +250,7 @@ func (s *SQLCurtailmentStore) UpdateResponseProfile(
 	expectedFacilityFanSettings models.ResponseProfileFanSettings,
 ) (*models.ResponseProfile, error) {
 	normalizedExpectedScopeJSON := normalizedResponseProfileScopeJSON(expectedScopeJSON)
-	row, err := db.WithTransaction(ctx, s.conn.DB, func(q *sqlc.Queries) (sqlc.CurtailmentResponseProfile, error) {
+	row, err := db.WithTransaction(ctx, s.conn.DB, func(q sqlc.Querier) (sqlc.CurtailmentResponseProfile, error) {
 		if err := lockResponseProfileAutomationMutation(ctx, q, profile.OrgID, profile.ID); err != nil {
 			return sqlc.CurtailmentResponseProfile{}, err
 		}
@@ -403,7 +403,7 @@ func (s *SQLCurtailmentStore) CreateAutomationRule(
 	rule models.AutomationRule,
 	expectedFanSettings models.ResponseProfileFanSettings,
 ) (*models.AutomationRule, error) {
-	inserted, err := db.WithTransaction(ctx, s.conn.DB, func(q *sqlc.Queries) (sqlc.CurtailmentAutomationRule, error) {
+	inserted, err := db.WithTransaction(ctx, s.conn.DB, func(q sqlc.Querier) (sqlc.CurtailmentAutomationRule, error) {
 		if err := requireResponseProfileForAutomation(ctx, q, rule.OrgID, rule.ResponseProfileID, expectedFanSettings); err != nil {
 			return sqlc.CurtailmentAutomationRule{}, err
 		}
@@ -431,7 +431,7 @@ func (s *SQLCurtailmentStore) UpdateAutomationRule(
 	rule models.AutomationRule,
 	expectedFanSettings models.ResponseProfileFanSettings,
 ) (*models.AutomationRule, error) {
-	result, err := db.WithTransaction(ctx, s.conn.DB, func(q *sqlc.Queries) (automationRuleMutationResult, error) {
+	result, err := db.WithTransaction(ctx, s.conn.DB, func(q sqlc.Querier) (automationRuleMutationResult, error) {
 		if err := requireResponseProfileForAutomation(ctx, q, rule.OrgID, rule.ResponseProfileID, expectedFanSettings); err != nil {
 			return automationRuleMutationResult{}, err
 		}
@@ -469,7 +469,7 @@ func (s *SQLCurtailmentStore) SetAutomationRuleEnabled(
 	var updated sqlc.CurtailmentAutomationRule
 	var err error
 	if enabled {
-		result, txErr := db.WithTransaction(ctx, s.conn.DB, func(q *sqlc.Queries) (automationRuleMutationResult, error) {
+		result, txErr := db.WithTransaction(ctx, s.conn.DB, func(q sqlc.Querier) (automationRuleMutationResult, error) {
 			rule, err := q.GetCurtailmentAutomationRuleByOrg(ctx, sqlc.GetCurtailmentAutomationRuleByOrgParams{
 				ID:    ruleID,
 				OrgID: orgID,
@@ -808,7 +808,7 @@ func mapAutomationRuleWriteError(action string, err error) error {
 	return fleeterror.NewInternalErrorf("failed to %s curtailment automation rule: %v", action, err)
 }
 
-func lockResponseProfileSitesForWrite(ctx context.Context, q *sqlc.Queries, orgID int64, scopeJSONs [][]byte, siteIDs ...*int64) error {
+func lockResponseProfileSitesForWrite(ctx context.Context, q sqlc.Querier, orgID int64, scopeJSONs [][]byte, siteIDs ...*int64) error {
 	var ids []int64
 	for _, scopeJSON := range scopeJSONs {
 		scopeSiteIDs, err := responseProfileScopeSiteIDsForLock(scopeJSON)
@@ -829,7 +829,7 @@ func lockResponseProfileSitesForWrite(ctx context.Context, q *sqlc.Queries, orgI
 	return nil
 }
 
-func lockResponseProfileAutomationMutation(ctx context.Context, q *sqlc.Queries, orgID, profileID int64) error {
+func lockResponseProfileAutomationMutation(ctx context.Context, q sqlc.Querier, orgID, profileID int64) error {
 	if err := q.LockCurtailmentResponseProfileAutomationMutation(ctx, sqlc.LockCurtailmentResponseProfileAutomationMutationParams{
 		OrgID:     orgID,
 		ProfileID: profileID,
@@ -841,7 +841,7 @@ func lockResponseProfileAutomationMutation(ctx context.Context, q *sqlc.Queries,
 
 func requireResponseProfileForAutomation(
 	ctx context.Context,
-	q *sqlc.Queries,
+	q sqlc.Querier,
 	orgID,
 	profileID int64,
 	expectedFanSettings models.ResponseProfileFanSettings,
@@ -876,7 +876,7 @@ func responseProfileFanSettingsMatch(
 
 func lockResponseProfileInfrastructureDevicesForWrite(
 	ctx context.Context,
-	q *sqlc.Queries,
+	q sqlc.Querier,
 	orgID int64,
 	expected map[int64]models.ResponseProfileInfrastructureDevice,
 ) error {
@@ -976,7 +976,7 @@ func (s *SQLCurtailmentStore) InsertEventWithTargets(
 		)
 	}
 	replayRace := false
-	result, err := db.WithTransaction(ctx, s.conn.DB, func(q *sqlc.Queries) (*models.InsertEventResult, error) {
+	result, err := db.WithTransaction(ctx, s.conn.DB, func(q sqlc.Querier) (*models.InsertEventResult, error) {
 		if replay, err := lookupReplayEventInTx(ctx, q, event); err != nil {
 			return nil, err
 		} else if replay != nil {
@@ -1263,7 +1263,7 @@ func containsNonPositiveInt64(values []int64) bool {
 	return false
 }
 
-func lookupReplayEventInTx(ctx context.Context, q *sqlc.Queries, event models.InsertEventParams) (*models.Event, error) {
+func lookupReplayEventInTx(ctx context.Context, q sqlc.Querier, event models.InsertEventParams) (*models.Event, error) {
 	if event.IdempotencyKey != nil {
 		row, err := q.GetCurtailmentEventByIdempotencyKey(ctx, sqlc.GetCurtailmentEventByIdempotencyKeyParams{
 			OrgID:          event.OrgID,
@@ -1476,7 +1476,7 @@ func (s *SQLCurtailmentStore) AdminTerminateEvent(
 	targetState models.EventState,
 	reason string,
 ) (*models.Event, bool, error) {
-	result, err := db.WithTransaction(ctx, s.conn.DB, func(q *sqlc.Queries) (adminTerminateResult, error) {
+	result, err := db.WithTransaction(ctx, s.conn.DB, func(q sqlc.Querier) (adminTerminateResult, error) {
 		current, err := q.GetCurtailmentEventByUUID(ctx, sqlc.GetCurtailmentEventByUUIDParams{
 			EventUuid: eventUUID,
 			OrgID:     orgID,
@@ -1570,7 +1570,7 @@ func (s *SQLCurtailmentStore) AdminTerminateEventWithFanRecovery(
 	if command == nil {
 		return nil, false, fleeterror.NewInvalidArgumentError("admin-terminate fan recovery command is required")
 	}
-	result, err := db.WithTransaction(ctx, s.conn.DB, func(q *sqlc.Queries) (adminTerminateResult, error) {
+	result, err := db.WithTransaction(ctx, s.conn.DB, func(q sqlc.Querier) (adminTerminateResult, error) {
 		current, err := q.LockCurtailmentEventByUUIDForWrite(ctx, sqlc.LockCurtailmentEventByUUIDForWriteParams{
 			EventUuid: eventUUID,
 			OrgID:     orgID,
@@ -1647,14 +1647,14 @@ func (s *SQLCurtailmentStore) ForceReleaseEvent(
 	eventUUID uuid.UUID,
 	reason string,
 ) (interfaces.ForceReleaseEventResult, error) {
-	return db.WithTransaction(ctx, s.conn.DB, func(q *sqlc.Queries) (interfaces.ForceReleaseEventResult, error) {
+	return db.WithTransaction(ctx, s.conn.DB, func(q sqlc.Querier) (interfaces.ForceReleaseEventResult, error) {
 		return s.forceReleaseEvent(ctx, q, orgID, eventUUID, reason)
 	})
 }
 
 func (s *SQLCurtailmentStore) forceReleaseEvent(
 	ctx context.Context,
-	q *sqlc.Queries,
+	q sqlc.Querier,
 	orgID int64,
 	eventUUID uuid.UUID,
 	reason string,
@@ -1994,14 +1994,14 @@ func (s *SQLCurtailmentStore) commandFanState(
 	params interfaces.UpdateCurtailmentFanStateParams,
 	command func(context.Context) *string,
 ) (*string, error) {
-	return db.WithTransaction(ctx, s.conn.DB, func(q *sqlc.Queries) (*string, error) {
+	return db.WithTransaction(ctx, s.conn.DB, func(q sqlc.Querier) (*string, error) {
 		return s.commandFanStateWithQueries(ctx, q, eventID, params, command)
 	})
 }
 
 func (s *SQLCurtailmentStore) commandFanStateWithQueries(
 	ctx context.Context,
-	q *sqlc.Queries,
+	q sqlc.Querier,
 	eventID int64,
 	params interfaces.UpdateCurtailmentFanStateParams,
 	command func(context.Context) *string,
@@ -2080,7 +2080,7 @@ func (s *SQLCurtailmentStore) ForceReleaseEventWithFanRecovery(
 		)
 	}
 
-	return db.WithTransaction(ctx, s.conn.DB, func(q *sqlc.Queries) (interfaces.ForceReleaseEventResult, error) {
+	return db.WithTransaction(ctx, s.conn.DB, func(q sqlc.Querier) (interfaces.ForceReleaseEventResult, error) {
 		for _, fanID := range fanIDs {
 			if err := q.LockCurtailmentFanDeviceForWrite(ctx, strconv.FormatInt(fanID, 10)); err != nil {
 				return interfaces.ForceReleaseEventResult{}, fleeterror.NewInternalErrorf("failed to lock force-release facility fan claim: %v", err)
@@ -2171,7 +2171,7 @@ func (s *SQLCurtailmentStore) RecoverTerminalFanState(
 		return fleeterror.NewInvalidArgumentError("terminal fan recovery command is required")
 	}
 
-	_, err := db.WithTransaction(ctx, s.conn.DB, func(q *sqlc.Queries) (struct{}, error) {
+	_, err := db.WithTransaction(ctx, s.conn.DB, func(q sqlc.Querier) (struct{}, error) {
 		for _, fanID := range fanIDs {
 			if err := q.LockCurtailmentFanDeviceForWrite(ctx, strconv.FormatInt(fanID, 10)); err != nil {
 				return struct{}{}, fleeterror.NewInternalErrorf("failed to lock terminal facility fan recovery: %v", err)
@@ -2287,7 +2287,7 @@ func (s *SQLCurtailmentStore) BeginRestoreTransition(
 	eventUUID uuid.UUID,
 	params interfaces.BeginRestoreTransitionParams,
 ) (*models.Event, error) {
-	return db.WithTransaction(ctx, s.conn.DB, func(q *sqlc.Queries) (*models.Event, error) {
+	return db.WithTransaction(ctx, s.conn.DB, func(q sqlc.Querier) (*models.Event, error) {
 		current, err := q.GetCurtailmentEventByUUID(ctx, sqlc.GetCurtailmentEventByUUIDParams{
 			EventUuid: eventUUID,
 			OrgID:     orgID,
@@ -2385,7 +2385,7 @@ func (s *SQLCurtailmentStore) BeginRestoreTransition(
 
 func guardAutomationDemandForRestore(
 	ctx context.Context,
-	q *sqlc.Queries,
+	q sqlc.Querier,
 	orgID int64,
 	eventUUID uuid.UUID,
 	guard *interfaces.AutomationDemandGuard,
@@ -2422,7 +2422,7 @@ func (s *SQLCurtailmentStore) BeginRecurtailTransition(
 	orgID int64,
 	eventUUID uuid.UUID,
 ) (*models.Event, error) {
-	return db.WithTransaction(ctx, s.conn.DB, func(q *sqlc.Queries) (*models.Event, error) {
+	return db.WithTransaction(ctx, s.conn.DB, func(q sqlc.Querier) (*models.Event, error) {
 		current, err := q.GetCurtailmentEventByUUID(ctx, sqlc.GetCurtailmentEventByUUIDParams{
 			EventUuid: eventUUID,
 			OrgID:     orgID,
@@ -2503,7 +2503,7 @@ func (s *SQLCurtailmentStore) ClaimClosedLoopFullFleetTargets(
 	if err != nil {
 		return nil, fleeterror.NewInternalErrorf("failed to encode curtailment target payload: %v", err)
 	}
-	rows, err := db.WithTransaction(ctx, s.conn.DB, func(q *sqlc.Queries) ([]sqlc.CurtailmentTarget, error) {
+	rows, err := db.WithTransaction(ctx, s.conn.DB, func(q sqlc.Querier) ([]sqlc.CurtailmentTarget, error) {
 		rows, err := q.ClaimClosedLoopFullFleetTargets(ctx, sqlc.ClaimClosedLoopFullFleetTargetsParams{
 			CurtailmentEventID: eventID,
 			TargetsJsonb:       payload,
@@ -2596,7 +2596,7 @@ func (s *SQLCurtailmentStore) BulkRefreshAllPairedTargetReadiness(
 
 func ensureTargetsOutsideCooldown(
 	ctx context.Context,
-	q *sqlc.Queries,
+	q sqlc.Querier,
 	orgID int64,
 	cooldownSec int32,
 	deviceIdentifiers []string,

--- a/server/internal/domain/stores/sqlstores/device.go
+++ b/server/internal/domain/stores/sqlstores/device.go
@@ -1321,7 +1321,7 @@ func (s *SQLDeviceStore) SoftDeleteDevices(ctx context.Context, deviceIdentifier
 		return 0, nil
 	}
 
-	deletedCount, err := db.WithTransaction(ctx, s.conn.DB, func(q *sqlc.Queries) (int64, error) {
+	deletedCount, err := db.WithTransaction(ctx, s.conn.DB, func(q sqlc.Querier) (int64, error) {
 		allBelong, err := q.AllDevicesBelongToOrg(ctx, sqlc.AllDevicesBelongToOrgParams{
 			ExpectedCount:     len(deviceIdentifiers),
 			DeviceIdentifiers: deviceIdentifiers,
@@ -1792,7 +1792,7 @@ func (s *SQLDeviceStore) UpdateDeviceCustomNames(ctx context.Context, orgID int6
 	if txQueries := s.GetTxQueries(ctx); txQueries != nil {
 		return updateDeviceCustomNamesWithQueries(ctx, txQueries, orgID, names)
 	}
-	return db.WithTransactionNoResult(ctx, s.conn.DB, func(q *sqlc.Queries) error {
+	return db.WithTransactionNoResult(ctx, s.conn.DB, func(q sqlc.Querier) error {
 		return updateDeviceCustomNamesWithQueries(ctx, q, orgID, names)
 	})
 }

--- a/server/internal/domain/stores/sqlstores/notification_history.go
+++ b/server/internal/domain/stores/sqlstores/notification_history.go
@@ -55,7 +55,7 @@ func (s *SQLNotificationHistoryStore) InsertBatch(ctx context.Context, notifs []
 	if len(notifs) == 0 {
 		return nil
 	}
-	return db.WithTransactionNoResult(ctx, s.conn.DB, func(q *sqlc.Queries) error {
+	return db.WithTransactionNoResult(ctx, s.conn.DB, func(q sqlc.Querier) error {
 		for start := 0; start < len(notifs); start += maxBatchRows {
 			end := min(start+maxBatchRows, len(notifs))
 			chunk := notifs[start:end]

--- a/server/internal/domain/stores/sqlstores/transactor.go
+++ b/server/internal/domain/stores/sqlstores/transactor.go
@@ -34,7 +34,7 @@ func (f *SQLTransactor) RunInTxWithResult(ctx context.Context, action func(ctx c
 		// If the context already has a transaction, just use the existing context
 		return action(ctx)
 	}
-	return db.WithTransaction(ctx, f.conn.DB, func(q *sqlc.Queries) (any, error) {
+	return db.WithTransaction(ctx, f.conn.DB, func(q sqlc.Querier) (any, error) {
 		txCtx := db.WithTxQueries(ctx, q)
 		return action(txCtx)
 	})

--- a/server/internal/handlers/apikey/handler_test.go
+++ b/server/internal/handlers/apikey/handler_test.go
@@ -191,7 +191,7 @@ func TestApiKeyHandler(t *testing.T) {
 		assert.NoError(t, err)
 
 		var viewerDBID int64
-		err = db2.WithTransactionNoResult(context.Background(), databaseService.DB, func(q *sqlc.Queries) error {
+		err = db2.WithTransactionNoResult(context.Background(), databaseService.DB, func(q sqlc.Querier) error {
 			userID, err := q.CreateUser(context.Background(), sqlc.CreateUserParams{
 				UserID:       id.GenerateID(),
 				Username:     "viewer@example.com",

--- a/server/internal/handlers/command/handler_test.go
+++ b/server/internal/handlers/command/handler_test.go
@@ -85,7 +85,7 @@ func TestHandler_GetCommandBatchDeviceResults_PassesThroughHappyPath(t *testing.
 
 	batchUUID := "handler-happy-1"
 	ctx := context.Background()
-	require.NoError(t, db2.WithTransactionNoResult(ctx, dbService.DB, func(q *sqlc.Queries) error {
+	require.NoError(t, db2.WithTransactionNoResult(ctx, dbService.DB, func(q sqlc.Querier) error {
 		_, e := q.CreateCommandBatchLog(ctx, sqlc.CreateCommandBatchLogParams{
 			Uuid:           batchUUID,
 			Type:           "REBOOT",
@@ -101,7 +101,7 @@ func TestHandler_GetCommandBatchDeviceResults_PassesThroughHappyPath(t *testing.
 	_, err = dbService.DB.ExecContext(ctx,
 		`UPDATE command_batch_log SET finished_at = NOW() WHERE uuid = $1`, batchUUID)
 	require.NoError(t, err)
-	require.NoError(t, db2.WithTransactionNoResult(ctx, dbService.DB, func(q *sqlc.Queries) error {
+	require.NoError(t, db2.WithTransactionNoResult(ctx, dbService.DB, func(q sqlc.Querier) error {
 		return q.UpsertCommandOnDeviceLog(ctx, sqlc.UpsertCommandOnDeviceLogParams{
 			Uuid:      batchUUID,
 			DeviceID:  dev.DatabaseID,
@@ -183,7 +183,7 @@ func TestHandler_GetCommandBatchDeviceResults_PropagatesNotFound(t *testing.T) {
 
 	batchUUID := "handler-cross-org-1"
 	ctx := context.Background()
-	require.NoError(t, db2.WithTransactionNoResult(ctx, dbService.DB, func(q *sqlc.Queries) error {
+	require.NoError(t, db2.WithTransactionNoResult(ctx, dbService.DB, func(q sqlc.Querier) error {
 		_, e := q.CreateCommandBatchLog(ctx, sqlc.CreateCommandBatchLogParams{
 			Uuid:           batchUUID,
 			Type:           "REBOOT",

--- a/server/internal/handlers/onboarding/handler_test.go
+++ b/server/internal/handlers/onboarding/handler_test.go
@@ -102,7 +102,7 @@ func TestHandler_GetFleetInitStatus(t *testing.T) {
 }
 
 func assertRoleAndOrgCreated(t *testing.T, conn *sql.DB, username string) error {
-	return db.WithTransactionNoResult(t.Context(), conn, func(q *sqlc.Queries) error {
+	return db.WithTransactionNoResult(t.Context(), conn, func(q sqlc.Querier) error {
 		dbUser, err := q.GetUserByUsername(t.Context(), username)
 		assert.NoError(t, err)
 		dbOrgs, err := q.GetOrganizationsForUser(t.Context(), dbUser.ID)

--- a/server/internal/infrastructure/db/failover_reset_querier.go
+++ b/server/internal/infrastructure/db/failover_reset_querier.go
@@ -10,8 +10,9 @@ import (
 // NewFailoverResettingQuerier returns a normal sqlc handle whose complete
 // operations reset stale idle connections when scan/deferred errors indicate a
 // PostgreSQL failover. It intentionally does not add another retry layer.
+// Queries are traced; the span covers any RetryDB-level retries.
 func NewFailoverResettingQuerier(conn *RetryDB) sqlc.Querier {
-	return newFailoverResettingQuerier(sqlc.New(conn), conn.resetPool)
+	return NewTracingQuerier(newFailoverResettingQuerier(sqlc.New(conn), conn.resetPool))
 }
 
 func newFailoverResettingQuerier(next sqlc.Querier, resetPool func()) sqlc.Querier {

--- a/server/internal/infrastructure/db/ha_reset_test.go
+++ b/server/internal/infrastructure/db/ha_reset_test.go
@@ -41,7 +41,7 @@ func TestWithTransactionBeginFailoverResetsPoolWithoutRetry(t *testing.T) {
 		resets++
 	})
 
-	_, err := WithTransaction(context.Background(), sqlDB, func(*sqlc.Queries) (struct{}, error) {
+	_, err := WithTransaction(context.Background(), sqlDB, func(sqlc.Querier) (struct{}, error) {
 		t.Fatal("transaction action should not run")
 		return struct{}{}, nil
 	})
@@ -64,7 +64,7 @@ func TestWithTransactionActionFailoverResetsPoolWithoutRetry(t *testing.T) {
 	})
 
 	calls := 0
-	_, err := WithTransaction(context.Background(), sqlDB, func(*sqlc.Queries) (struct{}, error) {
+	_, err := WithTransaction(context.Background(), sqlDB, func(sqlc.Querier) (struct{}, error) {
 		calls++
 		return struct{}{}, pgErr
 	})
@@ -99,7 +99,7 @@ func TestWithTransactionQueryFailoverResetsPoolAfterRollback(t *testing.T) {
 		}
 	})
 
-	_, err := WithTransaction(context.Background(), sqlDB, func(q *sqlc.Queries) (struct{}, error) {
+	_, err := WithTransaction(context.Background(), sqlDB, func(q sqlc.Querier) (struct{}, error) {
 		_, queryErr := q.GetSessionByID(context.Background(), "session")
 		if !errors.Is(queryErr, pgErr) {
 			t.Fatalf("query error = %v, want wrapped failover error", queryErr)
@@ -147,7 +147,7 @@ func TestWithTransactionCommitFailoverResetsPoolWithoutRetry(t *testing.T) {
 	})
 
 	calls := 0
-	_, err := WithTransaction(context.Background(), sqlDB, func(*sqlc.Queries) (struct{}, error) {
+	_, err := WithTransaction(context.Background(), sqlDB, func(sqlc.Querier) (struct{}, error) {
 		calls++
 		return struct{}{}, nil
 	})

--- a/server/internal/infrastructure/db/prepared_querier.go
+++ b/server/internal/infrastructure/db/prepared_querier.go
@@ -20,7 +20,7 @@ func NewPreparedQuerier(ctx context.Context, conn *sql.DB) (*PreparedQuerier, er
 		return nil, err
 	}
 	return &PreparedQuerier{
-		Querier:  sqlc.NewRetryingQuerier(prepared, newRetrier(conn)),
+		Querier:  NewTracingQuerier(sqlc.NewRetryingQuerier(prepared, newRetrier(conn))),
 		prepared: prepared,
 	}, nil
 }

--- a/server/internal/infrastructure/db/tracing_querier.go
+++ b/server/internal/infrastructure/db/tracing_querier.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
@@ -49,8 +50,16 @@ func (t tracingInterceptor) RetryQuery(ctx context.Context, operationName string
 	completed = true
 	// sql.ErrNoRows is an expected outcome for lookups, not a span failure.
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, err.Error())
+		span.SetStatus(codes.Error, statusDescription(err))
 	}
 	return err
+}
+
+// statusDescription keeps raw error text (which can embed user-supplied values) out of exported spans; SQLSTATE codes are data-free.
+func statusDescription(err error) string {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		return "SQLSTATE " + pgErr.Code
+	}
+	return "query failed"
 }

--- a/server/internal/infrastructure/db/tracing_querier.go
+++ b/server/internal/infrastructure/db/tracing_querier.go
@@ -1,0 +1,56 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/block/proto-fleet/server/generated/sqlc"
+)
+
+const dbTracerName = "github.com/block/proto-fleet/server/internal/infrastructure/db"
+
+// NewTracingQuerier wraps next so each query runs in a client span named after the sqlc method under the ctx's existing span; wrap outermost so spans cover retries.
+func NewTracingQuerier(next sqlc.Querier) sqlc.Querier {
+	return sqlc.NewRetryingQuerier(next, tracingInterceptor{tracer: otel.Tracer(dbTracerName)})
+}
+
+// tracingInterceptor uses the QueryRetrier seam as a non-retrying query interceptor, like failoverResetRetrier.
+type tracingInterceptor struct {
+	tracer trace.Tracer
+}
+
+var _ sqlc.QueryRetrier = tracingInterceptor{}
+
+func (t tracingInterceptor) RetryQuery(ctx context.Context, operationName string, fn func() error) error {
+	// Trace only inside an existing trace; parentless background polls would otherwise each export their own root trace.
+	if !trace.SpanContextFromContext(ctx).IsValid() {
+		return fn()
+	}
+	_, span := t.tracer.Start(ctx, "db."+operationName,
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(semconv.DBSystemPostgreSQL, semconv.DBOperationName(operationName)),
+	)
+	completed := false
+	// Ending via defer keeps a panic recovered upstream from exporting a success-looking span.
+	defer func() {
+		if !completed {
+			span.SetStatus(codes.Error, "query panicked")
+		}
+		span.End()
+	}()
+
+	err := fn()
+	completed = true
+	// sql.ErrNoRows is an expected outcome for lookups, not a span failure.
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+	}
+	return err
+}

--- a/server/internal/infrastructure/db/tracing_querier_test.go
+++ b/server/internal/infrastructure/db/tracing_querier_test.go
@@ -1,0 +1,141 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+
+	"github.com/block/proto-fleet/server/generated/sqlc"
+)
+
+func newRecordingInterceptor() (*tracetest.SpanRecorder, tracingInterceptor, trace.Tracer) {
+	recorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	tracer := tp.Tracer("test")
+	return recorder, tracingInterceptor{tracer: tracer}, tracer
+}
+
+func TestTracingInterceptorNestsSpanUnderRequestSpan(t *testing.T) {
+	recorder, interceptor, tracer := newRecordingInterceptor()
+
+	ctx, requestSpan := tracer.Start(context.Background(), "http.request")
+	err := interceptor.RetryQuery(ctx, "GetUserById", func() error { return nil })
+	require.NoError(t, err)
+	requestSpan.End()
+
+	spans := recorder.Ended()
+	require.Len(t, spans, 2)
+
+	dbSpan := spans[0]
+	require.Equal(t, "db.GetUserById", dbSpan.Name())
+	require.Equal(t, trace.SpanKindClient, dbSpan.SpanKind())
+	require.Equal(t, requestSpan.SpanContext().SpanID(), dbSpan.Parent().SpanID())
+	require.Equal(t, requestSpan.SpanContext().TraceID(), dbSpan.SpanContext().TraceID())
+	require.Equal(t, codes.Unset, dbSpan.Status().Code)
+
+	attrs := attribute.NewSet(dbSpan.Attributes()...)
+	requireAttr(t, attrs, "db.system", "postgresql")
+	requireAttr(t, attrs, "db.operation.name", "GetUserById")
+}
+
+func TestTracingInterceptorRecordsQueryError(t *testing.T) {
+	recorder, interceptor, tracer := newRecordingInterceptor()
+	ctx, requestSpan := tracer.Start(context.Background(), "http.request")
+	defer requestSpan.End()
+
+	queryErr := errors.New("connection refused")
+	err := interceptor.RetryQuery(ctx, "GetUserById", func() error { return queryErr })
+	require.ErrorIs(t, err, queryErr)
+
+	spans := recorder.Ended()
+	require.Len(t, spans, 1)
+	require.Equal(t, codes.Error, spans[0].Status().Code)
+	require.NotEmpty(t, spans[0].Events())
+}
+
+func TestTracingInterceptorTreatsNoRowsAsSuccess(t *testing.T) {
+	recorder, interceptor, tracer := newRecordingInterceptor()
+	ctx, requestSpan := tracer.Start(context.Background(), "http.request")
+	defer requestSpan.End()
+
+	err := interceptor.RetryQuery(ctx, "GetUserById", func() error { return sql.ErrNoRows })
+	require.ErrorIs(t, err, sql.ErrNoRows)
+
+	spans := recorder.Ended()
+	require.Len(t, spans, 1)
+	require.Equal(t, codes.Unset, spans[0].Status().Code)
+	require.Empty(t, spans[0].Events())
+}
+
+func TestTracingInterceptorSkipsParentlessQueries(t *testing.T) {
+	recorder, interceptor, _ := newRecordingInterceptor()
+
+	calls := 0
+	queryErr := errors.New("connection refused")
+	err := interceptor.RetryQuery(context.Background(), "GetUserById", func() error { calls++; return queryErr })
+	require.ErrorIs(t, err, queryErr)
+	require.Equal(t, 1, calls)
+	require.Empty(t, recorder.Ended())
+}
+
+func TestTracingInterceptorMarksPanickedQueries(t *testing.T) {
+	recorder, interceptor, tracer := newRecordingInterceptor()
+	ctx, requestSpan := tracer.Start(context.Background(), "http.request")
+	defer requestSpan.End()
+
+	require.Panics(t, func() {
+		_ = interceptor.RetryQuery(ctx, "GetUserById", func() error { panic("scan exploded") })
+	})
+
+	spans := recorder.Ended()
+	require.Len(t, spans, 1)
+	require.Equal(t, codes.Error, spans[0].Status().Code)
+	require.Equal(t, "query panicked", spans[0].Status().Description)
+}
+
+// stubQuerier panics on every method except the one overridden below.
+type stubQuerier struct {
+	sqlc.Querier
+}
+
+func (stubQuerier) GetUserById(context.Context, int64) (sqlc.User, error) {
+	return sqlc.User{ID: 42}, nil
+}
+
+func TestNewTracingQuerierTracesGeneratedMethods(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	otel.SetTracerProvider(sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder)))
+	t.Cleanup(func() {
+		// Reset to no-ops: restoring the pre-test defaults would re-install delegators already bound to this test's provider.
+		otel.SetTracerProvider(noop.NewTracerProvider())
+	})
+
+	ctx, requestSpan := otel.Tracer("test").Start(context.Background(), "http.request")
+	defer requestSpan.End()
+
+	q := NewTracingQuerier(stubQuerier{})
+	user, err := q.GetUserById(ctx, 42)
+	require.NoError(t, err)
+	require.Equal(t, int64(42), user.ID)
+
+	spans := recorder.Ended()
+	require.Len(t, spans, 1)
+	require.Equal(t, "db.GetUserById", spans[0].Name())
+}
+
+func requireAttr(t *testing.T, attrs attribute.Set, key attribute.Key, want string) {
+	t.Helper()
+	got, ok := attrs.Value(key)
+	require.True(t, ok, "missing attribute %s", key)
+	require.Equal(t, want, got.AsString())
+}

--- a/server/internal/infrastructure/db/tracing_querier_test.go
+++ b/server/internal/infrastructure/db/tracing_querier_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"testing"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -53,14 +55,31 @@ func TestTracingInterceptorRecordsQueryError(t *testing.T) {
 	ctx, requestSpan := tracer.Start(context.Background(), "http.request")
 	defer requestSpan.End()
 
-	queryErr := errors.New("connection refused")
+	queryErr := errors.New("connection refused to 10.0.0.5")
 	err := interceptor.RetryQuery(ctx, "GetUserById", func() error { return queryErr })
 	require.ErrorIs(t, err, queryErr)
 
 	spans := recorder.Ended()
 	require.Len(t, spans, 1)
 	require.Equal(t, codes.Error, spans[0].Status().Code)
-	require.NotEmpty(t, spans[0].Events())
+	require.Equal(t, "query failed", spans[0].Status().Description)
+	require.Empty(t, spans[0].Events(), "raw error text must not be exported as an event")
+}
+
+func TestTracingInterceptorExportsOnlySQLStateForPostgresErrors(t *testing.T) {
+	recorder, interceptor, tracer := newRecordingInterceptor()
+	ctx, requestSpan := tracer.Start(context.Background(), "http.request")
+	defer requestSpan.End()
+
+	pgErr := &pgconn.PgError{Code: "23505", Message: "duplicate key", Detail: `Key (email)=(pii@example.com) already exists.`}
+	err := interceptor.RetryQuery(ctx, "GetUserById", func() error { return fmt.Errorf("insert user: %w", pgErr) })
+	require.ErrorIs(t, err, error(pgErr))
+
+	spans := recorder.Ended()
+	require.Len(t, spans, 1)
+	require.Equal(t, codes.Error, spans[0].Status().Code)
+	require.Equal(t, "SQLSTATE 23505", spans[0].Status().Description)
+	require.Empty(t, spans[0].Events())
 }
 
 func TestTracingInterceptorTreatsNoRowsAsSuccess(t *testing.T) {

--- a/server/internal/infrastructure/db/with_transaction.go
+++ b/server/internal/infrastructure/db/with_transaction.go
@@ -13,11 +13,11 @@ import (
 // WithTransaction runs action in a transaction and retries the entire action for
 // retryable PostgreSQL errors. The action must be safe to replay and should not
 // perform side effects outside the transaction.
-func WithTransaction[T any](ctx context.Context, db *sql.DB, action func(q *sqlc.Queries) (T, error), opts ...*sql.TxOptions) (T, error) {
+func WithTransaction[T any](ctx context.Context, db *sql.DB, action func(q sqlc.Querier) (T, error), opts ...*sql.TxOptions) (T, error) {
 	return withTransactionWithRetry(ctx, db, action, DefaultRetryConfig, firstTxOpts(opts))
 }
 
-func withTransactionWithRetry[T any](ctx context.Context, db *sql.DB, action func(q *sqlc.Queries) (T, error), config RetryConfig, txOpts *sql.TxOptions) (T, error) {
+func withTransactionWithRetry[T any](ctx context.Context, db *sql.DB, action func(q sqlc.Querier) (T, error), config RetryConfig, txOpts *sql.TxOptions) (T, error) {
 	var zero T
 	var lastErr error
 	attempts := 0
@@ -67,7 +67,7 @@ func withTransactionWithRetry[T any](ctx context.Context, db *sql.DB, action fun
 	return zero, fleeterror.NewInternalErrorf("transaction failed after %d attempts: %w", attempts, lastErr)
 }
 
-func executeTransaction[T any](ctx context.Context, db *sql.DB, action func(q *sqlc.Queries) (T, error), txOpts *sql.TxOptions) (T, error) {
+func executeTransaction[T any](ctx context.Context, db *sql.DB, action func(q sqlc.Querier) (T, error), txOpts *sql.TxOptions) (T, error) {
 	var zero T
 
 	//nolint:forbidigo // This helper is the canonical boundary for opening SQL transactions.
@@ -79,7 +79,7 @@ func executeTransaction[T any](ctx context.Context, db *sql.DB, action func(q *s
 	//goland:noinspection GoUnhandledErrorResult
 	defer tx.Rollback()
 
-	sq := sqlc.New(tx)
+	sq := NewTracingQuerier(sqlc.New(tx))
 	result, err := action(sq)
 	if err != nil {
 		return zero, err
@@ -96,12 +96,12 @@ func executeTransaction[T any](ctx context.Context, db *sql.DB, action func(q *s
 // WithTransactionNoResult runs action in a transaction and retries the entire
 // action for retryable PostgreSQL errors. The action must be safe to replay and
 // should not perform side effects outside the transaction.
-func WithTransactionNoResult(ctx context.Context, db *sql.DB, action func(q *sqlc.Queries) error, opts ...*sql.TxOptions) error {
+func WithTransactionNoResult(ctx context.Context, db *sql.DB, action func(q sqlc.Querier) error, opts ...*sql.TxOptions) error {
 	return withTransactionNoResultWithRetry(ctx, db, action, DefaultRetryConfig, firstTxOpts(opts))
 }
 
-func withTransactionNoResultWithRetry(ctx context.Context, db *sql.DB, action func(q *sqlc.Queries) error, config RetryConfig, txOpts *sql.TxOptions) error {
-	_, err := withTransactionWithRetry(ctx, db, func(sq *sqlc.Queries) (any, error) {
+func withTransactionNoResultWithRetry(ctx context.Context, db *sql.DB, action func(q sqlc.Querier) error, config RetryConfig, txOpts *sql.TxOptions) error {
+	_, err := withTransactionWithRetry(ctx, db, func(sq sqlc.Querier) (any, error) {
 		var emptyResult any
 		return emptyResult, action(sq)
 	}, config, txOpts)

--- a/server/internal/infrastructure/queue/service.go
+++ b/server/internal/infrastructure/queue/service.go
@@ -58,7 +58,7 @@ func (d DatabaseMessageQueue) EnqueueMany(ctx context.Context, commandBatchLogUU
 }
 
 func (d DatabaseMessageQueue) enqueueEncoded(ctx context.Context, commandBatchLogUUID string, commandType commandtype.Type, messages []encodedMessage) error {
-	return db.WithTransactionNoResult(ctx, d.conn, func(q *sqlc.Queries) error {
+	return db.WithTransactionNoResult(ctx, d.conn, func(q sqlc.Querier) error {
 		for _, message := range messages {
 			err := q.CreateQueueMessage(ctx, sqlc.CreateQueueMessageParams{
 				CommandBatchLogUuid: commandBatchLogUUID,
@@ -83,7 +83,7 @@ func (d DatabaseMessageQueue) Dequeue(ctx context.Context, limit int32) ([]Messa
 	if d.config.DequeLimit > 0 {
 		limit = min(limit, d.config.DequeLimit)
 	}
-	messages, err := db.WithTransaction(ctx, d.conn, func(q *sqlc.Queries) ([]Message, error) {
+	messages, err := db.WithTransaction(ctx, d.conn, func(q sqlc.Querier) ([]Message, error) {
 		dbMessages, err := q.GetMessagesToProcess(ctx, sqlc.GetMessagesToProcessParams{
 			RetryCount: d.config.MaxFailureRetries,
 			Limit:      limit,
@@ -130,7 +130,7 @@ func (d DatabaseMessageQueue) Dequeue(ctx context.Context, limit int32) ([]Messa
 }
 
 func (d DatabaseMessageQueue) MarkSuccess(ctx context.Context, messageID int64) error {
-	updated, err := db.WithTransaction(ctx, d.conn, func(q *sqlc.Queries) (bool, error) {
+	updated, err := db.WithTransaction(ctx, d.conn, func(q sqlc.Querier) (bool, error) {
 		result, err := q.UpdateMessageStatus(ctx, sqlc.UpdateMessageStatusParams{
 			ID:     messageID,
 			Status: sqlc.QueueStatusEnumSUCCESS,
@@ -151,7 +151,7 @@ func (d DatabaseMessageQueue) MarkSuccess(ctx context.Context, messageID int64) 
 }
 
 func (d DatabaseMessageQueue) MarkFailed(ctx context.Context, messageID int64, errorInfo string) error {
-	updated, err := db.WithTransaction(ctx, d.conn, func(q *sqlc.Queries) (bool, error) {
+	updated, err := db.WithTransaction(ctx, d.conn, func(q sqlc.Querier) (bool, error) {
 		result, err := q.UpdateMessageAfterFailure(ctx, sqlc.UpdateMessageAfterFailureParams{
 			ID:         messageID,
 			RetryCount: d.config.MaxFailureRetries,
@@ -173,7 +173,7 @@ func (d DatabaseMessageQueue) MarkFailed(ctx context.Context, messageID int64, e
 }
 
 func (d DatabaseMessageQueue) MarkPermanentlyFailed(ctx context.Context, messageID int64, errorInfo string) error {
-	updated, err := db.WithTransaction(ctx, d.conn, func(q *sqlc.Queries) (bool, error) {
+	updated, err := db.WithTransaction(ctx, d.conn, func(q sqlc.Querier) (bool, error) {
 		result, err := q.UpdateMessagePermanentlyFailed(ctx, sqlc.UpdateMessagePermanentlyFailedParams{
 			ID:        messageID,
 			ErrorInfo: sql.NullString{String: errorInfo, Valid: true},
@@ -196,13 +196,13 @@ func (d DatabaseMessageQueue) MarkPermanentlyFailed(ctx context.Context, message
 type BatchStatusCheckFunc func(ctx context.Context, commandBatchLogID int64) (bool, error)
 
 func (d DatabaseMessageQueue) IsBatchFinished(ctx context.Context, commandBatchLogUUID string) (bool, error) {
-	return db.WithTransaction(ctx, d.conn, func(q *sqlc.Queries) (bool, error) {
+	return db.WithTransaction(ctx, d.conn, func(q sqlc.Querier) (bool, error) {
 		return q.IsBatchFinished(ctx, commandBatchLogUUID)
 	})
 }
 
 func (d DatabaseMessageQueue) IsBatchProcessing(ctx context.Context, commandBatchLogUUID string) (bool, error) {
-	return db.WithTransaction(ctx, d.conn, func(q *sqlc.Queries) (bool, error) {
+	return db.WithTransaction(ctx, d.conn, func(q sqlc.Querier) (bool, error) {
 		return q.IsBatchProcessing(ctx, commandBatchLogUUID)
 	})
 }

--- a/server/internal/infrastructure/timescaledb/telemetry_store.go
+++ b/server/internal/infrastructure/timescaledb/telemetry_store.go
@@ -1842,7 +1842,7 @@ func (s *TimescaleTelemetryStore) UpsertFleetMetricRollups(ctx context.Context, 
 	ctx, cancel := context.WithTimeout(ctx, s.config.WriteTimeout)
 	defer cancel()
 
-	return db.WithTransactionNoResult(ctx, s.db, func(q *sqlc.Queries) error {
+	return db.WithTransactionNoResult(ctx, s.db, func(q sqlc.Querier) error {
 		if err := q.DeleteFleetMetricRollupsForWindow(ctx, sqlc.DeleteFleetMetricRollupsForWindowParams{
 			StartTime: startTime,
 			EndTime:   endTime,

--- a/server/internal/testutil/database_queries.go
+++ b/server/internal/testutil/database_queries.go
@@ -61,7 +61,7 @@ func (s *DatabaseService) CreateSuperAdminUser() *TestUser {
 	testUser.Username = username
 	testUser.Password = password
 
-	err = db2.WithTransactionNoResult(context.Background(), s.DB, func(q *sqlc.Queries) error {
+	err = db2.WithTransactionNoResult(context.Background(), s.DB, func(q sqlc.Querier) error {
 		userID, err := q.CreateUser(context.Background(), sqlc.CreateUserParams{
 			UserID:       externalUserID,
 			Username:     username,
@@ -132,7 +132,7 @@ func (s *DatabaseService) CreateSuperAdminUser2() *TestUser {
 	testUser.Username = username
 	testUser.Password = password
 
-	err = db2.WithTransactionNoResult(context.Background(), s.DB, func(q *sqlc.Queries) error {
+	err = db2.WithTransactionNoResult(context.Background(), s.DB, func(q sqlc.Querier) error {
 		userID, err := q.CreateUser(context.Background(), sqlc.CreateUserParams{
 			UserID:       externalUserID,
 			Username:     username,
@@ -190,7 +190,7 @@ func (s *DatabaseService) CreateSuperAdminUser2() *TestUser {
 
 func (s *DatabaseService) CreateDevice(organizationID int64, driverName string) DeviceIdentification {
 	uuidCurrent := id.GenerateID()
-	deviceIdentification, err := db2.WithTransaction(context.Background(), s.DB, func(q *sqlc.Queries) (DeviceIdentification, error) {
+	deviceIdentification, err := db2.WithTransaction(context.Background(), s.DB, func(q sqlc.Querier) (DeviceIdentification, error) {
 		// Use unique IP per device to prevent constraint violations on (org_id, ip_address, port)
 		// Use atomic counter to ensure true uniqueness even in parallel tests
 		ipSuffix := atomic.AddUint64(&testDeviceIPCounter, 1)
@@ -236,7 +236,7 @@ func (s *DatabaseService) CreateDevice(organizationID int64, driverName string) 
 }
 
 func (s *DatabaseService) createDeviceIPAssignment(deviceID int64, ipAddress string, port string, urlScheme networking.Protocol) {
-	err := db2.WithTransactionNoResult(context.Background(), s.DB, func(q *sqlc.Queries) error {
+	err := db2.WithTransactionNoResult(context.Background(), s.DB, func(q sqlc.Querier) error {
 		return q.UpdateDeviceIPAssignment(context.Background(), sqlc.UpdateDeviceIPAssignmentParams{
 			IpAddress: ipAddress,
 			Port:      port,
@@ -248,13 +248,13 @@ func (s *DatabaseService) createDeviceIPAssignment(deviceID int64, ipAddress str
 }
 
 func (s *DatabaseService) GetDevicePairingByDeviceIdentifier(databaseDeviceID int64) (sqlc.PairingStatusEnum, error) {
-	return db2.WithTransaction(context.Background(), s.DB, func(q *sqlc.Queries) (sqlc.PairingStatusEnum, error) {
+	return db2.WithTransaction(context.Background(), s.DB, func(q sqlc.Querier) (sqlc.PairingStatusEnum, error) {
 		return q.GetDevicePairingStatusByDeviceDatabaseID(context.Background(), databaseDeviceID)
 	})
 }
 
 func (s *DatabaseService) GetTotalDevicePairings(orgID int64, _ int32) (int, error) {
-	return db2.WithTransaction(context.Background(), s.DB, func(q *sqlc.Queries) (int, error) {
+	return db2.WithTransaction(context.Background(), s.DB, func(q sqlc.Querier) (int, error) {
 		count, err := q.GetTotalPairedDevices(context.Background(), sqlc.GetTotalPairedDevicesParams{
 			OrgID: orgID,
 		})
@@ -320,7 +320,7 @@ func (s *DatabaseService) CreateTestMiners(orgID int64, count int, mockMinerURL 
 		}
 		s.createDeviceIPAssignment(device.DatabaseID, uniqueHost, portStr, protocol)
 
-		err = db2.WithTransactionNoResult(s.t.Context(), s.DB, func(q *sqlc.Queries) error {
+		err = db2.WithTransactionNoResult(s.t.Context(), s.DB, func(q sqlc.Querier) error {
 			_, err := q.UpsertDevicePairing(s.t.Context(), sqlc.UpsertDevicePairingParams{
 				DeviceID:      device.DatabaseID,
 				PairingStatus: sqlc.PairingStatusEnumPAIRED,


### PR DESCRIPTION
Reviewable diff: +154/-92 across 18 files (excludes generated, test, and story files).

## Summary

Extends the request tracing shipped in #813 down to the database layer: every sqlc query now emits an OpenTelemetry client span (`db.<MethodName>`) nested under the incoming request span, so a single trace in Jaeger/Datadog shows which queries a request ran, how long each took, and which one failed. Queries on a context without an active span (background pollers, MQTT ingest) are deliberately not traced, so no new root traces are created.

## How it works

The `otelhttp` middleware already puts the request span on the context, and that context is threaded through handlers → services → stores → sqlc. The new `db.NewTracingQuerier` decorator plugs into the generated `QueryRetrier` seam (the same interceptor seam `failoverResetRetrier` uses), which hands it the context plus the sqlc method name for all ~700 query methods. For each call it starts a `CLIENT` span named after the method with `db.system=postgresql` / `db.operation.name` attributes, runs the query, and records the outcome: errors mark the span failed (except `sql.ErrNoRows`, an expected lookup outcome), and a panic unwinding through the deferred `End` marks the span `query panicked` instead of exporting a success-looking span.

The decorator is installed at every place a query handle is built, always outermost so one span covers all retry attempts:

- `NewFailoverResettingQuerier` — the handle every SQL store uses
- `NewPreparedQuerier` — the prepared-statement handle (MQTT path)
- `executeTransaction` — the tx-scoped handle passed to `WithTransaction` actions
- `authz.Service` — previously built an ad-hoc untraced handle for `ListRoles`; now holds the canonical failover-reset + retry + tracing stack

To let the traced handle flow through transactions, `WithTransaction`/`WithTransactionNoResult` actions now take the `sqlc.Querier` interface instead of the concrete `*sqlc.Queries` — that mechanical signature change is the bulk of the diff.

## Diagrams

```mermaid
flowchart TD
    A["otelhttp middleware<br/>(request span in ctx)"] --> B["Connect handler / service"]
    B --> C["store method (ctx)"]
    C --> D["NewTracingQuerier<br/>span: db.&lt;Method&gt;"]
    D --> E["retry / failover-reset querier"]
    E --> F["sqlc.Queries"]
    F --> G["RetryDB / *sql.Tx"]
    G --> H[("PostgreSQL")]

    B2["WithTransaction action"] --> D2["NewTracingQuerier"]
    D2 --> F2["sqlc.Queries (tx-bound)"]
    F2 --> G
```

```mermaid
sequenceDiagram
    participant I as tracingInterceptor
    participant Q as query fn
    I->>I: ctx has valid span context?
    alt no (background poll, telemetry off)
        I->>Q: run query untraced
    else yes
        I->>I: start span db.Method (CLIENT)
        I->>Q: run query
        alt error (not ErrNoRows)
            I->>I: status Error (SQLSTATE code only)
        else panic
            I->>I: status Error "query panicked"
        end
        I->>I: end span
    end
```

## Areas of the code involved

| Area | What changed | Why it matters for review |
|---|---|---|
| `server/internal/infrastructure/db/tracing_querier.go` (new) | The tracing interceptor + `NewTracingQuerier` constructor | Core logic: skip rule, error/panic status, span naming |
| `server/internal/infrastructure/db/{failover_reset_querier,prepared_querier,with_transaction}.go` | Wrap handles with tracing; `WithTransaction` action signature `*sqlc.Queries` → `sqlc.Querier` | Wrap ordering decides whether spans cover retries |
| `server/internal/domain/authz/service.go` | Constructor-held querier replaces per-call `sqlc.New(s.conn)` in `ListRoles` | Also restores failover pool-reset + retry behavior that the ad-hoc handle lacked |
| `server/internal/{domain,infrastructure,handlers,testutil}/**` (~20 files) | Mechanical closure param change to `sqlc.Querier` | Compile-checked; no behavior change |
| `server/internal/infrastructure/db/tracing_querier_test.go` (new) | Unit tests: nesting, error, ErrNoRows, parentless skip, panic, end-to-end via generated decorator | — |

## Key technical decisions & trade-offs

- **Reuse the generated `QueryRetrier` seam** instead of adding `otelsql`/`otelpgx` driver-level instrumentation: method-name span granularity, zero new dependencies, and spans cover row scanning — at the cost of not covering raw-SQL paths outside sqlc.
- **Widen `WithTransaction` actions to `sqlc.Querier`** instead of wrapping the tx `DBTX`: uniform span fidelity (a `DBTX` wrapper can't see `QueryRow` errors or row-iteration time) in exchange for a mechanical, compile-checked signature sweep.
- **Skip queries on span-less contexts**: the 1s queue-dequeue poll, reapers, and MQTT ingest would otherwise export ~90k+ single-span root traces/day at the default sample rate. Adding a job-level span to any background loop re-enables its query tracing automatically. Side effect: telemetry-disabled deployments do no span work at all.
- **`sql.ErrNoRows` is not a span failure** — it's the normal not-found outcome for `:one` lookups and would otherwise pollute error-rate views.
- **Deliberately untraced**: the TimescaleDB metrics-ingest writers (`timescaledb/telemetry_store.go`, `metrics/store.go` — span-per-row would flood the exporter) and the transaction itself (no begin/commit span yet). **Failed spans export only a SQLSTATE code** (`SQLSTATE 23505`) or `query failed` as the status description, never `err.Error()` — raw Postgres messages can embed user-supplied values (e.g. unique-key DETAIL), which belong in server logs, not the tracing backend. Trade-off: correlating a specific span to its exact error means jumping to logs by trace/time.

## Testing & validation

- `just lint` green (buf, eslint, golangci-lint — 0 issues).
- `go build ./...` / `go vet ./...` clean after rebasing onto current main.
- New unit tests cover span naming/attributes, parent-child nesting under a request span, error status, `ErrNoRows`, the parentless skip, panic marking, and an end-to-end call through the generated decorator; db package also run with `-shuffle=on` and `-race`.
- Integration suites against the dev database (`DB_PASSWORD=fleet`, `-p 1`): `infrastructure/db`, `authz`, `command`, `sqlstores` (rerun on this base), plus `apikey`, `handlers/{apikey,command,onboarding}`, `timescaledb`, `metrics` earlier on the same diff — all pass.
- `/code-review max --fix` ran over the diff; its fixes (parentless skip, panic status, authz querier) are included.
- Not covered: no automated assertion that spans land in Jaeger end-to-end (verified logic-level only); metrics-ingest stores intentionally untraced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
