### PR TITLE
Darken overlay scrims

### DIFF
--- a/client/src/shared/components/ActionSheet/ActionSheet.tsx
+++ b/client/src/shared/components/ActionSheet/ActionSheet.tsx
@@ -73,7 +73,7 @@ const ActionSheet = ({
 
   return createPortal(
     <div
-      className="fixed inset-0 z-60 flex items-end bg-grayscale-gray-5"
+      className="fixed inset-0 z-60 flex items-end bg-grayscale-gray-20"
       data-testid={testId}
       role="presentation"
       onClick={(event) => {

--- a/client/src/shared/components/PageOverlay/PageOverlay.tsx
+++ b/client/src/shared/components/PageOverlay/PageOverlay.tsx
@@ -43,7 +43,7 @@ const PageOverlayContent = ({
       exit={{ opacity: 0 }}
       transition={{ duration: 0.3, ease: "easeInOut" }}
       className={clsx(
-        "fixed top-0 left-0 m-0! flex h-dvh w-screen justify-center overflow-hidden! bg-grayscale-gray-5",
+        "fixed top-0 left-0 m-0! flex h-dvh w-screen justify-center overflow-hidden! bg-grayscale-gray-20",
         zIndex,
         {
           "items-center-safe p-0!": position === "center",

--- a/client/src/shared/components/Popover/Popover.tsx
+++ b/client/src/shared/components/Popover/Popover.tsx
@@ -124,7 +124,7 @@ const Popover = ({
   if (isPhone) {
     return createPortal(
       <div
-        className="fixed inset-0 z-60 flex items-end bg-grayscale-gray-5"
+        className="fixed inset-0 z-60 flex items-end bg-grayscale-gray-20"
         data-testid={testId ? `${testId}-sheet` : "popover-sheet"}
         onMouseDown={canDismissPopover ? (event) => event.stopPropagation() : undefined}
         onTouchStart={canDismissPopover ? (event) => event.stopPropagation() : undefined}


### PR DESCRIPTION
Reviewable diff: +3/-3 across 3 files (excludes generated, test, and story files).

**Summary**
This PR darkens the shared page-blocking overlay behind dialogs, modals, fullscreen modals, action sheets, and mobile popover sheets. The scrim moves from the 5% grayscale token to the 20% grayscale token so modal surfaces read with stronger separation from the underlying page in both light and dark themes.

**How it works**
`PageOverlay` is the shared wrapper used by `Modal`, `Dialog`, fullscreen modal variants, and direct fullscreen overlay flows. Updating its background class changes the standard modal/dialog scrim broadly. The sheet-style overlays that bypass `PageOverlay` for mobile action sheets and mobile popover sheets now use the same 20% scrim token for consistency.

**Diagrams**
```mermaid
flowchart TD
  User["User opens modal or sheet"] --> Surface{"Overlay primitive"}
  Surface --> PageOverlay["PageOverlay"]
  Surface --> ActionSheet["ActionSheet backdrop"]
  Surface --> PopoverSheet["Mobile Popover sheet backdrop"]
  PageOverlay --> Scrim["bg-grayscale-gray-20"]
  ActionSheet --> Scrim
  PopoverSheet --> Scrim
  Scrim --> Page["Underlying page dimmed at 20% black"]
```

**Areas of the code involved**
| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/src/shared/components/PageOverlay/PageOverlay.tsx` | Replaced `bg-grayscale-gray-5` with `bg-grayscale-gray-20` | Broad modal, dialog, and fullscreen modal backdrop behavior |
| `client/src/shared/components/ActionSheet/ActionSheet.tsx` | Replaced `bg-grayscale-gray-5` with `bg-grayscale-gray-20` | Keeps action sheet scrims aligned with modal scrims |
| `client/src/shared/components/Popover/Popover.tsx` | Replaced mobile sheet backdrop from `bg-grayscale-gray-5` to `bg-grayscale-gray-20` | Keeps mobile popover sheet scrims aligned with modal scrims |

**Key technical decisions & trade-offs**
| Decision | Alternative |
| --- | --- |
| Update backdrop usages to `bg-grayscale-gray-20` instead of redefining `grayscale-gray-5` | Avoids darkening unrelated faint surfaces that use the 5% token |
| Keep the existing grayscale token behavior in dark mode | Preserves current black scrim semantics while increasing opacity consistently |

**Testing & validation**
| Check | Result |
| --- | --- |
| `bin/just lint` | Passed |
| `bin/npm --prefix client test -- --run src/shared/components/ActionSheet/ActionSheet.test.tsx src/shared/components/Popover/Popover.test.tsx src/shared/components/Modal/Modal.test.tsx src/shared/components/Dialog/Dialog.test.tsx` | Passed, 4 files / 12 tests |
| Pre-push hooks | Passed: check-push-org, plugin-antminer-lint, plugin-proto-lint, server-lint, client-typecheck, lint |
| Client boundary hygiene | Passed: touched shared files do not import app-specific modules and do not add `console.log` |

E2E tests were not run because this is a shared styling-token usage change with focused component coverage.
