### PR TITLE
feat(updates): add safe deployment upgrade primitives

### DIFF
--- a/.github/workflows/deployment-config-checks.yml
+++ b/.github/workflows/deployment-config-checks.yml
@@ -19,3 +19,6 @@ jobs:
 
       - name: Validate HA deployment profile
         run: ./deployment-files/ha/tests/test-profile.sh
+
+      - name: Validate non-interactive upgrade safety
+        run: ./deployment-files/tests/test-run-fleet-upgrade.sh

--- a/.github/workflows/proto-fleet-artifact-build.yml
+++ b/.github/workflows/proto-fleet-artifact-build.yml
@@ -49,8 +49,8 @@ jobs:
           INPUT_IS_PRERELEASE: ${{ inputs.is_prerelease }}
           INPUT_VERSION: ${{ inputs.version }}
         run: |
-          if [[ ! "$INPUT_VERSION" =~ ^[A-Za-z0-9._-]+$ ]]; then
-            echo "::error::Version '$INPUT_VERSION' must only contain letters, numbers, dots, underscores, or hyphens."
+          if [[ ! "$INPUT_VERSION" =~ ^[A-Za-z0-9_][A-Za-z0-9._-]{0,127}$ ]] || [[ "$INPUT_VERSION" == "latest" ]]; then
+            echo "::error::Version '$INPUT_VERSION' must be a release-specific Docker tag (1-128 letters, numbers, dots, underscores, or hyphens; not 'latest')."
             exit 1
           fi
 
@@ -338,6 +338,7 @@ jobs:
 
   build-timescaledb-image:
     name: Build TimescaleDB images (${{ matrix.arch }})
+    needs: [metadata]
     strategy:
       matrix:
         include:
@@ -346,6 +347,8 @@ jobs:
           - arch: arm64
             runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
+    env:
+      IMAGE_TAG: ${{ needs.metadata.outputs.version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -356,24 +359,40 @@ jobs:
       - name: Build TimescaleDB images
         run: |
           docker buildx build \
-            -t proto-fleet-timescaledb:latest \
+            --tag "proto-fleet-timescaledb:${IMAGE_TAG}" \
             --load \
             server/timescaledb
 
           docker build \
             --file deployment-files/ha/patroni.Dockerfile \
             --build-arg SOURCE_COMMIT="${GITHUB_SHA}" \
-            --tag proto-fleet-timescaledb-ha:latest \
+            --build-arg "TIMESCALEDB_IMAGE_TAG=${IMAGE_TAG}" \
+            --tag "proto-fleet-timescaledb-ha:${IMAGE_TAG}" \
             deployment-files/ha
 
           ./deployment-files/ha/tests/validate-image.sh \
-            proto-fleet-timescaledb-ha:latest \
+            "proto-fleet-timescaledb-ha:${IMAGE_TAG}" \
             "${GITHUB_SHA}"
 
           docker save \
             --output timescaledb-${{ matrix.arch }}.tar \
-            proto-fleet-timescaledb:latest \
-            proto-fleet-timescaledb-ha:latest
+            "proto-fleet-timescaledb:${IMAGE_TAG}" \
+            "proto-fleet-timescaledb-ha:${IMAGE_TAG}"
+
+          ARCHIVE_MANIFEST=$(tar -xOf timescaledb-${{ matrix.arch }}.tar manifest.json)
+          for image in \
+            "proto-fleet-timescaledb:${IMAGE_TAG}" \
+            "proto-fleet-timescaledb-ha:${IMAGE_TAG}"; do
+            if ! grep -Fq "\"${image}\"" <<<"$ARCHIVE_MANIFEST"; then
+              echo "::error::TimescaleDB archive is missing required image ${image}."
+              exit 1
+            fi
+          done
+          if grep -Fq ':latest"' <<<"$ARCHIVE_MANIFEST"; then
+            echo "::error::TimescaleDB archive must not contain shared latest tags."
+            exit 1
+          fi
+
           gzip -9 --force timescaledb-${{ matrix.arch }}.tar
           echo "${{ matrix.arch }} image size: $(du -h timescaledb-${{ matrix.arch }}.tar.gz | cut -f1)"
 
@@ -482,6 +501,8 @@ jobs:
 
           mkdir -p deployment/images
           cp /tmp/timescaledb-images/timescaledb-${{ matrix.arch }}.tar.gz deployment/images/timescaledb.tar.gz
+
+          deployment/scripts/pin-release-images.sh deployment "$VERSION"
 
       - name: Create version file
         run: |

--- a/.github/workflows/proto-fleet-artifact-build.yml
+++ b/.github/workflows/proto-fleet-artifact-build.yml
@@ -516,6 +516,12 @@ jobs:
       - name: Create immutable deployment manifest
         run: |
           cd deployment
+          unsupported_entries=$(find . ! -type f ! -type d -print)
+          if [ -n "$unsupported_entries" ]; then
+            echo "Deployment bundle contains unsupported non-regular entries:" >&2
+            printf '  %s\n' "$unsupported_entries" >&2
+            exit 1
+          fi
           find . -type f ! -path './deployment-manifest.sha256' -print0 \
             | LC_ALL=C sort -z \
             | xargs -0 sha256sum \

--- a/.github/workflows/proto-fleet-artifact-build.yml
+++ b/.github/workflows/proto-fleet-artifact-build.yml
@@ -492,6 +492,14 @@ jobs:
             echo "channel: $CHANNEL" >> deployment/version.txt
           fi
 
+      - name: Create immutable deployment manifest
+        run: |
+          cd deployment
+          find . -type f ! -path './deployment-manifest.sha256' -print0 \
+            | LC_ALL=C sort -z \
+            | xargs -0 sha256sum \
+            > deployment-manifest.sha256
+
       - name: Package ProtoFleet deployment bundle
         run: |
           tar -czf "proto-fleet-${VERSION}-${{ matrix.arch }}.tar.gz" deployment

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@ tests/plugin-contract/bin/
 
 # Generated nginx config (copied from nginx.http.conf or nginx.https.conf by run-fleet.sh)
 deployment-files/client/nginx.conf
+# Successful upgrade preflight marker, consumed after activation.
+deployment-files/.update-preflight-complete
 
 # Local HA bootstrap artifacts
 deployment-files/ha/fleet-ha

--- a/deployment-files/docker-compose.yaml
+++ b/deployment-files/docker-compose.yaml
@@ -6,6 +6,8 @@ services:
     extends:
       file: ./server/docker-compose.base.yaml
       service: fleet-api
+    image: proto-fleet-api:latest
+    pull_policy: never
     build:
       context: ./server
     environment:
@@ -55,6 +57,8 @@ services:
         compress: "true"
 
   fleet-client:
+    image: proto-fleet-client:latest
+    pull_policy: never
     build:
       context: ./client
     depends_on:

--- a/deployment-files/docker-compose.yaml
+++ b/deployment-files/docker-compose.yaml
@@ -2,6 +2,8 @@ x-extends:
   file: ./server/docker-compose.base.yaml
 
 services:
+  # Source checkouts use :latest for local builds. Release packaging replaces
+  # every Proto Fleet runtime reference with the bundle's literal version tag.
   fleet-api:
     extends:
       file: ./server/docker-compose.base.yaml

--- a/deployment-files/ha/compose.yaml
+++ b/deployment-files/ha/compose.yaml
@@ -44,6 +44,7 @@ services:
   patroni:
     profiles:
       - database
+    # Release packaging replaces this local-build tag with the bundle version.
     image: proto-fleet-timescaledb-ha:latest
     network_mode: host
     # Bootstrap needs root to copy host-owned 0600 secrets; the entrypoint drops to postgres.

--- a/deployment-files/ha/patroni.Dockerfile
+++ b/deployment-files/ha/patroni.Dockerfile
@@ -1,4 +1,5 @@
-FROM proto-fleet-timescaledb:latest
+ARG TIMESCALEDB_IMAGE_TAG=latest
+FROM proto-fleet-timescaledb:${TIMESCALEDB_IMAGE_TAG}
 
 ARG SOURCE_COMMIT=unknown
 

--- a/deployment-files/ha/tests/test-profile.sh
+++ b/deployment-files/ha/tests/test-profile.sh
@@ -71,6 +71,8 @@ test_patroni_contract() {
     assert_contains "$entrypoint" "render-patroni-config"
     assert_contains "$bootstrap" 'psql --dbname="$connection_url" --set=ON_ERROR_STOP=1'
     assert_not_contains "$bootstrap" 'PGDATABASE="$connection_url"'
+    assert_contains "$dockerfile" 'ARG TIMESCALEDB_IMAGE_TAG=latest'
+    assert_contains "$dockerfile" 'FROM proto-fleet-timescaledb:${TIMESCALEDB_IMAGE_TAG}'
 
     [[ "$(grep -E '^[[:space:]]*USER[[:space:]]+' "$dockerfile" | tail -n 1)" == "USER postgres" ]] ||
         fail "Patroni image must default to the postgres user"

--- a/deployment-files/run-fleet.sh
+++ b/deployment-files/run-fleet.sh
@@ -51,6 +51,61 @@ env_last_value() {
     printf '%s' "$value"
 }
 
+parse_compose_env_value() {
+    local value="$1"
+    local double_quoted='^"(.*)"[[:space:]]*(#.*)?$'
+    local single_quoted="^'(.*)'[[:space:]]*(#.*)?$"
+
+    value=$(printf '%s' "$value" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
+    case "$value" in
+        \"*)
+            [[ "$value" =~ $double_quoted ]] || return 2
+            value="${BASH_REMATCH[1]}"
+            ;;
+        \'*)
+            [[ "$value" =~ $single_quoted ]] || return 2
+            value="${BASH_REMATCH[1]}"
+            ;;
+        *)
+            # Compose treats # as an inline comment only when whitespace
+            # separates it from an unquoted value.
+            value=$(printf '%s' "$value" | sed -E 's/[[:space:]]+#.*$//; s/[[:space:]]+$//')
+            ;;
+    esac
+    printf '%s' "$value"
+}
+
+# Read one key using Compose's documented dotenv delimiters/comments. This is
+# separate from the older deployment-value reader above because project
+# identity must never silently fall back when a valid Compose assignment uses
+# `KEY: value` syntax. Returns 1 when absent and 2 when present but malformed.
+compose_env_last_value() {
+    local key="$1" line normalized parsed found=false
+    local assignment_re="^${key}[[:space:]]*([=:])(.*)$"
+    local malformed_re="^${key}([[:space:]]|$)"
+
+    [ -e "$ENV_FILE" ] || return 1
+    [ -f "$ENV_FILE" ] && [ -r "$ENV_FILE" ] || return 2
+    while IFS= read -r line || [ -n "$line" ]; do
+        normalized=$(printf '%s' "$line" | sed -E 's/^[[:space:]]+//')
+        case "$normalized" in
+            export[[:space:]]*)
+                normalized="${normalized#export}"
+                normalized=$(printf '%s' "$normalized" | sed -E 's/^[[:space:]]+//')
+                ;;
+        esac
+        if [[ "$normalized" =~ $assignment_re ]]; then
+            parsed=$(parse_compose_env_value "${BASH_REMATCH[2]}") || return 2
+            found=true
+        elif [[ "$normalized" =~ $malformed_re ]]; then
+            return 2
+        fi
+    done < "$ENV_FILE"
+
+    [ "$found" = "true" ] || return 1
+    printf '%s' "$parsed"
+}
+
 env_has_nonempty_value() {
     local value
     value=$(env_last_value "$1") || return 1
@@ -58,8 +113,17 @@ env_has_nonempty_value() {
 }
 
 env_boolean_is_true() {
-    local key="$1" value
-    value=$(env_last_value "$key") || return 1
+    local key="$1" value read_status
+    if value=$(compose_env_last_value "$key"); then
+        :
+    else
+        read_status=$?
+        if [ "$read_status" -eq 1 ]; then
+            return 1
+        fi
+        echo "Error: $key in $ENV_FILE uses unsupported or malformed Compose dotenv syntax." >&2
+        exit 1
+    fi
     value=$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')
     case "$value" in
         true) return 0 ;;
@@ -72,14 +136,29 @@ env_boolean_is_true() {
 }
 
 resolve_compose_project_name() {
-    local project_name
+    local project_name persisted_status
 
     if [ -n "${COMPOSE_PROJECT_NAME:-}" ]; then
         project_name="$COMPOSE_PROJECT_NAME"
     else
-        # Preserve Compose's historical per-directory project identity for
-        # source checkouts and renamed/nonstandard deployment directories.
-        project_name=$(basename "$PROJECT_ROOT")
+        project_name=$(compose_env_last_value COMPOSE_PROJECT_NAME)
+        persisted_status=$?
+        case "$persisted_status" in
+            0)
+                if [ -z "$project_name" ]; then
+                    project_name=$(basename "$PROJECT_ROOT")
+                fi
+                ;;
+            1)
+                # Preserve Compose's historical per-directory project identity
+                # when neither the process nor deployment .env selects one.
+                project_name=$(basename "$PROJECT_ROOT")
+                ;;
+            *)
+                echo "Error: COMPOSE_PROJECT_NAME in $ENV_FILE uses unsupported or malformed Compose dotenv syntax." >&2
+                return 1
+                ;;
+        esac
     fi
 
     # The same value is also used to select volumes below, so reject names
@@ -370,6 +449,89 @@ validate_timescaledb_archive_tags() {
             fi
         done
     fi
+}
+
+is_managed_release_image_tag() {
+    local tag="$1"
+    [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9][A-Za-z0-9._-]*)?$ ]] ||
+        [[ "$tag" =~ ^nightly-[0-9]{8}-[0-9a-f]{12}$ ]]
+}
+
+prune_obsolete_release_images() {
+    local repository image tag image_id containers
+    local candidates=()
+    local protected_tags=(latest "$RELEASE_IMAGE_TAG")
+
+    # Source-tree runs intentionally share mutable :latest tags and must not
+    # participate in packaged-release retention.
+    [ "$RELEASE_IMAGE_TAG" != "latest" ] || return 0
+
+    # Collect the complete candidate set before deleting anything. If Docker
+    # cannot enumerate one reserved repository, fail safe and leave every tag
+    # untouched rather than making a partial retention decision.
+    for repository in \
+        proto-fleet-api \
+        proto-fleet-client \
+        proto-fleet-timescaledb \
+        proto-fleet-timescaledb-ha; do
+        local listed_images
+        if ! listed_images=$(docker image ls --format '{{.Repository}}:{{.Tag}}' "$repository" 2>/dev/null); then
+            echo "Warning: could not inspect $repository images; skipping Proto Fleet release image cleanup." >&2
+            return 0
+        fi
+        while IFS= read -r image; do
+            [ -n "$image" ] || continue
+            case "$image" in
+                "$repository":*) ;;
+                *) continue ;;
+            esac
+            [ "${image##*:}" != "<none>" ] || continue
+            candidates+=("$image")
+        done <<< "$listed_images"
+    done
+
+    # A container may reference only three images from a four-image release
+    # (the standard and HA database images are mutually exclusive). Protect
+    # the whole release tag whenever any running or stopped container uses it.
+    for image in "${candidates[@]}"; do
+        tag="${image##*:}"
+        if [ "$tag" = "latest" ] || [ "$tag" = "$RELEASE_IMAGE_TAG" ] ||
+            ! is_managed_release_image_tag "$tag"; then
+            continue
+        fi
+        if ! image_id=$(docker image inspect --format '{{.Id}}' "$image" 2>/dev/null); then
+            echo "Warning: could not inspect obsolete Proto Fleet image $image; retaining its release tag." >&2
+            protected_tags+=("$tag")
+            continue
+        fi
+        if ! containers=$(docker container ls --all --quiet --filter "ancestor=$image_id" 2>/dev/null); then
+            echo "Warning: could not inspect containers using $image; retaining its release tag." >&2
+            protected_tags+=("$tag")
+            continue
+        fi
+        if [ -n "$containers" ]; then
+            protected_tags+=("$tag")
+        fi
+    done
+
+    for image in "${candidates[@]}"; do
+        tag="${image##*:}"
+        is_managed_release_image_tag "$tag" || continue
+        local protected=false protected_tag
+        for protected_tag in "${protected_tags[@]}"; do
+            if [ "$tag" = "$protected_tag" ]; then
+                protected=true
+                break
+            fi
+        done
+        [ "$protected" = "false" ] || continue
+
+        if ! docker image rm "$image" >/dev/null 2>&1; then
+            # Retention is best-effort housekeeping. A cleanup race or daemon
+            # error must not turn a verified upgrade into an outage.
+            echo "Warning: could not remove obsolete Proto Fleet image $image; continuing." >&2
+        fi
+    done
 }
 
 sha256() {
@@ -1202,10 +1364,12 @@ atomic_set_env_values() {
             }
         }
         {
-            separator = index($0, "=")
-            if (separator > 0) {
-                name = substr($0, 1, separator - 1)
-                sub(/[[:space:]]+$/, "", name)
+            assignment = $0
+            sub(/^[[:space:]]+/, "", assignment)
+            sub(/^export[[:space:]]+/, "", assignment)
+            if (match(assignment, /^[A-Za-z_][A-Za-z0-9_]*[[:space:]]*[:=]/)) {
+                name = substr(assignment, 1, RLENGTH)
+                sub(/[[:space:]]*[:=]$/, "", name)
                 if (name in removed) {
                     next
                 }
@@ -2101,6 +2265,7 @@ fi
 # ----------------------------------------------------------------------------
 
 echo "Cleaning up old Docker images and build cache..."
+prune_obsolete_release_images
 docker image prune -f 2>/dev/null || true
 docker builder prune -f 2>/dev/null || true
 

--- a/deployment-files/run-fleet.sh
+++ b/deployment-files/run-fleet.sh
@@ -4,16 +4,21 @@
 # Proto Fleet Installation and Setup Script
 # ============================================================================
 
-PROJECT_ROOT="$(pwd)"
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COMPOSE_FILE="$PROJECT_ROOT/docker-compose.yaml"
 COMPOSE_ALERTS_FILE="$PROJECT_ROOT/docker-compose.alerts.yaml"
 COMPOSE_SYSTEM_MONITORING_FILE="$PROJECT_ROOT/docker-compose.system-monitoring.yaml"
 COMPOSE_TRACING_FILE="$PROJECT_ROOT/docker-compose.tracing.yaml"
+COMPOSE_UPDATER_FILE="$PROJECT_ROOT/docker-compose.updater.yaml"
 ENV_FILE="$PROJECT_ROOT/.env"
 
 ENABLE_BETA_ALERTS=false
 ENABLE_SYSTEM_MONITORING=false
 ENABLE_TRACING=false
+ENABLE_ONE_CLICK_UPDATES=false
+NON_INTERACTIVE=false
+PREFLIGHT_ONLY=false
+SKIP_BUILD=false
 
 # How long the post-start steps wait for fleet-api to finish its migrations.
 # 300 x 2s = 10 minutes: a first boot on SD-card-class hardware (Raspberry Pi)
@@ -49,6 +54,17 @@ Options:
                                 the .env file. Off by default. Can also be
                                 enabled by setting ENABLE_TRACING=true in
                                 the .env file.
+  --enable-one-click-updates     Connect fleet-api to the host updater Unix
+                                socket. The installer sets this after the
+                                systemd updater is installed successfully.
+  --non-interactive              Reuse complete persisted configuration and
+                                fail instead of prompting. Intended for the
+                                host updater, not first-time setup.
+  --preflight-only               Validate configuration, load release images,
+                                and build the new stack without stopping the
+                                running deployment.
+  --skip-build                   Skip image preparation because a successful
+                                preflight already prepared this exact release.
   -h, --help                    Show this help and exit.
 EOF
 }
@@ -67,6 +83,22 @@ while [ $# -gt 0 ]; do
             ENABLE_TRACING=true
             shift
             ;;
+        --enable-one-click-updates)
+            ENABLE_ONE_CLICK_UPDATES=true
+            shift
+            ;;
+        --non-interactive)
+            NON_INTERACTIVE=true
+            shift
+            ;;
+        --preflight-only)
+            PREFLIGHT_ONLY=true
+            shift
+            ;;
+        --skip-build)
+            SKIP_BUILD=true
+            shift
+            ;;
         -h|--help)
             usage
             exit 0
@@ -83,16 +115,24 @@ while [ $# -gt 0 ]; do
     esac
 done
 
+if [ "$PREFLIGHT_ONLY" = "true" ] && [ "$SKIP_BUILD" = "true" ]; then
+    echo "Error: --preflight-only and --skip-build cannot be combined." >&2
+    exit 1
+fi
+
 # Also honor ENABLE_BETA_ALERTS=true from the .env file.
-if grep -Eqi "^ENABLE_BETA_ALERTS=true$" "$ENV_FILE" 2>/dev/null; then
+if grep -Eqi "^ENABLE_BETA_ALERTS=true[[:space:]]*$" "$ENV_FILE" 2>/dev/null; then
     ENABLE_BETA_ALERTS=true
 fi
-if grep -Eqi "^ENABLE_SYSTEM_MONITORING=true$" "$ENV_FILE" 2>/dev/null; then
+if grep -Eqi "^ENABLE_SYSTEM_MONITORING=true[[:space:]]*$" "$ENV_FILE" 2>/dev/null; then
     ENABLE_SYSTEM_MONITORING=true
 fi
 # [[:space:]]*$ tolerates CRLF line endings from Windows/WSL-edited .env files.
 if grep -Eqi "^ENABLE_TRACING=true[[:space:]]*$" "$ENV_FILE" 2>/dev/null; then
     ENABLE_TRACING=true
+fi
+if grep -Eqi "^ENABLE_ONE_CLICK_UPDATES=true[[:space:]]*$" "$ENV_FILE" 2>/dev/null; then
+    ENABLE_ONE_CLICK_UPDATES=true
 fi
 
 # System monitoring rides the alerts stack (the in-process metrics writer,
@@ -130,6 +170,13 @@ refresh_compose_files() {
     fi
     if [ "$ENABLE_TRACING" = "true" ] && [ -f "$COMPOSE_TRACING_FILE" ]; then
         COMPOSE_FILES+=(-f "$COMPOSE_TRACING_FILE")
+    fi
+    if [ "$ENABLE_ONE_CLICK_UPDATES" = "true" ]; then
+        if [ ! -f "$COMPOSE_UPDATER_FILE" ]; then
+            echo "Error: one-click updates are enabled but $COMPOSE_UPDATER_FILE is missing." >&2
+            exit 1
+        fi
+        COMPOSE_FILES+=(-f "$COMPOSE_UPDATER_FILE")
     fi
 }
 refresh_compose_files
@@ -386,6 +433,10 @@ fix_wsl_networking() {
 # ----------------------------------------------------------------------------
 
 if ! command -v docker &> /dev/null; then
+    if [ "$NON_INTERACTIVE" = "true" ]; then
+        echo "Error: Docker is not installed; non-interactive upgrade cannot install host prerequisites." >&2
+        exit 1
+    fi
     echo "Docker is not installed. Attempting to install Docker..."
 
     if [ "$(uname)" == "Linux" ]; then
@@ -409,6 +460,10 @@ fi
 if [ "$(uname)" == "Linux" ]; then
     # Check if Docker is set to start on boot
     if ! systemctl is-enabled docker &>/dev/null; then
+        if [ "$NON_INTERACTIVE" = "true" ]; then
+            echo "Error: Docker is not enabled at boot; fix the host before retrying the upgrade." >&2
+            exit 1
+        fi
         echo "Configuring Docker to start on system boot..."
         sudo systemctl enable docker
     fi
@@ -420,6 +475,10 @@ if [ "$(uname)" == "Linux" ]; then
     # for the sudo-mismatch detection in install.sh) would exit here telling
     # the user to log out and back in, leaving the upgrade half-applied.
     if [ "$(id -u)" -ne 0 ] && ! groups $USER | grep -q '\bdocker\b'; then
+        if [ "$NON_INTERACTIVE" = "true" ]; then
+            echo "Error: the upgrade user cannot access Docker." >&2
+            exit 1
+        fi
         echo "Adding current user to the docker group for passwordless Docker usage..."
         sudo usermod -aG docker $USER
         echo "Please log out and log back in to apply group changes, then re-run this script."
@@ -432,6 +491,10 @@ fi
 # ----------------------------------------------------------------------------
 
 if ! docker info > /dev/null 2>&1; then
+    if [ "$NON_INTERACTIVE" = "true" ]; then
+        echo "Error: Docker daemon is not available; non-interactive upgrade will not mutate host services." >&2
+        exit 1
+    fi
     echo "Docker daemon is not running. Starting Docker..."
 
     # For macOS, attempt to start Docker Desktop
@@ -485,6 +548,10 @@ fi
 # ----------------------------------------------------------------------------
 
 if ! docker compose version &> /dev/null; then
+    if [ "$NON_INTERACTIVE" = "true" ]; then
+        echo "Error: docker compose is not installed; non-interactive upgrade cannot install host prerequisites." >&2
+        exit 1
+    fi
     echo "docker compose is not installed. Attempting to install it..."
 
     if [ "$(uname)" == "Linux" ]; then
@@ -582,7 +649,9 @@ prompt_fleet_profile() {
 # curl | bash installs reach prompts with stdin at EOF; never let an
 # unanswered prompt persist a profile
 maybe_prompt_fleet_profile() {
-    if [ -t 0 ]; then
+    if [ "$NON_INTERACTIVE" = "true" ]; then
+        echo "No FLEET_PROFILE is persisted; keeping the existing conservative defaults."
+    elif [ -t 0 ]; then
         prompt_fleet_profile
     else
         echo "Hint: host profiles are available; set FLEET_PROFILE=standard|mini|max in $ENV_FILE and re-run to tune for this hardware."
@@ -610,8 +679,12 @@ if [ -f "$ENV_FILE" ]; then
     done
 
     if [ $missing_keys -eq 0 ]; then
-        echo -n "Existing environment file found with all required keys. Use it? (Y/n): "
-        read use_existing_creds
+        if [ "$NON_INTERACTIVE" = "true" ]; then
+            use_existing_creds="y"
+        else
+            echo -n "Existing environment file found with all required keys. Use it? (Y/n): "
+            read use_existing_creds
+        fi
         if [[ -z "$use_existing_creds" || $use_existing_creds =~ ^[Yy]$ ]]; then
             use_existing="yes"
             echo "Using existing environment file."
@@ -623,9 +696,18 @@ if [ -f "$ENV_FILE" ]; then
             prompt_store_reinit || { echo "Aborting due to existing data volume."; exit 1; }
         fi
     else
+        if [ "$NON_INTERACTIVE" = "true" ]; then
+            echo "Error: existing environment file is incomplete; refusing to regenerate secrets during an upgrade." >&2
+            exit 1
+        fi
         echo "Existing environment file is incomplete. Regenerating…"
         prompt_store_reinit || { echo "Cannot proceed with incomplete env + existing data."; exit 1; }
     fi
+fi
+
+if [ "$NON_INTERACTIVE" = "true" ] && [ "$use_existing" = "no" ]; then
+    echo "Error: non-interactive mode requires an existing complete $ENV_FILE." >&2
+    exit 1
 fi
 
 # ----------------------------------------------------------------------------
@@ -707,6 +789,31 @@ if [ "$use_existing" == "no" ]; then
     chmod 600 "$ENV_FILE"
     echo "Environment variables saved to $ENV_FILE"
 fi
+
+# Persist every deployment overlay as explicit state. Historically, flags were
+# process-only, so the next upgrade could silently disable alerts, monitoring,
+# or tracing. Last value wins, matching Compose's .env behavior.
+persist_boolean_setting() {
+    local key="$1"
+    local value="$2"
+    local temp
+    temp=$(mktemp)
+    grep -v "^${key}=" "$ENV_FILE" > "$temp" || true
+    if [ -s "$temp" ] && [ -n "$(tail -c1 "$temp")" ]; then
+        echo >> "$temp"
+    fi
+    echo "${key}=${value}" >> "$temp"
+    cat "$temp" > "$ENV_FILE"
+    rm -f "$temp"
+}
+
+persist_boolean_setting ENABLE_BETA_ALERTS "$ENABLE_BETA_ALERTS"
+persist_boolean_setting ENABLE_SYSTEM_MONITORING "$ENABLE_SYSTEM_MONITORING"
+persist_boolean_setting ENABLE_TRACING "$ENABLE_TRACING"
+persist_boolean_setting ENABLE_ONE_CLICK_UPDATES "$ENABLE_ONE_CLICK_UPDATES"
+chmod 600 "$ENV_FILE"
+refresh_compose_files
+refresh_compose_env_args
 
 # ----------------------------------------------------------------------------
 # Docker Compose File Validation
@@ -807,6 +914,14 @@ if [ -f "$SSL_CERT" ] && [ -f "$SSL_KEY" ]; then
     echo "  Private Key: $SSL_KEY"
     PROTOCOL_MODE="https"
 else
+    if [ "$NON_INTERACTIVE" = "true" ]; then
+        if grep -Eqi "^SESSION_COOKIE_SECURE=true[[:space:]]*$" "$ENV_FILE"; then
+            echo "Error: HTTPS is persisted but its certificate/key are missing; refusing to switch protocol during upgrade." >&2
+            exit 1
+        fi
+        echo "No SSL certificates found; preserving HTTP mode from $ENV_FILE."
+        PROTOCOL_MODE="http"
+    else
     echo ""
     echo "No SSL certificates found in $SSL_DIR"
     echo ""
@@ -842,6 +957,7 @@ else
             PROTOCOL_MODE="http"
             ;;
     esac
+    fi
 fi
 
 echo ""
@@ -882,26 +998,38 @@ refresh_compose_env_args
 # Docker Image Preparation
 # ----------------------------------------------------------------------------
 
-echo "Pulling latest Docker images..."
-compose pull
-
-# Load pre-built TimescaleDB image if available (built in CI for the target architecture)
-TSDB_IMAGE="$PROJECT_ROOT/images/timescaledb.tar.gz"
-if [ -f "$TSDB_IMAGE" ]; then
-    echo "Loading pre-built TimescaleDB image..."
-    if gunzip -c "$TSDB_IMAGE" | docker load; then
-        echo "TimescaleDB image loaded successfully."
-    else
-        echo "Error: Failed to load TimescaleDB image from $TSDB_IMAGE"
+if [ "$SKIP_BUILD" != "true" ]; then
+    echo "Pulling latest Docker images..."
+    if ! compose pull; then
+        echo "Error: Failed to pull required Docker images."
         exit 1
     fi
+
+    # Load pre-built TimescaleDB image if available (built in CI for the target architecture)
+    TSDB_IMAGE="$PROJECT_ROOT/images/timescaledb.tar.gz"
+    if [ -f "$TSDB_IMAGE" ]; then
+        echo "Loading pre-built TimescaleDB image..."
+        if gunzip -c "$TSDB_IMAGE" | docker load; then
+            echo "TimescaleDB image loaded successfully."
+        else
+            echo "Error: Failed to load TimescaleDB image from $TSDB_IMAGE"
+            exit 1
+        fi
+    else
+        echo "Warning: Pre-built TimescaleDB image not found at $TSDB_IMAGE."
+        echo "The deployment will fail unless the image 'proto-fleet-timescaledb:latest' already exists locally."
+    fi
+
+    # Build Docker images (fleet-api and fleet-client only; TimescaleDB uses pre-built image)
+    compose build --no-cache || { echo "Error: Build failed. Exiting."; exit 1; }
 else
-    echo "Warning: Pre-built TimescaleDB image not found at $TSDB_IMAGE."
-    echo "The deployment will fail unless the image 'proto-fleet-timescaledb:latest' already exists locally."
+    echo "Skipping image preparation; this release already passed updater preflight."
 fi
 
-# Build Docker images (fleet-api and fleet-client only; TimescaleDB uses pre-built image)
-compose build --no-cache || { echo "Error: Build failed. Exiting."; exit 1; }
+if [ "$PREFLIGHT_ONLY" = "true" ]; then
+    echo "Upgrade preflight completed successfully; the running stack was not stopped."
+    exit 0
+fi
 
 # ----------------------------------------------------------------------------
 # Service Management

--- a/deployment-files/run-fleet.sh
+++ b/deployment-files/run-fleet.sh
@@ -15,6 +15,7 @@ VERSION_FILE="$PROJECT_ROOT/version.txt"
 RELEASE_MANIFEST_FILE="$PROJECT_ROOT/deployment-manifest.sha256"
 TSDB_IMAGE="$PROJECT_ROOT/images/timescaledb.tar.gz"
 PREFLIGHT_MARKER="$PROJECT_ROOT/.update-preflight-complete"
+NGINX_CONFIG_TEMP=""
 
 # Preserve process-level Compose overrides before the script initializes its
 # runtime flags with the same names. Plain shell assignment keeps an inherited
@@ -700,12 +701,25 @@ find_immutable_release_entries() {
     find_release_entries ! -path './deployment-manifest.sha256' "$@"
 }
 
+validate_generated_runtime_entries() {
+    local nginx_config="$PROJECT_ROOT/client/nginx.conf"
+
+    # Generated state stays outside the immutable manifest, but excluding its
+    # contents must not also permit a symlink, FIFO, device, or directory at
+    # the path the privileged runner replaces.
+    if [ -L "$nginx_config" ] || { [ -e "$nginx_config" ] && [ ! -f "$nginx_config" ]; }; then
+        echo "Error: generated nginx config $nginx_config must be a regular, non-symlink file when present." >&2
+        return 1
+    fi
+}
+
 verify_release_manifest() {
     local manifest_name="${RELEASE_MANIFEST_FILE##*/}" manifest_paths current_paths unsupported_entries
     if [ ! -f "$RELEASE_MANIFEST_FILE" ]; then
         echo "Error: upgrade preflight requires the immutable release manifest at $RELEASE_MANIFEST_FILE." >&2
         return 1
     fi
+    validate_generated_runtime_entries || return 1
 
     # Validate and extract the GNU sha256sum path column before asking a
     # checksum utility to open anything. Release paths must stay below the
@@ -1106,20 +1120,72 @@ generate_self_signed_cert() {
     echo "      into your browser/OS trust store."
 }
 
-# Copy appropriate nginx configuration based on protocol mode
+cleanup_nginx_config_temp() {
+    if [ -n "$NGINX_CONFIG_TEMP" ]; then
+        if ! rm -f "$NGINX_CONFIG_TEMP"; then
+            echo "Warning: could not remove temporary nginx config $NGINX_CONFIG_TEMP." >&2
+            return 1
+        fi
+        NGINX_CONFIG_TEMP=""
+    fi
+    return 0
+}
+
+abort_nginx_config_write() {
+    echo "Error: $1" >&2
+    cleanup_nginx_config_temp || true
+    return 1
+}
+
+# Copy appropriate nginx configuration based on protocol mode. Build the
+# replacement beside its destination and rename it over the stable directory
+# entry; this prevents a planted symlink or hard link from being truncated.
+# Concurrent control of the parent directory is outside this shell-level
+# defense and is excluded by the updater's trusted deployment-owner model.
 copy_nginx_config() {
     local mode="$1"
     local src_conf="$NGINX_CONF_DIR/nginx.${mode}.conf"
+    local dest_conf="$NGINX_CONF_DIR/nginx.conf"
 
-    if [ ! -f "$src_conf" ]; then
-        echo "Error: nginx config not found: $src_conf"
+    if [ ! -d "$NGINX_CONF_DIR" ] || [ -L "$NGINX_CONF_DIR" ]; then
+        echo "Error: nginx config parent $NGINX_CONF_DIR must be a real directory, not a symlink." >&2
+        return 1
+    fi
+    if [ ! -f "$src_conf" ] || [ -L "$src_conf" ]; then
+        echo "Error: nginx config source $src_conf must be a regular, non-symlink file." >&2
+        return 1
+    fi
+    if [ -L "$dest_conf" ] || { [ -e "$dest_conf" ] && [ ! -f "$dest_conf" ]; }; then
+        echo "Error: generated nginx config $dest_conf must be a regular, non-symlink file when present." >&2
         return 1
     fi
 
-    if ! cp "$src_conf" "$NGINX_CONF_DIR/nginx.conf"; then
-        echo "Error: Failed to copy nginx config"
+    NGINX_CONFIG_TEMP=$(umask 077; mktemp "$NGINX_CONF_DIR/.nginx.conf.tmp.XXXXXX") || {
+        NGINX_CONFIG_TEMP=""
+        echo "Error: could not create a temporary nginx config beside $dest_conf." >&2
+        return 1
+    }
+    if ! cp "$src_conf" "$NGINX_CONFIG_TEMP"; then
+        abort_nginx_config_write "could not write the temporary nginx config"
         return 1
     fi
+    if ! chmod 644 "$NGINX_CONFIG_TEMP"; then
+        abort_nginx_config_write "could not set permissions on the temporary nginx config"
+        return 1
+    fi
+    # Recheck the stable parent and destination immediately before replacement
+    # so a planted directory, symlink, or FIFO fails clearly. This narrows the
+    # check/write interval but is not a lock against a concurrent parent owner.
+    if [ ! -d "$NGINX_CONF_DIR" ] || [ -L "$NGINX_CONF_DIR" ] ||
+        [ -L "$dest_conf" ] || { [ -e "$dest_conf" ] && [ ! -f "$dest_conf" ]; }; then
+        abort_nginx_config_write "$dest_conf changed to a non-regular path during configuration"
+        return 1
+    fi
+    if ! mv -f "$NGINX_CONFIG_TEMP" "$dest_conf"; then
+        abort_nginx_config_write "could not atomically replace $dest_conf"
+        return 1
+    fi
+    NGINX_CONFIG_TEMP=""
 }
 
 # Detect if running inside WSL
@@ -1410,8 +1476,8 @@ abort_env_rewrite() {
 }
 
 # Keep cleanup in the main shell so a supervisor signalling only the runner
-# cannot leave a child rewrite process behind.
-trap cleanup_env_rewrite EXIT
+# cannot leave a partial generated config or environment rewrite behind.
+trap 'cleanup_nginx_config_temp || true; cleanup_env_rewrite || true' EXIT
 trap 'exit 129' HUP
 trap 'exit 130' INT
 trap 'exit 143' TERM

--- a/deployment-files/run-fleet.sh
+++ b/deployment-files/run-fleet.sh
@@ -1109,16 +1109,149 @@ for flag in --wait --wait-timeout --no-build --pull; do
     fi
 done
 
-scrub_env_key() {
-    local key="$1"
-    local tmp
-    if grep -Eq "^${key}[[:space:]]*=" "$ENV_FILE" 2>/dev/null; then
-        tmp=$(mktemp)
-        grep -Ev "^${key}[[:space:]]*=" "$ENV_FILE" > "$tmp" || true
-        # Overwrite in place to preserve the 0600 perms set elsewhere.
-        cat "$tmp" > "$ENV_FILE"
-        rm -f "$tmp"
+# Replace exact keys without ever truncating the live environment file. The
+# temporary file lives beside .env so the final rename is atomic, while the
+# checked ownership handoff preserves access for deployments upgraded by a
+# root-owned service on behalf of a non-root operator.
+file_owner_group() {
+    local owner_group
+    if owner_group=$(stat -c '%u:%g' "$1" 2>/dev/null); then
+        :
+    elif owner_group=$(stat -f '%u:%g' "$1" 2>/dev/null); then
+        :
+    else
+        return 1
     fi
+    [ -n "$owner_group" ] || return 1
+    printf '%s' "$owner_group"
+}
+
+ENV_REWRITE_TEMP=""
+
+cleanup_env_rewrite() {
+    if [ -n "$ENV_REWRITE_TEMP" ]; then
+        if ! rm -f "$ENV_REWRITE_TEMP"; then
+            echo "Warning: could not remove temporary environment file $ENV_REWRITE_TEMP." >&2
+            return 1
+        fi
+        ENV_REWRITE_TEMP=""
+    fi
+    return 0
+}
+
+abort_env_rewrite() {
+    echo "Error: $1; the original was not changed." >&2
+    cleanup_env_rewrite || true
+    return 1
+}
+
+# Keep cleanup in the main shell so a supervisor signalling only the runner
+# cannot leave a child rewrite process behind.
+trap cleanup_env_rewrite EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+atomic_set_env_values() {
+    local key value key_csv original_owner temp_owner last_byte assignment
+    local -a removed_keys=()
+    local -a assignments=()
+
+    if [ "$#" -eq 0 ] || [ $(( $# % 2 )) -ne 0 ]; then
+        echo "Error: environment updates require key/value pairs." >&2
+        return 1
+    fi
+    while [ "$#" -gt 0 ]; do
+        key="$1"
+        value="$2"
+        shift 2
+        if [[ ! "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+            echo "Error: invalid environment key: $key" >&2
+            return 1
+        fi
+        if [[ "$value" == *$'\n'* || "$value" == *$'\r'* ]]; then
+            echo "Error: refusing to persist a multiline value for $key." >&2
+            return 1
+        fi
+        removed_keys+=("$key")
+        assignments+=("${key}=${value}")
+    done
+
+    if [ ! -f "$ENV_FILE" ] || [ -L "$ENV_FILE" ]; then
+        echo "Error: $ENV_FILE must be a regular, non-symlink file." >&2
+        return 1
+    fi
+
+    key_csv=$(IFS=,; printf '%s' "${removed_keys[*]}")
+
+    original_owner=$(file_owner_group "$ENV_FILE") || {
+        abort_env_rewrite "could not read owner/group metadata from $ENV_FILE"
+        return 1
+    }
+    ENV_REWRITE_TEMP=$(umask 077; mktemp "${ENV_FILE}.tmp.XXXXXX") || {
+        ENV_REWRITE_TEMP=""
+        abort_env_rewrite "could not create a temporary environment file next to $ENV_FILE"
+        return 1
+    }
+
+    if ! awk -v keys="$key_csv" '
+        BEGIN {
+            count = split(keys, names, ",")
+            for (i = 1; i <= count; i++) {
+                removed[names[i]] = 1
+            }
+        }
+        {
+            separator = index($0, "=")
+            if (separator > 0) {
+                name = substr($0, 1, separator - 1)
+                sub(/[[:space:]]+$/, "", name)
+                if (name in removed) {
+                    next
+                }
+            }
+            print
+        }
+    ' "$ENV_FILE" > "$ENV_REWRITE_TEMP"; then
+        abort_env_rewrite "could not build a replacement for $ENV_FILE"
+        return 1
+    fi
+
+    if [ -s "$ENV_REWRITE_TEMP" ]; then
+        last_byte=$(tail -c 1 "$ENV_REWRITE_TEMP") || {
+            abort_env_rewrite "could not inspect the temporary environment file"
+            return 1
+        }
+        if [ -n "$last_byte" ] && ! printf '\n' >> "$ENV_REWRITE_TEMP"; then
+            abort_env_rewrite "could not complete the temporary environment file"
+            return 1
+        fi
+    fi
+    for assignment in "${assignments[@]}"; do
+        if ! printf '%s\n' "$assignment" >> "$ENV_REWRITE_TEMP"; then
+            abort_env_rewrite "could not write the temporary environment file"
+            return 1
+        fi
+    done
+
+    temp_owner=$(file_owner_group "$ENV_REWRITE_TEMP") || {
+        abort_env_rewrite "could not read owner/group metadata from the temporary environment file"
+        return 1
+    }
+    if [ "$temp_owner" != "$original_owner" ] && ! chown "$original_owner" "$ENV_REWRITE_TEMP"; then
+        abort_env_rewrite "could not preserve owner/group for $ENV_FILE"
+        return 1
+    fi
+    if ! chmod 600 "$ENV_REWRITE_TEMP"; then
+        abort_env_rewrite "could not restrict permissions on the replacement for $ENV_FILE"
+        return 1
+    fi
+    if ! mv -f "$ENV_REWRITE_TEMP" "$ENV_FILE"; then
+        abort_env_rewrite "could not atomically replace $ENV_FILE"
+        return 1
+    fi
+
+    ENV_REWRITE_TEMP=""
 }
 
 # ----------------------------------------------------------------------------
@@ -1325,25 +1458,16 @@ fi
 
 # Persist every deployment overlay as explicit state. Historically, flags were
 # process-only, so the next upgrade could silently disable alerts, monitoring,
-# or tracing. Last value wins, matching Compose's .env behavior.
-persist_boolean_setting() {
-    local key="$1"
-    local value="$2"
-    local temp
-    temp=$(mktemp)
-    grep -Ev "^${key}[[:space:]]*=" "$ENV_FILE" > "$temp" || true
-    if [ -s "$temp" ] && [ -n "$(tail -c1 "$temp")" ]; then
-        echo >> "$temp"
-    fi
-    echo "${key}=${value}" >> "$temp"
-    cat "$temp" > "$ENV_FILE"
-    rm -f "$temp"
-}
-
-persist_boolean_setting ENABLE_BETA_ALERTS "$ENABLE_BETA_ALERTS"
-persist_boolean_setting ENABLE_SYSTEM_MONITORING "$ENABLE_SYSTEM_MONITORING"
-persist_boolean_setting ENABLE_TRACING "$ENABLE_TRACING"
-chmod 600 "$ENV_FILE"
+# or tracing. Replace the three values as one transaction so a failure cannot
+# leave partially updated state. Last value wins, matching Compose's .env
+# behavior.
+if ! atomic_set_env_values \
+    ENABLE_BETA_ALERTS "$ENABLE_BETA_ALERTS" \
+    ENABLE_SYSTEM_MONITORING "$ENABLE_SYSTEM_MONITORING" \
+    ENABLE_TRACING "$ENABLE_TRACING"; then
+    echo "Error: could not persist deployment overlay settings; aborting before Compose validation or service changes." >&2
+    exit 1
+fi
 refresh_compose_files
 refresh_compose_env_args
 
@@ -1372,13 +1496,17 @@ if [ "$ENABLE_BETA_ALERTS" = "true" ]; then
     fi
 
     if ! env_has_nonempty_value GRAFANA_DB_USERNAME; then
-        scrub_env_key GRAFANA_DB_USERNAME
-        echo "GRAFANA_DB_USERNAME=grafana_ro" >> "$ENV_FILE"
+        if ! atomic_set_env_values GRAFANA_DB_USERNAME grafana_ro; then
+            echo "Error: could not persist the Grafana database username." >&2
+            exit 1
+        fi
     fi
     if ! env_has_nonempty_value GRAFANA_DB_PASSWORD; then
-        scrub_env_key GRAFANA_DB_PASSWORD
         GRAFANA_DB_PASSWORD=$(openssl rand -base64 24)
-        echo "GRAFANA_DB_PASSWORD=$GRAFANA_DB_PASSWORD" >> "$ENV_FILE"
+        if ! atomic_set_env_values GRAFANA_DB_PASSWORD "$GRAFANA_DB_PASSWORD"; then
+            echo "Error: could not persist the generated Grafana database password." >&2
+            exit 1
+        fi
         echo "Generated Grafana DB password (stored in $ENV_FILE)."
     fi
 
@@ -1537,12 +1665,14 @@ fi
 
 # Update environment file with cookie security setting.
 if [ "$PROTOCOL_MODE" == "https" ]; then
-    persist_boolean_setting SESSION_COOKIE_SECURE true
+    cookie_secure=true
 else
-    persist_boolean_setting SESSION_COOKIE_SECURE false
+    cookie_secure=false
 fi
-
-chmod 600 "$ENV_FILE"
+if ! atomic_set_env_values SESSION_COOKIE_SECURE "$cookie_secure"; then
+    echo "Error: could not persist the session cookie security setting; aborting before Compose validation or service changes." >&2
+    exit 1
+fi
 
 # Pick up FLEET_PROFILE written during env setup
 refresh_compose_env_args
@@ -1938,9 +2068,10 @@ provision_grafana_service_account_token() {
         return 1
     fi
 
-    scrub_env_key FLEET_ALERTS_GRAFANA_TOKEN
-    echo "FLEET_ALERTS_GRAFANA_TOKEN=$token" >> "$ENV_FILE"
-    chmod 600 "$ENV_FILE"
+    if ! atomic_set_env_values FLEET_ALERTS_GRAFANA_TOKEN "$token"; then
+        echo "Error: could not persist the Grafana service-account token." >&2
+        return 1
+    fi
     echo "Provisioned Grafana service-account token for fleet-api (stored in $ENV_FILE)."
 
     echo "Restarting fleet-api to pick up the Grafana token…"

--- a/deployment-files/run-fleet.sh
+++ b/deployment-files/run-fleet.sh
@@ -10,6 +10,8 @@ COMPOSE_ALERTS_FILE="$PROJECT_ROOT/docker-compose.alerts.yaml"
 COMPOSE_SYSTEM_MONITORING_FILE="$PROJECT_ROOT/docker-compose.system-monitoring.yaml"
 COMPOSE_TRACING_FILE="$PROJECT_ROOT/docker-compose.tracing.yaml"
 ENV_FILE="$PROJECT_ROOT/.env"
+VERSION_FILE="$PROJECT_ROOT/version.txt"
+TSDB_IMAGE="$PROJECT_ROOT/images/timescaledb.tar.gz"
 PREFLIGHT_MARKER="$PROJECT_ROOT/.update-preflight-complete"
 
 ENABLE_BETA_ALERTS=false
@@ -18,6 +20,7 @@ ENABLE_TRACING=false
 NON_INTERACTIVE=false
 PREFLIGHT_ONLY=false
 SKIP_BUILD=false
+PREFLIGHT_FINGERPRINT=""
 
 # How long the post-start steps wait for fleet-api to finish its migrations.
 # 300 x 2s = 10 minutes: a first boot on SD-card-class hardware (Raspberry Pi)
@@ -235,6 +238,150 @@ compose() {
     docker compose ${COMPOSE_ENV_ARGS[@]+"${COMPOSE_ENV_ARGS[@]}"} "${COMPOSE_FILES[@]}" "$@"
 }
 
+sha256() {
+    local output
+    if command -v sha256sum >/dev/null 2>&1; then
+        output=$(sha256sum "$@") || return 1
+    elif command -v shasum >/dev/null 2>&1; then
+        output=$(shasum -a 256 "$@") || return 1
+    else
+        echo "Error: SHA-256 support requires sha256sum or shasum." >&2
+        return 1
+    fi
+    printf '%s\n' "$output" | awk '{print $1}'
+}
+
+project_relative_path() {
+    case "$1" in
+        "$PROJECT_ROOT"/*) printf '%s' "${1#"$PROJECT_ROOT"/}" ;;
+        *) printf '%s' "$1" ;;
+    esac
+}
+
+compose_config_hash() {
+    local rendered hash status
+    rendered=$(mktemp) || {
+        echo "Error: could not create a temporary file for Compose validation." >&2
+        return 1
+    }
+    if ! compose config > "$rendered"; then
+        rm -f "$rendered"
+        echo "Error: could not render Docker Compose configuration for preflight verification." >&2
+        return 1
+    fi
+
+    # Compose resolves bind/build paths to the staging directory. The updater
+    # renames that directory into place between preflight and activation, so
+    # redact only that literal prefix before hashing the normalized model.
+    hash=$(awk -v root="$PROJECT_ROOT" '
+        {
+            line = $0
+            normalized = ""
+            while ((position = index(line, root)) > 0) {
+                normalized = normalized substr(line, 1, position - 1) "<PROJECT_ROOT>"
+                line = substr(line, position + length(root))
+            }
+            print normalized line
+        }
+    ' "$rendered" | sha256)
+    status=$?
+    rm -f "$rendered"
+    [ "$status" -eq 0 ] || return "$status"
+    printf '%s' "$hash"
+}
+
+write_preflight_metadata() {
+    local config_hash digest file relative index
+
+    for file in "$VERSION_FILE" "$ENV_FILE" "$TSDB_IMAGE" "$PROJECT_ROOT/run-fleet.sh" "$NGINX_CONF_DIR/nginx.conf"; do
+        if [ ! -f "$file" ]; then
+            echo "Error: upgrade preflight metadata requires $file." >&2
+            return 1
+        fi
+    done
+
+    config_hash=$(compose_config_hash) || return 1
+    printf 'format=1\n'
+    digest=$(sha256 "$VERSION_FILE") || return 1
+    printf 'release_manifest_sha256=%s\n' "$digest"
+    digest=$(sha256 "$PROJECT_ROOT/run-fleet.sh") || return 1
+    printf 'runner_sha256=%s\n' "$digest"
+    digest=$(sha256 "$NGINX_CONF_DIR/nginx.conf") || return 1
+    printf 'nginx_config_sha256=%s\n' "$digest"
+    printf 'compose_config_sha256=%s\n' "$config_hash"
+    printf 'feature_state=alerts:%s,system_monitoring:%s,tracing:%s,protocol:%s\n' \
+        "$ENABLE_BETA_ALERTS" "$ENABLE_SYSTEM_MONITORING" "$ENABLE_TRACING" "$PROTOCOL_MODE"
+
+    for ((index = 1; index < ${#COMPOSE_FILES[@]}; index += 2)); do
+        file="${COMPOSE_FILES[$index]}"
+        relative=$(project_relative_path "$file")
+        digest=$(sha256 "$file") || return 1
+        printf 'compose_file=%s:%s\n' "$relative" "$digest"
+    done
+
+    for ((index = 1; index < ${#COMPOSE_ENV_ARGS[@]}; index += 2)); do
+        file="${COMPOSE_ENV_ARGS[$index]}"
+        relative=$(project_relative_path "$file")
+        digest=$(sha256 "$file") || return 1
+        printf 'compose_env_file=%s:%s\n' "$relative" "$digest"
+    done
+
+    digest=$(sha256 "$TSDB_IMAGE") || return 1
+    printf 'timescaledb_archive_sha256=%s\n' "$digest"
+}
+
+preflight_fingerprint() {
+    local metadata
+    metadata=$(write_preflight_metadata) || return 1
+    printf '%s' "$metadata" | sha256
+}
+
+record_preflight_marker() {
+    local prepared_fingerprint="$1" current_fingerprint temporary_marker
+    current_fingerprint=$(preflight_fingerprint) || return 1
+    if [ "$current_fingerprint" != "$prepared_fingerprint" ]; then
+        echo "Error: release or configuration changed during preflight; run preflight again." >&2
+        return 1
+    fi
+    temporary_marker=$(umask 077; mktemp "$PREFLIGHT_MARKER.tmp.XXXXXX") || return 1
+    if ! printf 'proto-fleet-preflight-v1:%s\n' "$prepared_fingerprint" > "$temporary_marker"; then
+        rm -f "$temporary_marker"
+        return 1
+    fi
+    if ! chmod 600 "$temporary_marker"; then
+        rm -f "$temporary_marker"
+        return 1
+    fi
+    if ! mv -f "$temporary_marker" "$PREFLIGHT_MARKER"; then
+        rm -f "$temporary_marker"
+        return 1
+    fi
+}
+
+verify_preflight_marker() {
+    local actual expected
+    if [ ! -f "$PREFLIGHT_MARKER" ]; then
+        echo "Error: --skip-build requires a successful preflight for this deployment." >&2
+        return 1
+    fi
+
+    if ! expected=$(preflight_fingerprint); then
+        if ! rm -f "$PREFLIGHT_MARKER"; then
+            echo "Error: preflight verification failed and the stale marker could not be removed." >&2
+        fi
+        return 1
+    fi
+    actual=$(cat "$PREFLIGHT_MARKER") || return 1
+    if [ "$actual" != "proto-fleet-preflight-v1:$expected" ]; then
+        if ! rm -f "$PREFLIGHT_MARKER"; then
+            echo "Error: preflight inputs changed and the stale marker could not be removed." >&2
+            return 1
+        fi
+        echo "Error: release or configuration changed after preflight; run preflight again before activation." >&2
+        return 1
+    fi
+}
+
 # Poll psql until the query returns true; caller owns the warning.
 wait_for_psql_true() {
     local query="$1" attempt result
@@ -283,8 +430,33 @@ validate_base64_key() {
     return 0  # Valid
 }
 
+validate_grafana_db_role_names() {
+    local grafana_user="$1" db_name="$2" app_user="$3"
+
+    # These values are spliced into SQL as quoted identifiers. Restrict them
+    # to PostgreSQL's safe identifier shape and reject roles that can never be
+    # used as the dedicated, least-privilege Grafana reader.
+    if ! [[ "$grafana_user" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+        echo "Error: GRAFANA_DB_USERNAME must be a valid SQL identifier (got: $grafana_user)" >&2
+        return 1
+    fi
+    if ! [[ "$db_name" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+        echo "Error: DB_NAME must be a valid SQL identifier (got: $db_name)" >&2
+        return 1
+    fi
+    if [ "$grafana_user" = "$app_user" ] || [ "$grafana_user" = "postgres" ]; then
+        echo "Error: GRAFANA_DB_USERNAME ('$grafana_user') must not match the application DB role ('$app_user') or the postgres superuser." >&2
+        echo "       Pick a dedicated read-only role name (e.g. grafana_ro) and re-run." >&2
+        return 1
+    fi
+    if [[ "$grafana_user" = pg_* ]]; then
+        echo "Error: GRAFANA_DB_USERNAME must not use PostgreSQL's reserved pg_ role prefix (got: $grafana_user)" >&2
+        return 1
+    fi
+}
+
 validate_non_interactive_environment() {
-    local key auth_secret encryption_key invalid=0
+    local key auth_secret encryption_key grafana_user db_name app_user invalid=0
     local -a alert_keys=(
         GRAFANA_ADMIN_PASSWORD
         GRAFANA_DB_USERNAME
@@ -320,6 +492,14 @@ validate_non_interactive_environment() {
                 invalid=1
             fi
         done
+        grafana_user=$(env_last_value GRAFANA_DB_USERNAME 2>/dev/null || true)
+        db_name=$(env_last_value DB_NAME 2>/dev/null || true)
+        db_name="${db_name:-fleet}"
+        app_user=$(env_last_value DB_USERNAME 2>/dev/null || true)
+        if [ -n "$grafana_user" ] && [ -n "$app_user" ] && \
+            ! validate_grafana_db_role_names "$grafana_user" "$db_name" "$app_user"; then
+            invalid=1
+        fi
     fi
 
     [ "$invalid" -eq 0 ]
@@ -1077,6 +1257,18 @@ if ! compose config --quiet; then
     exit 1
 fi
 
+if [ "$SKIP_BUILD" = "true" ]; then
+    if ! verify_preflight_marker; then
+        echo "Error: --skip-build can only activate the unchanged release prepared by preflight." >&2
+        exit 1
+    fi
+elif [ "$PREFLIGHT_ONLY" = "true" ]; then
+    PREFLIGHT_FINGERPRINT=$(preflight_fingerprint) || {
+        echo "Error: could not fingerprint the release before preflight." >&2
+        exit 1
+    }
+fi
+
 # ----------------------------------------------------------------------------
 # Docker Image Preparation
 # ----------------------------------------------------------------------------
@@ -1089,7 +1281,6 @@ if [ "$SKIP_BUILD" != "true" ]; then
     fi
 
     # Load pre-built TimescaleDB image if available (built in CI for the target architecture)
-    TSDB_IMAGE="$PROJECT_ROOT/images/timescaledb.tar.gz"
     if [ -f "$TSDB_IMAGE" ]; then
         if ! gunzip -c "$TSDB_IMAGE" | tar -xOf - manifest.json 2>/dev/null | grep -q '"proto-fleet-timescaledb:latest"'; then
             echo "Error: $TSDB_IMAGE does not contain the required proto-fleet-timescaledb:latest tag." >&2
@@ -1125,7 +1316,7 @@ else
 fi
 
 if [ "$PREFLIGHT_ONLY" = "true" ]; then
-    if ! (umask 077; : > "$PREFLIGHT_MARKER"); then
+    if ! record_preflight_marker "$PREFLIGHT_FINGERPRINT"; then
         echo "Error: could not record successful preflight at $PREFLIGHT_MARKER." >&2
         exit 1
     fi
@@ -1233,20 +1424,7 @@ provision_grafana_db_role() {
         return 1
     fi
 
-    # We splice these as SQL identifiers, so require them to match the
-    # safe identifier shape rather than try to quote arbitrary input.
-    if ! [[ "$grafana_user" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
-        echo "Error: GRAFANA_DB_USERNAME must be a valid SQL identifier (got: $grafana_user)" >&2
-        return 1
-    fi
-    if ! [[ "$db_name" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
-        echo "Error: DB_NAME must be a valid SQL identifier (got: $db_name)" >&2
-        return 1
-    fi
-
-    if [ "$grafana_user" = "$app_user" ] || [ "$grafana_user" = "postgres" ]; then
-        echo "Error: GRAFANA_DB_USERNAME ('$grafana_user') must not match the application DB role ('$app_user') or the postgres superuser." >&2
-        echo "       Pick a dedicated read-only role name (e.g. grafana_ro) and re-run." >&2
+    if ! validate_grafana_db_role_names "$grafana_user" "$db_name" "$app_user"; then
         return 1
     fi
 

--- a/deployment-files/run-fleet.sh
+++ b/deployment-files/run-fleet.sh
@@ -9,13 +9,12 @@ COMPOSE_FILE="$PROJECT_ROOT/docker-compose.yaml"
 COMPOSE_ALERTS_FILE="$PROJECT_ROOT/docker-compose.alerts.yaml"
 COMPOSE_SYSTEM_MONITORING_FILE="$PROJECT_ROOT/docker-compose.system-monitoring.yaml"
 COMPOSE_TRACING_FILE="$PROJECT_ROOT/docker-compose.tracing.yaml"
-COMPOSE_UPDATER_FILE="$PROJECT_ROOT/docker-compose.updater.yaml"
 ENV_FILE="$PROJECT_ROOT/.env"
+PREFLIGHT_MARKER="$PROJECT_ROOT/.update-preflight-complete"
 
 ENABLE_BETA_ALERTS=false
 ENABLE_SYSTEM_MONITORING=false
 ENABLE_TRACING=false
-ENABLE_ONE_CLICK_UPDATES=false
 NON_INTERACTIVE=false
 PREFLIGHT_ONLY=false
 SKIP_BUILD=false
@@ -28,8 +27,38 @@ SKIP_BUILD=false
 # time when migrations are genuinely stuck.
 MIGRATION_WAIT_ATTEMPTS=300
 
+env_last_value() {
+    local line value
+    line=$(grep -E "^${1}[[:space:]]*=" "$ENV_FILE" 2>/dev/null | tail -1)
+    [ -n "$line" ] || return 1
+
+    value="${line#*=}"
+    value=$(printf '%s' "$value" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
+    case "$value" in
+        \"*\") value="${value#\"}"; value="${value%\"}" ;;
+        \'*\') value="${value#\'}"; value="${value%\'}" ;;
+    esac
+    printf '%s' "$value"
+}
+
 env_has_nonempty_value() {
-    grep -Eq "^${1}=.+" "$ENV_FILE" 2>/dev/null
+    local value
+    value=$(env_last_value "$1") || return 1
+    [ -n "$value" ]
+}
+
+env_boolean_is_true() {
+    local key="$1" value
+    value=$(env_last_value "$key") || return 1
+    value=$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')
+    case "$value" in
+        true) return 0 ;;
+        false|'') return 1 ;;
+        *)
+            echo "Error: $key must be true or false in $ENV_FILE." >&2
+            exit 1
+            ;;
+    esac
 }
 
 usage() {
@@ -54,9 +83,6 @@ Options:
                                 the .env file. Off by default. Can also be
                                 enabled by setting ENABLE_TRACING=true in
                                 the .env file.
-  --enable-one-click-updates     Connect fleet-api to the host updater Unix
-                                socket. The installer sets this after the
-                                systemd updater is installed successfully.
   --non-interactive              Reuse complete persisted configuration and
                                 fail instead of prompting. Intended for the
                                 host updater, not first-time setup.
@@ -81,10 +107,6 @@ while [ $# -gt 0 ]; do
             ;;
         --enable-tracing)
             ENABLE_TRACING=true
-            shift
-            ;;
-        --enable-one-click-updates)
-            ENABLE_ONE_CLICK_UPDATES=true
             shift
             ;;
         --non-interactive)
@@ -120,21 +142,30 @@ if [ "$PREFLIGHT_ONLY" = "true" ] && [ "$SKIP_BUILD" = "true" ]; then
     exit 1
 fi
 
-# Also honor ENABLE_BETA_ALERTS=true from the .env file.
-if grep -Eqi "^ENABLE_BETA_ALERTS=true[[:space:]]*$" "$ENV_FILE" 2>/dev/null; then
-    ENABLE_BETA_ALERTS=true
-fi
-if grep -Eqi "^ENABLE_SYSTEM_MONITORING=true[[:space:]]*$" "$ENV_FILE" 2>/dev/null; then
-    ENABLE_SYSTEM_MONITORING=true
-fi
-# [[:space:]]*$ tolerates CRLF line endings from Windows/WSL-edited .env files.
-if grep -Eqi "^ENABLE_TRACING=true[[:space:]]*$" "$ENV_FILE" 2>/dev/null; then
-    ENABLE_TRACING=true
-fi
-if grep -Eqi "^ENABLE_ONE_CLICK_UPDATES=true[[:space:]]*$" "$ENV_FILE" 2>/dev/null; then
-    ENABLE_ONE_CLICK_UPDATES=true
+if [ "$SKIP_BUILD" = "true" ] && [ ! -f "$PREFLIGHT_MARKER" ]; then
+    echo "Error: --skip-build requires a successful preflight for this deployment." >&2
+    exit 1
 fi
 
+if [ "$PREFLIGHT_ONLY" = "true" ]; then
+    # A failed retry must not leave an older success marker reusable.
+    if ! rm -f "$PREFLIGHT_MARKER"; then
+        echo "Error: could not clear the previous preflight marker at $PREFLIGHT_MARKER." >&2
+        exit 1
+    fi
+fi
+
+# Also honor persisted overlay state. Use the last exact-key assignment, as
+# Docker Compose does, and accept quoted/case-insensitive boolean values.
+if env_boolean_is_true ENABLE_BETA_ALERTS; then
+    ENABLE_BETA_ALERTS=true
+fi
+if env_boolean_is_true ENABLE_SYSTEM_MONITORING; then
+    ENABLE_SYSTEM_MONITORING=true
+fi
+if env_boolean_is_true ENABLE_TRACING; then
+    ENABLE_TRACING=true
+fi
 # System monitoring rides the alerts stack (the in-process metrics writer,
 # Grafana rule evaluation, and webhook delivery are all alerts-gated), so it
 # cannot run alone.
@@ -170,13 +201,6 @@ refresh_compose_files() {
     fi
     if [ "$ENABLE_TRACING" = "true" ] && [ -f "$COMPOSE_TRACING_FILE" ]; then
         COMPOSE_FILES+=(-f "$COMPOSE_TRACING_FILE")
-    fi
-    if [ "$ENABLE_ONE_CLICK_UPDATES" = "true" ]; then
-        if [ ! -f "$COMPOSE_UPDATER_FILE" ]; then
-            echo "Error: one-click updates are enabled but $COMPOSE_UPDATER_FILE is missing." >&2
-            exit 1
-        fi
-        COMPOSE_FILES+=(-f "$COMPOSE_UPDATER_FILE")
     fi
 }
 refresh_compose_files
@@ -257,6 +281,48 @@ validate_base64_key() {
     fi
 
     return 0  # Valid
+}
+
+validate_non_interactive_environment() {
+    local key auth_secret encryption_key invalid=0
+    local -a alert_keys=(
+        GRAFANA_ADMIN_PASSWORD
+        GRAFANA_DB_USERNAME
+        GRAFANA_DB_PASSWORD
+        FLEET_ALERTS_WEBHOOK_TOKEN
+        GRAFANA_SECRET_KEY
+        FLEET_ALERTS_GRAFANA_TOKEN
+    )
+
+    for key in DB_USERNAME DB_PASSWORD AUTH_CLIENT_SECRET_KEY ENCRYPT_SERVICE_MASTER_KEY; do
+        if ! env_has_nonempty_value "$key"; then
+            echo "Error: missing or empty required key in $ENV_FILE: $key" >&2
+            invalid=1
+        fi
+    done
+
+    auth_secret=$(env_last_value AUTH_CLIENT_SECRET_KEY 2>/dev/null || true)
+    if [ -n "$auth_secret" ] && [ "${#auth_secret}" -lt 32 ]; then
+        echo "Error: AUTH_CLIENT_SECRET_KEY in $ENV_FILE must be at least 32 characters." >&2
+        invalid=1
+    fi
+
+    encryption_key=$(env_last_value ENCRYPT_SERVICE_MASTER_KEY 2>/dev/null || true)
+    if [ -n "$encryption_key" ] && ! validate_base64_key "$encryption_key"; then
+        echo "Error: ENCRYPT_SERVICE_MASTER_KEY in $ENV_FILE must decode to exactly 32 bytes." >&2
+        invalid=1
+    fi
+
+    if [ "$ENABLE_BETA_ALERTS" = "true" ]; then
+        for key in "${alert_keys[@]}"; do
+            if ! env_has_nonempty_value "$key"; then
+                echo "Error: alerts are enabled but $key is missing or empty in $ENV_FILE." >&2
+                invalid=1
+            fi
+        done
+    fi
+
+    [ "$invalid" -eq 0 ]
 }
 
 # Get local network IP addresses (excludes loopback, includes IPv4 and global IPv6)
@@ -540,7 +606,15 @@ fi
 
 # Fix WSL networking issues (IPv6/DNS) if running in WSL
 if is_wsl; then
-    fix_wsl_networking
+    if [ "$NON_INTERACTIVE" = "true" ]; then
+        echo "Detected WSL environment. Checking Docker registry connectivity..."
+        if ! curl -s --max-time 5 https://registry-1.docker.io/v2/ >/dev/null 2>&1; then
+            echo "Error: Docker registry connectivity is unavailable in WSL; non-interactive upgrade will not modify host networking." >&2
+            exit 1
+        fi
+    else
+        fix_wsl_networking
+    fi
 fi
 
 # ----------------------------------------------------------------------------
@@ -585,9 +659,9 @@ done
 scrub_env_key() {
     local key="$1"
     local tmp
-    if grep -q "^${key}=" "$ENV_FILE" 2>/dev/null; then
+    if grep -Eq "^${key}[[:space:]]*=" "$ENV_FILE" 2>/dev/null; then
         tmp=$(mktemp)
-        grep -v "^${key}=" "$ENV_FILE" > "$tmp" || true
+        grep -Ev "^${key}[[:space:]]*=" "$ENV_FILE" > "$tmp" || true
         # Overwrite in place to preserve the 0600 perms set elsewhere.
         cat "$tmp" > "$ENV_FILE"
         rm -f "$tmp"
@@ -672,9 +746,9 @@ if [ -f "$ENV_FILE" ]; then
     # Check for missing required keys
     missing_keys=0
     for key in "${required_keys[@]}"; do
-        if ! grep -q "^$key=" "$ENV_FILE"; then
+        if ! env_has_nonempty_value "$key"; then
             missing_keys=1
-            echo "Missing required key in environment file: $key"
+            echo "Missing or empty required key in environment file: $key"
         fi
     done
 
@@ -707,6 +781,11 @@ fi
 
 if [ "$NON_INTERACTIVE" = "true" ] && [ "$use_existing" = "no" ]; then
     echo "Error: non-interactive mode requires an existing complete $ENV_FILE." >&2
+    exit 1
+fi
+
+if [ "$NON_INTERACTIVE" = "true" ] && ! validate_non_interactive_environment; then
+    echo "Error: non-interactive mode requires complete, valid persisted configuration." >&2
     exit 1
 fi
 
@@ -798,7 +877,7 @@ persist_boolean_setting() {
     local value="$2"
     local temp
     temp=$(mktemp)
-    grep -v "^${key}=" "$ENV_FILE" > "$temp" || true
+    grep -Ev "^${key}[[:space:]]*=" "$ENV_FILE" > "$temp" || true
     if [ -s "$temp" ] && [ -n "$(tail -c1 "$temp")" ]; then
         echo >> "$temp"
     fi
@@ -810,7 +889,6 @@ persist_boolean_setting() {
 persist_boolean_setting ENABLE_BETA_ALERTS "$ENABLE_BETA_ALERTS"
 persist_boolean_setting ENABLE_SYSTEM_MONITORING "$ENABLE_SYSTEM_MONITORING"
 persist_boolean_setting ENABLE_TRACING "$ENABLE_TRACING"
-persist_boolean_setting ENABLE_ONE_CLICK_UPDATES "$ENABLE_ONE_CLICK_UPDATES"
 chmod 600 "$ENV_FILE"
 refresh_compose_files
 refresh_compose_env_args
@@ -907,56 +985,65 @@ echo "==========================================================================
 echo "SSL/TLS Configuration"
 echo "============================================================================"
 
-# Check if user-provided certificates exist
-if [ -f "$SSL_CERT" ] && [ -f "$SSL_KEY" ]; then
-    echo "Found existing SSL certificates in $SSL_DIR"
-    echo "  Certificate: $SSL_CERT"
-    echo "  Private Key: $SSL_KEY"
-    PROTOCOL_MODE="https"
-else
-    if [ "$NON_INTERACTIVE" = "true" ]; then
-        if grep -Eqi "^SESSION_COOKIE_SECURE=true[[:space:]]*$" "$ENV_FILE"; then
+# Non-interactive upgrades preserve the persisted transport. Certificate files
+# can be stale after an operator switches back to HTTP, so their mere presence
+# must not silently re-enable HTTPS.
+if [ "$NON_INTERACTIVE" = "true" ]; then
+    if env_boolean_is_true SESSION_COOKIE_SECURE; then
+        if [ ! -f "$SSL_CERT" ] || [ ! -f "$SSL_KEY" ]; then
             echo "Error: HTTPS is persisted but its certificate/key are missing; refusing to switch protocol during upgrade." >&2
             exit 1
         fi
-        echo "No SSL certificates found; preserving HTTP mode from $ENV_FILE."
-        PROTOCOL_MODE="http"
+        echo "Preserving HTTPS mode from $ENV_FILE."
+        PROTOCOL_MODE="https"
     else
-    echo ""
-    echo "No SSL certificates found in $SSL_DIR"
-    echo ""
-    echo "Options:"
-    echo "  1) HTTP only (no encryption) - simplest for isolated LANs"
-    echo "  2) HTTPS with self-signed certificate - browsers will show warnings"
-    echo "  3) HTTPS with your own certificates - place cert.pem and key.pem in $SSL_DIR"
-    echo ""
-    echo -n "Select option [1]: "
-    read ssl_choice
-    ssl_choice=${ssl_choice:-1}
+        echo "Preserving HTTP mode from $ENV_FILE."
+        PROTOCOL_MODE="http"
+    fi
+else
+    # Interactive setup treats a complete certificate pair as an explicit
+    # request for HTTPS, preserving the existing installer behavior.
+    if [ -f "$SSL_CERT" ] && [ -f "$SSL_KEY" ]; then
+        echo "Found existing SSL certificates in $SSL_DIR"
+        echo "  Certificate: $SSL_CERT"
+        echo "  Private Key: $SSL_KEY"
+        PROTOCOL_MODE="https"
+    else
+        echo ""
+        echo "No SSL certificates found in $SSL_DIR"
+        echo ""
+        echo "Options:"
+        echo "  1) HTTP only (no encryption) - simplest for isolated LANs"
+        echo "  2) HTTPS with self-signed certificate - browsers will show warnings"
+        echo "  3) HTTPS with your own certificates - place cert.pem and key.pem in $SSL_DIR"
+        echo ""
+        echo -n "Select option [1]: "
+        read ssl_choice
+        ssl_choice=${ssl_choice:-1}
 
-    case "$ssl_choice" in
-        2)
-            if generate_self_signed_cert; then
-                PROTOCOL_MODE="https"
-            else
-                echo "Falling back to HTTP mode."
+        case "$ssl_choice" in
+            2)
+                if generate_self_signed_cert; then
+                    PROTOCOL_MODE="https"
+                else
+                    echo "Falling back to HTTP mode."
+                    PROTOCOL_MODE="http"
+                fi
+                ;;
+            3)
+                echo ""
+                echo "Please place your SSL certificates in $SSL_DIR:"
+                echo "  - $SSL_CERT (certificate)"
+                echo "  - $SSL_KEY (private key)"
+                echo ""
+                echo "Then re-run this script."
+                exit 0
+                ;;
+            *)
+                echo "Using HTTP mode (no encryption)."
                 PROTOCOL_MODE="http"
-            fi
-            ;;
-        3)
-            echo ""
-            echo "Please place your SSL certificates in $SSL_DIR:"
-            echo "  - $SSL_CERT (certificate)"
-            echo "  - $SSL_KEY (private key)"
-            echo ""
-            echo "Then re-run this script."
-            exit 0
-            ;;
-        *)
-            echo "Using HTTP mode (no encryption)."
-            PROTOCOL_MODE="http"
-            ;;
-    esac
+                ;;
+        esac
     fi
 fi
 
@@ -972,27 +1059,23 @@ if ! copy_nginx_config "$PROTOCOL_MODE"; then
     exit 1
 fi
 
-# Update environment file with cookie security setting
-if grep -q "^SESSION_COOKIE_SECURE=" "$ENV_FILE"; then
-    # Update existing setting
-    if [ "$PROTOCOL_MODE" == "https" ]; then
-        sed -i.bak 's/^SESSION_COOKIE_SECURE=.*/SESSION_COOKIE_SECURE=true/' "$ENV_FILE" && rm -f "$ENV_FILE.bak"
-    else
-        sed -i.bak 's/^SESSION_COOKIE_SECURE=.*/SESSION_COOKIE_SECURE=false/' "$ENV_FILE" && rm -f "$ENV_FILE.bak"
-    fi
+# Update environment file with cookie security setting.
+if [ "$PROTOCOL_MODE" == "https" ]; then
+    persist_boolean_setting SESSION_COOKIE_SECURE true
 else
-    # Add new setting
-    if [ "$PROTOCOL_MODE" == "https" ]; then
-        echo "SESSION_COOKIE_SECURE=true" >> "$ENV_FILE"
-    else
-        echo "SESSION_COOKIE_SECURE=false" >> "$ENV_FILE"
-    fi
+    persist_boolean_setting SESSION_COOKIE_SECURE false
 fi
 
 chmod 600 "$ENV_FILE"
 
 # Pick up FLEET_PROFILE written during env setup
 refresh_compose_env_args
+
+echo "Validating Docker Compose configuration..."
+if ! compose config --quiet; then
+    echo "Error: Docker Compose configuration is invalid; services were not stopped." >&2
+    exit 1
+fi
 
 # ----------------------------------------------------------------------------
 # Docker Image Preparation
@@ -1008,6 +1091,10 @@ if [ "$SKIP_BUILD" != "true" ]; then
     # Load pre-built TimescaleDB image if available (built in CI for the target architecture)
     TSDB_IMAGE="$PROJECT_ROOT/images/timescaledb.tar.gz"
     if [ -f "$TSDB_IMAGE" ]; then
+        if ! gunzip -c "$TSDB_IMAGE" | tar -xOf - manifest.json 2>/dev/null | grep -q '"proto-fleet-timescaledb:latest"'; then
+            echo "Error: $TSDB_IMAGE does not contain the required proto-fleet-timescaledb:latest tag." >&2
+            exit 1
+        fi
         echo "Loading pre-built TimescaleDB image..."
         if gunzip -c "$TSDB_IMAGE" | docker load; then
             echo "TimescaleDB image loaded successfully."
@@ -1015,9 +1102,20 @@ if [ "$SKIP_BUILD" != "true" ]; then
             echo "Error: Failed to load TimescaleDB image from $TSDB_IMAGE"
             exit 1
         fi
+        if ! docker image inspect proto-fleet-timescaledb:latest >/dev/null 2>&1; then
+            echo "Error: $TSDB_IMAGE loaded without the required proto-fleet-timescaledb:latest tag." >&2
+            exit 1
+        fi
     else
-        echo "Warning: Pre-built TimescaleDB image not found at $TSDB_IMAGE."
-        echo "The deployment will fail unless the image 'proto-fleet-timescaledb:latest' already exists locally."
+        if [ "$PREFLIGHT_ONLY" = "true" ]; then
+            echo "Error: upgrade preflight requires the release's pre-built TimescaleDB image at $TSDB_IMAGE." >&2
+            exit 1
+        fi
+        if ! docker image inspect proto-fleet-timescaledb:latest >/dev/null 2>&1; then
+            echo "Error: Pre-built TimescaleDB image not found at $TSDB_IMAGE and proto-fleet-timescaledb:latest is not loaded." >&2
+            exit 1
+        fi
+        echo "Pre-built TimescaleDB archive not found; reusing the loaded proto-fleet-timescaledb:latest image."
     fi
 
     # Build Docker images (fleet-api and fleet-client only; TimescaleDB uses pre-built image)
@@ -1027,6 +1125,10 @@ else
 fi
 
 if [ "$PREFLIGHT_ONLY" = "true" ]; then
+    if ! (umask 077; : > "$PREFLIGHT_MARKER"); then
+        echo "Error: could not record successful preflight at $PREFLIGHT_MARKER." >&2
+        exit 1
+    fi
     echo "Upgrade preflight completed successfully; the running stack was not stopped."
     exit 0
 fi
@@ -1064,7 +1166,7 @@ apply_database_tuning() {
     # during an upgrade the previous deploy's row already reads clean while
     # migrations (and the policy jobs they create) are still pending.
     local api_addr api_port attempt
-    api_addr=$(grep -E '^HTTP_LISTEN_ADDRESS=' "$ENV_FILE" 2>/dev/null | tail -1 | cut -d= -f2- || true)
+    api_addr=$(env_last_value HTTP_LISTEN_ADDRESS 2>/dev/null || true)
     api_port="${api_addr##*:}"
     case "$api_port" in *[!0-9]*|"") api_port=4000 ;; esac
 
@@ -1118,11 +1220,11 @@ fi
 provision_grafana_db_role() {
     local grafana_user grafana_pass db_name app_user pw_escaped stats_grant stats_smoke
 
-    grafana_user=$(grep -E '^GRAFANA_DB_USERNAME=' "$ENV_FILE" | head -1 | cut -d= -f2-)
-    grafana_pass=$(grep -E '^GRAFANA_DB_PASSWORD=' "$ENV_FILE" | head -1 | cut -d= -f2-)
-    db_name=$(grep -E '^DB_NAME=' "$ENV_FILE" | head -1 | cut -d= -f2-)
+    grafana_user=$(env_last_value GRAFANA_DB_USERNAME 2>/dev/null || true)
+    grafana_pass=$(env_last_value GRAFANA_DB_PASSWORD 2>/dev/null || true)
+    db_name=$(env_last_value DB_NAME 2>/dev/null || true)
     db_name="${db_name:-fleet}"
-    app_user=$(grep -E '^DB_USERNAME=' "$ENV_FILE" | head -1 | cut -d= -f2-)
+    app_user=$(env_last_value DB_USERNAME 2>/dev/null || true)
     app_user="${app_user:-fleet}"
 
     if [ -z "$grafana_user" ] || [ -z "$grafana_pass" ]; then
@@ -1300,7 +1402,7 @@ provision_grafana_service_account_token() {
         return 0
     fi
 
-    admin_pass=$(grep -E '^GRAFANA_ADMIN_PASSWORD=' "$ENV_FILE" | head -1 | cut -d= -f2-)
+    admin_pass=$(env_last_value GRAFANA_ADMIN_PASSWORD 2>/dev/null || true)
     if [ -z "$admin_pass" ]; then
         echo "Error: GRAFANA_ADMIN_PASSWORD missing/empty in $ENV_FILE; cannot mint a Grafana token." >&2
         return 1
@@ -1395,5 +1497,10 @@ for ip in $(get_local_ips); do
     echo "  LAN:    ${protocol}://$ip"
 done
 echo "--------------------------------------------------------------"
+
+if ! rm -f "$PREFLIGHT_MARKER"; then
+    echo "Error: Fleet is running, but the consumed preflight marker could not be removed: $PREFLIGHT_MARKER" >&2
+    exit 1
+fi
 
 exit 0

--- a/deployment-files/run-fleet.sh
+++ b/deployment-files/run-fleet.sh
@@ -20,12 +20,12 @@ PREFLIGHT_MARKER="$PROJECT_ROOT/.update-preflight-complete"
 # runtime flags with the same names. Plain shell assignment keeps an inherited
 # variable's export bit, so inspecting those names later would otherwise see
 # the script default instead of the invoking environment.
-INVOKING_ENABLE_BETA_ALERTS_SET="${ENABLE_BETA_ALERTS+x}"
-INVOKING_ENABLE_BETA_ALERTS_VALUE="${ENABLE_BETA_ALERTS-}"
-INVOKING_ENABLE_SYSTEM_MONITORING_SET="${ENABLE_SYSTEM_MONITORING+x}"
-INVOKING_ENABLE_SYSTEM_MONITORING_VALUE="${ENABLE_SYSTEM_MONITORING-}"
-INVOKING_ENABLE_TRACING_SET="${ENABLE_TRACING+x}"
-INVOKING_ENABLE_TRACING_VALUE="${ENABLE_TRACING-}"
+OVERLAY_FLAG_KEYS=(ENABLE_BETA_ALERTS ENABLE_SYSTEM_MONITORING ENABLE_TRACING)
+for overlay_key in "${OVERLAY_FLAG_KEYS[@]}"; do
+    printf -v "INVOKING_${overlay_key}_SET" '%s' "${!overlay_key+x}"
+    printf -v "INVOKING_${overlay_key}_VALUE" '%s' "${!overlay_key-}"
+done
+unset overlay_key
 
 ENABLE_BETA_ALERTS=false
 ENABLE_SYSTEM_MONITORING=false
@@ -39,6 +39,13 @@ FLEET_API_IMAGE=""
 FLEET_CLIENT_IMAGE=""
 TIMESCALEDB_IMAGE=""
 TIMESCALEDB_HA_IMAGE=""
+# Every repository whose tags release retention may protect or remove.
+PROTO_FLEET_IMAGE_REPOSITORIES=(
+    proto-fleet-api
+    proto-fleet-client
+    proto-fleet-timescaledb
+    proto-fleet-timescaledb-ha
+)
 PREVIOUS_RELEASE_IMAGE_TAGS=()
 RELEASE_IMAGE_CLEANUP_SAFE=true
 
@@ -51,33 +58,21 @@ RELEASE_IMAGE_CLEANUP_SAFE=true
 FLEET_API_READY_ATTEMPTS="${FLEET_API_READY_ATTEMPTS:-300}"
 
 env_last_value() {
-    local key="$1"
+    local key="$1" snapshot_set snapshot_value
     # Compose interpolation gives the invoking process precedence over .env.
     # Validate that same effective value rather than silently checking the
-    # persisted fallback while containers receive an exported override.
+    # persisted fallback while containers receive an exported override. The
+    # overlay flags read their pre-initialization snapshot because the script
+    # reuses their names for its runtime defaults.
     case "$key" in
-        ENABLE_BETA_ALERTS)
-            if [ "$INVOKING_ENABLE_BETA_ALERTS_SET" = "x" ]; then
-                printf '%s' "$INVOKING_ENABLE_BETA_ALERTS_VALUE"
-            else
-                compose_env_last_value "$key"
+        ENABLE_BETA_ALERTS|ENABLE_SYSTEM_MONITORING|ENABLE_TRACING)
+            snapshot_set="INVOKING_${key}_SET"
+            snapshot_value="INVOKING_${key}_VALUE"
+            if [ "${!snapshot_set}" = "x" ]; then
+                printf '%s' "${!snapshot_value}"
+                return 0
             fi
-            return $?
-            ;;
-        ENABLE_SYSTEM_MONITORING)
-            if [ "$INVOKING_ENABLE_SYSTEM_MONITORING_SET" = "x" ]; then
-                printf '%s' "$INVOKING_ENABLE_SYSTEM_MONITORING_VALUE"
-            else
-                compose_env_last_value "$key"
-            fi
-            return $?
-            ;;
-        ENABLE_TRACING)
-            if [ "$INVOKING_ENABLE_TRACING_SET" = "x" ]; then
-                printf '%s' "$INVOKING_ENABLE_TRACING_VALUE"
-            else
-                compose_env_last_value "$key"
-            fi
+            compose_env_last_value "$key"
             return $?
             ;;
     esac
@@ -93,7 +88,10 @@ parse_compose_env_value() {
     local double_quoted='^"([^"\\]*)"[[:space:]]*(#.*)?$'
     local single_quoted="^'([^']*)'[[:space:]]*(#.*)?$"
 
-    value=$(printf '%s' "$value" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
+    # Fork-free trims: these run per line per key lookup, which adds up on
+    # SD-card-class hardware.
+    value="${value#"${value%%[![:space:]]*}"}"
+    value="${value%"${value##*[![:space:]]}"}"
     case "$value" in
         \"*)
             [[ "$value" =~ $double_quoted ]] || return 2
@@ -112,7 +110,8 @@ parse_compose_env_value() {
         *)
             # Compose treats # as an inline comment only when whitespace
             # separates it from an unquoted value.
-            value=$(printf '%s' "$value" | sed -E 's/[[:space:]]+#.*$//; s/[[:space:]]+$//')
+            value="${value%%[[:space:]]#*}"
+            value="${value%"${value##*[![:space:]]}"}"
             # Unquoted values undergo Compose interpolation.
             [[ "$value" != *'$'* ]] || return 2
             ;;
@@ -126,24 +125,20 @@ parse_compose_env_value() {
 # divergence from Compose.
 compose_env_last_value() {
     local key="$1" line normalized parsed found=false
-    local equals_assignment_re="^${key}[[:space:]]*=(.*)$"
-    local colon_assignment_re="^${key}[[:space:]]*:(.*)$"
+    local assignment_re="^${key}[[:space:]]*[:=](.*)$"
     local malformed_re="^${key}([[:space:]]|$)"
 
     [ -e "$ENV_FILE" ] || return 1
     [ -f "$ENV_FILE" ] && [ -r "$ENV_FILE" ] || return 2
     while IFS= read -r line || [ -n "$line" ]; do
-        normalized=$(printf '%s' "$line" | sed -E 's/^[[:space:]]+//')
+        normalized="${line#"${line%%[![:space:]]*}"}"
         case "$normalized" in
             export[[:space:]]*)
                 normalized="${normalized#export}"
-                normalized=$(printf '%s' "$normalized" | sed -E 's/^[[:space:]]+//')
+                normalized="${normalized#"${normalized%%[![:space:]]*}"}"
                 ;;
         esac
-        if [[ "$normalized" =~ $equals_assignment_re ]]; then
-            parsed=$(parse_compose_env_value "${BASH_REMATCH[1]}") || return 2
-            found=true
-        elif [[ "$normalized" =~ $colon_assignment_re ]]; then
+        if [[ "$normalized" =~ $assignment_re ]]; then
             parsed=$(parse_compose_env_value "${BASH_REMATCH[1]}") || return 2
             found=true
         elif [[ "$normalized" =~ $malformed_re ]]; then
@@ -204,10 +199,9 @@ env_has_nonempty_value() {
 
 env_boolean_is_true() {
     local key="$1" value read_status
-    if value=$(env_last_value "$key"); then
-        :
-    else
-        read_status=$?
+    value=$(env_last_value "$key")
+    read_status=$?
+    if [ "$read_status" -ne 0 ]; then
         if [ "$read_status" -eq 1 ]; then
             return 1
         fi
@@ -549,6 +543,16 @@ is_managed_release_image_tag() {
         [[ "$tag" =~ ^nightly-[0-9]{8}-[0-9a-f]{12}$ ]]
 }
 
+is_proto_fleet_image_reference() {
+    local image="$1" repository
+    for repository in "${PROTO_FLEET_IMAGE_REPOSITORIES[@]}"; do
+        case "$image" in
+            "$repository":*) return 0 ;;
+        esac
+    done
+    return 1
+}
+
 prune_obsolete_release_images() {
     local repository image tag image_id containers
     local candidates=()
@@ -562,11 +566,7 @@ prune_obsolete_release_images() {
     # Collect the complete candidate set before deleting anything. If Docker
     # cannot enumerate one reserved repository, fail safe and leave every tag
     # untouched rather than making a partial retention decision.
-    for repository in \
-        proto-fleet-api \
-        proto-fleet-client \
-        proto-fleet-timescaledb \
-        proto-fleet-timescaledb-ha; do
+    for repository in "${PROTO_FLEET_IMAGE_REPOSITORIES[@]}"; do
         local listed_images
         if ! listed_images=$(docker image ls --format '{{.Repository}}:{{.Tag}}' "$repository" 2>/dev/null); then
             echo "Warning: could not inspect $repository images; skipping Proto Fleet release image cleanup." >&2
@@ -574,10 +574,6 @@ prune_obsolete_release_images() {
         fi
         while IFS= read -r image; do
             [ -n "$image" ] || continue
-            case "$image" in
-                "$repository":*) ;;
-                *) continue ;;
-            esac
             [ "${image##*:}" != "<none>" ] || continue
             candidates+=("$image")
         done <<< "$listed_images"
@@ -641,10 +637,7 @@ capture_previous_release_image_tags() {
         return 0
     fi
     while IFS= read -r image; do
-        case "$image" in
-            proto-fleet-api:*|proto-fleet-client:*|proto-fleet-timescaledb:*|proto-fleet-timescaledb-ha:*) ;;
-            *) continue ;;
-        esac
+        is_proto_fleet_image_reference "$image" || continue
         tag="${image##*:}"
         is_managed_release_image_tag "$tag" || continue
         for existing_tag in "${PREVIOUS_RELEASE_IMAGE_TAGS[@]}"; do
@@ -666,16 +659,25 @@ capture_previous_release_image_tags() {
     fi
 }
 
-sha256() {
-    local output
+# Resolved once and shared by digest computation and manifest verification.
+SHA256_CMD=()
+
+resolve_sha256_cmd() {
+    [ "${#SHA256_CMD[@]}" -eq 0 ] || return 0
     if command -v sha256sum >/dev/null 2>&1; then
-        output=$(sha256sum "$@") || return 1
+        SHA256_CMD=(sha256sum)
     elif command -v shasum >/dev/null 2>&1; then
-        output=$(shasum -a 256 "$@") || return 1
+        SHA256_CMD=(shasum -a 256)
     else
         echo "Error: SHA-256 support requires sha256sum or shasum." >&2
         return 1
     fi
+}
+
+sha256() {
+    local output
+    resolve_sha256_cmd || return 1
+    output=$("${SHA256_CMD[@]}" "$@") || return 1
     printf '%s\n' "$output" | awk '{print $1}'
 }
 
@@ -705,18 +707,12 @@ verify_release_manifest() {
         return 1
     fi
 
-    manifest_paths=$(mktemp) || return 1
-    current_paths=$(mktemp) || {
-        rm -f "$manifest_paths"
-        return 1
-    }
-
     # Validate and extract the GNU sha256sum path column before asking a
     # checksum utility to open anything. Release paths must stay below the
     # deployment root, and the sorted path set must exactly match the current
     # immutable files so added provisioning/config files cannot bypass the
     # manifest by simply being absent from it.
-    if ! awk '
+    if ! manifest_paths=$(awk '
         {
             digest = substr($0, 1, 64)
             separator = substr($0, 65, 2)
@@ -728,44 +724,28 @@ verify_release_manifest() {
             }
             print path
         }
-    ' "$RELEASE_MANIFEST_FILE" > "$manifest_paths"; then
-        rm -f "$manifest_paths" "$current_paths"
+    ' "$RELEASE_MANIFEST_FILE"); then
         echo "Error: immutable release manifest has an invalid entry." >&2
         return 1
     fi
 
-    if ! unsupported_entries=$(cd "$PROJECT_ROOT" && \
-        find_release_entries ! -type f ! -type d -print); then
-        rm -f "$manifest_paths" "$current_paths"
-        return 1
-    fi
+    unsupported_entries=$(cd "$PROJECT_ROOT" && \
+        find_release_entries ! -type f ! -type d -print) || return 1
     if [ -n "$unsupported_entries" ]; then
-        rm -f "$manifest_paths" "$current_paths"
         echo "Error: immutable release contains unsupported non-regular entries:" >&2
         printf '  %s\n' "$unsupported_entries" >&2
         return 1
     fi
 
-    if ! (cd "$PROJECT_ROOT" && \
-        find_immutable_release_entries -type f -print | LC_ALL=C sort) > "$current_paths"; then
-        rm -f "$manifest_paths" "$current_paths"
-        return 1
-    fi
-    if ! cmp -s "$manifest_paths" "$current_paths"; then
-        rm -f "$manifest_paths" "$current_paths"
+    current_paths=$(cd "$PROJECT_ROOT" && \
+        find_immutable_release_entries -type f -print | LC_ALL=C sort) || return 1
+    if [ "$manifest_paths" != "$current_paths" ]; then
         echo "Error: immutable release file set does not match the packaged manifest." >&2
         return 1
     fi
-    rm -f "$manifest_paths" "$current_paths"
 
-    if command -v sha256sum >/dev/null 2>&1; then
-        (cd "$PROJECT_ROOT" && sha256sum -c "$manifest_name" >/dev/null)
-    elif command -v shasum >/dev/null 2>&1; then
-        (cd "$PROJECT_ROOT" && shasum -a 256 -c "$manifest_name" >/dev/null)
-    else
-        echo "Error: SHA-256 support requires sha256sum or shasum." >&2
-        return 1
-    fi
+    resolve_sha256_cmd || return 1
+    (cd "$PROJECT_ROOT" && "${SHA256_CMD[@]}" -c "$manifest_name" >/dev/null)
 }
 
 prepared_images_fingerprint() {
@@ -789,9 +769,9 @@ prepared_images_fingerprint() {
             echo "Error: Docker returned an empty image ID for $image." >&2
             return 1
         }
-        metadata="${metadata}${image}=${image_id}\n"
+        metadata="${metadata}${image}=${image_id}"$'\n'
     done
-    printf '%b' "$metadata" | sha256
+    printf '%s' "$metadata" | sha256
 }
 
 project_relative_path() {
@@ -1235,15 +1215,22 @@ fix_wsl_networking() {
     fi
 }
 
+# Unattended upgrades never mutate the host: every interactive repair below
+# (installs, service enablement, group changes) must fail through this guard
+# instead of running.
+refuse_non_interactive_host_repair() {
+    if [ "$NON_INTERACTIVE" = "true" ]; then
+        echo "Error: $1" >&2
+        exit 1
+    fi
+}
+
 # ----------------------------------------------------------------------------
 # Docker Installation Check and Setup
 # ----------------------------------------------------------------------------
 
 if ! command -v docker &> /dev/null; then
-    if [ "$NON_INTERACTIVE" = "true" ]; then
-        echo "Error: Docker is not installed; non-interactive upgrade cannot install host prerequisites." >&2
-        exit 1
-    fi
+    refuse_non_interactive_host_repair "Docker is not installed; non-interactive upgrade cannot install host prerequisites."
     echo "Docker is not installed. Attempting to install Docker..."
 
     if [ "$(uname)" == "Linux" ]; then
@@ -1272,10 +1259,7 @@ if [ "$(uname)" == "Linux" ]; then
     if ! is_wsl; then
         # Check if Docker is set to start on boot on native Linux hosts.
         if ! systemctl is-enabled docker &>/dev/null; then
-            if [ "$NON_INTERACTIVE" = "true" ]; then
-                echo "Error: Docker is not enabled at boot; fix the host before retrying the upgrade." >&2
-                exit 1
-            fi
+            refuse_non_interactive_host_repair "Docker is not enabled at boot; fix the host before retrying the upgrade."
             echo "Configuring Docker to start on system boot..."
             sudo systemctl enable docker
         fi
@@ -1288,10 +1272,7 @@ if [ "$(uname)" == "Linux" ]; then
     # for the sudo-mismatch detection in install.sh) would exit here telling
     # the user to log out and back in, leaving the upgrade half-applied.
     if [ "$(id -u)" -ne 0 ] && ! groups $USER | grep -q '\bdocker\b'; then
-        if [ "$NON_INTERACTIVE" = "true" ]; then
-            echo "Error: the upgrade user cannot access Docker." >&2
-            exit 1
-        fi
+        refuse_non_interactive_host_repair "the upgrade user cannot access Docker."
         echo "Adding current user to the docker group for passwordless Docker usage..."
         sudo usermod -aG docker $USER
         echo "Please log out and log back in to apply group changes, then re-run this script."
@@ -1304,10 +1285,7 @@ fi
 # ----------------------------------------------------------------------------
 
 if ! docker info > /dev/null 2>&1; then
-    if [ "$NON_INTERACTIVE" = "true" ]; then
-        echo "Error: Docker daemon is not available; non-interactive upgrade will not mutate host services." >&2
-        exit 1
-    fi
+    refuse_non_interactive_host_repair "Docker daemon is not available; non-interactive upgrade will not mutate host services."
     echo "Docker daemon is not running. Starting Docker..."
 
     # For macOS, attempt to start Docker Desktop
@@ -1369,10 +1347,7 @@ fi
 # ----------------------------------------------------------------------------
 
 if ! docker compose version &> /dev/null; then
-    if [ "$NON_INTERACTIVE" = "true" ]; then
-        echo "Error: docker compose is not installed; non-interactive upgrade cannot install host prerequisites." >&2
-        exit 1
-    fi
+    refuse_non_interactive_host_repair "docker compose is not installed; non-interactive upgrade cannot install host prerequisites."
     echo "docker compose is not installed. Attempting to install it..."
 
     if [ "$(uname)" == "Linux" ]; then
@@ -1409,13 +1384,8 @@ done
 # root-owned service on behalf of a non-root operator.
 file_owner_group() {
     local owner_group
-    if owner_group=$(stat -c '%u:%g' "$1" 2>/dev/null); then
-        :
-    elif owner_group=$(stat -f '%u:%g' "$1" 2>/dev/null); then
-        :
-    else
-        return 1
-    fi
+    owner_group=$(stat -c '%u:%g' "$1" 2>/dev/null) ||
+        owner_group=$(stat -f '%u:%g' "$1" 2>/dev/null) || return 1
     [ -n "$owner_group" ] || return 1
     printf '%s' "$owner_group"
 }
@@ -1764,8 +1734,6 @@ if ! atomic_set_env_values \
     echo "Error: could not persist deployment overlay settings; aborting before Compose validation or service changes." >&2
     exit 1
 fi
-refresh_compose_files
-refresh_compose_env_args
 
 # ----------------------------------------------------------------------------
 # Docker Compose File Validation
@@ -2077,49 +2045,40 @@ if ! compose up --remove-orphans -d --wait --wait-timeout 300 --no-build --pull 
     exit 1
 fi
 
-wait_for_fleet_api_ready() {
-    local attempt
+wait_for_http_ready() {
+    local label="$1" url="$2" attempt
+    shift 2
 
-    echo "Waiting for fleet-api readiness after migrations…"
     for attempt in $(seq 1 "$FLEET_API_READY_ATTEMPTS"); do
-        # The deployment Compose model fixes fleet-api to 0.0.0.0:4000 in its
-        # extended service definition. Do not let an unrelated dotenv value
-        # redirect this probe to nginx or another process.
-        if curl -fsS -o /dev/null --max-time 2 "http://127.0.0.1:4000/health/ready"; then
+        if curl "$@" -o /dev/null --max-time 2 "$url"; then
             return 0
         fi
         if [ "$attempt" -eq "$FLEET_API_READY_ATTEMPTS" ]; then
-            echo "Error: fleet-api did not become ready within $((FLEET_API_READY_ATTEMPTS * 2))s." >&2
+            echo "Error: $label did not become ready within $((FLEET_API_READY_ATTEMPTS * 2))s." >&2
             return 1
         fi
         sleep 2
     done
 }
 
-wait_for_fleet_client_ready() {
-    local attempt client_url
+wait_for_fleet_api_ready() {
+    echo "Waiting for fleet-api readiness after migrations…"
+    # The deployment Compose model fixes fleet-api to 0.0.0.0:4000 in its
+    # extended service definition. Do not let an unrelated dotenv value
+    # redirect this probe to nginx or another process.
+    wait_for_http_ready fleet-api "http://127.0.0.1:4000/health/ready" -fsS
+}
 
-    client_url="${PROTOCOL_MODE}://127.0.0.1/"
+wait_for_fleet_client_ready() {
+    local -a curl_flags=(-fsS)
+    if [ "$PROTOCOL_MODE" = "https" ]; then
+        # The packaged certificate can be self-signed; this is a loopback
+        # liveness probe, not a remote identity check.
+        curl_flags=(-fkSs)
+    fi
 
     echo "Waiting for fleet-client readiness…"
-    for attempt in $(seq 1 "$FLEET_API_READY_ATTEMPTS"); do
-        if [ "$PROTOCOL_MODE" = "https" ]; then
-            # The packaged certificate can be self-signed; this is a loopback
-            # liveness probe, not a remote identity check.
-            if curl -fkSs -o /dev/null --max-time 2 "$client_url"; then
-                return 0
-            fi
-        else
-            if curl -fsS -o /dev/null --max-time 2 "$client_url"; then
-                return 0
-            fi
-        fi
-        if [ "$attempt" -eq "$FLEET_API_READY_ATTEMPTS" ]; then
-            echo "Error: fleet-client did not become ready after $FLEET_API_READY_ATTEMPTS attempts." >&2
-            return 1
-        fi
-        sleep 2
-    done
+    wait_for_http_ready fleet-client "${PROTOCOL_MODE}://127.0.0.1/" "${curl_flags[@]}"
 }
 
 if ! wait_for_fleet_api_ready; then

--- a/deployment-files/run-fleet.sh
+++ b/deployment-files/run-fleet.sh
@@ -151,8 +151,22 @@ compose_env_last_value() {
     printf '%s' "$parsed"
 }
 
-validate_runner_env_values() {
+validate_runner_env_value_syntax() {
     local key status
+    for key in "$@"; do
+        if compose_env_last_value "$key" >/dev/null; then
+            status=0
+        else
+            status=$?
+        fi
+        [ "$status" -eq 0 ] && continue
+        [ "$status" -eq 1 ] && continue
+        echo "Error: $key in $ENV_FILE uses unsupported Compose dotenv syntax; use a literal same-line value (single-quote literal dollar signs)." >&2
+        return 1
+    done
+}
+
+validate_runner_env_values() {
     local keys=(
         COMPOSE_PROJECT_NAME
         ENABLE_BETA_ALERTS
@@ -164,14 +178,7 @@ validate_runner_env_values() {
         DB_NAME
         AUTH_CLIENT_SECRET_KEY
         ENCRYPT_SERVICE_MASTER_KEY
-        DD_API_KEY
         SESSION_COOKIE_SECURE
-        GRAFANA_ADMIN_PASSWORD
-        GRAFANA_DB_USERNAME
-        GRAFANA_DB_PASSWORD
-        GRAFANA_SECRET_KEY
-        FLEET_ALERTS_WEBHOOK_TOKEN
-        FLEET_ALERTS_GRAFANA_TOKEN
     )
 
     [ -e "$ENV_FILE" ] || return 0
@@ -179,17 +186,7 @@ validate_runner_env_values() {
         echo "Error: $ENV_FILE must be a readable regular file." >&2
         return 1
     fi
-    for key in "${keys[@]}"; do
-        if compose_env_last_value "$key" >/dev/null; then
-            status=0
-        else
-            status=$?
-        fi
-        [ "$status" -eq 0 ] && continue
-        [ "$status" -eq 1 ] && continue
-        echo "Error: $key in $ENV_FILE uses unsupported Compose dotenv syntax; use a literal same-line value (single-quote literal dollar signs)." >&2
-        return 1
-    done
+    validate_runner_env_value_syntax "${keys[@]}"
 }
 
 env_has_nonempty_value() {
@@ -385,14 +382,6 @@ if [ "$SKIP_BUILD" = "true" ] && [ ! -f "$PREFLIGHT_MARKER" ]; then
     exit 1
 fi
 
-if [ "$PREFLIGHT_ONLY" = "true" ]; then
-    # A failed retry must not leave an older success marker reusable.
-    if ! rm -f "$PREFLIGHT_MARKER"; then
-        echo "Error: could not clear the previous preflight marker at $PREFLIGHT_MARKER." >&2
-        exit 1
-    fi
-fi
-
 # Also honor persisted overlay state. Use the last exact-key assignment, as
 # Docker Compose does, and accept quoted/case-insensitive boolean values.
 if env_boolean_is_true ENABLE_BETA_ALERTS; then
@@ -413,9 +402,23 @@ if [ "$ENABLE_SYSTEM_MONITORING" = "true" ] && [ "$ENABLE_BETA_ALERTS" != "true"
     exit 1
 fi
 
+# Optional settings are interpreted by the runner only while their matching
+# overlay is active. Preserve Compose's full dotenv surface for dormant values,
+# while continuing to fail closed before any state changes when they are used.
+if [ "$ENABLE_BETA_ALERTS" = "true" ]; then
+    validate_runner_env_value_syntax \
+        GRAFANA_ADMIN_PASSWORD \
+        GRAFANA_DB_USERNAME \
+        GRAFANA_DB_PASSWORD \
+        GRAFANA_SECRET_KEY \
+        FLEET_ALERTS_WEBHOOK_TOKEN \
+        FLEET_ALERTS_GRAFANA_TOKEN || exit 1
+fi
+
 # Validate tracing prerequisites before the overlay is layered: its ${DD_API_KEY:?}
 # interpolation would otherwise abort every compose command, even `compose down`.
 if [ "$ENABLE_TRACING" = "true" ]; then
+    validate_runner_env_value_syntax DD_API_KEY || exit 1
     if [ ! -f "$COMPOSE_TRACING_FILE" ]; then
         echo "Error: --enable-tracing was passed but $COMPOSE_TRACING_FILE is missing." >&2
         exit 1
@@ -423,6 +426,14 @@ if [ "$ENABLE_TRACING" = "true" ]; then
     # Compose interpolation reads the shell environment and the .env file; accept either.
     if [ -z "${DD_API_KEY:-}" ] && ! env_has_nonempty_value DD_API_KEY; then
         echo "Error: --enable-tracing requires DD_API_KEY (a Datadog API key) in $ENV_FILE." >&2
+        exit 1
+    fi
+fi
+
+if [ "$PREFLIGHT_ONLY" = "true" ]; then
+    # A failed retry must not leave an older success marker reusable.
+    if ! rm -f "$PREFLIGHT_MARKER"; then
+        echo "Error: could not clear the previous preflight marker at $PREFLIGHT_MARKER." >&2
         exit 1
     fi
 fi
@@ -1395,8 +1406,10 @@ fi
 # WSL Networking Fix
 # ----------------------------------------------------------------------------
 
-# Fix WSL networking issues (IPv6/DNS) if running in WSL
-if is_wsl; then
+# Registry diagnostics and host-network repair are needed only when image
+# preparation may pull. A prepared activation verifies local image IDs and
+# starts with --no-build/--pull never, so it must remain usable offline.
+if [ "$SKIP_BUILD" != "true" ] && is_wsl; then
     if [ "$NON_INTERACTIVE" = "true" ]; then
         echo "Detected WSL environment. Checking Docker registry connectivity..."
         if ! curl -s --max-time 5 https://registry-1.docker.io/v2/ >/dev/null 2>&1; then

--- a/deployment-files/run-fleet.sh
+++ b/deployment-files/run-fleet.sh
@@ -11,6 +11,7 @@ COMPOSE_SYSTEM_MONITORING_FILE="$PROJECT_ROOT/docker-compose.system-monitoring.y
 COMPOSE_TRACING_FILE="$PROJECT_ROOT/docker-compose.tracing.yaml"
 ENV_FILE="$PROJECT_ROOT/.env"
 VERSION_FILE="$PROJECT_ROOT/version.txt"
+RELEASE_MANIFEST_FILE="$PROJECT_ROOT/deployment-manifest.sha256"
 TSDB_IMAGE="$PROJECT_ROOT/images/timescaledb.tar.gz"
 PREFLIGHT_MARKER="$PROJECT_ROOT/.update-preflight-complete"
 
@@ -251,6 +252,97 @@ sha256() {
     printf '%s\n' "$output" | awk '{print $1}'
 }
 
+verify_release_manifest() {
+    local manifest_name="${RELEASE_MANIFEST_FILE##*/}" manifest_paths current_paths
+    if [ ! -f "$RELEASE_MANIFEST_FILE" ]; then
+        echo "Error: upgrade preflight requires the immutable release manifest at $RELEASE_MANIFEST_FILE." >&2
+        return 1
+    fi
+
+    manifest_paths=$(mktemp) || return 1
+    current_paths=$(mktemp) || {
+        rm -f "$manifest_paths"
+        return 1
+    }
+
+    # Validate and extract the GNU sha256sum path column before asking a
+    # checksum utility to open anything. Release paths must stay below the
+    # deployment root, and the sorted path set must exactly match the current
+    # immutable files so added provisioning/config files cannot bypass the
+    # manifest by simply being absent from it.
+    if ! awk '
+        {
+            digest = substr($0, 1, 64)
+            separator = substr($0, 65, 2)
+            path = substr($0, 67)
+            if (length(digest) != 64 || digest !~ /^[0-9a-fA-F]+$/ ||
+                separator != "  " || path !~ /^\.\// ||
+                path ~ /(^|\/)\.\.(\/|$)/) {
+                exit 1
+            }
+            print path
+        }
+    ' "$RELEASE_MANIFEST_FILE" > "$manifest_paths"; then
+        rm -f "$manifest_paths" "$current_paths"
+        echo "Error: immutable release manifest has an invalid entry." >&2
+        return 1
+    fi
+
+    if ! (cd "$PROJECT_ROOT" && find . -type f \
+        ! -path './deployment-manifest.sha256' \
+        ! -path './.env' \
+        ! -path './.update-preflight-complete' \
+        ! -path './.update-preflight-complete.tmp.*' \
+        ! -path './client/nginx.conf' \
+        ! -path './ssl/*' \
+        ! -path './server/influx_config/.env' \
+        -print | LC_ALL=C sort) > "$current_paths"; then
+        rm -f "$manifest_paths" "$current_paths"
+        return 1
+    fi
+    if ! cmp -s "$manifest_paths" "$current_paths"; then
+        rm -f "$manifest_paths" "$current_paths"
+        echo "Error: immutable release file set does not match the packaged manifest." >&2
+        return 1
+    fi
+    rm -f "$manifest_paths" "$current_paths"
+
+    if command -v sha256sum >/dev/null 2>&1; then
+        (cd "$PROJECT_ROOT" && sha256sum -c "$manifest_name" >/dev/null)
+    elif command -v shasum >/dev/null 2>&1; then
+        (cd "$PROJECT_ROOT" && shasum -a 256 -c "$manifest_name" >/dev/null)
+    else
+        echo "Error: SHA-256 support requires sha256sum or shasum." >&2
+        return 1
+    fi
+}
+
+prepared_images_fingerprint() {
+    local images image image_id metadata=""
+    images=$(compose config --images) || {
+        echo "Error: could not list the images required by this release." >&2
+        return 1
+    }
+    images=$(printf '%s\n' "$images" | sort -u)
+    if [ -z "$images" ]; then
+        echo "Error: Docker Compose did not report any release images." >&2
+        return 1
+    fi
+
+    for image in $images; do
+        image_id=$(docker image inspect --format '{{.Id}}' "$image" 2>/dev/null) || {
+            echo "Error: prepared image is missing before activation: $image" >&2
+            return 1
+        }
+        [ -n "$image_id" ] || {
+            echo "Error: Docker returned an empty image ID for $image." >&2
+            return 1
+        }
+        metadata="${metadata}${image}=${image_id}\n"
+    done
+    printf '%b' "$metadata" | sha256
+}
+
 project_relative_path() {
     case "$1" in
         "$PROJECT_ROOT"/*) printf '%s' "${1#"$PROJECT_ROOT"/}" ;;
@@ -293,7 +385,7 @@ compose_config_hash() {
 write_preflight_metadata() {
     local config_hash digest file relative index
 
-    for file in "$VERSION_FILE" "$ENV_FILE" "$TSDB_IMAGE" "$PROJECT_ROOT/run-fleet.sh" "$NGINX_CONF_DIR/nginx.conf"; do
+    for file in "$VERSION_FILE" "$RELEASE_MANIFEST_FILE" "$ENV_FILE" "$TSDB_IMAGE" "$PROJECT_ROOT/run-fleet.sh" "$NGINX_CONF_DIR/nginx.conf"; do
         if [ ! -f "$file" ]; then
             echo "Error: upgrade preflight metadata requires $file." >&2
             return 1
@@ -303,11 +395,21 @@ write_preflight_metadata() {
     config_hash=$(compose_config_hash) || return 1
     printf 'format=1\n'
     digest=$(sha256 "$VERSION_FILE") || return 1
-    printf 'release_manifest_sha256=%s\n' "$digest"
+    printf 'version_file_sha256=%s\n' "$digest"
+    digest=$(sha256 "$RELEASE_MANIFEST_FILE") || return 1
+    printf 'deployment_manifest_sha256=%s\n' "$digest"
     digest=$(sha256 "$PROJECT_ROOT/run-fleet.sh") || return 1
     printf 'runner_sha256=%s\n' "$digest"
     digest=$(sha256 "$NGINX_CONF_DIR/nginx.conf") || return 1
     printf 'nginx_config_sha256=%s\n' "$digest"
+    if [ "$PROTOCOL_MODE" = "https" ]; then
+        digest=$(sha256 "$SSL_CERT") || return 1
+        printf 'ssl_certificate_sha256=%s\n' "$digest"
+        digest=$(sha256 "$SSL_KEY") || return 1
+        printf 'ssl_private_key_sha256=%s\n' "$digest"
+    else
+        printf 'ssl_state=disabled\n'
+    fi
     printf 'compose_config_sha256=%s\n' "$config_hash"
     printf 'feature_state=alerts:%s,system_monitoring:%s,tracing:%s,protocol:%s\n' \
         "$ENABLE_BETA_ALERTS" "$ENABLE_SYSTEM_MONITORING" "$ENABLE_TRACING" "$PROTOCOL_MODE"
@@ -337,14 +439,19 @@ preflight_fingerprint() {
 }
 
 record_preflight_marker() {
-    local prepared_fingerprint="$1" current_fingerprint temporary_marker
+    local prepared_fingerprint="$1" current_fingerprint image_fingerprint temporary_marker
+    if ! verify_release_manifest; then
+        echo "Error: release or configuration changed during preflight; immutable release files no longer match." >&2
+        return 1
+    fi
     current_fingerprint=$(preflight_fingerprint) || return 1
     if [ "$current_fingerprint" != "$prepared_fingerprint" ]; then
         echo "Error: release or configuration changed during preflight; run preflight again." >&2
         return 1
     fi
+    image_fingerprint=$(prepared_images_fingerprint) || return 1
     temporary_marker=$(umask 077; mktemp "$PREFLIGHT_MARKER.tmp.XXXXXX") || return 1
-    if ! printf 'proto-fleet-preflight-v1:%s\n' "$prepared_fingerprint" > "$temporary_marker"; then
+    if ! printf 'proto-fleet-preflight-v2:%s:%s\n' "$prepared_fingerprint" "$image_fingerprint" > "$temporary_marker"; then
         rm -f "$temporary_marker"
         return 1
     fi
@@ -359,20 +466,23 @@ record_preflight_marker() {
 }
 
 verify_preflight_marker() {
-    local actual expected
+    local actual expected image_fingerprint
     if [ ! -f "$PREFLIGHT_MARKER" ]; then
         echo "Error: --skip-build requires a successful preflight for this deployment." >&2
         return 1
     fi
 
-    if ! expected=$(preflight_fingerprint); then
+    if ! verify_release_manifest || \
+        ! expected=$(preflight_fingerprint) || \
+        ! image_fingerprint=$(prepared_images_fingerprint); then
         if ! rm -f "$PREFLIGHT_MARKER"; then
             echo "Error: preflight verification failed and the stale marker could not be removed." >&2
         fi
+        echo "Error: release, prepared images, or configuration changed after preflight; run preflight again before activation." >&2
         return 1
     fi
     actual=$(cat "$PREFLIGHT_MARKER") || return 1
-    if [ "$actual" != "proto-fleet-preflight-v1:$expected" ]; then
+    if [ "$actual" != "proto-fleet-preflight-v2:$expected:$image_fingerprint" ]; then
         if ! rm -f "$PREFLIGHT_MARKER"; then
             echo "Error: preflight inputs changed and the stale marker could not be removed." >&2
             return 1
@@ -828,7 +938,7 @@ fi
 # (Compose v2.17.0+). Fail fast here, before `docker compose down` takes an
 # existing stack offline.
 compose_up_help=$(docker compose up --help 2>&1 || true)
-for flag in --wait --wait-timeout; do
+for flag in --wait --wait-timeout --no-build --pull; do
     if ! grep -qE -- "(^|[[:space:]])${flag}([[:space:]]|$)" <<<"$compose_up_help"; then
         echo "Error: your docker compose does not support ${flag}."
         echo "run-fleet.sh requires Compose v2.17.0+. Upgrade: https://docs.docker.com/compose/install/"
@@ -1169,15 +1279,37 @@ echo "==========================================================================
 # can be stale after an operator switches back to HTTP, so their mere presence
 # must not silently re-enable HTTPS.
 if [ "$NON_INTERACTIVE" = "true" ]; then
-    if env_boolean_is_true SESSION_COOKIE_SECURE; then
-        if [ ! -f "$SSL_CERT" ] || [ ! -f "$SSL_KEY" ]; then
-            echo "Error: HTTPS is persisted but its certificate/key are missing; refusing to switch protocol during upgrade." >&2
-            exit 1
-        fi
-        echo "Preserving HTTPS mode from $ENV_FILE."
+    if persisted_cookie_mode=$(env_last_value SESSION_COOKIE_SECURE); then
+        persisted_cookie_mode=$(printf '%s' "$persisted_cookie_mode" | tr '[:upper:]' '[:lower:]')
+        case "$persisted_cookie_mode" in
+            true)
+                if [ ! -f "$SSL_CERT" ] || [ ! -f "$SSL_KEY" ]; then
+                    echo "Error: HTTPS is persisted but its certificate/key are missing; refusing to switch protocol during upgrade." >&2
+                    exit 1
+                fi
+                echo "Preserving HTTPS mode from $ENV_FILE."
+                PROTOCOL_MODE="https"
+                ;;
+            false)
+                echo "Preserving HTTP mode from $ENV_FILE."
+                PROTOCOL_MODE="http"
+                ;;
+            *)
+                echo "Error: SESSION_COOKIE_SECURE must be true or false in $ENV_FILE." >&2
+                exit 1
+                ;;
+        esac
+    elif [ -f "$SSL_CERT" ] && [ -f "$SSL_KEY" ]; then
+        # Releases before transport mode was persisted inferred HTTPS from a
+        # complete certificate pair. Preserve that secure legacy behavior and
+        # write the explicit setting below for future unattended upgrades.
+        echo "Preserving legacy HTTPS mode from the existing certificate pair."
         PROTOCOL_MODE="https"
+    elif [ -f "$SSL_CERT" ] || [ -f "$SSL_KEY" ]; then
+        echo "Error: SESSION_COOKIE_SECURE is missing and the legacy certificate pair is incomplete; refusing to switch protocol during upgrade." >&2
+        exit 1
     else
-        echo "Preserving HTTP mode from $ENV_FILE."
+        echo "No persisted transport or certificate pair found; preserving legacy HTTP mode."
         PROTOCOL_MODE="http"
     fi
 else
@@ -1263,6 +1395,10 @@ if [ "$SKIP_BUILD" = "true" ]; then
         exit 1
     fi
 elif [ "$PREFLIGHT_ONLY" = "true" ]; then
+    if ! verify_release_manifest; then
+        echo "Error: immutable release manifest validation failed before preflight." >&2
+        exit 1
+    fi
     PREFLIGHT_FINGERPRINT=$(preflight_fingerprint) || {
         echo "Error: could not fingerprint the release before preflight." >&2
         exit 1
@@ -1275,7 +1411,7 @@ fi
 
 if [ "$SKIP_BUILD" != "true" ]; then
     echo "Pulling latest Docker images..."
-    if ! compose pull; then
+    if ! compose pull --ignore-buildable; then
         echo "Error: Failed to pull required Docker images."
         exit 1
     fi
@@ -1335,7 +1471,7 @@ echo "Starting services..."
 # --wait blocks until every service is running (or healthy, when a healthcheck is defined).
 # Without it, `up -d` can exit 0 while containers stay in Created (e.g. port conflicts under
 # host networking), producing a false "Proto Fleet is now running!" banner.
-if ! compose up --remove-orphans -d --wait --wait-timeout 300; then
+if ! compose up --remove-orphans -d --wait --wait-timeout 300 --no-build --pull never; then
     echo "Error: services failed to reach running state."
     echo "Check logs with: docker compose ${COMPOSE_ENV_ARGS[*]} ${COMPOSE_FILES[*]} logs"
     exit 1

--- a/deployment-files/run-fleet.sh
+++ b/deployment-files/run-fleet.sh
@@ -820,14 +820,20 @@ fi
 
 # Configure Docker for Linux systems
 if [ "$(uname)" == "Linux" ]; then
-    # Check if Docker is set to start on boot
-    if ! systemctl is-enabled docker &>/dev/null; then
-        if [ "$NON_INTERACTIVE" = "true" ]; then
-            echo "Error: Docker is not enabled at boot; fix the host before retrying the upgrade." >&2
-            exit 1
+    # The Windows installer supports non-systemd WSL distros by starting
+    # Docker through `service` or its init script and maintaining a Windows
+    # scheduled task. Do not reject that supported setup before the
+    # authoritative `docker info` probe below.
+    if ! is_wsl; then
+        # Check if Docker is set to start on boot on native Linux hosts.
+        if ! systemctl is-enabled docker &>/dev/null; then
+            if [ "$NON_INTERACTIVE" = "true" ]; then
+                echo "Error: Docker is not enabled at boot; fix the host before retrying the upgrade." >&2
+                exit 1
+            fi
+            echo "Configuring Docker to start on system boot..."
+            sudo systemctl enable docker
         fi
-        echo "Configuring Docker to start on system boot..."
-        sudo systemctl enable docker
     fi
 
     # Check if current user is in the docker group.

--- a/deployment-files/run-fleet.sh
+++ b/deployment-files/run-fleet.sh
@@ -302,6 +302,7 @@ verify_release_manifest() {
         ! -path './client/nginx.conf' \
         ! -path './ssl/*' \
         ! -path './server/influx_config/.env' \
+        ! -path './ha/node.env' \
         -print | LC_ALL=C sort) > "$current_paths"; then
         rm -f "$manifest_paths" "$current_paths"
         return 1

--- a/deployment-files/run-fleet.sh
+++ b/deployment-files/run-fleet.sh
@@ -5,6 +5,7 @@
 # ============================================================================
 
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FLEET_COMPOSE_PROJECT_NAME="deployment"
 COMPOSE_FILE="$PROJECT_ROOT/docker-compose.yaml"
 COMPOSE_ALERTS_FILE="$PROJECT_ROOT/docker-compose.alerts.yaml"
 COMPOSE_SYSTEM_MONITORING_FILE="$PROJECT_ROOT/docker-compose.system-monitoring.yaml"
@@ -236,7 +237,12 @@ refresh_compose_env_args() {
 refresh_compose_env_args
 
 compose() {
-    docker compose ${COMPOSE_ENV_ARGS[@]+"${COMPOSE_ENV_ARGS[@]}"} "${COMPOSE_FILES[@]}" "$@"
+    # Official installs have always lived in a directory named `deployment`.
+    # Pin that existing implicit project identity so an updater's temporary
+    # parent directory cannot change Compose's rendered name, containers, or
+    # persistent volume namespace between preflight and activation.
+    docker compose --project-name "$FLEET_COMPOSE_PROJECT_NAME" \
+        ${COMPOSE_ENV_ARGS[@]+"${COMPOSE_ENV_ARGS[@]}"} "${COMPOSE_FILES[@]}" "$@"
 }
 
 sha256() {

--- a/deployment-files/run-fleet.sh
+++ b/deployment-files/run-fleet.sh
@@ -385,8 +385,27 @@ sha256() {
     printf '%s\n' "$output" | awk '{print $1}'
 }
 
+# Keep the release scope shared by the type and path-set checks. These narrow
+# exclusions are operator-owned runtime state; selected files are fingerprinted
+# separately by write_preflight_metadata.
+find_release_entries() {
+    find . \
+        ! -path './.env' \
+        ! -path './.update-preflight-complete' \
+        ! -path './.update-preflight-complete.tmp.*' \
+        ! -path './client/nginx.conf' \
+        ! -path './ssl/*' \
+        ! -path './server/influx_config/.env' \
+        ! -path './ha/node.env' \
+        "$@"
+}
+
+find_immutable_release_entries() {
+    find_release_entries ! -path './deployment-manifest.sha256' "$@"
+}
+
 verify_release_manifest() {
-    local manifest_name="${RELEASE_MANIFEST_FILE##*/}" manifest_paths current_paths
+    local manifest_name="${RELEASE_MANIFEST_FILE##*/}" manifest_paths current_paths unsupported_entries
     if [ ! -f "$RELEASE_MANIFEST_FILE" ]; then
         echo "Error: upgrade preflight requires the immutable release manifest at $RELEASE_MANIFEST_FILE." >&2
         return 1
@@ -421,16 +440,20 @@ verify_release_manifest() {
         return 1
     fi
 
-    if ! (cd "$PROJECT_ROOT" && find . -type f \
-        ! -path './deployment-manifest.sha256' \
-        ! -path './.env' \
-        ! -path './.update-preflight-complete' \
-        ! -path './.update-preflight-complete.tmp.*' \
-        ! -path './client/nginx.conf' \
-        ! -path './ssl/*' \
-        ! -path './server/influx_config/.env' \
-        ! -path './ha/node.env' \
-        -print | LC_ALL=C sort) > "$current_paths"; then
+    if ! unsupported_entries=$(cd "$PROJECT_ROOT" && \
+        find_release_entries ! -type f ! -type d -print); then
+        rm -f "$manifest_paths" "$current_paths"
+        return 1
+    fi
+    if [ -n "$unsupported_entries" ]; then
+        rm -f "$manifest_paths" "$current_paths"
+        echo "Error: immutable release contains unsupported non-regular entries:" >&2
+        printf '  %s\n' "$unsupported_entries" >&2
+        return 1
+    fi
+
+    if ! (cd "$PROJECT_ROOT" && \
+        find_immutable_release_entries -type f -print | LC_ALL=C sort) > "$current_paths"; then
         rm -f "$manifest_paths" "$current_paths"
         return 1
     fi

--- a/deployment-files/run-fleet.sh
+++ b/deployment-files/run-fleet.sh
@@ -23,6 +23,11 @@ NON_INTERACTIVE=false
 PREFLIGHT_ONLY=false
 SKIP_BUILD=false
 PREFLIGHT_FINGERPRINT=""
+RELEASE_IMAGE_TAG=""
+FLEET_API_IMAGE=""
+FLEET_CLIENT_IMAGE=""
+TIMESCALEDB_IMAGE=""
+TIMESCALEDB_HA_IMAGE=""
 
 # How long the post-start steps wait for fleet-api to finish its migrations.
 # 300 x 2s = 10 minutes: a first boot on SD-card-class hardware (Raspberry Pi)
@@ -64,6 +69,37 @@ env_boolean_is_true() {
             exit 1
             ;;
     esac
+}
+
+resolve_release_image_tag() {
+    local count tag
+
+    if [ ! -f "$VERSION_FILE" ]; then
+        if [ "$PREFLIGHT_ONLY" = "true" ] || [ "$SKIP_BUILD" = "true" ]; then
+            echo "Error: updater preflight and activation require packaged release metadata at $VERSION_FILE." >&2
+            return 1
+        fi
+        # Source-tree and local development installs do not carry version.txt.
+        # Keep their historical mutable tag; release bundles are pinned below.
+        printf 'latest'
+        return 0
+    fi
+
+    count=$(grep -c '^version:' "$VERSION_FILE" 2>/dev/null || true)
+    if [ "$count" -ne 1 ]; then
+        echo "Error: $VERSION_FILE must contain exactly one version entry." >&2
+        return 1
+    fi
+    tag=$(sed -n -E 's/^version:[[:space:]]*([^[:space:]]+)[[:space:]]*$/\1/p' "$VERSION_FILE")
+    if [[ ! "$tag" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]*$ ]] || [ "${#tag}" -gt 128 ]; then
+        echo "Error: the packaged release version is not a valid Docker image tag." >&2
+        return 1
+    fi
+    if [ "$tag" = "latest" ]; then
+        echo "Error: packaged releases must not use the shared latest image tag." >&2
+        return 1
+    fi
+    printf '%s' "$tag"
 }
 
 usage() {
@@ -146,6 +182,12 @@ if [ "$PREFLIGHT_ONLY" = "true" ] && [ "$SKIP_BUILD" = "true" ]; then
     echo "Error: --preflight-only and --skip-build cannot be combined." >&2
     exit 1
 fi
+
+RELEASE_IMAGE_TAG=$(resolve_release_image_tag) || exit 1
+FLEET_API_IMAGE="proto-fleet-api:${RELEASE_IMAGE_TAG}"
+FLEET_CLIENT_IMAGE="proto-fleet-client:${RELEASE_IMAGE_TAG}"
+TIMESCALEDB_IMAGE="proto-fleet-timescaledb:${RELEASE_IMAGE_TAG}"
+TIMESCALEDB_HA_IMAGE="proto-fleet-timescaledb-ha:${RELEASE_IMAGE_TAG}"
 
 if [ "$SKIP_BUILD" = "true" ] && [ ! -f "$PREFLIGHT_MARKER" ]; then
     echo "Error: --skip-build requires a successful preflight for this deployment." >&2
@@ -243,6 +285,69 @@ compose() {
     # persistent volume namespace between preflight and activation.
     docker compose --project-name "$FLEET_COMPOSE_PROJECT_NAME" \
         ${COMPOSE_ENV_ARGS[@]+"${COMPOSE_ENV_ARGS[@]}"} "${COMPOSE_FILES[@]}" "$@"
+}
+
+verify_release_image_references() {
+    local images required ha_compose="$PROJECT_ROOT/ha/compose.yaml"
+    images=$(compose config --images) || {
+        echo "Error: could not list Docker Compose image references." >&2
+        return 1
+    }
+
+    for required in "$FLEET_API_IMAGE" "$FLEET_CLIENT_IMAGE" "$TIMESCALEDB_IMAGE"; do
+        if ! printf '%s\n' "$images" | grep -Fxq "$required"; then
+            echo "Error: the packaged Compose model is not pinned to required image $required." >&2
+            return 1
+        fi
+    done
+
+    # A release bundle also carries the HA database image in the same archive.
+    # Its separate Compose profile must stay pinned even though this runner does
+    # not activate that profile itself.
+    if [ -f "$VERSION_FILE" ]; then
+        if [ ! -f "$ha_compose" ] || ! grep -Fq "image: $TIMESCALEDB_HA_IMAGE" "$ha_compose"; then
+            echo "Error: the packaged HA Compose model is not pinned to required image $TIMESCALEDB_HA_IMAGE." >&2
+            return 1
+        fi
+        for required in \
+            'proto-fleet-api:latest' \
+            'proto-fleet-client:latest' \
+            'proto-fleet-timescaledb:latest'; do
+            if printf '%s\n' "$images" | grep -Fxq "$required"; then
+                echo "Error: release Compose configuration still references shared image $required." >&2
+                return 1
+            fi
+        done
+        if grep -Fq 'proto-fleet-timescaledb-ha:latest' "$ha_compose"; then
+            echo "Error: release HA Compose configuration still references the shared latest image tag." >&2
+            return 1
+        fi
+    fi
+}
+
+validate_timescaledb_archive_tags() {
+    local manifest required forbidden
+    manifest=$(gunzip -c "$TSDB_IMAGE" | tar -xOf - manifest.json 2>/dev/null) || {
+        echo "Error: $TSDB_IMAGE does not contain a readable Docker image manifest." >&2
+        return 1
+    }
+
+    for required in "$TIMESCALEDB_IMAGE" "$TIMESCALEDB_HA_IMAGE"; do
+        if ! printf '%s\n' "$manifest" | grep -Fq "\"$required\""; then
+            echo "Error: $TSDB_IMAGE does not contain required image $required." >&2
+            return 1
+        fi
+    done
+    if [ "$RELEASE_IMAGE_TAG" != "latest" ]; then
+        for forbidden in \
+            'proto-fleet-timescaledb:latest' \
+            'proto-fleet-timescaledb-ha:latest'; do
+            if printf '%s\n' "$manifest" | grep -Fq "\"$forbidden\""; then
+                echo "Error: $TSDB_IMAGE contains forbidden shared image $forbidden." >&2
+                return 1
+            fi
+        done
+    fi
 }
 
 sha256() {
@@ -1401,6 +1506,10 @@ if ! compose config --quiet; then
     echo "Error: Docker Compose configuration is invalid; services were not stopped." >&2
     exit 1
 fi
+if ! verify_release_image_references; then
+    echo "Error: Docker Compose image references do not match this release; services were not stopped." >&2
+    exit 1
+fi
 
 if [ "$SKIP_BUILD" = "true" ]; then
     if ! verify_preflight_marker; then
@@ -1435,8 +1544,7 @@ if [ "$SKIP_BUILD" != "true" ]; then
 
     # Load pre-built TimescaleDB image if available (built in CI for the target architecture)
     if [ -f "$TSDB_IMAGE" ]; then
-        if ! gunzip -c "$TSDB_IMAGE" | tar -xOf - manifest.json 2>/dev/null | grep -q '"proto-fleet-timescaledb:latest"'; then
-            echo "Error: $TSDB_IMAGE does not contain the required proto-fleet-timescaledb:latest tag." >&2
+        if ! validate_timescaledb_archive_tags; then
             exit 1
         fi
         echo "Loading pre-built TimescaleDB image..."
@@ -1446,20 +1554,22 @@ if [ "$SKIP_BUILD" != "true" ]; then
             echo "Error: Failed to load TimescaleDB image from $TSDB_IMAGE"
             exit 1
         fi
-        if ! docker image inspect proto-fleet-timescaledb:latest >/dev/null 2>&1; then
-            echo "Error: $TSDB_IMAGE loaded without the required proto-fleet-timescaledb:latest tag." >&2
-            exit 1
-        fi
+        for image in "$TIMESCALEDB_IMAGE" "$TIMESCALEDB_HA_IMAGE"; do
+            if ! docker image inspect "$image" >/dev/null 2>&1; then
+                echo "Error: $TSDB_IMAGE loaded without required image $image." >&2
+                exit 1
+            fi
+        done
     else
         if [ "$PREFLIGHT_ONLY" = "true" ]; then
             echo "Error: upgrade preflight requires the release's pre-built TimescaleDB image at $TSDB_IMAGE." >&2
             exit 1
         fi
-        if ! docker image inspect proto-fleet-timescaledb:latest >/dev/null 2>&1; then
-            echo "Error: Pre-built TimescaleDB image not found at $TSDB_IMAGE and proto-fleet-timescaledb:latest is not loaded." >&2
+        if ! docker image inspect "$TIMESCALEDB_IMAGE" >/dev/null 2>&1; then
+            echo "Error: Pre-built TimescaleDB image not found at $TSDB_IMAGE and $TIMESCALEDB_IMAGE is not loaded." >&2
             exit 1
         fi
-        echo "Pre-built TimescaleDB archive not found; reusing the loaded proto-fleet-timescaledb:latest image."
+        echo "Pre-built TimescaleDB archive not found; reusing loaded image $TIMESCALEDB_IMAGE."
     fi
 
     # Build Docker images (fleet-api and fleet-client only; TimescaleDB uses pre-built image)

--- a/deployment-files/run-fleet.sh
+++ b/deployment-files/run-fleet.sh
@@ -16,6 +16,17 @@ RELEASE_MANIFEST_FILE="$PROJECT_ROOT/deployment-manifest.sha256"
 TSDB_IMAGE="$PROJECT_ROOT/images/timescaledb.tar.gz"
 PREFLIGHT_MARKER="$PROJECT_ROOT/.update-preflight-complete"
 
+# Preserve process-level Compose overrides before the script initializes its
+# runtime flags with the same names. Plain shell assignment keeps an inherited
+# variable's export bit, so inspecting those names later would otherwise see
+# the script default instead of the invoking environment.
+INVOKING_ENABLE_BETA_ALERTS_SET="${ENABLE_BETA_ALERTS+x}"
+INVOKING_ENABLE_BETA_ALERTS_VALUE="${ENABLE_BETA_ALERTS-}"
+INVOKING_ENABLE_SYSTEM_MONITORING_SET="${ENABLE_SYSTEM_MONITORING+x}"
+INVOKING_ENABLE_SYSTEM_MONITORING_VALUE="${ENABLE_SYSTEM_MONITORING-}"
+INVOKING_ENABLE_TRACING_SET="${ENABLE_TRACING+x}"
+INVOKING_ENABLE_TRACING_VALUE="${ENABLE_TRACING-}"
+
 ENABLE_BETA_ALERTS=false
 ENABLE_SYSTEM_MONITORING=false
 ENABLE_TRACING=false
@@ -28,6 +39,8 @@ FLEET_API_IMAGE=""
 FLEET_CLIENT_IMAGE=""
 TIMESCALEDB_IMAGE=""
 TIMESCALEDB_HA_IMAGE=""
+PREVIOUS_RELEASE_IMAGE_TAGS=()
+RELEASE_IMAGE_CLEANUP_SAFE=true
 
 # How long the post-start steps wait for fleet-api to finish its migrations.
 # 300 x 2s = 10 minutes: a first boot on SD-card-class hardware (Raspberry Pi)
@@ -35,53 +48,86 @@ TIMESCALEDB_HA_IMAGE=""
 # old 2-4 minute caps and previously left grafana_ro unprovisioned. On a warm
 # database these polls return on the first attempt, so the high cap only costs
 # time when migrations are genuinely stuck.
-MIGRATION_WAIT_ATTEMPTS=300
+FLEET_API_READY_ATTEMPTS="${FLEET_API_READY_ATTEMPTS:-300}"
 
 env_last_value() {
-    local line value
-    line=$(grep -E "^${1}[[:space:]]*=" "$ENV_FILE" 2>/dev/null | tail -1)
-    [ -n "$line" ] || return 1
-
-    value="${line#*=}"
-    value=$(printf '%s' "$value" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
-    case "$value" in
-        \"*\") value="${value#\"}"; value="${value%\"}" ;;
-        \'*\') value="${value#\'}"; value="${value%\'}" ;;
+    local key="$1"
+    # Compose interpolation gives the invoking process precedence over .env.
+    # Validate that same effective value rather than silently checking the
+    # persisted fallback while containers receive an exported override.
+    case "$key" in
+        ENABLE_BETA_ALERTS)
+            if [ "$INVOKING_ENABLE_BETA_ALERTS_SET" = "x" ]; then
+                printf '%s' "$INVOKING_ENABLE_BETA_ALERTS_VALUE"
+            else
+                compose_env_last_value "$key"
+            fi
+            return $?
+            ;;
+        ENABLE_SYSTEM_MONITORING)
+            if [ "$INVOKING_ENABLE_SYSTEM_MONITORING_SET" = "x" ]; then
+                printf '%s' "$INVOKING_ENABLE_SYSTEM_MONITORING_VALUE"
+            else
+                compose_env_last_value "$key"
+            fi
+            return $?
+            ;;
+        ENABLE_TRACING)
+            if [ "$INVOKING_ENABLE_TRACING_SET" = "x" ]; then
+                printf '%s' "$INVOKING_ENABLE_TRACING_VALUE"
+            else
+                compose_env_last_value "$key"
+            fi
+            return $?
+            ;;
     esac
-    printf '%s' "$value"
+    if [ "${!key+x}" = "x" ]; then
+        printf '%s' "${!key}"
+        return 0
+    fi
+    compose_env_last_value "$key"
 }
 
 parse_compose_env_value() {
     local value="$1"
-    local double_quoted='^"(.*)"[[:space:]]*(#.*)?$'
-    local single_quoted="^'(.*)'[[:space:]]*(#.*)?$"
+    local double_quoted='^"([^"\\]*)"[[:space:]]*(#.*)?$'
+    local single_quoted="^'([^']*)'[[:space:]]*(#.*)?$"
 
     value=$(printf '%s' "$value" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
     case "$value" in
         \"*)
             [[ "$value" =~ $double_quoted ]] || return 2
             value="${BASH_REMATCH[1]}"
+            # Compose expands $ references and decodes backslash escapes in
+            # double-quoted values. Reject those uncommon forms rather than
+            # validating a different secret from the one Compose will use.
+            [[ "$value" != *'$'* && "$value" != *\\* ]] || return 2
             ;;
         \'*)
             [[ "$value" =~ $single_quoted ]] || return 2
             value="${BASH_REMATCH[1]}"
+            # An escaped quote cannot match the restricted expression above;
+            # other backslashes remain literal under Compose single quotes.
             ;;
         *)
             # Compose treats # as an inline comment only when whitespace
             # separates it from an unquoted value.
             value=$(printf '%s' "$value" | sed -E 's/[[:space:]]+#.*$//; s/[[:space:]]+$//')
+            # Unquoted values undergo Compose interpolation.
+            [[ "$value" != *'$'* ]] || return 2
             ;;
     esac
     printf '%s' "$value"
 }
 
-# Read one key using Compose's documented dotenv delimiters/comments. This is
-# separate from the older deployment-value reader above because project
-# identity must never silently fall back when a valid Compose assignment uses
-# `KEY: value` syntax. Returns 1 when absent and 2 when present but malformed.
+# Read one key using the literal subset of Compose's documented dotenv
+# delimiters, quoting, and comment rules. Returns 1 when absent and 2 when a
+# runner-consumed value is present but cannot be interpreted without risking
+# divergence from Compose.
 compose_env_last_value() {
     local key="$1" line normalized parsed found=false
-    local assignment_re="^${key}[[:space:]]*([=:])(.*)$"
+    local equals_assignment_re="^${key}[[:space:]]*=(.*)$"
+    local colon_assignment_re="^${key}[[:space:]]*:(.*)$"
     local malformed_re="^${key}([[:space:]]|$)"
 
     [ -e "$ENV_FILE" ] || return 1
@@ -94,8 +140,11 @@ compose_env_last_value() {
                 normalized=$(printf '%s' "$normalized" | sed -E 's/^[[:space:]]+//')
                 ;;
         esac
-        if [[ "$normalized" =~ $assignment_re ]]; then
-            parsed=$(parse_compose_env_value "${BASH_REMATCH[2]}") || return 2
+        if [[ "$normalized" =~ $equals_assignment_re ]]; then
+            parsed=$(parse_compose_env_value "${BASH_REMATCH[1]}") || return 2
+            found=true
+        elif [[ "$normalized" =~ $colon_assignment_re ]]; then
+            parsed=$(parse_compose_env_value "${BASH_REMATCH[1]}") || return 2
             found=true
         elif [[ "$normalized" =~ $malformed_re ]]; then
             return 2
@@ -106,6 +155,47 @@ compose_env_last_value() {
     printf '%s' "$parsed"
 }
 
+validate_runner_env_values() {
+    local key status
+    local keys=(
+        COMPOSE_PROJECT_NAME
+        ENABLE_BETA_ALERTS
+        ENABLE_SYSTEM_MONITORING
+        ENABLE_TRACING
+        FLEET_PROFILE
+        DB_USERNAME
+        DB_PASSWORD
+        DB_NAME
+        AUTH_CLIENT_SECRET_KEY
+        ENCRYPT_SERVICE_MASTER_KEY
+        DD_API_KEY
+        SESSION_COOKIE_SECURE
+        GRAFANA_ADMIN_PASSWORD
+        GRAFANA_DB_USERNAME
+        GRAFANA_DB_PASSWORD
+        GRAFANA_SECRET_KEY
+        FLEET_ALERTS_WEBHOOK_TOKEN
+        FLEET_ALERTS_GRAFANA_TOKEN
+    )
+
+    [ -e "$ENV_FILE" ] || return 0
+    if [ ! -f "$ENV_FILE" ] || [ ! -r "$ENV_FILE" ]; then
+        echo "Error: $ENV_FILE must be a readable regular file." >&2
+        return 1
+    fi
+    for key in "${keys[@]}"; do
+        if compose_env_last_value "$key" >/dev/null; then
+            status=0
+        else
+            status=$?
+        fi
+        [ "$status" -eq 0 ] && continue
+        [ "$status" -eq 1 ] && continue
+        echo "Error: $key in $ENV_FILE uses unsupported Compose dotenv syntax; use a literal same-line value (single-quote literal dollar signs)." >&2
+        return 1
+    done
+}
+
 env_has_nonempty_value() {
     local value
     value=$(env_last_value "$1") || return 1
@@ -114,7 +204,7 @@ env_has_nonempty_value() {
 
 env_boolean_is_true() {
     local key="$1" value read_status
-    if value=$(compose_env_last_value "$key"); then
+    if value=$(env_last_value "$key"); then
         :
     else
         read_status=$?
@@ -129,7 +219,7 @@ env_boolean_is_true() {
         true) return 0 ;;
         false|'') return 1 ;;
         *)
-            echo "Error: $key must be true or false in $ENV_FILE." >&2
+            echo "Error: the effective $key value must be true or false (process environment takes precedence over $ENV_FILE)." >&2
             exit 1
             ;;
     esac
@@ -283,6 +373,11 @@ if [ "$PREFLIGHT_ONLY" = "true" ] && [ "$SKIP_BUILD" = "true" ]; then
     exit 1
 fi
 
+validate_runner_env_values || exit 1
+if [[ ! "$FLEET_API_READY_ATTEMPTS" =~ ^[1-9][0-9]*$ ]]; then
+    echo "Error: FLEET_API_READY_ATTEMPTS must be a positive integer." >&2
+    exit 1
+fi
 FLEET_COMPOSE_PROJECT_NAME=$(resolve_compose_project_name) || exit 1
 RELEASE_IMAGE_TAG=$(resolve_release_image_tag) || exit 1
 FLEET_API_IMAGE="proto-fleet-api:${RELEASE_IMAGE_TAG}"
@@ -360,11 +455,8 @@ refresh_compose_files
 refresh_compose_env_args() {
     COMPOSE_ENV_ARGS=()
     local profile profile_file
-    # `|| true` keeps a missing FLEET_PROFILE line from killing set -euo
-    # pipefail callers; tail -1 matches compose's last-wins env semantics.
-    # Normalize whitespace/CR/quotes and case: compose accepts .env syntax
-    # (CRLF edits on WSL, quoted values) that the filename match would reject
-    profile=$(grep -E '^FLEET_PROFILE=' "$ENV_FILE" 2>/dev/null | tail -1 | cut -d= -f2- | tr -d '[:space:]"'"'" | tr '[:upper:]' '[:lower:]' || true)
+    profile=$(env_last_value FLEET_PROFILE 2>/dev/null || true)
+    profile=$(printf '%s' "$profile" | tr '[:upper:]' '[:lower:]')
     if [ -n "$profile" ]; then
         profile_file="$PROJECT_ROOT/profiles/${profile}.env"
         if [[ "$profile" =~ ^[a-z]+$ ]] && [ -f "$profile_file" ]; then
@@ -460,11 +552,12 @@ is_managed_release_image_tag() {
 prune_obsolete_release_images() {
     local repository image tag image_id containers
     local candidates=()
-    local protected_tags=(latest "$RELEASE_IMAGE_TAG")
+    local protected_tags=(latest "$RELEASE_IMAGE_TAG" "${PREVIOUS_RELEASE_IMAGE_TAGS[@]}")
 
     # Source-tree runs intentionally share mutable :latest tags and must not
     # participate in packaged-release retention.
     [ "$RELEASE_IMAGE_TAG" != "latest" ] || return 0
+    [ "$RELEASE_IMAGE_CLEANUP_SAFE" = "true" ] || return 0
 
     # Collect the complete candidate set before deleting anything. If Docker
     # cannot enumerate one reserved repository, fail safe and leave every tag
@@ -532,6 +625,45 @@ prune_obsolete_release_images() {
             echo "Warning: could not remove obsolete Proto Fleet image $image; continuing." >&2
         fi
     done
+}
+
+capture_previous_release_image_tags() {
+    local images image tag existing_tag found_target=false
+    PREVIOUS_RELEASE_IMAGE_TAGS=()
+    RELEASE_IMAGE_CLEANUP_SAFE=true
+
+    [ "$RELEASE_IMAGE_TAG" != "latest" ] || return 0
+    if ! images=$(docker container ls --all \
+        --filter "label=com.docker.compose.project=$FLEET_COMPOSE_PROJECT_NAME" \
+        --format '{{.Image}}' 2>/dev/null); then
+        echo "Warning: could not identify the active Proto Fleet release; skipping release image cleanup." >&2
+        RELEASE_IMAGE_CLEANUP_SAFE=false
+        return 0
+    fi
+    while IFS= read -r image; do
+        case "$image" in
+            proto-fleet-api:*|proto-fleet-client:*|proto-fleet-timescaledb:*|proto-fleet-timescaledb-ha:*) ;;
+            *) continue ;;
+        esac
+        tag="${image##*:}"
+        is_managed_release_image_tag "$tag" || continue
+        for existing_tag in "${PREVIOUS_RELEASE_IMAGE_TAGS[@]}"; do
+            [ "$existing_tag" != "$tag" ] || continue 2
+        done
+        PREVIOUS_RELEASE_IMAGE_TAGS+=("$tag")
+        [ "$tag" != "$RELEASE_IMAGE_TAG" ] || found_target=true
+    done <<< "$images"
+
+    if [ "${#PREVIOUS_RELEASE_IMAGE_TAGS[@]}" -eq 0 ]; then
+        echo "Warning: no active Proto Fleet release tag was found; skipping release image cleanup." >&2
+        RELEASE_IMAGE_CLEANUP_SAFE=false
+    elif [ "$found_target" = "true" ]; then
+        # On a retry, target containers may already have replaced every source
+        # of the previous known-good tag. Even a second, stale project tag does
+        # not prove which intervening release is the recovery target.
+        echo "Warning: the target Proto Fleet release is already active; skipping release image cleanup because the previous tag cannot be identified safely." >&2
+        RELEASE_IMAGE_CLEANUP_SAFE=false
+    fi
 }
 
 sha256() {
@@ -814,7 +946,7 @@ verify_preflight_marker() {
 # Poll psql until the query returns true; caller owns the warning.
 wait_for_psql_true() {
     local query="$1" attempt result
-    for attempt in $(seq 1 "$MIGRATION_WAIT_ATTEMPTS"); do
+    for attempt in $(seq 1 "$FLEET_API_READY_ATTEMPTS"); do
         result=$(compose exec -T timescaledb \
             bash -c "psql -U \"\$POSTGRES_USER\" -d \"\$POSTGRES_DB\" -tAc \"$query\"" \
             2>/dev/null | tr -d '[:space:]')
@@ -1514,7 +1646,7 @@ if [ -f "$ENV_FILE" ]; then
             use_existing="yes"
             echo "Using existing environment file."
             # Pre-profile installs upgrading: ask once
-            if ! grep -q "^FLEET_PROFILE=" "$ENV_FILE"; then
+            if ! env_last_value FLEET_PROFILE >/dev/null 2>&1; then
                 maybe_prompt_fleet_profile
             fi
         else
@@ -1932,6 +2064,7 @@ fi
 # ----------------------------------------------------------------------------
 
 echo "Stopping any running services..."
+capture_previous_release_image_tags
 compose down --remove-orphans
 
 echo "Starting services..."
@@ -1941,6 +2074,56 @@ echo "Starting services..."
 if ! compose up --remove-orphans -d --wait --wait-timeout 300 --no-build --pull never; then
     echo "Error: services failed to reach running state."
     echo "Check logs with: docker compose --project-name $FLEET_COMPOSE_PROJECT_NAME ${COMPOSE_ENV_ARGS[*]} ${COMPOSE_FILES[*]} logs"
+    exit 1
+fi
+
+wait_for_fleet_api_ready() {
+    local attempt
+
+    echo "Waiting for fleet-api readiness after migrations…"
+    for attempt in $(seq 1 "$FLEET_API_READY_ATTEMPTS"); do
+        # The deployment Compose model fixes fleet-api to 0.0.0.0:4000 in its
+        # extended service definition. Do not let an unrelated dotenv value
+        # redirect this probe to nginx or another process.
+        if curl -fsS -o /dev/null --max-time 2 "http://127.0.0.1:4000/health/ready"; then
+            return 0
+        fi
+        if [ "$attempt" -eq "$FLEET_API_READY_ATTEMPTS" ]; then
+            echo "Error: fleet-api did not become ready within $((FLEET_API_READY_ATTEMPTS * 2))s." >&2
+            return 1
+        fi
+        sleep 2
+    done
+}
+
+wait_for_fleet_client_ready() {
+    local attempt client_url
+
+    client_url="${PROTOCOL_MODE}://127.0.0.1/"
+
+    echo "Waiting for fleet-client readiness…"
+    for attempt in $(seq 1 "$FLEET_API_READY_ATTEMPTS"); do
+        if [ "$PROTOCOL_MODE" = "https" ]; then
+            # The packaged certificate can be self-signed; this is a loopback
+            # liveness probe, not a remote identity check.
+            if curl -fkSs -o /dev/null --max-time 2 "$client_url"; then
+                return 0
+            fi
+        else
+            if curl -fsS -o /dev/null --max-time 2 "$client_url"; then
+                return 0
+            fi
+        fi
+        if [ "$attempt" -eq "$FLEET_API_READY_ATTEMPTS" ]; then
+            echo "Error: fleet-client did not become ready after $FLEET_API_READY_ATTEMPTS attempts." >&2
+            return 1
+        fi
+        sleep 2
+    done
+}
+
+if ! wait_for_fleet_api_ready; then
+    echo "Error: refusing to consume the preflight proof or remove previous release images." >&2
     exit 1
 fi
 
@@ -1954,28 +2137,6 @@ fi
 # re-applied on every run so jobs added by new migrations get staggered on
 # the next upgrade.
 apply_database_tuning() {
-    # fleetd binds its HTTP listener only after applying every pending
-    # migration (cmd/fleetd/main.go), so a responding API is the reliable
-    # all-migrations-applied signal. schema_migrations.dirty=false is not:
-    # during an upgrade the previous deploy's row already reads clean while
-    # migrations (and the policy jobs they create) are still pending.
-    local api_addr api_port attempt
-    api_addr=$(env_last_value HTTP_LISTEN_ADDRESS 2>/dev/null || true)
-    api_port="${api_addr##*:}"
-    case "$api_port" in *[!0-9]*|"") api_port=4000 ;; esac
-
-    echo "Waiting for fleet-api to finish database migrations before applying tuning…"
-    for attempt in $(seq 1 "$MIGRATION_WAIT_ATTEMPTS"); do
-        if curl -s -o /dev/null --max-time 2 "http://127.0.0.1:${api_port}/"; then
-            break
-        fi
-        if [ "$attempt" -eq "$MIGRATION_WAIT_ATTEMPTS" ]; then
-            echo "Warning: fleet-api did not come up within $((MIGRATION_WAIT_ATTEMPTS * 2))s; skipping database tuning." >&2
-            return 1
-        fi
-        sleep 2
-    done
-
     compose exec -T timescaledb \
         bash -c 'psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB"' <<'SQL'
 CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
@@ -2258,6 +2419,15 @@ if [ "$ENABLE_BETA_ALERTS" = "true" ]; then
         echo "         so alert channel/rule/silence management will 401 until this succeeds." >&2
         echo "         Re-run this script (Grafana must be reachable on 127.0.0.1:3030) to retry." >&2
     fi
+fi
+
+# Token provisioning can recreate fleet-api after the initial post-migration
+# probe. Make the cleanup boundary definitive: never consume the preflight
+# proof or remove recovery images unless the final API process is DB-ready and
+# nginx is serving (or redirecting to) the frontend.
+if ! wait_for_fleet_api_ready || ! wait_for_fleet_client_ready; then
+    echo "Error: refusing to consume the preflight proof or remove previous release images." >&2
+    exit 1
 fi
 
 # ----------------------------------------------------------------------------

--- a/deployment-files/run-fleet.sh
+++ b/deployment-files/run-fleet.sh
@@ -5,7 +5,7 @@
 # ============================================================================
 
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-FLEET_COMPOSE_PROJECT_NAME="deployment"
+FLEET_COMPOSE_PROJECT_NAME=""
 COMPOSE_FILE="$PROJECT_ROOT/docker-compose.yaml"
 COMPOSE_ALERTS_FILE="$PROJECT_ROOT/docker-compose.alerts.yaml"
 COMPOSE_SYSTEM_MONITORING_FILE="$PROJECT_ROOT/docker-compose.system-monitoring.yaml"
@@ -69,6 +69,27 @@ env_boolean_is_true() {
             exit 1
             ;;
     esac
+}
+
+resolve_compose_project_name() {
+    local project_name
+
+    if [ -n "${COMPOSE_PROJECT_NAME:-}" ]; then
+        project_name="$COMPOSE_PROJECT_NAME"
+    else
+        # Preserve Compose's historical per-directory project identity for
+        # source checkouts and renamed/nonstandard deployment directories.
+        project_name=$(basename "$PROJECT_ROOT")
+    fi
+
+    # The same value is also used to select volumes below, so reject names
+    # outside Compose's documented grammar before any destructive operation.
+    if [[ ! "$project_name" =~ ^[a-z0-9][a-z0-9_-]*$ ]]; then
+        echo "Error: COMPOSE_PROJECT_NAME must start with a lowercase letter or digit and contain only lowercase letters, digits, hyphens, and underscores." >&2
+        return 1
+    fi
+
+    printf '%s' "$project_name"
 }
 
 resolve_release_image_tag() {
@@ -183,6 +204,7 @@ if [ "$PREFLIGHT_ONLY" = "true" ] && [ "$SKIP_BUILD" = "true" ]; then
     exit 1
 fi
 
+FLEET_COMPOSE_PROJECT_NAME=$(resolve_compose_project_name) || exit 1
 RELEASE_IMAGE_TAG=$(resolve_release_image_tag) || exit 1
 FLEET_API_IMAGE="proto-fleet-api:${RELEASE_IMAGE_TAG}"
 FLEET_CLIENT_IMAGE="proto-fleet-client:${RELEASE_IMAGE_TAG}"
@@ -279,10 +301,10 @@ refresh_compose_env_args() {
 refresh_compose_env_args
 
 compose() {
-    # Official installs have always lived in a directory named `deployment`.
-    # Pin that existing implicit project identity so an updater's temporary
-    # parent directory cannot change Compose's rendered name, containers, or
-    # persistent volume namespace between preflight and activation.
+    # Resolve this once so Compose operations, volume detection, and printed
+    # recovery commands all target the same project. Packaged updater paths
+    # keep the implicit `deployment` identity because both their staged and
+    # active release directories have that basename.
     docker compose --project-name "$FLEET_COMPOSE_PROJECT_NAME" \
         ${COMPOSE_ENV_ARGS[@]+"${COMPOSE_ENV_ARGS[@]}"} "${COMPOSE_FILES[@]}" "$@"
 }
@@ -1082,8 +1104,9 @@ scrub_env_key() {
 
 # Prompt user to reinitialize TimescaleDB data volume if it exists
 prompt_store_reinit() {
-  local proj=$(basename "$PROJECT_ROOT")
-  local vol=$(docker volume ls -q | grep -E "^${proj}[-_]timescaledb-data$")
+  local proj="$FLEET_COMPOSE_PROJECT_NAME"
+  local vol
+  vol=$(docker volume ls -q | grep -E "^${proj}[-_]timescaledb-data$")
   if [[ -n $vol ]]; then
     echo "⚠️  Detected existing TimescaleDB data volume: $vol"
     read -p "   Remove & reinitialize this volume now? ALL DATA WILL BE LOST (y/N): " answer
@@ -1600,7 +1623,7 @@ echo "Starting services..."
 # host networking), producing a false "Proto Fleet is now running!" banner.
 if ! compose up --remove-orphans -d --wait --wait-timeout 300 --no-build --pull never; then
     echo "Error: services failed to reach running state."
-    echo "Check logs with: docker compose ${COMPOSE_ENV_ARGS[*]} ${COMPOSE_FILES[*]} logs"
+    echo "Check logs with: docker compose --project-name $FLEET_COMPOSE_PROJECT_NAME ${COMPOSE_ENV_ARGS[*]} ${COMPOSE_FILES[*]} logs"
     exit 1
 fi
 
@@ -1901,7 +1924,7 @@ provision_grafana_service_account_token() {
     if ! compose up -d --no-deps --force-recreate fleet-api; then
         echo "Error: wrote the Grafana token to $ENV_FILE but failed to restart fleet-api; it is still" >&2
         echo "       running with the pre-token environment and will 401 against Grafana. Restart it with:" >&2
-        echo "         docker compose ${COMPOSE_ENV_ARGS[*]} ${COMPOSE_FILES[*]} up -d --no-deps --force-recreate fleet-api" >&2
+        echo "         docker compose --project-name $FLEET_COMPOSE_PROJECT_NAME ${COMPOSE_ENV_ARGS[*]} ${COMPOSE_FILES[*]} up -d --no-deps --force-recreate fleet-api" >&2
         return 1
     fi
 }

--- a/deployment-files/run-fleet.sh
+++ b/deployment-files/run-fleet.sh
@@ -1417,6 +1417,10 @@ fi
 
 if [ "$SKIP_BUILD" != "true" ]; then
     echo "Pulling latest Docker images..."
+    # Compose v2.17+ reports pull_policy: never services as skipped without
+    # requiring their image in the local cache. Keep external pulls first so
+    # a registry failure cannot retag the bundled TimescaleDB image before the
+    # preflight aborts; the verified archive is loaded immediately afterward.
     if ! compose pull --ignore-buildable; then
         echo "Error: Failed to pull required Docker images."
         exit 1

--- a/deployment-files/scripts/pin-release-images.sh
+++ b/deployment-files/scripts/pin-release-images.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: pin-release-images.sh DEPLOYMENT_ROOT RELEASE_TAG" >&2
+    exit 1
+fi
+
+deployment_root="$1"
+release_tag="$2"
+
+if [[ ! "$release_tag" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]*$ ]] || [ "${#release_tag}" -gt 128 ]; then
+    echo "Error: release tag must be a valid Docker tag of at most 128 characters." >&2
+    exit 1
+fi
+if [ "$release_tag" = "latest" ]; then
+    echo "Error: release bundles must not use the shared latest image tag." >&2
+    exit 1
+fi
+
+pin_reference() {
+    local file="$1" source="$2" target="$3" count temporary line pinned_line
+
+    if [ ! -f "$file" ]; then
+        echo "Error: release image pinning requires $file." >&2
+        return 1
+    fi
+    count=$(grep -Foc "$source" "$file" || true)
+    if [ "$count" -ne 1 ]; then
+        echo "Error: expected exactly one $source reference in $file; found $count." >&2
+        return 1
+    fi
+
+    temporary=$(mktemp "${file}.tmp.XXXXXX") || return 1
+    if ! while IFS= read -r line || [ -n "$line" ]; do
+        pinned_line=${line//$source/$target}
+        printf '%s\n' "$pinned_line"
+    done < "$file" > "$temporary"; then
+        rm -f "$temporary"
+        return 1
+    fi
+    if ! cat "$temporary" > "$file"; then
+        rm -f "$temporary"
+        return 1
+    fi
+    rm -f "$temporary"
+}
+
+pin_reference \
+    "$deployment_root/docker-compose.yaml" \
+    "proto-fleet-api:latest" \
+    "proto-fleet-api:${release_tag}"
+pin_reference \
+    "$deployment_root/docker-compose.yaml" \
+    "proto-fleet-client:latest" \
+    "proto-fleet-client:${release_tag}"
+pin_reference \
+    "$deployment_root/docker-compose.yaml" \
+    "proto-fleet-timescaledb:latest" \
+    "proto-fleet-timescaledb:${release_tag}"
+pin_reference \
+    "$deployment_root/ha/compose.yaml" \
+    "proto-fleet-timescaledb-ha:latest" \
+    "proto-fleet-timescaledb-ha:${release_tag}"

--- a/deployment-files/scripts/pin-release-images.sh
+++ b/deployment-files/scripts/pin-release-images.sh
@@ -33,8 +33,7 @@ pin_reference() {
 
     temporary=$(mktemp "${file}.tmp.XXXXXX") || return 1
     if ! while IFS= read -r line || [ -n "$line" ]; do
-        pinned_line=${line//$source/$target}
-        printf '%s\n' "$pinned_line"
+        printf '%s\n' "${line//$source/$target}"
     done < "$file" > "$temporary"; then
         rm -f "$temporary"
         return 1
@@ -46,18 +45,12 @@ pin_reference() {
     rm -f "$temporary"
 }
 
-pin_reference \
-    "$deployment_root/docker-compose.yaml" \
-    "proto-fleet-api:latest" \
-    "proto-fleet-api:${release_tag}"
-pin_reference \
-    "$deployment_root/docker-compose.yaml" \
-    "proto-fleet-client:latest" \
-    "proto-fleet-client:${release_tag}"
-pin_reference \
-    "$deployment_root/docker-compose.yaml" \
-    "proto-fleet-timescaledb:latest" \
-    "proto-fleet-timescaledb:${release_tag}"
+for repository in proto-fleet-api proto-fleet-client proto-fleet-timescaledb; do
+    pin_reference \
+        "$deployment_root/docker-compose.yaml" \
+        "${repository}:latest" \
+        "${repository}:${release_tag}"
+done
 pin_reference \
     "$deployment_root/ha/compose.yaml" \
     "proto-fleet-timescaledb-ha:latest" \

--- a/deployment-files/tests/test-profiles.sh
+++ b/deployment-files/tests/test-profiles.sh
@@ -8,6 +8,8 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 PROFILES_DIR="$REPO_ROOT/deployment-files/profiles"
 BASE_COMPOSE="$REPO_ROOT/server/docker-compose.base.yaml"
 PROD_COMPOSE="$REPO_ROOT/deployment-files/docker-compose.yaml"
+PIN_RELEASE_IMAGES="$REPO_ROOT/deployment-files/scripts/pin-release-images.sh"
+RELEASE_TAG="v1.2.3"
 
 FAILURES=0
 
@@ -212,14 +214,43 @@ fi
 
 STAGE=$(mktemp -d)
 trap 'rm -rf "$STRICT_TMP" "$STAGE"' EXIT
-mkdir -p "$STAGE/server" "$STAGE/client"
+mkdir -p "$STAGE/server" "$STAGE/client" "$STAGE/ha"
 cp "$PROD_COMPOSE" "$STAGE/"
+cp "$REPO_ROOT/deployment-files/ha/compose.yaml" "$STAGE/ha/"
 cp "$BASE_COMPOSE" "$STAGE/server/"
 cp -r "$PROFILES_DIR" "$STAGE/profiles"
 printf 'FROM scratch\n' > "$STAGE/server/Dockerfile"
 printf 'FROM scratch\n' > "$STAGE/client/Dockerfile"
 printf 'DB_USERNAME=fleet\nDB_PASSWORD=test\nAUTH_CLIENT_SECRET_KEY=test\nENCRYPT_SERVICE_MASTER_KEY=test\n' > "$STAGE/base-secrets.env"
 printf 'DB_USERNAME=fleet\nDB_PASSWORD=test\nAUTH_CLIENT_SECRET_KEY=test\nENCRYPT_SERVICE_MASTER_KEY=test\nPG_SHARED_BUFFERS=999MB\n' > "$STAGE/override.env"
+
+if "$PIN_RELEASE_IMAGES" "$STAGE" latest >/dev/null 2>&1; then
+    fail "release packaging accepted the shared latest image tag"
+else
+    pass "release packaging rejects the shared latest image tag"
+fi
+if "$PIN_RELEASE_IMAGES" "$STAGE" "$RELEASE_TAG"; then
+    pass "release packaging pins immutable image references"
+else
+    fail "release packaging could not pin immutable image references"
+fi
+for image in \
+    "proto-fleet-api:$RELEASE_TAG" \
+    "proto-fleet-client:$RELEASE_TAG" \
+    "proto-fleet-timescaledb:$RELEASE_TAG"; do
+    grep -Fq "image: $image" "$STAGE/docker-compose.yaml" || \
+        fail "packaged Compose is missing $image"
+done
+grep -Fq "image: proto-fleet-timescaledb-ha:$RELEASE_TAG" "$STAGE/ha/compose.yaml" || \
+    fail "packaged HA Compose is missing its release-specific image"
+if grep -Fq 'proto-fleet-api:latest' "$STAGE/docker-compose.yaml" || \
+   grep -Fq 'proto-fleet-client:latest' "$STAGE/docker-compose.yaml" || \
+   grep -Fq 'proto-fleet-timescaledb:latest' "$STAGE/docker-compose.yaml" || \
+   grep -Fq 'proto-fleet-timescaledb-ha:latest' "$STAGE/ha/compose.yaml"; then
+    fail "release packaging left a shared latest runtime image reference"
+else
+    pass "release packaging removes shared latest runtime image references"
+fi
 
 render() { # env-file args...
     (cd "$STAGE" && docker compose "$@" -f docker-compose.yaml config 2>"$STAGE/render.err")
@@ -243,6 +274,9 @@ assert_rendered() { # description rendered_output expected...
 
 out=$(render --env-file base-secrets.env)
 assert_rendered "no-profile render keeps defaults" "$out" \
+    "image: proto-fleet-api:$RELEASE_TAG" \
+    "image: proto-fleet-client:$RELEASE_TAG" \
+    "image: proto-fleet-timescaledb:$RELEASE_TAG" \
     "shared_buffers=256MB" "max_worker_processes=19" "wal_compression=off" \
     "shared_preload_libraries=timescaledb,pg_stat_statements" \
     "pg_stat_statements.track_utility=off" \

--- a/deployment-files/tests/test-run-fleet-upgrade.sh
+++ b/deployment-files/tests/test-run-fleet-upgrade.sh
@@ -105,12 +105,12 @@ make_stage() {
     local name="$1"
     STAGE="$TMP_DIR/$name"
     local runtime="$STAGE-runtime"
-    mkdir -p "$STAGE/client" "$STAGE/ha" "$STAGE/server/monitoring/grafana/provisioning/datasources" "$runtime/bin"
-    ln -s "$runtime/bin" "$STAGE/bin"
-    : > "$runtime/calls.log"
-    : > "$runtime/output.log"
-    ln -s "$runtime/calls.log" "$STAGE/calls.log"
-    ln -s "$runtime/output.log" "$STAGE/output.log"
+    HARNESS_BIN_DIR="$runtime/bin"
+    HARNESS_CALL_LOG="$runtime/calls.log"
+    HARNESS_OUTPUT_LOG="$runtime/output.log"
+    mkdir -p "$STAGE/client" "$STAGE/ha" "$STAGE/server/monitoring/grafana/provisioning/datasources" "$HARNESS_BIN_DIR"
+    : > "$HARNESS_CALL_LOG"
+    : > "$HARNESS_OUTPUT_LOG"
     cp "$DEPLOY_DIR/run-fleet.sh" "$STAGE/"
     cp "$DEPLOY_DIR/docker-compose.yaml" "$STAGE/"
     cp "$DEPLOY_DIR/docker-compose.alerts.yaml" "$STAGE/"
@@ -129,9 +129,9 @@ make_stage() {
     (cd "$STAGE/image-fixture" && tar -cf - manifest.json) | gzip > "$STAGE/images/timescaledb.tar.gz"
     rm -rf "$STAGE/image-fixture"
     write_valid_env "$STAGE/.env"
-    : > "$STAGE/calls.log"
+    : > "$HARNESS_CALL_LOG"
 
-    cat > "$STAGE/bin/docker" <<'EOF'
+    cat > "$HARNESS_BIN_DIR/docker" <<'EOF'
 #!/bin/bash
 printf 'docker' >> "$CALL_LOG"
 printf ' %s' "$@" >> "$CALL_LOG"
@@ -217,13 +217,13 @@ case " $* " in
 esac
 EOF
 
-    cat > "$STAGE/bin/systemctl" <<'EOF'
+    cat > "$HARNESS_BIN_DIR/systemctl" <<'EOF'
 #!/bin/bash
 printf 'systemctl %s\n' "$*" >> "$CALL_LOG"
 [ "${FAKE_SYSTEMD_UNAVAILABLE:-false}" != "true" ]
 EOF
 
-    cat > "$STAGE/bin/id" <<'EOF'
+    cat > "$HARNESS_BIN_DIR/id" <<'EOF'
 #!/bin/bash
 if [ "${1:-}" = "-u" ]; then
     echo 0
@@ -232,12 +232,12 @@ else
 fi
 EOF
 
-    cat > "$STAGE/bin/uname" <<'EOF'
+    cat > "$HARNESS_BIN_DIR/uname" <<'EOF'
 #!/bin/bash
 echo Linux
 EOF
 
-    cat > "$STAGE/bin/grep" <<'EOF'
+    cat > "$HARNESS_BIN_DIR/grep" <<'EOF'
 #!/bin/bash
 if [ "${FAKE_WSL:-false}" = "true" ]; then
     for argument in "$@"; do
@@ -249,7 +249,7 @@ fi
 exec "$REAL_GREP" "$@"
 EOF
 
-    cat > "$STAGE/bin/curl" <<'EOF'
+    cat > "$HARNESS_BIN_DIR/curl" <<'EOF'
 #!/bin/bash
 printf 'curl %s\n' "$*" >> "$CALL_LOG"
 case " $* " in
@@ -260,13 +260,13 @@ case " $* " in
 esac
 EOF
 
-    cat > "$STAGE/bin/sudo" <<'EOF'
+    cat > "$HARNESS_BIN_DIR/sudo" <<'EOF'
 #!/bin/bash
 printf 'sudo %s\n' "$*" >> "$CALL_LOG"
 exit 0
 EOF
 
-    cat > "$STAGE/bin/hostname" <<'EOF'
+    cat > "$HARNESS_BIN_DIR/hostname" <<'EOF'
 #!/bin/bash
 if [ "${1:-}" = "-I" ]; then
     echo '192.0.2.10'
@@ -275,30 +275,30 @@ else
 fi
 EOF
 
-    cat > "$STAGE/bin/ip" <<'EOF'
+    cat > "$HARNESS_BIN_DIR/ip" <<'EOF'
 #!/bin/bash
 exit 0
 EOF
 
-    chmod +x "$STAGE/run-fleet.sh" "$STAGE/bin/"*
+    chmod +x "$STAGE/run-fleet.sh" "$HARNESS_BIN_DIR/"*
     write_release_manifest "$STAGE"
 }
 
 run_stage() {
     local stage="$1"
     shift
-    CALL_LOG="$stage/calls.log" \
+    CALL_LOG="$HARNESS_CALL_LOG" \
     STAGE_ROOT="$stage" \
     REAL_GREP="$REAL_GREP" \
-    PATH="$stage/bin:$PATH" \
-    /bin/bash "$stage/run-fleet.sh" "$@" > "$stage/output.log" 2>&1
+    PATH="$HARNESS_BIN_DIR:$PATH" \
+    /bin/bash "$stage/run-fleet.sh" "$@" > "$HARNESS_OUTPUT_LOG" 2>&1
 }
 
 # The updater-specific option is intentionally deferred until its Compose
 # overlay is shipped and packaged later in the stack.
 make_stage help
 if run_stage "$STAGE" --help; then
-    assert_not_contains "help omits the unavailable updater overlay" "$STAGE/output.log" "enable-one-click-updates"
+    assert_not_contains "help omits the unavailable updater overlay" "$HARNESS_OUTPUT_LOG" "enable-one-click-updates"
 else
     fail "--help should succeed"
 fi
@@ -315,9 +315,9 @@ if FAKE_SOURCE_INSTALL=true run_stage "$STAGE" --non-interactive; then
 else
     fail "source-tree run should preserve its Compose project identity"
 fi
-assert_contains "source-tree run targets its directory project" "$STAGE/calls.log" "compose --project-name source-layout"
-assert_not_contains "source-tree run cannot target an installed deployment project" "$STAGE/calls.log" "compose --project-name deployment "
-assert_contains "source-tree run reaches teardown in its isolated project" "$STAGE/calls.log" " down --remove-orphans"
+assert_contains "source-tree run targets its directory project" "$HARNESS_CALL_LOG" "compose --project-name source-layout"
+assert_not_contains "source-tree run cannot target an installed deployment project" "$HARNESS_CALL_LOG" "compose --project-name deployment "
+assert_contains "source-tree run reaches teardown in its isolated project" "$HARNESS_CALL_LOG" " down --remove-orphans"
 
 # Existing process-level overrides remain authoritative and are reused by
 # volume detection. Do not persist a new multi-install identity here: the
@@ -328,7 +328,7 @@ if COMPOSE_PROJECT_NAME=fleet-blue run_stage "$STAGE" --non-interactive --prefli
 else
     fail "explicit Compose project override should be preserved"
 fi
-assert_contains "explicit project override reaches Compose" "$STAGE/calls.log" "compose --project-name fleet-blue"
+assert_contains "explicit project override reaches Compose" "$HARNESS_CALL_LOG" "compose --project-name fleet-blue"
 
 make_stage project-volume
 env_without_password="$STAGE/.env.without-password"
@@ -339,7 +339,7 @@ if printf 'n\n' | COMPOSE_PROJECT_NAME=fleet-blue FAKE_DOCKER_VOLUME=fleet-blue_
 else
     pass "volume guard uses the explicit Compose project override"
 fi
-assert_contains "volume guard finds the overridden project volume" "$STAGE/output.log" "Detected existing TimescaleDB data volume: fleet-blue_timescaledb-data"
+assert_contains "volume guard finds the overridden project volume" "$HARNESS_OUTPUT_LOG" "Detected existing TimescaleDB data volume: fleet-blue_timescaledb-data"
 
 make_stage invalid-project-override
 if COMPOSE_PROJECT_NAME='Fleet Blue' run_stage "$STAGE" --non-interactive --preflight-only; then
@@ -347,8 +347,8 @@ if COMPOSE_PROJECT_NAME='Fleet Blue' run_stage "$STAGE" --non-interactive --pref
 else
     pass "invalid Compose project override fails before Docker activity"
 fi
-assert_contains "invalid project override is diagnosed" "$STAGE/output.log" "COMPOSE_PROJECT_NAME must start with a lowercase letter or digit"
-assert_not_contains "invalid project override cannot target Docker" "$STAGE/calls.log" "docker "
+assert_contains "invalid project override is diagnosed" "$HARNESS_OUTPUT_LOG" "COMPOSE_PROJECT_NAME must start with a lowercase letter or digit"
+assert_not_contains "invalid project override cannot target Docker" "$HARNESS_CALL_LOG" "docker "
 
 # A successful preflight validates and prepares images, but never stops or
 # starts the active stack. It records a same-directory activation marker.
@@ -358,16 +358,16 @@ if run_stage "$STAGE" --non-interactive --preflight-only; then
 else
     fail "valid non-interactive preflight should succeed"
 fi
-assert_contains "preflight validates Compose" "$STAGE/calls.log" "config --quiet"
-assert_contains "preflight pins the Compose project identity" "$STAGE/calls.log" "compose --project-name deployment"
-assert_contains "preflight pulls images" "$STAGE/calls.log" " pull"
-assert_contains "preflight builds images" "$STAGE/calls.log" " build --no-cache"
-assert_contains "preflight verifies the release API image" "$STAGE/calls.log" "image inspect --format {{.Id}} $FLEET_API_IMAGE"
-assert_contains "preflight verifies the release client image" "$STAGE/calls.log" "image inspect --format {{.Id}} $FLEET_CLIENT_IMAGE"
-assert_contains "preflight verifies the release database image" "$STAGE/calls.log" "image inspect --format {{.Id}} $TIMESCALEDB_IMAGE"
-assert_not_contains "preflight never targets shared latest image tags" "$STAGE/calls.log" ":latest"
-assert_not_contains "preflight leaves services running" "$STAGE/calls.log" " down --remove-orphans"
-assert_not_contains "preflight never starts replacement services" "$STAGE/calls.log" " up --remove-orphans"
+assert_contains "preflight validates Compose" "$HARNESS_CALL_LOG" "config --quiet"
+assert_contains "preflight pins the Compose project identity" "$HARNESS_CALL_LOG" "compose --project-name deployment"
+assert_contains "preflight pulls images" "$HARNESS_CALL_LOG" " pull"
+assert_contains "preflight builds images" "$HARNESS_CALL_LOG" " build --no-cache"
+assert_contains "preflight verifies the release API image" "$HARNESS_CALL_LOG" "image inspect --format {{.Id}} $FLEET_API_IMAGE"
+assert_contains "preflight verifies the release client image" "$HARNESS_CALL_LOG" "image inspect --format {{.Id}} $FLEET_CLIENT_IMAGE"
+assert_contains "preflight verifies the release database image" "$HARNESS_CALL_LOG" "image inspect --format {{.Id}} $TIMESCALEDB_IMAGE"
+assert_not_contains "preflight never targets shared latest image tags" "$HARNESS_CALL_LOG" ":latest"
+assert_not_contains "preflight leaves services running" "$HARNESS_CALL_LOG" " down --remove-orphans"
+assert_not_contains "preflight never starts replacement services" "$HARNESS_CALL_LOG" " up --remove-orphans"
 [ -f "$STAGE/.update-preflight-complete" ] || fail "preflight should create its activation marker"
 if grep -Eq '^proto-fleet-preflight-v2:[0-9a-f]{64}:[0-9a-f]{64}$' "$STAGE/.update-preflight-complete"; then
     pass "preflight marker records versioned release metadata"
@@ -393,18 +393,18 @@ fi
 
 # Activation consumes the marker, reuses prepared images, and performs the
 # service transition without another pull or build.
-: > "$STAGE/calls.log"
+: > "$HARNESS_CALL_LOG"
 if run_stage "$STAGE" --non-interactive --skip-build; then
     pass "prepared activation succeeds"
 else
     fail "prepared activation should succeed"
 fi
-assert_not_contains "activation skips pulls" "$STAGE/calls.log" " pull"
-assert_not_contains "activation skips builds" "$STAGE/calls.log" " build --no-cache"
-assert_contains "activation forbids implicit image preparation" "$STAGE/calls.log" "up --remove-orphans -d --wait --wait-timeout 300 --no-build --pull never"
-assert_not_contains "activation never resolves shared latest image tags" "$STAGE/calls.log" ":latest"
-assert_contains "activation stops the old stack" "$STAGE/calls.log" " down --remove-orphans"
-assert_contains "activation starts the new stack" "$STAGE/calls.log" " up --remove-orphans"
+assert_not_contains "activation skips pulls" "$HARNESS_CALL_LOG" " pull"
+assert_not_contains "activation skips builds" "$HARNESS_CALL_LOG" " build --no-cache"
+assert_contains "activation forbids implicit image preparation" "$HARNESS_CALL_LOG" "up --remove-orphans -d --wait --wait-timeout 300 --no-build --pull never"
+assert_not_contains "activation never resolves shared latest image tags" "$HARNESS_CALL_LOG" ":latest"
+assert_contains "activation stops the old stack" "$HARNESS_CALL_LOG" " down --remove-orphans"
+assert_contains "activation starts the new stack" "$HARNESS_CALL_LOG" " up --remove-orphans"
 [ ! -f "$STAGE/.update-preflight-complete" ] || fail "successful activation should consume its marker"
 
 # The updater preflights and activates directories that are both named
@@ -419,13 +419,13 @@ relocated_stage="$TMP_DIR/activated-release/deployment"
 mkdir -p "$(dirname "$relocated_stage")"
 mv "$STAGE" "$relocated_stage"
 STAGE="$relocated_stage"
-: > "$STAGE/calls.log"
+: > "$HARNESS_CALL_LOG"
 if run_stage "$STAGE" --non-interactive --skip-build; then
     pass "preflight proof survives the updater's directory rename"
 else
     fail "unchanged relocated release should activate"
 fi
-assert_contains "relocated activation stops the old stack" "$STAGE/calls.log" " down --remove-orphans"
+assert_contains "relocated activation stops the old stack" "$HARNESS_CALL_LOG" " down --remove-orphans"
 
 # Every input that defines the prepared release is bound into the marker. A
 # changed or forged marker fails before the active deployment is stopped and
@@ -452,15 +452,15 @@ for mutation in env compose version nginx runner runtime tls timescaledb; do
         tls) printf '\nchanged after preflight\n' >> "$STAGE/ssl/cert.pem" ;;
         timescaledb) printf 'changed-after-preflight' >> "$STAGE/images/timescaledb.tar.gz" ;;
     esac
-    : > "$STAGE/calls.log"
+    : > "$HARNESS_CALL_LOG"
     if run_stage "$STAGE" --non-interactive --skip-build; then
         fail "$mutation changes should invalidate preflight"
     else
         pass "$mutation changes invalidate preflight"
     fi
-    assert_contains "$mutation mismatch is diagnosed" "$STAGE/output.log" "changed after preflight"
-    assert_not_contains "$mutation mismatch prevents teardown" "$STAGE/calls.log" " down --remove-orphans"
-    assert_not_contains "$mutation mismatch prevents startup" "$STAGE/calls.log" " up --remove-orphans"
+    assert_contains "$mutation mismatch is diagnosed" "$HARNESS_OUTPUT_LOG" "changed after preflight"
+    assert_not_contains "$mutation mismatch prevents teardown" "$HARNESS_CALL_LOG" " down --remove-orphans"
+    assert_not_contains "$mutation mismatch prevents startup" "$HARNESS_CALL_LOG" " up --remove-orphans"
     [ ! -e "$STAGE/.update-preflight-complete" ] || fail "$mutation mismatch should remove the stale marker"
 done
 
@@ -468,28 +468,28 @@ make_stage missing-prepared-image
 if ! run_stage "$STAGE" --non-interactive --preflight-only; then
     fail "missing-image fixture preflight should succeed"
 fi
-: > "$STAGE/calls.log"
+: > "$HARNESS_CALL_LOG"
 if FAKE_PREPARED_IMAGE_MISSING=true run_stage "$STAGE" --non-interactive --skip-build; then
     fail "missing prepared image should fail activation validation"
 else
     pass "missing prepared image fails before activation"
 fi
-assert_contains "missing image is diagnosed" "$STAGE/output.log" "prepared image is missing before activation"
-assert_not_contains "missing image prevents teardown" "$STAGE/calls.log" " down --remove-orphans"
+assert_contains "missing image is diagnosed" "$HARNESS_OUTPUT_LOG" "prepared image is missing before activation"
+assert_not_contains "missing image prevents teardown" "$HARNESS_CALL_LOG" " down --remove-orphans"
 [ ! -e "$STAGE/.update-preflight-complete" ] || fail "missing image should invalidate the marker"
 
 make_stage changed-prepared-image
 if ! run_stage "$STAGE" --non-interactive --preflight-only; then
     fail "changed-image fixture preflight should succeed"
 fi
-: > "$STAGE/calls.log"
+: > "$HARNESS_CALL_LOG"
 if FAKE_PREPARED_IMAGE_CHANGED=true run_stage "$STAGE" --non-interactive --skip-build; then
     fail "changed prepared image should fail activation validation"
 else
     pass "changed prepared image fails before activation"
 fi
-assert_contains "changed image is diagnosed" "$STAGE/output.log" "changed after preflight"
-assert_not_contains "changed image prevents teardown" "$STAGE/calls.log" " down --remove-orphans"
+assert_contains "changed image is diagnosed" "$HARNESS_OUTPUT_LOG" "changed after preflight"
+assert_not_contains "changed image prevents teardown" "$HARNESS_CALL_LOG" " down --remove-orphans"
 [ ! -e "$STAGE/.update-preflight-complete" ] || fail "changed image should invalidate the marker"
 
 make_stage added-release-file
@@ -497,15 +497,41 @@ if ! run_stage "$STAGE" --non-interactive --preflight-only; then
     fail "added-file fixture preflight should succeed"
 fi
 printf 'apiVersion: 1\n' > "$STAGE/server/monitoring/grafana/provisioning/datasources/added-after-preflight.yaml"
-: > "$STAGE/calls.log"
+: > "$HARNESS_CALL_LOG"
 if run_stage "$STAGE" --non-interactive --skip-build; then
     fail "an added immutable release file should fail activation validation"
 else
     pass "an added immutable release file fails before activation"
 fi
-assert_contains "added release file is diagnosed" "$STAGE/output.log" "file set does not match"
-assert_not_contains "added release file prevents teardown" "$STAGE/calls.log" " down --remove-orphans"
+assert_contains "added release file is diagnosed" "$HARNESS_OUTPUT_LOG" "file set does not match"
+assert_not_contains "added release file prevents teardown" "$HARNESS_CALL_LOG" " down --remove-orphans"
 [ ! -e "$STAGE/.update-preflight-complete" ] || fail "added release file should invalidate the marker"
+
+# Non-regular entries are not valid release content. In particular, Grafana
+# recursively consumes this provisioning directory, so a symlink or FIFO added
+# after preflight must invalidate activation just like an added regular file.
+for entry_type in symlink fifo; do
+    make_stage "added-release-$entry_type"
+    if ! run_stage "$STAGE" --non-interactive --preflight-only; then
+        fail "$entry_type fixture preflight should succeed"
+        continue
+    fi
+    entry="$STAGE/server/monitoring/grafana/provisioning/datasources/added-after-preflight-$entry_type.yaml"
+    case "$entry_type" in
+        symlink) ln -s base.yaml "$entry" ;;
+        fifo) mkfifo "$entry" ;;
+    esac
+    : > "$HARNESS_CALL_LOG"
+    if run_stage "$STAGE" --non-interactive --skip-build; then
+        fail "an added immutable $entry_type should fail activation validation"
+    else
+        pass "an added immutable $entry_type fails before activation"
+    fi
+    assert_contains "$entry_type addition is diagnosed" "$HARNESS_OUTPUT_LOG" "unsupported non-regular entries"
+    assert_not_contains "$entry_type addition prevents teardown" "$HARNESS_CALL_LOG" " down --remove-orphans"
+    assert_not_contains "$entry_type addition prevents startup" "$HARNESS_CALL_LOG" " up --remove-orphans"
+    [ ! -e "$STAGE/.update-preflight-complete" ] || fail "$entry_type addition should invalidate the marker"
+done
 
 # HA's node.env is operator-owned runtime state, not a packaged release file.
 # Permit that exact path while keeping every other added HA artifact inside the
@@ -520,14 +546,14 @@ else
     fail "operator-owned HA node environment should not fail preflight"
 fi
 printf 'tampered\n' > "$STAGE/ha/added-after-preflight.yaml"
-: > "$STAGE/calls.log"
+: > "$HARNESS_CALL_LOG"
 if run_stage "$STAGE" --non-interactive --skip-build; then
     fail "an added HA release file should fail activation validation"
 else
     pass "other added HA files remain immutable"
 fi
-assert_contains "added HA release file is diagnosed" "$STAGE/output.log" "file set does not match"
-assert_not_contains "added HA release file prevents teardown" "$STAGE/calls.log" " down --remove-orphans"
+assert_contains "added HA release file is diagnosed" "$HARNESS_OUTPUT_LOG" "file set does not match"
+assert_not_contains "added HA release file prevents teardown" "$HARNESS_CALL_LOG" " down --remove-orphans"
 [ ! -e "$STAGE/.update-preflight-complete" ] || fail "added HA release file should invalidate the marker"
 
 make_stage missing-release-manifest
@@ -537,8 +563,8 @@ if run_stage "$STAGE" --non-interactive --preflight-only; then
 else
     pass "missing release manifest fails preflight"
 fi
-assert_contains "missing manifest is diagnosed" "$STAGE/output.log" "requires the immutable release manifest"
-assert_not_contains "missing manifest prevents pulls" "$STAGE/calls.log" " pull"
+assert_contains "missing manifest is diagnosed" "$HARNESS_OUTPUT_LOG" "requires the immutable release manifest"
+assert_not_contains "missing manifest prevents pulls" "$HARNESS_CALL_LOG" " pull"
 [ ! -e "$STAGE/.update-preflight-complete" ] || fail "missing manifest must not create a marker"
 
 # Release bundles must pin literal image references before any preparation.
@@ -550,10 +576,10 @@ if FAKE_COMPOSE_USES_LATEST=true run_stage "$STAGE" --non-interactive --prefligh
 else
     pass "release Compose model rejects shared latest tags"
 fi
-assert_contains "unpinned Compose is diagnosed" "$STAGE/output.log" "not pinned to required image $FLEET_API_IMAGE"
-assert_not_contains "unpinned Compose prevents pulls" "$STAGE/calls.log" " pull"
-assert_not_contains "unpinned Compose prevents archive loading" "$STAGE/calls.log" "docker load"
-assert_not_contains "unpinned Compose prevents builds" "$STAGE/calls.log" " build --no-cache"
+assert_contains "unpinned Compose is diagnosed" "$HARNESS_OUTPUT_LOG" "not pinned to required image $FLEET_API_IMAGE"
+assert_not_contains "unpinned Compose prevents pulls" "$HARNESS_CALL_LOG" " pull"
+assert_not_contains "unpinned Compose prevents archive loading" "$HARNESS_CALL_LOG" "docker load"
+assert_not_contains "unpinned Compose prevents builds" "$HARNESS_CALL_LOG" " build --no-cache"
 
 make_stage unpinned-ha-compose
 sed -i.bak "s|$TIMESCALEDB_HA_IMAGE|proto-fleet-timescaledb-ha:latest|" "$STAGE/ha/compose.yaml"
@@ -564,8 +590,8 @@ if run_stage "$STAGE" --non-interactive --preflight-only; then
 else
     pass "release HA Compose model rejects the shared latest tag"
 fi
-assert_contains "unpinned HA Compose is diagnosed" "$STAGE/output.log" "not pinned to required image $TIMESCALEDB_HA_IMAGE"
-assert_not_contains "unpinned HA Compose prevents archive loading" "$STAGE/calls.log" "docker load"
+assert_contains "unpinned HA Compose is diagnosed" "$HARNESS_OUTPUT_LOG" "not pinned to required image $TIMESCALEDB_HA_IMAGE"
+assert_not_contains "unpinned HA Compose prevents archive loading" "$HARNESS_CALL_LOG" "docker load"
 
 make_stage changed-during-preflight
 if FAKE_MUTATE_TSDB_DURING_BUILD=true run_stage "$STAGE" --non-interactive --preflight-only; then
@@ -573,10 +599,10 @@ if FAKE_MUTATE_TSDB_DURING_BUILD=true run_stage "$STAGE" --non-interactive --pre
 else
     pass "inputs changed during preparation fail preflight"
 fi
-assert_contains "mid-preflight mutation is diagnosed" "$STAGE/output.log" "release or configuration changed during preflight"
-assert_contains "mid-preflight mutation occurs after the build starts" "$STAGE/calls.log" " build --no-cache"
-assert_not_contains "failed preflight leaves shared latest tags untouched" "$STAGE/calls.log" ":latest"
-assert_not_contains "mid-preflight mutation prevents teardown" "$STAGE/calls.log" " down --remove-orphans"
+assert_contains "mid-preflight mutation is diagnosed" "$HARNESS_OUTPUT_LOG" "release or configuration changed during preflight"
+assert_contains "mid-preflight mutation occurs after the build starts" "$HARNESS_CALL_LOG" " build --no-cache"
+assert_not_contains "failed preflight leaves shared latest tags untouched" "$HARNESS_CALL_LOG" ":latest"
+assert_not_contains "mid-preflight mutation prevents teardown" "$HARNESS_CALL_LOG" " down --remove-orphans"
 [ ! -e "$STAGE/.update-preflight-complete" ] || fail "mid-preflight mutation must not create a marker"
 
 make_stage forged-marker
@@ -586,7 +612,7 @@ if run_stage "$STAGE" --non-interactive --skip-build; then
 else
     pass "an empty forged marker is rejected"
 fi
-assert_not_contains "forged marker prevents teardown" "$STAGE/calls.log" " down --remove-orphans"
+assert_not_contains "forged marker prevents teardown" "$HARNESS_CALL_LOG" " down --remove-orphans"
 [ ! -e "$STAGE/.update-preflight-complete" ] || fail "forged marker should be invalidated"
 
 # A failed activation retains the marker so the recovery command can retry the
@@ -595,14 +621,14 @@ make_stage failed-activation
 if ! run_stage "$STAGE" --non-interactive --preflight-only; then
     fail "failed-activation fixture preflight should succeed"
 fi
-: > "$STAGE/calls.log"
+: > "$HARNESS_CALL_LOG"
 if FAKE_ACTIVATION_FAILURE=true run_stage "$STAGE" --non-interactive --skip-build; then
     fail "simulated activation failure should propagate"
 else
     pass "activation failure propagates"
 fi
 [ -f "$STAGE/.update-preflight-complete" ] || fail "failed activation should retain its recovery marker"
-assert_contains "activation recovery command keeps the resolved project" "$STAGE/output.log" "docker compose --project-name failed-activation"
+assert_contains "activation recovery command keeps the resolved project" "$HARNESS_OUTPUT_LOG" "docker compose --project-name failed-activation"
 
 # Skip-build must not be usable without proof that this exact deployment
 # directory completed preflight.
@@ -612,7 +638,7 @@ if run_stage "$STAGE" --non-interactive --skip-build; then
 else
     pass "skip-build rejects an unprepared deployment"
 fi
-assert_not_contains "unprepared activation makes no Docker calls" "$STAGE/calls.log" "docker "
+assert_not_contains "unprepared activation makes no Docker calls" "$HARNESS_CALL_LOG" "docker "
 
 # Invalid persisted booleans fail before even read-only Docker probes.
 make_stage invalid-boolean
@@ -622,7 +648,7 @@ if run_stage "$STAGE" --non-interactive --preflight-only; then
 else
     pass "invalid persisted boolean fails preflight"
 fi
-assert_not_contains "invalid boolean makes no Docker calls" "$STAGE/calls.log" "docker "
+assert_not_contains "invalid boolean makes no Docker calls" "$HARNESS_CALL_LOG" "docker "
 
 # Invalid persisted configuration must fail before mutation or image/service
 # operations, so activation cannot discover it only after teardown.
@@ -636,8 +662,8 @@ else
     pass "empty required settings fail preflight"
 fi
 cmp -s "$STAGE/env.before" "$STAGE/.env" || fail "invalid preflight should not rewrite .env"
-assert_not_contains "invalid settings prevent pulls" "$STAGE/calls.log" " pull"
-assert_not_contains "invalid settings prevent teardown" "$STAGE/calls.log" " down --remove-orphans"
+assert_not_contains "invalid settings prevent pulls" "$HARNESS_CALL_LOG" " pull"
+assert_not_contains "invalid settings prevent teardown" "$HARNESS_CALL_LOG" " down --remove-orphans"
 
 make_stage invalid-secrets
 sed -i.bak \
@@ -650,9 +676,9 @@ if run_stage "$STAGE" --non-interactive --preflight-only; then
 else
     pass "malformed secrets fail preflight"
 fi
-assert_contains "short auth secret is diagnosed" "$STAGE/output.log" "must be at least 32 characters"
-assert_contains "invalid encryption key is diagnosed" "$STAGE/output.log" "must decode to exactly 32 bytes"
-assert_not_contains "malformed secrets prevent pulls" "$STAGE/calls.log" " pull"
+assert_contains "short auth secret is diagnosed" "$HARNESS_OUTPUT_LOG" "must be at least 32 characters"
+assert_contains "invalid encryption key is diagnosed" "$HARNESS_OUTPUT_LOG" "must decode to exactly 32 bytes"
+assert_not_contains "malformed secrets prevent pulls" "$HARNESS_CALL_LOG" " pull"
 
 # Existing alert deployments must retain their secrets; an unattended run
 # fails instead of generating replacements for incomplete persisted state.
@@ -671,8 +697,8 @@ else
     pass "missing alert secrets fail preflight"
 fi
 cmp -s "$STAGE/env.before" "$STAGE/.env" || fail "alert validation should not rewrite .env"
-assert_contains "missing alert service token is diagnosed" "$STAGE/output.log" "FLEET_ALERTS_GRAFANA_TOKEN"
-assert_not_contains "missing alert secrets prevent pulls" "$STAGE/calls.log" " pull"
+assert_contains "missing alert service token is diagnosed" "$HARNESS_OUTPUT_LOG" "FLEET_ALERTS_GRAFANA_TOKEN"
+assert_not_contains "missing alert secrets prevent pulls" "$HARNESS_CALL_LOG" " pull"
 
 # Grafana role names are deterministic local validation, so reject known-bad
 # SQL identifiers and privileged/conflicting role names during preflight rather
@@ -717,9 +743,9 @@ for role_case in invalid-grafana-identifier invalid-db-identifier postgres-role 
         pass "$role_case fails preflight"
     fi
     cmp -s "$STAGE/env.before" "$STAGE/.env" || fail "$role_case validation should not rewrite .env"
-    assert_contains "$role_case is diagnosed" "$STAGE/output.log" "$expected_error"
-    assert_not_contains "$role_case prevents pulls" "$STAGE/calls.log" " pull"
-    assert_not_contains "$role_case prevents teardown" "$STAGE/calls.log" " down --remove-orphans"
+    assert_contains "$role_case is diagnosed" "$HARNESS_OUTPUT_LOG" "$expected_error"
+    assert_not_contains "$role_case prevents pulls" "$HARNESS_CALL_LOG" " pull"
+    assert_not_contains "$role_case prevents teardown" "$HARNESS_CALL_LOG" " down --remove-orphans"
     [ ! -e "$STAGE/.update-preflight-complete" ] || fail "$role_case must not create a preflight marker"
 done
 
@@ -732,8 +758,8 @@ if FAKE_COMPOSE_CONFIG_FAILURE=true run_stage "$STAGE" --non-interactive --prefl
 else
     pass "invalid Compose configuration fails preflight"
 fi
-assert_not_contains "invalid Compose prevents pulls" "$STAGE/calls.log" " pull"
-assert_not_contains "invalid Compose prevents teardown" "$STAGE/calls.log" " down --remove-orphans"
+assert_not_contains "invalid Compose prevents pulls" "$HARNESS_CALL_LOG" " pull"
+assert_not_contains "invalid Compose prevents teardown" "$HARNESS_CALL_LOG" " down --remove-orphans"
 [ ! -f "$STAGE/.update-preflight-complete" ] || fail "invalid Compose must not leave a preflight marker"
 
 # A non-removable stale marker fails closed before Docker activity.
@@ -744,7 +770,7 @@ if run_stage "$STAGE" --non-interactive --preflight-only; then
 else
     pass "non-removable preflight marker fails closed"
 fi
-assert_not_contains "marker cleanup failure makes no Docker calls" "$STAGE/calls.log" "docker "
+assert_not_contains "marker cleanup failure makes no Docker calls" "$HARNESS_CALL_LOG" "docker "
 
 # Missing packaged and local database images must fail before a preflight can
 # authorize service activation.
@@ -756,8 +782,8 @@ if run_stage "$STAGE" --non-interactive --preflight-only; then
 else
     pass "missing TimescaleDB image fails preflight"
 fi
-assert_not_contains "missing database image prevents builds" "$STAGE/calls.log" " build --no-cache"
-assert_not_contains "missing database image prevents teardown" "$STAGE/calls.log" " down --remove-orphans"
+assert_not_contains "missing database image prevents builds" "$HARNESS_CALL_LOG" " build --no-cache"
+assert_not_contains "missing database image prevents teardown" "$HARNESS_CALL_LOG" " down --remove-orphans"
 [ ! -f "$STAGE/.update-preflight-complete" ] || fail "missing database image must not leave a preflight marker"
 
 # Compose skips pull_policy: never services even when their local image is
@@ -769,10 +795,10 @@ if FAKE_TSDB_IMAGE_COLD_CACHE=true run_stage "$STAGE" --non-interactive --prefli
 else
     fail "compose pull should skip an uncached pull_policy-never TimescaleDB image"
 fi
-assert_contains "cold cache still pulls external dependencies" "$STAGE/calls.log" " pull --ignore-buildable"
-assert_contains "cold cache loads the packaged database image" "$STAGE/calls.log" "docker load"
-pull_line=$(grep -nF ' pull --ignore-buildable' "$STAGE/calls.log" | head -1 | cut -d: -f1)
-load_line=$(grep -nF 'docker load' "$STAGE/calls.log" | head -1 | cut -d: -f1)
+assert_contains "cold cache still pulls external dependencies" "$HARNESS_CALL_LOG" " pull --ignore-buildable"
+assert_contains "cold cache loads the packaged database image" "$HARNESS_CALL_LOG" "docker load"
+pull_line=$(grep -nF ' pull --ignore-buildable' "$HARNESS_CALL_LOG" | head -1 | cut -d: -f1)
+load_line=$(grep -nF 'docker load' "$HARNESS_CALL_LOG" | head -1 | cut -d: -f1)
 if [ -n "$pull_line" ] && [ -n "$load_line" ] && [ "$pull_line" -lt "$load_line" ]; then
     pass "external pull fails before any packaged database retagging"
 else
@@ -791,8 +817,8 @@ if run_stage "$STAGE" --non-interactive --preflight-only; then
 else
     pass "mistagged TimescaleDB archive fails preflight"
 fi
-assert_not_contains "mistagged database image is not loaded" "$STAGE/calls.log" "docker load"
-assert_not_contains "mistagged database image prevents builds" "$STAGE/calls.log" " build --no-cache"
+assert_not_contains "mistagged database image is not loaded" "$HARNESS_CALL_LOG" "docker load"
+assert_not_contains "mistagged database image prevents builds" "$HARNESS_CALL_LOG" " build --no-cache"
 
 # Requiring only the standard release tag would still allow docker load to
 # move the daemon-global HA latest tag.
@@ -808,9 +834,9 @@ if run_stage "$STAGE" --non-interactive --preflight-only; then
 else
     pass "archive with a shared HA latest tag fails preflight"
 fi
-assert_contains "shared HA archive tag is diagnosed" "$STAGE/output.log" "contains forbidden shared image proto-fleet-timescaledb-ha:latest"
-assert_not_contains "shared HA archive tag is not loaded" "$STAGE/calls.log" "docker load"
-assert_not_contains "shared HA archive tag prevents builds" "$STAGE/calls.log" " build --no-cache"
+assert_contains "shared HA archive tag is diagnosed" "$HARNESS_OUTPUT_LOG" "contains forbidden shared image proto-fleet-timescaledb-ha:latest"
+assert_not_contains "shared HA archive tag is not loaded" "$HARNESS_CALL_LOG" "docker load"
+assert_not_contains "shared HA archive tag prevents builds" "$HARNESS_CALL_LOG" " build --no-cache"
 
 make_stage unloaded-tsdb-image
 if FAKE_TSDB_IMAGE_MISSING=true run_stage "$STAGE" --non-interactive --preflight-only; then
@@ -818,8 +844,8 @@ if FAKE_TSDB_IMAGE_MISSING=true run_stage "$STAGE" --non-interactive --preflight
 else
     pass "loaded archive must expose the expected TimescaleDB tag"
 fi
-assert_not_contains "unloaded database image prevents builds" "$STAGE/calls.log" " build --no-cache"
-assert_not_contains "unloaded database image prevents teardown" "$STAGE/calls.log" " down --remove-orphans"
+assert_not_contains "unloaded database image prevents builds" "$HARNESS_CALL_LOG" " build --no-cache"
+assert_not_contains "unloaded database image prevents teardown" "$HARNESS_CALL_LOG" " down --remove-orphans"
 
 # Legacy HTTPS deployments predate SESSION_COOKIE_SECURE persistence. A full
 # certificate pair remains authoritative only when the key is absent; this
@@ -836,7 +862,7 @@ if run_stage "$STAGE" --non-interactive --preflight-only; then
 else
     fail "legacy HTTPS should be inferred from its complete certificate pair"
 fi
-assert_contains "legacy HTTPS transport is preserved" "$STAGE/output.log" "Preserving legacy HTTPS mode"
+assert_contains "legacy HTTPS transport is preserved" "$HARNESS_OUTPUT_LOG" "Preserving legacy HTTPS mode"
 if cmp -s "$STAGE/client/nginx.https.conf" "$STAGE/client/nginx.conf" && grep -q '^SESSION_COOKIE_SECURE=true$' "$STAGE/.env"; then
     pass "legacy HTTPS is persisted explicitly"
 else
@@ -854,7 +880,7 @@ if run_stage "$STAGE" --non-interactive --preflight-only; then
 else
     fail "persisted HTTP with stale certificates should preflight"
 fi
-assert_contains "HTTP transport is explicitly preserved" "$STAGE/output.log" "Preserving HTTP mode"
+assert_contains "HTTP transport is explicitly preserved" "$HARNESS_OUTPUT_LOG" "Preserving HTTP mode"
 if cmp -s "$STAGE/client/nginx.http.conf" "$STAGE/client/nginx.conf"; then
     pass "HTTP nginx configuration remains active"
 else
@@ -870,8 +896,8 @@ if FAKE_WSL=true FAKE_SYSTEMD_UNAVAILABLE=true run_stage "$STAGE" --non-interact
 else
     fail "non-systemd WSL should rely on the Docker daemon probe"
 fi
-assert_not_contains "non-systemd WSL skips the systemd boot check" "$STAGE/calls.log" "systemctl is-enabled docker"
-assert_contains "non-systemd WSL reaches the Docker daemon probe" "$STAGE/calls.log" "docker info"
+assert_not_contains "non-systemd WSL skips the systemd boot check" "$HARNESS_CALL_LOG" "systemctl is-enabled docker"
+assert_contains "non-systemd WSL reaches the Docker daemon probe" "$HARNESS_CALL_LOG" "docker info"
 
 make_stage native-linux-without-systemd
 if FAKE_SYSTEMD_UNAVAILABLE=true run_stage "$STAGE" --non-interactive --preflight-only; then
@@ -879,8 +905,8 @@ if FAKE_SYSTEMD_UNAVAILABLE=true run_stage "$STAGE" --non-interactive --prefligh
 else
     pass "native Linux retains the Docker boot-enable guard"
 fi
-assert_contains "native Linux boot failure is diagnosed" "$STAGE/output.log" "Docker is not enabled at boot"
-assert_not_contains "native Linux boot failure prevents image pulls" "$STAGE/calls.log" " pull"
+assert_contains "native Linux boot failure is diagnosed" "$HARNESS_OUTPUT_LOG" "Docker is not enabled at boot"
+assert_not_contains "native Linux boot failure prevents image pulls" "$HARNESS_CALL_LOG" " pull"
 
 # A transient WSL registry outage is diagnostic-only in non-interactive mode;
 # it must not invoke sudo, edit host networking, or prune the build cache.
@@ -890,9 +916,9 @@ if FAKE_WSL=true FAKE_REGISTRY_FAILURE=true run_stage "$STAGE" --non-interactive
 else
     pass "WSL registry outage fails without repair mutations"
 fi
-assert_not_contains "WSL failure does not invoke sudo" "$STAGE/calls.log" "sudo "
-assert_not_contains "WSL failure does not prune build cache" "$STAGE/calls.log" "builder prune -af"
-assert_not_contains "WSL failure prevents pulls" "$STAGE/calls.log" " pull"
+assert_not_contains "WSL failure does not invoke sudo" "$HARNESS_CALL_LOG" "sudo "
+assert_not_contains "WSL failure does not prune build cache" "$HARNESS_CALL_LOG" "builder prune -af"
+assert_not_contains "WSL failure prevents pulls" "$HARNESS_CALL_LOG" " pull"
 
 if [ "$FAILURES" -ne 0 ]; then
     while IFS= read -r -d '' output; do

--- a/deployment-files/tests/test-run-fleet-upgrade.sh
+++ b/deployment-files/tests/test-run-fleet-upgrade.sh
@@ -145,7 +145,12 @@ case " $* " in
         [ "${FAKE_COMPOSE_CONFIG_FAILURE:-false}" != "true" ]
         ;;
     *" compose "*" config --images "*)
-        if [ "${FAKE_COMPOSE_USES_LATEST:-false}" = "true" ]; then
+        if [ "${FAKE_SOURCE_INSTALL:-false}" = "true" ]; then
+            printf '%s\n' \
+                'proto-fleet-api:latest' \
+                'proto-fleet-client:latest' \
+                'proto-fleet-timescaledb:latest'
+        elif [ "${FAKE_COMPOSE_USES_LATEST:-false}" = "true" ]; then
             printf '%s\n' \
                 'proto-fleet-api:latest' \
                 'proto-fleet-client:v1.2.3' \
@@ -186,6 +191,11 @@ case " $* " in
         ;;
     *" compose "*" exec "*)
         echo 't'
+        ;;
+    *" volume ls -q "*)
+        if [ -n "${FAKE_DOCKER_VOLUME:-}" ]; then
+            printf '%s\n' "$FAKE_DOCKER_VOLUME"
+        fi
         ;;
     *" image inspect --format "*)
         image="${!#}"
@@ -293,9 +303,56 @@ else
     fail "--help should succeed"
 fi
 
+# Ordinary source-tree runs retain their directory-derived project identity,
+# so a checkout cannot stop or reuse resources from an installed `deployment`
+# project on the same Docker daemon.
+make_stage source-layout
+rm -f "$STAGE/version.txt" "$STAGE/deployment-manifest.sha256" "$STAGE/images/timescaledb.tar.gz"
+cp "$DEPLOY_DIR/docker-compose.yaml" "$STAGE/"
+cp "$DEPLOY_DIR/ha/compose.yaml" "$STAGE/ha/"
+if FAKE_SOURCE_INSTALL=true run_stage "$STAGE" --non-interactive; then
+    pass "source-tree run succeeds with its own Compose project"
+else
+    fail "source-tree run should preserve its Compose project identity"
+fi
+assert_contains "source-tree run targets its directory project" "$STAGE/calls.log" "compose --project-name source-layout"
+assert_not_contains "source-tree run cannot target an installed deployment project" "$STAGE/calls.log" "compose --project-name deployment "
+assert_contains "source-tree run reaches teardown in its isolated project" "$STAGE/calls.log" " down --remove-orphans"
+
+# Existing process-level overrides remain authoritative and are reused by
+# volume detection. Do not persist a new multi-install identity here: the
+# surrounding migration and uninstall tools do not support that contract.
+make_stage project-override
+if COMPOSE_PROJECT_NAME=fleet-blue run_stage "$STAGE" --non-interactive --preflight-only; then
+    pass "explicit Compose project override preflights"
+else
+    fail "explicit Compose project override should be preserved"
+fi
+assert_contains "explicit project override reaches Compose" "$STAGE/calls.log" "compose --project-name fleet-blue"
+
+make_stage project-volume
+env_without_password="$STAGE/.env.without-password"
+grep -Ev '^DB_PASSWORD=' "$STAGE/.env" > "$env_without_password"
+mv "$env_without_password" "$STAGE/.env"
+if printf 'n\n' | COMPOSE_PROJECT_NAME=fleet-blue FAKE_DOCKER_VOLUME=fleet-blue_timescaledb-data run_stage "$STAGE"; then
+    fail "declining removal of an overridden project volume should abort"
+else
+    pass "volume guard uses the explicit Compose project override"
+fi
+assert_contains "volume guard finds the overridden project volume" "$STAGE/output.log" "Detected existing TimescaleDB data volume: fleet-blue_timescaledb-data"
+
+make_stage invalid-project-override
+if COMPOSE_PROJECT_NAME='Fleet Blue' run_stage "$STAGE" --non-interactive --preflight-only; then
+    fail "invalid Compose project override should fail"
+else
+    pass "invalid Compose project override fails before Docker activity"
+fi
+assert_contains "invalid project override is diagnosed" "$STAGE/output.log" "COMPOSE_PROJECT_NAME must start with a lowercase letter or digit"
+assert_not_contains "invalid project override cannot target Docker" "$STAGE/calls.log" "docker "
+
 # A successful preflight validates and prepares images, but never stops or
 # starts the active stack. It records a same-directory activation marker.
-make_stage preflight
+make_stage preflight-parent/deployment
 if run_stage "$STAGE" --non-interactive --preflight-only; then
     pass "valid non-interactive preflight succeeds"
 else
@@ -350,10 +407,11 @@ assert_contains "activation stops the old stack" "$STAGE/calls.log" " down --rem
 assert_contains "activation starts the new stack" "$STAGE/calls.log" " up --remove-orphans"
 [ ! -f "$STAGE/.update-preflight-complete" ] || fail "successful activation should consume its marker"
 
-# The updater preflights under a temporary parent and then renames the release
-# into the stable deployment path. Absolute paths in rendered Compose output
-# are normalized so that safe relocation does not invalidate the proof.
-make_stage relocated-preflight
+# The updater preflights and activates directories that are both named
+# `deployment`; only their parent changes. Absolute paths in rendered Compose
+# output are normalized so that this safe relocation does not invalidate the
+# proof, while Compose's native project identity stays stable.
+make_stage relocated-preflight/deployment
 if ! run_stage "$STAGE" --non-interactive --preflight-only; then
     fail "relocation fixture preflight should succeed"
 fi
@@ -544,6 +602,7 @@ else
     pass "activation failure propagates"
 fi
 [ -f "$STAGE/.update-preflight-complete" ] || fail "failed activation should retain its recovery marker"
+assert_contains "activation recovery command keeps the resolved project" "$STAGE/output.log" "docker compose --project-name failed-activation"
 
 # Skip-build must not be usable without proof that this exact deployment
 # directory completed preflight.
@@ -836,11 +895,10 @@ assert_not_contains "WSL failure does not prune build cache" "$STAGE/calls.log" 
 assert_not_contains "WSL failure prevents pulls" "$STAGE/calls.log" " pull"
 
 if [ "$FAILURES" -ne 0 ]; then
-    for output in "$TMP_DIR"/*/output.log; do
-        [ -f "$output" ] || continue
+    while IFS= read -r -d '' output; do
         echo "--- $output" >&2
         sed 's/^/    /' "$output" >&2
-    done
+    done < <(find "$TMP_DIR" -type f -name output.log -print0)
     echo "$FAILURES failure(s)" >&2
     exit 1
 fi

--- a/deployment-files/tests/test-run-fleet-upgrade.sh
+++ b/deployment-files/tests/test-run-fleet-upgrade.sh
@@ -562,6 +562,64 @@ fi
 assert_contains "unsupported interpolation is diagnosed without printing its value" "$HARNESS_OUTPUT_LOG" "AUTH_CLIENT_SECRET_KEY in $STAGE/.env uses unsupported Compose dotenv syntax"
 assert_not_contains "unsupported interpolation makes no Docker calls" "$HARNESS_CALL_LOG" "docker "
 
+# Optional overlay values are runner-consumed only while their overlay is
+# active. Dormant Compose interpolation must not block an otherwise unrelated
+# preflight, but the same syntax must still fail closed before Docker activity
+# once the matching overlay is enabled.
+make_stage dormant-overlay-interpolation
+printf '%s\n' \
+    'DD_API_KEY=${DATADOG_API_KEY}' \
+    'GRAFANA_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD_FROM_VAULT}' \
+    'GRAFANA_DB_USERNAME=${GRAFANA_DB_USERNAME_FROM_VAULT}' \
+    'GRAFANA_DB_PASSWORD=${GRAFANA_DB_PASSWORD_FROM_VAULT}' \
+    'GRAFANA_SECRET_KEY=${GRAFANA_SECRET_KEY_FROM_VAULT}' \
+    'FLEET_ALERTS_WEBHOOK_TOKEN=${FLEET_ALERTS_WEBHOOK_TOKEN_FROM_VAULT}' \
+    'FLEET_ALERTS_GRAFANA_TOKEN=${FLEET_ALERTS_GRAFANA_TOKEN_FROM_VAULT}' >> "$STAGE/.env"
+if run_stage "$STAGE" --non-interactive --preflight-only; then
+    pass "disabled overlays tolerate dormant Compose interpolation"
+else
+    fail "disabled overlays should ignore values they do not consume"
+fi
+assert_not_contains "disabled tracing omits its Compose overlay" "$HARNESS_CALL_LOG" "docker-compose.tracing.yaml"
+assert_not_contains "disabled alerts omit their Compose overlay" "$HARNESS_CALL_LOG" "docker-compose.alerts.yaml"
+assert_contains "dormant tracing value is preserved" "$STAGE/.env" 'DD_API_KEY=${DATADOG_API_KEY}'
+assert_contains "dormant alert value is preserved" "$STAGE/.env" 'GRAFANA_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD_FROM_VAULT}'
+
+make_stage interpolated-tracing-env
+printf '%s\n' \
+    'ENABLE_TRACING=true' \
+    'DD_API_KEY=${DATADOG_API_KEY}' >> "$STAGE/.env"
+cp "$STAGE/.env" "$HARNESS_OUTPUT_LOG.env-before"
+if run_stage "$STAGE" --non-interactive --preflight-only; then
+    fail "enabled tracing should reject unsupported DD_API_KEY interpolation"
+else
+    pass "enabled tracing validates its API key syntax"
+fi
+assert_contains "enabled tracing interpolation is diagnosed" "$HARNESS_OUTPUT_LOG" "DD_API_KEY in $STAGE/.env uses unsupported Compose dotenv syntax"
+assert_not_contains "invalid tracing interpolation makes no Docker calls" "$HARNESS_CALL_LOG" "docker "
+if cmp -s "$HARNESS_OUTPUT_LOG.env-before" "$STAGE/.env"; then
+    pass "invalid tracing interpolation leaves the environment unchanged"
+else
+    fail "invalid tracing interpolation should not rewrite the environment"
+fi
+
+make_stage interpolated-alerts-env
+enable_valid_alerts "$STAGE/.env"
+printf 'GRAFANA_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD_FROM_VAULT}\n' >> "$STAGE/.env"
+cp "$STAGE/.env" "$HARNESS_OUTPUT_LOG.env-before"
+if run_stage "$STAGE" --non-interactive --preflight-only; then
+    fail "enabled alerts should reject unsupported secret interpolation"
+else
+    pass "enabled alerts validate their secret syntax"
+fi
+assert_contains "enabled alert interpolation is diagnosed" "$HARNESS_OUTPUT_LOG" "GRAFANA_ADMIN_PASSWORD in $STAGE/.env uses unsupported Compose dotenv syntax"
+assert_not_contains "invalid alert interpolation makes no Docker calls" "$HARNESS_CALL_LOG" "docker "
+if cmp -s "$HARNESS_OUTPUT_LOG.env-before" "$STAGE/.env"; then
+    pass "invalid alert interpolation leaves the environment unchanged"
+else
+    fail "invalid alert interpolation should not rewrite the environment"
+fi
+
 make_stage empty-commented-secret
 printf 'DB_PASSWORD="" # valid Compose comment\n' >> "$STAGE/.env"
 if run_stage "$STAGE" --non-interactive --preflight-only; then
@@ -1577,6 +1635,35 @@ fi
 assert_not_contains "WSL failure does not invoke sudo" "$HARNESS_CALL_LOG" "sudo "
 assert_not_contains "WSL failure does not prune build cache" "$HARNESS_CALL_LOG" "builder prune -af"
 assert_not_contains "WSL failure prevents pulls" "$HARNESS_CALL_LOG" " pull"
+
+# A prepared activation is local-only: its marker binds every required image
+# ID and Compose runs with --no-build/--pull never, so a later registry outage
+# must not block activation or trigger WSL host-network repair.
+make_stage wsl-prepared-offline-activation
+if FAKE_WSL=true run_stage "$STAGE" --non-interactive --preflight-only; then
+    pass "WSL activation fixture preflights while the registry is available"
+else
+    fail "WSL activation fixture should preflight"
+fi
+assert_contains "WSL preflight checks required registry connectivity" "$HARNESS_CALL_LOG" "registry-1.docker.io"
+: > "$HARNESS_CALL_LOG"
+if FAKE_WSL=true FAKE_REGISTRY_FAILURE=true \
+    run_stage "$STAGE" --non-interactive --skip-build; then
+    pass "prepared WSL activation tolerates a registry outage"
+else
+    fail "prepared WSL activation should not require registry connectivity"
+fi
+assert_not_contains "prepared WSL activation skips the registry probe" "$HARNESS_CALL_LOG" "registry-1.docker.io"
+assert_not_contains "prepared WSL activation does not mutate host networking" "$HARNESS_CALL_LOG" "sudo "
+assert_not_contains "prepared WSL activation does not clear build cache" "$HARNESS_CALL_LOG" "builder prune -af"
+assert_not_contains "prepared WSL activation skips image pulls" "$HARNESS_CALL_LOG" " pull --ignore-buildable"
+assert_not_contains "prepared WSL activation skips image builds" "$HARNESS_CALL_LOG" " build --no-cache"
+assert_contains "prepared WSL activation reaches local-only Compose startup" "$HARNESS_CALL_LOG" "up --remove-orphans -d --wait --wait-timeout 300 --no-build --pull never"
+if [ -f "$STAGE/.update-preflight-complete" ]; then
+    fail "successful offline WSL activation should consume its marker"
+else
+    pass "successful offline WSL activation consumes its marker"
+fi
 
 if [ "$FAILURES" -ne 0 ]; then
     while IFS= read -r -d '' output; do

--- a/deployment-files/tests/test-run-fleet-upgrade.sh
+++ b/deployment-files/tests/test-run-fleet-upgrade.sh
@@ -193,7 +193,7 @@ EOF
     cat > "$STAGE/bin/systemctl" <<'EOF'
 #!/bin/bash
 printf 'systemctl %s\n' "$*" >> "$CALL_LOG"
-exit 0
+[ "${FAKE_SYSTEMD_UNAVAILABLE:-false}" != "true" ]
 EOF
 
     cat > "$STAGE/bin/id" <<'EOF'
@@ -710,6 +710,27 @@ if cmp -s "$STAGE/client/nginx.http.conf" "$STAGE/client/nginx.conf"; then
 else
     fail "stale certificates selected the wrong nginx configuration"
 fi
+
+# The Windows installer supports WSL distros whose Docker daemon is managed by
+# `service` or an init script. A healthy daemon must remain authoritative even
+# when systemctl is unavailable; native Linux retains its boot-enable guard.
+make_stage wsl-without-systemd
+if FAKE_WSL=true FAKE_SYSTEMD_UNAVAILABLE=true run_stage "$STAGE" --non-interactive --preflight-only; then
+    pass "healthy Docker on non-systemd WSL preflights"
+else
+    fail "non-systemd WSL should rely on the Docker daemon probe"
+fi
+assert_not_contains "non-systemd WSL skips the systemd boot check" "$STAGE/calls.log" "systemctl is-enabled docker"
+assert_contains "non-systemd WSL reaches the Docker daemon probe" "$STAGE/calls.log" "docker info"
+
+make_stage native-linux-without-systemd
+if FAKE_SYSTEMD_UNAVAILABLE=true run_stage "$STAGE" --non-interactive --preflight-only; then
+    fail "native Linux without Docker boot enablement should fail preflight"
+else
+    pass "native Linux retains the Docker boot-enable guard"
+fi
+assert_contains "native Linux boot failure is diagnosed" "$STAGE/output.log" "Docker is not enabled at boot"
+assert_not_contains "native Linux boot failure prevents image pulls" "$STAGE/calls.log" " pull"
 
 # A transient WSL registry outage is diagnostic-only in non-interactive mode;
 # it must not invoke sudo, edit host networking, or prune the build cache.

--- a/deployment-files/tests/test-run-fleet-upgrade.sh
+++ b/deployment-files/tests/test-run-fleet-upgrade.sh
@@ -141,13 +141,18 @@ case " $* " in
             'proto-fleet-timescaledb:latest'
         ;;
     *" compose "*" config "*)
+        project_name=''
         previous=''
         for argument in "$@"; do
+            if [ "$previous" = "--project-name" ]; then
+                project_name="$argument"
+            fi
             if [ "$previous" = "-f" ]; then
                 printf 'compose_file: %s\n' "$argument"
             fi
             previous="$argument"
         done
+        printf 'name: %s\n' "${project_name:-${STAGE_ROOT##*/}}"
         ;;
     *" compose "*" build --no-cache "*)
         if [ "${FAKE_MUTATE_TSDB_DURING_BUILD:-false}" = "true" ]; then
@@ -272,6 +277,7 @@ else
     fail "valid non-interactive preflight should succeed"
 fi
 assert_contains "preflight validates Compose" "$STAGE/calls.log" "config --quiet"
+assert_contains "preflight pins the Compose project identity" "$STAGE/calls.log" "compose --project-name deployment"
 assert_contains "preflight pulls images" "$STAGE/calls.log" " pull"
 assert_contains "preflight builds images" "$STAGE/calls.log" " build --no-cache"
 assert_not_contains "preflight leaves services running" "$STAGE/calls.log" " down --remove-orphans"

--- a/deployment-files/tests/test-run-fleet-upgrade.sh
+++ b/deployment-files/tests/test-run-fleet-upgrade.sh
@@ -154,6 +154,11 @@ case " $* " in
         done
         printf 'name: %s\n' "${project_name:-${STAGE_ROOT##*/}}"
         ;;
+    *" compose "*" pull --ignore-buildable "*)
+        if [ "${FAKE_TSDB_IMAGE_COLD_CACHE:-false}" = "true" ]; then
+            echo 'Image proto-fleet-timescaledb:latest Skipped'
+        fi
+        ;;
     *" compose "*" build --no-cache "*)
         if [ "${FAKE_MUTATE_TSDB_DURING_BUILD:-false}" = "true" ]; then
             printf 'changed-during-build' >> "$STAGE_ROOT/images/timescaledb.tar.gz"
@@ -177,6 +182,9 @@ case " $* " in
         printf 'sha256:test-%s\n' "$image"
         ;;
     *" image inspect proto-fleet-timescaledb:latest "*)
+        if [ "${FAKE_TSDB_IMAGE_COLD_CACHE:-false}" = "true" ] && ! grep -qF 'docker load' "$CALL_LOG"; then
+            exit 1
+        fi
         [ "${FAKE_TSDB_IMAGE_MISSING:-false}" != "true" ]
         ;;
 esac
@@ -620,6 +628,25 @@ fi
 assert_not_contains "missing database image prevents builds" "$STAGE/calls.log" " build --no-cache"
 assert_not_contains "missing database image prevents teardown" "$STAGE/calls.log" " down --remove-orphans"
 [ ! -f "$STAGE/.update-preflight-complete" ] || fail "missing database image must not leave a preflight marker"
+
+# Compose skips pull_policy: never services even when their local image is
+# absent. A clean host therefore pulls external dependencies first, then loads
+# the packaged TimescaleDB archive and completes preflight.
+make_stage cold-tsdb-cache
+if FAKE_TSDB_IMAGE_COLD_CACHE=true run_stage "$STAGE" --non-interactive --preflight-only; then
+    pass "a cold TimescaleDB image cache preflights from the packaged archive"
+else
+    fail "compose pull should skip an uncached pull_policy-never TimescaleDB image"
+fi
+assert_contains "cold cache still pulls external dependencies" "$STAGE/calls.log" " pull --ignore-buildable"
+assert_contains "cold cache loads the packaged database image" "$STAGE/calls.log" "docker load"
+pull_line=$(grep -nF ' pull --ignore-buildable' "$STAGE/calls.log" | head -1 | cut -d: -f1)
+load_line=$(grep -nF 'docker load' "$STAGE/calls.log" | head -1 | cut -d: -f1)
+if [ -n "$pull_line" ] && [ -n "$load_line" ] && [ "$pull_line" -lt "$load_line" ]; then
+    pass "external pull fails before any packaged database retagging"
+else
+    fail "external images should be pulled before loading the packaged database image"
+fi
 
 make_stage mistagged-tsdb-image
 mkdir -p "$STAGE/image-fixture"

--- a/deployment-files/tests/test-run-fleet-upgrade.sh
+++ b/deployment-files/tests/test-run-fleet-upgrade.sh
@@ -51,26 +51,16 @@ assert_not_contains() {
 
 file_owner_group() {
     local owner_group
-    if owner_group=$(stat -c '%u:%g' "$1" 2>/dev/null); then
-        :
-    elif owner_group=$(stat -f '%u:%g' "$1" 2>/dev/null); then
-        :
-    else
-        return 1
-    fi
+    owner_group=$(stat -c '%u:%g' "$1" 2>/dev/null) ||
+        owner_group=$(stat -f '%u:%g' "$1" 2>/dev/null) || return 1
     [ -n "$owner_group" ] || return 1
     printf '%s' "$owner_group"
 }
 
 file_mode() {
     local mode
-    if mode=$(stat -c '%a' "$1" 2>/dev/null); then
-        :
-    elif mode=$(stat -f '%Lp' "$1" 2>/dev/null); then
-        :
-    else
-        return 1
-    fi
+    mode=$(stat -c '%a' "$1" 2>/dev/null) ||
+        mode=$(stat -f '%Lp' "$1" 2>/dev/null) || return 1
     [ -n "$mode" ] || return 1
     printf '%s' "$mode"
 }
@@ -91,6 +81,18 @@ write_valid_env() {
     printf 'ENABLE_TRACING="FALSE" \r\n' >> "$env_file"
 }
 
+# Build a minimal docker-save-shaped archive whose manifest carries the given
+# RepoTags JSON fragment (comma-separated, pre-quoted).
+write_tsdb_archive() {
+    local stage="$1" repo_tags="$2"
+    local fixture="$stage/image-fixture"
+    mkdir -p "$stage/images" "$fixture"
+    printf '[{"Config":"config.json","RepoTags":[%s],"Layers":[]}]\n' \
+        "$repo_tags" > "$fixture/manifest.json"
+    (cd "$fixture" && tar -cf - manifest.json) | gzip > "$stage/images/timescaledb.tar.gz"
+    rm -rf "$fixture"
+}
+
 enable_valid_alerts() {
     local env_file="$1"
     printf '%s\n' \
@@ -105,31 +107,22 @@ enable_valid_alerts() {
 
 write_release_manifest() {
     local stage="$1"
+    local -a hasher=(sha256sum)
+    command -v sha256sum >/dev/null 2>&1 || hasher=(shasum -a 256)
     (
         cd "$stage" || exit 1
-        if command -v sha256sum >/dev/null 2>&1; then
-            find . -type f \
-                ! -path './.env' \
-                ! -path './.update-preflight-complete' \
-                ! -path './.update-preflight-complete.tmp.*' \
-                ! -path './client/nginx.conf' \
-                ! -path './ssl/*' \
-                ! -path './server/influx_config/.env' \
-                ! -path './ha/node.env' \
-                ! -path './deployment-manifest.sha256' \
-                -print0 | LC_ALL=C sort -z | xargs -0 sha256sum > deployment-manifest.sha256
-        else
-            find . -type f \
-                ! -path './.env' \
-                ! -path './.update-preflight-complete' \
-                ! -path './.update-preflight-complete.tmp.*' \
-                ! -path './client/nginx.conf' \
-                ! -path './ssl/*' \
-                ! -path './server/influx_config/.env' \
-                ! -path './ha/node.env' \
-                ! -path './deployment-manifest.sha256' \
-                -print0 | LC_ALL=C sort -z | xargs -0 shasum -a 256 > deployment-manifest.sha256
-        fi
+        # Must exclude the same operator-owned paths as find_release_entries
+        # in run-fleet.sh.
+        find . -type f \
+            ! -path './.env' \
+            ! -path './.update-preflight-complete' \
+            ! -path './.update-preflight-complete.tmp.*' \
+            ! -path './client/nginx.conf' \
+            ! -path './ssl/*' \
+            ! -path './server/influx_config/.env' \
+            ! -path './ha/node.env' \
+            ! -path './deployment-manifest.sha256' \
+            -print0 | LC_ALL=C sort -z | xargs -0 "${hasher[@]}" > deployment-manifest.sha256
     )
 }
 
@@ -156,13 +149,8 @@ make_stage() {
     printf 'apiVersion: 1\n' > "$STAGE/server/monitoring/grafana/provisioning/datasources/base.yaml"
     printf '%s\n' "version: $RELEASE_TAG" 'commit: test-release' > "$STAGE/version.txt"
     "$DEPLOY_DIR/scripts/pin-release-images.sh" "$STAGE" "$RELEASE_TAG"
-    mkdir -p "$STAGE/images" "$STAGE/image-fixture"
-    printf '[{"Config":"config.json","RepoTags":["%s","%s"],"Layers":[]}]\n' \
-        "$TIMESCALEDB_IMAGE" "$TIMESCALEDB_HA_IMAGE" > "$STAGE/image-fixture/manifest.json"
-    (cd "$STAGE/image-fixture" && tar -cf - manifest.json) | gzip > "$STAGE/images/timescaledb.tar.gz"
-    rm -rf "$STAGE/image-fixture"
+    write_tsdb_archive "$STAGE" "\"$TIMESCALEDB_IMAGE\",\"$TIMESCALEDB_HA_IMAGE\""
     write_valid_env "$STAGE/.env"
-    : > "$HARNESS_CALL_LOG"
 
     cat > "$HARNESS_BIN_DIR/docker" <<'EOF'
 #!/bin/bash
@@ -1405,11 +1393,7 @@ else
 fi
 
 make_stage mistagged-tsdb-image
-mkdir -p "$STAGE/image-fixture"
-printf '[{"Config":"config.json","RepoTags":["proto-fleet-timescaledb:latest","%s"],"Layers":[]}]\n' \
-    "$TIMESCALEDB_HA_IMAGE" > "$STAGE/image-fixture/manifest.json"
-(cd "$STAGE/image-fixture" && tar -cf - manifest.json) | gzip > "$STAGE/images/timescaledb.tar.gz"
-rm -rf "$STAGE/image-fixture"
+write_tsdb_archive "$STAGE" "\"proto-fleet-timescaledb:latest\",\"$TIMESCALEDB_HA_IMAGE\""
 write_release_manifest "$STAGE"
 if run_stage "$STAGE" --non-interactive --preflight-only; then
     fail "mistagged TimescaleDB archive should fail preflight"
@@ -1422,11 +1406,7 @@ assert_not_contains "mistagged database image prevents builds" "$HARNESS_CALL_LO
 # Requiring only the standard release tag would still allow docker load to
 # move the daemon-global HA latest tag.
 make_stage mixed-ha-tags
-mkdir -p "$STAGE/image-fixture"
-printf '[{"Config":"config.json","RepoTags":["%s","%s","proto-fleet-timescaledb-ha:latest"],"Layers":[]}]\n' \
-    "$TIMESCALEDB_IMAGE" "$TIMESCALEDB_HA_IMAGE" > "$STAGE/image-fixture/manifest.json"
-(cd "$STAGE/image-fixture" && tar -cf - manifest.json) | gzip > "$STAGE/images/timescaledb.tar.gz"
-rm -rf "$STAGE/image-fixture"
+write_tsdb_archive "$STAGE" "\"$TIMESCALEDB_IMAGE\",\"$TIMESCALEDB_HA_IMAGE\",\"proto-fleet-timescaledb-ha:latest\""
 write_release_manifest "$STAGE"
 if run_stage "$STAGE" --non-interactive --preflight-only; then
     fail "archive with a shared HA latest tag should fail preflight"

--- a/deployment-files/tests/test-run-fleet-upgrade.sh
+++ b/deployment-files/tests/test-run-fleet-upgrade.sh
@@ -1091,6 +1091,76 @@ assert_contains "added release file is diagnosed" "$HARNESS_OUTPUT_LOG" "file se
 assert_not_contains "added release file prevents teardown" "$HARNESS_CALL_LOG" " down --remove-orphans"
 [ ! -e "$STAGE/.update-preflight-complete" ] || fail "added release file should invalidate the marker"
 
+# client/nginx.conf is generated runtime state, so it is intentionally absent
+# from the immutable release manifest. It must still never be allowed to turn
+# the privileged config copy into a write through an attacker-controlled link.
+make_stage generated-nginx-symlink-preflight
+nginx_victim="$TMP_DIR/generated-nginx-preflight-victim"
+printf 'keep preflight victim unchanged\n' > "$nginx_victim"
+ln -s "$nginx_victim" "$STAGE/client/nginx.conf"
+: > "$HARNESS_CALL_LOG"
+if run_stage "$STAGE" --non-interactive --preflight-only; then
+    fail "a symlinked generated nginx config should fail preflight"
+else
+    pass "a symlinked generated nginx config fails preflight"
+fi
+assert_contains "preflight nginx symlink is diagnosed" "$HARNESS_OUTPUT_LOG" "must be a regular, non-symlink file"
+assert_not_contains "preflight nginx symlink prevents image preparation" "$HARNESS_CALL_LOG" " build --no-cache"
+assert_not_contains "preflight nginx symlink prevents teardown" "$HARNESS_CALL_LOG" " down --remove-orphans"
+if grep -Fxq 'keep preflight victim unchanged' "$nginx_victim"; then
+    pass "preflight nginx symlink does not overwrite its target"
+else
+    fail "preflight nginx symlink overwrote its target"
+fi
+[ ! -e "$STAGE/.update-preflight-complete" ] || fail "nginx symlink preflight must not create a marker"
+
+make_stage generated-nginx-hardlink-preflight
+nginx_victim="$TMP_DIR/generated-nginx-hardlink-victim"
+printf 'keep hardlink victim unchanged\n' > "$nginx_victim"
+if ! ln "$nginx_victim" "$STAGE/client/nginx.conf"; then
+    fail "hard-linked nginx fixture could not create its link"
+else
+    if run_stage "$STAGE" --non-interactive --preflight-only; then
+        pass "a hard-linked generated nginx config is replaced safely"
+    else
+        fail "a hard-linked generated nginx config should preflight"
+    fi
+    if grep -Fxq 'keep hardlink victim unchanged' "$nginx_victim"; then
+        pass "nginx config replacement does not mutate another hard link"
+    else
+        fail "nginx config replacement mutated another hard link"
+    fi
+    if cmp -s "$STAGE/client/nginx.http.conf" "$STAGE/client/nginx.conf"; then
+        pass "hard-linked nginx destination receives the selected configuration"
+    else
+        fail "hard-linked nginx destination was not replaced"
+    fi
+fi
+
+make_stage generated-nginx-symlink-activation
+if ! run_stage "$STAGE" --non-interactive --preflight-only; then
+    fail "nginx activation symlink fixture preflight should succeed"
+fi
+nginx_victim="$TMP_DIR/generated-nginx-activation-victim"
+printf 'keep activation victim unchanged\n' > "$nginx_victim"
+rm -f "$STAGE/client/nginx.conf"
+ln -s "$nginx_victim" "$STAGE/client/nginx.conf"
+: > "$HARNESS_CALL_LOG"
+if run_stage "$STAGE" --non-interactive --skip-build; then
+    fail "a symlinked generated nginx config should fail activation"
+else
+    pass "a symlinked generated nginx config fails activation"
+fi
+assert_contains "activation nginx symlink is diagnosed" "$HARNESS_OUTPUT_LOG" "must be a regular, non-symlink file"
+assert_not_contains "activation nginx symlink prevents teardown" "$HARNESS_CALL_LOG" " down --remove-orphans"
+assert_not_contains "activation nginx symlink prevents startup" "$HARNESS_CALL_LOG" " up --remove-orphans"
+if grep -Fxq 'keep activation victim unchanged' "$nginx_victim"; then
+    pass "activation nginx symlink does not overwrite its target"
+else
+    fail "activation nginx symlink overwrote its target"
+fi
+[ -f "$STAGE/.update-preflight-complete" ] || fail "nginx symlink activation should retain its recovery marker"
+
 # Non-regular entries are not valid release content. In particular, Grafana
 # recursively consumes this provisioning directory, so a symlink or FIFO added
 # after preflight must invalidate activation just like an added regular file.

--- a/deployment-files/tests/test-run-fleet-upgrade.sh
+++ b/deployment-files/tests/test-run-fleet-upgrade.sh
@@ -8,6 +8,11 @@ DEPLOY_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 TMP_DIR=$(mktemp -d)
 REAL_GREP=$(command -v grep)
 FAILURES=0
+RELEASE_TAG="v1.2.3"
+FLEET_API_IMAGE="proto-fleet-api:${RELEASE_TAG}"
+FLEET_CLIENT_IMAGE="proto-fleet-client:${RELEASE_TAG}"
+TIMESCALEDB_IMAGE="proto-fleet-timescaledb:${RELEASE_TAG}"
+TIMESCALEDB_HA_IMAGE="proto-fleet-timescaledb-ha:${RELEASE_TAG}"
 
 trap 'rm -rf "$TMP_DIR"' EXIT
 
@@ -100,7 +105,7 @@ make_stage() {
     local name="$1"
     STAGE="$TMP_DIR/$name"
     local runtime="$STAGE-runtime"
-    mkdir -p "$STAGE/client" "$STAGE/server/monitoring/grafana/provisioning/datasources" "$runtime/bin"
+    mkdir -p "$STAGE/client" "$STAGE/ha" "$STAGE/server/monitoring/grafana/provisioning/datasources" "$runtime/bin"
     ln -s "$runtime/bin" "$STAGE/bin"
     : > "$runtime/calls.log"
     : > "$runtime/output.log"
@@ -111,13 +116,16 @@ make_stage() {
     cp "$DEPLOY_DIR/docker-compose.alerts.yaml" "$STAGE/"
     cp "$DEPLOY_DIR/docker-compose.system-monitoring.yaml" "$STAGE/"
     cp "$DEPLOY_DIR/docker-compose.tracing.yaml" "$STAGE/"
+    cp "$DEPLOY_DIR/ha/compose.yaml" "$STAGE/ha/"
     cp "$DEPLOY_DIR/client/nginx.http.conf" "$STAGE/client/"
     cp "$DEPLOY_DIR/client/nginx.https.conf" "$STAGE/client/"
     cp "$DEPLOY_DIR/server/otel-collector-config.datadog.yaml" "$STAGE/server/"
     printf 'apiVersion: 1\n' > "$STAGE/server/monitoring/grafana/provisioning/datasources/base.yaml"
-    printf '%s\n' 'version: v1.2.3' 'commit: test-release' > "$STAGE/version.txt"
+    printf '%s\n' "version: $RELEASE_TAG" 'commit: test-release' > "$STAGE/version.txt"
+    "$DEPLOY_DIR/scripts/pin-release-images.sh" "$STAGE" "$RELEASE_TAG"
     mkdir -p "$STAGE/images" "$STAGE/image-fixture"
-    printf '[{"Config":"config.json","RepoTags":["proto-fleet-timescaledb:latest"],"Layers":[]}]\n' > "$STAGE/image-fixture/manifest.json"
+    printf '[{"Config":"config.json","RepoTags":["%s","%s"],"Layers":[]}]\n' \
+        "$TIMESCALEDB_IMAGE" "$TIMESCALEDB_HA_IMAGE" > "$STAGE/image-fixture/manifest.json"
     (cd "$STAGE/image-fixture" && tar -cf - manifest.json) | gzip > "$STAGE/images/timescaledb.tar.gz"
     rm -rf "$STAGE/image-fixture"
     write_valid_env "$STAGE/.env"
@@ -137,10 +145,17 @@ case " $* " in
         [ "${FAKE_COMPOSE_CONFIG_FAILURE:-false}" != "true" ]
         ;;
     *" compose "*" config --images "*)
-        printf '%s\n' \
-            'proto-fleet-api:latest' \
-            'proto-fleet-client:latest' \
-            'proto-fleet-timescaledb:latest'
+        if [ "${FAKE_COMPOSE_USES_LATEST:-false}" = "true" ]; then
+            printf '%s\n' \
+                'proto-fleet-api:latest' \
+                'proto-fleet-client:v1.2.3' \
+                'proto-fleet-timescaledb:v1.2.3'
+        else
+            printf '%s\n' \
+                'proto-fleet-api:v1.2.3' \
+                'proto-fleet-client:v1.2.3' \
+                'proto-fleet-timescaledb:v1.2.3'
+        fi
         ;;
     *" compose "*" config "*)
         project_name=''
@@ -158,7 +173,7 @@ case " $* " in
         ;;
     *" compose "*" pull --ignore-buildable "*)
         if [ "${FAKE_TSDB_IMAGE_COLD_CACHE:-false}" = "true" ]; then
-            echo 'Image proto-fleet-timescaledb:latest Skipped'
+            echo 'Image proto-fleet-timescaledb:v1.2.3 Skipped'
         fi
         ;;
     *" compose "*" build --no-cache "*)
@@ -174,16 +189,16 @@ case " $* " in
         ;;
     *" image inspect --format "*)
         image="${!#}"
-        if [ "${FAKE_PREPARED_IMAGE_MISSING:-false}" = "true" ] && [ "$image" = "proto-fleet-api:latest" ]; then
+        if [ "${FAKE_PREPARED_IMAGE_MISSING:-false}" = "true" ] && [ "$image" = "proto-fleet-api:v1.2.3" ]; then
             exit 1
         fi
-        if [ "${FAKE_PREPARED_IMAGE_CHANGED:-false}" = "true" ] && [ "$image" = "proto-fleet-api:latest" ]; then
+        if [ "${FAKE_PREPARED_IMAGE_CHANGED:-false}" = "true" ] && [ "$image" = "proto-fleet-api:v1.2.3" ]; then
             printf 'sha256:changed-%s\n' "$image"
             exit 0
         fi
         printf 'sha256:test-%s\n' "$image"
         ;;
-    *" image inspect proto-fleet-timescaledb:latest "*)
+    *" image inspect proto-fleet-timescaledb:v1.2.3 "*|*" image inspect proto-fleet-timescaledb-ha:v1.2.3 "*)
         if [ "${FAKE_TSDB_IMAGE_COLD_CACHE:-false}" = "true" ] && ! grep -qF 'docker load' "$CALL_LOG"; then
             exit 1
         fi
@@ -290,6 +305,10 @@ assert_contains "preflight validates Compose" "$STAGE/calls.log" "config --quiet
 assert_contains "preflight pins the Compose project identity" "$STAGE/calls.log" "compose --project-name deployment"
 assert_contains "preflight pulls images" "$STAGE/calls.log" " pull"
 assert_contains "preflight builds images" "$STAGE/calls.log" " build --no-cache"
+assert_contains "preflight verifies the release API image" "$STAGE/calls.log" "image inspect --format {{.Id}} $FLEET_API_IMAGE"
+assert_contains "preflight verifies the release client image" "$STAGE/calls.log" "image inspect --format {{.Id}} $FLEET_CLIENT_IMAGE"
+assert_contains "preflight verifies the release database image" "$STAGE/calls.log" "image inspect --format {{.Id}} $TIMESCALEDB_IMAGE"
+assert_not_contains "preflight never targets shared latest image tags" "$STAGE/calls.log" ":latest"
 assert_not_contains "preflight leaves services running" "$STAGE/calls.log" " down --remove-orphans"
 assert_not_contains "preflight never starts replacement services" "$STAGE/calls.log" " up --remove-orphans"
 [ -f "$STAGE/.update-preflight-complete" ] || fail "preflight should create its activation marker"
@@ -326,6 +345,7 @@ fi
 assert_not_contains "activation skips pulls" "$STAGE/calls.log" " pull"
 assert_not_contains "activation skips builds" "$STAGE/calls.log" " build --no-cache"
 assert_contains "activation forbids implicit image preparation" "$STAGE/calls.log" "up --remove-orphans -d --wait --wait-timeout 300 --no-build --pull never"
+assert_not_contains "activation never resolves shared latest image tags" "$STAGE/calls.log" ":latest"
 assert_contains "activation stops the old stack" "$STAGE/calls.log" " down --remove-orphans"
 assert_contains "activation starts the new stack" "$STAGE/calls.log" " up --remove-orphans"
 [ ! -f "$STAGE/.update-preflight-complete" ] || fail "successful activation should consume its marker"
@@ -463,6 +483,32 @@ assert_contains "missing manifest is diagnosed" "$STAGE/output.log" "requires th
 assert_not_contains "missing manifest prevents pulls" "$STAGE/calls.log" " pull"
 [ ! -e "$STAGE/.update-preflight-complete" ] || fail "missing manifest must not create a marker"
 
+# Release bundles must pin literal image references before any preparation.
+# This protects bare Compose and Windows installer paths that do not inherit
+# state from run-fleet.sh.
+make_stage unpinned-compose
+if FAKE_COMPOSE_USES_LATEST=true run_stage "$STAGE" --non-interactive --preflight-only; then
+    fail "release Compose model with a shared latest tag should fail preflight"
+else
+    pass "release Compose model rejects shared latest tags"
+fi
+assert_contains "unpinned Compose is diagnosed" "$STAGE/output.log" "not pinned to required image $FLEET_API_IMAGE"
+assert_not_contains "unpinned Compose prevents pulls" "$STAGE/calls.log" " pull"
+assert_not_contains "unpinned Compose prevents archive loading" "$STAGE/calls.log" "docker load"
+assert_not_contains "unpinned Compose prevents builds" "$STAGE/calls.log" " build --no-cache"
+
+make_stage unpinned-ha-compose
+sed -i.bak "s|$TIMESCALEDB_HA_IMAGE|proto-fleet-timescaledb-ha:latest|" "$STAGE/ha/compose.yaml"
+rm -f "$STAGE/ha/compose.yaml.bak"
+write_release_manifest "$STAGE"
+if run_stage "$STAGE" --non-interactive --preflight-only; then
+    fail "release HA Compose model with a shared latest tag should fail preflight"
+else
+    pass "release HA Compose model rejects the shared latest tag"
+fi
+assert_contains "unpinned HA Compose is diagnosed" "$STAGE/output.log" "not pinned to required image $TIMESCALEDB_HA_IMAGE"
+assert_not_contains "unpinned HA Compose prevents archive loading" "$STAGE/calls.log" "docker load"
+
 make_stage changed-during-preflight
 if FAKE_MUTATE_TSDB_DURING_BUILD=true run_stage "$STAGE" --non-interactive --preflight-only; then
     fail "inputs changed during preparation should fail preflight"
@@ -471,6 +517,7 @@ else
 fi
 assert_contains "mid-preflight mutation is diagnosed" "$STAGE/output.log" "release or configuration changed during preflight"
 assert_contains "mid-preflight mutation occurs after the build starts" "$STAGE/calls.log" " build --no-cache"
+assert_not_contains "failed preflight leaves shared latest tags untouched" "$STAGE/calls.log" ":latest"
 assert_not_contains "mid-preflight mutation prevents teardown" "$STAGE/calls.log" " down --remove-orphans"
 [ ! -e "$STAGE/.update-preflight-complete" ] || fail "mid-preflight mutation must not create a marker"
 
@@ -675,7 +722,8 @@ fi
 
 make_stage mistagged-tsdb-image
 mkdir -p "$STAGE/image-fixture"
-printf '[{"Config":"config.json","RepoTags":["wrong-image:latest"],"Layers":[]}]\n' > "$STAGE/image-fixture/manifest.json"
+printf '[{"Config":"config.json","RepoTags":["proto-fleet-timescaledb:latest","%s"],"Layers":[]}]\n' \
+    "$TIMESCALEDB_HA_IMAGE" > "$STAGE/image-fixture/manifest.json"
 (cd "$STAGE/image-fixture" && tar -cf - manifest.json) | gzip > "$STAGE/images/timescaledb.tar.gz"
 rm -rf "$STAGE/image-fixture"
 write_release_manifest "$STAGE"
@@ -686,6 +734,24 @@ else
 fi
 assert_not_contains "mistagged database image is not loaded" "$STAGE/calls.log" "docker load"
 assert_not_contains "mistagged database image prevents builds" "$STAGE/calls.log" " build --no-cache"
+
+# Requiring only the standard release tag would still allow docker load to
+# move the daemon-global HA latest tag.
+make_stage mixed-ha-tags
+mkdir -p "$STAGE/image-fixture"
+printf '[{"Config":"config.json","RepoTags":["%s","%s","proto-fleet-timescaledb-ha:latest"],"Layers":[]}]\n' \
+    "$TIMESCALEDB_IMAGE" "$TIMESCALEDB_HA_IMAGE" > "$STAGE/image-fixture/manifest.json"
+(cd "$STAGE/image-fixture" && tar -cf - manifest.json) | gzip > "$STAGE/images/timescaledb.tar.gz"
+rm -rf "$STAGE/image-fixture"
+write_release_manifest "$STAGE"
+if run_stage "$STAGE" --non-interactive --preflight-only; then
+    fail "archive with a shared HA latest tag should fail preflight"
+else
+    pass "archive with a shared HA latest tag fails preflight"
+fi
+assert_contains "shared HA archive tag is diagnosed" "$STAGE/output.log" "contains forbidden shared image proto-fleet-timescaledb-ha:latest"
+assert_not_contains "shared HA archive tag is not loaded" "$STAGE/calls.log" "docker load"
+assert_not_contains "shared HA archive tag prevents builds" "$STAGE/calls.log" " build --no-cache"
 
 make_stage unloaded-tsdb-image
 if FAKE_TSDB_IMAGE_MISSING=true run_stage "$STAGE" --non-interactive --preflight-only; then

--- a/deployment-files/tests/test-run-fleet-upgrade.sh
+++ b/deployment-files/tests/test-run-fleet-upgrade.sh
@@ -54,6 +54,18 @@ write_valid_env() {
     printf 'ENABLE_TRACING="FALSE" \r\n' >> "$env_file"
 }
 
+enable_valid_alerts() {
+    local env_file="$1"
+    printf '%s\n' \
+        'ENABLE_BETA_ALERTS=true' \
+        'GRAFANA_ADMIN_PASSWORD=admin-secret' \
+        'GRAFANA_DB_USERNAME=grafana_ro' \
+        'GRAFANA_DB_PASSWORD=db-secret' \
+        'FLEET_ALERTS_WEBHOOK_TOKEN=webhook-secret' \
+        'GRAFANA_SECRET_KEY=grafana-secret' \
+        'FLEET_ALERTS_GRAFANA_TOKEN=service-token' >> "$env_file"
+}
+
 make_stage() {
     local name="$1"
     STAGE="$TMP_DIR/$name"
@@ -65,6 +77,7 @@ make_stage() {
     cp "$DEPLOY_DIR/docker-compose.tracing.yaml" "$STAGE/"
     cp "$DEPLOY_DIR/client/nginx.http.conf" "$STAGE/client/"
     cp "$DEPLOY_DIR/client/nginx.https.conf" "$STAGE/client/"
+    printf '%s\n' 'version: v1.2.3' 'commit: test-release' > "$STAGE/version.txt"
     mkdir -p "$STAGE/images" "$STAGE/image-fixture"
     printf '[{"Config":"config.json","RepoTags":["proto-fleet-timescaledb:latest"],"Layers":[]}]\n' > "$STAGE/image-fixture/manifest.json"
     (cd "$STAGE/image-fixture" && tar -cf - manifest.json) | gzip > "$STAGE/images/timescaledb.tar.gz"
@@ -84,6 +97,20 @@ case " $* " in
         ;;
     *" compose "*" config --quiet "*)
         [ "${FAKE_COMPOSE_CONFIG_FAILURE:-false}" != "true" ]
+        ;;
+    *" compose "*" config "*)
+        previous=''
+        for argument in "$@"; do
+            if [ "$previous" = "-f" ]; then
+                printf 'compose_file: %s\n' "$argument"
+            fi
+            previous="$argument"
+        done
+        ;;
+    *" compose "*" build --no-cache "*)
+        if [ "${FAKE_MUTATE_TSDB_DURING_BUILD:-false}" = "true" ]; then
+            printf 'changed-during-build' >> "$STAGE_ROOT/images/timescaledb.tar.gz"
+        fi
         ;;
     *" compose "*" up --remove-orphans "*)
         [ "${FAKE_ACTIVATION_FAILURE:-false}" != "true" ]
@@ -167,6 +194,7 @@ run_stage() {
     local stage="$1"
     shift
     CALL_LOG="$stage/calls.log" \
+    STAGE_ROOT="$stage" \
     REAL_GREP="$REAL_GREP" \
     PATH="$stage/bin:$PATH" \
     /bin/bash "$stage/run-fleet.sh" "$@" > "$stage/output.log" 2>&1
@@ -195,6 +223,17 @@ assert_contains "preflight builds images" "$STAGE/calls.log" " build --no-cache"
 assert_not_contains "preflight leaves services running" "$STAGE/calls.log" " down --remove-orphans"
 assert_not_contains "preflight never starts replacement services" "$STAGE/calls.log" " up --remove-orphans"
 [ -f "$STAGE/.update-preflight-complete" ] || fail "preflight should create its activation marker"
+if grep -Eq '^proto-fleet-preflight-v1:[0-9a-f]{64}$' "$STAGE/.update-preflight-complete"; then
+    pass "preflight marker records versioned release metadata"
+else
+    fail "preflight marker should contain versioned release metadata"
+fi
+marker_mode=$(stat -c '%a' "$STAGE/.update-preflight-complete" 2>/dev/null || stat -f '%Lp' "$STAGE/.update-preflight-complete")
+if [ "$marker_mode" = "600" ]; then
+    pass "preflight marker is readable only by its owner"
+else
+    fail "preflight marker mode should be 600, got $marker_mode"
+fi
 if [ "$(grep -c '^ENABLE_BETA_ALERTS=' "$STAGE/.env")" -eq 1 ] && grep -q '^ENABLE_BETA_ALERTS=false$' "$STAGE/.env"; then
     pass "persisted booleans use the last Compose-style assignment"
 else
@@ -219,6 +258,75 @@ assert_not_contains "activation skips builds" "$STAGE/calls.log" " build --no-ca
 assert_contains "activation stops the old stack" "$STAGE/calls.log" " down --remove-orphans"
 assert_contains "activation starts the new stack" "$STAGE/calls.log" " up --remove-orphans"
 [ ! -f "$STAGE/.update-preflight-complete" ] || fail "successful activation should consume its marker"
+
+# The updater preflights under a temporary parent and then renames the release
+# into the stable deployment path. Absolute paths in rendered Compose output
+# are normalized so that safe relocation does not invalidate the proof.
+make_stage relocated-preflight
+if ! run_stage "$STAGE" --non-interactive --preflight-only; then
+    fail "relocation fixture preflight should succeed"
+fi
+relocated_stage="$TMP_DIR/activated-release/deployment"
+mkdir -p "$(dirname "$relocated_stage")"
+mv "$STAGE" "$relocated_stage"
+STAGE="$relocated_stage"
+: > "$STAGE/calls.log"
+if run_stage "$STAGE" --non-interactive --skip-build; then
+    pass "preflight proof survives the updater's directory rename"
+else
+    fail "unchanged relocated release should activate"
+fi
+assert_contains "relocated activation stops the old stack" "$STAGE/calls.log" " down --remove-orphans"
+
+# Every input that defines the prepared release is bound into the marker. A
+# changed or forged marker fails before the active deployment is stopped and
+# is invalidated so recovery cannot keep retrying stale preparation.
+for mutation in env compose version nginx runner timescaledb; do
+    make_stage "changed-$mutation"
+    if ! run_stage "$STAGE" --non-interactive --preflight-only; then
+        fail "$mutation mutation fixture preflight should succeed"
+        continue
+    fi
+    case "$mutation" in
+        env) printf 'DB_PASSWORD=changed-after-preflight\n' >> "$STAGE/.env" ;;
+        compose) printf '\n# changed after preflight\n' >> "$STAGE/docker-compose.yaml" ;;
+        version) printf 'commit: changed-after-preflight\n' >> "$STAGE/version.txt" ;;
+        nginx) printf '\n# changed after preflight\n' >> "$STAGE/client/nginx.http.conf" ;;
+        runner) printf '\n# changed after preflight\n' >> "$STAGE/run-fleet.sh" ;;
+        timescaledb) printf 'changed-after-preflight' >> "$STAGE/images/timescaledb.tar.gz" ;;
+    esac
+    : > "$STAGE/calls.log"
+    if run_stage "$STAGE" --non-interactive --skip-build; then
+        fail "$mutation changes should invalidate preflight"
+    else
+        pass "$mutation changes invalidate preflight"
+    fi
+    assert_contains "$mutation mismatch is diagnosed" "$STAGE/output.log" "release or configuration changed after preflight"
+    assert_not_contains "$mutation mismatch prevents teardown" "$STAGE/calls.log" " down --remove-orphans"
+    assert_not_contains "$mutation mismatch prevents startup" "$STAGE/calls.log" " up --remove-orphans"
+    [ ! -e "$STAGE/.update-preflight-complete" ] || fail "$mutation mismatch should remove the stale marker"
+done
+
+make_stage changed-during-preflight
+if FAKE_MUTATE_TSDB_DURING_BUILD=true run_stage "$STAGE" --non-interactive --preflight-only; then
+    fail "inputs changed during preparation should fail preflight"
+else
+    pass "inputs changed during preparation fail preflight"
+fi
+assert_contains "mid-preflight mutation is diagnosed" "$STAGE/output.log" "release or configuration changed during preflight"
+assert_contains "mid-preflight mutation occurs after the build starts" "$STAGE/calls.log" " build --no-cache"
+assert_not_contains "mid-preflight mutation prevents teardown" "$STAGE/calls.log" " down --remove-orphans"
+[ ! -e "$STAGE/.update-preflight-complete" ] || fail "mid-preflight mutation must not create a marker"
+
+make_stage forged-marker
+: > "$STAGE/.update-preflight-complete"
+if run_stage "$STAGE" --non-interactive --skip-build; then
+    fail "an empty forged marker should not authorize activation"
+else
+    pass "an empty forged marker is rejected"
+fi
+assert_not_contains "forged marker prevents teardown" "$STAGE/calls.log" " down --remove-orphans"
+[ ! -e "$STAGE/.update-preflight-complete" ] || fail "forged marker should be invalidated"
 
 # A failed activation retains the marker so the recovery command can retry the
 # prepared release without an unsafe rebuild.
@@ -303,6 +411,55 @@ fi
 cmp -s "$STAGE/env.before" "$STAGE/.env" || fail "alert validation should not rewrite .env"
 assert_contains "missing alert service token is diagnosed" "$STAGE/output.log" "FLEET_ALERTS_GRAFANA_TOKEN"
 assert_not_contains "missing alert secrets prevent pulls" "$STAGE/calls.log" " pull"
+
+# Grafana role names are deterministic local validation, so reject known-bad
+# SQL identifiers and privileged/conflicting role names during preflight rather
+# than after the running stack has been replaced.
+make_stage valid-alert-role
+enable_valid_alerts "$STAGE/.env"
+if run_stage "$STAGE" --non-interactive --preflight-only; then
+    pass "valid dedicated Grafana role passes preflight"
+else
+    fail "valid dedicated Grafana role should pass preflight"
+fi
+
+for role_case in invalid-grafana-identifier invalid-db-identifier postgres-role app-role reserved-pg-role; do
+    make_stage "$role_case"
+    enable_valid_alerts "$STAGE/.env"
+    case "$role_case" in
+        invalid-grafana-identifier)
+            printf 'GRAFANA_DB_USERNAME=grafana-ro\n' >> "$STAGE/.env"
+            expected_error='GRAFANA_DB_USERNAME must be a valid SQL identifier'
+            ;;
+        invalid-db-identifier)
+            printf 'DB_NAME=fleet-prod\n' >> "$STAGE/.env"
+            expected_error='DB_NAME must be a valid SQL identifier'
+            ;;
+        postgres-role)
+            printf 'GRAFANA_DB_USERNAME=postgres\n' >> "$STAGE/.env"
+            expected_error='must not match the application DB role'
+            ;;
+        app-role)
+            printf 'GRAFANA_DB_USERNAME=fleet\n' >> "$STAGE/.env"
+            expected_error='must not match the application DB role'
+            ;;
+        reserved-pg-role)
+            printf 'GRAFANA_DB_USERNAME=pg_custom\n' >> "$STAGE/.env"
+            expected_error="must not use PostgreSQL's reserved pg_ role prefix"
+            ;;
+    esac
+    cp "$STAGE/.env" "$STAGE/env.before"
+    if run_stage "$STAGE" --non-interactive --preflight-only; then
+        fail "$role_case should fail preflight"
+    else
+        pass "$role_case fails preflight"
+    fi
+    cmp -s "$STAGE/env.before" "$STAGE/.env" || fail "$role_case validation should not rewrite .env"
+    assert_contains "$role_case is diagnosed" "$STAGE/output.log" "$expected_error"
+    assert_not_contains "$role_case prevents pulls" "$STAGE/calls.log" " pull"
+    assert_not_contains "$role_case prevents teardown" "$STAGE/calls.log" " down --remove-orphans"
+    [ ! -e "$STAGE/.update-preflight-complete" ] || fail "$role_case must not create a preflight marker"
+done
 
 # Compose interpolation/render errors are also caught before image work or
 # service teardown.

--- a/deployment-files/tests/test-run-fleet-upgrade.sh
+++ b/deployment-files/tests/test-run-fleet-upgrade.sh
@@ -1,0 +1,405 @@
+#!/bin/bash
+# Exercises the non-interactive upgrade boundary without touching host Docker,
+# networking, or services. External commands are recorded through PATH shims.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEPLOY_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TMP_DIR=$(mktemp -d)
+REAL_GREP=$(command -v grep)
+FAILURES=0
+
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+fail() {
+    echo "FAIL: $*" >&2
+    FAILURES=$((FAILURES + 1))
+}
+
+pass() {
+    echo "ok: $*"
+}
+
+assert_contains() {
+    local description="$1" file="$2" expected="$3"
+    if grep -qF "$expected" "$file"; then
+        pass "$description"
+    else
+        fail "$description: expected '$expected' in $file"
+    fi
+}
+
+assert_not_contains() {
+    local description="$1" file="$2" unexpected="$3"
+    if grep -qF "$unexpected" "$file"; then
+        fail "$description: unexpected '$unexpected' in $file"
+    else
+        pass "$description"
+    fi
+}
+
+write_valid_env() {
+    local env_file="$1"
+    printf '%s\n' \
+        'DB_USERNAME=fleet' \
+        'DB_PASSWORD=test-password' \
+        'AUTH_CLIENT_SECRET_KEY=01234567890123456789012345678901' \
+        'ENCRYPT_SERVICE_MASTER_KEY=MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDE=' \
+        'SESSION_COOKIE_SECURE=true' \
+        'SESSION_COOKIE_SECURE="false"' \
+        'ENABLE_BETA_ALERTS=true' \
+        'ENABLE_BETA_ALERTS="false"' \
+        'ENABLE_SYSTEM_MONITORING=false' \
+        'ENABLE_TRACING=true' > "$env_file"
+    printf 'ENABLE_TRACING="FALSE" \r\n' >> "$env_file"
+}
+
+make_stage() {
+    local name="$1"
+    STAGE="$TMP_DIR/$name"
+    mkdir -p "$STAGE/bin" "$STAGE/client"
+    cp "$DEPLOY_DIR/run-fleet.sh" "$STAGE/"
+    cp "$DEPLOY_DIR/docker-compose.yaml" "$STAGE/"
+    cp "$DEPLOY_DIR/docker-compose.alerts.yaml" "$STAGE/"
+    cp "$DEPLOY_DIR/docker-compose.system-monitoring.yaml" "$STAGE/"
+    cp "$DEPLOY_DIR/docker-compose.tracing.yaml" "$STAGE/"
+    cp "$DEPLOY_DIR/client/nginx.http.conf" "$STAGE/client/"
+    cp "$DEPLOY_DIR/client/nginx.https.conf" "$STAGE/client/"
+    mkdir -p "$STAGE/images" "$STAGE/image-fixture"
+    printf '[{"Config":"config.json","RepoTags":["proto-fleet-timescaledb:latest"],"Layers":[]}]\n' > "$STAGE/image-fixture/manifest.json"
+    (cd "$STAGE/image-fixture" && tar -cf - manifest.json) | gzip > "$STAGE/images/timescaledb.tar.gz"
+    rm -rf "$STAGE/image-fixture"
+    write_valid_env "$STAGE/.env"
+    : > "$STAGE/calls.log"
+
+    cat > "$STAGE/bin/docker" <<'EOF'
+#!/bin/bash
+printf 'docker' >> "$CALL_LOG"
+printf ' %s' "$@" >> "$CALL_LOG"
+printf '\n' >> "$CALL_LOG"
+
+case " $* " in
+    *" compose up --help "*)
+        echo 'Options: --wait --wait-timeout'
+        ;;
+    *" compose "*" config --quiet "*)
+        [ "${FAKE_COMPOSE_CONFIG_FAILURE:-false}" != "true" ]
+        ;;
+    *" compose "*" up --remove-orphans "*)
+        [ "${FAKE_ACTIVATION_FAILURE:-false}" != "true" ]
+        ;;
+    *" compose "*" exec "*)
+        echo 't'
+        ;;
+    *" image inspect proto-fleet-timescaledb:latest "*)
+        [ "${FAKE_TSDB_IMAGE_MISSING:-false}" != "true" ]
+        ;;
+esac
+EOF
+
+    cat > "$STAGE/bin/systemctl" <<'EOF'
+#!/bin/bash
+printf 'systemctl %s\n' "$*" >> "$CALL_LOG"
+exit 0
+EOF
+
+    cat > "$STAGE/bin/id" <<'EOF'
+#!/bin/bash
+if [ "${1:-}" = "-u" ]; then
+    echo 0
+else
+    /usr/bin/id "$@"
+fi
+EOF
+
+    cat > "$STAGE/bin/uname" <<'EOF'
+#!/bin/bash
+echo Linux
+EOF
+
+    cat > "$STAGE/bin/grep" <<'EOF'
+#!/bin/bash
+if [ "${FAKE_WSL:-false}" = "true" ]; then
+    for argument in "$@"; do
+        if [ "$argument" = "/proc/version" ]; then
+            exit 0
+        fi
+    done
+fi
+exec "$REAL_GREP" "$@"
+EOF
+
+    cat > "$STAGE/bin/curl" <<'EOF'
+#!/bin/bash
+printf 'curl %s\n' "$*" >> "$CALL_LOG"
+case " $* " in
+    *registry-1.docker.io*)
+        [ "${FAKE_REGISTRY_FAILURE:-false}" != "true" ]
+        ;;
+    *) exit 0 ;;
+esac
+EOF
+
+    cat > "$STAGE/bin/sudo" <<'EOF'
+#!/bin/bash
+printf 'sudo %s\n' "$*" >> "$CALL_LOG"
+exit 0
+EOF
+
+    cat > "$STAGE/bin/hostname" <<'EOF'
+#!/bin/bash
+if [ "${1:-}" = "-I" ]; then
+    echo '192.0.2.10'
+else
+    echo 'proto-fleet-test'
+fi
+EOF
+
+    cat > "$STAGE/bin/ip" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+
+    chmod +x "$STAGE/run-fleet.sh" "$STAGE/bin/"*
+}
+
+run_stage() {
+    local stage="$1"
+    shift
+    CALL_LOG="$stage/calls.log" \
+    REAL_GREP="$REAL_GREP" \
+    PATH="$stage/bin:$PATH" \
+    /bin/bash "$stage/run-fleet.sh" "$@" > "$stage/output.log" 2>&1
+}
+
+# The updater-specific option is intentionally deferred until its Compose
+# overlay is shipped and packaged later in the stack.
+make_stage help
+if run_stage "$STAGE" --help; then
+    assert_not_contains "help omits the unavailable updater overlay" "$STAGE/output.log" "enable-one-click-updates"
+else
+    fail "--help should succeed"
+fi
+
+# A successful preflight validates and prepares images, but never stops or
+# starts the active stack. It records a same-directory activation marker.
+make_stage preflight
+if run_stage "$STAGE" --non-interactive --preflight-only; then
+    pass "valid non-interactive preflight succeeds"
+else
+    fail "valid non-interactive preflight should succeed"
+fi
+assert_contains "preflight validates Compose" "$STAGE/calls.log" "config --quiet"
+assert_contains "preflight pulls images" "$STAGE/calls.log" " pull"
+assert_contains "preflight builds images" "$STAGE/calls.log" " build --no-cache"
+assert_not_contains "preflight leaves services running" "$STAGE/calls.log" " down --remove-orphans"
+assert_not_contains "preflight never starts replacement services" "$STAGE/calls.log" " up --remove-orphans"
+[ -f "$STAGE/.update-preflight-complete" ] || fail "preflight should create its activation marker"
+if [ "$(grep -c '^ENABLE_BETA_ALERTS=' "$STAGE/.env")" -eq 1 ] && grep -q '^ENABLE_BETA_ALERTS=false$' "$STAGE/.env"; then
+    pass "persisted booleans use the last Compose-style assignment"
+else
+    fail "persisted booleans did not honor last-value-wins"
+fi
+if [ "$(grep -c '^SESSION_COOKIE_SECURE=' "$STAGE/.env")" -eq 1 ] && grep -q '^SESSION_COOKIE_SECURE=false$' "$STAGE/.env"; then
+    pass "cookie mode uses the last Compose-style assignment"
+else
+    fail "cookie mode did not honor last-value-wins"
+fi
+
+# Activation consumes the marker, reuses prepared images, and performs the
+# service transition without another pull or build.
+: > "$STAGE/calls.log"
+if run_stage "$STAGE" --non-interactive --skip-build; then
+    pass "prepared activation succeeds"
+else
+    fail "prepared activation should succeed"
+fi
+assert_not_contains "activation skips pulls" "$STAGE/calls.log" " pull"
+assert_not_contains "activation skips builds" "$STAGE/calls.log" " build --no-cache"
+assert_contains "activation stops the old stack" "$STAGE/calls.log" " down --remove-orphans"
+assert_contains "activation starts the new stack" "$STAGE/calls.log" " up --remove-orphans"
+[ ! -f "$STAGE/.update-preflight-complete" ] || fail "successful activation should consume its marker"
+
+# A failed activation retains the marker so the recovery command can retry the
+# prepared release without an unsafe rebuild.
+make_stage failed-activation
+if ! run_stage "$STAGE" --non-interactive --preflight-only; then
+    fail "failed-activation fixture preflight should succeed"
+fi
+: > "$STAGE/calls.log"
+if FAKE_ACTIVATION_FAILURE=true run_stage "$STAGE" --non-interactive --skip-build; then
+    fail "simulated activation failure should propagate"
+else
+    pass "activation failure propagates"
+fi
+[ -f "$STAGE/.update-preflight-complete" ] || fail "failed activation should retain its recovery marker"
+
+# Skip-build must not be usable without proof that this exact deployment
+# directory completed preflight.
+make_stage missing-marker
+if run_stage "$STAGE" --non-interactive --skip-build; then
+    fail "skip-build should fail without a preflight marker"
+else
+    pass "skip-build rejects an unprepared deployment"
+fi
+assert_not_contains "unprepared activation makes no Docker calls" "$STAGE/calls.log" "docker "
+
+# Invalid persisted booleans fail before even read-only Docker probes.
+make_stage invalid-boolean
+printf 'ENABLE_TRACING=maybe\n' >> "$STAGE/.env"
+if run_stage "$STAGE" --non-interactive --preflight-only; then
+    fail "invalid persisted boolean should fail preflight"
+else
+    pass "invalid persisted boolean fails preflight"
+fi
+assert_not_contains "invalid boolean makes no Docker calls" "$STAGE/calls.log" "docker "
+
+# Invalid persisted configuration must fail before mutation or image/service
+# operations, so activation cannot discover it only after teardown.
+make_stage invalid-env
+sed -i.bak 's/^DB_PASSWORD=.*/DB_PASSWORD=/' "$STAGE/.env"
+rm -f "$STAGE/.env.bak"
+cp "$STAGE/.env" "$STAGE/env.before"
+if run_stage "$STAGE" --non-interactive --preflight-only; then
+    fail "empty required settings should fail preflight"
+else
+    pass "empty required settings fail preflight"
+fi
+cmp -s "$STAGE/env.before" "$STAGE/.env" || fail "invalid preflight should not rewrite .env"
+assert_not_contains "invalid settings prevent pulls" "$STAGE/calls.log" " pull"
+assert_not_contains "invalid settings prevent teardown" "$STAGE/calls.log" " down --remove-orphans"
+
+make_stage invalid-secrets
+sed -i.bak \
+    -e 's/^AUTH_CLIENT_SECRET_KEY=.*/AUTH_CLIENT_SECRET_KEY=too-short/' \
+    -e 's|^ENCRYPT_SERVICE_MASTER_KEY=.*|ENCRYPT_SERVICE_MASTER_KEY=not-base64|' \
+    "$STAGE/.env"
+rm -f "$STAGE/.env.bak"
+if run_stage "$STAGE" --non-interactive --preflight-only; then
+    fail "malformed secrets should fail preflight"
+else
+    pass "malformed secrets fail preflight"
+fi
+assert_contains "short auth secret is diagnosed" "$STAGE/output.log" "must be at least 32 characters"
+assert_contains "invalid encryption key is diagnosed" "$STAGE/output.log" "must decode to exactly 32 bytes"
+assert_not_contains "malformed secrets prevent pulls" "$STAGE/calls.log" " pull"
+
+# Existing alert deployments must retain their secrets; an unattended run
+# fails instead of generating replacements for incomplete persisted state.
+make_stage invalid-alerts
+printf '%s\n' \
+    'ENABLE_BETA_ALERTS=true' \
+    'GRAFANA_ADMIN_PASSWORD=admin-secret' \
+    'GRAFANA_DB_USERNAME=grafana_ro' \
+    'GRAFANA_DB_PASSWORD=db-secret' \
+    'FLEET_ALERTS_WEBHOOK_TOKEN=webhook-secret' \
+    'GRAFANA_SECRET_KEY=grafana-secret' >> "$STAGE/.env"
+cp "$STAGE/.env" "$STAGE/env.before"
+if run_stage "$STAGE" --non-interactive --preflight-only; then
+    fail "missing alert secrets should fail preflight"
+else
+    pass "missing alert secrets fail preflight"
+fi
+cmp -s "$STAGE/env.before" "$STAGE/.env" || fail "alert validation should not rewrite .env"
+assert_contains "missing alert service token is diagnosed" "$STAGE/output.log" "FLEET_ALERTS_GRAFANA_TOKEN"
+assert_not_contains "missing alert secrets prevent pulls" "$STAGE/calls.log" " pull"
+
+# Compose interpolation/render errors are also caught before image work or
+# service teardown.
+make_stage invalid-compose
+: > "$STAGE/.update-preflight-complete"
+if FAKE_COMPOSE_CONFIG_FAILURE=true run_stage "$STAGE" --non-interactive --preflight-only; then
+    fail "invalid Compose configuration should fail preflight"
+else
+    pass "invalid Compose configuration fails preflight"
+fi
+assert_not_contains "invalid Compose prevents pulls" "$STAGE/calls.log" " pull"
+assert_not_contains "invalid Compose prevents teardown" "$STAGE/calls.log" " down --remove-orphans"
+[ ! -f "$STAGE/.update-preflight-complete" ] || fail "invalid Compose must not leave a preflight marker"
+
+# A non-removable stale marker fails closed before Docker activity.
+make_stage invalid-marker
+mkdir "$STAGE/.update-preflight-complete"
+if run_stage "$STAGE" --non-interactive --preflight-only; then
+    fail "non-removable preflight marker should fail"
+else
+    pass "non-removable preflight marker fails closed"
+fi
+assert_not_contains "marker cleanup failure makes no Docker calls" "$STAGE/calls.log" "docker "
+
+# Missing packaged and local database images must fail before a preflight can
+# authorize service activation.
+make_stage missing-tsdb-image
+rm -f "$STAGE/images/timescaledb.tar.gz"
+if run_stage "$STAGE" --non-interactive --preflight-only; then
+    fail "missing TimescaleDB image should fail preflight"
+else
+    pass "missing TimescaleDB image fails preflight"
+fi
+assert_not_contains "missing database image prevents builds" "$STAGE/calls.log" " build --no-cache"
+assert_not_contains "missing database image prevents teardown" "$STAGE/calls.log" " down --remove-orphans"
+[ ! -f "$STAGE/.update-preflight-complete" ] || fail "missing database image must not leave a preflight marker"
+
+make_stage mistagged-tsdb-image
+mkdir -p "$STAGE/image-fixture"
+printf '[{"Config":"config.json","RepoTags":["wrong-image:latest"],"Layers":[]}]\n' > "$STAGE/image-fixture/manifest.json"
+(cd "$STAGE/image-fixture" && tar -cf - manifest.json) | gzip > "$STAGE/images/timescaledb.tar.gz"
+rm -rf "$STAGE/image-fixture"
+if run_stage "$STAGE" --non-interactive --preflight-only; then
+    fail "mistagged TimescaleDB archive should fail preflight"
+else
+    pass "mistagged TimescaleDB archive fails preflight"
+fi
+assert_not_contains "mistagged database image is not loaded" "$STAGE/calls.log" "docker load"
+assert_not_contains "mistagged database image prevents builds" "$STAGE/calls.log" " build --no-cache"
+
+make_stage unloaded-tsdb-image
+if FAKE_TSDB_IMAGE_MISSING=true run_stage "$STAGE" --non-interactive --preflight-only; then
+    fail "archive that does not load the expected tag should fail preflight"
+else
+    pass "loaded archive must expose the expected TimescaleDB tag"
+fi
+assert_not_contains "unloaded database image prevents builds" "$STAGE/calls.log" " build --no-cache"
+assert_not_contains "unloaded database image prevents teardown" "$STAGE/calls.log" " down --remove-orphans"
+
+# Persisted HTTP remains authoritative even if stale certificate files remain
+# on disk from an older HTTPS configuration.
+make_stage stale-certificates
+mkdir -p "$STAGE/ssl"
+: > "$STAGE/ssl/cert.pem"
+: > "$STAGE/ssl/key.pem"
+if run_stage "$STAGE" --non-interactive --preflight-only; then
+    pass "stale certificates do not change persisted HTTP mode"
+else
+    fail "persisted HTTP with stale certificates should preflight"
+fi
+assert_contains "HTTP transport is explicitly preserved" "$STAGE/output.log" "Preserving HTTP mode"
+if cmp -s "$STAGE/client/nginx.http.conf" "$STAGE/client/nginx.conf"; then
+    pass "HTTP nginx configuration remains active"
+else
+    fail "stale certificates selected the wrong nginx configuration"
+fi
+
+# A transient WSL registry outage is diagnostic-only in non-interactive mode;
+# it must not invoke sudo, edit host networking, or prune the build cache.
+make_stage wsl-outage
+if FAKE_WSL=true FAKE_REGISTRY_FAILURE=true run_stage "$STAGE" --non-interactive --preflight-only; then
+    fail "WSL registry outage should fail preflight"
+else
+    pass "WSL registry outage fails without repair mutations"
+fi
+assert_not_contains "WSL failure does not invoke sudo" "$STAGE/calls.log" "sudo "
+assert_not_contains "WSL failure does not prune build cache" "$STAGE/calls.log" "builder prune -af"
+assert_not_contains "WSL failure prevents pulls" "$STAGE/calls.log" " pull"
+
+if [ "$FAILURES" -ne 0 ]; then
+    for output in "$TMP_DIR"/*/output.log; do
+        [ -f "$output" ] || continue
+        echo "--- $output" >&2
+        sed 's/^/    /' "$output" >&2
+    done
+    echo "$FAILURES failure(s)" >&2
+    exit 1
+fi
+
+echo "All run-fleet upgrade checks passed."

--- a/deployment-files/tests/test-run-fleet-upgrade.sh
+++ b/deployment-files/tests/test-run-fleet-upgrade.sh
@@ -66,10 +66,44 @@ enable_valid_alerts() {
         'FLEET_ALERTS_GRAFANA_TOKEN=service-token' >> "$env_file"
 }
 
+write_release_manifest() {
+    local stage="$1"
+    (
+        cd "$stage" || exit 1
+        if command -v sha256sum >/dev/null 2>&1; then
+            find . -type f \
+                ! -path './.env' \
+                ! -path './.update-preflight-complete' \
+                ! -path './.update-preflight-complete.tmp.*' \
+                ! -path './client/nginx.conf' \
+                ! -path './ssl/*' \
+                ! -path './server/influx_config/.env' \
+                ! -path './deployment-manifest.sha256' \
+                -print0 | LC_ALL=C sort -z | xargs -0 sha256sum > deployment-manifest.sha256
+        else
+            find . -type f \
+                ! -path './.env' \
+                ! -path './.update-preflight-complete' \
+                ! -path './.update-preflight-complete.tmp.*' \
+                ! -path './client/nginx.conf' \
+                ! -path './ssl/*' \
+                ! -path './server/influx_config/.env' \
+                ! -path './deployment-manifest.sha256' \
+                -print0 | LC_ALL=C sort -z | xargs -0 shasum -a 256 > deployment-manifest.sha256
+        fi
+    )
+}
+
 make_stage() {
     local name="$1"
     STAGE="$TMP_DIR/$name"
-    mkdir -p "$STAGE/bin" "$STAGE/client"
+    local runtime="$STAGE-runtime"
+    mkdir -p "$STAGE/client" "$STAGE/server/monitoring/grafana/provisioning/datasources" "$runtime/bin"
+    ln -s "$runtime/bin" "$STAGE/bin"
+    : > "$runtime/calls.log"
+    : > "$runtime/output.log"
+    ln -s "$runtime/calls.log" "$STAGE/calls.log"
+    ln -s "$runtime/output.log" "$STAGE/output.log"
     cp "$DEPLOY_DIR/run-fleet.sh" "$STAGE/"
     cp "$DEPLOY_DIR/docker-compose.yaml" "$STAGE/"
     cp "$DEPLOY_DIR/docker-compose.alerts.yaml" "$STAGE/"
@@ -77,6 +111,8 @@ make_stage() {
     cp "$DEPLOY_DIR/docker-compose.tracing.yaml" "$STAGE/"
     cp "$DEPLOY_DIR/client/nginx.http.conf" "$STAGE/client/"
     cp "$DEPLOY_DIR/client/nginx.https.conf" "$STAGE/client/"
+    cp "$DEPLOY_DIR/server/otel-collector-config.datadog.yaml" "$STAGE/server/"
+    printf 'apiVersion: 1\n' > "$STAGE/server/monitoring/grafana/provisioning/datasources/base.yaml"
     printf '%s\n' 'version: v1.2.3' 'commit: test-release' > "$STAGE/version.txt"
     mkdir -p "$STAGE/images" "$STAGE/image-fixture"
     printf '[{"Config":"config.json","RepoTags":["proto-fleet-timescaledb:latest"],"Layers":[]}]\n' > "$STAGE/image-fixture/manifest.json"
@@ -93,10 +129,16 @@ printf '\n' >> "$CALL_LOG"
 
 case " $* " in
     *" compose up --help "*)
-        echo 'Options: --wait --wait-timeout'
+        echo 'Options: --wait --wait-timeout --no-build --pull string'
         ;;
     *" compose "*" config --quiet "*)
         [ "${FAKE_COMPOSE_CONFIG_FAILURE:-false}" != "true" ]
+        ;;
+    *" compose "*" config --images "*)
+        printf '%s\n' \
+            'proto-fleet-api:latest' \
+            'proto-fleet-client:latest' \
+            'proto-fleet-timescaledb:latest'
         ;;
     *" compose "*" config "*)
         previous=''
@@ -117,6 +159,17 @@ case " $* " in
         ;;
     *" compose "*" exec "*)
         echo 't'
+        ;;
+    *" image inspect --format "*)
+        image="${!#}"
+        if [ "${FAKE_PREPARED_IMAGE_MISSING:-false}" = "true" ] && [ "$image" = "proto-fleet-api:latest" ]; then
+            exit 1
+        fi
+        if [ "${FAKE_PREPARED_IMAGE_CHANGED:-false}" = "true" ] && [ "$image" = "proto-fleet-api:latest" ]; then
+            printf 'sha256:changed-%s\n' "$image"
+            exit 0
+        fi
+        printf 'sha256:test-%s\n' "$image"
         ;;
     *" image inspect proto-fleet-timescaledb:latest "*)
         [ "${FAKE_TSDB_IMAGE_MISSING:-false}" != "true" ]
@@ -188,6 +241,7 @@ exit 0
 EOF
 
     chmod +x "$STAGE/run-fleet.sh" "$STAGE/bin/"*
+    write_release_manifest "$STAGE"
 }
 
 run_stage() {
@@ -223,7 +277,7 @@ assert_contains "preflight builds images" "$STAGE/calls.log" " build --no-cache"
 assert_not_contains "preflight leaves services running" "$STAGE/calls.log" " down --remove-orphans"
 assert_not_contains "preflight never starts replacement services" "$STAGE/calls.log" " up --remove-orphans"
 [ -f "$STAGE/.update-preflight-complete" ] || fail "preflight should create its activation marker"
-if grep -Eq '^proto-fleet-preflight-v1:[0-9a-f]{64}$' "$STAGE/.update-preflight-complete"; then
+if grep -Eq '^proto-fleet-preflight-v2:[0-9a-f]{64}:[0-9a-f]{64}$' "$STAGE/.update-preflight-complete"; then
     pass "preflight marker records versioned release metadata"
 else
     fail "preflight marker should contain versioned release metadata"
@@ -255,6 +309,7 @@ else
 fi
 assert_not_contains "activation skips pulls" "$STAGE/calls.log" " pull"
 assert_not_contains "activation skips builds" "$STAGE/calls.log" " build --no-cache"
+assert_contains "activation forbids implicit image preparation" "$STAGE/calls.log" "up --remove-orphans -d --wait --wait-timeout 300 --no-build --pull never"
 assert_contains "activation stops the old stack" "$STAGE/calls.log" " down --remove-orphans"
 assert_contains "activation starts the new stack" "$STAGE/calls.log" " up --remove-orphans"
 [ ! -f "$STAGE/.update-preflight-complete" ] || fail "successful activation should consume its marker"
@@ -281,8 +336,14 @@ assert_contains "relocated activation stops the old stack" "$STAGE/calls.log" " 
 # Every input that defines the prepared release is bound into the marker. A
 # changed or forged marker fails before the active deployment is stopped and
 # is invalidated so recovery cannot keep retrying stale preparation.
-for mutation in env compose version nginx runner timescaledb; do
+for mutation in env compose version nginx runner runtime tls timescaledb; do
     make_stage "changed-$mutation"
+    if [ "$mutation" = "tls" ]; then
+        printf 'SESSION_COOKIE_SECURE=true\n' >> "$STAGE/.env"
+        mkdir -p "$STAGE/ssl"
+        printf 'test certificate\n' > "$STAGE/ssl/cert.pem"
+        printf 'test private key\n' > "$STAGE/ssl/key.pem"
+    fi
     if ! run_stage "$STAGE" --non-interactive --preflight-only; then
         fail "$mutation mutation fixture preflight should succeed"
         continue
@@ -293,6 +354,8 @@ for mutation in env compose version nginx runner timescaledb; do
         version) printf 'commit: changed-after-preflight\n' >> "$STAGE/version.txt" ;;
         nginx) printf '\n# changed after preflight\n' >> "$STAGE/client/nginx.http.conf" ;;
         runner) printf '\n# changed after preflight\n' >> "$STAGE/run-fleet.sh" ;;
+        runtime) printf '\n# changed after preflight\n' >> "$STAGE/server/otel-collector-config.datadog.yaml" ;;
+        tls) printf '\nchanged after preflight\n' >> "$STAGE/ssl/cert.pem" ;;
         timescaledb) printf 'changed-after-preflight' >> "$STAGE/images/timescaledb.tar.gz" ;;
     esac
     : > "$STAGE/calls.log"
@@ -301,11 +364,65 @@ for mutation in env compose version nginx runner timescaledb; do
     else
         pass "$mutation changes invalidate preflight"
     fi
-    assert_contains "$mutation mismatch is diagnosed" "$STAGE/output.log" "release or configuration changed after preflight"
+    assert_contains "$mutation mismatch is diagnosed" "$STAGE/output.log" "changed after preflight"
     assert_not_contains "$mutation mismatch prevents teardown" "$STAGE/calls.log" " down --remove-orphans"
     assert_not_contains "$mutation mismatch prevents startup" "$STAGE/calls.log" " up --remove-orphans"
     [ ! -e "$STAGE/.update-preflight-complete" ] || fail "$mutation mismatch should remove the stale marker"
 done
+
+make_stage missing-prepared-image
+if ! run_stage "$STAGE" --non-interactive --preflight-only; then
+    fail "missing-image fixture preflight should succeed"
+fi
+: > "$STAGE/calls.log"
+if FAKE_PREPARED_IMAGE_MISSING=true run_stage "$STAGE" --non-interactive --skip-build; then
+    fail "missing prepared image should fail activation validation"
+else
+    pass "missing prepared image fails before activation"
+fi
+assert_contains "missing image is diagnosed" "$STAGE/output.log" "prepared image is missing before activation"
+assert_not_contains "missing image prevents teardown" "$STAGE/calls.log" " down --remove-orphans"
+[ ! -e "$STAGE/.update-preflight-complete" ] || fail "missing image should invalidate the marker"
+
+make_stage changed-prepared-image
+if ! run_stage "$STAGE" --non-interactive --preflight-only; then
+    fail "changed-image fixture preflight should succeed"
+fi
+: > "$STAGE/calls.log"
+if FAKE_PREPARED_IMAGE_CHANGED=true run_stage "$STAGE" --non-interactive --skip-build; then
+    fail "changed prepared image should fail activation validation"
+else
+    pass "changed prepared image fails before activation"
+fi
+assert_contains "changed image is diagnosed" "$STAGE/output.log" "changed after preflight"
+assert_not_contains "changed image prevents teardown" "$STAGE/calls.log" " down --remove-orphans"
+[ ! -e "$STAGE/.update-preflight-complete" ] || fail "changed image should invalidate the marker"
+
+make_stage added-release-file
+if ! run_stage "$STAGE" --non-interactive --preflight-only; then
+    fail "added-file fixture preflight should succeed"
+fi
+printf 'apiVersion: 1\n' > "$STAGE/server/monitoring/grafana/provisioning/datasources/added-after-preflight.yaml"
+: > "$STAGE/calls.log"
+if run_stage "$STAGE" --non-interactive --skip-build; then
+    fail "an added immutable release file should fail activation validation"
+else
+    pass "an added immutable release file fails before activation"
+fi
+assert_contains "added release file is diagnosed" "$STAGE/output.log" "file set does not match"
+assert_not_contains "added release file prevents teardown" "$STAGE/calls.log" " down --remove-orphans"
+[ ! -e "$STAGE/.update-preflight-complete" ] || fail "added release file should invalidate the marker"
+
+make_stage missing-release-manifest
+rm -f "$STAGE/deployment-manifest.sha256"
+if run_stage "$STAGE" --non-interactive --preflight-only; then
+    fail "missing release manifest should fail preflight"
+else
+    pass "missing release manifest fails preflight"
+fi
+assert_contains "missing manifest is diagnosed" "$STAGE/output.log" "requires the immutable release manifest"
+assert_not_contains "missing manifest prevents pulls" "$STAGE/calls.log" " pull"
+[ ! -e "$STAGE/.update-preflight-complete" ] || fail "missing manifest must not create a marker"
 
 make_stage changed-during-preflight
 if FAKE_MUTATE_TSDB_DURING_BUILD=true run_stage "$STAGE" --non-interactive --preflight-only; then
@@ -488,6 +605,7 @@ assert_not_contains "marker cleanup failure makes no Docker calls" "$STAGE/calls
 # authorize service activation.
 make_stage missing-tsdb-image
 rm -f "$STAGE/images/timescaledb.tar.gz"
+write_release_manifest "$STAGE"
 if run_stage "$STAGE" --non-interactive --preflight-only; then
     fail "missing TimescaleDB image should fail preflight"
 else
@@ -502,6 +620,7 @@ mkdir -p "$STAGE/image-fixture"
 printf '[{"Config":"config.json","RepoTags":["wrong-image:latest"],"Layers":[]}]\n' > "$STAGE/image-fixture/manifest.json"
 (cd "$STAGE/image-fixture" && tar -cf - manifest.json) | gzip > "$STAGE/images/timescaledb.tar.gz"
 rm -rf "$STAGE/image-fixture"
+write_release_manifest "$STAGE"
 if run_stage "$STAGE" --non-interactive --preflight-only; then
     fail "mistagged TimescaleDB archive should fail preflight"
 else
@@ -518,6 +637,28 @@ else
 fi
 assert_not_contains "unloaded database image prevents builds" "$STAGE/calls.log" " build --no-cache"
 assert_not_contains "unloaded database image prevents teardown" "$STAGE/calls.log" " down --remove-orphans"
+
+# Legacy HTTPS deployments predate SESSION_COOKIE_SECURE persistence. A full
+# certificate pair remains authoritative only when the key is absent; this
+# avoids silently downgrading those installs while explicit false still wins.
+make_stage legacy-https
+legacy_env="$STAGE/.env.without-cookie-mode"
+grep -Ev '^SESSION_COOKIE_SECURE[[:space:]]*=' "$STAGE/.env" > "$legacy_env"
+mv "$legacy_env" "$STAGE/.env"
+mkdir -p "$STAGE/ssl"
+: > "$STAGE/ssl/cert.pem"
+: > "$STAGE/ssl/key.pem"
+if run_stage "$STAGE" --non-interactive --preflight-only; then
+    pass "legacy HTTPS without a persisted cookie mode preflights"
+else
+    fail "legacy HTTPS should be inferred from its complete certificate pair"
+fi
+assert_contains "legacy HTTPS transport is preserved" "$STAGE/output.log" "Preserving legacy HTTPS mode"
+if cmp -s "$STAGE/client/nginx.https.conf" "$STAGE/client/nginx.conf" && grep -q '^SESSION_COOKIE_SECURE=true$' "$STAGE/.env"; then
+    pass "legacy HTTPS is persisted explicitly"
+else
+    fail "legacy HTTPS did not select HTTPS config and persist secure cookies"
+fi
 
 # Persisted HTTP remains authoritative even if stale certificate files remain
 # on disk from an older HTTPS configuration.

--- a/deployment-files/tests/test-run-fleet-upgrade.sh
+++ b/deployment-files/tests/test-run-fleet-upgrade.sh
@@ -169,6 +169,50 @@ printf 'docker' >> "$CALL_LOG"
 printf ' %s' "$@" >> "$CALL_LOG"
 printf '\n' >> "$CALL_LOG"
 
+if [ "${1:-}" = "image" ] && [ "${2:-}" = "ls" ]; then
+    repository=''
+    for argument in "$@"; do
+        case "$argument" in
+            proto-fleet-api|proto-fleet-client|proto-fleet-timescaledb|proto-fleet-timescaledb-ha)
+                repository="$argument"
+                ;;
+        esac
+    done
+    if [ "${FAKE_IMAGE_LIST_FAILURE:-}" = "$repository" ]; then
+        exit 1
+    fi
+    for image in ${FAKE_RELEASE_IMAGES:-}; do
+        case "$image" in
+            "$repository":*) printf '%s\n' "$image" ;;
+        esac
+    done
+    exit 0
+fi
+
+if [ "${1:-}" = "container" ] && [ "${2:-}" = "ls" ]; then
+    if [ "${FAKE_CONTAINER_LIST_FAILURE:-false}" = "true" ]; then
+        exit 1
+    fi
+    ancestor=''
+    for argument in "$@"; do
+        case "$argument" in
+            ancestor=*) ancestor="${argument#ancestor=}" ;;
+        esac
+    done
+    for image in ${FAKE_CONTAINER_IMAGE_REFS:-}; do
+        if [ "sha256:test-$image" = "$ancestor" ]; then
+            printf 'container-using-%s\n' "${image##*:}"
+            break
+        fi
+    done
+    exit 0
+fi
+
+if [ "${1:-}" = "image" ] && [ "${2:-}" = "rm" ]; then
+    [ "${FAKE_IMAGE_RM_FAILURE:-}" != "${3:-}" ]
+    exit
+fi
+
 case " $* " in
     *" compose up --help "*)
         echo 'Options: --wait --wait-timeout --no-build --pull string'
@@ -231,6 +275,9 @@ case " $* " in
         ;;
     *" image inspect --format "*)
         image="${!#}"
+        if [ "${FAKE_IMAGE_INSPECT_FAILURE:-}" = "$image" ]; then
+            exit 1
+        fi
         if [ "${FAKE_PREPARED_IMAGE_MISSING:-false}" = "true" ] && [ "$image" = "proto-fleet-api:v1.2.3" ]; then
             exit 1
         fi
@@ -430,23 +477,72 @@ assert_contains "source-tree run reaches teardown in its isolated project" "$HAR
 # volume detection. Do not persist a new multi-install identity here: the
 # surrounding migration and uninstall tools do not support that contract.
 make_stage project-override
+printf 'COMPOSE_PROJECT_NAME=persisted-project\n' >> "$STAGE/.env"
 if COMPOSE_PROJECT_NAME=fleet-blue run_stage "$STAGE" --non-interactive --preflight-only; then
     pass "explicit Compose project override preflights"
 else
     fail "explicit Compose project override should be preserved"
 fi
 assert_contains "explicit project override reaches Compose" "$HARNESS_CALL_LOG" "compose --project-name fleet-blue"
+assert_not_contains "process project override beats persisted identity" "$HARNESS_CALL_LOG" "compose --project-name persisted-project"
+
+# Compose historically accepted a project identity from the deployment .env.
+# Preserve its last non-empty assignment when the process has no override.
+make_stage persisted-project
+printf 'COMPOSE_PROJECT_NAME=ignored-project\n' >> "$STAGE/.env"
+printf 'export COMPOSE_PROJECT_NAME: "fleet-blue" # retained identity\r\n' >> "$STAGE/.env"
+if run_stage "$STAGE" --non-interactive --preflight-only; then
+    pass "persisted Compose project name preflights"
+else
+    fail "persisted Compose project name should be preserved"
+fi
+assert_contains "last persisted project name reaches Compose" "$HARNESS_CALL_LOG" "compose --project-name fleet-blue"
+assert_not_contains "earlier persisted project name is ignored" "$HARNESS_CALL_LOG" "compose --project-name ignored-project"
+
+# Compose also accepts `KEY: value`. Read true overlay settings through that
+# syntax and atomically normalize every prior form to one final assignment.
+make_stage compose-env-booleans
+enable_valid_alerts "$STAGE/.env"
+printf 'DD_API_KEY=test-datadog-key\n' >> "$STAGE/.env"
+printf '%s\n' \
+    'export ENABLE_BETA_ALERTS: true # preserve alerts' \
+    'ENABLE_SYSTEM_MONITORING: "true"' \
+    'ENABLE_TRACING: TRUE' >> "$STAGE/.env"
+if run_stage "$STAGE" --non-interactive --preflight-only; then
+    pass "Compose colon-form overlay settings preflight"
+else
+    fail "Compose colon-form overlay settings should be preserved"
+fi
+for persisted_boolean in ENABLE_BETA_ALERTS ENABLE_SYSTEM_MONITORING ENABLE_TRACING; do
+    if [ "$(grep -Ec "^[[:space:]]*(export[[:space:]]+)?${persisted_boolean}[[:space:]]*[:=]" "$STAGE/.env")" -eq 1 ] \
+        && grep -q "^${persisted_boolean}=true$" "$STAGE/.env"; then
+        pass "$persisted_boolean normalizes Compose colon syntax without changing its value"
+    else
+        fail "$persisted_boolean did not preserve its Compose colon-form true value"
+    fi
+done
 
 make_stage project-volume
+printf 'COMPOSE_PROJECT_NAME=fleet-blue\n' >> "$STAGE/.env"
 env_without_password="$STAGE/.env.without-password"
 grep -Ev '^DB_PASSWORD=' "$STAGE/.env" > "$env_without_password"
 mv "$env_without_password" "$STAGE/.env"
-if printf 'n\n' | COMPOSE_PROJECT_NAME=fleet-blue FAKE_DOCKER_VOLUME=fleet-blue_timescaledb-data run_stage "$STAGE"; then
+if printf 'n\n' | FAKE_DOCKER_VOLUME=fleet-blue_timescaledb-data run_stage "$STAGE"; then
     fail "declining removal of an overridden project volume should abort"
 else
-    pass "volume guard uses the explicit Compose project override"
+    pass "volume guard uses the persisted Compose project name"
 fi
-assert_contains "volume guard finds the overridden project volume" "$HARNESS_OUTPUT_LOG" "Detected existing TimescaleDB data volume: fleet-blue_timescaledb-data"
+assert_contains "volume guard finds the persisted project volume" "$HARNESS_OUTPUT_LOG" "Detected existing TimescaleDB data volume: fleet-blue_timescaledb-data"
+
+make_stage invalid-persisted-project
+printf 'COMPOSE_PROJECT_NAME=Fleet Blue\n' >> "$STAGE/.env"
+if run_stage "$STAGE" --non-interactive --preflight-only; then
+    fail "invalid persisted Compose project name should fail"
+else
+    pass "invalid persisted Compose project name fails before Docker activity"
+fi
+assert_contains "invalid persisted project name is diagnosed" "$HARNESS_OUTPUT_LOG" "COMPOSE_PROJECT_NAME must start with a lowercase letter or digit"
+assert_not_contains "invalid persisted project name cannot target Docker" "$HARNESS_CALL_LOG" "docker "
 
 make_stage invalid-project-override
 if COMPOSE_PROJECT_NAME='Fleet Blue' run_stage "$STAGE" --non-interactive --preflight-only; then
@@ -604,14 +700,105 @@ assert_contains "activation stops the old stack" "$HARNESS_CALL_LOG" " down --re
 assert_contains "activation starts the new stack" "$HARNESS_CALL_LOG" " up --remove-orphans"
 [ ! -f "$STAGE/.update-preflight-complete" ] || fail "successful activation should consume its marker"
 
+# Preflight must never delete an installed release merely because its stack is
+# stopped. Garbage collection runs only after successful activation, when the
+# old deployment is no longer the recovery path.
+make_stage release-image-retention/deployment
+gc_images=$(printf '%s\n' \
+    'proto-fleet-api:latest' \
+    'proto-fleet-api:debug' \
+    "proto-fleet-api:$RELEASE_TAG" \
+    'proto-fleet-timescaledb-ha:v1.2.3' \
+    'proto-fleet-api:v1.0.0' \
+    'proto-fleet-client:v1.0.0' \
+    'proto-fleet-timescaledb:v1.0.0' \
+    'proto-fleet-timescaledb-ha:v1.0.0' \
+    'proto-fleet-api:v1.1.0' \
+    'proto-fleet-client:v1.1.0' \
+    'proto-fleet-timescaledb:v1.1.0' \
+    'proto-fleet-timescaledb-ha:v1.1.0' \
+    'proto-fleet-api:nightly-20260731-abcdef123456')
+if FAKE_RELEASE_IMAGES="$gc_images" run_stage "$STAGE" --non-interactive --preflight-only; then
+    pass "preflight preserves installed and abandoned release tags"
+else
+    fail "release image retention fixture should preflight"
+fi
+assert_not_contains "preflight never garbage-collects release images" "$HARNESS_CALL_LOG" "docker image rm "
+
+# After activation, remove only unused obsolete Proto Fleet release tags. Keep
+# source :latest tags, the target release, local/debug tags, and all four
+# images for a release if any running or stopped container still uses it.
+: > "$HARNESS_CALL_LOG"
+if FAKE_RELEASE_IMAGES="$gc_images" \
+    FAKE_CONTAINER_IMAGE_REFS='proto-fleet-api:v1.0.0' \
+    run_stage "$STAGE" --non-interactive --skip-build; then
+    pass "successful activation prunes only unused obsolete release tags"
+else
+    fail "post-activation release image cleanup should be nonfatal"
+fi
+for obsolete_image in \
+    proto-fleet-api:v1.1.0 \
+    proto-fleet-client:v1.1.0 \
+    proto-fleet-timescaledb:v1.1.0 \
+    proto-fleet-timescaledb-ha:v1.1.0 \
+    proto-fleet-api:nightly-20260731-abcdef123456; do
+    assert_contains "activation removes obsolete image $obsolete_image" "$HARNESS_CALL_LOG" "docker image rm $obsolete_image"
+done
+for retained_image in \
+    proto-fleet-api:latest \
+    proto-fleet-api:debug \
+    "proto-fleet-api:$RELEASE_TAG" \
+    proto-fleet-timescaledb-ha:v1.2.3 \
+    proto-fleet-api:v1.0.0 \
+    proto-fleet-client:v1.0.0 \
+    proto-fleet-timescaledb:v1.0.0 \
+    proto-fleet-timescaledb-ha:v1.0.0; do
+    assert_not_contains "activation retains image $retained_image" "$HARNESS_CALL_LOG" "docker image rm $retained_image"
+done
+assert_contains "retention checks stopped containers by immutable image ID" "$HARNESS_CALL_LOG" \
+    "docker container ls --all --quiet --filter ancestor=sha256:test-proto-fleet-api:v1.0.0"
+assert_not_contains "activation retains its current API image" "$HARNESS_CALL_LOG" "docker image rm $FLEET_API_IMAGE"
+up_line=$(grep -nF ' up --remove-orphans' "$HARNESS_CALL_LOG" | head -1 | cut -d: -f1)
+gc_line=$(grep -nF 'docker image rm proto-fleet-api:v1.1.0' "$HARNESS_CALL_LOG" | head -1 | cut -d: -f1)
+if [ -n "$up_line" ] && [ -n "$gc_line" ] && [ "$up_line" -lt "$gc_line" ]; then
+    pass "obsolete release cleanup runs only after successful startup"
+else
+    fail "obsolete release cleanup should follow successful startup"
+fi
+
+# Docker inspection/removal errors are fail-safe housekeeping failures: no
+# uncertain tag is deleted, and a successful deployment remains successful.
+make_stage release-image-list-failure/deployment
+if FAKE_RELEASE_IMAGES='proto-fleet-api:v1.1.0' \
+    FAKE_IMAGE_LIST_FAILURE=proto-fleet-client \
+    run_stage "$STAGE" --non-interactive; then
+    pass "image-list failure does not fail deployment"
+else
+    fail "image-list failure should skip cleanup without failing deployment"
+fi
+assert_contains "image-list failure is diagnosed" "$HARNESS_OUTPUT_LOG" "skipping Proto Fleet release image cleanup"
+assert_not_contains "image-list failure prevents partial deletion" "$HARNESS_CALL_LOG" "docker image rm proto-fleet-api:v1.1.0"
+
+make_stage release-image-remove-failure/deployment
+if FAKE_RELEASE_IMAGES='proto-fleet-api:v1.1.0' \
+    FAKE_IMAGE_RM_FAILURE=proto-fleet-api:v1.1.0 \
+    run_stage "$STAGE" --non-interactive; then
+    pass "image removal failure does not fail deployment"
+else
+    fail "image removal failure should remain best-effort"
+fi
+assert_contains "image removal failure is diagnosed" "$HARNESS_OUTPUT_LOG" "could not remove obsolete Proto Fleet image proto-fleet-api:v1.1.0"
+
 # The updater preflights and activates directories that are both named
 # `deployment`; only their parent changes. Absolute paths in rendered Compose
 # output are normalized so that this safe relocation does not invalidate the
 # proof, while Compose's native project identity stays stable.
 make_stage relocated-preflight/deployment
+printf 'COMPOSE_PROJECT_NAME=fleet-blue\n' >> "$STAGE/.env"
 if ! run_stage "$STAGE" --non-interactive --preflight-only; then
     fail "relocation fixture preflight should succeed"
 fi
+assert_contains "relocated preflight uses the persisted project" "$HARNESS_CALL_LOG" "compose --project-name fleet-blue"
 relocated_stage="$TMP_DIR/activated-release/deployment"
 mkdir -p "$(dirname "$relocated_stage")"
 mv "$STAGE" "$relocated_stage"
@@ -623,6 +810,7 @@ else
     fail "unchanged relocated release should activate"
 fi
 assert_contains "relocated activation stops the old stack" "$HARNESS_CALL_LOG" " down --remove-orphans"
+assert_contains "relocated activation keeps the persisted project" "$HARNESS_CALL_LOG" "compose --project-name fleet-blue"
 
 # Every input that defines the prepared release is bound into the marker. A
 # changed or forged marker fails before the active deployment is stopped and
@@ -819,13 +1007,16 @@ if ! run_stage "$STAGE" --non-interactive --preflight-only; then
     fail "failed-activation fixture preflight should succeed"
 fi
 : > "$HARNESS_CALL_LOG"
-if FAKE_ACTIVATION_FAILURE=true run_stage "$STAGE" --non-interactive --skip-build; then
+if FAKE_ACTIVATION_FAILURE=true \
+    FAKE_RELEASE_IMAGES='proto-fleet-api:v1.1.0' \
+    run_stage "$STAGE" --non-interactive --skip-build; then
     fail "simulated activation failure should propagate"
 else
     pass "activation failure propagates"
 fi
 [ -f "$STAGE/.update-preflight-complete" ] || fail "failed activation should retain its recovery marker"
 assert_contains "activation recovery command keeps the resolved project" "$HARNESS_OUTPUT_LOG" "docker compose --project-name failed-activation"
+assert_not_contains "failed activation cannot prune prepared or retired releases" "$HARNESS_CALL_LOG" "docker image rm proto-fleet-api:v1.1.0"
 
 # Skip-build must not be usable without proof that this exact deployment
 # directory completed preflight.

--- a/deployment-files/tests/test-run-fleet-upgrade.sh
+++ b/deployment-files/tests/test-run-fleet-upgrade.sh
@@ -78,6 +78,7 @@ write_release_manifest() {
                 ! -path './client/nginx.conf' \
                 ! -path './ssl/*' \
                 ! -path './server/influx_config/.env' \
+                ! -path './ha/node.env' \
                 ! -path './deployment-manifest.sha256' \
                 -print0 | LC_ALL=C sort -z | xargs -0 sha256sum > deployment-manifest.sha256
         else
@@ -88,6 +89,7 @@ write_release_manifest() {
                 ! -path './client/nginx.conf' \
                 ! -path './ssl/*' \
                 ! -path './server/influx_config/.env' \
+                ! -path './ha/node.env' \
                 ! -path './deployment-manifest.sha256' \
                 -print0 | LC_ALL=C sort -z | xargs -0 shasum -a 256 > deployment-manifest.sha256
         fi
@@ -426,6 +428,29 @@ fi
 assert_contains "added release file is diagnosed" "$STAGE/output.log" "file set does not match"
 assert_not_contains "added release file prevents teardown" "$STAGE/calls.log" " down --remove-orphans"
 [ ! -e "$STAGE/.update-preflight-complete" ] || fail "added release file should invalidate the marker"
+
+# HA's node.env is operator-owned runtime state, not a packaged release file.
+# Permit that exact path while keeping every other added HA artifact inside the
+# immutable release boundary.
+make_stage ha-operator-state
+mkdir -p "$STAGE/ha"
+printf 'HA_NODE_NAME=ha-a\n' > "$STAGE/ha/node.env"
+chmod 600 "$STAGE/ha/node.env"
+if run_stage "$STAGE" --non-interactive --preflight-only; then
+    pass "HA node environment remains outside the immutable release set"
+else
+    fail "operator-owned HA node environment should not fail preflight"
+fi
+printf 'tampered\n' > "$STAGE/ha/added-after-preflight.yaml"
+: > "$STAGE/calls.log"
+if run_stage "$STAGE" --non-interactive --skip-build; then
+    fail "an added HA release file should fail activation validation"
+else
+    pass "other added HA files remain immutable"
+fi
+assert_contains "added HA release file is diagnosed" "$STAGE/output.log" "file set does not match"
+assert_not_contains "added HA release file prevents teardown" "$STAGE/calls.log" " down --remove-orphans"
+[ ! -e "$STAGE/.update-preflight-complete" ] || fail "added HA release file should invalidate the marker"
 
 make_stage missing-release-manifest
 rm -f "$STAGE/deployment-manifest.sha256"

--- a/deployment-files/tests/test-run-fleet-upgrade.sh
+++ b/deployment-files/tests/test-run-fleet-upgrade.sh
@@ -6,7 +6,13 @@ set -u
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DEPLOY_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 TMP_DIR=$(mktemp -d)
+REAL_AWK=$(command -v awk)
+REAL_CHMOD=$(command -v chmod)
+REAL_CHOWN=$(command -v chown)
 REAL_GREP=$(command -v grep)
+REAL_MKTEMP=$(command -v mktemp)
+REAL_MV=$(command -v mv)
+REAL_STAT=$(command -v stat)
 FAILURES=0
 RELEASE_TAG="v1.2.3"
 FLEET_API_IMAGE="proto-fleet-api:${RELEASE_TAG}"
@@ -41,6 +47,32 @@ assert_not_contains() {
     else
         pass "$description"
     fi
+}
+
+file_owner_group() {
+    local owner_group
+    if owner_group=$(stat -c '%u:%g' "$1" 2>/dev/null); then
+        :
+    elif owner_group=$(stat -f '%u:%g' "$1" 2>/dev/null); then
+        :
+    else
+        return 1
+    fi
+    [ -n "$owner_group" ] || return 1
+    printf '%s' "$owner_group"
+}
+
+file_mode() {
+    local mode
+    if mode=$(stat -c '%a' "$1" 2>/dev/null); then
+        :
+    elif mode=$(stat -f '%Lp' "$1" 2>/dev/null); then
+        :
+    else
+        return 1
+    fi
+    [ -n "$mode" ] || return 1
+    printf '%s' "$mode"
 }
 
 write_valid_env() {
@@ -249,6 +281,75 @@ fi
 exec "$REAL_GREP" "$@"
 EOF
 
+    cat > "$HARNESS_BIN_DIR/mktemp" <<'EOF'
+#!/bin/bash
+if [ "${FAKE_ENV_REWRITE_FAILURE:-}" = "mktemp" ] && \
+    [ "${1:-}" = "$STAGE_ROOT/.env.tmp.XXXXXX" ]; then
+    exit 1
+fi
+exec "$REAL_MKTEMP" "$@"
+EOF
+
+    cat > "$HARNESS_BIN_DIR/stat" <<'EOF'
+#!/bin/bash
+target="${@: -1}"
+if [ "$target" = "$STAGE_ROOT/.env" ]; then
+    case "${FAKE_ENV_REWRITE_FAILURE:-}" in
+        metadata) exit 1 ;;
+        chown)
+            printf '99999:99999\n'
+            exit 0
+            ;;
+    esac
+fi
+exec "$REAL_STAT" "$@"
+EOF
+
+    cat > "$HARNESS_BIN_DIR/chown" <<'EOF'
+#!/bin/bash
+target="${@: -1}"
+if [ "${FAKE_ENV_REWRITE_FAILURE:-}" = "chown" ] && \
+    [[ "$target" == "$STAGE_ROOT/.env.tmp."* ]]; then
+    exit 1
+fi
+exec "$REAL_CHOWN" "$@"
+EOF
+
+    cat > "$HARNESS_BIN_DIR/chmod" <<'EOF'
+#!/bin/bash
+target="${@: -1}"
+if [ "${FAKE_ENV_REWRITE_FAILURE:-}" = "chmod" ] && \
+    [[ "$target" == "$STAGE_ROOT/.env.tmp."* ]]; then
+    exit 1
+fi
+exec "$REAL_CHMOD" "$@"
+EOF
+
+    cat > "$HARNESS_BIN_DIR/awk" <<'EOF'
+#!/bin/bash
+if [ "${FAKE_ENV_REWRITE_FAILURE:-}" = "filter" ]; then
+    for argument in "$@"; do
+        if [ "$argument" = "$STAGE_ROOT/.env" ]; then
+            printf 'PARTIAL_REPLACEMENT=true\n'
+            exit 2
+        fi
+    done
+fi
+exec "$REAL_AWK" "$@"
+EOF
+
+    cat > "$HARNESS_BIN_DIR/mv" <<'EOF'
+#!/bin/bash
+source_path="${@: -2:1}"
+destination_path="${@: -1}"
+if [ "${FAKE_ENV_REWRITE_FAILURE:-}" = "mv" ] && \
+    [[ "$source_path" == "$STAGE_ROOT/.env.tmp."* ]] && \
+    [ "$destination_path" = "$STAGE_ROOT/.env" ]; then
+    exit 1
+fi
+exec "$REAL_MV" "$@"
+EOF
+
     cat > "$HARNESS_BIN_DIR/curl" <<'EOF'
 #!/bin/bash
 printf 'curl %s\n' "$*" >> "$CALL_LOG"
@@ -289,7 +390,13 @@ run_stage() {
     shift
     CALL_LOG="$HARNESS_CALL_LOG" \
     STAGE_ROOT="$stage" \
+    REAL_AWK="$REAL_AWK" \
+    REAL_CHMOD="$REAL_CHMOD" \
+    REAL_CHOWN="$REAL_CHOWN" \
     REAL_GREP="$REAL_GREP" \
+    REAL_MKTEMP="$REAL_MKTEMP" \
+    REAL_MV="$REAL_MV" \
+    REAL_STAT="$REAL_STAT" \
     PATH="$HARNESS_BIN_DIR:$PATH" \
     /bin/bash "$stage/run-fleet.sh" "$@" > "$HARNESS_OUTPUT_LOG" 2>&1
 }
@@ -350,9 +457,75 @@ fi
 assert_contains "invalid project override is diagnosed" "$HARNESS_OUTPUT_LOG" "COMPOSE_PROJECT_NAME must start with a lowercase letter or digit"
 assert_not_contains "invalid project override cannot target Docker" "$HARNESS_CALL_LOG" "docker "
 
+# Every failure in the .env replacement transaction must leave secrets and
+# metadata untouched, clean up the partial file, and abort before Compose
+# validation or any image/service mutation.
+for rewrite_failure in metadata mktemp filter chown chmod mv; do
+    make_stage "env-rewrite-$rewrite_failure"
+    env_before="$HARNESS_BIN_DIR/../env.before"
+    cp -p "$STAGE/.env" "$env_before"
+    metadata_available=true
+    if ! owner_before=$(file_owner_group "$STAGE/.env"); then
+        fail "$rewrite_failure fixture could not read .env owner/group"
+        metadata_available=false
+    fi
+    if ! mode_before=$(file_mode "$STAGE/.env"); then
+        fail "$rewrite_failure fixture could not read .env mode"
+        metadata_available=false
+    fi
+    case "$rewrite_failure" in
+        metadata) expected_rewrite_error="could not read owner/group metadata" ;;
+        mktemp) expected_rewrite_error="could not create a temporary environment file" ;;
+        filter) expected_rewrite_error="could not build a replacement" ;;
+        chown) expected_rewrite_error="could not preserve owner/group" ;;
+        chmod) expected_rewrite_error="could not restrict permissions" ;;
+        mv) expected_rewrite_error="could not atomically replace" ;;
+    esac
+
+    if FAKE_ENV_REWRITE_FAILURE="$rewrite_failure" run_stage "$STAGE" --non-interactive --preflight-only; then
+        fail "$rewrite_failure failure should abort the environment rewrite"
+    else
+        pass "$rewrite_failure failure aborts the environment rewrite"
+    fi
+    cmp -s "$env_before" "$STAGE/.env" || fail "$rewrite_failure failure changed .env contents"
+    if ! owner_after=$(file_owner_group "$STAGE/.env"); then
+        fail "$rewrite_failure result could not read .env owner/group"
+        metadata_available=false
+    fi
+    if ! mode_after=$(file_mode "$STAGE/.env"); then
+        fail "$rewrite_failure result could not read .env mode"
+        metadata_available=false
+    fi
+    if [ "$metadata_available" = "true" ]; then
+        if [ "$owner_after" = "$owner_before" ] && [ "$mode_after" = "$mode_before" ]; then
+            pass "$rewrite_failure failure preserves .env metadata"
+        else
+            fail "$rewrite_failure failure changed .env metadata"
+        fi
+    fi
+    assert_contains "$rewrite_failure failure reaches the intended operation" "$HARNESS_OUTPUT_LOG" "$expected_rewrite_error"
+    assert_contains "$rewrite_failure failure is diagnosed" "$HARNESS_OUTPUT_LOG" "could not persist deployment overlay settings"
+    assert_not_contains "$rewrite_failure failure prevents Compose validation" "$HARNESS_CALL_LOG" " config --quiet"
+    assert_not_contains "$rewrite_failure failure prevents pulls" "$HARNESS_CALL_LOG" " pull"
+    assert_not_contains "$rewrite_failure failure prevents builds" "$HARNESS_CALL_LOG" " build --no-cache"
+    assert_not_contains "$rewrite_failure failure prevents teardown" "$HARNESS_CALL_LOG" " down --remove-orphans"
+    assert_not_contains "$rewrite_failure failure prevents startup" "$HARNESS_CALL_LOG" " up --remove-orphans"
+    if compgen -G "$STAGE/.env.tmp.*" >/dev/null; then
+        fail "$rewrite_failure failure left an environment rewrite temporary file"
+    else
+        pass "$rewrite_failure failure cleans its environment rewrite temporary file"
+    fi
+    [ ! -e "$STAGE/.update-preflight-complete" ] || fail "$rewrite_failure failure must not create a preflight marker"
+done
+
 # A successful preflight validates and prepares images, but never stops or
 # starts the active stack. It records a same-directory activation marker.
 make_stage preflight-parent/deployment
+printf 'NO_TRAILING_NEWLINE=preserved' >> "$STAGE/.env"
+if ! preflight_env_owner=$(file_owner_group "$STAGE/.env"); then
+    fail "preflight fixture could not read .env owner/group"
+    preflight_env_owner=""
+fi
 if run_stage "$STAGE" --non-interactive --preflight-only; then
     pass "valid non-interactive preflight succeeds"
 else
@@ -380,15 +553,39 @@ if [ "$marker_mode" = "600" ]; then
 else
     fail "preflight marker mode should be 600, got $marker_mode"
 fi
-if [ "$(grep -c '^ENABLE_BETA_ALERTS=' "$STAGE/.env")" -eq 1 ] && grep -q '^ENABLE_BETA_ALERTS=false$' "$STAGE/.env"; then
-    pass "persisted booleans use the last Compose-style assignment"
+for persisted_boolean in ENABLE_BETA_ALERTS ENABLE_SYSTEM_MONITORING ENABLE_TRACING SESSION_COOKIE_SECURE; do
+    if [ "$(grep -c "^${persisted_boolean}=" "$STAGE/.env")" -eq 1 ] && \
+        grep -q "^${persisted_boolean}=false$" "$STAGE/.env"; then
+        pass "$persisted_boolean uses one normalized last-value assignment"
+    else
+        fail "$persisted_boolean did not honor last-value-wins"
+    fi
+done
+for preserved_secret in \
+    'DB_PASSWORD=test-password' \
+    'AUTH_CLIENT_SECRET_KEY=01234567890123456789012345678901' \
+    'ENCRYPT_SERVICE_MASTER_KEY=MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDE='; do
+    if [ "$(grep -cFx "$preserved_secret" "$STAGE/.env")" -eq 1 ]; then
+        pass "environment rewrite preserves ${preserved_secret%%=*}"
+    else
+        fail "environment rewrite lost ${preserved_secret%%=*}"
+    fi
+done
+if grep -qFx 'NO_TRAILING_NEWLINE=preserved' "$STAGE/.env"; then
+    pass "environment rewrite handles a source without a trailing newline"
 else
-    fail "persisted booleans did not honor last-value-wins"
+    fail "environment rewrite corrupted the source's final line"
 fi
-if [ "$(grep -c '^SESSION_COOKIE_SECURE=' "$STAGE/.env")" -eq 1 ] && grep -q '^SESSION_COOKIE_SECURE=false$' "$STAGE/.env"; then
-    pass "cookie mode uses the last Compose-style assignment"
+if preflight_env_mode=$(file_mode "$STAGE/.env") && [ "$preflight_env_mode" = "600" ]; then
+    pass "environment rewrite restricts .env permissions to 600"
 else
-    fail "cookie mode did not honor last-value-wins"
+    fail "environment rewrite did not restrict .env permissions"
+fi
+if preflight_env_owner_after=$(file_owner_group "$STAGE/.env") && \
+    [ -n "$preflight_env_owner" ] && [ "$preflight_env_owner_after" = "$preflight_env_owner" ]; then
+    pass "environment rewrite preserves .env owner and group"
+else
+    fail "environment rewrite changed .env owner or group"
 fi
 
 # Activation consumes the marker, reuses prepared images, and performs the

--- a/deployment-files/tests/test-run-fleet-upgrade.sh
+++ b/deployment-files/tests/test-run-fleet-upgrade.sh
@@ -33,7 +33,7 @@ pass() {
 
 assert_contains() {
     local description="$1" file="$2" expected="$3"
-    if grep -qF "$expected" "$file"; then
+    if grep -qF -- "$expected" "$file"; then
         pass "$description"
     else
         fail "$description: expected '$expected' in $file"
@@ -42,7 +42,7 @@ assert_contains() {
 
 assert_not_contains() {
     local description="$1" file="$2" unexpected="$3"
-    if grep -qF "$unexpected" "$file"; then
+    if grep -qF -- "$unexpected" "$file"; then
         fail "$description: unexpected '$unexpected' in $file"
     else
         pass "$description"
@@ -140,7 +140,7 @@ make_stage() {
     HARNESS_BIN_DIR="$runtime/bin"
     HARNESS_CALL_LOG="$runtime/calls.log"
     HARNESS_OUTPUT_LOG="$runtime/output.log"
-    mkdir -p "$STAGE/client" "$STAGE/ha" "$STAGE/server/monitoring/grafana/provisioning/datasources" "$HARNESS_BIN_DIR"
+    mkdir -p "$STAGE/client" "$STAGE/ha" "$STAGE/profiles" "$STAGE/server/monitoring/grafana/provisioning/datasources" "$HARNESS_BIN_DIR"
     : > "$HARNESS_CALL_LOG"
     : > "$HARNESS_OUTPUT_LOG"
     cp "$DEPLOY_DIR/run-fleet.sh" "$STAGE/"
@@ -149,6 +149,7 @@ make_stage() {
     cp "$DEPLOY_DIR/docker-compose.system-monitoring.yaml" "$STAGE/"
     cp "$DEPLOY_DIR/docker-compose.tracing.yaml" "$STAGE/"
     cp "$DEPLOY_DIR/ha/compose.yaml" "$STAGE/ha/"
+    cp "$DEPLOY_DIR/profiles/mini.env" "$STAGE/profiles/"
     cp "$DEPLOY_DIR/client/nginx.http.conf" "$STAGE/client/"
     cp "$DEPLOY_DIR/client/nginx.https.conf" "$STAGE/client/"
     cp "$DEPLOY_DIR/server/otel-collector-config.datadog.yaml" "$STAGE/server/"
@@ -190,6 +191,17 @@ if [ "${1:-}" = "image" ] && [ "${2:-}" = "ls" ]; then
 fi
 
 if [ "${1:-}" = "container" ] && [ "${2:-}" = "ls" ]; then
+    case " $* " in
+        *" --filter label=com.docker.compose.project="*" --format {{.Image}} "*)
+            if [ "${FAKE_ACTIVE_IMAGE_LIST_FAILURE:-false}" = "true" ]; then
+                exit 1
+            fi
+            for image in ${FAKE_ACTIVE_RELEASE_IMAGES:-}; do
+                printf '%s\n' "$image"
+            done
+            exit 0
+            ;;
+    esac
     if [ "${FAKE_CONTAINER_LIST_FAILURE:-false}" = "true" ]; then
         exit 1
     fi
@@ -404,6 +416,12 @@ case " $* " in
     *registry-1.docker.io*)
         [ "${FAKE_REGISTRY_FAILURE:-false}" != "true" ]
         ;;
+    *"/health/ready"*)
+        [ "${FAKE_API_READINESS_FAILURE:-false}" != "true" ]
+        ;;
+    *"://127.0.0.1/"*)
+        [ "${FAKE_CLIENT_READINESS_FAILURE:-false}" != "true" ]
+        ;;
     *) exit 0 ;;
 esac
 EOF
@@ -521,6 +539,82 @@ for persisted_boolean in ENABLE_BETA_ALERTS ENABLE_SYSTEM_MONITORING ENABLE_TRAC
         fail "$persisted_boolean did not preserve its Compose colon-form true value"
     fi
 done
+
+# Required credentials use the same literal dotenv forms accepted for project
+# identity and booleans. Mixed duplicate delimiters, export prefixes, quoting,
+# and inline comments must validate the values Compose will actually consume.
+make_stage compose-env-credentials
+printf '%s\n' \
+    'DB_USERNAME: "fleet" # database role' \
+    "export DB_PASSWORD: 'test\$password' # literal dollar" \
+    'AUTH_CLIENT_SECRET_KEY: "01234567890123456789012345678901" # auth secret' \
+    'ENCRYPT_SERVICE_MASTER_KEY: "MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDE=" # encryption key' >> "$STAGE/.env"
+if run_stage "$STAGE" --non-interactive --preflight-only; then
+    pass "Compose dotenv credential forms preflight"
+else
+    fail "Compose dotenv credential forms should validate their effective values"
+fi
+
+make_stage compose-env-profile
+printf 'FLEET_PROFILE: "MINI" # low-power host\n' >> "$STAGE/.env"
+if run_stage "$STAGE" --non-interactive --preflight-only; then
+    pass "Compose colon-form host profile preflights"
+else
+    fail "Compose colon-form host profile should select its profile env"
+fi
+assert_contains "colon-form host profile reaches Compose" "$HARNESS_CALL_LOG" "--env-file $STAGE/profiles/mini.env"
+
+make_stage interpolated-env
+printf 'AUTH_CLIENT_SECRET_KEY: "${SHORT_SECRET:-01234567890123456789012345678901}"\n' >> "$STAGE/.env"
+if run_stage "$STAGE" --non-interactive --preflight-only; then
+    fail "interpolated persisted secrets should fail closed"
+else
+    pass "interpolated persisted secrets fail before validation diverges from Compose"
+fi
+assert_contains "unsupported interpolation is diagnosed without printing its value" "$HARNESS_OUTPUT_LOG" "AUTH_CLIENT_SECRET_KEY in $STAGE/.env uses unsupported Compose dotenv syntax"
+assert_not_contains "unsupported interpolation makes no Docker calls" "$HARNESS_CALL_LOG" "docker "
+
+make_stage empty-commented-secret
+printf 'DB_PASSWORD="" # valid Compose comment\n' >> "$STAGE/.env"
+if run_stage "$STAGE" --non-interactive --preflight-only; then
+    fail "an empty quoted credential with a comment should fail"
+else
+    pass "empty commented credential is validated as Compose consumes it"
+fi
+assert_contains "empty commented credential is diagnosed" "$HARNESS_OUTPUT_LOG" "Missing or empty required key in environment file: DB_PASSWORD"
+assert_not_contains "empty commented credential prevents image preparation" "$HARNESS_CALL_LOG" " pull"
+
+make_stage short-commented-secret
+printf 'AUTH_CLIENT_SECRET_KEY="short" # this padding must not count\n' >> "$STAGE/.env"
+if run_stage "$STAGE" --non-interactive --preflight-only; then
+    fail "a short quoted auth secret with a comment should fail"
+else
+    pass "comment text cannot satisfy auth secret length validation"
+fi
+assert_contains "short commented auth secret is diagnosed" "$HARNESS_OUTPUT_LOG" "AUTH_CLIENT_SECRET_KEY in $STAGE/.env must be at least 32 characters"
+assert_not_contains "short commented auth secret prevents image preparation" "$HARNESS_CALL_LOG" " pull"
+
+make_stage no-space-colon-secret
+printf '%s\n' \
+    'AUTH_CLIENT_SECRET_KEY=01234567890123456789012345678901' \
+    'AUTH_CLIENT_SECRET_KEY:short' >> "$STAGE/.env"
+if run_stage "$STAGE" --non-interactive --preflight-only; then
+    fail "a no-space colon must participate in Compose last-value precedence"
+else
+    pass "no-space colon syntax cannot hide a short effective auth secret"
+fi
+assert_contains "no-space colon supplies the Compose-effective short secret" "$HARNESS_OUTPUT_LOG" \
+    "AUTH_CLIENT_SECRET_KEY in $STAGE/.env must be at least 32 characters"
+assert_not_contains "no-space colon bypass prevents image preparation" "$HARNESS_CALL_LOG" " pull"
+
+make_stage empty-process-secret
+if DB_PASSWORD= run_stage "$STAGE" --non-interactive --preflight-only; then
+    fail "an empty process credential override should fail"
+else
+    pass "process credential precedence matches Compose and fails closed"
+fi
+assert_contains "empty process credential is validated as effective" "$HARNESS_OUTPUT_LOG" "Missing or empty required key in environment file: DB_PASSWORD"
+assert_not_contains "empty process credential prevents image preparation" "$HARNESS_CALL_LOG" " pull"
 
 make_stage project-volume
 printf 'COMPOSE_PROJECT_NAME=fleet-blue\n' >> "$STAGE/.env"
@@ -713,6 +807,10 @@ gc_images=$(printf '%s\n' \
     'proto-fleet-client:v1.0.0' \
     'proto-fleet-timescaledb:v1.0.0' \
     'proto-fleet-timescaledb-ha:v1.0.0' \
+    'proto-fleet-api:v0.9.0' \
+    'proto-fleet-client:v0.9.0' \
+    'proto-fleet-timescaledb:v0.9.0' \
+    'proto-fleet-timescaledb-ha:v0.9.0' \
     'proto-fleet-api:v1.1.0' \
     'proto-fleet-client:v1.1.0' \
     'proto-fleet-timescaledb:v1.1.0' \
@@ -730,7 +828,8 @@ assert_not_contains "preflight never garbage-collects release images" "$HARNESS_
 # images for a release if any running or stopped container still uses it.
 : > "$HARNESS_CALL_LOG"
 if FAKE_RELEASE_IMAGES="$gc_images" \
-    FAKE_CONTAINER_IMAGE_REFS='proto-fleet-api:v1.0.0' \
+    FAKE_ACTIVE_RELEASE_IMAGES='proto-fleet-api:v1.0.0' \
+    FAKE_CONTAINER_IMAGE_REFS='proto-fleet-api:v0.9.0' \
     run_stage "$STAGE" --non-interactive --skip-build; then
     pass "successful activation prunes only unused obsolete release tags"
 else
@@ -752,24 +851,52 @@ for retained_image in \
     proto-fleet-api:v1.0.0 \
     proto-fleet-client:v1.0.0 \
     proto-fleet-timescaledb:v1.0.0 \
-    proto-fleet-timescaledb-ha:v1.0.0; do
+    proto-fleet-timescaledb-ha:v1.0.0 \
+    proto-fleet-api:v0.9.0 \
+    proto-fleet-client:v0.9.0 \
+    proto-fleet-timescaledb:v0.9.0 \
+    proto-fleet-timescaledb-ha:v0.9.0; do
     assert_not_contains "activation retains image $retained_image" "$HARNESS_CALL_LOG" "docker image rm $retained_image"
 done
 assert_contains "retention checks stopped containers by immutable image ID" "$HARNESS_CALL_LOG" \
-    "docker container ls --all --quiet --filter ancestor=sha256:test-proto-fleet-api:v1.0.0"
+    "docker container ls --all --quiet --filter ancestor=sha256:test-proto-fleet-api:v0.9.0"
+assert_contains "activation records the previous release before teardown" "$HARNESS_CALL_LOG" \
+    "docker container ls --all --filter label=com.docker.compose.project=deployment --format {{.Image}}"
 assert_not_contains "activation retains its current API image" "$HARNESS_CALL_LOG" "docker image rm $FLEET_API_IMAGE"
 up_line=$(grep -nF ' up --remove-orphans' "$HARNESS_CALL_LOG" | head -1 | cut -d: -f1)
 gc_line=$(grep -nF 'docker image rm proto-fleet-api:v1.1.0' "$HARNESS_CALL_LOG" | head -1 | cut -d: -f1)
-if [ -n "$up_line" ] && [ -n "$gc_line" ] && [ "$up_line" -lt "$gc_line" ]; then
-    pass "obsolete release cleanup runs only after successful startup"
+final_ready_line=$(grep -nF 'curl -fsS -o /dev/null --max-time 2 http://127.0.0.1:4000/health/ready' "$HARNESS_CALL_LOG" | tail -1 | cut -d: -f1)
+client_ready_line=$(grep -nF 'curl -fsS -o /dev/null --max-time 2 http://127.0.0.1/' "$HARNESS_CALL_LOG" | tail -1 | cut -d: -f1)
+ready_probe_count=$(grep -cF 'curl -fsS -o /dev/null --max-time 2 http://127.0.0.1:4000/health/ready' "$HARNESS_CALL_LOG")
+if [ -n "$up_line" ] && [ -n "$final_ready_line" ] && [ -n "$client_ready_line" ] && [ -n "$gc_line" ] \
+    && [ "$up_line" -lt "$final_ready_line" ] && [ "$final_ready_line" -lt "$client_ready_line" ] \
+    && [ "$client_ready_line" -lt "$gc_line" ] \
+    && [ "$ready_probe_count" -ge 2 ]; then
+    pass "obsolete release cleanup runs only after final API and client readiness"
 else
-    fail "obsolete release cleanup should follow successful startup"
+    fail "obsolete release cleanup should follow the final API and client readiness probes"
 fi
+
+# A retry can find target-release containers plus an unrelated stale project
+# container after the first activation attempt. Neither identifies the actual
+# previous known-good tag, so leave every managed image available for recovery.
+make_stage retry-release-discovery/deployment
+if FAKE_RELEASE_IMAGES='proto-fleet-api:v1.1.0 proto-fleet-api:v1.0.0' \
+    FAKE_ACTIVE_RELEASE_IMAGES="$FLEET_API_IMAGE proto-fleet-api:v0.9.0" \
+    run_stage "$STAGE" --non-interactive; then
+    pass "retry release discovery skips ambiguous cleanup"
+else
+    fail "retry release discovery should remain a successful activation"
+fi
+assert_contains "retry discovery is diagnosed" "$HARNESS_OUTPUT_LOG" "the target Proto Fleet release is already active"
+assert_not_contains "retry discovery preserves immediate recovery images" "$HARNESS_CALL_LOG" "docker image rm proto-fleet-api:v1.1.0"
+assert_not_contains "retry discovery preserves unidentifiable recovery images" "$HARNESS_CALL_LOG" "docker image rm proto-fleet-api:v1.0.0"
 
 # Docker inspection/removal errors are fail-safe housekeeping failures: no
 # uncertain tag is deleted, and a successful deployment remains successful.
 make_stage release-image-list-failure/deployment
 if FAKE_RELEASE_IMAGES='proto-fleet-api:v1.1.0' \
+    FAKE_ACTIVE_RELEASE_IMAGES='proto-fleet-api:v1.0.0' \
     FAKE_IMAGE_LIST_FAILURE=proto-fleet-client \
     run_stage "$STAGE" --non-interactive; then
     pass "image-list failure does not fail deployment"
@@ -781,6 +908,7 @@ assert_not_contains "image-list failure prevents partial deletion" "$HARNESS_CAL
 
 make_stage release-image-remove-failure/deployment
 if FAKE_RELEASE_IMAGES='proto-fleet-api:v1.1.0' \
+    FAKE_ACTIVE_RELEASE_IMAGES='proto-fleet-api:v1.0.0' \
     FAKE_IMAGE_RM_FAILURE=proto-fleet-api:v1.1.0 \
     run_stage "$STAGE" --non-interactive; then
     pass "image removal failure does not fail deployment"
@@ -788,6 +916,89 @@ else
     fail "image removal failure should remain best-effort"
 fi
 assert_contains "image removal failure is diagnosed" "$HARNESS_OUTPUT_LOG" "could not remove obsolete Proto Fleet image proto-fleet-api:v1.1.0"
+
+make_stage release-image-active-query-failure/deployment
+if FAKE_RELEASE_IMAGES='proto-fleet-api:v1.1.0' \
+    FAKE_ACTIVE_IMAGE_LIST_FAILURE=true \
+    run_stage "$STAGE" --non-interactive; then
+    pass "active-release discovery failure does not fail deployment"
+else
+    fail "active-release discovery failure should only skip cleanup"
+fi
+assert_contains "active-release discovery failure is diagnosed" "$HARNESS_OUTPUT_LOG" "could not identify the active Proto Fleet release"
+assert_not_contains "unknown previous-release state prevents release deletion" "$HARNESS_CALL_LOG" "docker image rm proto-fleet-api:v1.1.0"
+
+# A container being merely "running" is not sufficient after forward-only
+# migrations. Require fleet-api's DB-backed readiness endpoint before any
+# cleanup or success marker consumption.
+make_stage api-readiness-failure/deployment
+if ! run_stage "$STAGE" --non-interactive --preflight-only; then
+    fail "API readiness failure fixture should preflight"
+fi
+: > "$HARNESS_CALL_LOG"
+if FLEET_API_READY_ATTEMPTS=1 \
+    FAKE_API_READINESS_FAILURE=true \
+    FAKE_ACTIVE_RELEASE_IMAGES='proto-fleet-api:v1.0.0' \
+    run_stage "$STAGE" --non-interactive --skip-build; then
+    fail "activation should fail when fleet-api never becomes ready"
+else
+    pass "fleet-api readiness failure blocks upgrade completion"
+fi
+[ -f "$STAGE/.update-preflight-complete" ] || fail "readiness failure should retain its recovery marker"
+assert_contains "activation probes the DB-backed readiness endpoint" "$HARNESS_CALL_LOG" "curl -fsS -o /dev/null --max-time 2 http://127.0.0.1:4000/health/ready"
+assert_not_contains "readiness failure preserves previous release images" "$HARNESS_CALL_LOG" "docker image rm "
+assert_not_contains "readiness failure never reports success" "$HARNESS_OUTPUT_LOG" "Proto Fleet is now running!"
+
+make_stage ignored-api-listen-override/deployment
+printf 'HTTP_LISTEN_ADDRESS=:80\n' >> "$STAGE/.env"
+if ! run_stage "$STAGE" --non-interactive --preflight-only; then
+    fail "ignored API listen override fixture should preflight"
+fi
+: > "$HARNESS_CALL_LOG"
+if FAKE_ACTIVE_RELEASE_IMAGES='proto-fleet-api:v1.0.0' \
+    run_stage "$STAGE" --non-interactive --skip-build; then
+    pass "API readiness uses the deployment service port"
+else
+    fail "an unrelated dotenv listen address should not redirect API readiness"
+fi
+assert_contains "API readiness probes Compose's fixed fleet-api port" "$HARNESS_CALL_LOG" \
+    "curl -fsS -o /dev/null --max-time 2 http://127.0.0.1:4000/health/ready"
+assert_not_contains "nginx cannot masquerade as API readiness" "$HARNESS_CALL_LOG" \
+    "http://127.0.0.1:80/health/ready"
+
+make_stage client-readiness-failure/deployment
+if ! run_stage "$STAGE" --non-interactive --preflight-only; then
+    fail "client readiness failure fixture should preflight"
+fi
+: > "$HARNESS_CALL_LOG"
+if FLEET_API_READY_ATTEMPTS=1 \
+    FAKE_CLIENT_READINESS_FAILURE=true \
+    FAKE_ACTIVE_RELEASE_IMAGES='proto-fleet-api:v1.0.0' \
+    run_stage "$STAGE" --non-interactive --skip-build; then
+    fail "activation should fail when fleet-client never becomes ready"
+else
+    pass "fleet-client readiness failure blocks upgrade completion"
+fi
+[ -f "$STAGE/.update-preflight-complete" ] || fail "client readiness failure should retain its recovery marker"
+assert_contains "activation probes the fleet-client endpoint" "$HARNESS_CALL_LOG" "curl -fsS -o /dev/null --max-time 2 http://127.0.0.1/"
+assert_not_contains "client readiness failure preserves previous release images" "$HARNESS_CALL_LOG" "docker image rm "
+assert_not_contains "client readiness failure never reports success" "$HARNESS_OUTPUT_LOG" "Proto Fleet is now running!"
+
+# Alerts-enabled activation exercises the DB-object readiness poll. Keep its
+# attempt budget tied to the validated service-readiness setting.
+make_stage alerts-activation/deployment
+enable_valid_alerts "$STAGE/.env"
+if ! run_stage "$STAGE" --non-interactive --preflight-only; then
+    fail "alerts activation fixture should preflight"
+fi
+: > "$HARNESS_CALL_LOG"
+if FAKE_ACTIVE_RELEASE_IMAGES='proto-fleet-api:v1.0.0' \
+    run_stage "$STAGE" --non-interactive --skip-build; then
+    pass "alerts-enabled activation completes its DB readiness poll"
+else
+    fail "alerts-enabled activation should not lose its readiness attempt budget"
+fi
+assert_contains "alerts activation provisions the Grafana DB role" "$HARNESS_OUTPUT_LOG" "Provisioning Grafana read-only DB role"
 
 # The updater preflights and activates directories that are both named
 # `deployment`; only their parent changes. Absolute paths in rendered Compose
@@ -1256,6 +1467,15 @@ if cmp -s "$STAGE/client/nginx.https.conf" "$STAGE/client/nginx.conf" && grep -q
 else
     fail "legacy HTTPS did not select HTTPS config and persist secure cookies"
 fi
+: > "$HARNESS_CALL_LOG"
+if FAKE_ACTIVE_RELEASE_IMAGES='proto-fleet-api:v1.0.0' \
+    run_stage "$STAGE" --non-interactive --skip-build; then
+    pass "HTTPS activation probes the served frontend"
+else
+    fail "HTTPS activation should verify the app entrypoint directly"
+fi
+assert_contains "HTTPS frontend readiness bypasses only the loopback self-signed certificate" "$HARNESS_CALL_LOG" \
+    "curl -fkSs -o /dev/null --max-time 2 https://127.0.0.1/"
 
 # Persisted HTTP remains authoritative even if stale certificate files remain
 # on disk from an older HTTPS configuration.


### PR DESCRIPTION
Reviewable diff: +694/-111 across 5 files (excludes generated, test, and story files).

## Summary

Adds the dormant deployment-runner primitives required for safe host-driven upgrades: validated non-interactive execution, preparation without teardown, and activation using the exact packaged release and prepared images. Preflight fails closed on incomplete configuration, transport drift, invalid Compose state, missing or changed images, or any immutable/runtime input change before activation. Existing interactive installs remain supported, and no one-click action or updater-overlay option is exposed yet.

*Stack:* [#841](https://github.com/block/proto-fleet/pull/841) → [#842](https://github.com/block/proto-fleet/pull/842) → [#843](https://github.com/block/proto-fleet/pull/843) → [#844](https://github.com/block/proto-fleet/pull/844) → [#845](https://github.com/block/proto-fleet/pull/845) are merged; this PR is **1/6** of the one-click phase and its diff is relative to `main`. [#836](https://github.com/block/proto-fleet/pull/836) adds the updater engine, [#837](https://github.com/block/proto-fleet/pull/837) adds the Fleet API bridge, [#838](https://github.com/block/proto-fleet/pull/838) packages the updater and will introduce the updater Compose option alongside its overlay, [#839](https://github.com/block/proto-fleet/pull/839) installs and activates it, and [#840](https://github.com/block/proto-fleet/pull/840) adds the client action.

## How it works

Release packaging creates a SHA-256 manifest after every deployment artifact, configuration file, and version file is assembled. Preflight validates both every listed digest and the exact immutable file set, so changed or newly added bind-mounted Grafana/OTel configuration is rejected. Operator-owned state is handled separately: HA `node.env` remains outside the immutable release set, while `.env`, generated nginx configuration, effective Compose inputs, active TLS certificate/key, feature state, and the bundled TimescaleDB archive are fingerprinted explicitly.

On WSL, the runner treats a successful Docker daemon probe as authoritative, so service- or init-managed Docker installations remain supported without weakening the native-Linux boot-enable check.

The runner validates persisted secrets and Grafana role boundaries before image work, preserves explicit HTTP/HTTPS state, and recognizes legacy HTTPS installs from a complete certificate pair when the persisted cookie setting is absent. It pins the existing `deployment` Compose project identity across staging and activation, pulls only non-buildable dependencies, loads and verifies the bundled TimescaleDB image, and builds stable, local-only API/client image tags while the active deployment keeps running.

After preparation, the runner revalidates the release and records both the input fingerprint and every required local image ID in an atomic mode-0600 marker. Activation recomputes both proofs before teardown, invalidates stale markers, and starts with `--no-build --pull never`; Compose cannot rebuild or substitute a registry image during the transition.

## Diagrams

```mermaid
flowchart LR
  P["Release packaging"] --> M["Immutable file manifest"]
  U["Future host updater"] --> V["Validate config, transport, and manifest"]
  M --> V
  V --> F1["Fingerprint runtime inputs"]
  F1 --> B["Pull dependencies, load DB, build local images"]
  B --> F2["Reverify files and capture image IDs"]
  F2 --> A["Atomic activation marker"]
  A --> R["Reverify before teardown"]
  R --> S["Compose up with no-build and pull never"]
```

```mermaid
sequenceDiagram
  participant Updater
  participant Runner as run-fleet.sh
  participant Docker
  Updater->>Runner: --non-interactive --preflight-only
  Runner->>Runner: validate exact release and runtime fingerprint
  Runner->>Docker: pull external images, load DB image, build API/client
  Runner->>Docker: inspect every required image ID
  Runner-->>Updater: bound input + image marker
  Updater->>Runner: --non-interactive --skip-build
  Runner->>Runner: revalidate files, runtime state, and image IDs
  Runner->>Docker: down
  Runner->>Docker: up --no-build --pull never --wait
  alt activation succeeds
    Runner-->>Updater: consume marker and complete
  else validation or activation fails
    Runner-->>Updater: fail without implicit image preparation
  end
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
|---|---|---|
| `deployment-files/run-fleet.sh` | Adds non-interactive preflight/activation modes, exact release/runtime proofs, image-ID binding, stable Compose identity, legacy HTTPS preservation, and fail-closed validation | Defines the safety boundary before the running stack is stopped |
| `deployment-files/docker-compose.yaml` | Gives locally built services stable tags with `pull_policy: never` | Ensures preflight and activation address the same local images |
| `.github/workflows/proto-fleet-artifact-build.yml` | Generates the immutable deployment manifest immediately before packaging | Covers all packaged binaries, configs, and bind-mounted runtime assets |
| `deployment-files/tests/test-run-fleet-upgrade.sh` | Exercises lifecycle, relocation, file/image drift, transport compatibility, and failure boundaries through command shims | Regression coverage without touching host Docker, networking, or services |
| `.github/workflows/deployment-config-checks.yml` | Runs the upgrade-safety harness in CI | Makes the deployment contract merge-gating |
| `.gitignore` | Ignores the ephemeral preflight marker | Prevents local preflight state from entering commits |

## Key technical decisions & trade-offs

- Defer the updater-overlay option to #838, where the overlay and artifact-copy step arrive, so every exposed flag works after its merge.
- Use an exact artifact manifest plus explicit runtime fingerprints instead of a partial bind-mount allowlist; added as well as changed release files fail validation.
- Bind activation to stable local tags and recorded image IDs, then disable builds and pulls during startup; this favors a visible failure over substituting unprepared content.
- Pin Compose's existing `deployment` project name instead of stripping rendered `name:`; this preserves current container/volume namespaces and makes relocation deterministic.
- Normalize only the staged deployment-root prefix in rendered Compose paths so the updater's atomic directory rename remains valid without weakening other checks.
- Infer HTTPS only for legacy deployments with both certificate files and no persisted setting; explicit `false` remains authoritative even when stale certificates exist.
- Fail rather than repair or regenerate in non-interactive mode; host mutation and secret creation remain explicit operator actions.

## Testing & validation

- `./deployment-files/tests/test-run-fleet-upgrade.sh` — full preflight/activation lifecycle; staging relocation with rendered Compose project identity; exact file-set and listed-file mutations; HA node-state allowance and adjacent-file rejection; missing/changed image IDs; TLS/runtime/Compose drift; marker permissions; Grafana validation; TimescaleDB artifact validation; legacy HTTPS and explicit HTTP preservation; non-systemd WSL compatibility; WSL no-mutation behavior.
- `./deployment-files/tests/test-profiles.sh` — all profile invariants and Compose render checks passed.
- `/bin/bash -n deployment-files/run-fleet.sh deployment-files/tests/test-run-fleet-upgrade.sh` on macOS Bash 3.2.
- `git diff --check` and repository pre-push hooks passed.
- Full host activation is not run locally; later updater-engine integration and release-artifact CI cover the cross-process/package path.
