### PR TITLE
refactor(ha): derive writer identity from PostgreSQL

### DIFF
--- a/server/generated/sqlc/ha.sql.go
+++ b/server/generated/sqlc/ha.sql.go
@@ -20,13 +20,15 @@ WITH lease_context AS (
     FROM connected_postgres_identity AS connected
     WHERE
         NOT connected.in_recovery
+        AND connected.system_identifier
+            = $1::TEXT
         AND connected.server_address = $5::TEXT
         AND connected.server_port = $6::INTEGER
-        AND connected.timeline = $7::BIGINT
+        AND connected.timeline = $2::BIGINT
 )
 INSERT INTO fleet_runtime_lease AS current_lease (
     lease_name,
-    dcs_cluster_id,
+    postgres_system_identifier,
     highest_writer_generation,
     lease_epoch,
     holder_id,
@@ -71,7 +73,8 @@ SET
     END
 WHERE
     -- A newer writer may supersede a live lease; same-generation takeover waits for expiry.
-    current_lease.dcs_cluster_id = EXCLUDED.dcs_cluster_id
+    current_lease.postgres_system_identifier
+        = EXCLUDED.postgres_system_identifier
     AND EXCLUDED.highest_writer_generation
         >= current_lease.highest_writer_generation
     AND (
@@ -82,7 +85,7 @@ WHERE
             <= (SELECT database_time FROM lease_context)
     )
 RETURNING
-    dcs_cluster_id,
+    postgres_system_identifier,
     highest_writer_generation,
     lease_epoch,
     holder_id,
@@ -91,37 +94,35 @@ RETURNING
 `
 
 type AcquireFleetRuntimeLeaseParams struct {
-	DcsClusterID              string
+	PostgresSystemIdentifier  string
 	WriterGeneration          int64
 	HolderID                  uuid.UUID
 	LeaseDurationMilliseconds int64
 	ServerAddress             string
 	ServerPort                int32
-	Timeline                  int64
 }
 
 type AcquireFleetRuntimeLeaseRow struct {
-	DcsClusterID            string
-	HighestWriterGeneration int64
-	LeaseEpoch              int64
-	HolderID                uuid.UUID
-	ExpiresAt               time.Time
-	DatabaseTime            time.Time
+	PostgresSystemIdentifier string
+	HighestWriterGeneration  int64
+	LeaseEpoch               int64
+	HolderID                 uuid.UUID
+	ExpiresAt                time.Time
+	DatabaseTime             time.Time
 }
 
 func (q *Queries) AcquireFleetRuntimeLease(ctx context.Context, arg AcquireFleetRuntimeLeaseParams) (AcquireFleetRuntimeLeaseRow, error) {
 	row := q.queryRow(ctx, q.acquireFleetRuntimeLeaseStmt, acquireFleetRuntimeLease,
-		arg.DcsClusterID,
+		arg.PostgresSystemIdentifier,
 		arg.WriterGeneration,
 		arg.HolderID,
 		arg.LeaseDurationMilliseconds,
 		arg.ServerAddress,
 		arg.ServerPort,
-		arg.Timeline,
 	)
 	var i AcquireFleetRuntimeLeaseRow
 	err := row.Scan(
-		&i.DcsClusterID,
+		&i.PostgresSystemIdentifier,
 		&i.HighestWriterGeneration,
 		&i.LeaseEpoch,
 		&i.HolderID,
@@ -133,6 +134,7 @@ func (q *Queries) AcquireFleetRuntimeLease(ctx context.Context, arg AcquireFleet
 
 const getConnectedPostgresIdentity = `-- name: GetConnectedPostgresIdentity :one
 SELECT
+    system_identifier,
     server_address,
     server_port,
     in_recovery,
@@ -144,6 +146,7 @@ func (q *Queries) GetConnectedPostgresIdentity(ctx context.Context) (ConnectedPo
 	row := q.queryRow(ctx, q.getConnectedPostgresIdentityStmt, getConnectedPostgresIdentity)
 	var i ConnectedPostgresIdentity
 	err := row.Scan(
+		&i.SystemIdentifier,
 		&i.ServerAddress,
 		&i.ServerPort,
 		&i.InRecovery,
@@ -160,9 +163,11 @@ WITH lease_context AS (
     FROM connected_postgres_identity AS connected
     WHERE
         NOT connected.in_recovery
+        AND connected.system_identifier
+            = $2::TEXT
         AND connected.server_address = $6::TEXT
         AND connected.server_port = $7::INTEGER
-        AND connected.timeline = $8::BIGINT
+        AND connected.timeline = $3::BIGINT
 )
 UPDATE fleet_runtime_lease
 SET
@@ -173,13 +178,13 @@ FROM lease_context
 WHERE
     -- Renewal requires the exact, unexpired ownership tuple on the expected writer.
     lease_name = 'fleet-active'
-    AND dcs_cluster_id = $2
+    AND postgres_system_identifier = $2
     AND highest_writer_generation = $3
     AND lease_epoch = $4
     AND holder_id = $5
     AND expires_at > lease_context.database_time
 RETURNING
-    fleet_runtime_lease.dcs_cluster_id,
+    fleet_runtime_lease.postgres_system_identifier,
     fleet_runtime_lease.highest_writer_generation,
     fleet_runtime_lease.lease_epoch,
     fleet_runtime_lease.holder_id,
@@ -189,38 +194,36 @@ RETURNING
 
 type RenewFleetRuntimeLeaseParams struct {
 	LeaseDurationMilliseconds int64
-	DcsClusterID              string
+	PostgresSystemIdentifier  string
 	WriterGeneration          int64
 	LeaseEpoch                int64
 	HolderID                  uuid.UUID
 	ServerAddress             string
 	ServerPort                int32
-	Timeline                  int64
 }
 
 type RenewFleetRuntimeLeaseRow struct {
-	DcsClusterID            string
-	HighestWriterGeneration int64
-	LeaseEpoch              int64
-	HolderID                uuid.UUID
-	ExpiresAt               time.Time
-	DatabaseTime            time.Time
+	PostgresSystemIdentifier string
+	HighestWriterGeneration  int64
+	LeaseEpoch               int64
+	HolderID                 uuid.UUID
+	ExpiresAt                time.Time
+	DatabaseTime             time.Time
 }
 
 func (q *Queries) RenewFleetRuntimeLease(ctx context.Context, arg RenewFleetRuntimeLeaseParams) (RenewFleetRuntimeLeaseRow, error) {
 	row := q.queryRow(ctx, q.renewFleetRuntimeLeaseStmt, renewFleetRuntimeLease,
 		arg.LeaseDurationMilliseconds,
-		arg.DcsClusterID,
+		arg.PostgresSystemIdentifier,
 		arg.WriterGeneration,
 		arg.LeaseEpoch,
 		arg.HolderID,
 		arg.ServerAddress,
 		arg.ServerPort,
-		arg.Timeline,
 	)
 	var i RenewFleetRuntimeLeaseRow
 	err := row.Scan(
-		&i.DcsClusterID,
+		&i.PostgresSystemIdentifier,
 		&i.HighestWriterGeneration,
 		&i.LeaseEpoch,
 		&i.HolderID,

--- a/server/generated/sqlc/models.go
+++ b/server/generated/sqlc/models.go
@@ -444,10 +444,11 @@ type CommandOnDeviceLog struct {
 }
 
 type ConnectedPostgresIdentity struct {
-	ServerAddress string
-	ServerPort    int32
-	InRecovery    bool
-	Timeline      int64
+	SystemIdentifier string
+	ServerAddress    string
+	ServerPort       int32
+	InRecovery       bool
+	Timeline         int64
 }
 
 type CurtailmentAutomationRule struct {
@@ -940,12 +941,12 @@ type FleetPollableDevicePresence struct {
 }
 
 type FleetRuntimeLease struct {
-	LeaseName               string
-	DcsClusterID            string
-	HighestWriterGeneration int64
-	LeaseEpoch              int64
-	HolderID                uuid.UUID
-	ExpiresAt               time.Time
+	LeaseName                string
+	PostgresSystemIdentifier string
+	HighestWriterGeneration  int64
+	LeaseEpoch               int64
+	HolderID                 uuid.UUID
+	ExpiresAt                time.Time
 }
 
 type FleetTelemetryPollHeartbeat struct {

--- a/server/internal/ha/coordinator.go
+++ b/server/internal/ha/coordinator.go
@@ -25,13 +25,13 @@ type CoordinatorConfig struct {
 
 // Snapshot is a non-authoritative view of the coordinator's current state.
 type Snapshot struct {
-	State        State
-	HolderID     uuid.UUID
-	DCSClusterID string
-	Token        Token
-	ExpiresAt    time.Time
-	LastError    string
-	UpdatedAt    time.Time
+	State                    State
+	HolderID                 uuid.UUID
+	PostgresSystemIdentifier string
+	Token                    Token
+	ExpiresAt                time.Time
+	LastError                string
+	UpdatedAt                time.Time
 }
 
 type Coordinator struct {
@@ -117,7 +117,7 @@ func (c *Coordinator) Snapshot() Snapshot {
 	}
 	if c.activeCtx != nil {
 		snapshot.State = StateActive
-		snapshot.DCSClusterID = c.ownership.DCSClusterID
+		snapshot.PostgresSystemIdentifier = c.ownership.PostgresSystemIdentifier
 		snapshot.Token = c.ownership.Token
 		snapshot.ExpiresAt = c.ownership.ExpiresAt
 	}
@@ -174,7 +174,7 @@ func (c *Coordinator) step(ctx context.Context) error {
 			ownership      Ownership
 			requestStarted time.Time
 		)
-		observed, err := c.observer.ObserveAndRun(
+		_, err := c.observer.ObserveAndRun(
 			stepCtx,
 			func(actionCtx context.Context, observed WriterObservation) error {
 				requestStarted = time.Now()
@@ -192,12 +192,7 @@ func (c *Coordinator) step(ctx context.Context) error {
 			c.deactivate(err)
 			return err
 		}
-		if err := c.activate(
-			ctx,
-			ownership,
-			requestStarted,
-			observed.DCSProofDeadline,
-		); err != nil {
+		if err := c.activate(ctx, ownership, requestStarted); err != nil {
 			c.deactivate(err)
 			return err
 		}
@@ -208,17 +203,17 @@ func (c *Coordinator) step(ctx context.Context) error {
 		renewed        Ownership
 		requestStarted time.Time
 	)
-	observed, err := c.observer.ObserveAndRun(
+	_, err := c.observer.ObserveAndRun(
 		stepCtx,
 		func(actionCtx context.Context, observed WriterObservation) error {
-			if observed.DCSClusterID != current.DCSClusterID ||
+			if observed.PostgresSystemIdentifier != current.PostgresSystemIdentifier ||
 				observed.WriterGeneration != current.Token.WriterGeneration {
 				return fmt.Errorf(
 					"%w: held %s@%d, observed %s@%d",
 					ErrWriterChanged,
-					current.DCSClusterID,
+					current.PostgresSystemIdentifier,
 					current.Token.WriterGeneration,
-					observed.DCSClusterID,
+					observed.PostgresSystemIdentifier,
 					observed.WriterGeneration,
 				)
 			}
@@ -237,12 +232,7 @@ func (c *Coordinator) step(ctx context.Context) error {
 		c.deactivate(err)
 		return err
 	}
-	if err := c.updateActive(
-		renewed,
-		current,
-		requestStarted,
-		observed.DCSProofDeadline,
-	); err != nil {
+	if err := c.updateActive(renewed, current, requestStarted); err != nil {
 		c.deactivate(err)
 		return err
 	}
@@ -253,13 +243,8 @@ func (c *Coordinator) activate(
 	parent context.Context,
 	ownership Ownership,
 	requestStarted time.Time,
-	dcsProofDeadline time.Time,
 ) error {
-	deadline, err := localOwnershipDeadline(
-		ownership,
-		requestStarted,
-		dcsProofDeadline,
-	)
+	deadline, err := localOwnershipDeadline(ownership, requestStarted)
 	if err != nil {
 		return err
 	}
@@ -284,13 +269,8 @@ func (c *Coordinator) updateActive(
 	ownership Ownership,
 	expected Ownership,
 	requestStarted time.Time,
-	dcsProofDeadline time.Time,
 ) error {
-	deadline, err := localOwnershipDeadline(
-		ownership,
-		requestStarted,
-		dcsProofDeadline,
-	)
+	deadline, err := localOwnershipDeadline(ownership, requestStarted)
 	if err != nil {
 		return err
 	}
@@ -298,7 +278,7 @@ func (c *Coordinator) updateActive(
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.activeCtx == nil ||
-		c.ownership.DCSClusterID != expected.DCSClusterID ||
+		c.ownership.PostgresSystemIdentifier != expected.PostgresSystemIdentifier ||
 		c.ownership.Token != expected.Token ||
 		c.ownership.HolderID != expected.HolderID {
 		return ErrOwnershipLost
@@ -313,19 +293,12 @@ func (c *Coordinator) updateActive(
 func localOwnershipDeadline(
 	ownership Ownership,
 	requestStarted time.Time,
-	dcsProofDeadline time.Time,
 ) (time.Time, error) {
 	validFor := ownership.ExpiresAt.Sub(ownership.DatabaseTime)
 	if requestStarted.IsZero() || validFor <= 0 {
 		return time.Time{}, ErrOwnershipExpired
 	}
 	deadline := requestStarted.Add(validFor)
-	if dcsProofDeadline.IsZero() {
-		return time.Time{}, ErrLeaderLeaseExpired
-	}
-	if dcsProofDeadline.Before(deadline) {
-		deadline = dcsProofDeadline
-	}
 	if !deadline.After(time.Now()) {
 		return time.Time{}, ErrOwnershipExpired
 	}

--- a/server/internal/ha/coordinator_test.go
+++ b/server/internal/ha/coordinator_test.go
@@ -41,7 +41,7 @@ func TestCoordinatorActivatesAndExposesLifetime(t *testing.T) {
 	holder := uuid.New()
 	store := &fakeLeaseStore{}
 	coordinator := newCoordinatorWithHolder(
-		staticObserver{observation: coordinatorObservation("cluster-a", 41, time.Second)},
+		staticObserver{observation: coordinatorObservation("cluster-a", 41)},
 		store,
 		coordinatorTestConfig(),
 		holder,
@@ -59,8 +59,8 @@ func TestCoordinatorCancelsLifetimeOnObservationLoss(t *testing.T) {
 	holder := uuid.New()
 	observer := &sequenceObserver{
 		results: []observerResult{
-			{observation: coordinatorObservation("cluster-a", 41, time.Second)},
-			{err: errors.New("DCS unavailable")},
+			{observation: coordinatorObservation("cluster-a", 41)},
+			{err: errors.New("writer unavailable")},
 		},
 	}
 	coordinator := newCoordinatorWithHolder(
@@ -78,10 +78,10 @@ func TestCoordinatorCancelsLifetimeOnObservationLoss(t *testing.T) {
 
 func TestCoordinatorKeepsHolderAfterPassiveAcquisitionProofFailure(t *testing.T) {
 	holder := uuid.New()
-	proofErr := errors.New("closing DCS proof failed")
+	proofErr := errors.New("closing writer validation failed")
 	coordinator := newCoordinatorWithHolder(
 		actionThenErrorObserver{
-			observation: coordinatorObservation("cluster-a", 41, time.Second),
+			observation: coordinatorObservation("cluster-a", 41),
 			err:         proofErr,
 		},
 		&fakeLeaseStore{},
@@ -97,7 +97,7 @@ func TestCoordinatorKeepsHolderAfterPassiveAcquisitionProofFailure(t *testing.T)
 func TestCoordinatorCancelsLifetimeOnRenewalLoss(t *testing.T) {
 	store := &fakeLeaseStore{renewErr: ErrOwnershipLost}
 	coordinator := newCoordinatorWithHolder(
-		staticObserver{observation: coordinatorObservation("cluster-a", 41, time.Second)},
+		staticObserver{observation: coordinatorObservation("cluster-a", 41)},
 		store,
 		coordinatorTestConfig(),
 		uuid.New(),
@@ -114,8 +114,8 @@ func TestCoordinatorCancelsLifetimeOnRenewalLoss(t *testing.T) {
 func TestCoordinatorCancelsLifetimeOnWriterGenerationChange(t *testing.T) {
 	observer := &sequenceObserver{
 		results: []observerResult{
-			{observation: coordinatorObservation("cluster-a", 41, time.Second)},
-			{observation: coordinatorObservation("cluster-a", 42, time.Second)},
+			{observation: coordinatorObservation("cluster-a", 41)},
+			{observation: coordinatorObservation("cluster-a", 42)},
 		},
 	}
 	coordinator := newCoordinatorWithHolder(
@@ -135,7 +135,7 @@ func TestCoordinatorCancelsLifetimeWhenLeaseExpiresWithoutRenewal(t *testing.T) 
 	config.LeaseDuration = 40 * time.Millisecond
 	config.RenewInterval = 10 * time.Millisecond
 	coordinator := newCoordinatorWithHolder(
-		staticObserver{observation: coordinatorObservation("cluster-a", 41, time.Second)},
+		staticObserver{observation: coordinatorObservation("cluster-a", 41)},
 		&fakeLeaseStore{},
 		config,
 		uuid.New(),
@@ -176,10 +176,10 @@ func TestCoordinatorRunRetriesWhenPassiveObservationBlocks(t *testing.T) {
 
 func TestCoordinatorActiveRenewalStopsAtWatchdogDeadline(t *testing.T) {
 	config := coordinatorTestConfig()
-	config.LeaseDuration = time.Second
+	config.LeaseDuration = 40 * time.Millisecond
 	config.RenewInterval = 10 * time.Millisecond
 	observer := &activateThenBlockObserver{
-		observation: coordinatorObservation("cluster-a", 41, 40*time.Millisecond),
+		observation: coordinatorObservation("cluster-a", 41),
 	}
 	coordinator := newCoordinatorWithHolder(
 		observer,
@@ -202,7 +202,7 @@ func TestCoordinatorRejectsLeaseThatExpiredBeforeAcquireReturned(t *testing.T) {
 	config.RenewInterval = 5 * time.Millisecond
 	store := &fakeLeaseStore{acquireDelay: 20 * time.Millisecond}
 	coordinator := newCoordinatorWithHolder(
-		staticObserver{observation: coordinatorObservation("cluster-a", 41, time.Second)},
+		staticObserver{observation: coordinatorObservation("cluster-a", 41)},
 		store,
 		config,
 		uuid.New(),
@@ -214,32 +214,14 @@ func TestCoordinatorRejectsLeaseThatExpiredBeforeAcquireReturned(t *testing.T) {
 	require.Equal(t, StatePassive, coordinator.Snapshot().State)
 }
 
-func TestCoordinatorCapsLifetimeAtDCSProofDeadline(t *testing.T) {
-	config := coordinatorTestConfig()
-	config.LeaseDuration = time.Second
-	config.RenewInterval = 100 * time.Millisecond
-	coordinator := newCoordinatorWithHolder(
-		staticObserver{observation: coordinatorObservation("cluster-a", 41, 40*time.Millisecond)},
-		&fakeLeaseStore{},
-		config,
-		uuid.New(),
-	)
-
-	require.NoError(t, coordinator.step(t.Context()))
-	activeCtx, _, active := coordinator.ActiveLifetime()
-	require.True(t, active)
-	require.Eventually(t, func() bool { return activeCtx.Err() != nil }, time.Second, time.Millisecond)
-	require.Equal(t, StatePassive, coordinator.Snapshot().State)
-}
-
 func TestCoordinatorSuccessfulRenewalExtendsWatchdog(t *testing.T) {
 	config := coordinatorTestConfig()
 	config.LeaseDuration = 200 * time.Millisecond
 	config.RenewInterval = 50 * time.Millisecond
 	observer := &sequenceObserver{
 		results: []observerResult{
-			{observation: coordinatorObservation("cluster-a", 41, time.Second)},
-			{observation: coordinatorObservation("cluster-a", 41, time.Second)},
+			{observation: coordinatorObservation("cluster-a", 41)},
+			{observation: coordinatorObservation("cluster-a", 41)},
 		},
 	}
 	coordinator := newCoordinatorWithHolder(
@@ -273,13 +255,10 @@ func requireCall(t *testing.T, calls <-chan struct{}) {
 }
 
 func coordinatorObservation(
-	clusterID string,
+	systemIdentifier string,
 	generation int64,
-	proofTTL time.Duration,
 ) WriterObservation {
-	observed := observation(clusterID, generation)
-	observed.DCSProofDeadline = time.Now().Add(proofTTL)
-	return observed
+	return observation(systemIdentifier, generation)
 }
 
 func coordinatorTestConfig() CoordinatorConfig {
@@ -411,7 +390,7 @@ func (f *fakeLeaseStore) Acquire(
 		time.Sleep(f.acquireDelay)
 	}
 	f.ownership = Ownership{
-		DCSClusterID: observed.DCSClusterID,
+		PostgresSystemIdentifier: observed.PostgresSystemIdentifier,
 		Token: Token{
 			WriterGeneration: observed.WriterGeneration,
 			LeaseEpoch:       1,

--- a/server/internal/ha/observer.go
+++ b/server/internal/ha/observer.go
@@ -1,19 +1,14 @@
 package ha
 
 import (
-	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"net/http"
 	"net/url"
-	"slices"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/block/proto-fleet/server/generated/sqlc"
@@ -21,41 +16,20 @@ import (
 )
 
 var (
-	ErrDCSClusterIdentityMismatch = errors.New("DCS cluster identity mismatch")
-	ErrLeaderLeaseExpired         = errors.New("DCS leader lease is not live")
-	ErrTimelineMismatch           = errors.New("Patroni and PostgreSQL timelines do not match")
-	ErrWritableServerMismatch     = errors.New("DCS leader does not match writable PostgreSQL server")
-	ErrWriterChanged              = errors.New("DCS writer changed during validation")
+	ErrTimelineMismatch       = errors.New("Patroni and PostgreSQL timelines do not match")
+	ErrWritableServerMismatch = errors.New("Patroni does not confirm the writable PostgreSQL server")
+	ErrWriterChanged          = errors.New("PostgreSQL writer changed during validation")
 )
 
-const defaultHAHTTPTimeout = 5 * time.Second
-
-// DCSMember is the connection identity Patroni publishes for one member.
-type DCSMember struct {
-	Name    string
-	APIURL  string
-	ConnURL string
-}
-
-// DCSSnapshot is one linearizable view of the Patroni leader and matching member.
-type DCSSnapshot struct {
-	ClusterID        string
-	Revision         int64
-	LeaderName       string
-	WriterGeneration int64
-	LeaderLeaseID    int64
-	Member           DCSMember
-}
+const (
+	defaultHAHTTPTimeout = 5 * time.Second
+	defaultPatroniPort   = 8008
+)
 
 // PatroniIdentity is returned only when Patroni's /primary check succeeds.
 type PatroniIdentity struct {
 	Role     string
 	Timeline int64
-}
-
-type dcsReader interface {
-	Snapshot(ctx context.Context, clusterPath string) (DCSSnapshot, error)
-	LeaseTTL(ctx context.Context, leaseID int64) (time.Duration, error)
 }
 
 type postgresIdentityReader interface {
@@ -67,55 +41,33 @@ type postgresIdentityReader interface {
 type patroniIdentityReader interface {
 	PrimaryIdentity(
 		ctx context.Context,
-		memberAPIURL string,
-		expectedServerAddress string,
+		serverAddress string,
 	) (PatroniIdentity, error)
 }
 
-type hostResolver func(context.Context, string) ([]string, error)
-
-// Observer validates every authority needed to use a DCS leader revision as a
-// writer generation. It deliberately owns no retry or caching policy.
+// Observer binds Fleet ownership to the writable PostgreSQL server selected by
+// the multi-host DSN and to Patroni's primary lock for that same server.
 type Observer struct {
-	clusterPath string
-	dcs         dcsReader
-	postgres    postgresIdentityReader
-	patroni     patroniIdentityReader
-	resolve     hostResolver
+	postgres postgresIdentityReader
+	patroni  patroniIdentityReader
 }
 
-// NewObserver builds a production observer from narrow DCS, SQL, and Patroni
-// readers. The caller supplies clients configured for the deployment's trust
-// boundary.
 func NewObserver(
-	clusterPath string,
-	dcs dcsReader,
 	postgres postgresIdentityReader,
 	patroni patroniIdentityReader,
 ) (*Observer, error) {
-	clusterPath = strings.TrimRight(clusterPath, "/")
-	if clusterPath == "" || dcs == nil || postgres == nil || patroni == nil {
-		return nil, errors.New("HA writer observer requires cluster path and readers")
+	if postgres == nil || patroni == nil {
+		return nil, errors.New("HA writer observer requires PostgreSQL and Patroni readers")
 	}
-	return &Observer{
-		clusterPath: clusterPath,
-		dcs:         dcs,
-		postgres:    postgres,
-		patroni:     patroni,
-		resolve:     resolveHost,
-	}, nil
+	return &Observer{postgres: postgres, patroni: patroni}, nil
 }
 
-// Observe brackets writer validation with linearizable DCS reads and fails
-// closed unless the DCS member, writable SQL server, Patroni role, timeline,
-// live leader lease, and cluster identity agree.
 func (o *Observer) Observe(ctx context.Context) (WriterObservation, error) {
-	return o.observeAndRun(ctx, nil)
+	return o.observeWriter(ctx)
 }
 
-// ObserveAndRun executes action after validating the candidate writer and
-// before the closing DCS read. The action must independently bind its database
-// write to the server identity in the observation.
+// ObserveAndRun validates the writer before and after action. The action must
+// also bind its database write to the supplied server identity.
 func (o *Observer) ObserveAndRun(
 	ctx context.Context,
 	action func(context.Context, WriterObservation) error,
@@ -123,27 +75,42 @@ func (o *Observer) ObserveAndRun(
 	if action == nil {
 		return WriterObservation{}, errors.New("HA writer observation action is required")
 	}
-	return o.observeAndRun(ctx, action)
-}
-
-func (o *Observer) observeAndRun(
-	ctx context.Context,
-	action func(context.Context, WriterObservation) error,
-) (WriterObservation, error) {
-	first, err := o.dcs.Snapshot(ctx, o.clusterPath)
+	observed, err := o.observeWriter(ctx)
 	if err != nil {
-		return WriterObservation{}, fmt.Errorf("read initial DCS snapshot: %w", err)
-	}
-	if err := validateDCSSnapshot(first); err != nil {
 		return WriterObservation{}, err
 	}
+	if err := action(ctx, observed); err != nil {
+		return WriterObservation{}, err
+	}
+	verified, err := o.observeWriter(ctx)
+	if err != nil {
+		return WriterObservation{}, err
+	}
+	if verified != observed {
+		return WriterObservation{}, fmt.Errorf(
+			"%w: started with %s@%d on %s:%d, finished with %s@%d on %s:%d",
+			ErrWriterChanged,
+			observed.PostgresSystemIdentifier,
+			observed.WriterGeneration,
+			observed.ServerAddress,
+			observed.ServerPort,
+			verified.PostgresSystemIdentifier,
+			verified.WriterGeneration,
+			verified.ServerAddress,
+			verified.ServerPort,
+		)
+	}
+	return verified, nil
+}
 
+func (o *Observer) observeWriter(ctx context.Context) (WriterObservation, error) {
 	connected, err := o.postgres.GetConnectedPostgresIdentity(ctx)
 	if err != nil {
 		return WriterObservation{}, fmt.Errorf("read connected PostgreSQL identity: %w", err)
 	}
-	if connected.InRecovery ||
-		connected.ServerAddress == "" ||
+	if connected.SystemIdentifier == "" ||
+		connected.InRecovery ||
+		net.ParseIP(connected.ServerAddress) == nil ||
 		connected.ServerPort <= 0 ||
 		connected.Timeline <= 0 {
 		return WriterObservation{}, fmt.Errorf(
@@ -151,20 +118,17 @@ func (o *Observer) observeAndRun(
 			ErrWritableServerMismatch,
 		)
 	}
-	if err := o.validateConnectedPostgresEndpoints(ctx, first.Member, connected); err != nil {
-		return WriterObservation{}, err
-	}
 
-	patroni, err := o.patroni.PrimaryIdentity(
-		ctx,
-		first.Member.APIURL,
-		connected.ServerAddress,
-	)
+	patroni, err := o.patroni.PrimaryIdentity(ctx, connected.ServerAddress)
 	if err != nil {
 		return WriterObservation{}, fmt.Errorf("validate Patroni primary: %w", err)
 	}
 	if !isPrimaryRole(patroni.Role) {
-		return WriterObservation{}, fmt.Errorf("%w: Patroni role is %q", ErrWritableServerMismatch, patroni.Role)
+		return WriterObservation{}, fmt.Errorf(
+			"%w: Patroni role is %q",
+			ErrWritableServerMismatch,
+			patroni.Role,
+		)
 	}
 	if patroni.Timeline != connected.Timeline {
 		return WriterObservation{}, fmt.Errorf(
@@ -175,441 +139,70 @@ func (o *Observer) observeAndRun(
 		)
 	}
 
-	observed := writerObservation(first, connected)
-	if action != nil {
-		if err := action(ctx, observed); err != nil {
-			return WriterObservation{}, err
-		}
-	}
-
-	second, err := o.dcs.Snapshot(ctx, o.clusterPath)
-	if err != nil {
-		return WriterObservation{}, fmt.Errorf("read final DCS snapshot: %w", err)
-	}
-	if err := validateDCSSnapshot(second); err != nil {
-		return WriterObservation{}, err
-	}
-	if second.ClusterID != first.ClusterID {
-		return WriterObservation{}, fmt.Errorf(
-			"%w: started with %s, finished with %s",
-			ErrDCSClusterIdentityMismatch,
-			first.ClusterID,
-			second.ClusterID,
-		)
-	}
-	if second.LeaderName != first.LeaderName ||
-		second.WriterGeneration != first.WriterGeneration ||
-		second.LeaderLeaseID != first.LeaderLeaseID ||
-		second.Member.APIURL != first.Member.APIURL ||
-		second.Member.ConnURL != first.Member.ConnURL {
-		return WriterObservation{}, fmt.Errorf(
-			"%w: started with %s@%d, finished with %s@%d",
-			ErrWriterChanged,
-			first.LeaderName,
-			first.WriterGeneration,
-			second.LeaderName,
-			second.WriterGeneration,
-		)
-	}
-
-	ttlRequestStarted := time.Now()
-	ttl, err := o.dcs.LeaseTTL(ctx, second.LeaderLeaseID)
-	if err != nil {
-		return WriterObservation{}, fmt.Errorf("validate DCS leader lease: %w", err)
-	}
-	if ttl <= 0 {
-		return WriterObservation{}, ErrLeaderLeaseExpired
-	}
-	proofDeadline := ttlRequestStarted.Add(ttl)
-	if !proofDeadline.After(time.Now()) {
-		return WriterObservation{}, ErrLeaderLeaseExpired
-	}
-
-	observed = writerObservation(second, connected)
-	observed.DCSProofDeadline = proofDeadline
-	return observed, nil
-}
-
-func writerObservation(
-	snapshot DCSSnapshot,
-	connected sqlc.ConnectedPostgresIdentity,
-) WriterObservation {
 	return WriterObservation{
-		DCSClusterID:     snapshot.ClusterID,
-		WriterGeneration: snapshot.WriterGeneration,
-		LeaderName:       snapshot.LeaderName,
-		ServerAddress:    connected.ServerAddress,
-		ServerPort:       connected.ServerPort,
-		Timeline:         connected.Timeline,
-	}
-}
-
-func (o *Observer) validateConnectedPostgresEndpoints(
-	ctx context.Context,
-	member DCSMember,
-	connected sqlc.ConnectedPostgresIdentity,
-) error {
-	conn, err := url.Parse(member.ConnURL)
-	if err != nil || conn.Hostname() == "" {
-		return fmt.Errorf("%w: invalid Patroni conn_url", ErrWritableServerMismatch)
-	}
-	port := int32(5432)
-	if conn.Port() != "" {
-		parsedPort, err := strconv.ParseInt(conn.Port(), 10, 32)
-		if err != nil {
-			return fmt.Errorf("%w: invalid Patroni conn_url port", ErrWritableServerMismatch)
-		}
-		port = int32(parsedPort)
-	}
-	if port != connected.ServerPort {
-		return fmt.Errorf(
-			"%w: SQL selected port %d, DCS advertised %d",
-			ErrWritableServerMismatch,
-			connected.ServerPort,
-			port,
-		)
-	}
-	api, err := url.Parse(member.APIURL)
-	if err != nil || api.Hostname() == "" {
-		return fmt.Errorf("%w: invalid Patroni member URL", ErrWritableServerMismatch)
-	}
-
-	connectedAddress := normalizedIP(connected.ServerAddress)
-	resolvedHosts := make(map[string][]string, 2)
-	for _, endpoint := range []struct {
-		host    string
-		display string
-	}{
-		{host: conn.Hostname(), display: endpointAuthority(conn)},
-		{host: api.Hostname(), display: endpointAuthority(api)},
-	} {
-		addresses, ok := resolvedHosts[endpoint.host]
-		if !ok {
-			addresses, err = o.resolve(ctx, endpoint.host)
-			if err != nil {
-				return fmt.Errorf("%w: resolve DCS leader: %v", ErrWritableServerMismatch, err)
-			}
-			resolvedHosts[endpoint.host] = addresses
-		}
-		matched := slices.ContainsFunc(addresses, func(address string) bool {
-			return normalizedIP(address) == connectedAddress
-		})
-		if !matched {
-			return fmt.Errorf(
-				"%w: SQL selected %s:%d, DCS advertised %s",
-				ErrWritableServerMismatch,
-				connected.ServerAddress,
-				connected.ServerPort,
-				endpoint.display,
-			)
-		}
-	}
-	return nil
-}
-
-func endpointAuthority(endpoint *url.URL) string {
-	return (&url.URL{Scheme: endpoint.Scheme, Host: endpoint.Host}).String()
-}
-
-func validateDCSSnapshot(snapshot DCSSnapshot) error {
-	switch {
-	case snapshot.ClusterID == "" || snapshot.ClusterID == "0":
-		return errors.New("DCS snapshot has no cluster identity")
-	case snapshot.Revision <= 0:
-		return errors.New("DCS snapshot has no revision")
-	case snapshot.LeaderName == "":
-		return errors.New("DCS snapshot has no leader")
-	case snapshot.WriterGeneration <= 0:
-		return errors.New("DCS leader create_revision is invalid")
-	case snapshot.LeaderLeaseID <= 0:
-		return errors.New("DCS leader lease is invalid")
-	case snapshot.Member.Name != snapshot.LeaderName ||
-		snapshot.Member.APIURL == "" ||
-		snapshot.Member.ConnURL == "":
-		return errors.New("DCS snapshot has no matching leader member")
-	default:
-		return nil
-	}
-}
-
-func resolveHost(ctx context.Context, host string) ([]string, error) {
-	addresses, err := net.DefaultResolver.LookupIPAddr(ctx, host)
-	if err != nil {
-		return nil, fmt.Errorf("resolve host %s: %w", host, err)
-	}
-	result := make([]string, 0, len(addresses))
-	for _, address := range addresses {
-		result = append(result, address.IP.String())
-	}
-	return result, nil
-}
-
-func normalizedIP(address string) string {
-	if parsed := net.ParseIP(address); parsed != nil {
-		return parsed.String()
-	}
-	return address
+		PostgresSystemIdentifier: connected.SystemIdentifier,
+		WriterGeneration:         connected.Timeline,
+		ServerAddress:            connected.ServerAddress,
+		ServerPort:               connected.ServerPort,
+	}, nil
 }
 
 func isPrimaryRole(role string) bool {
 	return role == "primary" || role == "master"
 }
 
-// EtcdHTTPClient implements the minimal etcd v3 JSON-gateway surface required
-// for linearizable Patroni leader observations.
-type EtcdHTTPClient struct {
-	endpoint string
-	client   *http.Client
-}
-
-func NewEtcdHTTPClient(endpoint string, client *http.Client) *EtcdHTTPClient {
-	if client == nil {
-		client = &http.Client{Timeout: defaultHAHTTPTimeout}
-	}
-	return &EtcdHTTPClient{endpoint: strings.TrimRight(endpoint, "/"), client: client}
-}
-
-func (c *EtcdHTTPClient) Snapshot(ctx context.Context, clusterPath string) (DCSSnapshot, error) {
-	prefix := []byte(strings.TrimRight(clusterPath, "/") + "/")
-	payload := map[string]any{
-		"key":          base64.StdEncoding.EncodeToString(prefix),
-		"range_end":    base64.StdEncoding.EncodeToString(prefixRangeEnd(prefix)),
-		"serializable": false,
-	}
-	var response etcdRangeResponse
-	if err := c.post(ctx, "/v3/kv/range", payload, &response); err != nil {
-		return DCSSnapshot{}, err
-	}
-	return extractDCSSnapshot(response, clusterPath)
-}
-
-func (c *EtcdHTTPClient) LeaseTTL(ctx context.Context, leaseID int64) (time.Duration, error) {
-	var response struct {
-		ID  string `json:"ID"`
-		TTL string `json:"TTL"`
-	}
-	if err := c.post(
-		ctx,
-		"/v3/lease/timetolive",
-		map[string]any{"ID": strconv.FormatInt(leaseID, 10), "keys": false},
-		&response,
-	); err != nil {
-		return 0, err
-	}
-	returnedID, err := parsePositiveInt(response.ID, "leader lease ID")
-	if err != nil || returnedID != leaseID {
-		return 0, errors.New("etcd returned a different leader lease")
-	}
-	ttl, err := strconv.ParseInt(response.TTL, 10, 64)
-	if err != nil {
-		return 0, fmt.Errorf("parse leader lease TTL: %w", err)
-	}
-	return time.Duration(ttl) * time.Second, nil
-}
-
-func (c *EtcdHTTPClient) post(
-	ctx context.Context,
-	path string,
-	payload any,
-	result any,
-) error {
-	body, err := json.Marshal(payload)
-	if err != nil {
-		return fmt.Errorf("encode etcd %s request: %w", path, err)
-	}
-	req, err := http.NewRequestWithContext(
-		ctx,
-		http.MethodPost,
-		c.endpoint+path,
-		bytes.NewReader(body),
-	)
-	if err != nil {
-		return fmt.Errorf("create etcd %s request: %w", path, err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	response, err := c.client.Do(req)
-	if err != nil {
-		return fmt.Errorf("call etcd %s: %w", path, err)
-	}
-	defer response.Body.Close()
-	if response.StatusCode != http.StatusOK {
-		limited, _ := io.ReadAll(io.LimitReader(response.Body, 1024))
-		return fmt.Errorf("etcd %s returned %s: %s", path, response.Status, strings.TrimSpace(string(limited)))
-	}
-	if err := json.NewDecoder(response.Body).Decode(result); err != nil {
-		return fmt.Errorf("decode etcd %s response: %w", path, err)
-	}
-	return nil
-}
-
-type etcdRangeResponse struct {
-	Header struct {
-		ClusterID string `json:"cluster_id"`
-		Revision  string `json:"revision"`
-	} `json:"header"`
-	KVs []struct {
-		Key            string `json:"key"`
-		Value          string `json:"value"`
-		CreateRevision string `json:"create_revision"`
-		Lease          string `json:"lease"`
-	} `json:"kvs"`
-}
-
-func extractDCSSnapshot(response etcdRangeResponse, clusterPath string) (DCSSnapshot, error) {
-	clusterPath = strings.TrimRight(clusterPath, "/")
-	leaderPath := clusterPath + "/leader"
-	var leaderName string
-	var generation, leaseID int64
-	members := make(map[string]DCSMember)
-
-	for _, kv := range response.KVs {
-		keyBytes, err := base64.StdEncoding.DecodeString(kv.Key)
-		if err != nil {
-			return DCSSnapshot{}, fmt.Errorf("decode etcd key: %w", err)
-		}
-		valueBytes, err := base64.StdEncoding.DecodeString(kv.Value)
-		if err != nil {
-			return DCSSnapshot{}, fmt.Errorf("decode etcd value for %s: %w", keyBytes, err)
-		}
-		key := string(keyBytes)
-		switch {
-		case key == leaderPath:
-			if leaderName != "" {
-				return DCSSnapshot{}, errors.New("DCS snapshot has duplicate leader key")
-			}
-			leaderName = string(valueBytes)
-			generation, err = parsePositiveInt(kv.CreateRevision, "leader create_revision")
-			if err != nil {
-				return DCSSnapshot{}, err
-			}
-			leaseID, err = parsePositiveInt(kv.Lease, "leader lease")
-			if err != nil {
-				return DCSSnapshot{}, err
-			}
-		case strings.HasPrefix(key, clusterPath+"/members/"):
-			name := strings.TrimPrefix(key, clusterPath+"/members/")
-			var value struct {
-				APIURL  string `json:"api_url"`
-				ConnURL string `json:"conn_url"`
-			}
-			if err := json.Unmarshal(valueBytes, &value); err != nil {
-				return DCSSnapshot{}, fmt.Errorf("decode DCS member %s: %w", name, err)
-			}
-			members[name] = DCSMember{Name: name, APIURL: value.APIURL, ConnURL: value.ConnURL}
-		}
-	}
-
-	revision, err := parsePositiveInt(response.Header.Revision, "DCS revision")
-	if err != nil {
-		return DCSSnapshot{}, err
-	}
-	snapshot := DCSSnapshot{
-		ClusterID:        response.Header.ClusterID,
-		Revision:         revision,
-		LeaderName:       leaderName,
-		WriterGeneration: generation,
-		LeaderLeaseID:    leaseID,
-		Member:           members[leaderName],
-	}
-	return snapshot, validateDCSSnapshot(snapshot)
-}
-
-func parsePositiveInt(value string, field string) (int64, error) {
-	parsed, err := strconv.ParseInt(value, 10, 64)
-	if err != nil || parsed <= 0 {
-		return 0, fmt.Errorf("%s is missing or invalid", field)
-	}
-	return parsed, nil
-}
-
-func prefixRangeEnd(prefix []byte) []byte {
-	result := append([]byte(nil), prefix...)
-	for i := len(result) - 1; i >= 0; i-- {
-		if result[i] < 0xff {
-			result[i]++
-			return result[:i+1]
-		}
-	}
-	return []byte{0}
-}
-
-// PatroniHTTPClient validates the member's /primary response.
+// PatroniHTTPClient confirms that the selected PostgreSQL server owns
+// Patroni's primary lock.
 type PatroniHTTPClient struct {
 	client *http.Client
+	port   int
 }
 
-func NewPatroniHTTPClient(client *http.Client) *PatroniHTTPClient {
+func NewPatroniHTTPClient(client *http.Client) (*PatroniHTTPClient, error) {
 	if client == nil {
 		client = &http.Client{Timeout: defaultHAHTTPTimeout}
 	}
-	return &PatroniHTTPClient{client: client}
-}
-
-func (c *PatroniHTTPClient) PrimaryIdentity(
-	ctx context.Context,
-	memberAPIURL string,
-	expectedServerAddress string,
-) (PatroniIdentity, error) {
-	parsed, err := url.Parse(memberAPIURL)
-	if err != nil {
-		return PatroniIdentity{}, fmt.Errorf("parse Patroni member API URL: %w", err)
-	}
-	if parsed.Scheme != "http" && parsed.Scheme != "https" {
-		return PatroniIdentity{}, fmt.Errorf(
-			"Patroni member API URL scheme must be http or https; got %q",
-			parsed.Scheme,
-		)
-	}
-	if parsed.Hostname() == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" {
-		return PatroniIdentity{}, errors.New("Patroni member API URL is malformed")
-	}
-	pinnedIP := net.ParseIP(expectedServerAddress)
-	if pinnedIP == nil {
-		return PatroniIdentity{}, errors.New("validated PostgreSQL server address is not an IP")
-	}
-
-	baseTransport := c.client.Transport
+	baseTransport := client.Transport
 	if baseTransport == nil {
 		baseTransport = http.DefaultTransport
 	}
 	transport, ok := baseTransport.(*http.Transport)
 	if !ok {
-		return PatroniIdentity{}, errors.New("Patroni HTTP client transport cannot be safely cloned")
+		return nil, errors.New("Patroni HTTP client transport cannot be safely cloned")
 	}
 	transport = transport.Clone()
-	if transport.DialTLSContext != nil || transport.DialTLS != nil {
-		return PatroniIdentity{}, errors.New("Patroni HTTP client transport has a custom TLS dialer")
-	}
 	transport.Proxy = nil
-	if parsed.Scheme == "https" && transport.TLSClientConfig != nil {
-		transport.TLSClientConfig.ServerName = parsed.Hostname()
-	}
-	// Keep the URL hostname for Host and TLS SNI, but dial only the IP that
-	// PostgreSQL and both DCS endpoints were already validated against.
-	var dialer net.Dialer
-	transport.Dial = nil
-	transport.DialContext = func(
-		ctx context.Context,
-		network string,
-		address string,
-	) (net.Conn, error) {
-		_, port, err := net.SplitHostPort(address)
-		if err != nil {
-			return nil, fmt.Errorf("parse Patroni dial address: %w", err)
-		}
-		return dialer.DialContext(ctx, network, net.JoinHostPort(pinnedIP.String(), port))
-	}
-	client := *c.client
-	client.Transport = transport
-	client.CheckRedirect = transportguard.RejectRedirect
-	defer transport.CloseIdleConnections()
+	configuredClient := *client
+	configuredClient.Transport = transport
+	configuredClient.CheckRedirect = transportguard.RejectRedirect
+	return &PatroniHTTPClient{
+		client: &configuredClient,
+		port:   defaultPatroniPort,
+	}, nil
+}
 
-	parsed.Path = strings.TrimSuffix(parsed.Path, "/patroni") + "/primary"
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, parsed.String(), nil)
+func (c *PatroniHTTPClient) PrimaryIdentity(
+	ctx context.Context,
+	serverAddress string,
+) (PatroniIdentity, error) {
+	ip := net.ParseIP(serverAddress)
+	if ip == nil {
+		return PatroniIdentity{}, errors.New("validated PostgreSQL server address is not an IP")
+	}
+	if c.port <= 0 || c.port > 65535 {
+		return PatroniIdentity{}, errors.New("Patroni API port is invalid")
+	}
+
+	endpoint := url.URL{
+		Scheme: "http",
+		Host:   net.JoinHostPort(ip.String(), strconv.Itoa(c.port)),
+		Path:   "/primary",
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
 	if err != nil {
 		return PatroniIdentity{}, fmt.Errorf("create Patroni primary request: %w", err)
 	}
-	response, err := client.Do(req)
+	response, err := c.client.Do(req)
 	if err != nil {
 		return PatroniIdentity{}, fmt.Errorf("call Patroni primary endpoint: %w", err)
 	}
@@ -617,10 +210,8 @@ func (c *PatroniHTTPClient) PrimaryIdentity(
 	if response.StatusCode != http.StatusOK {
 		return PatroniIdentity{}, fmt.Errorf("Patroni /primary returned %s", response.Status)
 	}
-	var state struct {
-		Role     string `json:"role"`
-		Timeline int64  `json:"timeline"`
-	}
+
+	var state PatroniIdentity
 	if err := json.NewDecoder(response.Body).Decode(&state); err != nil {
 		return PatroniIdentity{}, fmt.Errorf("decode Patroni primary response: %w", err)
 	}
@@ -630,5 +221,5 @@ func (c *PatroniHTTPClient) PrimaryIdentity(
 	if state.Timeline <= 0 {
 		return PatroniIdentity{}, errors.New("Patroni reports invalid timeline")
 	}
-	return PatroniIdentity{Role: state.Role, Timeline: state.Timeline}, nil
+	return state, nil
 }

--- a/server/internal/ha/observer_test.go
+++ b/server/internal/ha/observer_test.go
@@ -2,7 +2,6 @@ package ha
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"net"
@@ -18,44 +17,17 @@ import (
 	"github.com/block/proto-fleet/server/generated/sqlc"
 )
 
-func TestEtcdHTTPClientSnapshotUsesLinearizablePrefixRead(t *testing.T) {
-	const clusterPath = "/service/fleet"
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/v3/kv/range", r.URL.Path)
-		var body struct {
-			Key          string `json:"key"`
-			RangeEnd     string `json:"range_end"`
-			Serializable bool   `json:"serializable"`
-		}
-		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
-		require.False(t, body.Serializable)
-		require.Equal(t, clusterPath+"/", decodeBase64(t, body.Key))
-		require.NotEmpty(t, decodeBase64(t, body.RangeEnd))
-
-		writeJSON(t, w, etcdSnapshotResponse("cluster-a", "patroni-a", 41, 998))
-	}))
-	t.Cleanup(server.Close)
-
-	client := NewEtcdHTTPClient(server.URL, server.Client())
-	snapshot, err := client.Snapshot(t.Context(), clusterPath)
+func TestPatroniHTTPClientUsesBoundedDefaultTimeout(t *testing.T) {
+	client, err := NewPatroniHTTPClient(nil)
 	require.NoError(t, err)
-	require.Equal(t, "cluster-a", snapshot.ClusterID)
-	require.Equal(t, int64(41), snapshot.WriterGeneration)
-	require.Equal(t, int64(998), snapshot.LeaderLeaseID)
+	require.Greater(t, client.client.Timeout, time.Duration(0))
 }
 
-func TestHAHTTPClientsUseBoundedDefaultTimeout(t *testing.T) {
-	require.Greater(t, NewEtcdHTTPClient("http://etcd", nil).client.Timeout, time.Duration(0))
-	require.Greater(t, NewPatroniHTTPClient(nil).client.Timeout, time.Duration(0))
-}
-
-func TestPatroniHTTPClientRejectsUnsupportedScheme(t *testing.T) {
-	_, err := NewPatroniHTTPClient(nil).PrimaryIdentity(
-		t.Context(),
-		"file:///var/run/patroni",
-		"127.0.0.1",
-	)
-	require.ErrorContains(t, err, "scheme must be http or https")
+func TestPatroniHTTPClientRejectsInvalidPostgresAddress(t *testing.T) {
+	client, err := NewPatroniHTTPClient(nil)
+	require.NoError(t, err)
+	_, err = client.PrimaryIdentity(t.Context(), "postgres.internal")
+	require.ErrorContains(t, err, "not an IP")
 }
 
 func TestPatroniHTTPClientRejectsRedirect(t *testing.T) {
@@ -64,123 +36,62 @@ func TestPatroniHTTPClientRejectsRedirect(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	_, err := NewPatroniHTTPClient(server.Client()).PrimaryIdentity(
+	_, err := patroniClientForServer(t, server).PrimaryIdentity(
 		t.Context(),
-		server.URL,
-		"127.0.0.1",
+		serverAddress(t, server),
 	)
 	require.ErrorContains(t, err, "redirects are not allowed")
 }
 
-func TestPatroniHTTPClientDialsValidatedPostgresAddress(t *testing.T) {
-	var expectedHost string
+func TestPatroniHTTPClientCallsPrimaryOnPostgresServer(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "/primary", r.URL.Path)
-		require.Equal(t, expectedHost, r.Host)
 		writeJSON(t, w, map[string]any{"role": "primary", "timeline": 7})
 	}))
 	t.Cleanup(server.Close)
 
-	serverURL, err := url.Parse(server.URL)
-	require.NoError(t, err)
-	_, port, err := net.SplitHostPort(serverURL.Host)
-	require.NoError(t, err)
-	expectedHost = net.JoinHostPort("patroni.invalid", port)
-
-	identity, err := NewPatroniHTTPClient(server.Client()).PrimaryIdentity(
+	identity, err := patroniClientForServer(t, server).PrimaryIdentity(
 		t.Context(),
-		"http://"+expectedHost,
-		serverURL.Hostname(),
+		serverAddress(t, server),
 	)
 	require.NoError(t, err)
 	require.Equal(t, PatroniIdentity{Role: "primary", Timeline: 7}, identity)
 }
 
-func TestObserverAcceptsStableBoundWriter(t *testing.T) {
-	observer := validObserver(
-		[]DCSSnapshot{
-			validDCSSnapshot(),
-			validDCSSnapshot(),
-		},
-	)
+func TestPatroniHTTPClientReusesConnections(t *testing.T) {
+	remoteAddresses := make(map[string]struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		remoteAddresses[r.RemoteAddr] = struct{}{}
+		writeJSON(t, w, map[string]any{"role": "primary", "timeline": 7})
+	}))
+	t.Cleanup(server.Close)
+	client := patroniClientForServer(t, server)
+
+	_, err := client.PrimaryIdentity(t.Context(), serverAddress(t, server))
+	require.NoError(t, err)
+	_, err = client.PrimaryIdentity(t.Context(), serverAddress(t, server))
+	require.NoError(t, err)
+	require.Len(t, remoteAddresses, 1)
+}
+
+func TestObserverAcceptsPostgresWriterConfirmedByPatroni(t *testing.T) {
+	observer, _, _ := validObserver(1)
 
 	observation, err := observer.Observe(t.Context())
 	require.NoError(t, err)
-	require.Equal(t, "cluster-a", observation.DCSClusterID)
-	require.Equal(t, int64(41), observation.WriterGeneration)
-	require.Equal(t, "patroni-a", observation.LeaderName)
-	require.WithinDuration(
-		t,
-		time.Now().Add(10*time.Second),
-		observation.DCSProofDeadline,
-		50*time.Millisecond,
-	)
+	require.Equal(t, "7668091434102423594", observation.PostgresSystemIdentifier)
+	require.Equal(t, int64(7), observation.WriterGeneration)
+	require.Equal(t, "172.30.0.12", observation.ServerAddress)
+	require.Equal(t, int32(5432), observation.ServerPort)
 }
 
-func TestObserverValidatesAuthoritiesInOrder(t *testing.T) {
+func TestObserverBracketsActionWithWriterValidation(t *testing.T) {
 	var calls []string
-	var patroniServerAddress string
-	observer := validObserver([]DCSSnapshot{validDCSSnapshot(), validDCSSnapshot()})
-	dcs, ok := observer.dcs.(*fakeDCSReader)
-	require.True(t, ok)
-	dcs.calls = &calls
-	observer.postgres = fakePostgresReader{
-		identity: sqlc.ConnectedPostgresIdentity{
-			ServerAddress: "172.30.0.12",
-			ServerPort:    5432,
-			Timeline:      7,
-		},
-		calls: &calls,
-	}
-	observer.resolve = func(context.Context, string) ([]string, error) {
-		calls = append(calls, "resolve")
-		return []string{"172.30.0.12"}, nil
-	}
-	observer.patroni = fakePatroniReader{
-		identity:      PatroniIdentity{Role: "primary", Timeline: 7},
-		calls:         &calls,
-		serverAddress: &patroniServerAddress,
-	}
-
-	_, err := observer.Observe(t.Context())
-	require.NoError(t, err)
-	require.Equal(t, "172.30.0.12", patroniServerAddress)
-	require.Equal(
-		t,
-		[]string{
-			"dcs-snapshot",
-			"postgres",
-			"resolve",
-			"patroni",
-			"dcs-snapshot",
-			"dcs-lease",
-		},
-		calls,
-	)
-}
-
-func TestObserverRunsActionInsideDCSValidationBracket(t *testing.T) {
-	var calls []string
-	observer := validObserver([]DCSSnapshot{validDCSSnapshot(), validDCSSnapshot()})
-	dcs, ok := observer.dcs.(*fakeDCSReader)
-	require.True(t, ok)
-	dcs.calls = &calls
-	observer.postgres = fakePostgresReader{
-		identity: sqlc.ConnectedPostgresIdentity{
-			ServerAddress: "172.30.0.12",
-			ServerPort:    5432,
-			Timeline:      7,
-		},
-		calls: &calls,
-	}
-	observer.resolve = func(context.Context, string) ([]string, error) {
-		calls = append(calls, "resolve")
-		return []string{"172.30.0.12"}, nil
-	}
-	observer.patroni = fakePatroniReader{
-		identity: PatroniIdentity{Role: "primary", Timeline: 7},
-		calls:    &calls,
-	}
+	var patroniServerAddresses []string
+	observer, postgres, patroni := validObserver(2)
+	postgres.calls = &calls
+	patroni.calls = &calls
+	patroni.serverAddresses = &patroniServerAddresses
 
 	_, err := observer.ObserveAndRun(
 		t.Context(),
@@ -192,329 +103,241 @@ func TestObserverRunsActionInsideDCSValidationBracket(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(
 		t,
-		[]string{
-			"dcs-snapshot",
-			"postgres",
-			"resolve",
-			"patroni",
-			"action",
-			"dcs-snapshot",
-			"dcs-lease",
-		},
+		[]string{"postgres", "patroni", "action", "postgres", "patroni"},
 		calls,
 	)
+	require.Equal(t, []string{"172.30.0.12", "172.30.0.12"}, patroniServerAddresses)
 }
 
-func TestObserverRejectsPatroniAPIServerMismatch(t *testing.T) {
-	observer := validObserver([]DCSSnapshot{validDCSSnapshot()})
-	observer.resolve = func(_ context.Context, host string) ([]string, error) {
-		if host == "patroni-a" {
-			return []string{"172.30.0.12"}, nil
-		}
-		return []string{"172.30.0.99"}, nil
-	}
-	snapshotReader, ok := observer.dcs.(*fakeDCSReader)
-	require.True(t, ok)
-	snapshotReader.snapshots[0].Member.APIURL = "http://patroni-api-elsewhere:8008"
-
-	_, err := observer.Observe(t.Context())
-	require.ErrorIs(t, err, ErrWritableServerMismatch)
-}
-
-func TestObserverRedactsDCSURLSecretsFromEndpointMismatchErrors(t *testing.T) {
-	tests := []struct {
-		name       string
-		mutate     func(*DCSMember)
-		safeURL    string
-		sensitive  []string
-		mismatched string
+func TestObserverRejectsWriterChangeAcrossAction(t *testing.T) {
+	tests := map[string]struct {
+		mutatePostgres func(*sqlc.ConnectedPostgresIdentity)
+		mutatePatroni  func(*PatroniIdentity)
 	}{
-		{
-			name: "PostgreSQL connection URL",
-			mutate: func(member *DCSMember) {
-				member.ConnURL = "postgres://db-user:db-password@patroni-db:5432/private-db?sslpassword=query-secret#conn-fragment"
+		"system identifier": {
+			mutatePostgres: func(identity *sqlc.ConnectedPostgresIdentity) {
+				identity.SystemIdentifier = "7668091434102423595"
 			},
-			safeURL:    "postgres://patroni-db:5432",
-			sensitive:  []string{"db-user", "db-password", "private-db", "query-secret", "conn-fragment"},
-			mismatched: "patroni-db",
 		},
-		{
-			name: "Patroni API URL",
-			mutate: func(member *DCSMember) {
-				member.APIURL = "http://api-user:api-password@patroni-api:8008/private-api?token=query-secret#api-fragment"
+		"server address": {
+			mutatePostgres: func(identity *sqlc.ConnectedPostgresIdentity) {
+				identity.ServerAddress = "172.30.0.13"
 			},
-			safeURL:    "http://patroni-api:8008",
-			sensitive:  []string{"api-user", "api-password", "private-api", "query-secret", "api-fragment"},
-			mismatched: "patroni-api",
+		},
+		"server port": {
+			mutatePostgres: func(identity *sqlc.ConnectedPostgresIdentity) {
+				identity.ServerPort = 5433
+			},
+		},
+		"timeline": {
+			mutatePostgres: func(identity *sqlc.ConnectedPostgresIdentity) {
+				identity.Timeline = 8
+			},
+			mutatePatroni: func(identity *PatroniIdentity) {
+				identity.Timeline = 8
+			},
 		},
 	}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			snapshot := validDCSSnapshot()
-			test.mutate(&snapshot.Member)
-			observer := validObserver([]DCSSnapshot{snapshot})
-			observer.resolve = func(_ context.Context, host string) ([]string, error) {
-				if host == test.mismatched {
-					return []string{"172.30.0.99"}, nil
-				}
-				return []string{"172.30.0.12"}, nil
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			firstPostgres := validPostgresIdentity()
+			secondPostgres := firstPostgres
+			test.mutatePostgres(&secondPostgres)
+			firstPatroni := validPatroniIdentity()
+			secondPatroni := firstPatroni
+			if test.mutatePatroni != nil {
+				test.mutatePatroni(&secondPatroni)
+			}
+			observer := &Observer{
+				postgres: &fakePostgresReader{
+					identities: []sqlc.ConnectedPostgresIdentity{
+						firstPostgres,
+						secondPostgres,
+					},
+				},
+				patroni: &fakePatroniReader{
+					identities: []PatroniIdentity{firstPatroni, secondPatroni},
+				},
 			}
 
-			_, err := observer.Observe(t.Context())
-
-			require.ErrorIs(t, err, ErrWritableServerMismatch)
-			require.ErrorContains(t, err, test.safeURL)
-			for _, sensitive := range test.sensitive {
-				require.NotContains(t, err.Error(), sensitive)
-			}
+			_, err := observer.ObserveAndRun(
+				t.Context(),
+				func(context.Context, WriterObservation) error { return nil },
+			)
+			require.ErrorIs(t, err, ErrWriterChanged)
 		})
 	}
 }
 
-func TestObserverRejectsLeaderLeaseChangeInsideValidationBracket(t *testing.T) {
-	second := validDCSSnapshot()
-	second.LeaderLeaseID++
-	observer := validObserver([]DCSSnapshot{validDCSSnapshot(), second})
-
-	_, err := observer.Observe(t.Context())
-	require.ErrorIs(t, err, ErrWriterChanged)
-}
-
-func TestObserverRejectsChangedLeaderTerm(t *testing.T) {
-	second := validDCSSnapshot()
-	second.LeaderName = "patroni-b"
-	second.Member = DCSMember{
-		Name:    "patroni-b",
-		APIURL:  "http://patroni-b:8008",
-		ConnURL: "postgres://patroni-b:5432/postgres",
+func TestObserverRejectsInvalidPostgresIdentity(t *testing.T) {
+	tests := map[string]func(*sqlc.ConnectedPostgresIdentity){
+		"system identifier": func(identity *sqlc.ConnectedPostgresIdentity) {
+			identity.SystemIdentifier = ""
+		},
+		"server address": func(identity *sqlc.ConnectedPostgresIdentity) {
+			identity.ServerAddress = ""
+		},
+		"server port": func(identity *sqlc.ConnectedPostgresIdentity) {
+			identity.ServerPort = 0
+		},
+		"timeline": func(identity *sqlc.ConnectedPostgresIdentity) {
+			identity.Timeline = 0
+		},
+		"replica": func(identity *sqlc.ConnectedPostgresIdentity) {
+			identity.InRecovery = true
+		},
 	}
-	observer := validObserver([]DCSSnapshot{validDCSSnapshot(), second})
 
-	_, err := observer.Observe(t.Context())
-	require.ErrorIs(t, err, ErrWriterChanged)
-}
-
-func TestObserverRejectsDCSClusterIdentityChange(t *testing.T) {
-	second := validDCSSnapshot()
-	second.ClusterID = "cluster-b"
-	observer := validObserver([]DCSSnapshot{validDCSSnapshot(), second})
-
-	_, err := observer.Observe(t.Context())
-	require.ErrorIs(t, err, ErrDCSClusterIdentityMismatch)
-}
-
-func TestObserverRejectsMissingDCSIdentityData(t *testing.T) {
-	tests := map[string]func(*DCSSnapshot){
-		"cluster identity": func(snapshot *DCSSnapshot) { snapshot.ClusterID = "" },
-		"leader":           func(snapshot *DCSSnapshot) { snapshot.LeaderName = "" },
-		"member":           func(snapshot *DCSSnapshot) { snapshot.Member = DCSMember{} },
-		"generation":       func(snapshot *DCSSnapshot) { snapshot.WriterGeneration = 0 },
-		"lease":            func(snapshot *DCSSnapshot) { snapshot.LeaderLeaseID = 0 },
-	}
 	for name, mutate := range tests {
 		t.Run(name, func(t *testing.T) {
-			snapshot := validDCSSnapshot()
-			mutate(&snapshot)
-			observer := validObserver([]DCSSnapshot{snapshot})
+			identity := validPostgresIdentity()
+			mutate(&identity)
+			observer := &Observer{
+				postgres: &fakePostgresReader{
+					identities: []sqlc.ConnectedPostgresIdentity{identity},
+				},
+				patroni: &fakePatroniReader{
+					identities: []PatroniIdentity{validPatroniIdentity()},
+				},
+			}
 
 			_, err := observer.Observe(t.Context())
-			require.Error(t, err)
+			require.ErrorIs(t, err, ErrWritableServerMismatch)
 		})
 	}
-}
-
-func TestObserverRejectsWritableServerMismatch(t *testing.T) {
-	observer := validObserver([]DCSSnapshot{validDCSSnapshot()})
-	observer.resolve = func(context.Context, string) ([]string, error) {
-		return []string{"172.30.0.99"}, nil
-	}
-
-	_, err := observer.Observe(t.Context())
-	require.ErrorIs(t, err, ErrWritableServerMismatch)
-}
-
-func TestObserverRejectsPostgresReplica(t *testing.T) {
-	observer := validObserver([]DCSSnapshot{validDCSSnapshot()})
-	observer.postgres = fakePostgresReader{identity: sqlc.ConnectedPostgresIdentity{
-		ServerAddress: "172.30.0.12",
-		ServerPort:    5432,
-		InRecovery:    true,
-		Timeline:      7,
-	}}
-
-	_, err := observer.Observe(t.Context())
-	require.ErrorIs(t, err, ErrWritableServerMismatch)
 }
 
 func TestObserverRejectsTimelineMismatch(t *testing.T) {
-	observer := validObserver([]DCSSnapshot{validDCSSnapshot()})
-	observer.patroni = fakePatroniReader{identity: PatroniIdentity{
-		Role:     "primary",
-		Timeline: 8,
-	}}
+	observer, _, patroni := validObserver(1)
+	patroni.identities[0].Timeline = 8
 
 	_, err := observer.Observe(t.Context())
 	require.ErrorIs(t, err, ErrTimelineMismatch)
 }
 
 func TestObserverRejectsNonPrimaryPatroniMember(t *testing.T) {
-	observer := validObserver([]DCSSnapshot{validDCSSnapshot()})
-	observer.patroni = fakePatroniReader{identity: PatroniIdentity{
-		Role:     "replica",
-		Timeline: 7,
-	}}
+	observer, _, patroni := validObserver(1)
+	patroni.identities[0].Role = "replica"
 
 	_, err := observer.Observe(t.Context())
 	require.ErrorIs(t, err, ErrWritableServerMismatch)
 }
 
-func TestObserverRejectsExpiredLeaderLease(t *testing.T) {
-	observer := validObserver([]DCSSnapshot{validDCSSnapshot(), validDCSSnapshot()})
-	dcs, ok := observer.dcs.(*fakeDCSReader)
-	require.True(t, ok)
-	dcs.leaseTTL = 0
+func TestObserverStopsWhenActionFails(t *testing.T) {
+	actionErr := errors.New("lease write failed")
+	observer, postgres, patroni := validObserver(2)
 
-	_, err := observer.Observe(t.Context())
-	require.ErrorIs(t, err, ErrLeaderLeaseExpired)
+	_, err := observer.ObserveAndRun(
+		t.Context(),
+		func(context.Context, WriterObservation) error { return actionErr },
+	)
+	require.ErrorIs(t, err, actionErr)
+	require.Len(t, postgres.identities, 1)
+	require.Len(t, patroni.identities, 1)
 }
 
-func validObserver(snapshots []DCSSnapshot) *Observer {
-	return &Observer{
-		clusterPath: "/service/fleet",
-		dcs: &fakeDCSReader{
-			snapshots: snapshots,
-			leaseTTL:  10 * time.Second,
-		},
-		postgres: fakePostgresReader{identity: sqlc.ConnectedPostgresIdentity{
-			ServerAddress: "172.30.0.12",
-			ServerPort:    5432,
-			Timeline:      7,
-		}},
-		patroni: fakePatroniReader{identity: PatroniIdentity{
-			Role:     "primary",
-			Timeline: 7,
-		}},
-		resolve: func(context.Context, string) ([]string, error) {
-			return []string{"172.30.0.12"}, nil
-		},
+func validObserver(
+	observations int,
+) (*Observer, *fakePostgresReader, *fakePatroniReader) {
+	postgresIdentities := make([]sqlc.ConnectedPostgresIdentity, observations)
+	patroniIdentities := make([]PatroniIdentity, observations)
+	for index := range observations {
+		postgresIdentities[index] = validPostgresIdentity()
+		patroniIdentities[index] = validPatroniIdentity()
+	}
+	postgres := &fakePostgresReader{identities: postgresIdentities}
+	patroni := &fakePatroniReader{identities: patroniIdentities}
+	return &Observer{postgres: postgres, patroni: patroni}, postgres, patroni
+}
+
+func validPostgresIdentity() sqlc.ConnectedPostgresIdentity {
+	return sqlc.ConnectedPostgresIdentity{
+		SystemIdentifier: "7668091434102423594",
+		ServerAddress:    "172.30.0.12",
+		ServerPort:       5432,
+		Timeline:         7,
 	}
 }
 
-func validDCSSnapshot() DCSSnapshot {
-	return DCSSnapshot{
-		ClusterID:        "cluster-a",
-		Revision:         50,
-		LeaderName:       "patroni-a",
-		WriterGeneration: 41,
-		LeaderLeaseID:    998,
-		Member: DCSMember{
-			Name:    "patroni-a",
-			APIURL:  "http://patroni-a:8008",
-			ConnURL: "postgres://patroni-a:5432/postgres",
-		},
-	}
-}
-
-type fakeDCSReader struct {
-	snapshots []DCSSnapshot
-	leaseTTL  time.Duration
-	calls     *[]string
-}
-
-func (f *fakeDCSReader) Snapshot(context.Context, string) (DCSSnapshot, error) {
-	if f.calls != nil {
-		*f.calls = append(*f.calls, "dcs-snapshot")
-	}
-	if len(f.snapshots) == 0 {
-		return DCSSnapshot{}, errors.New("no snapshot")
-	}
-	snapshot := f.snapshots[0]
-	f.snapshots = f.snapshots[1:]
-	return snapshot, nil
-}
-
-func (f *fakeDCSReader) LeaseTTL(context.Context, int64) (time.Duration, error) {
-	if f.calls != nil {
-		*f.calls = append(*f.calls, "dcs-lease")
-	}
-	return f.leaseTTL, nil
+func validPatroniIdentity() PatroniIdentity {
+	return PatroniIdentity{Role: "primary", Timeline: 7}
 }
 
 type fakePostgresReader struct {
-	identity sqlc.ConnectedPostgresIdentity
-	err      error
-	calls    *[]string
+	identities []sqlc.ConnectedPostgresIdentity
+	err        error
+	calls      *[]string
 }
 
-func (f fakePostgresReader) GetConnectedPostgresIdentity(
+func (f *fakePostgresReader) GetConnectedPostgresIdentity(
 	context.Context,
 ) (sqlc.ConnectedPostgresIdentity, error) {
 	if f.calls != nil {
 		*f.calls = append(*f.calls, "postgres")
 	}
-	return f.identity, f.err
+	if f.err != nil {
+		return sqlc.ConnectedPostgresIdentity{}, f.err
+	}
+	if len(f.identities) == 0 {
+		return sqlc.ConnectedPostgresIdentity{}, errors.New("no PostgreSQL identity")
+	}
+	identity := f.identities[0]
+	f.identities = f.identities[1:]
+	return identity, nil
 }
 
 type fakePatroniReader struct {
-	identity      PatroniIdentity
-	err           error
-	calls         *[]string
-	serverAddress *string
+	identities      []PatroniIdentity
+	err             error
+	calls           *[]string
+	serverAddresses *[]string
 }
 
-func (f fakePatroniReader) PrimaryIdentity(
+func (f *fakePatroniReader) PrimaryIdentity(
 	_ context.Context,
-	_ string,
 	serverAddress string,
 ) (PatroniIdentity, error) {
 	if f.calls != nil {
 		*f.calls = append(*f.calls, "patroni")
 	}
-	if f.serverAddress != nil {
-		*f.serverAddress = serverAddress
+	if f.serverAddresses != nil {
+		*f.serverAddresses = append(*f.serverAddresses, serverAddress)
 	}
-	return f.identity, f.err
+	if f.err != nil {
+		return PatroniIdentity{}, f.err
+	}
+	if len(f.identities) == 0 {
+		return PatroniIdentity{}, errors.New("no Patroni identity")
+	}
+	identity := f.identities[0]
+	f.identities = f.identities[1:]
+	return identity, nil
 }
 
-func decodeBase64(t *testing.T, value string) string {
+func patroniClientForServer(t *testing.T, server *httptest.Server) *PatroniHTTPClient {
 	t.Helper()
-	decoded, err := base64.StdEncoding.DecodeString(value)
+	parsed, err := url.Parse(server.URL)
 	require.NoError(t, err)
-	return string(decoded)
+	port, err := strconv.Atoi(parsed.Port())
+	require.NoError(t, err)
+	client, err := NewPatroniHTTPClient(server.Client())
+	require.NoError(t, err)
+	client.port = port
+	return client
+}
+
+func serverAddress(t *testing.T, server *httptest.Server) string {
+	t.Helper()
+	parsed, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	address := net.ParseIP(parsed.Hostname())
+	require.NotNil(t, address)
+	return address.String()
 }
 
 func writeJSON(t *testing.T, w http.ResponseWriter, value any) {
 	t.Helper()
 	w.Header().Set("Content-Type", "application/json")
 	require.NoError(t, json.NewEncoder(w).Encode(value))
-}
-
-func etcdSnapshotResponse(clusterID, leader string, generation, leaseID int64) map[string]any {
-	encoded := func(value string) string {
-		return base64.StdEncoding.EncodeToString([]byte(value))
-	}
-	clusterPath := "/service/fleet"
-	return map[string]any{
-		"header": map[string]string{
-			"cluster_id": clusterID,
-			"revision":   "50",
-		},
-		"kvs": []map[string]string{
-			{
-				"key":             encoded(clusterPath + "/leader"),
-				"value":           encoded(leader),
-				"create_revision": strconv.FormatInt(generation, 10),
-				"mod_revision":    "47",
-				"lease":           strconv.FormatInt(leaseID, 10),
-			},
-			{
-				"key": encoded(clusterPath + "/members/" + leader),
-				"value": encoded(`{"api_url":"http://` + leader + `:8008",` +
-					`"conn_url":"postgres://` + leader + `:5432/postgres"}`),
-				"create_revision": "13",
-				"mod_revision":    "48",
-			},
-		},
-	}
 }

--- a/server/internal/ha/store.go
+++ b/server/internal/ha/store.go
@@ -56,8 +56,7 @@ func (s *LeaseStore) Acquire(
 		sqlc.AcquireFleetRuntimeLeaseParams{
 			ServerAddress:             observed.ServerAddress,
 			ServerPort:                observed.ServerPort,
-			Timeline:                  observed.Timeline,
-			DcsClusterID:              observed.DCSClusterID,
+			PostgresSystemIdentifier:  observed.PostgresSystemIdentifier,
 			WriterGeneration:          observed.WriterGeneration,
 			HolderID:                  holderID,
 			LeaseDurationMilliseconds: duration.Milliseconds(),
@@ -82,9 +81,9 @@ func (s *LeaseStore) Renew(
 	if err := validateWriterObservation(observed); err != nil {
 		return Ownership{}, err
 	}
-	if observed.DCSClusterID != ownership.DCSClusterID ||
+	if observed.PostgresSystemIdentifier != ownership.PostgresSystemIdentifier ||
 		observed.WriterGeneration != ownership.Token.WriterGeneration ||
-		ownership.DCSClusterID == "" ||
+		ownership.PostgresSystemIdentifier == "" ||
 		ownership.Token.WriterGeneration <= 0 ||
 		ownership.Token.LeaseEpoch <= 0 ||
 		ownership.HolderID == uuid.Nil ||
@@ -96,9 +95,8 @@ func (s *LeaseStore) Renew(
 		sqlc.RenewFleetRuntimeLeaseParams{
 			ServerAddress:             observed.ServerAddress,
 			ServerPort:                observed.ServerPort,
-			Timeline:                  observed.Timeline,
 			LeaseDurationMilliseconds: duration.Milliseconds(),
-			DcsClusterID:              ownership.DCSClusterID,
+			PostgresSystemIdentifier:  ownership.PostgresSystemIdentifier,
 			WriterGeneration:          ownership.Token.WriterGeneration,
 			LeaseEpoch:                ownership.Token.LeaseEpoch,
 			HolderID:                  ownership.HolderID,
@@ -111,7 +109,7 @@ func (s *LeaseStore) Renew(
 		return Ownership{}, fmt.Errorf("renew Fleet active lease: %w", err)
 	}
 	return Ownership{
-		DCSClusterID: row.DcsClusterID,
+		PostgresSystemIdentifier: row.PostgresSystemIdentifier,
 		Token: Token{
 			WriterGeneration: row.HighestWriterGeneration,
 			LeaseEpoch:       row.LeaseEpoch,
@@ -140,11 +138,10 @@ func validateLeaseInput(
 }
 
 func validateWriterObservation(observed WriterObservation) error {
-	if observed.DCSClusterID == "" ||
+	if observed.PostgresSystemIdentifier == "" ||
 		observed.WriterGeneration <= 0 ||
 		observed.ServerAddress == "" ||
-		observed.ServerPort <= 0 ||
-		observed.Timeline <= 0 {
+		observed.ServerPort <= 0 {
 		return errors.New("invalid writer observation for Fleet active lease")
 	}
 	return nil
@@ -152,7 +149,7 @@ func validateWriterObservation(observed WriterObservation) error {
 
 func ownershipFromAcquire(row sqlc.AcquireFleetRuntimeLeaseRow) Ownership {
 	return Ownership{
-		DCSClusterID: row.DcsClusterID,
+		PostgresSystemIdentifier: row.PostgresSystemIdentifier,
 		Token: Token{
 			WriterGeneration: row.HighestWriterGeneration,
 			LeaseEpoch:       row.LeaseEpoch,

--- a/server/internal/ha/store_integration_test.go
+++ b/server/internal/ha/store_integration_test.go
@@ -16,18 +16,23 @@ import (
 func TestLeaseStoreAcquireAndRenewUseDatabaseTime(t *testing.T) {
 	store, reader := leaseTestSurfaces(t)
 	holder := uuid.New()
+	observed := databaseObservation(t, reader)
 
 	ownership, err := store.Acquire(
-		t.Context(), databaseObservation(t, reader, "cluster-a", 41), holder, 2*time.Second,
+		t.Context(), observed, holder, 2*time.Second,
 	)
 	require.NoError(t, err)
 	require.Equal(t, holder, ownership.HolderID)
-	require.Equal(t, Token{WriterGeneration: 41, LeaseEpoch: 1}, ownership.Token)
+	require.Equal(
+		t,
+		Token{WriterGeneration: observed.WriterGeneration, LeaseEpoch: 1},
+		ownership.Token,
+	)
 	require.WithinDuration(t, ownership.DatabaseTime.Add(2*time.Second), ownership.ExpiresAt, 50*time.Millisecond)
 
 	renewed, err := store.Renew(
 		t.Context(),
-		databaseObservation(t, reader, "cluster-a", 41),
+		observed,
 		ownership,
 		time.Second,
 	)
@@ -38,7 +43,7 @@ func TestLeaseStoreAcquireAndRenewUseDatabaseTime(t *testing.T) {
 
 func TestRacingCoordinatorsProduceOneOwner(t *testing.T) {
 	store, reader := leaseTestSurfaces(t)
-	observer := staticObserver{observation: databaseObservation(t, reader, "cluster-a", 41)}
+	observer := staticObserver{observation: databaseObservation(t, reader)}
 	coordinators := []*Coordinator{
 		newCoordinatorWithHolder(observer, store, coordinatorTestConfig(), uuid.New()),
 		newCoordinatorWithHolder(observer, store, coordinatorTestConfig(), uuid.New()),
@@ -68,11 +73,11 @@ func TestRacingCoordinatorsProduceOneOwner(t *testing.T) {
 
 func TestLeaseStoreCoordinatorDemotionRequiresExpiryBeforeSameWriterReacquisition(t *testing.T) {
 	store, reader := leaseTestSurfaces(t)
-	observed := databaseObservation(t, reader, "cluster-a", 41)
+	observed := databaseObservation(t, reader)
 	observer := &sequenceObserver{
 		results: []observerResult{
 			{observation: observed},
-			{err: errors.New("DCS unavailable")},
+			{err: errors.New("writer unavailable")},
 			{observation: observed},
 			{observation: observed},
 		},
@@ -101,52 +106,18 @@ func TestLeaseStoreCoordinatorDemotionRequiresExpiryBeforeSameWriterReacquisitio
 	require.Greater(t, second.Token.LeaseEpoch, first.Token.LeaseEpoch)
 }
 
-func TestPromotionAfterLostAsyncLeaseStateSupersedesUnexpiredLease(t *testing.T) {
+func TestLeaseStoreRejectsPostgresSystemIdentifierMismatch(t *testing.T) {
 	store, reader := leaseTestSurfaces(t)
-	// This unexpired generation-41 row represents lease state acknowledged on
-	// the former primary and then exposed again after asynchronous rollback.
-	first, err := store.Acquire(
-		t.Context(), databaseObservation(t, reader, "cluster-a", 41), uuid.New(), time.Minute,
-	)
-	require.NoError(t, err)
+	observed := databaseObservation(t, reader)
+	observed.PostgresSystemIdentifier += "-different"
 
-	second, err := store.Acquire(
-		t.Context(), databaseObservation(t, reader, "cluster-a", 42), uuid.New(), time.Minute,
-	)
-	require.NoError(t, err)
-	require.Equal(t, int64(42), second.Token.WriterGeneration)
-	require.Greater(t, second.Token.LeaseEpoch, first.Token.LeaseEpoch)
-}
-
-func TestLeaseStoreRejectsClusterIdentityMismatch(t *testing.T) {
-	store, reader := leaseTestSurfaces(t)
-	_, err := store.Acquire(
-		t.Context(), databaseObservation(t, reader, "cluster-a", 41), uuid.New(), time.Minute,
-	)
-	require.NoError(t, err)
-
-	_, err = store.Acquire(
-		t.Context(), databaseObservation(t, reader, "cluster-b", 42), uuid.New(), time.Minute,
-	)
-	require.ErrorIs(t, err, ErrLeaseUnavailable)
-}
-
-func TestLeaseStoreRejectsGenerationRegression(t *testing.T) {
-	store, reader := leaseTestSurfaces(t)
-	_, err := store.Acquire(
-		t.Context(), databaseObservation(t, reader, "cluster-a", 42), uuid.New(), time.Minute,
-	)
-	require.NoError(t, err)
-
-	_, err = store.Acquire(
-		t.Context(), databaseObservation(t, reader, "cluster-a", 41), uuid.New(), time.Minute,
-	)
+	_, err := store.Acquire(t.Context(), observed, uuid.New(), time.Minute)
 	require.ErrorIs(t, err, ErrLeaseUnavailable)
 }
 
 func TestLeaseStoreSameGenerationWaitsForExpiry(t *testing.T) {
 	store, reader := leaseTestSurfaces(t)
-	observed := databaseObservation(t, reader, "cluster-a", 41)
+	observed := databaseObservation(t, reader)
 	first, err := store.Acquire(
 		t.Context(),
 		observed,
@@ -168,12 +139,12 @@ func TestLeaseStoreSameHolderAcquireDoesNotExtendUnexpiredLease(t *testing.T) {
 	store, reader := leaseTestSurfaces(t)
 	holder := uuid.New()
 	first, err := store.Acquire(
-		t.Context(), databaseObservation(t, reader, "cluster-a", 41), holder, time.Minute,
+		t.Context(), databaseObservation(t, reader), holder, time.Minute,
 	)
 	require.NoError(t, err)
 
 	second, err := store.Acquire(
-		t.Context(), databaseObservation(t, reader, "cluster-a", 41), holder, 2*time.Minute,
+		t.Context(), databaseObservation(t, reader), holder, 2*time.Minute,
 	)
 	require.NoError(t, err)
 	require.Equal(t, first.Token, second.Token)
@@ -183,7 +154,7 @@ func TestLeaseStoreSameHolderAcquireDoesNotExtendUnexpiredLease(t *testing.T) {
 
 func TestLeaseStoreSameHolderAfterExpiryAdvancesEpoch(t *testing.T) {
 	store, reader := leaseTestSurfaces(t)
-	observed := databaseObservation(t, reader, "cluster-a", 41)
+	observed := databaseObservation(t, reader)
 	holder := uuid.New()
 	first, err := store.Acquire(
 		t.Context(),
@@ -202,15 +173,13 @@ func TestLeaseStoreSameHolderAfterExpiryAdvancesEpoch(t *testing.T) {
 func TestLeaseStoreRenewRequiresExactOwnership(t *testing.T) {
 	store, reader := leaseTestSurfaces(t)
 	ownership, err := store.Acquire(
-		t.Context(), databaseObservation(t, reader, "cluster-a", 41), uuid.New(), time.Minute,
+		t.Context(), databaseObservation(t, reader), uuid.New(), time.Minute,
 	)
 	require.NoError(t, err)
 
 	tests := map[string]func(*Ownership){
-		"holder":     func(wrong *Ownership) { wrong.HolderID = uuid.New() },
-		"generation": func(wrong *Ownership) { wrong.Token.WriterGeneration++ },
-		"epoch":      func(wrong *Ownership) { wrong.Token.LeaseEpoch++ },
-		"cluster":    func(wrong *Ownership) { wrong.DCSClusterID = "cluster-b" },
+		"holder": func(wrong *Ownership) { wrong.HolderID = uuid.New() },
+		"epoch":  func(wrong *Ownership) { wrong.Token.LeaseEpoch++ },
 	}
 	for name, mutate := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -218,12 +187,7 @@ func TestLeaseStoreRenewRequiresExactOwnership(t *testing.T) {
 			mutate(&wrong)
 			_, renewErr := store.Renew(
 				t.Context(),
-				databaseObservation(
-					t,
-					reader,
-					wrong.DCSClusterID,
-					wrong.Token.WriterGeneration,
-				),
+				databaseObservation(t, reader),
 				wrong,
 				time.Minute,
 			)
@@ -234,7 +198,7 @@ func TestLeaseStoreRenewRequiresExactOwnership(t *testing.T) {
 
 func TestLeaseStoreRejectsDifferentWritableServerIdentity(t *testing.T) {
 	store, reader := leaseTestSurfaces(t)
-	observed := databaseObservation(t, reader, "cluster-a", 41)
+	observed := databaseObservation(t, reader)
 	observed.ServerAddress = "203.0.113.1"
 
 	_, err := store.Acquire(t.Context(), observed, uuid.New(), time.Minute)
@@ -242,42 +206,26 @@ func TestLeaseStoreRejectsDifferentWritableServerIdentity(t *testing.T) {
 
 	ownership, err := store.Acquire(
 		t.Context(),
-		databaseObservation(t, reader, "cluster-a", 41),
+		databaseObservation(t, reader),
 		uuid.New(),
 		time.Minute,
 	)
 	require.NoError(t, err)
-	require.Equal(t, Token{WriterGeneration: 41, LeaseEpoch: 1}, ownership.Token)
-}
-
-func TestLeaseStoreRejectsRenewalOnDifferentWritableServerIdentity(t *testing.T) {
-	store, reader := leaseTestSurfaces(t)
-	observed := databaseObservation(t, reader, "cluster-a", 41)
-	ownership, err := store.Acquire(t.Context(), observed, uuid.New(), time.Minute)
-	require.NoError(t, err)
-	observed.Timeline++
-
-	_, err = store.Renew(t.Context(), observed, ownership, time.Minute)
-	require.ErrorIs(t, err, ErrOwnershipLost)
+	require.Equal(t, int64(1), ownership.Token.LeaseEpoch)
 }
 
 func databaseObservation(
 	t *testing.T,
 	reader postgresIdentityReader,
-	clusterID string,
-	generation int64,
 ) WriterObservation {
 	t.Helper()
 	identity, err := reader.GetConnectedPostgresIdentity(t.Context())
 	require.NoError(t, err)
 	return WriterObservation{
-		DCSClusterID:     clusterID,
-		WriterGeneration: generation,
-		LeaderName:       "patroni-a",
-		ServerAddress:    identity.ServerAddress,
-		ServerPort:       identity.ServerPort,
-		Timeline:         identity.Timeline,
-		DCSProofDeadline: time.Now().Add(time.Minute),
+		PostgresSystemIdentifier: identity.SystemIdentifier,
+		WriterGeneration:         identity.Timeline,
+		ServerAddress:            identity.ServerAddress,
+		ServerPort:               identity.ServerPort,
 	}
 }
 
@@ -287,11 +235,10 @@ func leaseTestSurfaces(t *testing.T) (*LeaseStore, postgresIdentityReader) {
 	return NewLeaseStore(queries), queries
 }
 
-func observation(clusterID string, generation int64) WriterObservation {
+func observation(systemIdentifier string, generation int64) WriterObservation {
 	return WriterObservation{
-		DCSClusterID:     clusterID,
-		WriterGeneration: generation,
-		LeaderName:       "patroni-a",
+		PostgresSystemIdentifier: systemIdentifier,
+		WriterGeneration:         generation,
 	}
 }
 

--- a/server/internal/ha/types.go
+++ b/server/internal/ha/types.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/uuid"
 )
 
-// Token totally orders Fleet ownership within one DCS cluster identity.
+// Token totally orders Fleet ownership within one PostgreSQL cluster.
 type Token struct {
 	WriterGeneration int64
 	LeaseEpoch       int64
@@ -23,25 +23,22 @@ func (t Token) Compare(other Token) int {
 	)
 }
 
-// WriterObservation is a fail-closed binding between one DCS leader term and
-// the writable PostgreSQL server reached through Fleet's multi-host DSN.
+// WriterObservation identifies the writable PostgreSQL server reached through
+// Fleet's multi-host DSN. The timeline is the writer generation.
 type WriterObservation struct {
-	DCSClusterID     string
-	WriterGeneration int64
-	LeaderName       string
-	ServerAddress    string
-	ServerPort       int32
-	Timeline         int64
-	DCSProofDeadline time.Time
+	PostgresSystemIdentifier string
+	WriterGeneration         int64
+	ServerAddress            string
+	ServerPort               int32
 }
 
 // Ownership is the exact database lease identity held by one Fleet process.
 type Ownership struct {
-	DCSClusterID string
-	Token        Token
-	HolderID     uuid.UUID
-	DatabaseTime time.Time
-	ExpiresAt    time.Time
+	PostgresSystemIdentifier string
+	Token                    Token
+	HolderID                 uuid.UUID
+	DatabaseTime             time.Time
+	ExpiresAt                time.Time
 }
 
 type writerObserver interface {

--- a/server/migrations/000131_use_postgres_writer_identity.down.sql
+++ b/server/migrations/000131_use_postgres_writer_identity.down.sql
@@ -1,0 +1,12 @@
+DROP VIEW connected_postgres_identity;
+
+TRUNCATE fleet_runtime_lease;
+ALTER TABLE fleet_runtime_lease
+    RENAME COLUMN postgres_system_identifier TO dcs_cluster_id;
+
+CREATE VIEW connected_postgres_identity AS
+SELECT
+    COALESCE(host(inet_server_addr()), '')::TEXT AS server_address,
+    COALESCE(inet_server_port(), 0)::INTEGER AS server_port,
+    pg_is_in_recovery() AS in_recovery,
+    (pg_control_checkpoint()).timeline_id::BIGINT AS timeline;

--- a/server/migrations/000131_use_postgres_writer_identity.up.sql
+++ b/server/migrations/000131_use_postgres_writer_identity.up.sql
@@ -1,0 +1,20 @@
+DROP VIEW connected_postgres_identity;
+
+-- HA is not live yet, so discard the old etcd-derived singleton before
+-- changing its cluster identity source.
+TRUNCATE fleet_runtime_lease;
+ALTER TABLE fleet_runtime_lease
+    RENAME COLUMN dcs_cluster_id TO postgres_system_identifier;
+
+CREATE VIEW connected_postgres_identity AS
+SELECT
+    (pg_control_system()).system_identifier::TEXT AS system_identifier,
+    COALESCE(host(inet_server_addr()), '')::TEXT AS server_address,
+    COALESCE(inet_server_port(), 0)::INTEGER AS server_port,
+    pg_is_in_recovery() AS in_recovery,
+    CASE
+        WHEN pg_is_in_recovery() THEN 0
+        ELSE (
+            pg_split_walfile_name(pg_walfile_name(pg_current_wal_lsn()))
+        ).timeline_id
+    END::BIGINT AS timeline;

--- a/server/sqlc/queries/ha.sql
+++ b/server/sqlc/queries/ha.sql
@@ -1,5 +1,6 @@
 -- name: GetConnectedPostgresIdentity :one
 SELECT
+    system_identifier,
     server_address,
     server_port,
     in_recovery,
@@ -14,13 +15,15 @@ WITH lease_context AS (
     FROM connected_postgres_identity AS connected
     WHERE
         NOT connected.in_recovery
+        AND connected.system_identifier
+            = sqlc.arg('postgres_system_identifier')::TEXT
         AND connected.server_address = sqlc.arg('server_address')::TEXT
         AND connected.server_port = sqlc.arg('server_port')::INTEGER
-        AND connected.timeline = sqlc.arg('timeline')::BIGINT
+        AND connected.timeline = sqlc.arg('writer_generation')::BIGINT
 )
 INSERT INTO fleet_runtime_lease AS current_lease (
     lease_name,
-    dcs_cluster_id,
+    postgres_system_identifier,
     highest_writer_generation,
     lease_epoch,
     holder_id,
@@ -28,7 +31,7 @@ INSERT INTO fleet_runtime_lease AS current_lease (
 )
 SELECT
     'fleet-active',
-    sqlc.arg('dcs_cluster_id'),
+    sqlc.arg('postgres_system_identifier'),
     sqlc.arg('writer_generation'),
     1,
     sqlc.arg('holder_id'),
@@ -65,7 +68,8 @@ SET
     END
 WHERE
     -- A newer writer may supersede a live lease; same-generation takeover waits for expiry.
-    current_lease.dcs_cluster_id = EXCLUDED.dcs_cluster_id
+    current_lease.postgres_system_identifier
+        = EXCLUDED.postgres_system_identifier
     AND EXCLUDED.highest_writer_generation
         >= current_lease.highest_writer_generation
     AND (
@@ -76,7 +80,7 @@ WHERE
             <= (SELECT database_time FROM lease_context)
     )
 RETURNING
-    dcs_cluster_id,
+    postgres_system_identifier,
     highest_writer_generation,
     lease_epoch,
     holder_id,
@@ -91,9 +95,11 @@ WITH lease_context AS (
     FROM connected_postgres_identity AS connected
     WHERE
         NOT connected.in_recovery
+        AND connected.system_identifier
+            = sqlc.arg('postgres_system_identifier')::TEXT
         AND connected.server_address = sqlc.arg('server_address')::TEXT
         AND connected.server_port = sqlc.arg('server_port')::INTEGER
-        AND connected.timeline = sqlc.arg('timeline')::BIGINT
+        AND connected.timeline = sqlc.arg('writer_generation')::BIGINT
 )
 UPDATE fleet_runtime_lease
 SET
@@ -104,13 +110,13 @@ FROM lease_context
 WHERE
     -- Renewal requires the exact, unexpired ownership tuple on the expected writer.
     lease_name = 'fleet-active'
-    AND dcs_cluster_id = sqlc.arg('dcs_cluster_id')
+    AND postgres_system_identifier = sqlc.arg('postgres_system_identifier')
     AND highest_writer_generation = sqlc.arg('writer_generation')
     AND lease_epoch = sqlc.arg('lease_epoch')
     AND holder_id = sqlc.arg('holder_id')
     AND expires_at > lease_context.database_time
 RETURNING
-    fleet_runtime_lease.dcs_cluster_id,
+    fleet_runtime_lease.postgres_system_identifier,
     fleet_runtime_lease.highest_writer_generation,
     fleet_runtime_lease.lease_epoch,
     fleet_runtime_lease.holder_id,


### PR DESCRIPTION
Reviewable diff: +174/-578 across 7 files (excludes generated, test, and story files).

## Summary

Fleet can now prove which PostgreSQL primary it is connected to without interpreting Patroni's internal etcd records. It uses PostgreSQL's stable cluster identifier and promotion timeline, then asks Patroni on that same database host to confirm it still owns the primary lock. This keeps the existing database lease fence while deleting the direct etcd client, hostname resolution, lease-TTL parsing, and their associated failure modes.

Patroni still uses etcd to elect one PostgreSQL primary. Fleet simply stops depending on the layout and semantics of Patroni's etcd data.

## How it works

Patroni is the process that starts, stops, promotes, and demotes PostgreSQL. Its nodes coordinate through etcd so only one node should own the primary role. Fleet connects through a multi-host PostgreSQL URL with `target_session_attrs=read-write`, so PostgreSQL selects the currently writable node.

For every Fleet lease acquisition or renewal:

1. Fleet queries the selected PostgreSQL connection for:
   - `system_identifier`: a durable ID created with the PostgreSQL cluster and shared by all of its replicas;
   - the selected server IP and port;
   - whether the server is in recovery;
   - the live WAL timeline, which increases whenever a replica is promoted.
2. Fleet calls `GET http://<selected-database-ip>:8008/primary`.
   - Patroni returns HTTP 200 only when that node is PostgreSQL primary and still owns Patroni's leader lock.
   - Fleet compares Patroni's timeline with PostgreSQL's live WAL timeline.
3. Fleet performs the lease write on the same PostgreSQL connection. The SQL statement rechecks the system identifier, server address, server port, recovery state, and timeline as part of the write.
4. Fleet repeats the PostgreSQL and Patroni checks. If the writer changed anywhere around the lease write, the operation fails closed and the coordinator remains or becomes passive.
5. Only after the full bracket succeeds does the coordinator expose an active lifetime. A local watchdog cancels that lifetime no later than the database lease expiration.

```mermaid
flowchart LR
    E["etcd quorum"] --> P["Patroni nodes elect one primary"]
    P --> PG["Multi-host PostgreSQL connection selects read-write server"]
    PG --> ID["Read system ID, server address, and live timeline"]
    ID --> API["Call Patroni /primary on the same server IP"]
    API --> SQL["Acquire or renew Fleet database lease"]
    SQL --> VERIFY["Repeat PostgreSQL and Patroni validation"]
    VERIFY --> ACTIVE["Expose active lifetime"]
```

```mermaid
sequenceDiagram
    participant C as Fleet coordinator
    participant DB as Selected PostgreSQL server
    participant P as Patroni on selected server

    C->>DB: Read system ID, address, recovery state, live timeline
    DB-->>C: cluster-123, 10.0.0.12:5432, primary, timeline 8
    C->>P: GET /primary
    P-->>C: 200, role primary, timeline 8
    C->>DB: Acquire or renew lease for cluster-123 at timeline 8
    DB-->>C: Lease token and database expiration
    C->>DB: Read identity again
    C->>P: GET /primary again
    C->>C: Activate only if both observations are unchanged
```

### The lease row

`fleet_runtime_lease` remains a one-row database fence:

| Column | Meaning |
| --- | --- |
| `lease_name` | Fixed singleton key, `fleet-active` |
| `postgres_system_identifier` | Prevents a lease from crossing into a different PostgreSQL cluster |
| `highest_writer_generation` | The highest PostgreSQL timeline admitted so an older primary cannot take ownership back |
| `lease_epoch` | Increases when ownership changes within the same timeline |
| `holder_id` | Identifies the exact Fleet process that owns the term |
| `expires_at` | Database-time deadline after which another process may acquire ownership |

The ordered fencing token is `(writer_generation, lease_epoch)`. A promotion advances the first value, so the new writer can supersede any live lease from an older timeline, including lease state affected by asynchronous replication loss.

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/internal/ha/observer.go` | Replaces direct etcd observation with PostgreSQL identity plus a direct Patroni primary check; reuses one proxy-disabled HTTP transport and rejects redirects | Main trust boundary: the Patroni response must describe the exact server selected by PostgreSQL |
| `server/internal/ha/coordinator.go` | Uses the database lease as the watchdog deadline and compares PostgreSQL cluster/timeline identity during renewal | Determines when Fleet may report active and how quickly it demotes |
| `server/internal/ha/store.go` | Binds lease acquisition and renewal to the PostgreSQL system identifier and timeline | Preserves atomic ownership fencing inside PostgreSQL |
| `server/sqlc/queries/ha.sql` | Rechecks cluster, server, recovery, and timeline identity in each lease mutation | Prevents an observation/write race from silently granting ownership |
| `server/migrations/000131_use_postgres_writer_identity.*.sql` | Renames the ephemeral identity column and exposes PostgreSQL's system ID and live WAL timeline | Defines the persisted ownership identity and promotion generation |
| `server/internal/ha/*_test.go` | Refocuses coordinator, observer, and real-Postgres lease tests on the simplified contract | Covers fail-closed validation, races, expiry, renewal, and exact ownership |
| `server/generated/sqlc/*.go` | Regenerated query parameters and result models | Generated - skip detailed review |

## Key technical decisions & trade-offs

- PostgreSQL `system_identifier` is the cluster identity, replacing Patroni's etcd cluster ID. It is native to every primary and replica and requires no knowledge of Patroni's DCS schema.
- PostgreSQL's live WAL timeline is the writer generation. The view reads it from the current WAL filename on a primary rather than the last checkpoint, so a freshly promoted writer is visible immediately.
- Patroni `/primary` remains the proof that the selected server owns the leader lock. Fleet does not need a second etcd client, but it intentionally fails passive when Patroni is unreachable.
- The Patroni check targets the selected database IP on HTTP port 8008. That matches the supported host-network deployment profile and avoids the hostname-mapping layer this change removes.
- The migration truncates the singleton lease before renaming its identity column. HA is not live and deployments are new, so preserving an incompatible pre-activation lease would add complexity without value.
- The observer validates before and after the database mutation. The SQL mutation independently checks the same PostgreSQL identity, keeping the race window fail-closed.

## Testing & validation

- `DB_PASSWORD=fleet ../bin/go test ./internal/ha -count=1` - passes, including migrations and real-PostgreSQL lease integration tests.
- `PATH="<repo>/bin:$PATH" just lint` from `server/` - passes with 0 issues.
- `git diff --check` - clean.
- Direction-aware migration version check - `000131` has exactly one up and one down migration and is free on the latest `origin/main`.
- Disposable two-node PostgreSQL 18 + Patroni + three-node etcd proof - passes:
  - stable PostgreSQL system identifier across all nodes;
  - live timeline progression `1 -> 2 -> 3 -> 4 -> 5`;
  - two clean promotions;
  - promotion after an acknowledged asynchronous write was intentionally lost;
  - promotion after isolating the old primary from the control network;
  - former primaries rejoining as replicas;
  - final PostgreSQL timeline matching Patroni `/primary`.

The disposable failover fixture is intentionally not included in this PR. Repository-wide `just lint` reached the client step but could not run locally because client `eslint` dependencies are not installed; the affected server lint is clean.

## Post-Deploy Monitoring & Validation

This PR does not yet wire the coordinator into server startup, so its immediate deployment effect is the schema transition rather than active/passive traffic behavior.

- Before migration: `SELECT COUNT(*) FROM fleet_runtime_lease;` must return `0`.
- After migration: confirm `fleet_runtime_lease` contains `postgres_system_identifier` and no `dcs_cluster_id`.
- On the writable connection: `SELECT system_identifier, server_address, server_port, in_recovery, timeline FROM connected_postgres_identity;` must return one row with a nonempty identifier, positive port and timeline, and `in_recovery = false`.
- After runtime wiring lands: healthy behavior is one active Fleet holder, successful renewals, a stable system identifier, and a strictly increasing timeline after promotion.
- Investigate `validate Patroni primary`, `PostgreSQL writer changed during validation`, lease renewal failures, or repeated passive transitions.
- Roll back the binary and schema together only while HA remains disabled; the down migration deliberately discards the ephemeral lease row.

## New concepts

### PostgreSQL timelines as promotion fences

A PostgreSQL timeline identifies one branch of WAL history. Promoting a replica creates a new timeline, so it is a native, monotonically increasing generation for a writer term.

That makes `(timeline, lease_epoch)` a useful fence: a new primary always outranks ownership issued on an older timeline, while `lease_epoch` orders process takeovers that happen without another database promotion.

```mermaid
flowchart LR
    T7["Timeline 7: old primary"] --> PROMOTE["Replica promotion"]
    PROMOTE --> T8["Timeline 8: new primary"]
    T8 --> FENCE["Timeline 8 lease supersedes every timeline 7 lease"]
```

This is appropriate for nodes in one physical PostgreSQL cluster. It must not be used as the only cluster identity, because an unrelated PostgreSQL cluster can have the same timeline number; that is why the token is also scoped by `system_identifier`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
