### PR TITLE
feat(fleet): list/grid view toggle on Buildings tab (#375)

### DIFF
--- a/client/src/protoFleet/features/fleetManagement/pages/FleetBuildingsPage.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/FleetBuildingsPage.test.tsx
@@ -49,10 +49,23 @@ vi.mock("@/protoFleet/store", async (importActual) => {
 });
 
 vi.mock("@/protoFleet/features/fleetManagement/components/BuildingList", () => ({
-  default: (props: { buildings: BuildingWithCounts[] }) => {
+  default: (props: { buildings: BuildingWithCounts[]; onSelectedIdsChange?: (ids: string[]) => void }) => {
     buildingListSpy(props);
-    return <div data-testid="building-list">{props.buildings.length} rows</div>;
+    return (
+      <div data-testid="building-list">
+        {props.buildings.length} rows
+        <button type="button" onClick={() => props.onSelectedIdsChange?.(["1"])}>
+          select-first
+        </button>
+      </div>
+    );
   },
+}));
+
+// The bulk action bar renders only when a selection exists; a marker is
+// enough to assert its presence/absence across view switches.
+vi.mock("@/protoFleet/features/fleetManagement/components/FleetGroupActionsMenu/FleetGroupListActionBar", () => ({
+  default: () => <div data-testid="bulk-action-bar" />,
 }));
 
 vi.mock("@/protoFleet/features/buildings/components/BuildingCard", () => ({
@@ -142,6 +155,21 @@ describe("FleetBuildingsPage view toggle", () => {
 
     expect(screen.getAllByTestId("building-card")).toHaveLength(2);
     expect(screen.queryByTestId("building-list")).not.toBeInTheDocument();
+  });
+
+  test("clears a list-mode selection and drops the bulk action bar when switching to grid", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    // Seed a selection in list view; the bulk action bar mounts.
+    await user.click(screen.getByRole("button", { name: "select-first" }));
+    expect(screen.getByTestId("bulk-action-bar")).toBeInTheDocument();
+
+    await user.click(screen.getAllByRole("button", { name: "View grid" })[0]!);
+
+    // Grid entry clears the stale selection, so the bar must not linger.
+    expect(screen.queryByTestId("bulk-action-bar")).not.toBeInTheDocument();
+    expect(screen.getAllByTestId("building-card")).toHaveLength(2);
   });
 
   test("forces list view and hides the toggle when the reader lacks stats permissions", () => {

--- a/client/src/protoFleet/features/fleetManagement/pages/FleetBuildingsPage.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/FleetBuildingsPage.test.tsx
@@ -110,33 +110,33 @@ describe("FleetBuildingsPage view toggle", () => {
     buildingListSpy.mockReset();
     buildingCardSpy.mockReset();
     // Reset the persisted preference to the default before each case.
-    useFleetStore.getState().ui.setBuildingsViewMode("grid");
+    useFleetStore.getState().ui.setBuildingsViewMode("list");
   });
 
-  test("defaults to the grid view, rendering a BuildingCard per building with a count line", () => {
+  test("defaults to the list view, rendering the BuildingList table", () => {
     renderPage();
 
-    expect(screen.getAllByTestId("building-card")).toHaveLength(2);
-    expect(screen.queryByTestId("building-list")).not.toBeInTheDocument();
-    expect(screen.getByTestId("fleet-buildings-count-label")).toHaveTextContent("2 buildings");
+    expect(screen.getByTestId("building-list")).toBeInTheDocument();
+    expect(screen.queryByTestId("building-card")).not.toBeInTheDocument();
   });
 
-  test("switching to list view renders the table and persists the preference", async () => {
+  test("switching to grid view renders a BuildingCard per building with a count line and persists the preference", async () => {
     const user = userEvent.setup();
     renderPage();
 
     // Both the mobile and desktop toggles render the control; either works.
-    await user.click(screen.getAllByRole("button", { name: "View list" })[0]!);
+    await user.click(screen.getAllByRole("button", { name: "View grid" })[0]!);
 
-    expect(screen.getByTestId("building-list")).toBeInTheDocument();
-    expect(screen.queryByTestId("building-card")).not.toBeInTheDocument();
-    expect(useFleetStore.getState().ui.buildingsViewMode).toBe("list");
+    expect(screen.getAllByTestId("building-card")).toHaveLength(2);
+    expect(screen.queryByTestId("building-list")).not.toBeInTheDocument();
+    expect(screen.getByTestId("fleet-buildings-count-label")).toHaveTextContent("2 buildings");
+    expect(useFleetStore.getState().ui.buildingsViewMode).toBe("grid");
   });
 
-  test("respects the ?display=list URL param over the stored grid preference", () => {
-    renderPage("/fleet/buildings?display=list");
+  test("respects the ?display=grid URL param over the stored list preference", () => {
+    renderPage("/fleet/buildings?display=grid");
 
-    expect(screen.getByTestId("building-list")).toBeInTheDocument();
-    expect(screen.queryByTestId("building-card")).not.toBeInTheDocument();
+    expect(screen.getAllByTestId("building-card")).toHaveLength(2);
+    expect(screen.queryByTestId("building-list")).not.toBeInTheDocument();
   });
 });

--- a/client/src/protoFleet/features/fleetManagement/pages/FleetBuildingsPage.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/FleetBuildingsPage.test.tsx
@@ -12,6 +12,7 @@ const listBuildingsMock = vi.hoisted(() => vi.fn());
 const useActiveSiteMock = vi.hoisted(() => vi.fn());
 const buildingListSpy = vi.hoisted(() => vi.fn());
 const buildingCardSpy = vi.hoisted(() => vi.fn());
+const hasPermissionMock = vi.hoisted(() => vi.fn((_: string) => true));
 
 vi.mock("@/protoFleet/api/buildings", async (importActual) => {
   const actual = await importActual<typeof import("@/protoFleet/api/buildings")>();
@@ -38,12 +39,12 @@ vi.mock("@/protoFleet/components/PageHeader/SitePicker", async (importActual) =>
 });
 
 // Keep the real Zustand store (so view-mode persistence is under test) and
-// only force permissions on.
+// route permission checks through a per-test mock.
 vi.mock("@/protoFleet/store", async (importActual) => {
   const actual = await importActual<typeof import("@/protoFleet/store")>();
   return {
     ...actual,
-    useHasPermission: () => true,
+    useHasPermission: (permission: string) => hasPermissionMock(permission),
   };
 });
 
@@ -109,6 +110,9 @@ describe("FleetBuildingsPage view toggle", () => {
     useActiveSiteMock.mockReturnValue({ activeSite: { kind: "all" }, setActiveSite: vi.fn() });
     buildingListSpy.mockReset();
     buildingCardSpy.mockReset();
+    // Default: all permissions granted. Individual cases override.
+    hasPermissionMock.mockReset();
+    hasPermissionMock.mockImplementation(() => true);
     // Reset the persisted preference to the default before each case.
     useFleetStore.getState().ui.setBuildingsViewMode("list");
   });
@@ -138,5 +142,18 @@ describe("FleetBuildingsPage view toggle", () => {
 
     expect(screen.getAllByTestId("building-card")).toHaveLength(2);
     expect(screen.queryByTestId("building-list")).not.toBeInTheDocument();
+  });
+
+  test("forces list view and hides the toggle when the reader lacks stats permissions", () => {
+    // A site:read-only reader (no fleet:read / miner:read) reaches the tab,
+    // but the grid's BuildingCards would 403 on GetBuildingStats, so grid is
+    // unavailable even via ?display=grid.
+    hasPermissionMock.mockImplementation((permission: string) => permission === "site:read");
+
+    renderPage("/fleet/buildings?display=grid");
+
+    expect(screen.getByTestId("building-list")).toBeInTheDocument();
+    expect(screen.queryByTestId("building-card")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "View grid" })).not.toBeInTheDocument();
   });
 });

--- a/client/src/protoFleet/features/fleetManagement/pages/FleetBuildingsPage.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/FleetBuildingsPage.test.tsx
@@ -1,0 +1,142 @@
+import { MemoryRouter, Outlet, Route, Routes } from "react-router-dom";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
+
+import FleetBuildingsPage from "./FleetBuildingsPage";
+import { type BuildingWithCounts } from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
+import type { FleetOutletContext } from "@/protoFleet/features/fleetManagement/components/FleetLayout";
+import { useFleetStore } from "@/protoFleet/store/useFleetStore";
+
+const listBuildingsMock = vi.hoisted(() => vi.fn());
+const useActiveSiteMock = vi.hoisted(() => vi.fn());
+const buildingListSpy = vi.hoisted(() => vi.fn());
+const buildingCardSpy = vi.hoisted(() => vi.fn());
+
+vi.mock("@/protoFleet/api/buildings", async (importActual) => {
+  const actual = await importActual<typeof import("@/protoFleet/api/buildings")>();
+  return {
+    ...actual,
+    useBuildings: () => ({ listBuildings: listBuildingsMock }),
+  };
+});
+
+vi.mock("@/protoFleet/api/sites", async (importActual) => {
+  const actual = await importActual<typeof import("@/protoFleet/api/sites")>();
+  return {
+    ...actual,
+    useSites: () => ({ assignBuildingsToSite: vi.fn() }),
+  };
+});
+
+vi.mock("@/protoFleet/components/PageHeader/SitePicker", async (importActual) => {
+  const actual = await importActual<typeof import("@/protoFleet/components/PageHeader/SitePicker")>();
+  return {
+    ...actual,
+    useActiveSite: useActiveSiteMock,
+  };
+});
+
+// Keep the real Zustand store (so view-mode persistence is under test) and
+// only force permissions on.
+vi.mock("@/protoFleet/store", async (importActual) => {
+  const actual = await importActual<typeof import("@/protoFleet/store")>();
+  return {
+    ...actual,
+    useHasPermission: () => true,
+  };
+});
+
+vi.mock("@/protoFleet/features/fleetManagement/components/BuildingList", () => ({
+  default: (props: { buildings: BuildingWithCounts[] }) => {
+    buildingListSpy(props);
+    return <div data-testid="building-list">{props.buildings.length} rows</div>;
+  },
+}));
+
+vi.mock("@/protoFleet/features/buildings/components/BuildingCard", () => ({
+  default: (props: { building: BuildingWithCounts }) => {
+    buildingCardSpy(props);
+    return <div data-testid="building-card">{props.building.building?.name}</div>;
+  },
+}));
+
+// The modal stack is irrelevant to the view toggle and drags in heavy
+// dependencies, so render it inert.
+vi.mock("@/protoFleet/features/buildings/components/BuildingModals", () => ({
+  default: () => null,
+}));
+
+// The reparent flow transitively pulls in the QR scanner, which imports a
+// wasm module Vite's test server refuses to transform. Stub it out.
+vi.mock("@/protoFleet/features/fleetManagement/hooks/useQrScanner", () => ({
+  canUseLiveCamera: () => false,
+  useQrScanner: () => ({}),
+}));
+
+const buildings = [
+  { building: { id: 1n, name: "Building 1" } },
+  { building: { id: 2n, name: "Building 2" } },
+] as unknown as BuildingWithCounts[];
+
+const fleetContext = {
+  sites: [{ site: { id: 8n, name: "Austin" } }],
+  sitesError: null,
+  sitesLoaded: true,
+  siteCatalogAccessGranted: true,
+  refetchSites: vi.fn(),
+} as unknown as FleetOutletContext;
+
+const renderPage = (initialEntry = "/fleet/buildings", outletContext: FleetOutletContext = fleetContext) =>
+  render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Routes>
+        <Route path="/fleet" element={<Outlet context={outletContext} />}>
+          <Route path="buildings" element={<FleetBuildingsPage />} />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  );
+
+describe("FleetBuildingsPage view toggle", () => {
+  beforeEach(() => {
+    listBuildingsMock.mockReset();
+    // Resolve the list synchronously so the page leaves its loading state.
+    listBuildingsMock.mockImplementation(({ onSuccess }: { onSuccess?: (rows: BuildingWithCounts[]) => void }) => {
+      onSuccess?.(buildings);
+      return Promise.resolve();
+    });
+    useActiveSiteMock.mockReturnValue({ activeSite: { kind: "all" }, setActiveSite: vi.fn() });
+    buildingListSpy.mockReset();
+    buildingCardSpy.mockReset();
+    // Reset the persisted preference to the default before each case.
+    useFleetStore.getState().ui.setBuildingsViewMode("grid");
+  });
+
+  test("defaults to the grid view, rendering a BuildingCard per building with a count line", () => {
+    renderPage();
+
+    expect(screen.getAllByTestId("building-card")).toHaveLength(2);
+    expect(screen.queryByTestId("building-list")).not.toBeInTheDocument();
+    expect(screen.getByTestId("fleet-buildings-count-label")).toHaveTextContent("2 buildings");
+  });
+
+  test("switching to list view renders the table and persists the preference", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    // Both the mobile and desktop toggles render the control; either works.
+    await user.click(screen.getAllByRole("button", { name: "View list" })[0]!);
+
+    expect(screen.getByTestId("building-list")).toBeInTheDocument();
+    expect(screen.queryByTestId("building-card")).not.toBeInTheDocument();
+    expect(useFleetStore.getState().ui.buildingsViewMode).toBe("list");
+  });
+
+  test("respects the ?display=list URL param over the stored grid preference", () => {
+    renderPage("/fleet/buildings?display=list");
+
+    expect(screen.getByTestId("building-list")).toBeInTheDocument();
+    expect(screen.queryByTestId("building-card")).not.toBeInTheDocument();
+  });
+});

--- a/client/src/protoFleet/features/fleetManagement/pages/FleetBuildingsPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/FleetBuildingsPage.tsx
@@ -21,6 +21,7 @@ import {
 import ParentPickerModal from "@/protoFleet/components/ParentPickerModal";
 import { PAGE_SCROLL_CHROME_WIDTH } from "@/protoFleet/constants/layout";
 import { POLL_INTERVAL_MS } from "@/protoFleet/constants/polling";
+import BuildingCard from "@/protoFleet/features/buildings/components/BuildingCard";
 import BuildingModals from "@/protoFleet/features/buildings/components/BuildingModals";
 import { useBuildingModals } from "@/protoFleet/features/buildings/hooks/useBuildingModals";
 import { useFleetCreateFlow } from "@/protoFleet/features/fleetManagement/components/FleetCreateFlow/context";
@@ -39,13 +40,16 @@ import {
   TELEMETRY_FILTER_KEYS,
   type TelemetryFilterKey,
 } from "@/protoFleet/features/fleetManagement/utils/telemetryFilterBounds";
-import { useHasPermission } from "@/protoFleet/store";
+import { useFleetStore, useHasPermission } from "@/protoFleet/store";
 import { Alert, Building, Plus } from "@/shared/assets/icons";
 import Button, { sizes, variants } from "@/shared/components/Button";
 import Callout from "@/shared/components/Callout";
 import Header from "@/shared/components/Header";
 import FilterChipsBar, { type FilterChipsBarNumericFilter } from "@/shared/components/List/Filters/FilterChipsBar";
+import { formatListCountLabel } from "@/shared/components/List/listCountLabel";
+import SegmentedControl from "@/shared/components/SegmentedControl";
 import { pushToast, STATUSES } from "@/shared/features/toaster";
+import useMeasure from "@/shared/hooks/useMeasure";
 import { usePoll } from "@/shared/hooks/usePoll";
 import type { NumericRangeValue } from "@/shared/utils/filterValidation";
 
@@ -81,6 +85,52 @@ const FleetBuildingsPage = () => {
   const [buildingsError, setBuildingsError] = useState<string | null>(null);
   const [selectedBuildingIds, setSelectedBuildingIds] = useState<string[]>([]);
   const [isBulkActionBusy, setIsBulkActionBusy] = useState(false);
+
+  const storedBuildingsViewMode = useFleetStore((s) => s.ui.buildingsViewMode);
+  const setStoredBuildingsViewMode = useFleetStore((s) => s.ui.setBuildingsViewMode);
+
+  // URL is the source of truth for the segmented control (so a `?display=`
+  // deep link wins), falling back to the persisted Zustand preference so a
+  // default session keeps the operator's last choice. Mirrors RacksPage.
+  const urlBuildingsViewMode: "grid" | "list" | undefined = (() => {
+    const raw = searchParams.get("display");
+    return raw === "grid" || raw === "list" ? raw : undefined;
+  })();
+  const buildingsViewMode = urlBuildingsViewMode ?? storedBuildingsViewMode;
+
+  const setBuildingsViewMode = useCallback(
+    (mode: "grid" | "list") => {
+      setStoredBuildingsViewMode(mode);
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          next.set("display", mode);
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setStoredBuildingsViewMode, setSearchParams],
+  );
+
+  const handleBuildingsViewModeSelect = useCallback(
+    (key: string) => {
+      const nextViewMode = key === "list" ? "list" : "grid";
+      // The grid cards carry no selection affordance (matches RacksPage), so
+      // clear any list-mode selection when switching to grid.
+      if (nextViewMode === "grid") setSelectedBuildingIds([]);
+      setBuildingsViewMode(nextViewMode);
+    },
+    [setBuildingsViewMode],
+  );
+
+  // Responsive grid measurement — card min width matches RackCard (300px).
+  const [measureRef, contentRect] = useMeasure<HTMLDivElement>();
+  const BUILDING_CARD_MIN_WIDTH_PX = 300;
+  const numColumns = Math.max(
+    1,
+    Math.floor((contentRect.width || BUILDING_CARD_MIN_WIDTH_PX) / BUILDING_CARD_MIN_WIDTH_PX),
+  );
 
   // Validate scope against catalog access (authoritative now), not sitesLoaded:
   // a mid-session PermissionDenied clears `sites` to [] with sitesLoaded still
@@ -461,16 +511,45 @@ const FleetBuildingsPage = () => {
   ) : null;
 
   const filterControls = (
-    <div className="flex flex-row flex-wrap items-center gap-2">
-      <FilterChipsBar
-        filters={filterChipsBarFilters}
-        onChange={handleFilterChange}
-        numericFilters={TELEMETRY_FILTER_CHIPS}
-        selectedNumericValues={selectedNumericValues}
-        onNumericChange={handleNumericFilterChange}
-        onClearAll={handleClearFilters}
-      />
-      <div className="ml-auto">{addBuildingButton}</div>
+    <div className="flex flex-col gap-2">
+      {/* View toggle — full width on tablet/phone */}
+      <div className="block laptop:hidden">
+        <SegmentedControl
+          key={`buildings-mobile-${buildingsViewMode}`}
+          className="!w-full whitespace-nowrap [&>button]:flex-1"
+          segmentClassName="text-center"
+          segments={[
+            { key: "grid", title: "View grid" },
+            { key: "list", title: "View list" },
+          ]}
+          initialSegmentKey={buildingsViewMode}
+          onSelect={handleBuildingsViewModeSelect}
+        />
+      </div>
+      <div className="flex flex-row flex-wrap items-center gap-2">
+        {/* View toggle — inline on desktop */}
+        <div className="hidden laptop:block">
+          <SegmentedControl
+            key={`buildings-desktop-${buildingsViewMode}`}
+            className="shrink-0 whitespace-nowrap"
+            segments={[
+              { key: "grid", title: "View grid" },
+              { key: "list", title: "View list" },
+            ]}
+            initialSegmentKey={buildingsViewMode}
+            onSelect={handleBuildingsViewModeSelect}
+          />
+        </div>
+        <FilterChipsBar
+          filters={filterChipsBarFilters}
+          onChange={handleFilterChange}
+          numericFilters={TELEMETRY_FILTER_CHIPS}
+          selectedNumericValues={selectedNumericValues}
+          onNumericChange={handleNumericFilterChange}
+          onClearAll={handleClearFilters}
+        />
+        <div className="ml-auto">{addBuildingButton}</div>
+      </div>
     </div>
   );
 
@@ -596,19 +675,44 @@ const FleetBuildingsPage = () => {
           {inlineErrors}
           {filterControls}
         </FilterRow>
-        <div className={LIST_WRAPPER}>
-          <BuildingList
-            buildings={visibleBuildings}
-            sites={sites}
-            totalUnfiltered={totalUnfilteredBuildings}
-            hasActiveFilters={hasActiveFilters}
-            onEditBuilding={canManageBuildings ? openEditBuilding : undefined}
-            onAddBuildingToSite={canManageBuildings ? handleAddBuildingToSite : undefined}
-            selectedIds={selectedBuildingIds}
-            onSelectedIdsChange={handleSelectedBuildingIdsChange}
-            activeSite={activeSite}
-          />
-        </div>
+        {buildingsViewMode === "grid" ? (
+          <>
+            {/* The List component renders its own count line; the grid has no
+                equivalent, so mirror it here (matches RacksPage). */}
+            <div
+              className="px-6 pt-6 pb-4 text-emphasis-300 text-text-primary-70 laptop:px-10"
+              data-testid="fleet-buildings-count-label"
+            >
+              {formatListCountLabel(visibleBuildings.length, {
+                unfilteredTotal: totalUnfilteredBuildings,
+                hasActiveFilters,
+                singular: "building",
+                plural: "buildings",
+              })}
+            </div>
+            <div className="px-6 pb-6 laptop:px-10" ref={measureRef}>
+              <div className="grid gap-1" style={{ gridTemplateColumns: `repeat(${numColumns}, 1fr)` }}>
+                {visibleBuildings.map((building) => (
+                  <BuildingCard key={(building.building?.id ?? 0n).toString()} building={building} />
+                ))}
+              </div>
+            </div>
+          </>
+        ) : (
+          <div className={LIST_WRAPPER}>
+            <BuildingList
+              buildings={visibleBuildings}
+              sites={sites}
+              totalUnfiltered={totalUnfilteredBuildings}
+              hasActiveFilters={hasActiveFilters}
+              onEditBuilding={canManageBuildings ? openEditBuilding : undefined}
+              onAddBuildingToSite={canManageBuildings ? handleAddBuildingToSite : undefined}
+              selectedIds={selectedBuildingIds}
+              onSelectedIdsChange={handleSelectedBuildingIdsChange}
+              activeSite={activeSite}
+            />
+          </div>
+        )}
       </>
     );
   }

--- a/client/src/protoFleet/features/fleetManagement/pages/FleetBuildingsPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/FleetBuildingsPage.tsx
@@ -692,8 +692,11 @@ const FleetBuildingsPage = () => {
             </div>
             <div className="px-6 pb-6 laptop:px-10" ref={measureRef}>
               <div className="grid gap-1" style={{ gridTemplateColumns: `repeat(${numColumns}, 1fr)` }}>
-                {visibleBuildings.map((building) => (
-                  <BuildingCard key={(building.building?.id ?? 0n).toString()} building={building} />
+                {visibleBuildings.map((building, index) => (
+                  <BuildingCard
+                    key={building.building?.id ? building.building.id.toString() : `building-${index}`}
+                    building={building}
+                  />
                 ))}
               </div>
             </div>

--- a/client/src/protoFleet/features/fleetManagement/pages/FleetBuildingsPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/FleetBuildingsPage.tsx
@@ -127,11 +127,9 @@ const FleetBuildingsPage = () => {
 
   const handleBuildingsViewModeSelect = useCallback(
     (key: string) => {
-      const nextViewMode = key === "list" ? "list" : "grid";
-      // The grid cards carry no selection affordance (matches RacksPage), so
-      // clear any list-mode selection when switching to grid.
-      if (nextViewMode === "grid") setSelectedBuildingIds([]);
-      setBuildingsViewMode(nextViewMode);
+      // Selection is cleared on grid entry by the effect below, which also
+      // covers URL-driven switches; the handler just records the mode.
+      setBuildingsViewMode(key === "list" ? "list" : "grid");
     },
     [setBuildingsViewMode],
   );
@@ -328,6 +326,15 @@ const FleetBuildingsPage = () => {
       return next.length === prev.length ? prev : next;
     });
   }, [visibleBuildingScopes]);
+  // Grid mode has no selection affordance, so a selection carried in from list
+  // mode would strand the bulk action bar over the grid. Clear it on every
+  // grid entry — not just the toggle handler — so URL-driven switches (saved
+  // views with `display=grid`, browser history) can't leave a stale selection.
+  useEffect(() => {
+    if (buildingsViewMode !== "grid") return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- selection is invalid in grid; clear on entry.
+    setSelectedBuildingIds((prev) => (prev.length ? [] : prev));
+  }, [buildingsViewMode]);
   const handleSelectAllVisibleBuildings = useCallback(
     () => setSelectedBuildingIds(visibleBuildingScopes.map((building) => building.id.toString())),
     [visibleBuildingScopes],
@@ -597,8 +604,11 @@ const FleetBuildingsPage = () => {
     </>
   );
 
+  // List-only: selection is a list-view capability. Gating here (not just on
+  // the cleared selection) keeps the bar from flashing over the grid on the
+  // render before the grid-entry effect clears the selection.
   const bulkActionBar =
-    selectedBuildingScopes.length > 0 || isBulkActionBusy ? (
+    buildingsViewMode === "list" && (selectedBuildingScopes.length > 0 || isBulkActionBusy) ? (
       <FleetGroupListActionBar
         selectedScopes={selectedBuildingScopes}
         kind="building"

--- a/client/src/protoFleet/features/fleetManagement/pages/FleetBuildingsPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/FleetBuildingsPage.tsx
@@ -89,6 +89,18 @@ const FleetBuildingsPage = () => {
   const storedBuildingsViewMode = useFleetStore((s) => s.ui.buildingsViewMode);
   const setStoredBuildingsViewMode = useFleetStore((s) => s.ui.setBuildingsViewMode);
 
+  // Grid renders a BuildingCard per row, each of which polls GetBuildingStats
+  // (server requires site:read + fleet:read + miner:read). A site:read-only
+  // reader can still reach this tab, so for them the grid would 403 on every
+  // card every poll and show permanent skeletons. Gate grid on the stats
+  // permissions and fall back to the list, which renders the same buildings
+  // from the ListBuildings counts (site:read only).
+  // Both hooks must be called unconditionally (rules of hooks) — don't
+  // short-circuit the second behind `&&`.
+  const canReadFleet = useHasPermission("fleet:read");
+  const canReadMinerStats = useHasPermission("miner:read");
+  const canViewBuildingStats = canReadFleet && canReadMinerStats;
+
   // URL is the source of truth for the segmented control (so a `?display=`
   // deep link wins), falling back to the persisted Zustand preference so a
   // default session keeps the operator's last choice. Mirrors RacksPage.
@@ -96,7 +108,7 @@ const FleetBuildingsPage = () => {
     const raw = searchParams.get("display");
     return raw === "grid" || raw === "list" ? raw : undefined;
   })();
-  const buildingsViewMode = urlBuildingsViewMode ?? storedBuildingsViewMode;
+  const buildingsViewMode = canViewBuildingStats ? (urlBuildingsViewMode ?? storedBuildingsViewMode) : "list";
 
   const setBuildingsViewMode = useCallback(
     (mode: "grid" | "list") => {
@@ -512,26 +524,14 @@ const FleetBuildingsPage = () => {
 
   const filterControls = (
     <div className="flex flex-col gap-2">
-      {/* View toggle — full width on tablet/phone */}
-      <div className="block laptop:hidden">
-        <SegmentedControl
-          key={`buildings-mobile-${buildingsViewMode}`}
-          className="!w-full whitespace-nowrap [&>button]:flex-1"
-          segmentClassName="text-center"
-          segments={[
-            { key: "grid", title: "View grid" },
-            { key: "list", title: "View list" },
-          ]}
-          initialSegmentKey={buildingsViewMode}
-          onSelect={handleBuildingsViewModeSelect}
-        />
-      </div>
-      <div className="flex flex-row flex-wrap items-center gap-2">
-        {/* View toggle — inline on desktop */}
-        <div className="hidden laptop:block">
+      {/* View toggle — full width on tablet/phone. Hidden without stats
+          permissions, since grid is unavailable and list is the only view. */}
+      {canViewBuildingStats ? (
+        <div className="block laptop:hidden">
           <SegmentedControl
-            key={`buildings-desktop-${buildingsViewMode}`}
-            className="shrink-0 whitespace-nowrap"
+            key={`buildings-mobile-${buildingsViewMode}`}
+            className="!w-full whitespace-nowrap [&>button]:flex-1"
+            segmentClassName="text-center"
             segments={[
               { key: "grid", title: "View grid" },
               { key: "list", title: "View list" },
@@ -540,6 +540,23 @@ const FleetBuildingsPage = () => {
             onSelect={handleBuildingsViewModeSelect}
           />
         </div>
+      ) : null}
+      <div className="flex flex-row flex-wrap items-center gap-2">
+        {/* View toggle — inline on desktop */}
+        {canViewBuildingStats ? (
+          <div className="hidden laptop:block">
+            <SegmentedControl
+              key={`buildings-desktop-${buildingsViewMode}`}
+              className="shrink-0 whitespace-nowrap"
+              segments={[
+                { key: "grid", title: "View grid" },
+                { key: "list", title: "View list" },
+              ]}
+              initialSegmentKey={buildingsViewMode}
+              onSelect={handleBuildingsViewModeSelect}
+            />
+          </div>
+        ) : null}
         <FilterChipsBar
           filters={filterChipsBarFilters}
           onChange={handleFilterChange}

--- a/client/src/protoFleet/features/fleetManagement/views/savedViews.ts
+++ b/client/src/protoFleet/features/fleetManagement/views/savedViews.ts
@@ -44,7 +44,9 @@ const TELEMETRY_FILTER_KEYS: readonly string[] = Object.keys(TELEMETRY_FILTER_BO
 ]);
 
 const RACK_FILTER_KEYS: readonly string[] = ["building", "site", "zone", "issues", "display", ...TELEMETRY_FILTER_KEYS];
-const BUILDING_FILTER_KEYS: readonly string[] = ["site", "issues", ...TELEMETRY_FILTER_KEYS];
+// Buildings tab, like Racks, owns a `display` (grid/list) toggle, so its
+// view-mode is capturable into a saved view.
+const BUILDING_FILTER_KEYS: readonly string[] = ["site", "issues", "display", ...TELEMETRY_FILTER_KEYS];
 const SITE_FILTER_KEYS: readonly string[] = ["issues", ...TELEMETRY_FILTER_KEYS];
 const INFRASTRUCTURE_FILTER_KEYS: readonly string[] = [];
 

--- a/client/src/protoFleet/features/fleetManagement/views/viewSummary.test.ts
+++ b/client/src/protoFleet/features/fleetManagement/views/viewSummary.test.ts
@@ -168,11 +168,21 @@ describe("summarizeDisplay", () => {
     expect(summarizeDisplay(new URLSearchParams("display=carousel"), "racks")).toBeUndefined();
   });
 
+  it("humanizes display on the buildings tab", () => {
+    expect(summarizeDisplay(new URLSearchParams("display=grid"), "buildings")).toEqual({
+      mode: "grid",
+      label: "Grid view",
+    });
+    expect(summarizeDisplay(new URLSearchParams("display=list"), "buildings")).toEqual({
+      mode: "list",
+      label: "List view",
+    });
+  });
+
   it("ignores display params on tabs that don't own display", () => {
-    // Only racks has a grid/list toggle today; other tabs must not surface
-    // display as a saveable setting.
+    // Racks and Buildings have a grid/list toggle; the toggle-less tabs must
+    // not surface display as a saveable setting.
     expect(summarizeDisplay(new URLSearchParams("display=grid"), "miners")).toBeUndefined();
-    expect(summarizeDisplay(new URLSearchParams("display=grid"), "buildings")).toBeUndefined();
     expect(summarizeDisplay(new URLSearchParams("display=grid"), "sites")).toBeUndefined();
   });
 });

--- a/client/src/protoFleet/features/fleetManagement/views/viewSummary.ts
+++ b/client/src/protoFleet/features/fleetManagement/views/viewSummary.ts
@@ -279,11 +279,12 @@ export const stripSortFromSearchParams = (searchParams: string): string => {
 };
 
 /**
- * Tabs that own a `display` URL param. Miners has no grid/list toggle, so
- * surfacing display on that tab would let the modal offer an "Include
- * display mode" control whose value the canonicalization whitelist strips.
+ * Tabs that own a `display` (grid/list) URL param. Racks and Buildings both
+ * have a grid/list toggle. Miners and Sites have no toggle, so surfacing
+ * display on those tabs would let the modal offer an "Include display mode"
+ * control whose value the canonicalization whitelist strips.
  */
-const TABS_WITH_DISPLAY: ReadonlySet<FleetTabId> = new Set(["racks"]);
+const TABS_WITH_DISPLAY: ReadonlySet<FleetTabId> = new Set(["racks", "buildings"]);
 
 export const summarizeDisplay = (params: URLSearchParams, tab: FleetTabId): DisplaySummary | undefined => {
   if (!TABS_WITH_DISPLAY.has(tab)) return undefined;

--- a/client/src/protoFleet/store/slices/uiSlice.ts
+++ b/client/src/protoFleet/store/slices/uiSlice.ts
@@ -14,6 +14,7 @@ import type { TemperatureUnit, Theme, ThemeColor } from "@/shared/features/prefe
 // =============================================================================
 
 export type RacksViewMode = "grid" | "list";
+export type BuildingsViewMode = "grid" | "list";
 
 export interface UISlice {
   theme: Theme;
@@ -23,6 +24,7 @@ export interface UISlice {
   bulkRenamePreferences: BulkRenamePreferences;
   bulkWorkerNamePreferences: BulkRenamePreferences;
   racksViewMode: RacksViewMode;
+  buildingsViewMode: BuildingsViewMode;
   isActionBarVisible: boolean;
   activeSite: ActiveSite;
   // Monotonic counter bumped whenever the org's site list changes (create /
@@ -41,6 +43,7 @@ export interface UISlice {
   setBulkRenamePreferences: (preferences: BulkRenamePreferences) => void;
   setBulkWorkerNamePreferences: (preferences: BulkRenamePreferences) => void;
   setRacksViewMode: (mode: RacksViewMode) => void;
+  setBuildingsViewMode: (mode: BuildingsViewMode) => void;
   setActionBarVisible: (visible: boolean) => void;
   setActiveSite: (next: ActiveSite) => void;
   bumpSitesRevision: () => void;
@@ -59,6 +62,7 @@ export const createUISlice: StateCreator<FleetStore, [["zustand/immer", never]],
   bulkRenamePreferences: createDefaultBulkRenamePreferences(),
   bulkWorkerNamePreferences: createDefaultBulkRenamePreferences(bulkRenameModes.worker),
   racksViewMode: "grid",
+  buildingsViewMode: "grid",
   isActionBarVisible: false,
   activeSite: DEFAULT_ACTIVE_SITE,
   sitesRevision: 0,
@@ -97,6 +101,11 @@ export const createUISlice: StateCreator<FleetStore, [["zustand/immer", never]],
   setRacksViewMode: (mode) =>
     set((state) => {
       state.ui.racksViewMode = mode;
+    }),
+
+  setBuildingsViewMode: (mode) =>
+    set((state) => {
+      state.ui.buildingsViewMode = mode;
     }),
 
   setActionBarVisible: (visible) =>

--- a/client/src/protoFleet/store/slices/uiSlice.ts
+++ b/client/src/protoFleet/store/slices/uiSlice.ts
@@ -62,7 +62,10 @@ export const createUISlice: StateCreator<FleetStore, [["zustand/immer", never]],
   bulkRenamePreferences: createDefaultBulkRenamePreferences(),
   bulkWorkerNamePreferences: createDefaultBulkRenamePreferences(bulkRenameModes.worker),
   racksViewMode: "grid",
-  buildingsViewMode: "grid",
+  // Buildings defaults to the list: the tab's actions (counts, rack
+  // placement, bulk select) live in the table; the grid is a browse-only
+  // affordance. Racks defaults to grid because its cards are interactive.
+  buildingsViewMode: "list",
   isActionBarVisible: false,
   activeSite: DEFAULT_ACTIVE_SITE,
   sitesRevision: 0,

--- a/client/src/protoFleet/store/useFleetStore.ts
+++ b/client/src/protoFleet/store/useFleetStore.ts
@@ -46,6 +46,7 @@ type PersistedFleetState = {
     | "bulkRenamePreferences"
     | "bulkWorkerNamePreferences"
     | "racksViewMode"
+    | "buildingsViewMode"
     | "activeSite"
   >;
 };
@@ -127,6 +128,7 @@ const createMultiKeyStorage = (): PersistStorage<PersistedFleetState> => {
                 bulkRenamePreferences: state.ui.bulkRenamePreferences,
                 bulkWorkerNamePreferences: state.ui.bulkWorkerNamePreferences,
                 racksViewMode: state.ui.racksViewMode,
+                buildingsViewMode: state.ui.buildingsViewMode,
               },
             },
             version: value.version,
@@ -192,6 +194,7 @@ export const useFleetStore = create<FleetStore>()(
               bulkRenamePreferences: state.ui.bulkRenamePreferences,
               bulkWorkerNamePreferences: state.ui.bulkWorkerNamePreferences,
               racksViewMode: state.ui.racksViewMode,
+              buildingsViewMode: state.ui.buildingsViewMode,
               activeSite: state.ui.activeSite,
             },
           }),
@@ -244,6 +247,7 @@ export const useFleetStore = create<FleetStore>()(
                 temperatureUnit: persisted?.ui?.temperatureUnit ?? currentState.ui.temperatureUnit,
                 duration: isFleetDuration(persistedDuration) ? persistedDuration : currentState.ui.duration,
                 racksViewMode: persisted?.ui?.racksViewMode ?? currentState.ui.racksViewMode,
+                buildingsViewMode: persisted?.ui?.buildingsViewMode ?? currentState.ui.buildingsViewMode,
                 bulkRenamePreferences: normalizeBulkRenamePreferences(
                   persisted?.ui?.bulkRenamePreferences ?? currentState.ui.bulkRenamePreferences,
                 ),


### PR DESCRIPTION
Reviewable diff: +155/-29 across 5 files (excludes generated, test, and story files).

## Summary

Adds a list/grid view toggle to the **Buildings** tab of the multi-site Fleet page (`/fleet/buildings`), extending the affordance the Racks tab already has. Operators can now flip between the existing tabular `BuildingList` and a responsive grid of `BuildingCard`s, and the choice is remembered per tab across sessions. This is a follow-up to the Fleet page scaffold (#368) and implements the Buildings-tab portion of the multi-site redesign plan (J3). Closes #375.

## How it works

The page resolves the active view mode from two sources, in priority order:

1. **`?display=` URL param** — the source of truth, so deep links and saved views (which capture `display=grid|list`) win.
2. **Persisted preference** — a new `buildingsViewMode` field on the UI store, falling back to the operator's last choice when the URL has no `display` param. Default is `list` (the tab's actions live in the table; the grid is a browse-only affordance).

The tab is also wired into the saved-view layer: `display` is a saveable Buildings key (`BUILDING_FILTER_KEYS`) and Buildings is a display-owning tab (`TABS_WITH_DISPLAY`), so a saved Buildings view captures and restores the grid/list choice, matching Racks.

A `SegmentedControl` in the filter row drives the switch. Selecting a segment writes both the URL (`replace: true`, so no history spam) and the store preference, mirroring the exact pattern `RacksPage` already uses. The control renders full-width on tablet/phone and inline with the filters on desktop.

Rendering then branches on the resolved mode:

- **List view** — the existing `BuildingList` (a `List`-based table), unchanged. It renders its own count line and owns row selection / bulk actions.
- **Grid view** (opt-in via the toggle) — a CSS grid whose column count is computed at runtime from the measured container width (`useMeasure`) against a 300px minimum card width (matching `RackCard`), rendering one `BuildingCard` per building. Because the grid isn't a `List`, it renders its own "N buildings" count line via the shared `formatListCountLabel` helper so the count stays visible in both views.

`BuildingCard` self-fetches its telemetry/health stats and renders its own per-card actions menu, so the grid path needs no extra prop wiring for edit/add-to-site. Switching to grid clears any list-mode selection, since cards carry no selection affordance (same behavior as Racks).

The `buildingsViewMode` preference is threaded through all of the store's persistence machinery (persisted-shape type, the multi-key `setItem` writer, `partialize`, and `merge`) so it survives reloads in the shared `proto-ui-preferences` localStorage key, exactly alongside `racksViewMode`.

```mermaid
flowchart TD
    Toggle["SegmentedControl (grid/list)"] --> Handler["setBuildingsViewMode"]
    Handler --> URL["URL ?display= (replace)"]
    Handler --> Store["UI store buildingsViewMode"]
    URL --> Resolve["resolved viewMode = urlDisplay ?? storedPref"]
    Store --> Resolve
    Resolve -->|grid| Grid["useMeasure - numColumns @ 300px min"]
    Grid --> Cards["BuildingCard grid + count line"]
    Resolve -->|list| List["BuildingList table (unchanged)"]
    Store --> Persist["persist -> proto-ui-preferences (localStorage)"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/.../pages/FleetBuildingsPage.tsx` | Added view-mode resolution (URL + store), the `SegmentedControl` toggle in the filter row, grid rendering (`useMeasure` + `BuildingCard`) with its own count line, and selection-clear on grid switch. | Core of the change; the grid/list branch and URL-vs-store precedence are the main things to check. |
| `client/.../store/slices/uiSlice.ts` | New `buildingsViewMode` state + `setBuildingsViewMode` action (default `list`), alongside the existing `racksViewMode`. | New persisted UI preference. |
| `client/.../views/savedViews.ts`, `views/viewSummary.ts` | Added `display` to `BUILDING_FILTER_KEYS` and `buildings` to `TABS_WITH_DISPLAY`. | Buildings saved views now capture/restore the grid/list choice, matching Racks. |
| `client/.../store/useFleetStore.ts` | Wired `buildingsViewMode` into the persisted-shape type, `setItem` UI blob, `partialize`, and `merge`. | Ensures the preference actually persists and rehydrates; all four sites must agree or it silently drops. |
| `client/.../pages/FleetBuildingsPage.test.tsx` *(new)* | Page tests for the toggle. | New test file — see Testing. |

## Key technical decisions & trade-offs

- **URL param is the source of truth, store is the fallback** — copied verbatim from `RacksPage` so saved-view snapshots (`display=`) behave identically across tabs, over the alternative of a store-only preference that would ignore deep links.
- **List is the default view** — chosen over mirroring Racks' grid default because the Buildings tab's interactions (counts, rack placement, bulk select, row actions) all live in the table, while the grid is a browse-only affordance. The Racks *parity* the issue calls for is the toggle + persistence mechanism, not the default. Grid stays available and is captured in saved views.
- **Reused `BuildingCard` and `BuildingList` as-is** — no new card/table components, matching the issue's explicit "reuse existing component" scope. The grid path relies on `BuildingCard`'s built-in stats fetch and actions menu rather than lifting that state into the page.
- **Grid renders its own count line** — the `List` component supplies the count in list view but the grid has no equivalent, so the page mirrors it with the shared `formatListCountLabel` helper to keep parity with Racks, rather than dropping the count in grid mode.
- **Selection is list-only** — switching to grid clears selection because cards have no checkbox affordance; bulk actions remain a list-view capability. Consistent with Racks; grid-mode card selection is out of scope.
- **No grid sort control** — Racks offers a grid-only sort dropdown, but Buildings has no client-side sort today, so it was intentionally omitted rather than introducing new sort plumbing.

## Testing & validation

- **New page tests** (`FleetBuildingsPage.test.tsx`, 3 cases): list is the default and renders the `BuildingList` table; toggling to grid renders a `BuildingCard` per building plus the "N buildings" count line and persists `buildingsViewMode = "grid"` to the store; `?display=grid` overrides a stored `list` preference. Heavy children (`BuildingList`, `BuildingCard`, `BuildingModals`, the QR scanner hook) are mocked; the real Zustand store is used so persistence is genuinely exercised.
- **Saved-view tests** (`viewSummary.test.ts`): Buildings now humanizes `display=grid|list`; the toggle-less tabs (miners, sites) still ignore it.
- **Regression**: existing store tests (`useFleetStore`, `uiSlice`) pass unchanged — the persistence additions don't break the persisted shape.
- **Static checks**: `tsc --noEmit` clean, ESLint clean, Prettier conformant on all changed files.
- **Not covered**: no automated visual/responsive-breakpoint test for the mobile-vs-desktop toggle layout, and grid-view rendering of `BuildingCard`'s live telemetry is covered by that component's own tests, not here.

