### PR TITLE
fix(alerts): treat 403 folder probe as missing in EnsureFolder

### DIFF
--- a/server/internal/domain/alerts/grafana_client.go
+++ b/server/internal/domain/alerts/grafana_client.go
@@ -111,7 +111,8 @@ func (g *Grafana) EnsureFolder(ctx context.Context, uid, title string) error {
 	if err == nil {
 		return nil
 	}
-	if !IsNotFound(err) {
+	// Grafana 13 fails closed for non-admins on folder GETs only (uid-scoped authz runs before existence); unscoped provisioning/silence GETs still 404 when missing, so don't copy 403-as-missing to them.
+	if !IsNotFound(err) && !isForbidden(err) {
 		return fmt.Errorf("get folder: %w", err)
 	}
 	createErr := g.do(ctx, http.MethodPost, "/api/folders", GrafanaFolder{UID: uid, Title: title}, &got)
@@ -340,18 +341,24 @@ func (e *GrafanaError) Error() string {
 	return fmt.Sprintf("grafana %d: %s", e.StatusCode, e.Message)
 }
 
-func IsNotFound(err error) bool {
+// grafanaStatusCode returns the GrafanaError status, or 0 for non-Grafana errors.
+func grafanaStatusCode(err error) int {
 	var ge *GrafanaError
 	if errors.As(err, &ge) {
-		return ge.StatusCode == http.StatusNotFound
+		return ge.StatusCode
 	}
-	return false
+	return 0
+}
+
+func IsNotFound(err error) bool {
+	return grafanaStatusCode(err) == http.StatusNotFound
 }
 
 func isConflict(err error) bool {
-	var ge *GrafanaError
-	if errors.As(err, &ge) {
-		return ge.StatusCode == http.StatusConflict || ge.StatusCode == http.StatusPreconditionFailed
-	}
-	return false
+	code := grafanaStatusCode(err)
+	return code == http.StatusConflict || code == http.StatusPreconditionFailed
+}
+
+func isForbidden(err error) bool {
+	return grafanaStatusCode(err) == http.StatusForbidden
 }

--- a/server/internal/domain/alerts/grafana_client_test.go
+++ b/server/internal/domain/alerts/grafana_client_test.go
@@ -1,7 +1,10 @@
 package alerts
 
 import (
+	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -80,4 +83,96 @@ func TestRedactSecretsNonJSONIsNotPassedThrough(t *testing.T) {
 	assert.NotContains(t, out, "sk-secret")
 	assert.Contains(t, out, "non-JSON response body omitted")
 	assert.Equal(t, "", redactSecrets(nil))
+}
+
+// grafanaFolderFake serves the two folder endpoints EnsureFolder touches.
+type grafanaFolderFake struct {
+	getStatus    int
+	postStatus   int
+	createdUID   string
+	createdTitle string
+	createdCalls int
+}
+
+func (f *grafanaFolderFake) client(t *testing.T) *Grafana {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/folders/{uid}", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(f.getStatus)
+		switch f.getStatus {
+		case http.StatusOK:
+			_, _ = w.Write([]byte(`{"uid":"u","title":"t"}`))
+		case http.StatusForbidden:
+			// Grafana 13's fail-closed body for non-admins when the folder does not exist.
+			_, _ = w.Write([]byte(`{"accessErrorId":"ACE123","message":"You'll need additional permissions to perform this action. Permissions needed: folders:read","title":"Access denied"}`))
+		case http.StatusNotFound:
+			_, _ = w.Write([]byte(`{"message":"folder not found"}`))
+		default:
+			_, _ = w.Write([]byte(`{"message":"boom"}`))
+		}
+	})
+	mux.HandleFunc("POST /api/folders", func(w http.ResponseWriter, r *http.Request) {
+		f.createdCalls++
+		var folder GrafanaFolder
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&folder))
+		f.createdUID = folder.UID
+		f.createdTitle = folder.Title
+		w.Header().Set("Content-Type", "application/json")
+		// Cases that must not create leave postStatus zero; answer 500 so createdCalls fails the test cleanly instead of WriteHeader(0) panicking.
+		if f.postStatus == 0 {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"message":"unexpected folder create"}`))
+			return
+		}
+		w.WriteHeader(f.postStatus)
+		if f.postStatus == http.StatusOK {
+			// The real create echoes the folder back.
+			_ = json.NewEncoder(w).Encode(folder)
+			return
+		}
+		_, _ = w.Write([]byte(`{"message":"x"}`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return NewGrafana(GrafanaConfig{URL: srv.URL})
+}
+
+func TestEnsureFolder(t *testing.T) {
+	cases := []struct {
+		name       string
+		getStatus  int
+		postStatus int
+		wantErr    string
+		wantCreate bool
+	}{
+		{"already exists", http.StatusOK, 0, "", false},
+		{"missing then created", http.StatusNotFound, http.StatusOK, "", true},
+		// Grafana 13 returns 403 folders:read (not 404) to non-admins for a missing folder.
+		{"forbidden probe then created", http.StatusForbidden, http.StatusOK, "", true},
+		{"forbidden probe, concurrent create conflict", http.StatusForbidden, http.StatusConflict, "", true},
+		{"forbidden probe, create 412 tolerated as conflict", http.StatusForbidden, http.StatusPreconditionFailed, "", true},
+		{"forbidden probe, create also forbidden", http.StatusForbidden, http.StatusForbidden, "create folder", true},
+		// 401 means bad credentials, not fail-closed absence: it must stay on the loud probe error and never attempt a create.
+		{"unauthorized probe", http.StatusUnauthorized, 0, "get folder", false},
+		{"probe server error", http.StatusInternalServerError, 0, "get folder", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &grafanaFolderFake{getStatus: tc.getStatus, postStatus: tc.postStatus}
+			err := fake.client(t).EnsureFolder(context.Background(), "proto-fleet-user-7", "Proto Fleet User Rules (org 7)")
+			if tc.wantErr != "" {
+				require.ErrorContains(t, err, tc.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+			if tc.wantCreate {
+				assert.Equal(t, 1, fake.createdCalls)
+				assert.Equal(t, "proto-fleet-user-7", fake.createdUID)
+				assert.Equal(t, "Proto Fleet User Rules (org 7)", fake.createdTitle)
+			} else {
+				assert.Zero(t, fake.createdCalls)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Problem

Creating an org's **first** user alert rule in a deployed instance fails with:

```
{"accessErrorId":"ACE…","message":"You'll need additional permissions to perform this action. Permissions needed: folders:read","title":"Access denied"}
```

## Root cause

`EnsureFolder` probes `GET /api/folders/{uid}` and only creates the folder on a 404. Grafana 13 fails closed for non-admin identities on that uid-scoped endpoint: when the folder **does not exist**, a non-admin gets **403 `folders:read`** instead of 404 (scope resolution fails before the existence check). Deployments authenticate as the `fleet-api` Editor service account, so the probe 403s and `EnsureFolder` bails before ever creating the per-org folder.

Dev never hits this because `docker-compose.alerts.yaml` uses admin basic auth, and admins get a real 404 — which is why the bug only surfaced in the field.

Reproduced empirically against `grafana/grafana:13.0` with an Editor service-account token:

| Call | Editor SA | Admin |
|---|---|---|
| `GET /api/folders/<nonexistent>` | **403 `folders:read`** (exact error body above) | 404 |
| `POST /api/folders` | 200 | — |
| duplicate `POST /api/folders` | 412 | — |
| `POST /api/v1/provisioning/alert-rules` | 201 | — |

Everything except the missing-folder probe works for the Editor SA, so no service-account or provisioning changes are needed.

## Fix

`EnsureFolder` now treats a 403 on the probe the same as a 404 and falls through to `POST /api/folders`. A genuine permission problem still surfaces as an error on the POST, and the existing 409/412 conflict handling covers concurrent creates. The comment scopes the 403-as-missing reasoning to uid-scoped folder GETs so it doesn't get copied to the unscoped provisioning/silence endpoints, where 403 means outage, not absence.

Also dedupes the three status predicates (`IsNotFound`/`isConflict`/`isForbidden`) behind a `grafanaStatusCode` helper.

## Tests

New `TestEnsureFolder` table: folder exists, 404→create, 403→create (with Grafana 13's real fail-closed body), 403 + concurrent-create 409/412, 403 probe + 403 create (error surfaces), 401 probe (loud error, no create attempted), 500 probe (loud error, no create attempted).

Affected orgs need no manual remediation — the first rule-create attempt after deploy creates the folder and succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)