### PR TITLE
feat(updates): add host updater engine

### DIFF
--- a/server/cmd/fleet-updater/main.go
+++ b/server/cmd/fleet-updater/main.go
@@ -54,9 +54,13 @@ func run() error {
 		fmt.Println(version)
 		return nil
 	}
+	selfUpdateStartup, err := updater.PrepareSelfUpdateStartup(*selfUpdatePath, *selfUpdateHandoff)
+	if err != nil {
+		return fmt.Errorf("prepare updater startup: %w", err)
+	}
 	absoluteInstallRoot, err := filepath.Abs(*installRoot)
 	if err != nil {
-		return fmt.Errorf("resolve install root: %w", err)
+		return handleSelfUpdateStartupFailure(selfUpdateStartup, fmt.Errorf("resolve install root: %w", err))
 	}
 	manager, err := updater.NewManager(updater.Config{
 		InstallRoot:    absoluteInstallRoot,
@@ -64,7 +68,7 @@ func run() error {
 		SelfUpdatePath: *selfUpdatePath,
 	})
 	if err != nil {
-		return handleSelfUpdateStartupFailure(*selfUpdateHandoff, fmt.Errorf("initialize updater: %w", err))
+		return handleSelfUpdateStartupFailure(selfUpdateStartup, fmt.Errorf("initialize updater: %w", err))
 	}
 	defer func() {
 		if err := manager.Close(); err != nil {
@@ -86,8 +90,14 @@ func run() error {
 	// Signals are intentional shutdowns, not evidence that the candidate is bad.
 	select {
 	case <-server.Ready():
+		if err := selfUpdateStartup.Commit(); err != nil {
+			startupErr := fmt.Errorf("commit refreshed updater startup: %w", err)
+			if shutdownErr := shutdownUpdater(server, manager); shutdownErr != nil {
+				startupErr = errors.Join(startupErr, fmt.Errorf("shutdown after startup commit failure: %w", shutdownErr))
+			}
+			return handleSelfUpdateStartupFailure(selfUpdateStartup, startupErr)
+		}
 		log.Printf("proto-fleet-updater %s listening on %s", version, *socketPath)
-		*selfUpdateHandoff = ""
 	case sig := <-signals:
 		log.Printf("received %s during startup, shutting down", sig)
 		if err := shutdownUpdater(server, manager); err != nil {
@@ -98,7 +108,7 @@ func run() error {
 		if errors.Is(err, http.ErrServerClosed) {
 			return nil
 		}
-		return handleSelfUpdateStartupFailure(*selfUpdateHandoff, fmt.Errorf("serve updater API: %w", err))
+		return handleSelfUpdateStartupFailure(selfUpdateStartup, fmt.Errorf("serve updater API: %w", err))
 	}
 
 	select {
@@ -136,11 +146,11 @@ func run() error {
 	}
 }
 
-func handleSelfUpdateStartupFailure(handoffPath string, startupErr error) error {
-	if handoffPath == "" {
+func handleSelfUpdateStartupFailure(selfUpdateStartup *updater.SelfUpdateStartup, startupErr error) error {
+	if selfUpdateStartup == nil {
 		return startupErr
 	}
-	if rollbackErr := updater.RollbackSelfUpdateExecutable(handoffPath); rollbackErr != nil {
+	if rollbackErr := selfUpdateStartup.Rollback(); rollbackErr != nil {
 		return errors.Join(
 			startupErr,
 			fmt.Errorf("restore previous updater after replacement startup failure: %w", rollbackErr),

--- a/server/cmd/fleet-updater/main.go
+++ b/server/cmd/fleet-updater/main.go
@@ -29,16 +29,11 @@ func main() {
 	if defaultSocketPath == "" {
 		defaultSocketPath = "/run/proto-fleet-updater/updater.sock"
 	}
-	defaultDownloadBase := os.Getenv("PROTO_FLEET_DOWNLOAD_BASE_URL")
-	if defaultDownloadBase == "" {
-		defaultDownloadBase = "https://github.com/block/proto-fleet/releases/download"
-	}
 	defaultSelfUpdatePath := os.Getenv("PROTO_FLEET_UPDATER_BINARY_PATH")
 
 	installRoot := flag.String("install-root", defaultInstallRoot, "Proto Fleet installation root")
 	stateDir := flag.String("state-dir", defaultStateDir, "Durable updater state directory")
 	socketPath := flag.String("socket-path", defaultSocketPath, "Unix socket path")
-	downloadBase := flag.String("download-base-url", defaultDownloadBase, "Official release download base URL")
 	selfUpdatePath := flag.String("self-update-path", defaultSelfUpdatePath, "Installed updater binary path to atomically refresh")
 	showVersion := flag.Bool("version", false, "Print version and exit")
 	flag.Parse()
@@ -52,10 +47,9 @@ func main() {
 		log.Fatal(err)
 	}
 	manager, err := updater.NewManager(updater.Config{
-		InstallRoot:     absoluteInstallRoot,
-		StateDir:        *stateDir,
-		DownloadBaseURL: *downloadBase,
-		SelfUpdatePath:  *selfUpdatePath,
+		InstallRoot:    absoluteInstallRoot,
+		StateDir:       *stateDir,
+		SelfUpdatePath: *selfUpdatePath,
 	})
 	if err != nil {
 		log.Fatalf("initialize updater: %v", err)

--- a/server/cmd/fleet-updater/main.go
+++ b/server/cmd/fleet-updater/main.go
@@ -54,6 +54,11 @@ func main() {
 	if err != nil {
 		log.Fatalf("initialize updater: %v", err)
 	}
+	defer func() {
+		if err := manager.Close(); err != nil {
+			log.Printf("close updater manager: %v", err)
+		}
+	}()
 	server := updater.NewServer(manager)
 	errs := make(chan error, 1)
 	go func() {

--- a/server/cmd/fleet-updater/main.go
+++ b/server/cmd/fleet-updater/main.go
@@ -22,9 +22,17 @@ var version = "dev"
 const selfUpdateHandoffFlag = "self-update-handoff"
 
 func main() {
+	setSecureProcessUmask()
 	if err := run(); err != nil {
 		log.Fatal(err)
 	}
+}
+
+func setSecureProcessUmask() {
+	// Keep the Unix socket and updater-owned artifacts private from creation,
+	// including when the binary is started outside the hardened systemd unit.
+	// The umask is process-global, so establish it before run starts goroutines.
+	syscall.Umask(0o077)
 }
 
 func run() error {

--- a/server/cmd/fleet-updater/main.go
+++ b/server/cmd/fleet-updater/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -17,6 +18,8 @@ import (
 )
 
 var version = "dev"
+
+const selfUpdateHandoffFlag = "self-update-handoff"
 
 func main() {
 	if err := run(); err != nil {
@@ -43,6 +46,7 @@ func run() error {
 	stateDir := flag.String("state-dir", defaultStateDir, "Durable updater state directory")
 	socketPath := flag.String("socket-path", defaultSocketPath, "Unix socket path")
 	selfUpdatePath := flag.String("self-update-path", defaultSelfUpdatePath, "Installed updater binary path to atomically refresh")
+	selfUpdateHandoff := flag.String(selfUpdateHandoffFlag, "", "Internal one-shot rollback path for a refreshed updater")
 	showVersion := flag.Bool("version", false, "Print version and exit")
 	flag.Parse()
 
@@ -60,7 +64,7 @@ func run() error {
 		SelfUpdatePath: *selfUpdatePath,
 	})
 	if err != nil {
-		return fmt.Errorf("initialize updater: %w", err)
+		return handleSelfUpdateStartupFailure(*selfUpdateHandoff, fmt.Errorf("initialize updater: %w", err))
 	}
 	defer func() {
 		if err := manager.Close(); err != nil {
@@ -70,13 +74,33 @@ func run() error {
 	server := updater.NewServer(manager)
 	errs := make(chan error, 1)
 	go func() {
-		log.Printf("proto-fleet-updater %s listening on %s", version, *socketPath)
 		errs <- server.Serve(*socketPath)
 	}()
 
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
 	defer signal.Stop(signals)
+
+	// A refreshed process remains rollback-eligible only until it proves real
+	// startup with the production config/state and a bound, secured socket.
+	// Signals are intentional shutdowns, not evidence that the candidate is bad.
+	select {
+	case <-server.Ready():
+		log.Printf("proto-fleet-updater %s listening on %s", version, *socketPath)
+		*selfUpdateHandoff = ""
+	case sig := <-signals:
+		log.Printf("received %s during startup, shutting down", sig)
+		if err := shutdownUpdater(server, manager); err != nil {
+			log.Printf("shutdown: %v", err)
+		}
+		return nil
+	case err := <-errs:
+		if errors.Is(err, http.ErrServerClosed) {
+			return nil
+		}
+		return handleSelfUpdateStartupFailure(*selfUpdateHandoff, fmt.Errorf("serve updater API: %w", err))
+	}
+
 	select {
 	case sig := <-signals:
 		log.Printf("received %s, shutting down", sig)
@@ -92,7 +116,8 @@ func run() error {
 		if canonicalSelfUpdatePath == "" {
 			return fmt.Errorf("self-update completed without a configured executable path")
 		}
-		if err := syscall.Exec(canonicalSelfUpdatePath, os.Args, os.Environ()); err != nil {
+		execArgs := selfUpdateExecArgs(os.Args, canonicalSelfUpdatePath)
+		if err := syscall.Exec(canonicalSelfUpdatePath, execArgs, os.Environ()); err != nil {
 			rollbackErr := manager.RollbackSelfUpdate()
 			if rollbackErr != nil {
 				return errors.Join(
@@ -109,6 +134,39 @@ func run() error {
 		}
 		return nil
 	}
+}
+
+func handleSelfUpdateStartupFailure(handoffPath string, startupErr error) error {
+	if handoffPath == "" {
+		return startupErr
+	}
+	if rollbackErr := updater.RollbackSelfUpdateExecutable(handoffPath); rollbackErr != nil {
+		return errors.Join(
+			startupErr,
+			fmt.Errorf("restore previous updater after replacement startup failure: %w", rollbackErr),
+		)
+	}
+	return fmt.Errorf("start refreshed updater; previous executable restored: %w", startupErr)
+}
+
+func selfUpdateExecArgs(args []string, handoffPath string) []string {
+	if len(args) == 0 {
+		return []string{"proto-fleet-updater", "--" + selfUpdateHandoffFlag + "=" + handoffPath}
+	}
+	cleaned := make([]string, 0, len(args)+1)
+	cleaned = append(cleaned, args[0], "--"+selfUpdateHandoffFlag+"="+handoffPath)
+	for index := 1; index < len(args); index++ {
+		arg := args[index]
+		if arg == "--"+selfUpdateHandoffFlag || arg == "-"+selfUpdateHandoffFlag {
+			index++
+			continue
+		}
+		if strings.HasPrefix(arg, "--"+selfUpdateHandoffFlag+"=") || strings.HasPrefix(arg, "-"+selfUpdateHandoffFlag+"=") {
+			continue
+		}
+		cleaned = append(cleaned, arg)
+	}
+	return cleaned
 }
 
 func shutdownUpdater(server *updater.Server, manager *updater.Manager) error {

--- a/server/cmd/fleet-updater/main.go
+++ b/server/cmd/fleet-updater/main.go
@@ -125,6 +125,18 @@ func run() error {
 		if err := shutdownUpdater(server, manager); err != nil {
 			log.Printf("shutdown: %v", err)
 		}
+		rolledBackPath, err := rollbackSelfUpdateQueuedDuringShutdown(
+			manager.SelfUpdateReady(),
+			manager.RollbackSelfUpdate,
+		)
+		if err != nil {
+			return fmt.Errorf("restore previous updater after shutdown interrupted self-restart: %w", err)
+		}
+		if rolledBackPath != "" {
+			log.Printf(
+				"host updater refresh completed during shutdown; restored the previous updater and deferred the refresh until a future upgrade",
+			)
+		}
 		return nil
 	case canonicalSelfUpdatePath := <-manager.SelfUpdateReady():
 		log.Printf("activating refreshed host updater")
@@ -133,6 +145,18 @@ func run() error {
 		}
 		if canonicalSelfUpdatePath == "" {
 			return fmt.Errorf("self-update completed without a configured executable path")
+		}
+		// Shutdown may have waited for activation while an intentional stop was
+		// queued. Stop channel forwarding before the final check so a later signal
+		// uses its default disposition instead of being swallowed before exec.
+		signal.Stop(signals)
+		pendingSignal, err := rollbackSelfUpdateForPendingSignal(signals, manager.RollbackSelfUpdate)
+		if err != nil {
+			return fmt.Errorf("restore previous updater after shutdown interrupted self-restart: %w", err)
+		}
+		if pendingSignal != nil {
+			log.Printf("received %s while preparing self-restart; restored the previous updater and shutting down", pendingSignal)
+			return nil
 		}
 		execArgs := selfUpdateExecArgs(os.Args, canonicalSelfUpdatePath)
 		if err := syscall.Exec(canonicalSelfUpdatePath, execArgs, os.Environ()); err != nil {
@@ -193,4 +217,41 @@ func shutdownUpdater(server *updater.Server, manager *updater.Manager) error {
 	cancelServerShutdown()
 	managerErr := manager.Shutdown(context.Background())
 	return errors.Join(serverErr, managerErr)
+}
+
+// rollbackSelfUpdateQueuedDuringShutdown must run after Manager.Shutdown. At
+// that point an activating operation has finished, so this non-blocking read
+// cannot race a later self-update notification. A signal is an intentional
+// stop, so restore the previous updater instead of execing a new process.
+func rollbackSelfUpdateQueuedDuringShutdown(
+	ready <-chan string,
+	rollback func() error,
+) (string, error) {
+	select {
+	case canonicalPath := <-ready:
+		if canonicalPath == "" {
+			return "", fmt.Errorf("self-update completed without a configured executable path")
+		}
+		if err := rollback(); err != nil {
+			return canonicalPath, err
+		}
+		return canonicalPath, nil
+	default:
+		return "", nil
+	}
+}
+
+func rollbackSelfUpdateForPendingSignal(
+	signals <-chan os.Signal,
+	rollback func() error,
+) (os.Signal, error) {
+	select {
+	case pendingSignal := <-signals:
+		if err := rollback(); err != nil {
+			return pendingSignal, err
+		}
+		return pendingSignal, nil
+	default:
+		return nil, nil
+	}
 }

--- a/server/cmd/fleet-updater/main.go
+++ b/server/cmd/fleet-updater/main.go
@@ -93,7 +93,14 @@ func run() error {
 			return fmt.Errorf("self-update completed without a configured executable path")
 		}
 		if err := syscall.Exec(*selfUpdatePath, os.Args, os.Environ()); err != nil {
-			return fmt.Errorf("activate refreshed updater: %w", err)
+			rollbackErr := manager.RollbackSelfUpdate()
+			if rollbackErr != nil {
+				return errors.Join(
+					fmt.Errorf("activate refreshed updater: %w", err),
+					fmt.Errorf("restore previous updater after exec failure: %w", rollbackErr),
+				)
+			}
+			return fmt.Errorf("activate refreshed updater; previous executable restored: %w", err)
 		}
 		return nil
 	case err := <-errs:

--- a/server/cmd/fleet-updater/main.go
+++ b/server/cmd/fleet-updater/main.go
@@ -84,15 +84,15 @@ func run() error {
 			log.Printf("shutdown: %v", err)
 		}
 		return nil
-	case <-manager.SelfUpdateReady():
+	case canonicalSelfUpdatePath := <-manager.SelfUpdateReady():
 		log.Printf("activating refreshed host updater")
 		if err := shutdownUpdater(server, manager); err != nil {
 			return fmt.Errorf("drain updater before self-restart: %w", err)
 		}
-		if *selfUpdatePath == "" {
+		if canonicalSelfUpdatePath == "" {
 			return fmt.Errorf("self-update completed without a configured executable path")
 		}
-		if err := syscall.Exec(*selfUpdatePath, os.Args, os.Environ()); err != nil {
+		if err := syscall.Exec(canonicalSelfUpdatePath, os.Args, os.Environ()); err != nil {
 			rollbackErr := manager.RollbackSelfUpdate()
 			if rollbackErr != nil {
 				return errors.Join(

--- a/server/cmd/fleet-updater/main.go
+++ b/server/cmd/fleet-updater/main.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+
+	"github.com/block/proto-fleet/server/internal/updater"
+)
+
+var version = "dev"
+
+func main() {
+	defaultInstallRoot := os.Getenv("PROTO_FLEET_INSTALL_ROOT")
+	if defaultInstallRoot == "" {
+		defaultInstallRoot = "/opt/proto-fleet"
+	}
+	defaultStateDir := os.Getenv("PROTO_FLEET_UPDATER_STATE_DIR")
+	if defaultStateDir == "" {
+		defaultStateDir = "/var/lib/proto-fleet-updater"
+	}
+	defaultSocketPath := os.Getenv("PROTO_FLEET_UPDATER_SOCKET_PATH")
+	if defaultSocketPath == "" {
+		defaultSocketPath = "/run/proto-fleet-updater/updater.sock"
+	}
+	defaultDownloadBase := os.Getenv("PROTO_FLEET_DOWNLOAD_BASE_URL")
+	if defaultDownloadBase == "" {
+		defaultDownloadBase = "https://github.com/block/proto-fleet/releases/download"
+	}
+	defaultSelfUpdatePath := os.Getenv("PROTO_FLEET_UPDATER_BINARY_PATH")
+
+	installRoot := flag.String("install-root", defaultInstallRoot, "Proto Fleet installation root")
+	stateDir := flag.String("state-dir", defaultStateDir, "Durable updater state directory")
+	socketPath := flag.String("socket-path", defaultSocketPath, "Unix socket path")
+	downloadBase := flag.String("download-base-url", defaultDownloadBase, "Official release download base URL")
+	selfUpdatePath := flag.String("self-update-path", defaultSelfUpdatePath, "Installed updater binary path to atomically refresh")
+	showVersion := flag.Bool("version", false, "Print version and exit")
+	flag.Parse()
+
+	if *showVersion {
+		fmt.Println(version)
+		return
+	}
+	absoluteInstallRoot, err := filepath.Abs(*installRoot)
+	if err != nil {
+		log.Fatal(err)
+	}
+	manager, err := updater.NewManager(updater.Config{
+		InstallRoot:     absoluteInstallRoot,
+		StateDir:        *stateDir,
+		DownloadBaseURL: *downloadBase,
+		SelfUpdatePath:  *selfUpdatePath,
+	})
+	if err != nil {
+		log.Fatalf("initialize updater: %v", err)
+	}
+	server := updater.NewServer(manager)
+	errs := make(chan error, 1)
+	go func() {
+		log.Printf("proto-fleet-updater %s listening on %s", version, *socketPath)
+		errs <- server.Serve(*socketPath)
+	}()
+
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
+	select {
+	case sig := <-signals:
+		log.Printf("received %s, shutting down", sig)
+		if err := server.Shutdown(); err != nil {
+			log.Printf("shutdown: %v", err)
+		}
+	case err := <-errs:
+		if !errors.Is(err, http.ErrServerClosed) {
+			log.Fatalf("serve updater API: %v", err)
+		}
+	}
+}

--- a/server/cmd/fleet-updater/main.go
+++ b/server/cmd/fleet-updater/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"fmt"
@@ -10,6 +11,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"syscall"
+	"time"
 
 	"github.com/block/proto-fleet/server/internal/updater"
 )
@@ -68,15 +70,21 @@ func main() {
 
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(signals)
 	select {
 	case sig := <-signals:
 		log.Printf("received %s, shutting down", sig)
-		if err := server.Shutdown(); err != nil {
+		serverShutdownCtx, cancelServerShutdown := context.WithTimeout(context.Background(), 10*time.Second)
+		if err := server.Shutdown(serverShutdownCtx); err != nil {
 			log.Printf("shutdown: %v", err)
+		}
+		cancelServerShutdown()
+		if err := manager.Shutdown(context.Background()); err != nil {
+			log.Printf("stop updater operation: %v", err)
 		}
 	case err := <-errs:
 		if !errors.Is(err, http.ErrServerClosed) {
-			log.Fatalf("serve updater API: %v", err)
+			log.Printf("serve updater API: %v", err)
 		}
 	}
 }

--- a/server/cmd/fleet-updater/main.go
+++ b/server/cmd/fleet-updater/main.go
@@ -19,6 +19,12 @@ import (
 var version = "dev"
 
 func main() {
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run() error {
 	defaultInstallRoot := os.Getenv("PROTO_FLEET_INSTALL_ROOT")
 	if defaultInstallRoot == "" {
 		defaultInstallRoot = "/opt/proto-fleet"
@@ -42,11 +48,11 @@ func main() {
 
 	if *showVersion {
 		fmt.Println(version)
-		return
+		return nil
 	}
 	absoluteInstallRoot, err := filepath.Abs(*installRoot)
 	if err != nil {
-		log.Fatal(err)
+		return fmt.Errorf("resolve install root: %w", err)
 	}
 	manager, err := updater.NewManager(updater.Config{
 		InstallRoot:    absoluteInstallRoot,
@@ -54,7 +60,7 @@ func main() {
 		SelfUpdatePath: *selfUpdatePath,
 	})
 	if err != nil {
-		log.Fatalf("initialize updater: %v", err)
+		return fmt.Errorf("initialize updater: %w", err)
 	}
 	defer func() {
 		if err := manager.Close(); err != nil {
@@ -74,17 +80,34 @@ func main() {
 	select {
 	case sig := <-signals:
 		log.Printf("received %s, shutting down", sig)
-		serverShutdownCtx, cancelServerShutdown := context.WithTimeout(context.Background(), 10*time.Second)
-		if err := server.Shutdown(serverShutdownCtx); err != nil {
+		if err := shutdownUpdater(server, manager); err != nil {
 			log.Printf("shutdown: %v", err)
 		}
-		cancelServerShutdown()
-		if err := manager.Shutdown(context.Background()); err != nil {
-			log.Printf("stop updater operation: %v", err)
+		return nil
+	case <-manager.SelfUpdateReady():
+		log.Printf("activating refreshed host updater")
+		if err := shutdownUpdater(server, manager); err != nil {
+			return fmt.Errorf("drain updater before self-restart: %w", err)
 		}
+		if *selfUpdatePath == "" {
+			return fmt.Errorf("self-update completed without a configured executable path")
+		}
+		if err := syscall.Exec(*selfUpdatePath, os.Args, os.Environ()); err != nil {
+			return fmt.Errorf("activate refreshed updater: %w", err)
+		}
+		return nil
 	case err := <-errs:
 		if !errors.Is(err, http.ErrServerClosed) {
-			log.Printf("serve updater API: %v", err)
+			return fmt.Errorf("serve updater API: %w", err)
 		}
+		return nil
 	}
+}
+
+func shutdownUpdater(server *updater.Server, manager *updater.Manager) error {
+	serverShutdownCtx, cancelServerShutdown := context.WithTimeout(context.Background(), 10*time.Second)
+	serverErr := server.Shutdown(serverShutdownCtx)
+	cancelServerShutdown()
+	managerErr := manager.Shutdown(context.Background())
+	return errors.Join(serverErr, managerErr)
 }

--- a/server/cmd/fleet-updater/main_test.go
+++ b/server/cmd/fleet-updater/main_test.go
@@ -28,42 +28,19 @@ func TestSelfUpdateExecArgsReplacesPriorHandoff(t *testing.T) {
 	}, selfUpdateExecArgs(args, "/canonical/updater"))
 }
 
-func TestSelfUpdateStartupFailureRestoresOnlyMarkedHandoff(t *testing.T) {
+func TestSelfUpdateStartupFailureWithoutHandoffLeavesExecutable(t *testing.T) {
 	t.Parallel()
 
-	for _, test := range []struct {
-		name        string
-		handoff     bool
-		wantCurrent string
-		wantBackup  bool
-	}{
-		{name: "marked replacement", handoff: true, wantCurrent: "old updater", wantBackup: false},
-		{name: "ordinary startup", handoff: false, wantCurrent: "new updater", wantBackup: true},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
+	directory := t.TempDir()
+	destination := filepath.Join(directory, "proto-fleet-updater")
+	require.NoError(t, os.WriteFile(destination, []byte("new updater"), 0o755))
+	require.NoError(t, os.WriteFile(destination+".previous", []byte("old updater"), 0o755))
 
-			directory := t.TempDir()
-			destination := filepath.Join(directory, "proto-fleet-updater")
-			require.NoError(t, os.WriteFile(destination, []byte("new updater"), 0o755))
-			require.NoError(t, os.WriteFile(destination+".previous", []byte("old updater"), 0o755))
-			handoffPath := ""
-			if test.handoff {
-				handoffPath = destination
-			}
-
-			startupErr := errors.New("startup failed")
-			err := handleSelfUpdateStartupFailure(handoffPath, startupErr)
-			require.ErrorIs(t, err, startupErr)
-			assert.Equal(t, test.wantCurrent, mustReadFile(t, destination))
-			if test.wantBackup {
-				assert.FileExists(t, destination+".previous")
-			} else {
-				assert.NoFileExists(t, destination+".previous")
-				assert.ErrorContains(t, err, "previous executable restored")
-			}
-		})
-	}
+	startupErr := errors.New("startup failed")
+	err := handleSelfUpdateStartupFailure(nil, startupErr)
+	require.ErrorIs(t, err, startupErr)
+	assert.Equal(t, "new updater", mustReadFile(t, destination))
+	assert.FileExists(t, destination+".previous")
 }
 
 func mustReadFile(t *testing.T, path string) string {

--- a/server/cmd/fleet-updater/main_test.go
+++ b/server/cmd/fleet-updater/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"os"
@@ -9,6 +11,7 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/block/proto-fleet/server/internal/updater"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -67,6 +70,72 @@ func TestSelfUpdateStartupFailureWithoutHandoffLeavesExecutable(t *testing.T) {
 	require.ErrorIs(t, err, startupErr)
 	assert.Equal(t, "new updater", mustReadFile(t, destination))
 	assert.FileExists(t, destination+".previous")
+}
+
+func TestRollbackSelfUpdateQueuedDuringShutdown(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	installRoot := filepath.Join(root, "install")
+	require.NoError(t, os.MkdirAll(filepath.Join(installRoot, "deployment"), 0o700))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(installRoot, "deployment", "version.txt"),
+		[]byte("version: v1.0.0\n"),
+		0o600,
+	))
+
+	updaterDirectory := filepath.Join(root, "updater")
+	require.NoError(t, os.Mkdir(updaterDirectory, 0o700))
+	destination := filepath.Join(updaterDirectory, "proto-fleet-updater")
+	require.NoError(t, os.WriteFile(destination, []byte("old updater"), 0o755))
+
+	manager, err := updater.NewManager(updater.Config{
+		InstallRoot:    installRoot,
+		StateDir:       filepath.Join(root, "state"),
+		SelfUpdatePath: destination,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, manager.Close()) })
+	canonicalDestination, err := filepath.EvalSymlinks(destination)
+	require.NoError(t, err)
+
+	// Model an activation that installed and queued the replacement while
+	// Manager.Shutdown was waiting for the non-cancelable activation to finish.
+	require.NoError(t, os.Link(destination, destination+".previous"))
+	marker, err := json.Marshal(map[string]string{"executable_path": canonicalDestination})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(destination+".handoff", marker, 0o600))
+	candidate := destination + ".candidate"
+	require.NoError(t, os.WriteFile(candidate, []byte("new updater"), 0o755))
+	require.NoError(t, os.Rename(candidate, destination))
+
+	ready := make(chan string, 1)
+	ready <- canonicalDestination
+	require.NoError(t, manager.Shutdown(context.Background()))
+
+	rolledBackPath, err := rollbackSelfUpdateQueuedDuringShutdown(ready, manager.RollbackSelfUpdate)
+	require.NoError(t, err)
+	assert.Equal(t, canonicalDestination, rolledBackPath)
+	assert.Equal(t, "old updater", mustReadFile(t, destination))
+	assert.NoFileExists(t, destination+".handoff")
+	assert.FileExists(t, destination+".previous")
+}
+
+func TestRollbackSelfUpdateForPendingSignal(t *testing.T) {
+	t.Parallel()
+
+	signals := make(chan os.Signal, 1)
+	signals <- syscall.SIGTERM
+	rolledBack := false
+
+	pendingSignal, err := rollbackSelfUpdateForPendingSignal(signals, func() error {
+		rolledBack = true
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, syscall.SIGTERM, pendingSignal)
+	assert.True(t, rolledBack)
 }
 
 func mustReadFile(t *testing.T, path string) string {

--- a/server/cmd/fleet-updater/main_test.go
+++ b/server/cmd/fleet-updater/main_test.go
@@ -2,13 +2,39 @@ package main
 
 import (
 	"errors"
+	"flag"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+const updaterUmaskTestHelper = "PROTO_FLEET_UPDATER_UMASK_TEST_HELPER"
+
+func TestMainSetsSecureProcessUmask(t *testing.T) {
+	if os.Getenv(updaterUmaskTestHelper) == "1" {
+		// Keep the process-global umask change inside this one-shot child so it
+		// cannot race the package's parallel tests.
+		syscall.Umask(0)
+		os.Args = []string{"proto-fleet-updater", "--version"}
+		flag.CommandLine = flag.NewFlagSet("proto-fleet-updater", flag.ContinueOnError)
+
+		main()
+
+		actual := syscall.Umask(0)
+		assert.Equal(t, 0o077, actual)
+		return
+	}
+
+	command := exec.Command(os.Args[0], "-test.run=^TestMainSetsSecureProcessUmask$") //nolint:gosec // The current test executable is trusted.
+	command.Env = append(os.Environ(), updaterUmaskTestHelper+"=1")
+	output, err := command.CombinedOutput()
+	require.NoError(t, err, "umask helper failed: %s", output)
+}
 
 func TestSelfUpdateExecArgsReplacesPriorHandoff(t *testing.T) {
 	t.Parallel()

--- a/server/cmd/fleet-updater/main_test.go
+++ b/server/cmd/fleet-updater/main_test.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSelfUpdateExecArgsReplacesPriorHandoff(t *testing.T) {
+	t.Parallel()
+
+	args := []string{
+		"proto-fleet-updater",
+		"--state-dir", "/state",
+		"--self-update-handoff", "/stale",
+		"-self-update-handoff=/also-stale",
+		"--socket-path=/socket",
+	}
+	assert.Equal(t, []string{
+		"proto-fleet-updater",
+		"--self-update-handoff=/canonical/updater",
+		"--state-dir", "/state",
+		"--socket-path=/socket",
+	}, selfUpdateExecArgs(args, "/canonical/updater"))
+}
+
+func TestSelfUpdateStartupFailureRestoresOnlyMarkedHandoff(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name        string
+		handoff     bool
+		wantCurrent string
+		wantBackup  bool
+	}{
+		{name: "marked replacement", handoff: true, wantCurrent: "old updater", wantBackup: false},
+		{name: "ordinary startup", handoff: false, wantCurrent: "new updater", wantBackup: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			directory := t.TempDir()
+			destination := filepath.Join(directory, "proto-fleet-updater")
+			require.NoError(t, os.WriteFile(destination, []byte("new updater"), 0o755))
+			require.NoError(t, os.WriteFile(destination+".previous", []byte("old updater"), 0o755))
+			handoffPath := ""
+			if test.handoff {
+				handoffPath = destination
+			}
+
+			startupErr := errors.New("startup failed")
+			err := handleSelfUpdateStartupFailure(handoffPath, startupErr)
+			require.ErrorIs(t, err, startupErr)
+			assert.Equal(t, test.wantCurrent, mustReadFile(t, destination))
+			if test.wantBackup {
+				assert.FileExists(t, destination+".previous")
+			} else {
+				assert.NoFileExists(t, destination+".previous")
+				assert.ErrorContains(t, err, "previous executable restored")
+			}
+		})
+	}
+}
+
+func mustReadFile(t *testing.T, path string) string {
+	t.Helper()
+	contents, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return string(contents)
+}

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -2130,12 +2130,12 @@ func validateStagedRelease(deploymentPath, targetVersion string) error {
 }
 
 func preserveDeploymentState(ctx context.Context, current, staged string) error {
-	for _, path := range []string{".env", "server/influx_config/.env"} {
+	for _, path := range []string{".env", "server/influx_config/.env", "ha/node.env"} {
 		if err := ctx.Err(); err != nil {
 			return fmt.Errorf("preserve deployment configuration: %w", err)
 		}
 		source := filepath.Join(current, path)
-		if _, err := os.Stat(source); errors.Is(err, os.ErrNotExist) {
+		if _, err := os.Lstat(source); errors.Is(err, os.ErrNotExist) {
 			continue
 		} else if err != nil {
 			return fmt.Errorf("inspect preserved file %s: %w", path, err)

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -42,9 +42,17 @@ const (
 	maxCommandLogBytes       = int64(64 << 20)
 	canonicalDownloadBaseURL = "https://github.com/block/proto-fleet/releases/download"
 	processLockFilename      = "updater.lock"
+	activationMarkerFilename = "activation-swap.json"
+	activationMarkerTempName = ".activation-swap.json.tmp"
+	operationArtifactPrefix  = ".proto-fleet-upgrade-"
+	stateTempPrefix          = ".state-"
 )
 
-var canonicalRelease = regexp.MustCompile(`^v\d+\.\d+\.\d+(?:-rc\.\d+)?$`)
+var (
+	canonicalRelease         = regexp.MustCompile(`^v\d+\.\d+\.\d+(?:-rc\.\d+)?$`)
+	staleStateArtifactName   = regexp.MustCompile(`^\.proto-fleet-upgrade-[a-f0-9]{64}\.(?:tar\.gz|sha256|updater)$`)
+	staleStagingArtifactName = regexp.MustCompile(`^\.proto-fleet-upgrade-[a-f0-9]{64}$`)
+)
 
 var releaseImageRepositories = [...]string{
 	"proto-fleet-api",
@@ -105,17 +113,24 @@ type Config struct {
 	allowTestDownloadBaseURL bool
 }
 
+type activationMarker struct {
+	OperationID   string `json:"operation_id"`
+	TargetVersion string `json:"target_version"`
+}
+
 type Manager struct {
 	cfg Config
 
-	mu              sync.RWMutex
-	operation       *updaterapi.Operation
-	closing         bool
-	cancelOperation context.CancelFunc
-	operationWG     sync.WaitGroup
-	processLock     *os.File
-	closeOnce       sync.Once
-	closeErr        error
+	mu               sync.RWMutex
+	operation        *updaterapi.Operation
+	closing          bool
+	operationRunning bool
+	cancelOperation  context.CancelFunc
+	operationWG      sync.WaitGroup
+	selfUpdateReady  chan struct{}
+	processLock      *os.File
+	closeOnce        sync.Once
+	closeErr         error
 }
 
 func NewManager(cfg Config) (*Manager, error) {
@@ -185,10 +200,15 @@ func NewManager(cfg Config) (*Manager, error) {
 	}
 
 	m := &Manager{
-		cfg:         cfg,
-		processLock: processLock,
+		cfg:             cfg,
+		selfUpdateReady: make(chan struct{}, 1),
+		processLock:     processLock,
 	}
 	if err := m.loadState(); err != nil {
+		_ = processLock.Close()
+		return nil, err
+	}
+	if err := m.cleanupStaleArtifacts(); err != nil {
 		_ = processLock.Close()
 		return nil, err
 	}
@@ -197,6 +217,13 @@ func NewManager(cfg Config) (*Manager, error) {
 
 func (m *Manager) Close() error {
 	return m.Shutdown(context.Background())
+}
+
+// SelfUpdateReady is signaled once the replacement executable and successful
+// terminal state are both durable. The command process owns listener draining,
+// lock release, and exec so the manager remains independent of any supervisor.
+func (m *Manager) SelfUpdateReady() <-chan struct{} {
+	return m.selfUpdateReady
 }
 
 // Shutdown rejects future triggers, cancels work that has not crossed the
@@ -307,6 +334,16 @@ func (m *Manager) Trigger(targetVersion string) (updaterapi.Operation, error) {
 	if !canonicalRelease.MatchString(targetVersion) || !semver.IsValid(targetVersion) {
 		return updaterapi.Operation{}, fmt.Errorf("target version must be a stable or RC release tag")
 	}
+	marker, err := m.readActivationMarker()
+	if err != nil {
+		return updaterapi.Operation{}, fmt.Errorf("inspect pending activation recovery: %w", err)
+	}
+	if marker != nil {
+		return updaterapi.Operation{}, fmt.Errorf(
+			"activation recovery for operation %s is pending; restart the updater after completing recovery",
+			marker.OperationID,
+		)
+	}
 	currentVersion, err := readInstalledVersion(filepath.Join(m.cfg.InstallRoot, "deployment", "version.txt"))
 	if err != nil {
 		return updaterapi.Operation{}, err
@@ -326,6 +363,12 @@ func (m *Manager) Trigger(targetVersion string) (updaterapi.Operation, error) {
 	if m.operation != nil && !m.operation.Phase.Terminal() {
 		return updaterapi.Operation{}, fmt.Errorf("an upgrade to %s is already in progress", m.operation.TargetVersion)
 	}
+	if m.operationRunning {
+		return updaterapi.Operation{}, fmt.Errorf("the previous upgrade is still completing cleanup")
+	}
+	if err := m.cleanupStaleArtifacts(); err != nil {
+		return updaterapi.Operation{}, fmt.Errorf("clean stale upgrade artifacts: %w", err)
+	}
 	now := m.cfg.Now().UTC()
 	op := &updaterapi.Operation{
 		ID:            m.cfg.NewID(),
@@ -343,12 +386,21 @@ func (m *Manager) Trigger(targetVersion string) (updaterapi.Operation, error) {
 	operationCopy := *op
 	operationCtx, cancelOperation := context.WithCancel(context.Background())
 	m.cancelOperation = cancelOperation
+	m.operationRunning = true
 	m.operationWG.Add(1)
 	go func() {
 		defer m.operationWG.Done()
+		defer m.finishOperation()
 		m.run(operationCtx, operationCopy.ID, targetVersion)
 	}()
 	return operationCopy, nil
+}
+
+func (m *Manager) finishOperation() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.operationRunning = false
+	m.cancelOperation = nil
 }
 
 func (m *Manager) run(ctx context.Context, operationID, targetVersion string) {
@@ -383,8 +435,9 @@ func (m *Manager) run(ctx context.Context, operationID, targetVersion string) {
 
 	archiveName := fmt.Sprintf("proto-fleet-%s-%s.tar.gz", targetVersion, m.cfg.GOARCH)
 	archiveURL := strings.TrimSuffix(m.cfg.DownloadBaseURL, "/") + "/" + targetVersion + "/" + archiveName
-	archivePath := filepath.Join(m.cfg.StateDir, operationID+"-"+archiveName)
-	checksumPath := archivePath + ".sha256"
+	artifactBase := operationArtifactBase(operationID)
+	archivePath := filepath.Join(m.cfg.StateDir, artifactBase+".tar.gz")
+	checksumPath := filepath.Join(m.cfg.StateDir, artifactBase+".sha256")
 	defer os.Remove(archivePath)
 	defer os.Remove(checksumPath)
 
@@ -413,8 +466,8 @@ func (m *Manager) run(ctx context.Context, operationID, targetVersion string) {
 		return
 	}
 
-	stageRoot, err := os.MkdirTemp(m.cfg.InstallRoot, ".proto-fleet-upgrade-")
-	if err != nil {
+	stageRoot := filepath.Join(m.cfg.InstallRoot, artifactBase)
+	if err := os.Mkdir(stageRoot, 0o700); err != nil {
 		m.fail(operationID, fmt.Errorf("create staging directory: %w", err), recovery)
 		return
 	}
@@ -427,12 +480,12 @@ func (m *Manager) run(ctx context.Context, operationID, targetVersion string) {
 	var preparedUpdater *os.File
 	updaterCopied := false
 	if m.cfg.SelfUpdatePath != "" {
-		preparedUpdater, err = os.CreateTemp(m.cfg.StateDir, ".prepared-updater-")
+		preparedUpdaterPath := filepath.Join(m.cfg.StateDir, artifactBase+".updater")
+		preparedUpdater, err = os.OpenFile(preparedUpdaterPath, os.O_CREATE|os.O_EXCL|os.O_RDWR, 0o600)
 		if err != nil {
 			m.fail(operationID, fmt.Errorf("create protected updater copy: %w", err), recovery)
 			return
 		}
-		preparedUpdaterPath := preparedUpdater.Name()
 		defer os.Remove(preparedUpdaterPath)
 		defer func() {
 			if preparedUpdater != nil {
@@ -501,12 +554,16 @@ func (m *Manager) run(ctx context.Context, operationID, targetVersion string) {
 	}
 	backupDeployment := filepath.Join(m.cfg.InstallRoot, "deployment.previous")
 	if err := activateDeployment(stageDeployment, currentDeployment, backupDeployment); err != nil {
-		m.fail(operationID, err, recovery)
+		m.failActivation(operationID, targetVersion, err, logFile)
 		return
 	}
 	recovery = activationRecoveryCommand(currentDeployment)
 	if err := m.setRecoveryCommand(operationID, recovery); err != nil {
 		m.fail(operationID, fmt.Errorf("persist activation recovery command: %w", err), recovery)
+		return
+	}
+	if err := m.clearActivationMarker(); err != nil {
+		m.failActivation(operationID, targetVersion, fmt.Errorf("complete activation swap: %w", err), logFile)
 		return
 	}
 
@@ -518,18 +575,149 @@ func (m *Manager) run(ctx context.Context, operationID, targetVersion string) {
 		return
 	}
 	successMessage := fmt.Sprintf("Fleet %s is running", targetVersion)
+	selfUpdateSucceeded := false
 	if preparedUpdater != nil {
 		if err := atomicReplaceExecutableFromFile(preparedUpdater, m.cfg.SelfUpdatePath); err != nil {
 			_, _ = fmt.Fprintf(logFile, "[%s] warning: Fleet is healthy, but the host updater binary was not refreshed: %v\n", m.cfg.Now().UTC().Format(time.RFC3339), err)
 			successMessage += "; host updater refresh needs attention (see upgrade log)"
+		} else {
+			selfUpdateSucceeded = true
 		}
 	}
 
-	if err := m.succeed(operationID, successMessage); err != nil {
+	if err := m.succeed(operationID, successMessage, selfUpdateSucceeded); err != nil {
 		_, _ = fmt.Fprintf(logFile, "[%s] warning: persist successful terminal state: %v\n", m.cfg.Now().UTC().Format(time.RFC3339), err)
 		log.Printf("persist successful upgrade state: %v", err)
+	} else if selfUpdateSucceeded {
+		select {
+		case m.selfUpdateReady <- struct{}{}:
+		default:
+		}
 	}
 	_, _ = fmt.Fprintf(logFile, "[%s] upgrade completed\n", m.cfg.Now().UTC().Format(time.RFC3339))
+}
+
+func operationArtifactBase(operationID string) string {
+	digest := sha256.Sum256([]byte(operationID))
+	return operationArtifactPrefix + hex.EncodeToString(digest[:])
+}
+
+func (m *Manager) writeActivationMarker(marker activationMarker) error {
+	data, err := json.Marshal(marker)
+	if err != nil {
+		return fmt.Errorf("encode activation marker: %w", err)
+	}
+	path := filepath.Join(m.cfg.StateDir, activationMarkerFilename)
+	if _, err := os.Lstat(path); err == nil {
+		return fmt.Errorf("create activation marker: marker already exists")
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("inspect activation marker destination: %w", err)
+	}
+	tempPath := filepath.Join(m.cfg.StateDir, activationMarkerTempName)
+	fd, err := syscall.Open(
+		tempPath,
+		syscall.O_CREAT|syscall.O_EXCL|syscall.O_WRONLY|syscall.O_CLOEXEC|syscall.O_NOFOLLOW,
+		0o600,
+	)
+	if err != nil {
+		return fmt.Errorf("create activation marker temp file: %w", err)
+	}
+	file := os.NewFile(uintptr(fd), tempPath)
+	if file == nil {
+		_ = syscall.Close(fd)
+		return fmt.Errorf("create activation marker temp file")
+	}
+	tempInstalled := false
+	defer func() {
+		if !tempInstalled {
+			_ = os.Remove(tempPath)
+		}
+	}()
+	if _, err := file.Write(data); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("write activation marker: %w", err)
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("sync activation marker: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close activation marker: %w", err)
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		return fmt.Errorf("install activation marker: %w", err)
+	}
+	tempInstalled = true
+	if err := syncDirectory(m.cfg.StateDir); err != nil {
+		return fmt.Errorf("persist activation marker: %w", err)
+	}
+	return nil
+}
+
+func (m *Manager) readActivationMarker() (*activationMarker, error) {
+	path := filepath.Join(m.cfg.StateDir, activationMarkerFilename)
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("inspect activation marker: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("activation marker is not a regular file")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read activation marker: %w", err)
+	}
+	var marker activationMarker
+	if err := json.Unmarshal(data, &marker); err != nil {
+		return nil, fmt.Errorf("decode activation marker: %w", err)
+	}
+	if marker.OperationID == "" || !canonicalRelease.MatchString(marker.TargetVersion) || !semver.IsValid(marker.TargetVersion) {
+		return nil, fmt.Errorf("activation marker is invalid")
+	}
+	return &marker, nil
+}
+
+func (m *Manager) clearActivationMarker() error {
+	path := filepath.Join(m.cfg.StateDir, activationMarkerFilename)
+	if err := os.Remove(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return fmt.Errorf("remove activation marker: %w", err)
+	}
+	if err := syncDirectory(m.cfg.StateDir); err != nil {
+		return fmt.Errorf("persist activation marker removal: %w", err)
+	}
+	return nil
+}
+
+func (m *Manager) failActivation(
+	operationID string,
+	targetVersion string,
+	activationErr error,
+	logOutput io.Writer,
+) {
+	layout := &updaterapi.Operation{
+		TargetVersion: targetVersion,
+		Phase:         updaterapi.PhaseActivating,
+	}
+	restoredPrevious, reconcileErr := m.reconcileDeploymentLayout(layout, true, true, true)
+	if restoredPrevious {
+		_, _ = fmt.Fprintf(logOutput, "[%s] activation failed before Fleet stopped; restored the previous deployment\n", m.cfg.Now().UTC().Format(time.RFC3339))
+	}
+	if reconcileErr == nil {
+		reconcileErr = m.clearActivationMarker()
+	}
+	if reconcileErr != nil {
+		activationErr = errors.Join(
+			activationErr,
+			fmt.Errorf("reconcile failed activation layout: %w", reconcileErr),
+		)
+	}
+	m.fail(operationID, activationErr, layout.RecoveryCommand)
 }
 
 // activateDeployment makes the extracted release durable before entering the
@@ -780,10 +968,23 @@ func (m *Manager) beginActivation(id, message string) error {
 	if m.closing {
 		return fmt.Errorf("updater is shutting down before activation")
 	}
+	marker := activationMarker{
+		OperationID:   m.operation.ID,
+		TargetVersion: m.operation.TargetVersion,
+	}
+	if err := m.writeActivationMarker(marker); err != nil {
+		return fmt.Errorf("persist activation swap marker: %w", err)
+	}
 	m.operation.Phase = updaterapi.PhaseActivating
 	m.operation.Message = message
 	m.operation.UpdatedAt = m.cfg.Now().UTC()
-	return m.persistLocked()
+	if err := m.persistLocked(); err != nil {
+		return errors.Join(
+			fmt.Errorf("persist activating operation: %w", err),
+			m.clearActivationMarker(),
+		)
+	}
+	return nil
 }
 
 func (m *Manager) setLogPath(id, logPath, recovery string) error {
@@ -819,9 +1020,7 @@ func (m *Manager) fail(id string, err error, recovery string) {
 	m.operation.Phase = updaterapi.PhaseFailed
 	m.operation.Message = "Upgrade failed"
 	m.operation.Error = err.Error()
-	if recovery != "" {
-		m.operation.RecoveryCommand = recovery
-	}
+	m.operation.RecoveryCommand = recovery
 	m.operation.UpdatedAt = now
 	m.operation.CompletedAt = &now
 	if persistErr := m.persistLocked(); persistErr != nil {
@@ -829,7 +1028,7 @@ func (m *Manager) fail(id string, err error, recovery string) {
 	}
 }
 
-func (m *Manager) succeed(id, message string) error {
+func (m *Manager) succeed(id, message string, closeForSelfUpdate bool) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.operation == nil || m.operation.ID != id {
@@ -841,13 +1040,29 @@ func (m *Manager) succeed(id, message string) error {
 	m.operation.RecoveryCommand = ""
 	m.operation.UpdatedAt = now
 	m.operation.CompletedAt = &now
-	return m.persistLocked()
+	if err := m.persistLocked(); err != nil {
+		return err
+	}
+	if closeForSelfUpdate {
+		// Bar a second trigger before the restart notification is observable.
+		// The command process will drain this manager and exec the replacement.
+		m.closing = true
+	}
+	return nil
 }
 
 func (m *Manager) loadState() error {
+	marker, err := m.readActivationMarker()
+	if err != nil {
+		return err
+	}
 	data, err := os.ReadFile(filepath.Join(m.cfg.StateDir, stateFilename))
 	if errors.Is(err, os.ErrNotExist) {
-		return nil
+		if marker != nil {
+			return fmt.Errorf("activation marker exists without persisted operation state")
+		}
+		_, reconcileErr := m.reconcileDeploymentLayout(&updaterapi.Operation{}, false, false, false)
+		return reconcileErr
 	}
 	if err != nil {
 		return fmt.Errorf("read updater state: %w", err)
@@ -856,11 +1071,52 @@ func (m *Manager) loadState() error {
 	if err := json.Unmarshal(data, &op); err != nil {
 		return fmt.Errorf("decode updater state: %w", err)
 	}
-	if !op.Phase.Terminal() {
-		restoredPrevious, err := m.reconcileInterruptedActivation(&op)
-		if err != nil {
+	if marker != nil && (marker.OperationID != op.ID || marker.TargetVersion != op.TargetVersion) {
+		return fmt.Errorf("activation marker does not match persisted operation")
+	}
+	if marker != nil && op.Phase == updaterapi.PhaseSucceeded {
+		return fmt.Errorf("successful operation retains an unexpected activation marker")
+	}
+	wasTerminal := op.Phase.Terminal()
+	deriveForwardRecovery := op.Phase == updaterapi.PhaseActivating || marker != nil
+	if !wasTerminal && !deriveForwardRecovery {
+		op.RecoveryCommand = ""
+	}
+	restoredPrevious, err := m.reconcileDeploymentLayout(
+		&op,
+		deriveForwardRecovery,
+		marker != nil,
+		marker != nil,
+	)
+	if err != nil {
+		if marker != nil && op.RecoveryCommand != "" {
+			now := m.cfg.Now().UTC()
+			op.Phase = updaterapi.PhaseFailed
+			op.Message = "Activation layout requires manual recovery"
+			recoveryError := "Activation layout recovery did not complete: " + err.Error()
+			if !strings.Contains(op.Error, recoveryError) {
+				if op.Error != "" {
+					op.Error += " "
+				}
+				op.Error += recoveryError
+			}
+			op.UpdatedAt = now
+			if op.CompletedAt == nil {
+				op.CompletedAt = &now
+			}
+			m.operation = &op
+			if persistErr := m.persistLocked(); persistErr != nil {
+				return errors.Join(err, fmt.Errorf("persist activation recovery instructions: %w", persistErr))
+			}
+		}
+		return err
+	}
+	if marker != nil {
+		if err := m.clearActivationMarker(); err != nil {
 			return err
 		}
+	}
+	if !wasTerminal {
 		now := m.cfg.Now().UTC()
 		op.Phase = updaterapi.PhaseFailed
 		if restoredPrevious {
@@ -872,63 +1128,178 @@ func (m *Manager) loadState() error {
 		}
 		op.UpdatedAt = now
 		op.CompletedAt = &now
+	} else if restoredPrevious {
+		now := m.cfg.Now().UTC()
+		op.Phase = updaterapi.PhaseFailed
+		op.Message = "Previous deployment restored during updater startup"
+		if op.Error == "" {
+			op.Error = "The active deployment was missing; the updater restored the validated previous deployment."
+		} else {
+			op.Error += " The active deployment was missing during startup; the updater restored the validated previous deployment."
+		}
+		op.RecoveryCommand = ""
+		op.UpdatedAt = now
+		if op.CompletedAt == nil {
+			op.CompletedAt = &now
+		}
 	}
 	m.operation = &op
 	return m.persistLocked()
 }
 
-// reconcileInterruptedActivation repairs only the crash-safe gap between the
-// two activation renames. If the forward deployment already exists, it is
-// never rolled back: run-fleet may have applied forward-only migrations before
-// the updater stopped. Recovery commands are derived from the current on-disk
-// preflight proof rather than trusting a command persisted before the swap.
-func (m *Manager) reconcileInterruptedActivation(op *updaterapi.Operation) (bool, error) {
-	if op.Phase != updaterapi.PhaseActivating {
-		op.RecoveryCommand = ""
-		return false, nil
-	}
+// reconcileDeploymentLayout validates the active layout and repairs the
+// two-rename crash gap only when a durable activation marker proves the
+// operation had not yet crossed into command execution. A present forward
+// deployment is never rolled back because migrations may already be applied.
+func (m *Manager) reconcileDeploymentLayout(
+	op *updaterapi.Operation,
+	deriveForwardRecovery bool,
+	allowPreviousRestore bool,
+	ensureDurable bool,
+) (bool, error) {
 	current := filepath.Join(m.cfg.InstallRoot, "deployment")
 	previous := filepath.Join(m.cfg.InstallRoot, "deployment.previous")
 	currentInfo, err := os.Lstat(current)
 	if err == nil {
 		if !currentInfo.IsDir() {
-			return false, fmt.Errorf("reconcile interrupted activation: active deployment is not a directory")
+			return false, fmt.Errorf("reconcile deployment layout: active deployment is not a directory")
 		}
-		op.RecoveryCommand = ""
 		version, versionErr := readInstalledVersion(filepath.Join(current, "version.txt"))
-		if versionErr == nil && version == op.TargetVersion {
-			if markerInfo, markerErr := os.Lstat(filepath.Join(current, ".update-preflight-complete")); markerErr == nil && markerInfo.Mode().IsRegular() {
-				op.RecoveryCommand = activationRecoveryCommand(current)
-			} else if markerErr != nil && !errors.Is(markerErr, os.ErrNotExist) {
-				return false, fmt.Errorf("inspect interrupted activation preflight proof: %w", markerErr)
+		if versionErr != nil {
+			return false, fmt.Errorf("validate active deployment during reconciliation: %w", versionErr)
+		}
+		if deriveForwardRecovery {
+			op.RecoveryCommand = ""
+			if version == op.TargetVersion {
+				markerInfo, markerErr := os.Lstat(filepath.Join(current, ".update-preflight-complete"))
+				if markerErr == nil {
+					if !markerInfo.Mode().IsRegular() {
+						return false, fmt.Errorf("activation preflight proof is not a regular file")
+					}
+					op.RecoveryCommand = activationRecoveryCommand(current)
+				} else if !errors.Is(markerErr, os.ErrNotExist) {
+					return false, fmt.Errorf("inspect activation preflight proof: %w", markerErr)
+				}
+			}
+		}
+		if ensureDurable {
+			if err := syncDirectory(m.cfg.InstallRoot); err != nil {
+				return false, fmt.Errorf("persist reconciled active deployment: %w", err)
 			}
 		}
 		return false, nil
 	}
 	if !errors.Is(err, os.ErrNotExist) {
-		return false, fmt.Errorf("inspect interrupted active deployment: %w", err)
+		return false, fmt.Errorf("inspect active deployment during reconciliation: %w", err)
+	}
+	if !allowPreviousRestore {
+		return false, fmt.Errorf("active deployment is missing without a pending activation swap; refusing automatic rollback")
 	}
 	previousInfo, err := os.Lstat(previous)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			return false, fmt.Errorf("reconcile interrupted activation: both deployment and deployment.previous are missing")
+			return false, fmt.Errorf("reconcile deployment layout: both deployment and deployment.previous are missing")
 		}
-		return false, fmt.Errorf("inspect previous deployment for interrupted activation: %w", err)
+		return false, fmt.Errorf("inspect previous deployment during reconciliation: %w", err)
 	}
 	if !previousInfo.IsDir() {
-		return false, fmt.Errorf("reconcile interrupted activation: deployment.previous is not a directory")
+		return false, fmt.Errorf("reconcile deployment layout: deployment.previous is not a directory")
 	}
 	if _, err := readInstalledVersion(filepath.Join(previous, "version.txt")); err != nil {
-		return false, fmt.Errorf("validate previous deployment for interrupted activation: %w", err)
+		return false, fmt.Errorf("validate previous deployment during reconciliation: %w", err)
 	}
+	op.RecoveryCommand = activationRestoreCommand(current, previous)
 	if err := os.Rename(previous, current); err != nil {
-		return false, fmt.Errorf("restore previous deployment after interrupted activation: %w", err)
+		return false, fmt.Errorf("restore previous deployment during reconciliation: %w", err)
 	}
 	if err := syncDirectory(m.cfg.InstallRoot); err != nil {
-		return false, fmt.Errorf("persist restored deployment after interrupted activation: %w", err)
+		return false, fmt.Errorf("persist restored deployment during reconciliation: %w", err)
 	}
 	op.RecoveryCommand = ""
 	return true, nil
+}
+
+// cleanupStaleArtifacts runs only after the daemon-lifetime lock is held and
+// any interrupted deployment swap has been reconciled. Exact SHA-derived
+// names keep cleanup inside reserved direct-child slots. Non-directories are
+// unlinked without following them; directories in state-file slots fail closed.
+func (m *Manager) cleanupStaleArtifacts() error {
+	removedState, cleanupStateErr := cleanupStaleStateArtifacts(m.cfg.StateDir)
+	if removedState {
+		if err := syncDirectory(m.cfg.StateDir); err != nil {
+			return fmt.Errorf("persist stale updater state cleanup: %w", err)
+		}
+	}
+	if cleanupStateErr != nil {
+		return cleanupStateErr
+	}
+
+	removedStages, cleanupStagesErr := cleanupStaleStageDirectories(m.cfg.InstallRoot)
+	if removedStages {
+		if err := syncDirectory(m.cfg.InstallRoot); err != nil {
+			return fmt.Errorf("persist stale updater staging cleanup: %w", err)
+		}
+	}
+	if cleanupStagesErr != nil {
+		return cleanupStagesErr
+	}
+	return nil
+}
+
+func cleanupStaleStateArtifacts(stateDir string) (bool, error) {
+	entries, err := os.ReadDir(stateDir)
+	if err != nil {
+		return false, fmt.Errorf("list updater state for stale artifacts: %w", err)
+	}
+	removed := false
+	for _, entry := range entries {
+		name := entry.Name()
+		if !staleStateArtifactName.MatchString(name) &&
+			!strings.HasPrefix(name, stateTempPrefix) &&
+			name != activationMarkerTempName {
+			continue
+		}
+		path := filepath.Join(stateDir, name)
+		info, err := os.Lstat(path)
+		if err != nil {
+			return removed, fmt.Errorf("inspect stale updater state artifact %s: %w", name, err)
+		}
+		if info.IsDir() {
+			return removed, fmt.Errorf("refusing to remove stale updater state directory from file slot %s", name)
+		}
+		if err := os.Remove(path); err != nil {
+			return removed, fmt.Errorf("remove stale updater state artifact %s: %w", name, err)
+		}
+		removed = true
+	}
+	return removed, nil
+}
+
+func cleanupStaleStageDirectories(installRoot string) (bool, error) {
+	entries, err := os.ReadDir(installRoot)
+	if err != nil {
+		return false, fmt.Errorf("list install root for stale updater staging: %w", err)
+	}
+	removed := false
+	for _, entry := range entries {
+		if !staleStagingArtifactName.MatchString(entry.Name()) {
+			continue
+		}
+		path := filepath.Join(installRoot, entry.Name())
+		info, err := os.Lstat(path)
+		if err != nil {
+			return removed, fmt.Errorf("inspect stale updater staging directory %s: %w", entry.Name(), err)
+		}
+		remove := os.Remove
+		if info.IsDir() {
+			remove = os.RemoveAll
+		}
+		if err := remove(path); err != nil {
+			return removed, fmt.Errorf("remove stale updater staging directory %s: %w", entry.Name(), err)
+		}
+		removed = true
+	}
+	return removed, nil
 }
 
 func (m *Manager) persistLocked() error {
@@ -940,7 +1311,7 @@ func (m *Manager) persistLocked() error {
 		return fmt.Errorf("encode updater state: %w", err)
 	}
 	path := filepath.Join(m.cfg.StateDir, stateFilename)
-	temp, err := os.CreateTemp(m.cfg.StateDir, ".state-")
+	temp, err := os.CreateTemp(m.cfg.StateDir, stateTempPrefix)
 	if err != nil {
 		return fmt.Errorf("create updater state temp file: %w", err)
 	}
@@ -1356,4 +1727,17 @@ func shellQuote(value string) string {
 
 func activationRecoveryCommand(deploymentPath string) string {
 	return fmt.Sprintf("cd %s && ./run-fleet.sh --non-interactive --skip-build", shellQuote(deploymentPath))
+}
+
+func activationRestoreCommand(current, previous string) string {
+	quotedCurrent := shellQuote(current)
+	quotedPrevious := shellQuote(previous)
+	return fmt.Sprintf(
+		"test ! -e %s && test ! -L %s && test -d %s && mv -- %s %s && sync",
+		quotedCurrent,
+		quotedCurrent,
+		quotedPrevious,
+		quotedPrevious,
+		quotedCurrent,
+	)
 }

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -2,6 +2,7 @@ package updater
 
 import (
 	"archive/tar"
+	"bytes"
 	"compress/gzip"
 	"context"
 	"crypto/sha256"
@@ -11,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math"
 	"net/http"
 	"net/url"
 	"os"
@@ -18,6 +20,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"sort"
 	"strings"
 	"sync"
 	"syscall"
@@ -39,12 +42,17 @@ const (
 	defaultPreflightTimeout  = 2 * time.Hour
 	defaultActivationTimeout = 45 * time.Minute
 	defaultCleanupTimeout    = 2 * time.Minute
+	defaultCandidateTimeout  = 10 * time.Second
 	maxCommandLogBytes       = int64(64 << 20)
+	maxCandidateVersionBytes = int64(4096)
+	maxRetainedOperationLogs = 8
+	maxRetainedLogBytes      = int64(256 << 20)
 	canonicalDownloadBaseURL = "https://github.com/block/proto-fleet/releases/download"
 	processLockFilename      = "updater.lock"
 	activationMarkerFilename = "activation-swap.json"
 	activationMarkerTempName = ".activation-swap.json.tmp"
 	operationArtifactPrefix  = ".proto-fleet-upgrade-"
+	selfUpdateBackupSuffix   = ".previous"
 	stateTempPrefix          = ".state-"
 )
 
@@ -52,6 +60,7 @@ var (
 	canonicalRelease         = regexp.MustCompile(`^v\d+\.\d+\.\d+(?:-rc\.\d+)?$`)
 	staleStateArtifactName   = regexp.MustCompile(`^\.proto-fleet-upgrade-[a-f0-9]{64}\.(?:tar\.gz|sha256|updater)$`)
 	staleStagingArtifactName = regexp.MustCompile(`^\.proto-fleet-upgrade-[a-f0-9]{64}$`)
+	operationLogNamePattern  = regexp.MustCompile(`^\.proto-fleet-upgrade-[a-f0-9]{64}\.log$`)
 )
 
 var releaseImageRepositories = [...]string{
@@ -129,8 +138,77 @@ type Manager struct {
 	operationWG      sync.WaitGroup
 	selfUpdateReady  chan struct{}
 	processLock      *os.File
+	logRoot          *os.Root
 	closeOnce        sync.Once
 	closeErr         error
+}
+
+func ensureUpdaterStateDirectory(stateDir string) error {
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		return fmt.Errorf("create updater state directory: %w", err)
+	}
+	stateInfo, err := os.Lstat(stateDir)
+	if err != nil {
+		return fmt.Errorf("inspect updater state directory: %w", err)
+	}
+	if !stateInfo.IsDir() {
+		return fmt.Errorf("updater state path is not a directory")
+	}
+	return nil
+}
+
+func openOperationLogRoot(stateDir string) (*os.Root, error) {
+	stateRoot, err := os.OpenRoot(stateDir)
+	if err != nil {
+		return nil, fmt.Errorf("open updater state root: %w", err)
+	}
+	defer stateRoot.Close()
+
+	logInfo, err := stateRoot.Lstat("logs")
+	if errors.Is(err, os.ErrNotExist) {
+		if err := stateRoot.Mkdir("logs", 0o700); err != nil && !errors.Is(err, os.ErrExist) {
+			return nil, fmt.Errorf("create updater log directory: %w", err)
+		}
+		logInfo, err = stateRoot.Lstat("logs")
+	}
+	if err != nil {
+		return nil, fmt.Errorf("inspect updater log directory: %w", err)
+	}
+	if !logInfo.IsDir() {
+		return nil, fmt.Errorf("updater log path is not a directory")
+	}
+	logRoot, err := stateRoot.OpenRoot("logs")
+	if err != nil {
+		return nil, fmt.Errorf("open confined updater log directory: %w", err)
+	}
+	logDirectory, err := logRoot.Open(".")
+	if err != nil {
+		_ = logRoot.Close()
+		return nil, fmt.Errorf("open updater log directory handle: %w", err)
+	}
+	openedInfo, statErr := logDirectory.Stat()
+	chmodErr := logDirectory.Chmod(0o700)
+	closeErr := logDirectory.Close()
+	if statErr != nil || chmodErr != nil || closeErr != nil {
+		_ = logRoot.Close()
+		return nil, errors.Join(
+			wrapIfError("inspect opened updater log directory", statErr),
+			wrapIfError("secure updater log directory", chmodErr),
+			wrapIfError("close updater log directory handle", closeErr),
+		)
+	}
+	if !os.SameFile(logInfo, openedInfo) {
+		_ = logRoot.Close()
+		return nil, fmt.Errorf("updater log directory changed while it was opened")
+	}
+	return logRoot, nil
+}
+
+func wrapIfError(message string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%s: %w", message, err)
 }
 
 func NewManager(cfg Config) (*Manager, error) {
@@ -191,11 +269,16 @@ func NewManager(cfg Config) (*Manager, error) {
 	if cfg.PreflightTimeout < 0 || cfg.ActivationTimeout < 0 || cfg.CleanupTimeout < 0 {
 		return nil, fmt.Errorf("updater phase timeouts must be positive")
 	}
-	if err := os.MkdirAll(filepath.Join(cfg.StateDir, "logs"), 0o700); err != nil {
-		return nil, fmt.Errorf("create updater state directory: %w", err)
+	if err := ensureUpdaterStateDirectory(cfg.StateDir); err != nil {
+		return nil, err
 	}
 	processLock, err := acquireProcessLock(cfg.StateDir)
 	if err != nil {
+		return nil, err
+	}
+	logRoot, err := openOperationLogRoot(cfg.StateDir)
+	if err != nil {
+		_ = processLock.Close()
 		return nil, err
 	}
 
@@ -203,14 +286,26 @@ func NewManager(cfg Config) (*Manager, error) {
 		cfg:             cfg,
 		selfUpdateReady: make(chan struct{}, 1),
 		processLock:     processLock,
+		logRoot:         logRoot,
 	}
 	if err := m.loadState(); err != nil {
 		_ = processLock.Close()
+		_ = logRoot.Close()
 		return nil, err
 	}
 	if err := m.cleanupStaleArtifacts(); err != nil {
 		_ = processLock.Close()
+		_ = logRoot.Close()
 		return nil, err
+	}
+	protectedLogName := ""
+	if m.operation != nil {
+		protectedLogName = operationLogFilename(m.operation.ID)
+	}
+	if err := m.pruneOperationLogs(protectedLogName, 0, 0); err != nil {
+		_ = processLock.Close()
+		_ = logRoot.Close()
+		return nil, fmt.Errorf("prune updater operation logs: %w", err)
 	}
 	return m, nil
 }
@@ -224,6 +319,16 @@ func (m *Manager) Close() error {
 // lock release, and exec so the manager remains independent of any supervisor.
 func (m *Manager) SelfUpdateReady() <-chan struct{} {
 	return m.selfUpdateReady
+}
+
+// RollbackSelfUpdate atomically restores the executable that was retained
+// before the latest self-refresh. The command process calls this only when
+// exec of the already smoke-tested replacement unexpectedly fails.
+func (m *Manager) RollbackSelfUpdate() error {
+	if m.cfg.SelfUpdatePath == "" {
+		return fmt.Errorf("self-update path is not configured")
+	}
+	return restorePreviousExecutable(m.cfg.SelfUpdatePath)
 }
 
 // Shutdown rejects future triggers, cancels work that has not crossed the
@@ -251,9 +356,14 @@ func (m *Manager) Shutdown(ctx context.Context) error {
 			cancel()
 		}
 		m.closeOnce.Do(func() {
-			if m.processLock != nil {
-				m.closeErr = m.processLock.Close()
+			var closeErrors []error
+			if m.logRoot != nil {
+				closeErrors = append(closeErrors, m.logRoot.Close())
 			}
+			if m.processLock != nil {
+				closeErrors = append(closeErrors, m.processLock.Close())
+			}
+			m.closeErr = errors.Join(closeErrors...)
 		})
 		return m.closeErr
 	case <-ctx.Done():
@@ -369,6 +479,13 @@ func (m *Manager) Trigger(targetVersion string) (updaterapi.Operation, error) {
 	if err := m.cleanupStaleArtifacts(); err != nil {
 		return updaterapi.Operation{}, fmt.Errorf("clean stale upgrade artifacts: %w", err)
 	}
+	protectedLogName := ""
+	if m.operation != nil {
+		protectedLogName = operationLogFilename(m.operation.ID)
+	}
+	if err := m.pruneOperationLogs(protectedLogName, 1, maxCommandLogBytes); err != nil {
+		return updaterapi.Operation{}, fmt.Errorf("reserve updater operation log capacity: %w", err)
+	}
 	now := m.cfg.Now().UTC()
 	op := &updaterapi.Operation{
 		ID:            m.cfg.NewID(),
@@ -378,9 +495,10 @@ func (m *Manager) Trigger(targetVersion string) (updaterapi.Operation, error) {
 		StartedAt:     now,
 		UpdatedAt:     now,
 	}
+	previousOperation := m.operation
 	m.operation = op
 	if err := m.persistLocked(); err != nil {
-		m.operation = nil
+		m.operation = previousOperation
 		return updaterapi.Operation{}, err
 	}
 	operationCopy := *op
@@ -404,25 +522,33 @@ func (m *Manager) finishOperation() {
 }
 
 func (m *Manager) run(ctx context.Context, operationID, targetVersion string) {
-	logPath := filepath.Join(m.cfg.StateDir, "logs", operationID+".log")
-	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	logName := operationLogFilename(operationID)
+	logPath := filepath.Join(m.cfg.StateDir, "logs", logName)
+	logFile, err := m.logRoot.OpenFile(logName, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
 	if err != nil {
 		m.fail(operationID, fmt.Errorf("open upgrade log: %w", err), "")
 		return
 	}
-	defer logFile.Close()
 	defer func() {
 		operation := m.Status().Operation
-		if operation == nil || operation.ID != operationID || !operation.Phase.Terminal() {
-			return
+		if operation != nil && operation.ID == operationID && operation.Phase.Terminal() {
+			_, _ = fmt.Fprintf(
+				logFile,
+				"[%s] terminal phase=%s error=%q\n",
+				m.cfg.Now().UTC().Format(time.RFC3339),
+				operation.Phase,
+				operation.Error,
+			)
 		}
-		_, _ = fmt.Fprintf(
-			logFile,
-			"[%s] terminal phase=%s error=%q\n",
-			m.cfg.Now().UTC().Format(time.RFC3339),
-			operation.Phase,
-			operation.Error,
-		)
+		if err := logFile.Close(); err != nil {
+			log.Printf("close updater operation log: %v", err)
+		}
+		// Terminal state is already persisted by this point. Retention is best
+		// effort here so a filesystem cleanup problem cannot rewrite an upgrade
+		// outcome after Fleet has already been activated (or failed safely).
+		if err := m.pruneOperationLogs(operationLogFilename(operationID), 0, 0); err != nil {
+			log.Printf("prune updater operation logs after completion: %v", err)
+		}
 	}()
 	commandOutput := newCappedWriter(logFile, maxCommandLogBytes)
 
@@ -577,7 +703,7 @@ func (m *Manager) run(ctx context.Context, operationID, targetVersion string) {
 	successMessage := fmt.Sprintf("Fleet %s is running", targetVersion)
 	selfUpdateSucceeded := false
 	if preparedUpdater != nil {
-		if err := atomicReplaceExecutableFromFile(preparedUpdater, m.cfg.SelfUpdatePath); err != nil {
+		if err := m.refreshSelfUpdater(ctx, preparedUpdater, m.cfg.SelfUpdatePath, targetVersion); err != nil {
 			_, _ = fmt.Fprintf(logFile, "[%s] warning: Fleet is healthy, but the host updater binary was not refreshed: %v\n", m.cfg.Now().UTC().Format(time.RFC3339), err)
 			successMessage += "; host updater refresh needs attention (see upgrade log)"
 		} else {
@@ -600,6 +726,10 @@ func (m *Manager) run(ctx context.Context, operationID, targetVersion string) {
 func operationArtifactBase(operationID string) string {
 	digest := sha256.Sum256([]byte(operationID))
 	return operationArtifactPrefix + hex.EncodeToString(digest[:])
+}
+
+func operationLogFilename(operationID string) string {
+	return operationArtifactBase(operationID) + ".log"
 }
 
 func (m *Manager) writeActivationMarker(marker activationMarker) error {
@@ -1246,6 +1376,174 @@ func (m *Manager) cleanupStaleArtifacts() error {
 	return nil
 }
 
+// pruneOperationLogs retains the current operation log plus the newest prior
+// logs within a bounded count and aggregate size. Callers may reserve capacity
+// for an operation that has not created its log yet. The daemon-lifetime lock
+// must be held, and Trigger additionally keeps operationRunning false while it
+// prunes, so a live writer is never selected for removal.
+func (m *Manager) pruneOperationLogs(protectedName string, reserveFiles int, reserveBytes int64) error {
+	return pruneOperationLogsRoot(
+		m.logRoot,
+		protectedName,
+		maxRetainedOperationLogs,
+		maxRetainedLogBytes,
+		reserveFiles,
+		reserveBytes,
+	)
+}
+
+type operationLogEntry struct {
+	name    string
+	size    int64
+	modTime time.Time
+}
+
+func pruneOperationLogs(
+	logDir string,
+	protectedName string,
+	maxFiles int,
+	maxBytes int64,
+	reserveFiles int,
+	reserveBytes int64,
+) error {
+	logRoot, err := os.OpenRoot(logDir)
+	if err != nil {
+		return fmt.Errorf("open updater operation log root: %w", err)
+	}
+	defer logRoot.Close()
+	return pruneOperationLogsRoot(
+		logRoot,
+		protectedName,
+		maxFiles,
+		maxBytes,
+		reserveFiles,
+		reserveBytes,
+	)
+}
+
+func pruneOperationLogsRoot(
+	logRoot *os.Root,
+	protectedName string,
+	maxFiles int,
+	maxBytes int64,
+	reserveFiles int,
+	reserveBytes int64,
+) error {
+	if maxFiles < 0 || maxBytes < 0 || reserveFiles < 0 || reserveBytes < 0 ||
+		reserveFiles > maxFiles || reserveBytes > maxBytes {
+		return fmt.Errorf("invalid updater operation log retention limits")
+	}
+	logDirectory, err := logRoot.Open(".")
+	if err != nil {
+		return fmt.Errorf("open updater operation log directory: %w", err)
+	}
+	entries, readErr := logDirectory.ReadDir(-1)
+	closeErr := logDirectory.Close()
+	if readErr != nil || closeErr != nil {
+		return errors.Join(
+			wrapIfError("list updater operation logs", readErr),
+			wrapIfError("close updater operation log directory", closeErr),
+		)
+	}
+
+	logs := make([]operationLogEntry, 0, len(entries))
+	var totalBytes int64
+	for _, entry := range entries {
+		if !operationLogNamePattern.MatchString(entry.Name()) {
+			continue
+		}
+		info, err := logRoot.Lstat(entry.Name())
+		if err != nil {
+			return fmt.Errorf("inspect updater operation log %s: %w", entry.Name(), err)
+		}
+		// The updater creates regular files only. Ignore unexpected symlinks,
+		// directories, and other special entries: retention must never follow a
+		// link or recursively remove content it did not create.
+		if !info.Mode().IsRegular() {
+			continue
+		}
+		totalBytes = saturatingLogBytes(totalBytes, info.Size(), maxBytes)
+		logs = append(logs, operationLogEntry{
+			name:    entry.Name(),
+			size:    info.Size(),
+			modTime: info.ModTime(),
+		})
+	}
+	sort.Slice(logs, func(i, j int) bool {
+		if logs[i].modTime.Equal(logs[j].modTime) {
+			return logs[i].name < logs[j].name
+		}
+		return logs[i].modTime.Before(logs[j].modTime)
+	})
+
+	allowedFiles := maxFiles - reserveFiles
+	allowedBytes := maxBytes - reserveBytes
+	removed := false
+	var pruneErr error
+	for len(logs) > allowedFiles || totalBytes > allowedBytes {
+		removeIndex := -1
+		for i := range logs {
+			if logs[i].name != protectedName {
+				removeIndex = i
+				break
+			}
+		}
+		if removeIndex == -1 {
+			pruneErr = fmt.Errorf("current updater operation log leaves insufficient retained capacity")
+			break
+		}
+		candidate := logs[removeIndex]
+		// Root.Remove confines the operation to the stable directory handle. It
+		// cannot escape through an ancestor swap or a planted symlink.
+		if err := logRoot.Remove(candidate.name); err != nil {
+			pruneErr = fmt.Errorf("remove updater operation log %s: %w", candidate.name, err)
+			break
+		}
+		removed = true
+		if totalBytes > maxBytes {
+			// Recompute after a saturated sum so later removals use exact sizes.
+			totalBytes = 0
+			for i := range logs {
+				if i != removeIndex {
+					totalBytes = saturatingLogBytes(totalBytes, logs[i].size, maxBytes)
+				}
+			}
+		} else {
+			totalBytes -= candidate.size
+		}
+		logs = append(logs[:removeIndex], logs[removeIndex+1:]...)
+	}
+	if removed {
+		if err := syncOperationLogRoot(logRoot); err != nil {
+			pruneErr = errors.Join(pruneErr, fmt.Errorf("persist updater operation log retention: %w", err))
+		}
+	}
+	return pruneErr
+}
+
+func saturatingLogBytes(total, size, limit int64) int64 {
+	if total > limit || size > limit || total > limit-size {
+		if limit == math.MaxInt64 {
+			return math.MaxInt64
+		}
+		return limit + 1
+	}
+	return total + size
+}
+
+func syncOperationLogRoot(logRoot *os.Root) error {
+	logDirectory, err := logRoot.Open(".")
+	if err != nil {
+		return fmt.Errorf("open updater operation log directory for sync: %w", err)
+	}
+	syncErr := logDirectory.Sync()
+	closeErr := logDirectory.Close()
+	return errors.Join(
+		wrapIfError("sync updater operation log directory", syncErr),
+		wrapIfError("close updater operation log sync handle", closeErr),
+	)
+}
+
 func cleanupStaleStateArtifacts(stateDir string) (bool, error) {
 	entries, err := os.ReadDir(stateDir)
 	if err != nil {
@@ -1606,51 +1904,215 @@ func copyFile(ctx context.Context, source, destination string) error {
 	return nil
 }
 
-func atomicReplaceExecutable(source, destination string) error {
-	in, err := os.Open(source)
+func (m *Manager) refreshSelfUpdater(
+	parent context.Context,
+	in *os.File,
+	destination string,
+	targetVersion string,
+) error {
+	candidatePath, err := stageExecutableCandidate(in, destination)
 	if err != nil {
-		return fmt.Errorf("open staged updater: %w", err)
+		return err
 	}
-	defer in.Close()
-	return atomicReplaceExecutableFromFile(in, destination)
+	defer os.Remove(candidatePath)
+	if err := m.validateUpdaterCandidate(parent, candidatePath, targetVersion); err != nil {
+		return err
+	}
+	return installExecutableCandidate(candidatePath, destination)
 }
 
-func atomicReplaceExecutableFromFile(in *os.File, destination string) error {
+func stageExecutableCandidate(in *os.File, destination string) (string, error) {
 	if _, err := in.Seek(0, io.SeekStart); err != nil {
-		return fmt.Errorf("rewind staged updater: %w", err)
+		return "", fmt.Errorf("rewind staged updater: %w", err)
 	}
 	info, err := in.Stat()
 	if err != nil {
-		return fmt.Errorf("inspect staged updater: %w", err)
+		return "", fmt.Errorf("inspect staged updater: %w", err)
 	}
-	if !info.Mode().IsRegular() || info.Mode().Perm()&0o111 == 0 {
-		return fmt.Errorf("staged updater is not executable")
+	if !info.Mode().IsRegular() || info.Mode().Perm()&0o111 == 0 || info.Size() == 0 {
+		return "", fmt.Errorf("staged updater is not a non-empty executable")
 	}
-	temp, err := os.CreateTemp(filepath.Dir(destination), ".proto-fleet-updater-")
+	candidatePath := destination + ".candidate"
+	if removed, err := unlinkExecutableSlot(candidatePath); err != nil {
+		return "", fmt.Errorf("clean stale updater candidate: %w", err)
+	} else if removed {
+		if err := syncDirectory(filepath.Dir(destination)); err != nil {
+			return "", fmt.Errorf("persist stale updater candidate cleanup: %w", err)
+		}
+	}
+	fd, err := syscall.Open(
+		candidatePath,
+		syscall.O_CREAT|syscall.O_EXCL|syscall.O_WRONLY|syscall.O_CLOEXEC|syscall.O_NOFOLLOW,
+		0o600,
+	)
 	if err != nil {
-		return fmt.Errorf("create updater executable temp file: %w", err)
+		return "", fmt.Errorf("create updater executable candidate: %w", err)
 	}
-	tempPath := temp.Name()
-	defer os.Remove(tempPath)
-	if _, err := io.Copy(temp, in); err != nil {
-		temp.Close()
-		return fmt.Errorf("copy staged updater: %w", err)
+	candidate := os.NewFile(uintptr(fd), candidatePath)
+	if candidate == nil {
+		_ = syscall.Close(fd)
+		return "", fmt.Errorf("create updater executable candidate")
 	}
-	if err := temp.Chmod(0o755); err != nil {
-		temp.Close()
-		return fmt.Errorf("make updater executable: %w", err)
+	installed := false
+	defer func() {
+		if !installed {
+			_ = os.Remove(candidatePath)
+		}
+	}()
+	written, err := io.Copy(candidate, in)
+	if err != nil {
+		_ = candidate.Close()
+		return "", fmt.Errorf("copy staged updater: %w", err)
 	}
-	if err := temp.Sync(); err != nil {
-		temp.Close()
-		return fmt.Errorf("sync updater executable: %w", err)
+	if written == 0 {
+		_ = candidate.Close()
+		return "", fmt.Errorf("staged updater is empty")
 	}
-	if err := temp.Close(); err != nil {
-		return fmt.Errorf("close updater executable: %w", err)
+	if err := candidate.Chmod(0o755); err != nil {
+		_ = candidate.Close()
+		return "", fmt.Errorf("make updater candidate executable: %w", err)
 	}
-	if err := os.Rename(tempPath, destination); err != nil {
-		return fmt.Errorf("replace updater executable: %w", err)
+	if err := candidate.Sync(); err != nil {
+		_ = candidate.Close()
+		return "", fmt.Errorf("sync updater executable candidate: %w", err)
 	}
-	return syncDirectory(filepath.Dir(destination))
+	if err := candidate.Close(); err != nil {
+		return "", fmt.Errorf("close updater executable candidate: %w", err)
+	}
+	installed = true
+	return candidatePath, nil
+}
+
+func (m *Manager) validateUpdaterCandidate(parent context.Context, candidatePath, targetVersion string) error {
+	info, err := os.Lstat(candidatePath)
+	if err != nil {
+		return fmt.Errorf("inspect updater candidate: %w", err)
+	}
+	if !info.Mode().IsRegular() || info.Mode().Perm()&0o111 == 0 || info.Size() == 0 {
+		return fmt.Errorf("updater candidate is not a non-empty executable")
+	}
+	var versionOutput bytes.Buffer
+	boundedOutput := newCappedWriter(&versionOutput, maxCandidateVersionBytes)
+	// Actually executing --version asks the host kernel to validate the
+	// executable format and architecture. That is stronger and more portable
+	// than parsing an ELF header while still proving the updater CLI contract.
+	if err := m.runCommand(
+		parent,
+		defaultCandidateTimeout,
+		filepath.Dir(candidatePath),
+		boundedOutput,
+		candidatePath,
+		"--version",
+	); err != nil {
+		return fmt.Errorf("smoke-test updater candidate: %w", err)
+	}
+	if boundedOutput.truncated {
+		return fmt.Errorf("updater candidate version output exceeded %d bytes", maxCandidateVersionBytes)
+	}
+	reportedVersion := strings.TrimSpace(versionOutput.String())
+	if reportedVersion != targetVersion {
+		return fmt.Errorf(
+			"updater candidate reported version %q instead of %q",
+			reportedVersion,
+			targetVersion,
+		)
+	}
+	return nil
+}
+
+func installExecutableCandidate(candidatePath, destination string) error {
+	destinationInfo, err := os.Lstat(destination)
+	if err != nil {
+		return fmt.Errorf("inspect installed updater: %w", err)
+	}
+	if !destinationInfo.Mode().IsRegular() || destinationInfo.Mode().Perm()&0o111 == 0 || destinationInfo.Size() == 0 {
+		return fmt.Errorf("installed updater is not a non-empty executable")
+	}
+	candidateInfo, err := os.Lstat(candidatePath)
+	if err != nil {
+		return fmt.Errorf("inspect validated updater candidate: %w", err)
+	}
+	if !candidateInfo.Mode().IsRegular() || candidateInfo.Mode().Perm()&0o111 == 0 || candidateInfo.Size() == 0 {
+		return fmt.Errorf("validated updater candidate is not a non-empty executable")
+	}
+
+	parent := filepath.Dir(destination)
+	backupPath := destination + selfUpdateBackupSuffix
+	if removed, err := unlinkExecutableSlot(backupPath); err != nil {
+		return fmt.Errorf("clean previous updater backup: %w", err)
+	} else if removed {
+		if err := syncDirectory(parent); err != nil {
+			return fmt.Errorf("persist previous updater backup cleanup: %w", err)
+		}
+	}
+	// A hard link preserves the running executable without creating a window
+	// where the supervised destination is absent. It remains as an explicit
+	// recovery slot until a later successful refresh replaces it.
+	if err := os.Link(destination, backupPath); err != nil {
+		return fmt.Errorf("retain previous updater executable: %w", err)
+	}
+	if err := syncDirectory(parent); err != nil {
+		cleanupErr := os.Remove(backupPath)
+		if cleanupErr == nil {
+			cleanupErr = syncDirectory(parent)
+		}
+		return errors.Join(
+			fmt.Errorf("persist previous updater executable: %w", err),
+			cleanupErr,
+		)
+	}
+	if err := os.Rename(candidatePath, destination); err != nil {
+		cleanupErr := os.Remove(backupPath)
+		if cleanupErr == nil {
+			cleanupErr = syncDirectory(parent)
+		}
+		return errors.Join(fmt.Errorf("replace updater executable: %w", err), cleanupErr)
+	}
+	if err := syncDirectory(parent); err != nil {
+		restoreErr := restorePreviousExecutable(destination)
+		return errors.Join(fmt.Errorf("persist updater executable replacement: %w", err), restoreErr)
+	}
+	return nil
+}
+
+func restorePreviousExecutable(destination string) error {
+	backupPath := destination + selfUpdateBackupSuffix
+	backupInfo, err := os.Lstat(backupPath)
+	if err != nil {
+		return fmt.Errorf("inspect previous updater executable: %w", err)
+	}
+	if !backupInfo.Mode().IsRegular() || backupInfo.Mode().Perm()&0o111 == 0 || backupInfo.Size() == 0 {
+		return fmt.Errorf("previous updater backup is not a non-empty executable")
+	}
+	if destinationInfo, err := os.Lstat(destination); err == nil && destinationInfo.IsDir() {
+		return fmt.Errorf("refusing to replace updater destination directory")
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("inspect updater destination before restoration: %w", err)
+	}
+	if err := os.Rename(backupPath, destination); err != nil {
+		return fmt.Errorf("restore previous updater executable: %w", err)
+	}
+	if err := syncDirectory(filepath.Dir(destination)); err != nil {
+		return fmt.Errorf("persist previous updater executable restoration: %w", err)
+	}
+	return nil
+}
+
+func unlinkExecutableSlot(path string) (bool, error) {
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("inspect executable file slot: %w", err)
+	}
+	if info.IsDir() {
+		return false, fmt.Errorf("refusing to remove directory from executable file slot")
+	}
+	if err := syscall.Unlink(path); err != nil {
+		return false, fmt.Errorf("unlink executable file slot: %w", err)
+	}
+	return true, nil
 }
 
 func syncDirectory(path string) error {

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -1,0 +1,783 @@
+package updater
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/google/uuid"
+	"golang.org/x/mod/semver"
+
+	"github.com/block/proto-fleet/server/internal/updaterapi"
+)
+
+const (
+	stateFilename      = "state.json"
+	maxChecksumBytes   = 4096
+	maxDownloadBytes   = int64(8 << 30) // 8 GiB hard stop for a corrupt or hostile response.
+	maxExtractedBytes  = int64(16 << 30)
+	maxArchiveEntries  = 100_000
+	defaultHTTPTimeout = 30 * time.Minute
+)
+
+var canonicalRelease = regexp.MustCompile(`^v\d+\.\d+\.\d+(?:-rc\.\d+)?$`)
+
+type CommandRunner interface {
+	Run(ctx context.Context, dir string, output io.Writer, name string, args ...string) error
+}
+
+type execRunner struct{}
+
+func (execRunner) Run(ctx context.Context, dir string, output io.Writer, name string, args ...string) error {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = dir
+	cmd.Stdout = output
+	cmd.Stderr = output
+	cmd.Env = append(os.Environ(), "CI=1", "TERM=dumb")
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("run %s: %w", name, err)
+	}
+	return nil
+}
+
+type Config struct {
+	InstallRoot     string
+	StateDir        string
+	DownloadBaseURL string
+	HTTPClient      *http.Client
+	Runner          CommandRunner
+	Now             func() time.Time
+	NewID           func() string
+	GOARCH          string
+	SelfUpdatePath  string
+}
+
+type Manager struct {
+	cfg Config
+
+	mu        sync.RWMutex
+	operation *updaterapi.Operation
+}
+
+func NewManager(cfg Config) (*Manager, error) {
+	if !filepath.IsAbs(cfg.InstallRoot) {
+		return nil, fmt.Errorf("install root must be absolute")
+	}
+	if !filepath.IsAbs(cfg.StateDir) {
+		return nil, fmt.Errorf("state directory must be absolute")
+	}
+	if cfg.SelfUpdatePath != "" && !filepath.IsAbs(cfg.SelfUpdatePath) {
+		return nil, fmt.Errorf("self-update path must be absolute")
+	}
+	downloadBase, err := url.Parse(cfg.DownloadBaseURL)
+	if err != nil || downloadBase.Scheme != "https" || downloadBase.Host == "" ||
+		downloadBase.User != nil || downloadBase.RawQuery != "" || downloadBase.Fragment != "" {
+		return nil, fmt.Errorf("download base URL must use https")
+	}
+	if cfg.HTTPClient == nil {
+		cfg.HTTPClient = &http.Client{
+			Timeout: defaultHTTPTimeout,
+			CheckRedirect: func(req *http.Request, _ []*http.Request) error {
+				if req.URL.Scheme != "https" {
+					return fmt.Errorf("refusing non-HTTPS release redirect")
+				}
+				return nil
+			},
+		}
+	}
+	if cfg.Runner == nil {
+		cfg.Runner = execRunner{}
+	}
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+	if cfg.NewID == nil {
+		cfg.NewID = uuid.NewString
+	}
+	if cfg.GOARCH == "" {
+		cfg.GOARCH = runtime.GOARCH
+	}
+	if cfg.GOARCH != "amd64" && cfg.GOARCH != "arm64" {
+		return nil, fmt.Errorf("unsupported architecture %q", cfg.GOARCH)
+	}
+	if err := os.MkdirAll(filepath.Join(cfg.StateDir, "logs"), 0o700); err != nil {
+		return nil, fmt.Errorf("create updater state directory: %w", err)
+	}
+
+	m := &Manager{cfg: cfg}
+	if err := m.loadState(); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+func (m *Manager) Status() updaterapi.StatusResponse {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.operation == nil {
+		return updaterapi.StatusResponse{}
+	}
+	snapshot := *m.operation
+	return updaterapi.StatusResponse{Operation: &snapshot}
+}
+
+func (m *Manager) Trigger(targetVersion string) (updaterapi.Operation, error) {
+	if !canonicalRelease.MatchString(targetVersion) || !semver.IsValid(targetVersion) {
+		return updaterapi.Operation{}, fmt.Errorf("target version must be a stable or RC release tag")
+	}
+	currentVersion, err := readInstalledVersion(filepath.Join(m.cfg.InstallRoot, "deployment", "version.txt"))
+	if err != nil {
+		return updaterapi.Operation{}, err
+	}
+	if !semver.IsValid(currentVersion) {
+		return updaterapi.Operation{}, fmt.Errorf("installed version %q is not upgradeable", currentVersion)
+	}
+	if semver.Compare(targetVersion, currentVersion) <= 0 {
+		return updaterapi.Operation{}, fmt.Errorf("target version %s must be newer than installed version %s", targetVersion, currentVersion)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.operation != nil && !m.operation.Phase.Terminal() {
+		return updaterapi.Operation{}, fmt.Errorf("an upgrade to %s is already in progress", m.operation.TargetVersion)
+	}
+	now := m.cfg.Now().UTC()
+	op := &updaterapi.Operation{
+		ID:            m.cfg.NewID(),
+		TargetVersion: targetVersion,
+		Phase:         updaterapi.PhaseQueued,
+		Message:       "Upgrade queued",
+		StartedAt:     now,
+		UpdatedAt:     now,
+	}
+	m.operation = op
+	if err := m.persistLocked(); err != nil {
+		m.operation = nil
+		return updaterapi.Operation{}, err
+	}
+	operationCopy := *op
+	go m.run(operationCopy.ID, targetVersion)
+	return operationCopy, nil
+}
+
+func (m *Manager) run(operationID, targetVersion string) {
+	logPath := filepath.Join(m.cfg.StateDir, "logs", operationID+".log")
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		m.fail(operationID, fmt.Errorf("open upgrade log: %w", err), "")
+		return
+	}
+	defer logFile.Close()
+
+	ctx := context.Background()
+	recovery := fmt.Sprintf("cd %s && ./run-fleet.sh --non-interactive --skip-build", shellQuote(filepath.Join(m.cfg.InstallRoot, "deployment")))
+	if err := m.setLogPath(operationID, logPath, recovery); err != nil {
+		m.fail(operationID, fmt.Errorf("persist upgrade log location: %w", err), recovery)
+		return
+	}
+	_, _ = fmt.Fprintf(logFile, "[%s] starting upgrade to %s\n", m.cfg.Now().UTC().Format(time.RFC3339), targetVersion)
+
+	archiveName := fmt.Sprintf("proto-fleet-%s-%s.tar.gz", targetVersion, m.cfg.GOARCH)
+	archiveURL := strings.TrimSuffix(m.cfg.DownloadBaseURL, "/") + "/" + targetVersion + "/" + archiveName
+	archivePath := filepath.Join(m.cfg.StateDir, operationID+"-"+archiveName)
+	checksumPath := archivePath + ".sha256"
+	defer os.Remove(archivePath)
+	defer os.Remove(checksumPath)
+
+	if err := m.advance(operationID, updaterapi.PhaseDownloading, "Downloading release bundle"); err != nil {
+		m.fail(operationID, fmt.Errorf("persist download phase: %w", err), recovery)
+		return
+	}
+	if err := m.download(ctx, archiveURL, archivePath, maxDownloadBytes); err != nil {
+		m.fail(operationID, fmt.Errorf("download release bundle: %w", err), recovery)
+		return
+	}
+	if err := m.download(ctx, archiveURL+".sha256", checksumPath, maxChecksumBytes); err != nil {
+		m.fail(operationID, fmt.Errorf("download release checksum: %w", err), recovery)
+		return
+	}
+
+	if err := m.advance(operationID, updaterapi.PhaseVerifying, "Verifying release integrity"); err != nil {
+		m.fail(operationID, fmt.Errorf("persist verification phase: %w", err), recovery)
+		return
+	}
+	if err := verifyChecksum(archivePath, checksumPath, archiveName); err != nil {
+		m.fail(operationID, err, recovery)
+		return
+	}
+
+	stageRoot, err := os.MkdirTemp(m.cfg.InstallRoot, ".proto-fleet-upgrade-")
+	if err != nil {
+		m.fail(operationID, fmt.Errorf("create staging directory: %w", err), recovery)
+		return
+	}
+	defer os.RemoveAll(stageRoot)
+
+	if err := m.advance(operationID, updaterapi.PhaseStaging, "Staging release and preserving configuration"); err != nil {
+		m.fail(operationID, fmt.Errorf("persist staging phase: %w", err), recovery)
+		return
+	}
+	if err := extractArchive(archivePath, stageRoot); err != nil {
+		m.fail(operationID, fmt.Errorf("extract release bundle: %w", err), recovery)
+		return
+	}
+	stageDeployment := filepath.Join(stageRoot, "deployment")
+	currentDeployment := filepath.Join(m.cfg.InstallRoot, "deployment")
+	if err := validateStagedRelease(stageDeployment, targetVersion); err != nil {
+		m.fail(operationID, err, recovery)
+		return
+	}
+	if err := preserveDeploymentState(currentDeployment, stageDeployment); err != nil {
+		m.fail(operationID, fmt.Errorf("preserve deployment configuration: %w", err), recovery)
+		return
+	}
+	if err := preserveDeploymentOwnership(currentDeployment, stageDeployment); err != nil {
+		m.fail(operationID, fmt.Errorf("preserve deployment ownership: %w", err), recovery)
+		return
+	}
+
+	if err := m.advance(operationID, updaterapi.PhasePreflight, "Building and validating the new stack while Fleet stays online"); err != nil {
+		m.fail(operationID, fmt.Errorf("persist preflight phase: %w", err), recovery)
+		return
+	}
+	if err := m.cfg.Runner.Run(ctx, stageDeployment, logFile, "/bin/bash", "./run-fleet.sh", "--non-interactive", "--preflight-only"); err != nil {
+		m.fail(operationID, fmt.Errorf("upgrade preflight failed: %w", err), recovery)
+		return
+	}
+	if m.cfg.SelfUpdatePath != "" {
+		stagedUpdater := filepath.Join(stageDeployment, "updater", "proto-fleet-updater")
+		if err := atomicReplaceExecutable(stagedUpdater, m.cfg.SelfUpdatePath); err != nil {
+			m.fail(operationID, fmt.Errorf("update host updater binary: %w", err), recovery)
+			return
+		}
+	}
+
+	if err := m.advance(operationID, updaterapi.PhaseActivating, "Restarting Fleet; the client may disconnect for several minutes"); err != nil {
+		m.fail(operationID, fmt.Errorf("persist activation phase: %w", err), recovery)
+		return
+	}
+	backupDeployment := filepath.Join(m.cfg.InstallRoot, "deployment.previous")
+	if err := os.RemoveAll(backupDeployment); err != nil {
+		m.fail(operationID, fmt.Errorf("remove previous deployment backup: %w", err), recovery)
+		return
+	}
+	if err := os.Rename(currentDeployment, backupDeployment); err != nil {
+		m.fail(operationID, fmt.Errorf("back up current deployment: %w", err), recovery)
+		return
+	}
+	if err := os.Rename(stageDeployment, currentDeployment); err != nil {
+		// This is still pre-teardown and therefore safe to restore.
+		_ = os.Rename(backupDeployment, currentDeployment)
+		m.fail(operationID, fmt.Errorf("activate staged deployment: %w", err), recovery)
+		return
+	}
+
+	if err := m.cfg.Runner.Run(ctx, currentDeployment, logFile, "/bin/bash", "./run-fleet.sh", "--non-interactive", "--skip-build"); err != nil {
+		m.fail(operationID, fmt.Errorf("new stack failed to start: %w", err), recovery)
+		return
+	}
+
+	if err := m.succeed(operationID, fmt.Sprintf("Fleet %s is running", targetVersion)); err != nil {
+		_, _ = fmt.Fprintf(logFile, "[%s] warning: persist successful terminal state: %v\n", m.cfg.Now().UTC().Format(time.RFC3339), err)
+		log.Printf("persist successful upgrade state: %v", err)
+	}
+	_, _ = fmt.Fprintf(logFile, "[%s] upgrade completed\n", m.cfg.Now().UTC().Format(time.RFC3339))
+}
+
+func (m *Manager) download(ctx context.Context, rawURL, path string, maxBytes int64) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return fmt.Errorf("create download request: %w", err)
+	}
+	resp, err := m.cfg.HTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("download %s: %w", rawURL, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("GET %s returned %s", rawURL, resp.Status)
+	}
+	if resp.ContentLength > maxBytes {
+		return fmt.Errorf("response is larger than %d bytes", maxBytes)
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("create download file: %w", err)
+	}
+	defer file.Close()
+	written, err := io.Copy(file, io.LimitReader(resp.Body, maxBytes+1))
+	if err != nil {
+		return fmt.Errorf("write download file: %w", err)
+	}
+	if written > maxBytes {
+		return fmt.Errorf("response exceeded %d bytes", maxBytes)
+	}
+	if err := file.Sync(); err != nil {
+		return fmt.Errorf("sync download file: %w", err)
+	}
+	return nil
+}
+
+func (m *Manager) advance(id string, phase updaterapi.Phase, message string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.operation == nil || m.operation.ID != id {
+		return fmt.Errorf("operation %s is no longer current", id)
+	}
+	m.operation.Phase = phase
+	m.operation.Message = message
+	m.operation.UpdatedAt = m.cfg.Now().UTC()
+	return m.persistLocked()
+}
+
+func (m *Manager) setLogPath(id, logPath, recovery string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.operation == nil || m.operation.ID != id {
+		return fmt.Errorf("operation %s is no longer current", id)
+	}
+	m.operation.LogPath = logPath
+	m.operation.RecoveryCommand = recovery
+	m.operation.UpdatedAt = m.cfg.Now().UTC()
+	return m.persistLocked()
+}
+
+func (m *Manager) fail(id string, err error, recovery string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.operation == nil || m.operation.ID != id {
+		return
+	}
+	now := m.cfg.Now().UTC()
+	m.operation.Phase = updaterapi.PhaseFailed
+	m.operation.Message = "Upgrade failed"
+	m.operation.Error = err.Error()
+	if recovery != "" {
+		m.operation.RecoveryCommand = recovery
+	}
+	m.operation.UpdatedAt = now
+	m.operation.CompletedAt = &now
+	if persistErr := m.persistLocked(); persistErr != nil {
+		log.Printf("persist failed upgrade state: %v", persistErr)
+	}
+}
+
+func (m *Manager) succeed(id, message string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.operation == nil || m.operation.ID != id {
+		return fmt.Errorf("operation %s is no longer current", id)
+	}
+	now := m.cfg.Now().UTC()
+	m.operation.Phase = updaterapi.PhaseSucceeded
+	m.operation.Message = message
+	m.operation.UpdatedAt = now
+	m.operation.CompletedAt = &now
+	return m.persistLocked()
+}
+
+func (m *Manager) loadState() error {
+	data, err := os.ReadFile(filepath.Join(m.cfg.StateDir, stateFilename))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read updater state: %w", err)
+	}
+	var op updaterapi.Operation
+	if err := json.Unmarshal(data, &op); err != nil {
+		return fmt.Errorf("decode updater state: %w", err)
+	}
+	if !op.Phase.Terminal() {
+		now := m.cfg.Now().UTC()
+		op.Phase = updaterapi.PhaseFailed
+		op.Message = "Upgrade interrupted"
+		op.Error = "The updater restarted before the operation completed; inspect the host log before retrying."
+		op.UpdatedAt = now
+		op.CompletedAt = &now
+	}
+	m.operation = &op
+	return m.persistLocked()
+}
+
+func (m *Manager) persistLocked() error {
+	if m.operation == nil {
+		return nil
+	}
+	data, err := json.MarshalIndent(m.operation, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode updater state: %w", err)
+	}
+	path := filepath.Join(m.cfg.StateDir, stateFilename)
+	temp, err := os.CreateTemp(m.cfg.StateDir, ".state-")
+	if err != nil {
+		return fmt.Errorf("create updater state temp file: %w", err)
+	}
+	tempPath := temp.Name()
+	defer os.Remove(tempPath)
+	if err := temp.Chmod(0o600); err != nil {
+		temp.Close()
+		return fmt.Errorf("secure updater state temp file: %w", err)
+	}
+	if _, err := temp.Write(data); err != nil {
+		temp.Close()
+		return fmt.Errorf("write updater state temp file: %w", err)
+	}
+	if err := temp.Sync(); err != nil {
+		temp.Close()
+		return fmt.Errorf("sync updater state temp file: %w", err)
+	}
+	if err := temp.Close(); err != nil {
+		return fmt.Errorf("close updater state temp file: %w", err)
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		return fmt.Errorf("replace updater state: %w", err)
+	}
+	return syncDirectory(m.cfg.StateDir)
+}
+
+func readInstalledVersion(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read installed version: %w", err)
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if value, ok := strings.CutPrefix(strings.TrimSpace(line), "version:"); ok {
+			version := strings.TrimSpace(value)
+			if version != "" {
+				return version, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("installed version file has no version")
+}
+
+func verifyChecksum(archivePath, checksumPath, archiveName string) error {
+	data, err := os.ReadFile(checksumPath)
+	if err != nil {
+		return fmt.Errorf("read release checksum: %w", err)
+	}
+	fields := strings.Fields(string(data))
+	if len(fields) != 2 || strings.TrimPrefix(fields[1], "*") != archiveName {
+		return fmt.Errorf("release checksum does not describe %s", archiveName)
+	}
+	expected, err := hex.DecodeString(fields[0])
+	if err != nil || len(expected) != sha256.Size {
+		return fmt.Errorf("release checksum is not a valid SHA-256 digest")
+	}
+	file, err := os.Open(archivePath)
+	if err != nil {
+		return fmt.Errorf("open release bundle: %w", err)
+	}
+	defer file.Close()
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return fmt.Errorf("hash release bundle: %w", err)
+	}
+	if !equalBytes(hash.Sum(nil), expected) {
+		return fmt.Errorf("release checksum verification failed")
+	}
+	return nil
+}
+
+func equalBytes(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	var diff byte
+	for i := range a {
+		diff |= a[i] ^ b[i]
+	}
+	return diff == 0
+}
+
+func extractArchive(archivePath, destination string) error {
+	file, err := os.Open(archivePath)
+	if err != nil {
+		return fmt.Errorf("open release archive: %w", err)
+	}
+	defer file.Close()
+	gz, err := gzip.NewReader(file)
+	if err != nil {
+		return fmt.Errorf("open gzip stream: %w", err)
+	}
+	defer gz.Close()
+	tr := tar.NewReader(gz)
+	cleanDestination := filepath.Clean(destination) + string(os.PathSeparator)
+	var extractedBytes int64
+	entries := 0
+	for {
+		header, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("read archive entry: %w", err)
+		}
+		entries++
+		if entries > maxArchiveEntries {
+			return fmt.Errorf("archive contains more than %d entries", maxArchiveEntries)
+		}
+		if header.Size < 0 || header.Size > maxExtractedBytes-extractedBytes {
+			return fmt.Errorf("archive expands beyond %d bytes", maxExtractedBytes)
+		}
+		extractedBytes += header.Size
+		name := filepath.Clean(filepath.FromSlash(header.Name))
+		if filepath.IsAbs(name) || name == "." || strings.HasPrefix(name, ".."+string(os.PathSeparator)) {
+			return fmt.Errorf("archive contains unsafe path %q", header.Name)
+		}
+		target := filepath.Join(destination, name)
+		if !strings.HasPrefix(filepath.Clean(target)+string(os.PathSeparator), cleanDestination) {
+			return fmt.Errorf("archive path escapes staging directory: %q", header.Name)
+		}
+		switch header.Typeflag {
+		case tar.TypeDir:
+			mode := os.FileMode(uint32(header.Mode & 0o755)) // #nosec G115 -- masked to nine permission bits
+			if err := os.MkdirAll(target, mode); err != nil {
+				return fmt.Errorf("create archive directory %s: %w", header.Name, err)
+			}
+		case tar.TypeReg, tar.TypeRegA:
+			// #nosec G301 -- extracted deployment parents must be traversable
+			// by the account that owns and manually maintains the install.
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return fmt.Errorf("create archive parent for %s: %w", header.Name, err)
+			}
+			mode := os.FileMode(uint32(header.Mode & 0o755)) // #nosec G115 -- masked to nine permission bits
+			out, err := os.OpenFile(target, os.O_CREATE|os.O_EXCL|os.O_WRONLY, mode)
+			if err != nil {
+				return fmt.Errorf("create archive file %s: %w", header.Name, err)
+			}
+			// tar.Reader already bounds reads to header.Size; the additional
+			// LimitReader documents that bound for static analysis.
+			if _, err := io.Copy(out, io.LimitReader(tr, header.Size)); err != nil { // #nosec G110
+				out.Close()
+				return fmt.Errorf("extract archive file %s: %w", header.Name, err)
+			}
+			if err := out.Close(); err != nil {
+				return fmt.Errorf("close archive file %s: %w", header.Name, err)
+			}
+		default:
+			return fmt.Errorf("archive contains unsupported entry %q", header.Name)
+		}
+	}
+}
+
+func validateStagedRelease(deploymentPath, targetVersion string) error {
+	required := []string{
+		"docker-compose.yaml",
+		"run-fleet.sh",
+		"server/fleetd",
+		"server/proto-plugin",
+		"server/antminer-plugin",
+		"server/asicrs-plugin",
+	}
+	for _, path := range required {
+		info, err := os.Stat(filepath.Join(deploymentPath, path))
+		if err != nil || info.IsDir() {
+			return fmt.Errorf("release bundle is missing required file %s", path)
+		}
+	}
+	version, err := readInstalledVersion(filepath.Join(deploymentPath, "version.txt"))
+	if err != nil {
+		return fmt.Errorf("validate staged version: %w", err)
+	}
+	if version != targetVersion {
+		return fmt.Errorf("release bundle version %s does not match target %s", version, targetVersion)
+	}
+	return nil
+}
+
+func preserveDeploymentState(current, staged string) error {
+	for _, path := range []string{".env", "server/influx_config/.env"} {
+		source := filepath.Join(current, path)
+		if _, err := os.Stat(source); errors.Is(err, os.ErrNotExist) {
+			continue
+		} else if err != nil {
+			return fmt.Errorf("inspect preserved file %s: %w", path, err)
+		}
+		if err := copyFile(source, filepath.Join(staged, path)); err != nil {
+			return err
+		}
+	}
+	sourceSSL := filepath.Join(current, "ssl")
+	if _, err := os.Stat(sourceSSL); err == nil {
+		if err := copyTree(sourceSSL, filepath.Join(staged, "ssl")); err != nil {
+			return err
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("inspect preserved TLS directory: %w", err)
+	}
+	return nil
+}
+
+// The host updater runs as root so it can manage rootful Docker and its own
+// systemd unit. Keep the extracted deployment owned by the same account as
+// the previous deployment, otherwise one successful one-click upgrade would
+// make later manual maintenance unexpectedly require root.
+func preserveDeploymentOwnership(current, staged string) error {
+	if os.Geteuid() != 0 {
+		return nil
+	}
+	info, err := os.Stat(current)
+	if err != nil {
+		return fmt.Errorf("inspect current deployment owner: %w", err)
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return fmt.Errorf("read deployment owner")
+	}
+	err = filepath.WalkDir(staged, func(path string, _ os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return fmt.Errorf("walk staged deployment: %w", walkErr)
+		}
+		if err := os.Chown(path, int(stat.Uid), int(stat.Gid)); err != nil {
+			return fmt.Errorf("set staged deployment owner: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("preserve staged deployment ownership: %w", err)
+	}
+	return nil
+}
+
+func copyFile(source, destination string) error {
+	info, err := os.Lstat(source)
+	if err != nil {
+		return fmt.Errorf("inspect source file: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("refusing to copy non-regular file %s", source)
+	}
+	if err := os.MkdirAll(filepath.Dir(destination), 0o750); err != nil {
+		return fmt.Errorf("create destination parent: %w", err)
+	}
+	in, err := os.Open(source)
+	if err != nil {
+		return fmt.Errorf("open source file: %w", err)
+	}
+	defer in.Close()
+	out, err := os.OpenFile(destination, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, info.Mode().Perm())
+	if err != nil {
+		return fmt.Errorf("open destination file: %w", err)
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return fmt.Errorf("copy file contents: %w", err)
+	}
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("close destination file: %w", err)
+	}
+	return nil
+}
+
+func atomicReplaceExecutable(source, destination string) error {
+	info, err := os.Stat(source)
+	if err != nil {
+		return fmt.Errorf("inspect staged updater: %w", err)
+	}
+	if info.IsDir() || info.Mode().Perm()&0o111 == 0 {
+		return fmt.Errorf("staged updater is not executable")
+	}
+	temp, err := os.CreateTemp(filepath.Dir(destination), ".proto-fleet-updater-")
+	if err != nil {
+		return fmt.Errorf("create updater executable temp file: %w", err)
+	}
+	tempPath := temp.Name()
+	defer os.Remove(tempPath)
+	in, err := os.Open(source)
+	if err != nil {
+		temp.Close()
+		return fmt.Errorf("open staged updater: %w", err)
+	}
+	_, copyErr := io.Copy(temp, in)
+	closeInErr := in.Close()
+	if copyErr != nil {
+		temp.Close()
+		return fmt.Errorf("copy staged updater: %w", copyErr)
+	}
+	if closeInErr != nil {
+		temp.Close()
+		return fmt.Errorf("close staged updater: %w", closeInErr)
+	}
+	if err := temp.Chmod(0o755); err != nil {
+		temp.Close()
+		return fmt.Errorf("make updater executable: %w", err)
+	}
+	if err := temp.Sync(); err != nil {
+		temp.Close()
+		return fmt.Errorf("sync updater executable: %w", err)
+	}
+	if err := temp.Close(); err != nil {
+		return fmt.Errorf("close updater executable: %w", err)
+	}
+	if err := os.Rename(tempPath, destination); err != nil {
+		return fmt.Errorf("replace updater executable: %w", err)
+	}
+	return syncDirectory(filepath.Dir(destination))
+}
+
+func syncDirectory(path string) error {
+	directory, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open directory for sync: %w", err)
+	}
+	defer directory.Close()
+	if err := directory.Sync(); err != nil {
+		return fmt.Errorf("sync directory: %w", err)
+	}
+	return nil
+}
+
+func copyTree(source, destination string) error {
+	err := filepath.WalkDir(source, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return fmt.Errorf("walk preserved tree: %w", walkErr)
+		}
+		relative, err := filepath.Rel(source, path)
+		if err != nil {
+			return fmt.Errorf("resolve preserved tree path: %w", err)
+		}
+		target := filepath.Join(destination, relative)
+		info, err := entry.Info()
+		if err != nil {
+			return fmt.Errorf("inspect preserved tree entry: %w", err)
+		}
+		if entry.IsDir() {
+			if err := os.MkdirAll(target, info.Mode().Perm()); err != nil {
+				return fmt.Errorf("create preserved directory: %w", err)
+			}
+			return nil
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to preserve symlink %s", path)
+		}
+		return copyFile(path, target)
+	})
+	if err != nil {
+		return fmt.Errorf("copy preserved tree: %w", err)
+	}
+	return nil
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -61,7 +61,26 @@ var (
 	staleStateArtifactName   = regexp.MustCompile(`^\.proto-fleet-upgrade-[a-f0-9]{64}\.(?:tar\.gz|sha256|updater)$`)
 	staleStagingArtifactName = regexp.MustCompile(`^\.proto-fleet-upgrade-[a-f0-9]{64}$`)
 	operationLogNamePattern  = regexp.MustCompile(`^\.proto-fleet-upgrade-[a-f0-9]{64}\.log$`)
+	errTriggerBusy           = errors.New("updater is busy")
+	errTriggerClosing        = errors.New("updater is shutting down")
 )
+
+type classifiedTriggerError struct {
+	kind    error
+	message string
+}
+
+func (e *classifiedTriggerError) Error() string {
+	return e.message
+}
+
+func (e *classifiedTriggerError) Unwrap() error {
+	return e.kind
+}
+
+func newTriggerError(kind error, message string) error {
+	return &classifiedTriggerError{kind: kind, message: message}
+}
 
 var releaseImageRepositories = [...]string{
 	"proto-fleet-api",
@@ -126,6 +145,9 @@ type Config struct {
 	// Tests pause staged-tree durability to exercise shutdown and deadline
 	// behavior before the non-cancelable activation boundary.
 	syncStagedDeployment func(context.Context, string) error
+	// Tests observe ownership restoration ordering around preflight-generated
+	// artifacts without requiring the test process to run as root.
+	preserveDeploymentOwnership func(context.Context, string, string) error
 }
 
 type activationMarker struct {
@@ -569,6 +591,9 @@ func NewManager(cfg Config) (*Manager, error) {
 	if cfg.syncStagedDeployment == nil {
 		cfg.syncStagedDeployment = syncStagedDeployment
 	}
+	if cfg.preserveDeploymentOwnership == nil {
+		cfg.preserveDeploymentOwnership = preserveDeploymentOwnership
+	}
 	if cfg.PreflightTimeout < 0 || cfg.ActivationTimeout < 0 || cfg.CleanupTimeout < 0 {
 		return nil, fmt.Errorf("updater phase timeouts must be positive")
 	}
@@ -767,9 +792,12 @@ func (m *Manager) Trigger(targetVersion string) (updaterapi.Operation, error) {
 		return updaterapi.Operation{}, fmt.Errorf("inspect pending activation recovery: %w", err)
 	}
 	if marker != nil {
-		return updaterapi.Operation{}, fmt.Errorf(
-			"activation recovery for operation %s is pending; restart the updater after completing recovery",
-			marker.OperationID,
+		return updaterapi.Operation{}, newTriggerError(
+			errTriggerBusy,
+			fmt.Sprintf(
+				"activation recovery for operation %s is pending; restart the updater after completing recovery",
+				marker.OperationID,
+			),
 		)
 	}
 	currentVersion, err := readInstalledVersion(filepath.Join(m.cfg.InstallRoot, "deployment", "version.txt"))
@@ -786,13 +814,19 @@ func (m *Manager) Trigger(targetVersion string) (updaterapi.Operation, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.closing {
-		return updaterapi.Operation{}, fmt.Errorf("updater is shutting down")
+		return updaterapi.Operation{}, errTriggerClosing
 	}
 	if m.operation != nil && !m.operation.Phase.Terminal() {
-		return updaterapi.Operation{}, fmt.Errorf("an upgrade to %s is already in progress", m.operation.TargetVersion)
+		return updaterapi.Operation{}, newTriggerError(
+			errTriggerBusy,
+			fmt.Sprintf("an upgrade to %s is already in progress", m.operation.TargetVersion),
+		)
 	}
 	if m.operationRunning {
-		return updaterapi.Operation{}, fmt.Errorf("the previous upgrade is still completing cleanup")
+		return updaterapi.Operation{}, newTriggerError(
+			errTriggerBusy,
+			"the previous upgrade is still completing cleanup",
+		)
 	}
 	if err := m.cleanupStaleArtifacts(); err != nil {
 		return updaterapi.Operation{}, fmt.Errorf("clean stale upgrade artifacts: %w", err)
@@ -975,10 +1009,6 @@ func (m *Manager) run(ctx context.Context, operationID, targetVersion string) {
 		m.fail(operationID, fmt.Errorf("preserve deployment configuration: %w", err), recovery)
 		return
 	}
-	if err := preserveDeploymentOwnership(ctx, currentDeployment, stageDeployment); err != nil {
-		m.fail(operationID, fmt.Errorf("preserve deployment ownership: %w", err), recovery)
-		return
-	}
 
 	if err := m.advance(operationID, updaterapi.PhasePreflight, "Building and validating the new stack while Fleet stays online"); err != nil {
 		m.fail(operationID, fmt.Errorf("persist preflight phase: %w", err), recovery)
@@ -989,6 +1019,14 @@ func (m *Manager) run(ctx context.Context, operationID, targetVersion string) {
 			m.removeFailedPreflightImages(ctx, stageDeployment, commandOutput, logFile, targetVersion)
 		}
 		m.fail(operationID, fmt.Errorf("upgrade preflight failed: %w", err), recovery)
+		return
+	}
+	// Preflight runs as the root updater and creates the proof consumed by
+	// --skip-build. Restore the deployment owner after preflight so that proof,
+	// along with any other generated state, remains usable by the supported
+	// non-root deployment owner during manual recovery.
+	if err := m.cfg.preserveDeploymentOwnership(ctx, currentDeployment, stageDeployment); err != nil {
+		m.fail(operationID, fmt.Errorf("preserve deployment ownership: %w", err), recovery)
 		return
 	}
 	if err := m.advance(operationID, updaterapi.PhasePreflight, "Persisting the staged release before activation"); err != nil {
@@ -2232,14 +2270,28 @@ func preserveDeploymentOwnership(ctx context.Context, current, staged string) er
 	if !ok {
 		return fmt.Errorf("read deployment owner")
 	}
-	err = filepath.WalkDir(staged, func(path string, _ os.DirEntry, walkErr error) error {
+	return setDeploymentTreeOwnership(ctx, staged, int(stat.Uid), int(stat.Gid))
+}
+
+func setDeploymentTreeOwnership(ctx context.Context, staged string, uid, gid int) error {
+	err := filepath.WalkDir(staged, func(path string, _ os.DirEntry, walkErr error) error {
 		if err := ctx.Err(); err != nil {
 			return fmt.Errorf("preserve staged deployment ownership: %w", err)
 		}
 		if walkErr != nil {
 			return fmt.Errorf("walk staged deployment: %w", walkErr)
 		}
-		if err := os.Chown(path, int(stat.Uid), int(stat.Gid)); err != nil {
+		info, err := os.Lstat(path)
+		if err != nil {
+			return fmt.Errorf("inspect staged deployment entry: %w", err)
+		}
+		if !info.IsDir() && !info.Mode().IsRegular() {
+			return fmt.Errorf("refusing to preserve ownership of non-regular staged entry %s", path)
+		}
+		// Lchown keeps the walk fail-safe if an entry changes after Lstat: a
+		// replacement symlink itself may be re-owned, but its target is never
+		// followed outside the root-private staging tree.
+		if err := os.Lchown(path, uid, gid); err != nil {
 			return fmt.Errorf("set staged deployment owner: %w", err)
 		}
 		return nil

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -123,6 +123,9 @@ type Config struct {
 	// Tests inject deterministic state-write failures without weakening the
 	// production state-directory trust boundary.
 	beforePersistState func(updaterapi.Operation) error
+	// Tests pause staged-tree durability to exercise shutdown and deadline
+	// behavior before the non-cancelable activation boundary.
+	syncStagedDeployment func(context.Context, string) error
 }
 
 type activationMarker struct {
@@ -332,18 +335,10 @@ func ensureTrustedSelfUpdatePath(selfUpdatePath string) (string, error) {
 	if err := validateSelfUpdateExecutable(selfUpdatePath, configuredInfo); err != nil {
 		return "", err
 	}
-	configuredParent := filepath.Dir(selfUpdatePath)
-	if err := validateTrustedDirectoryChain(configuredParent, "self-update path", "", false, validateDaemonPathOwner); err != nil {
-		return "", err
-	}
-	canonicalParent, err := filepath.EvalSymlinks(configuredParent)
+	canonicalPath, err := ensureTrustedSelfUpdateLocation(selfUpdatePath)
 	if err != nil {
-		return "", fmt.Errorf("resolve self-update parent: %w", err)
-	}
-	if err := validateTrustedDirectoryChain(canonicalParent, "self-update path", "", false, validateDaemonPathOwner); err != nil {
 		return "", err
 	}
-	canonicalPath := filepath.Join(canonicalParent, filepath.Base(selfUpdatePath))
 	canonicalInfo, err := os.Lstat(canonicalPath)
 	if err != nil {
 		return "", fmt.Errorf("inspect canonical self-update path: %w", err)
@@ -355,6 +350,26 @@ func ensureTrustedSelfUpdatePath(selfUpdatePath string) (string, error) {
 		return "", fmt.Errorf("self-update path changed while it was validated")
 	}
 	return canonicalPath, nil
+}
+
+// ensureTrustedSelfUpdateLocation validates and canonicalizes the protected
+// parent chain without requiring the final executable entry to exist. Durable
+// handoff recovery uses this narrower primitive to restore a missing entry;
+// ordinary startup still uses ensureTrustedSelfUpdatePath above.
+func ensureTrustedSelfUpdateLocation(selfUpdatePath string) (string, error) {
+	selfUpdatePath = filepath.Clean(selfUpdatePath)
+	configuredParent := filepath.Dir(selfUpdatePath)
+	if err := validateTrustedDirectoryChain(configuredParent, "self-update path", "", false, validateDaemonPathOwner); err != nil {
+		return "", err
+	}
+	canonicalParent, err := filepath.EvalSymlinks(configuredParent)
+	if err != nil {
+		return "", fmt.Errorf("resolve self-update parent: %w", err)
+	}
+	if err := validateTrustedDirectoryChain(canonicalParent, "self-update path", "", false, validateDaemonPathOwner); err != nil {
+		return "", err
+	}
+	return filepath.Join(canonicalParent, filepath.Base(selfUpdatePath)), nil
 }
 
 func validateTrustedDirectoryChain(
@@ -551,6 +566,9 @@ func NewManager(cfg Config) (*Manager, error) {
 	if cfg.CleanupTimeout == 0 {
 		cfg.CleanupTimeout = defaultCleanupTimeout
 	}
+	if cfg.syncStagedDeployment == nil {
+		cfg.syncStagedDeployment = syncStagedDeployment
+	}
 	if cfg.PreflightTimeout < 0 || cfg.ActivationTimeout < 0 || cfg.CleanupTimeout < 0 {
 		return nil, fmt.Errorf("updater phase timeouts must be positive")
 	}
@@ -628,22 +646,7 @@ func (m *Manager) RollbackSelfUpdate() error {
 	if m.cfg.SelfUpdatePath == "" {
 		return fmt.Errorf("self-update path is not configured")
 	}
-	return restorePreviousExecutable(m.cfg.SelfUpdatePath)
-}
-
-// RollbackSelfUpdateExecutable validates the installed executable trust chain
-// before restoring its retained sibling backup. The command uses this during
-// the replacement process's one-shot startup window, including failures that
-// happen before a Manager can be constructed.
-func RollbackSelfUpdateExecutable(selfUpdatePath string) error {
-	if selfUpdatePath == "" {
-		return fmt.Errorf("self-update path is not configured")
-	}
-	canonicalPath, err := ensureTrustedSelfUpdatePath(selfUpdatePath)
-	if err != nil {
-		return fmt.Errorf("validate self-update rollback path: %w", err)
-	}
-	return restorePreviousExecutable(canonicalPath)
+	return rollbackPendingSelfUpdate(m.cfg.SelfUpdatePath)
 }
 
 // Shutdown rejects future triggers, cancels work that has not crossed the
@@ -988,6 +991,20 @@ func (m *Manager) run(ctx context.Context, operationID, targetVersion string) {
 		m.fail(operationID, fmt.Errorf("upgrade preflight failed: %w", err), recovery)
 		return
 	}
+	if err := m.advance(operationID, updaterapi.PhasePreflight, "Persisting the staged release before activation"); err != nil {
+		m.fail(operationID, fmt.Errorf("persist staged-release durability phase: %w", err), recovery)
+		return
+	}
+	syncCtx, cancelSync := context.WithTimeout(ctx, m.cfg.ActivationTimeout)
+	syncErr := m.cfg.syncStagedDeployment(syncCtx, stageDeployment)
+	if syncErr == nil {
+		syncErr = syncCtx.Err()
+	}
+	cancelSync()
+	if syncErr != nil {
+		m.fail(operationID, fmt.Errorf("persist staged deployment before activation: %w", syncErr), recovery)
+		return
+	}
 
 	if err := m.beginActivation(operationID, "Restarting Fleet; the client may disconnect for several minutes"); err != nil {
 		m.fail(operationID, fmt.Errorf("persist activation phase: %w", err), recovery)
@@ -1172,7 +1189,7 @@ func (m *Manager) failActivation(
 	m.fail(operationID, activationErr, layout.RecoveryCommand)
 }
 
-// activateDeployment makes the extracted release durable before entering the
+// activateDeployment swaps an already-durable staged release through the
 // two-rename activation window. The two renames cannot be committed as one
 // portable filesystem operation, so every completed metadata step is fsynced
 // and every pre-command failure attempts a checked restoration. Startup
@@ -1180,9 +1197,6 @@ func (m *Manager) failActivation(
 func activateDeployment(staged, current, previous string) error {
 	installRoot := filepath.Dir(current)
 	stageRoot := filepath.Dir(staged)
-	if err := syncTree(staged); err != nil {
-		return fmt.Errorf("sync staged deployment before activation: %w", err)
-	}
 	if err := os.RemoveAll(previous); err != nil {
 		return fmt.Errorf("remove previous deployment backup: %w", err)
 	}
@@ -1239,9 +1253,12 @@ func rollbackPreparedDeployment(current, staged, previous, installRoot, stageRoo
 	return nil
 }
 
-func syncTree(root string) error {
+func syncTree(ctx context.Context, root string) error {
 	var directories []string
 	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("cancel staged-tree sync: %w", err)
+		}
 		if walkErr != nil {
 			return fmt.Errorf("walk tree for sync: %w", walkErr)
 		}
@@ -1272,15 +1289,37 @@ func syncTree(root string) error {
 			}
 			return errors.Join(fileErrs...)
 		}
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("cancel staged-tree sync: %w", err)
+		}
 		return nil
 	})
 	if err != nil {
 		return fmt.Errorf("sync staged tree: %w", err)
 	}
 	for i := len(directories) - 1; i >= 0; i-- {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("sync staged tree: %w", err)
+		}
 		if err := syncDirectory(directories[i]); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+func syncStagedDeployment(ctx context.Context, staged string) error {
+	if err := syncTree(ctx, staged); err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("cancel staged deployment sync: %w", err)
+	}
+	if err := syncDirectory(filepath.Dir(staged)); err != nil {
+		return fmt.Errorf("sync staging parent directory: %w", err)
+	}
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("cancel staged deployment sync: %w", err)
 	}
 	return nil
 }
@@ -2398,16 +2437,40 @@ func installExecutableCandidate(candidatePath, destination string) error {
 			cleanupErr,
 		)
 	}
+	// The durable marker is installed after the previous executable is safely
+	// retained but before the candidate can replace the supervised path. It is
+	// the only cross-process authority to restore that backup.
+	if err := writeSelfUpdateHandoffMarker(destination); err != nil {
+		cleanupErr := cleanupFailedSelfUpdatePreparation(destination)
+		return errors.Join(fmt.Errorf("prepare updater startup handoff: %w", err), cleanupErr)
+	}
 	if err := os.Rename(candidatePath, destination); err != nil {
-		cleanupErr := os.Remove(backupPath)
-		if cleanupErr == nil {
-			cleanupErr = syncDirectory(parent)
-		}
-		return errors.Join(fmt.Errorf("replace updater executable: %w", err), cleanupErr)
+		return errors.Join(
+			fmt.Errorf("replace updater executable: %w", err),
+			rollbackPendingSelfUpdate(destination),
+		)
 	}
 	if err := syncDirectory(parent); err != nil {
-		restoreErr := restorePreviousExecutable(destination)
+		restoreErr := rollbackPendingSelfUpdate(destination)
 		return errors.Join(fmt.Errorf("persist updater executable replacement: %w", err), restoreErr)
+	}
+	return nil
+}
+
+func cleanupFailedSelfUpdatePreparation(destination string) error {
+	_, markerExists, err := readSelfUpdateHandoffMarker(destination)
+	if err != nil {
+		return err
+	}
+	if markerExists {
+		return rollbackPendingSelfUpdate(destination)
+	}
+	removed, err := unlinkExecutableSlot(destination + selfUpdateBackupSuffix)
+	if err != nil {
+		return err
+	}
+	if removed {
+		return syncDirectory(filepath.Dir(destination))
 	}
 	return nil
 }
@@ -2421,15 +2484,35 @@ func restorePreviousExecutable(destination string) error {
 	if !backupInfo.Mode().IsRegular() || backupInfo.Mode().Perm()&0o111 == 0 || backupInfo.Size() == 0 {
 		return fmt.Errorf("previous updater backup is not a non-empty executable")
 	}
-	if destinationInfo, err := os.Lstat(destination); err == nil && destinationInfo.IsDir() {
-		return fmt.Errorf("refusing to replace updater destination directory")
-	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+	destinationInfo, err := os.Lstat(destination)
+	if err == nil {
+		if !destinationInfo.Mode().IsRegular() {
+			return fmt.Errorf("refusing to replace non-regular updater destination")
+		}
+		if os.SameFile(destinationInfo, backupInfo) {
+			return nil
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("inspect updater destination before restoration: %w", err)
 	}
-	if err := os.Rename(backupPath, destination); err != nil {
+
+	parent := filepath.Dir(destination)
+	restorePath := destination + selfUpdateRestoreTempSuffix
+	if removed, err := unlinkExecutableSlot(restorePath); err != nil {
+		return fmt.Errorf("clean stale updater restoration link: %w", err)
+	} else if removed {
+		if err := syncDirectory(parent); err != nil {
+			return fmt.Errorf("persist stale updater restoration cleanup: %w", err)
+		}
+	}
+	if err := os.Link(backupPath, restorePath); err != nil {
+		return fmt.Errorf("prepare previous updater restoration: %w", err)
+	}
+	defer os.Remove(restorePath)
+	if err := os.Rename(restorePath, destination); err != nil {
 		return fmt.Errorf("restore previous updater executable: %w", err)
 	}
-	if err := syncDirectory(filepath.Dir(destination)); err != nil {
+	if err := syncDirectory(parent); err != nil {
 		return fmt.Errorf("persist previous updater executable restoration: %w", err)
 	}
 	return nil

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -69,6 +69,8 @@ var (
 	staleStateArtifactName   = regexp.MustCompile(`^\.proto-fleet-upgrade-[a-f0-9]{64}\.(?:tar\.gz|sha256|updater)$`)
 	staleStagingArtifactName = regexp.MustCompile(`^\.proto-fleet-upgrade-[a-f0-9]{64}$`)
 	operationLogNamePattern  = regexp.MustCompile(`^\.proto-fleet-upgrade-[a-f0-9]{64}\.log$`)
+	errTriggerInvalid        = errors.New("invalid updater trigger")
+	errTriggerPrecondition   = errors.New("updater trigger precondition failed")
 	errTriggerBusy           = errors.New("updater is busy")
 	errTriggerClosing        = errors.New("updater is shutting down")
 )
@@ -793,8 +795,56 @@ func (m *Manager) Status() updaterapi.StatusResponse {
 
 func (m *Manager) Trigger(targetVersion string) (updaterapi.Operation, error) {
 	if !canonicalRelease.MatchString(targetVersion) || !semver.IsValid(targetVersion) {
-		return updaterapi.Operation{}, fmt.Errorf("target version must be a stable or RC release tag")
+		return updaterapi.Operation{}, newTriggerError(
+			errTriggerInvalid,
+			"target version must be a stable or RC release tag",
+		)
 	}
+	if m.cfg.NewID == nil {
+		return updaterapi.Operation{}, fmt.Errorf("generate updater operation id: generator is not configured")
+	}
+	return m.trigger(targetVersion, m.cfg.NewID(), false)
+}
+
+// TriggerWithID accepts a caller-generated UUID so a client that loses the
+// HTTP response can reconcile the durable operation through Status without
+// guessing by target or time. Reusing the ID for the same target is
+// idempotent; reusing it for another target is rejected.
+func (m *Manager) TriggerWithID(targetVersion, operationID string) (updaterapi.Operation, error) {
+	parsedID, err := uuid.Parse(operationID)
+	if err != nil || parsedID.String() != operationID {
+		return updaterapi.Operation{}, newTriggerError(errTriggerInvalid, "operation id must be a canonical UUID")
+	}
+	return m.trigger(targetVersion, operationID, true)
+}
+
+func (m *Manager) trigger(targetVersion, operationID string, idempotent bool) (updaterapi.Operation, error) {
+	if operationID == "" {
+		return updaterapi.Operation{}, fmt.Errorf("generate updater operation id: empty value")
+	}
+	if !canonicalRelease.MatchString(targetVersion) || !semver.IsValid(targetVersion) {
+		return updaterapi.Operation{}, newTriggerError(
+			errTriggerInvalid,
+			"target version must be a stable or RC release tag",
+		)
+	}
+	// Check before host-state validation so a retry can recover the original
+	// response even after that operation has completed and changed the
+	// installed version. The write-locked check below closes the race with a
+	// first request that is still being admitted.
+	m.mu.RLock()
+	if idempotent && m.operation != nil && m.operation.ID == operationID {
+		existing := *m.operation
+		m.mu.RUnlock()
+		if existing.TargetVersion != targetVersion {
+			return updaterapi.Operation{}, newTriggerError(
+				errTriggerInvalid,
+				"operation id is already associated with another target",
+			)
+		}
+		return existing, nil
+	}
+	m.mu.RUnlock()
 	marker, err := m.readActivationMarker()
 	if err != nil {
 		return updaterapi.Operation{}, fmt.Errorf("inspect pending activation recovery: %w", err)
@@ -813,14 +863,29 @@ func (m *Manager) Trigger(targetVersion string) (updaterapi.Operation, error) {
 		return updaterapi.Operation{}, err
 	}
 	if !semver.IsValid(currentVersion) {
-		return updaterapi.Operation{}, fmt.Errorf("installed version %q is not upgradeable", currentVersion)
+		return updaterapi.Operation{}, newTriggerError(
+			errTriggerPrecondition,
+			fmt.Sprintf("installed version %q is not upgradeable", currentVersion),
+		)
 	}
 	if semver.Compare(targetVersion, currentVersion) <= 0 {
-		return updaterapi.Operation{}, fmt.Errorf("target version %s must be newer than installed version %s", targetVersion, currentVersion)
+		return updaterapi.Operation{}, newTriggerError(
+			errTriggerPrecondition,
+			fmt.Sprintf("target version %s must be newer than installed version %s", targetVersion, currentVersion),
+		)
 	}
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if idempotent && m.operation != nil && m.operation.ID == operationID {
+		if m.operation.TargetVersion != targetVersion {
+			return updaterapi.Operation{}, newTriggerError(
+				errTriggerInvalid,
+				"operation id is already associated with another target",
+			)
+		}
+		return *m.operation, nil
+	}
 	if m.closing {
 		return updaterapi.Operation{}, errTriggerClosing
 	}
@@ -848,7 +913,7 @@ func (m *Manager) Trigger(targetVersion string) (updaterapi.Operation, error) {
 	}
 	now := m.cfg.Now().UTC()
 	op := &updaterapi.Operation{
-		ID:            m.cfg.NewID(),
+		ID:            operationID,
 		TargetVersion: targetVersion,
 		Phase:         updaterapi.PhaseQueued,
 		Message:       "Upgrade queued",

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -1453,6 +1453,7 @@ func (m *Manager) fail(id string, err error, recovery string) {
 	if m.operation == nil || m.operation.ID != id {
 		return
 	}
+	previous := *m.operation
 	now := m.cfg.Now().UTC()
 	m.operation.Phase = updaterapi.PhaseFailed
 	m.operation.Message = "Upgrade failed"
@@ -1461,7 +1462,11 @@ func (m *Manager) fail(id string, err error, recovery string) {
 	m.operation.UpdatedAt = now
 	m.operation.CompletedAt = &now
 	if persistErr := m.persistLocked(); persistErr != nil {
-		log.Printf("persist failed upgrade state: %v", persistErr)
+		// Keep the last durable non-terminal state visible in memory so Trigger
+		// cannot replace its recovery context. Startup reconciliation will turn
+		// that durable state into a terminal failure once persistence recovers.
+		*m.operation = previous
+		log.Printf("upgrade failed (%v), but its terminal state was not persisted; further upgrades remain blocked until startup reconciliation: %v", err, persistErr)
 	}
 }
 

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -205,7 +205,7 @@ func (m *Manager) run(operationID, targetVersion string) {
 	defer logFile.Close()
 
 	ctx := context.Background()
-	recovery := fmt.Sprintf("cd %s && ./run-fleet.sh --non-interactive --skip-build", shellQuote(filepath.Join(m.cfg.InstallRoot, "deployment")))
+	recovery := activationRecoveryCommand(filepath.Join(m.cfg.InstallRoot, "deployment"))
 	if err := m.setLogPath(operationID, logPath, recovery); err != nil {
 		m.fail(operationID, fmt.Errorf("persist upgrade log location: %w", err), recovery)
 		return
@@ -328,18 +328,8 @@ func (m *Manager) run(operationID, targetVersion string) {
 		return
 	}
 	backupDeployment := filepath.Join(m.cfg.InstallRoot, "deployment.previous")
-	if err := os.RemoveAll(backupDeployment); err != nil {
-		m.fail(operationID, fmt.Errorf("remove previous deployment backup: %w", err), recovery)
-		return
-	}
-	if err := os.Rename(currentDeployment, backupDeployment); err != nil {
-		m.fail(operationID, fmt.Errorf("back up current deployment: %w", err), recovery)
-		return
-	}
-	if err := os.Rename(stageDeployment, currentDeployment); err != nil {
-		// This is still pre-teardown and therefore safe to restore.
-		_ = os.Rename(backupDeployment, currentDeployment)
-		m.fail(operationID, fmt.Errorf("activate staged deployment: %w", err), recovery)
+	if err := activateDeployment(stageDeployment, currentDeployment, backupDeployment); err != nil {
+		m.fail(operationID, err, recovery)
 		return
 	}
 
@@ -363,6 +353,119 @@ func (m *Manager) run(operationID, targetVersion string) {
 		log.Printf("persist successful upgrade state: %v", err)
 	}
 	_, _ = fmt.Fprintf(logFile, "[%s] upgrade completed\n", m.cfg.Now().UTC().Format(time.RFC3339))
+}
+
+// activateDeployment makes the extracted release durable before entering the
+// two-rename activation window. The two renames cannot be committed as one
+// portable filesystem operation, so every completed metadata step is fsynced
+// and every pre-command failure attempts a checked restoration. Startup
+// reconciliation covers a process or power loss between the renames.
+func activateDeployment(staged, current, previous string) error {
+	installRoot := filepath.Dir(current)
+	stageRoot := filepath.Dir(staged)
+	if err := syncTree(staged); err != nil {
+		return fmt.Errorf("sync staged deployment before activation: %w", err)
+	}
+	if err := os.RemoveAll(previous); err != nil {
+		return fmt.Errorf("remove previous deployment backup: %w", err)
+	}
+	if err := syncDirectory(installRoot); err != nil {
+		return fmt.Errorf("persist previous deployment backup removal: %w", err)
+	}
+	if err := os.Rename(current, previous); err != nil {
+		return fmt.Errorf("back up current deployment: %w", err)
+	}
+	if err := syncDirectory(installRoot); err != nil {
+		restoreErr := restorePreviousDeployment(current, previous, installRoot)
+		return errors.Join(
+			fmt.Errorf("persist current deployment backup: %w", err),
+			restoreErr,
+		)
+	}
+	if err := os.Rename(staged, current); err != nil {
+		restoreErr := restorePreviousDeployment(current, previous, installRoot)
+		return errors.Join(
+			fmt.Errorf("activate staged deployment: %w", err),
+			restoreErr,
+		)
+	}
+	if err := errors.Join(syncDirectory(stageRoot), syncDirectory(installRoot)); err != nil {
+		restoreErr := rollbackPreparedDeployment(current, staged, previous, installRoot, stageRoot)
+		return errors.Join(
+			fmt.Errorf("persist activated deployment swap: %w", err),
+			restoreErr,
+		)
+	}
+	return nil
+}
+
+func restorePreviousDeployment(current, previous, installRoot string) error {
+	if err := os.Rename(previous, current); err != nil {
+		return fmt.Errorf("restore previous deployment: %w", err)
+	}
+	if err := syncDirectory(installRoot); err != nil {
+		return fmt.Errorf("persist restored previous deployment: %w", err)
+	}
+	return nil
+}
+
+func rollbackPreparedDeployment(current, staged, previous, installRoot, stageRoot string) error {
+	if err := os.Rename(current, staged); err != nil {
+		return fmt.Errorf("move uncommitted deployment back to staging: %w", err)
+	}
+	if err := os.Rename(previous, current); err != nil {
+		return fmt.Errorf("restore previous deployment after durability failure: %w", err)
+	}
+	if err := errors.Join(syncDirectory(stageRoot), syncDirectory(installRoot)); err != nil {
+		return fmt.Errorf("persist deployment restoration: %w", err)
+	}
+	return nil
+}
+
+func syncTree(root string) error {
+	var directories []string
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return fmt.Errorf("walk tree for sync: %w", walkErr)
+		}
+		if entry.IsDir() {
+			directories = append(directories, path)
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return fmt.Errorf("inspect tree entry for sync: %w", err)
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("refusing to sync non-regular staged entry %s", path)
+		}
+		file, err := os.Open(path)
+		if err != nil {
+			return fmt.Errorf("open staged file for sync: %w", err)
+		}
+		syncErr := file.Sync()
+		closeErr := file.Close()
+		if syncErr != nil || closeErr != nil {
+			var fileErrs []error
+			if syncErr != nil {
+				fileErrs = append(fileErrs, fmt.Errorf("sync staged file %s: %w", path, syncErr))
+			}
+			if closeErr != nil {
+				fileErrs = append(fileErrs, fmt.Errorf("close staged file %s: %w", path, closeErr))
+			}
+			return errors.Join(fileErrs...)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	for i := len(directories) - 1; i >= 0; i-- {
+		if err := syncDirectory(directories[i]); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // removeFailedPreflightImages releases only the immutable target tags from a
@@ -484,15 +587,78 @@ func (m *Manager) loadState() error {
 		return fmt.Errorf("decode updater state: %w", err)
 	}
 	if !op.Phase.Terminal() {
+		restoredPrevious, err := m.reconcileInterruptedActivation(&op)
+		if err != nil {
+			return err
+		}
 		now := m.cfg.Now().UTC()
 		op.Phase = updaterapi.PhaseFailed
-		op.Message = "Upgrade interrupted"
-		op.Error = "The updater restarted before the operation completed; inspect the host log before retrying."
+		if restoredPrevious {
+			op.Message = "Upgrade interrupted; previous deployment restored"
+			op.Error = "The updater restarted during the activation swap before Fleet was stopped. The previous deployment was restored safely."
+		} else {
+			op.Message = "Upgrade interrupted"
+			op.Error = "The updater restarted before the operation completed; inspect the host log and recovery details before retrying."
+		}
 		op.UpdatedAt = now
 		op.CompletedAt = &now
 	}
 	m.operation = &op
 	return m.persistLocked()
+}
+
+// reconcileInterruptedActivation repairs only the crash-safe gap between the
+// two activation renames. If the forward deployment already exists, it is
+// never rolled back: run-fleet may have applied forward-only migrations before
+// the updater stopped. Recovery commands are derived from the current on-disk
+// preflight proof rather than trusting a command persisted before the swap.
+func (m *Manager) reconcileInterruptedActivation(op *updaterapi.Operation) (bool, error) {
+	if op.Phase != updaterapi.PhaseActivating {
+		op.RecoveryCommand = ""
+		return false, nil
+	}
+	current := filepath.Join(m.cfg.InstallRoot, "deployment")
+	previous := filepath.Join(m.cfg.InstallRoot, "deployment.previous")
+	currentInfo, err := os.Lstat(current)
+	if err == nil {
+		if !currentInfo.IsDir() {
+			return false, fmt.Errorf("reconcile interrupted activation: active deployment is not a directory")
+		}
+		op.RecoveryCommand = ""
+		version, versionErr := readInstalledVersion(filepath.Join(current, "version.txt"))
+		if versionErr == nil && version == op.TargetVersion {
+			if markerInfo, markerErr := os.Lstat(filepath.Join(current, ".update-preflight-complete")); markerErr == nil && markerInfo.Mode().IsRegular() {
+				op.RecoveryCommand = activationRecoveryCommand(current)
+			} else if markerErr != nil && !errors.Is(markerErr, os.ErrNotExist) {
+				return false, fmt.Errorf("inspect interrupted activation preflight proof: %w", markerErr)
+			}
+		}
+		return false, nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return false, fmt.Errorf("inspect interrupted active deployment: %w", err)
+	}
+	previousInfo, err := os.Lstat(previous)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, fmt.Errorf("reconcile interrupted activation: both deployment and deployment.previous are missing")
+		}
+		return false, fmt.Errorf("inspect previous deployment for interrupted activation: %w", err)
+	}
+	if !previousInfo.IsDir() {
+		return false, fmt.Errorf("reconcile interrupted activation: deployment.previous is not a directory")
+	}
+	if _, err := readInstalledVersion(filepath.Join(previous, "version.txt")); err != nil {
+		return false, fmt.Errorf("validate previous deployment for interrupted activation: %w", err)
+	}
+	if err := os.Rename(previous, current); err != nil {
+		return false, fmt.Errorf("restore previous deployment after interrupted activation: %w", err)
+	}
+	if err := syncDirectory(m.cfg.InstallRoot); err != nil {
+		return false, fmt.Errorf("persist restored deployment after interrupted activation: %w", err)
+	}
+	op.RecoveryCommand = ""
+	return true, nil
 }
 
 func (m *Manager) persistLocked() error {
@@ -881,4 +1047,8 @@ func copyTree(source, destination string) error {
 
 func shellQuote(value string) string {
 	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}
+
+func activationRecoveryCommand(deploymentPath string) string {
+	return fmt.Sprintf("cd %s && ./run-fleet.sh --non-interactive --skip-build", shellQuote(deploymentPath))
 }

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -37,6 +37,7 @@ const (
 	maxArchiveEntries        = 100_000
 	defaultHTTPTimeout       = 30 * time.Minute
 	canonicalDownloadBaseURL = "https://github.com/block/proto-fleet/releases/download"
+	processLockFilename      = "updater.lock"
 )
 
 var canonicalRelease = regexp.MustCompile(`^v\d+\.\d+\.\d+(?:-rc\.\d+)?$`)
@@ -85,8 +86,11 @@ type Config struct {
 type Manager struct {
 	cfg Config
 
-	mu        sync.RWMutex
-	operation *updaterapi.Operation
+	mu          sync.RWMutex
+	operation   *updaterapi.Operation
+	processLock *os.File
+	closeOnce   sync.Once
+	closeErr    error
 }
 
 func NewManager(cfg Config) (*Manager, error) {
@@ -138,12 +142,86 @@ func NewManager(cfg Config) (*Manager, error) {
 	if err := os.MkdirAll(filepath.Join(cfg.StateDir, "logs"), 0o700); err != nil {
 		return nil, fmt.Errorf("create updater state directory: %w", err)
 	}
+	processLock, err := acquireProcessLock(cfg.StateDir)
+	if err != nil {
+		return nil, err
+	}
 
-	m := &Manager{cfg: cfg}
+	m := &Manager{cfg: cfg, processLock: processLock}
 	if err := m.loadState(); err != nil {
+		_ = processLock.Close()
 		return nil, err
 	}
 	return m, nil
+}
+
+// Close releases the daemon-lifetime process lock. Production calls this only
+// after the listener has stopped and any operation has finished; closing the
+// descriptor is sufficient because the lock file must never be unlinked while
+// another process could still hold a flock on its inode.
+func (m *Manager) Close() error {
+	m.closeOnce.Do(func() {
+		if m.processLock != nil {
+			m.closeErr = m.processLock.Close()
+		}
+	})
+	return m.closeErr
+}
+
+func acquireProcessLock(stateDir string) (*os.File, error) {
+	lockPath := filepath.Join(stateDir, processLockFilename)
+	fd, err := syscall.Open(
+		lockPath,
+		syscall.O_CREAT|syscall.O_RDWR|syscall.O_CLOEXEC|syscall.O_NOFOLLOW,
+		0o600,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("open updater process lock: %w", err)
+	}
+	lockFile := os.NewFile(uintptr(fd), lockPath)
+	if lockFile == nil {
+		_ = syscall.Close(fd)
+		return nil, fmt.Errorf("open updater process lock")
+	}
+	closeWithError := func(err error) (*os.File, error) {
+		_ = lockFile.Close()
+		return nil, err
+	}
+	info, err := lockFile.Stat()
+	if err != nil {
+		return closeWithError(fmt.Errorf("inspect updater process lock: %w", err))
+	}
+	if !info.Mode().IsRegular() {
+		return closeWithError(fmt.Errorf("updater process lock is not a regular file"))
+	}
+	if err := lockFile.Chmod(0o600); err != nil {
+		return closeWithError(fmt.Errorf("secure updater process lock: %w", err))
+	}
+	if err := syscall.Flock(fd, syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+			return closeWithError(fmt.Errorf("another updater process is already running"))
+		}
+		return closeWithError(fmt.Errorf("acquire updater process lock: %w", err))
+	}
+	// PID metadata is diagnostic only; the open-file-description lock is the
+	// authority. Failure to refresh the hint must not weaken serialization.
+	if err := writeProcessLockPID(lockFile); err != nil {
+		log.Printf("write updater process lock owner: %v", err)
+	}
+	return lockFile, nil
+}
+
+func writeProcessLockPID(lockFile *os.File) error {
+	if _, err := lockFile.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+	if err := lockFile.Truncate(0); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(lockFile, "%d\n", os.Getpid()); err != nil {
+		return err
+	}
+	return lockFile.Sync()
 }
 
 func (m *Manager) Status() updaterapi.StatusResponse {

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -33,13 +33,21 @@ import (
 )
 
 const (
-	stateFilename            = "state.json"
-	maxChecksumBytes         = 4096
-	maxDownloadBytes         = int64(1 << 30) // Larger bundles require an explicit updater contract change.
-	maxExtractedBytes        = int64(16 << 30)
-	maxArchiveEntries        = 100_000
-	defaultHTTPTimeout       = 30 * time.Minute
-	defaultPreflightTimeout  = 2 * time.Hour
+	stateFilename     = "state.json"
+	maxChecksumBytes  = 4096
+	maxDownloadBytes  = int64(1 << 30) // Larger bundles require an explicit updater contract change.
+	maxExtractedBytes = int64(16 << 30)
+	maxArchiveEntries = 10_000 // Larger bundles require an explicit packaging contract change.
+	// The request deadline still permits release downloads over slow mine-site
+	// links; shutdown cancellation interrupts it immediately before activation.
+	defaultHTTPTimeout = 30 * time.Minute
+	// Fleet remains online while preflight pulls, loads, and builds images on
+	// supported ARM and SD-card-class hosts, so false timeouts cost more than
+	// the generous cancellable bound.
+	defaultPreflightTimeout = 2 * time.Hour
+	// Activation includes migrations and multiple readiness windows after the
+	// old stack is stopped. Timing out requires forward manual recovery, making
+	// this a minimum liveness bound rather than spare retry time.
 	defaultActivationTimeout = 45 * time.Minute
 	defaultCleanupTimeout    = 2 * time.Minute
 	defaultCandidateTimeout  = 10 * time.Second

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -36,6 +36,10 @@ const (
 	maxExtractedBytes        = int64(16 << 30)
 	maxArchiveEntries        = 100_000
 	defaultHTTPTimeout       = 30 * time.Minute
+	defaultPreflightTimeout  = 2 * time.Hour
+	defaultActivationTimeout = 45 * time.Minute
+	defaultCleanupTimeout    = 2 * time.Minute
+	maxCommandLogBytes       = int64(64 << 20)
 	canonicalDownloadBaseURL = "https://github.com/block/proto-fleet/releases/download"
 	processLockFilename      = "updater.lock"
 )
@@ -61,6 +65,21 @@ func (execRunner) Run(ctx context.Context, dir string, output io.Writer, name st
 	cmd.Stdout = output
 	cmd.Stderr = output
 	cmd.Env = append(os.Environ(), "CI=1", "TERM=dumb")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return os.ErrProcessDone
+		}
+		// Commands run in their own process group so a timed-out shell cannot
+		// leave Docker clients or other descendants running without supervision.
+		if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
+			if errors.Is(err, syscall.ESRCH) {
+				return os.ErrProcessDone
+			}
+			return fmt.Errorf("kill command process group: %w", err)
+		}
+		return nil
+	}
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("run %s: %w", name, err)
 	}
@@ -68,15 +87,18 @@ func (execRunner) Run(ctx context.Context, dir string, output io.Writer, name st
 }
 
 type Config struct {
-	InstallRoot     string
-	StateDir        string
-	DownloadBaseURL string
-	HTTPClient      *http.Client
-	Runner          CommandRunner
-	Now             func() time.Time
-	NewID           func() string
-	GOARCH          string
-	SelfUpdatePath  string
+	InstallRoot       string
+	StateDir          string
+	DownloadBaseURL   string
+	HTTPClient        *http.Client
+	Runner            CommandRunner
+	Now               func() time.Time
+	NewID             func() string
+	GOARCH            string
+	SelfUpdatePath    string
+	PreflightTimeout  time.Duration
+	ActivationTimeout time.Duration
+	CleanupTimeout    time.Duration
 
 	// Tests inject an httptest TLS endpoint without opening a production
 	// configuration path for alternate release mirrors.
@@ -86,11 +108,14 @@ type Config struct {
 type Manager struct {
 	cfg Config
 
-	mu          sync.RWMutex
-	operation   *updaterapi.Operation
-	processLock *os.File
-	closeOnce   sync.Once
-	closeErr    error
+	mu              sync.RWMutex
+	operation       *updaterapi.Operation
+	closing         bool
+	cancelOperation context.CancelFunc
+	operationWG     sync.WaitGroup
+	processLock     *os.File
+	closeOnce       sync.Once
+	closeErr        error
 }
 
 func NewManager(cfg Config) (*Manager, error) {
@@ -139,6 +164,18 @@ func NewManager(cfg Config) (*Manager, error) {
 	if cfg.GOARCH != "amd64" && cfg.GOARCH != "arm64" {
 		return nil, fmt.Errorf("unsupported architecture %q", cfg.GOARCH)
 	}
+	if cfg.PreflightTimeout == 0 {
+		cfg.PreflightTimeout = defaultPreflightTimeout
+	}
+	if cfg.ActivationTimeout == 0 {
+		cfg.ActivationTimeout = defaultActivationTimeout
+	}
+	if cfg.CleanupTimeout == 0 {
+		cfg.CleanupTimeout = defaultCleanupTimeout
+	}
+	if cfg.PreflightTimeout < 0 || cfg.ActivationTimeout < 0 || cfg.CleanupTimeout < 0 {
+		return nil, fmt.Errorf("updater phase timeouts must be positive")
+	}
 	if err := os.MkdirAll(filepath.Join(cfg.StateDir, "logs"), 0o700); err != nil {
 		return nil, fmt.Errorf("create updater state directory: %w", err)
 	}
@@ -147,7 +184,10 @@ func NewManager(cfg Config) (*Manager, error) {
 		return nil, err
 	}
 
-	m := &Manager{cfg: cfg, processLock: processLock}
+	m := &Manager{
+		cfg:         cfg,
+		processLock: processLock,
+	}
 	if err := m.loadState(); err != nil {
 		_ = processLock.Close()
 		return nil, err
@@ -155,17 +195,43 @@ func NewManager(cfg Config) (*Manager, error) {
 	return m, nil
 }
 
-// Close releases the daemon-lifetime process lock. Production calls this only
-// after the listener has stopped and any operation has finished; closing the
-// descriptor is sufficient because the lock file must never be unlinked while
-// another process could still hold a flock on its inode.
 func (m *Manager) Close() error {
-	m.closeOnce.Do(func() {
-		if m.processLock != nil {
-			m.closeErr = m.processLock.Close()
+	return m.Shutdown(context.Background())
+}
+
+// Shutdown rejects future triggers, cancels work that has not crossed the
+// activation boundary, waits for the operation to persist a terminal state,
+// and only then releases the daemon lock. An active forward migration is not
+// canceled; its own bounded activation deadline remains the safety limit.
+func (m *Manager) Shutdown(ctx context.Context) error {
+	m.mu.Lock()
+	m.closing = true
+	cancelOperation := m.operation == nil || m.operation.Phase != updaterapi.PhaseActivating
+	cancel := m.cancelOperation
+	m.mu.Unlock()
+	if cancelOperation && cancel != nil {
+		cancel()
+	}
+
+	done := make(chan struct{})
+	go func() {
+		m.operationWG.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		if cancel != nil {
+			cancel()
 		}
-	})
-	return m.closeErr
+		m.closeOnce.Do(func() {
+			if m.processLock != nil {
+				m.closeErr = m.processLock.Close()
+			}
+		})
+		return m.closeErr
+	case <-ctx.Done():
+		return fmt.Errorf("wait for updater operation shutdown: %w", ctx.Err())
+	}
 }
 
 func acquireProcessLock(stateDir string) (*os.File, error) {
@@ -213,15 +279,18 @@ func acquireProcessLock(stateDir string) (*os.File, error) {
 
 func writeProcessLockPID(lockFile *os.File) error {
 	if _, err := lockFile.Seek(0, io.SeekStart); err != nil {
-		return err
+		return fmt.Errorf("seek updater process lock: %w", err)
 	}
 	if err := lockFile.Truncate(0); err != nil {
-		return err
+		return fmt.Errorf("truncate updater process lock: %w", err)
 	}
 	if _, err := fmt.Fprintf(lockFile, "%d\n", os.Getpid()); err != nil {
-		return err
+		return fmt.Errorf("write updater process lock: %w", err)
 	}
-	return lockFile.Sync()
+	if err := lockFile.Sync(); err != nil {
+		return fmt.Errorf("sync updater process lock: %w", err)
+	}
+	return nil
 }
 
 func (m *Manager) Status() updaterapi.StatusResponse {
@@ -251,6 +320,9 @@ func (m *Manager) Trigger(targetVersion string) (updaterapi.Operation, error) {
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if m.closing {
+		return updaterapi.Operation{}, fmt.Errorf("updater is shutting down")
+	}
 	if m.operation != nil && !m.operation.Phase.Terminal() {
 		return updaterapi.Operation{}, fmt.Errorf("an upgrade to %s is already in progress", m.operation.TargetVersion)
 	}
@@ -269,11 +341,17 @@ func (m *Manager) Trigger(targetVersion string) (updaterapi.Operation, error) {
 		return updaterapi.Operation{}, err
 	}
 	operationCopy := *op
-	go m.run(operationCopy.ID, targetVersion)
+	operationCtx, cancelOperation := context.WithCancel(context.Background())
+	m.cancelOperation = cancelOperation
+	m.operationWG.Add(1)
+	go func() {
+		defer m.operationWG.Done()
+		m.run(operationCtx, operationCopy.ID, targetVersion)
+	}()
 	return operationCopy, nil
 }
 
-func (m *Manager) run(operationID, targetVersion string) {
+func (m *Manager) run(ctx context.Context, operationID, targetVersion string) {
 	logPath := filepath.Join(m.cfg.StateDir, "logs", operationID+".log")
 	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 	if err != nil {
@@ -281,9 +359,22 @@ func (m *Manager) run(operationID, targetVersion string) {
 		return
 	}
 	defer logFile.Close()
+	defer func() {
+		operation := m.Status().Operation
+		if operation == nil || operation.ID != operationID || !operation.Phase.Terminal() {
+			return
+		}
+		_, _ = fmt.Fprintf(
+			logFile,
+			"[%s] terminal phase=%s error=%q\n",
+			m.cfg.Now().UTC().Format(time.RFC3339),
+			operation.Phase,
+			operation.Error,
+		)
+	}()
+	commandOutput := newCappedWriter(logFile, maxCommandLogBytes)
 
-	ctx := context.Background()
-	recovery := activationRecoveryCommand(filepath.Join(m.cfg.InstallRoot, "deployment"))
+	recovery := ""
 	if err := m.setLogPath(operationID, logPath, recovery); err != nil {
 		m.fail(operationID, fmt.Errorf("persist upgrade log location: %w", err), recovery)
 		return
@@ -317,7 +408,7 @@ func (m *Manager) run(operationID, targetVersion string) {
 	// The fixed GitHub Releases origin is the publisher trust anchor. This
 	// sidecar detects transfer/storage corruption; it is not represented as an
 	// independent publisher signature.
-	if err := verifyChecksum(archivePath, checksumPath, archiveName); err != nil {
+	if err := verifyChecksum(ctx, archivePath, checksumPath, archiveName); err != nil {
 		m.fail(operationID, err, recovery)
 		return
 	}
@@ -350,6 +441,7 @@ func (m *Manager) run(operationID, targetVersion string) {
 		}()
 	}
 	if err := extractArchiveWithUpdaterCopy(
+		ctx,
 		archivePath,
 		stageRoot,
 		preparedUpdater,
@@ -382,11 +474,11 @@ func (m *Manager) run(operationID, targetVersion string) {
 		m.fail(operationID, err, recovery)
 		return
 	}
-	if err := preserveDeploymentState(currentDeployment, stageDeployment); err != nil {
+	if err := preserveDeploymentState(ctx, currentDeployment, stageDeployment); err != nil {
 		m.fail(operationID, fmt.Errorf("preserve deployment configuration: %w", err), recovery)
 		return
 	}
-	if err := preserveDeploymentOwnership(currentDeployment, stageDeployment); err != nil {
+	if err := preserveDeploymentOwnership(ctx, currentDeployment, stageDeployment); err != nil {
 		m.fail(operationID, fmt.Errorf("preserve deployment ownership: %w", err), recovery)
 		return
 	}
@@ -395,13 +487,15 @@ func (m *Manager) run(operationID, targetVersion string) {
 		m.fail(operationID, fmt.Errorf("persist preflight phase: %w", err), recovery)
 		return
 	}
-	if err := m.cfg.Runner.Run(ctx, stageDeployment, logFile, "/bin/bash", "./run-fleet.sh", "--non-interactive", "--preflight-only"); err != nil {
-		m.removeFailedPreflightImages(ctx, stageDeployment, logFile, targetVersion)
+	if err := m.runCommand(ctx, m.cfg.PreflightTimeout, stageDeployment, commandOutput, "/bin/bash", "./run-fleet.sh", "--non-interactive", "--preflight-only"); err != nil {
+		if ctx.Err() == nil {
+			m.removeFailedPreflightImages(ctx, stageDeployment, commandOutput, logFile, targetVersion)
+		}
 		m.fail(operationID, fmt.Errorf("upgrade preflight failed: %w", err), recovery)
 		return
 	}
 
-	if err := m.advance(operationID, updaterapi.PhaseActivating, "Restarting Fleet; the client may disconnect for several minutes"); err != nil {
+	if err := m.beginActivation(operationID, "Restarting Fleet; the client may disconnect for several minutes"); err != nil {
 		m.fail(operationID, fmt.Errorf("persist activation phase: %w", err), recovery)
 		return
 	}
@@ -410,8 +504,13 @@ func (m *Manager) run(operationID, targetVersion string) {
 		m.fail(operationID, err, recovery)
 		return
 	}
+	recovery = activationRecoveryCommand(currentDeployment)
+	if err := m.setRecoveryCommand(operationID, recovery); err != nil {
+		m.fail(operationID, fmt.Errorf("persist activation recovery command: %w", err), recovery)
+		return
+	}
 
-	if err := m.cfg.Runner.Run(ctx, currentDeployment, logFile, "/bin/bash", "./run-fleet.sh", "--non-interactive", "--skip-build"); err != nil {
+	if err := m.runCommand(ctx, m.cfg.ActivationTimeout, currentDeployment, commandOutput, "/bin/bash", "./run-fleet.sh", "--non-interactive", "--skip-build"); err != nil {
 		// run-fleet may have applied forward-only migrations before returning an
 		// error. Keep the new deployment active for forward recovery; restoring
 		// the previous binaries could make the schema and application incompatible.
@@ -536,7 +635,7 @@ func syncTree(root string) error {
 		return nil
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("sync staged tree: %w", err)
 	}
 	for i := len(directories) - 1; i >= 0; i-- {
 		if err := syncDirectory(directories[i]); err != nil {
@@ -546,16 +645,82 @@ func syncTree(root string) error {
 	return nil
 }
 
+func (m *Manager) runCommand(
+	parent context.Context,
+	timeout time.Duration,
+	dir string,
+	output io.Writer,
+	name string,
+	args ...string,
+) error {
+	ctx, cancel := context.WithTimeout(parent, timeout)
+	defer cancel()
+	err := m.cfg.Runner.Run(ctx, dir, output, name, args...)
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return fmt.Errorf("command did not complete within its phase deadline: %w", ctxErr)
+	}
+	return err
+}
+
+type cappedWriter struct {
+	mu        sync.Mutex
+	output    io.Writer
+	remaining int64
+	truncated bool
+}
+
+func newCappedWriter(output io.Writer, limit int64) *cappedWriter {
+	return &cappedWriter{output: output, remaining: limit}
+}
+
+func (w *cappedWriter) Write(data []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	originalLength := len(data)
+	allowed := originalLength
+	if int64(allowed) > w.remaining {
+		allowed = int(w.remaining)
+	}
+	if allowed > 0 {
+		written, err := w.output.Write(data[:allowed])
+		w.remaining -= int64(written)
+		if err != nil {
+			return written, fmt.Errorf("write bounded command output: %w", err)
+		}
+		if written != allowed {
+			return written, io.ErrShortWrite
+		}
+	}
+	if allowed < originalLength && !w.truncated {
+		w.truncated = true
+		if _, err := io.WriteString(w.output, "\n[command output truncated at configured limit]\n"); err != nil {
+			return allowed, fmt.Errorf("write command output truncation marker: %w", err)
+		}
+	}
+	// Discarded bytes are reported as consumed so verbose child commands keep
+	// running while manager-owned terminal messages remain writable directly to
+	// the underlying log file.
+	return originalLength, nil
+}
+
 // removeFailedPreflightImages releases only the immutable target tags from a
 // preflight that did not complete. The manager has already proved the target
 // is newer than the active release, and Docker refuses to remove an image used
 // by any running or stopped container. Cleanup is best-effort so it can never
 // hide the original preflight failure or make recovery less reliable.
-func (m *Manager) removeFailedPreflightImages(ctx context.Context, dir string, output io.Writer, targetVersion string) {
+func (m *Manager) removeFailedPreflightImages(
+	parent context.Context,
+	dir string,
+	commandOutput io.Writer,
+	logOutput io.Writer,
+	targetVersion string,
+) {
+	ctx, cancel := context.WithTimeout(parent, m.cfg.CleanupTimeout)
+	defer cancel()
 	for _, repository := range releaseImageRepositories {
 		image := repository + ":" + targetVersion
-		if err := m.cfg.Runner.Run(ctx, dir, output, "docker", "image", "rm", image); err != nil {
-			_, _ = fmt.Fprintf(output, "warning: could not remove failed preflight image %s: %v\n", image, err)
+		if err := m.cfg.Runner.Run(ctx, dir, commandOutput, "docker", "image", "rm", image); err != nil {
+			_, _ = fmt.Fprintf(logOutput, "warning: could not remove failed preflight image %s: %v\n", image, err)
 		}
 	}
 }
@@ -606,6 +771,21 @@ func (m *Manager) advance(id string, phase updaterapi.Phase, message string) err
 	return m.persistLocked()
 }
 
+func (m *Manager) beginActivation(id, message string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.operation == nil || m.operation.ID != id {
+		return fmt.Errorf("operation %s is no longer current", id)
+	}
+	if m.closing {
+		return fmt.Errorf("updater is shutting down before activation")
+	}
+	m.operation.Phase = updaterapi.PhaseActivating
+	m.operation.Message = message
+	m.operation.UpdatedAt = m.cfg.Now().UTC()
+	return m.persistLocked()
+}
+
 func (m *Manager) setLogPath(id, logPath, recovery string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -613,6 +793,17 @@ func (m *Manager) setLogPath(id, logPath, recovery string) error {
 		return fmt.Errorf("operation %s is no longer current", id)
 	}
 	m.operation.LogPath = logPath
+	m.operation.RecoveryCommand = recovery
+	m.operation.UpdatedAt = m.cfg.Now().UTC()
+	return m.persistLocked()
+}
+
+func (m *Manager) setRecoveryCommand(id, recovery string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.operation == nil || m.operation.ID != id {
+		return fmt.Errorf("operation %s is no longer current", id)
+	}
 	m.operation.RecoveryCommand = recovery
 	m.operation.UpdatedAt = m.cfg.Now().UTC()
 	return m.persistLocked()
@@ -647,6 +838,7 @@ func (m *Manager) succeed(id, message string) error {
 	now := m.cfg.Now().UTC()
 	m.operation.Phase = updaterapi.PhaseSucceeded
 	m.operation.Message = message
+	m.operation.RecoveryCommand = ""
 	m.operation.UpdatedAt = now
 	m.operation.CompletedAt = &now
 	return m.persistLocked()
@@ -791,7 +983,7 @@ func readInstalledVersion(path string) (string, error) {
 	return "", fmt.Errorf("installed version file has no version")
 }
 
-func verifyChecksum(archivePath, checksumPath, archiveName string) error {
+func verifyChecksum(ctx context.Context, archivePath, checksumPath, archiveName string) error {
 	data, err := os.ReadFile(checksumPath)
 	if err != nil {
 		return fmt.Errorf("read release checksum: %w", err)
@@ -810,7 +1002,7 @@ func verifyChecksum(archivePath, checksumPath, archiveName string) error {
 	}
 	defer file.Close()
 	hash := sha256.New()
-	if _, err := io.Copy(hash, file); err != nil {
+	if _, err := io.Copy(hash, readerWithContext(ctx, file)); err != nil {
 		return fmt.Errorf("hash release bundle: %w", err)
 	}
 	if !equalBytes(hash.Sum(nil), expected) {
@@ -831,7 +1023,7 @@ func equalBytes(a, b []byte) bool {
 }
 
 func extractArchive(archivePath, destination string) error {
-	return extractArchiveWithUpdaterCopy(archivePath, destination, nil, nil)
+	return extractArchiveWithUpdaterCopy(context.Background(), archivePath, destination, nil, nil)
 }
 
 // extractArchiveWithUpdaterCopy streams the updater payload directly from the
@@ -839,6 +1031,7 @@ func extractArchive(archivePath, destination string) error {
 // deployment tree. The protected copy is therefore never read back through an
 // operator-writable installation path before it replaces the host updater.
 func extractArchiveWithUpdaterCopy(
+	ctx context.Context,
 	archivePath string,
 	destination string,
 	updaterCopy *os.File,
@@ -849,7 +1042,7 @@ func extractArchiveWithUpdaterCopy(
 		return fmt.Errorf("open release archive: %w", err)
 	}
 	defer file.Close()
-	gz, err := gzip.NewReader(file)
+	gz, err := gzip.NewReader(readerWithContext(ctx, file))
 	if err != nil {
 		return fmt.Errorf("open gzip stream: %w", err)
 	}
@@ -859,6 +1052,9 @@ func extractArchiveWithUpdaterCopy(
 	var extractedBytes int64
 	entries := 0
 	for {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("extract release archive: %w", err)
+		}
 		header, err := tr.Next()
 		if errors.Is(err, io.EOF) {
 			return nil
@@ -947,21 +1143,24 @@ func validateStagedRelease(deploymentPath, targetVersion string) error {
 	return nil
 }
 
-func preserveDeploymentState(current, staged string) error {
+func preserveDeploymentState(ctx context.Context, current, staged string) error {
 	for _, path := range []string{".env", "server/influx_config/.env"} {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("preserve deployment configuration: %w", err)
+		}
 		source := filepath.Join(current, path)
 		if _, err := os.Stat(source); errors.Is(err, os.ErrNotExist) {
 			continue
 		} else if err != nil {
 			return fmt.Errorf("inspect preserved file %s: %w", path, err)
 		}
-		if err := copyFile(source, filepath.Join(staged, path)); err != nil {
+		if err := copyFile(ctx, source, filepath.Join(staged, path)); err != nil {
 			return err
 		}
 	}
 	sourceSSL := filepath.Join(current, "ssl")
 	if _, err := os.Stat(sourceSSL); err == nil {
-		if err := copyTree(sourceSSL, filepath.Join(staged, "ssl")); err != nil {
+		if err := copyTree(ctx, sourceSSL, filepath.Join(staged, "ssl")); err != nil {
 			return err
 		}
 	} else if !errors.Is(err, os.ErrNotExist) {
@@ -976,7 +1175,7 @@ func preserveDeploymentState(current, staged string) error {
 // owner can control the same rootful Docker daemon, and root-run installs are
 // root-owned. Preserve that owner so one successful upgrade does not make
 // later manual maintenance unexpectedly require a different account.
-func preserveDeploymentOwnership(current, staged string) error {
+func preserveDeploymentOwnership(ctx context.Context, current, staged string) error {
 	if os.Geteuid() != 0 {
 		return nil
 	}
@@ -989,6 +1188,9 @@ func preserveDeploymentOwnership(current, staged string) error {
 		return fmt.Errorf("read deployment owner")
 	}
 	err = filepath.WalkDir(staged, func(path string, _ os.DirEntry, walkErr error) error {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("preserve staged deployment ownership: %w", err)
+		}
 		if walkErr != nil {
 			return fmt.Errorf("walk staged deployment: %w", walkErr)
 		}
@@ -1003,7 +1205,7 @@ func preserveDeploymentOwnership(current, staged string) error {
 	return nil
 }
 
-func copyFile(source, destination string) error {
+func copyFile(ctx context.Context, source, destination string) error {
 	info, err := os.Lstat(source)
 	if err != nil {
 		return fmt.Errorf("inspect source file: %w", err)
@@ -1023,7 +1225,7 @@ func copyFile(source, destination string) error {
 	if err != nil {
 		return fmt.Errorf("open destination file: %w", err)
 	}
-	if _, err := io.Copy(out, in); err != nil {
+	if _, err := io.Copy(out, readerWithContext(ctx, in)); err != nil {
 		out.Close()
 		return fmt.Errorf("copy file contents: %w", err)
 	}
@@ -1092,8 +1294,11 @@ func syncDirectory(path string) error {
 	return nil
 }
 
-func copyTree(source, destination string) error {
+func copyTree(ctx context.Context, source, destination string) error {
 	err := filepath.WalkDir(source, func(path string, entry os.DirEntry, walkErr error) error {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("preserve deployment tree: %w", err)
+		}
 		if walkErr != nil {
 			return fmt.Errorf("walk preserved tree: %w", walkErr)
 		}
@@ -1115,12 +1320,34 @@ func copyTree(source, destination string) error {
 		if entry.Type()&os.ModeSymlink != 0 {
 			return fmt.Errorf("refusing to preserve symlink %s", path)
 		}
-		return copyFile(path, target)
+		return copyFile(ctx, path, target)
 	})
 	if err != nil {
 		return fmt.Errorf("copy preserved tree: %w", err)
 	}
 	return nil
+}
+
+type readerFunc func(data []byte) (int, error)
+
+func (read readerFunc) Read(data []byte) (int, error) {
+	return read(data)
+}
+
+func readerWithContext(ctx context.Context, reader io.Reader) io.Reader {
+	return readerFunc(func(data []byte) (int, error) {
+		if err := ctx.Err(); err != nil {
+			return 0, fmt.Errorf("read canceled: %w", err)
+		}
+		read, err := reader.Read(data)
+		if errors.Is(err, io.EOF) {
+			return read, io.EOF
+		}
+		if err != nil {
+			return read, fmt.Errorf("read source: %w", err)
+		}
+		return read, nil
+	})
 }
 
 func shellQuote(value string) string {

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -35,7 +35,7 @@ import (
 const (
 	stateFilename            = "state.json"
 	maxChecksumBytes         = 4096
-	maxDownloadBytes         = int64(8 << 30) // 8 GiB hard stop for a corrupt or hostile response.
+	maxDownloadBytes         = int64(1 << 30) // Larger bundles require an explicit updater contract change.
 	maxExtractedBytes        = int64(16 << 30)
 	maxArchiveEntries        = 100_000
 	defaultHTTPTimeout       = 30 * time.Minute

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -30,12 +30,13 @@ import (
 )
 
 const (
-	stateFilename      = "state.json"
-	maxChecksumBytes   = 4096
-	maxDownloadBytes   = int64(8 << 30) // 8 GiB hard stop for a corrupt or hostile response.
-	maxExtractedBytes  = int64(16 << 30)
-	maxArchiveEntries  = 100_000
-	defaultHTTPTimeout = 30 * time.Minute
+	stateFilename            = "state.json"
+	maxChecksumBytes         = 4096
+	maxDownloadBytes         = int64(8 << 30) // 8 GiB hard stop for a corrupt or hostile response.
+	maxExtractedBytes        = int64(16 << 30)
+	maxArchiveEntries        = 100_000
+	defaultHTTPTimeout       = 30 * time.Minute
+	canonicalDownloadBaseURL = "https://github.com/block/proto-fleet/releases/download"
 )
 
 var canonicalRelease = regexp.MustCompile(`^v\d+\.\d+\.\d+(?:-rc\.\d+)?$`)
@@ -75,6 +76,10 @@ type Config struct {
 	NewID           func() string
 	GOARCH          string
 	SelfUpdatePath  string
+
+	// Tests inject an httptest TLS endpoint without opening a production
+	// configuration path for alternate release mirrors.
+	allowTestDownloadBaseURL bool
 }
 
 type Manager struct {
@@ -93,6 +98,11 @@ func NewManager(cfg Config) (*Manager, error) {
 	}
 	if cfg.SelfUpdatePath != "" && !filepath.IsAbs(cfg.SelfUpdatePath) {
 		return nil, fmt.Errorf("self-update path must be absolute")
+	}
+	if cfg.DownloadBaseURL == "" {
+		cfg.DownloadBaseURL = canonicalDownloadBaseURL
+	} else if cfg.DownloadBaseURL != canonicalDownloadBaseURL && !cfg.allowTestDownloadBaseURL {
+		return nil, fmt.Errorf("download base URL must use the official GitHub Releases URL")
 	}
 	downloadBase, err := url.Parse(cfg.DownloadBaseURL)
 	if err != nil || downloadBase.Scheme != "https" || downloadBase.Host == "" ||
@@ -222,10 +232,13 @@ func (m *Manager) run(operationID, targetVersion string) {
 		return
 	}
 
-	if err := m.advance(operationID, updaterapi.PhaseVerifying, "Verifying release integrity"); err != nil {
+	if err := m.advance(operationID, updaterapi.PhaseVerifying, "Verifying release checksum"); err != nil {
 		m.fail(operationID, fmt.Errorf("persist verification phase: %w", err), recovery)
 		return
 	}
+	// The fixed GitHub Releases origin is the publisher trust anchor. This
+	// sidecar detects transfer/storage corruption; it is not represented as an
+	// independent publisher signature.
 	if err := verifyChecksum(archivePath, checksumPath, archiveName); err != nil {
 		m.fail(operationID, err, recovery)
 		return
@@ -242,9 +255,48 @@ func (m *Manager) run(operationID, targetVersion string) {
 		m.fail(operationID, fmt.Errorf("persist staging phase: %w", err), recovery)
 		return
 	}
-	if err := extractArchive(archivePath, stageRoot); err != nil {
+	var preparedUpdater *os.File
+	updaterCopied := false
+	if m.cfg.SelfUpdatePath != "" {
+		preparedUpdater, err = os.CreateTemp(m.cfg.StateDir, ".prepared-updater-")
+		if err != nil {
+			m.fail(operationID, fmt.Errorf("create protected updater copy: %w", err), recovery)
+			return
+		}
+		preparedUpdaterPath := preparedUpdater.Name()
+		defer os.Remove(preparedUpdaterPath)
+		defer func() {
+			if preparedUpdater != nil {
+				_ = preparedUpdater.Close()
+			}
+		}()
+	}
+	if err := extractArchiveWithUpdaterCopy(
+		archivePath,
+		stageRoot,
+		preparedUpdater,
+		&updaterCopied,
+	); err != nil {
 		m.fail(operationID, fmt.Errorf("extract release bundle: %w", err), recovery)
 		return
+	}
+	if preparedUpdater != nil {
+		if !updaterCopied {
+			m.fail(operationID, fmt.Errorf("release bundle is missing required updater binary"), recovery)
+			return
+		}
+		if err := preparedUpdater.Chmod(0o700); err != nil {
+			m.fail(operationID, fmt.Errorf("secure protected updater copy: %w", err), recovery)
+			return
+		}
+		if err := preparedUpdater.Sync(); err != nil {
+			m.fail(operationID, fmt.Errorf("sync protected updater copy: %w", err), recovery)
+			return
+		}
+		if _, err := preparedUpdater.Seek(0, io.SeekStart); err != nil {
+			m.fail(operationID, fmt.Errorf("rewind protected updater copy: %w", err), recovery)
+			return
+		}
 	}
 	stageDeployment := filepath.Join(stageRoot, "deployment")
 	currentDeployment := filepath.Join(m.cfg.InstallRoot, "deployment")
@@ -270,13 +322,6 @@ func (m *Manager) run(operationID, targetVersion string) {
 		m.fail(operationID, fmt.Errorf("upgrade preflight failed: %w", err), recovery)
 		return
 	}
-	if m.cfg.SelfUpdatePath != "" {
-		stagedUpdater := filepath.Join(stageDeployment, "updater", "proto-fleet-updater")
-		if err := atomicReplaceExecutable(stagedUpdater, m.cfg.SelfUpdatePath); err != nil {
-			m.fail(operationID, fmt.Errorf("update host updater binary: %w", err), recovery)
-			return
-		}
-	}
 
 	if err := m.advance(operationID, updaterapi.PhaseActivating, "Restarting Fleet; the client may disconnect for several minutes"); err != nil {
 		m.fail(operationID, fmt.Errorf("persist activation phase: %w", err), recovery)
@@ -299,11 +344,21 @@ func (m *Manager) run(operationID, targetVersion string) {
 	}
 
 	if err := m.cfg.Runner.Run(ctx, currentDeployment, logFile, "/bin/bash", "./run-fleet.sh", "--non-interactive", "--skip-build"); err != nil {
+		// run-fleet may have applied forward-only migrations before returning an
+		// error. Keep the new deployment active for forward recovery; restoring
+		// the previous binaries could make the schema and application incompatible.
 		m.fail(operationID, fmt.Errorf("new stack failed to start: %w", err), recovery)
 		return
 	}
+	successMessage := fmt.Sprintf("Fleet %s is running", targetVersion)
+	if preparedUpdater != nil {
+		if err := atomicReplaceExecutableFromFile(preparedUpdater, m.cfg.SelfUpdatePath); err != nil {
+			_, _ = fmt.Fprintf(logFile, "[%s] warning: Fleet is healthy, but the host updater binary was not refreshed: %v\n", m.cfg.Now().UTC().Format(time.RFC3339), err)
+			successMessage += "; host updater refresh needs attention (see upgrade log)"
+		}
+	}
 
-	if err := m.succeed(operationID, fmt.Sprintf("Fleet %s is running", targetVersion)); err != nil {
+	if err := m.succeed(operationID, successMessage); err != nil {
 		_, _ = fmt.Fprintf(logFile, "[%s] warning: persist successful terminal state: %v\n", m.cfg.Now().UTC().Format(time.RFC3339), err)
 		log.Printf("persist successful upgrade state: %v", err)
 	}
@@ -532,6 +587,19 @@ func equalBytes(a, b []byte) bool {
 }
 
 func extractArchive(archivePath, destination string) error {
+	return extractArchiveWithUpdaterCopy(archivePath, destination, nil, nil)
+}
+
+// extractArchiveWithUpdaterCopy streams the updater payload directly from the
+// checksum-verified archive into root-only state while extracting the ordinary
+// deployment tree. The protected copy is therefore never read back through an
+// operator-writable installation path before it replaces the host updater.
+func extractArchiveWithUpdaterCopy(
+	archivePath string,
+	destination string,
+	updaterCopy *os.File,
+	updaterCopied *bool,
+) error {
 	file, err := os.Open(archivePath)
 	if err != nil {
 		return fmt.Errorf("open release archive: %w", err)
@@ -587,11 +655,19 @@ func extractArchive(archivePath, destination string) error {
 			if err != nil {
 				return fmt.Errorf("create archive file %s: %w", header.Name, err)
 			}
+			writer := io.Writer(out)
+			copyUpdater := updaterCopy != nil && filepath.ToSlash(name) == "deployment/updater/proto-fleet-updater"
+			if copyUpdater {
+				writer = io.MultiWriter(out, updaterCopy)
+			}
 			// tar.Reader already bounds reads to header.Size; the additional
 			// LimitReader documents that bound for static analysis.
-			if _, err := io.Copy(out, io.LimitReader(tr, header.Size)); err != nil { // #nosec G110
+			if _, err := io.Copy(writer, io.LimitReader(tr, header.Size)); err != nil { // #nosec G110
 				out.Close()
 				return fmt.Errorf("extract archive file %s: %w", header.Name, err)
+			}
+			if copyUpdater && updaterCopied != nil {
+				*updaterCopied = true
 			}
 			if err := out.Close(); err != nil {
 				return fmt.Errorf("close archive file %s: %w", header.Name, err)
@@ -651,9 +727,11 @@ func preserveDeploymentState(current, staged string) error {
 }
 
 // The host updater runs as root so it can manage rootful Docker and its own
-// systemd unit. Keep the extracted deployment owned by the same account as
-// the previous deployment, otherwise one successful one-click upgrade would
-// make later manual maintenance unexpectedly require root.
+// systemd unit. The deployment owner is inside that same host-administrator
+// trust boundary: supported non-root installs enable one-click only when the
+// owner can control the same rootful Docker daemon, and root-run installs are
+// root-owned. Preserve that owner so one successful upgrade does not make
+// later manual maintenance unexpectedly require a different account.
 func preserveDeploymentOwnership(current, staged string) error {
 	if os.Geteuid() != 0 {
 		return nil
@@ -712,11 +790,23 @@ func copyFile(source, destination string) error {
 }
 
 func atomicReplaceExecutable(source, destination string) error {
-	info, err := os.Stat(source)
+	in, err := os.Open(source)
+	if err != nil {
+		return fmt.Errorf("open staged updater: %w", err)
+	}
+	defer in.Close()
+	return atomicReplaceExecutableFromFile(in, destination)
+}
+
+func atomicReplaceExecutableFromFile(in *os.File, destination string) error {
+	if _, err := in.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("rewind staged updater: %w", err)
+	}
+	info, err := in.Stat()
 	if err != nil {
 		return fmt.Errorf("inspect staged updater: %w", err)
 	}
-	if info.IsDir() || info.Mode().Perm()&0o111 == 0 {
+	if !info.Mode().IsRegular() || info.Mode().Perm()&0o111 == 0 {
 		return fmt.Errorf("staged updater is not executable")
 	}
 	temp, err := os.CreateTemp(filepath.Dir(destination), ".proto-fleet-updater-")
@@ -725,20 +815,9 @@ func atomicReplaceExecutable(source, destination string) error {
 	}
 	tempPath := temp.Name()
 	defer os.Remove(tempPath)
-	in, err := os.Open(source)
-	if err != nil {
+	if _, err := io.Copy(temp, in); err != nil {
 		temp.Close()
-		return fmt.Errorf("open staged updater: %w", err)
-	}
-	_, copyErr := io.Copy(temp, in)
-	closeInErr := in.Close()
-	if copyErr != nil {
-		temp.Close()
-		return fmt.Errorf("copy staged updater: %w", copyErr)
-	}
-	if closeInErr != nil {
-		temp.Close()
-		return fmt.Errorf("close staged updater: %w", closeInErr)
+		return fmt.Errorf("copy staged updater: %w", err)
 	}
 	if err := temp.Chmod(0o755); err != nil {
 		temp.Close()

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -40,6 +40,13 @@ const (
 
 var canonicalRelease = regexp.MustCompile(`^v\d+\.\d+\.\d+(?:-rc\.\d+)?$`)
 
+var releaseImageRepositories = [...]string{
+	"proto-fleet-api",
+	"proto-fleet-client",
+	"proto-fleet-timescaledb",
+	"proto-fleet-timescaledb-ha",
+}
+
 type CommandRunner interface {
 	Run(ctx context.Context, dir string, output io.Writer, name string, args ...string) error
 }
@@ -259,6 +266,7 @@ func (m *Manager) run(operationID, targetVersion string) {
 		return
 	}
 	if err := m.cfg.Runner.Run(ctx, stageDeployment, logFile, "/bin/bash", "./run-fleet.sh", "--non-interactive", "--preflight-only"); err != nil {
+		m.removeFailedPreflightImages(ctx, stageDeployment, logFile, targetVersion)
 		m.fail(operationID, fmt.Errorf("upgrade preflight failed: %w", err), recovery)
 		return
 	}
@@ -300,6 +308,20 @@ func (m *Manager) run(operationID, targetVersion string) {
 		log.Printf("persist successful upgrade state: %v", err)
 	}
 	_, _ = fmt.Fprintf(logFile, "[%s] upgrade completed\n", m.cfg.Now().UTC().Format(time.RFC3339))
+}
+
+// removeFailedPreflightImages releases only the immutable target tags from a
+// preflight that did not complete. The manager has already proved the target
+// is newer than the active release, and Docker refuses to remove an image used
+// by any running or stopped container. Cleanup is best-effort so it can never
+// hide the original preflight failure or make recovery less reliable.
+func (m *Manager) removeFailedPreflightImages(ctx context.Context, dir string, output io.Writer, targetVersion string) {
+	for _, repository := range releaseImageRepositories {
+		image := repository + ":" + targetVersion
+		if err := m.cfg.Runner.Run(ctx, dir, output, "docker", "image", "rm", image); err != nil {
+			_, _ = fmt.Fprintf(output, "warning: could not remove failed preflight image %s: %v\n", image, err)
+		}
+	}
 }
 
 func (m *Manager) download(ctx context.Context, rawURL, path string, maxBytes int64) error {

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -139,7 +139,7 @@ type Manager struct {
 	operationRunning bool
 	cancelOperation  context.CancelFunc
 	operationWG      sync.WaitGroup
-	selfUpdateReady  chan struct{}
+	selfUpdateReady  chan string
 	processLock      *os.File
 	logRoot          *os.Root
 	closeOnce        sync.Once
@@ -216,51 +216,22 @@ func nearestExistingPath(path string) (string, error) {
 }
 
 func validateTrustedUpdaterPath(path string, finalIsStateDir bool) error {
-	components := pathComponents(path)
-	for index, component := range components {
-		info, err := os.Lstat(component)
-		if err != nil {
-			return fmt.Errorf("inspect updater state path component %q: %w", component, err)
-		}
-		isFinal := index == len(components)-1
-		if info.Mode()&os.ModeSymlink != 0 {
-			if finalIsStateDir && isFinal {
-				return fmt.Errorf("updater state directory must not be a symlink: %q", component)
-			}
-			if err := validateTrustedUpdaterOwner(component, info); err != nil {
-				return err
-			}
-			continue
-		}
-		if !info.IsDir() {
-			return fmt.Errorf("updater state path component is not a directory: %q", component)
-		}
-		if err := validateTrustedUpdaterOwner(component, info); err != nil {
-			return err
-		}
-		if info.Mode().Perm()&0o022 == 0 {
-			continue
-		}
-		if finalIsStateDir && isFinal {
-			return fmt.Errorf("updater state directory must not be group- or world-writable: %q", component)
-		}
-		if info.Mode()&os.ModeSticky == 0 {
-			return fmt.Errorf("updater state ancestor is group- or world-writable without the sticky bit: %q", component)
-		}
-	}
-	return nil
+	return validateTrustedDirectoryChain(
+		path,
+		"updater state",
+		"updater state directory",
+		finalIsStateDir,
+		validateTrustedUpdaterOwner,
+	)
 }
 
 func validateTrustedUpdaterOwner(path string, info os.FileInfo) error {
-	stat, ok := info.Sys().(*syscall.Stat_t)
-	if !ok {
-		return fmt.Errorf("inspect owner of updater state path component %q", path)
+	uid, err := updaterPathOwnerUID(path, "updater state", info)
+	if err != nil {
+		return err
 	}
 	euid := uint32(os.Geteuid()) //nolint:gosec // Effective UIDs are non-negative on supported Unix hosts.
-	if stat.Uid != 0 && stat.Uid != euid {
-		return fmt.Errorf("updater state path component %q is owned by untrusted UID %d", path, stat.Uid)
-	}
-	return nil
+	return validateRootOrDaemonPathUID("updater state", path, uid, euid)
 }
 
 func pathComponents(path string) []string {
@@ -277,6 +248,198 @@ func pathComponents(path string) []string {
 		components[index] = reversed[len(reversed)-1-index]
 	}
 	return components
+}
+
+type installRootTrust struct {
+	adminUID uint32
+}
+
+func (trust *installRootTrust) validateOwner(path string, info os.FileInfo) error {
+	uid, err := updaterPathOwnerUID(path, "install root", info)
+	if err != nil {
+		return err
+	}
+	return trust.validateUID(path, uid)
+}
+
+func (trust *installRootTrust) validateUID(path string, uid uint32) error {
+	if uid == 0 {
+		return nil
+	}
+	if trust.adminUID == 0 {
+		trust.adminUID = uid
+		return nil
+	}
+	if trust.adminUID != uid {
+		return fmt.Errorf("install root path component %q is owned by UID %d, but trusted install-admin UID is %d", path, uid, trust.adminUID)
+	}
+	return nil
+}
+
+// ensureTrustedInstallRoot makes the installer-selected deployment owner an
+// explicit trust principal. The installer enables this root daemon only when
+// that one owner controls the same rootful Docker daemon and is therefore
+// already host-administrator-equivalent. Root and at most that single UID may
+// own path components; unrelated owners and writable paths fail closed.
+func ensureTrustedInstallRoot(installRoot string) (string, error) {
+	installRoot = filepath.Clean(installRoot)
+	trust := &installRootTrust{}
+	if err := validateTrustedDirectoryChain(installRoot, "install root", "install root", true, trust.validateOwner); err != nil {
+		return "", err
+	}
+	canonicalRoot, err := filepath.EvalSymlinks(installRoot)
+	if err != nil {
+		return "", fmt.Errorf("resolve install root: %w", err)
+	}
+	if err := validateTrustedDirectoryChain(canonicalRoot, "install root", "install root", true, trust.validateOwner); err != nil {
+		return "", err
+	}
+	configuredInfo, err := os.Lstat(installRoot)
+	if err != nil {
+		return "", fmt.Errorf("inspect install root: %w", err)
+	}
+	canonicalInfo, err := os.Lstat(canonicalRoot)
+	if err != nil {
+		return "", fmt.Errorf("inspect canonical install root: %w", err)
+	}
+	if !os.SameFile(configuredInfo, canonicalInfo) {
+		return "", fmt.Errorf("install root changed while it was validated")
+	}
+	for _, name := range []string{"deployment", "deployment.previous"} {
+		deploymentPath := filepath.Join(canonicalRoot, name)
+		if _, err := os.Lstat(deploymentPath); errors.Is(err, os.ErrNotExist) {
+			continue
+		} else if err != nil {
+			return "", fmt.Errorf("inspect %s directory: %w", name, err)
+		}
+		label := name + " directory"
+		if err := validateTrustedDirectoryChain(deploymentPath, label, label, true, trust.validateOwner); err != nil {
+			return "", err
+		}
+	}
+	return canonicalRoot, nil
+}
+
+// ensureTrustedSelfUpdatePath is intentionally stricter than InstallRoot. The
+// service executable and its path chain must be controlled by root or the
+// daemon UID, and later mutations use the validated canonical path.
+func ensureTrustedSelfUpdatePath(selfUpdatePath string) (string, error) {
+	selfUpdatePath = filepath.Clean(selfUpdatePath)
+	configuredInfo, err := os.Lstat(selfUpdatePath)
+	if err != nil {
+		return "", fmt.Errorf("inspect self-update path: %w", err)
+	}
+	if err := validateSelfUpdateExecutable(selfUpdatePath, configuredInfo); err != nil {
+		return "", err
+	}
+	configuredParent := filepath.Dir(selfUpdatePath)
+	if err := validateTrustedDirectoryChain(configuredParent, "self-update path", "", false, validateDaemonPathOwner); err != nil {
+		return "", err
+	}
+	canonicalParent, err := filepath.EvalSymlinks(configuredParent)
+	if err != nil {
+		return "", fmt.Errorf("resolve self-update parent: %w", err)
+	}
+	if err := validateTrustedDirectoryChain(canonicalParent, "self-update path", "", false, validateDaemonPathOwner); err != nil {
+		return "", err
+	}
+	canonicalPath := filepath.Join(canonicalParent, filepath.Base(selfUpdatePath))
+	canonicalInfo, err := os.Lstat(canonicalPath)
+	if err != nil {
+		return "", fmt.Errorf("inspect canonical self-update path: %w", err)
+	}
+	if err := validateSelfUpdateExecutable(canonicalPath, canonicalInfo); err != nil {
+		return "", err
+	}
+	if !os.SameFile(configuredInfo, canonicalInfo) {
+		return "", fmt.Errorf("self-update path changed while it was validated")
+	}
+	return canonicalPath, nil
+}
+
+func validateTrustedDirectoryChain(
+	path string,
+	pathName string,
+	finalName string,
+	protectFinal bool,
+	validateOwner func(string, os.FileInfo) error,
+) error {
+	components := pathComponents(path)
+	for index, component := range components {
+		info, err := os.Lstat(component)
+		if err != nil {
+			return fmt.Errorf("inspect %s path component %q: %w", pathName, component, err)
+		}
+		isFinal := index == len(components)-1
+		if info.Mode()&os.ModeSymlink != 0 {
+			if protectFinal && isFinal {
+				return fmt.Errorf("%s must not be a symlink: %q", finalName, component)
+			}
+			if err := validateOwner(component, info); err != nil {
+				return err
+			}
+			continue
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("%s path component is not a directory: %q", pathName, component)
+		}
+		if err := validateOwner(component, info); err != nil {
+			return err
+		}
+		if info.Mode().Perm()&0o022 == 0 {
+			continue
+		}
+		if protectFinal && isFinal {
+			return fmt.Errorf("%s must not be group- or world-writable: %q", finalName, component)
+		}
+		if info.Mode()&os.ModeSticky == 0 {
+			return fmt.Errorf("%s ancestor is group- or world-writable without the sticky bit: %q", pathName, component)
+		}
+	}
+	return nil
+}
+
+func updaterPathOwnerUID(path, name string, info os.FileInfo) (uint32, error) {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, fmt.Errorf("inspect owner of %s path component %q", name, path)
+	}
+	return stat.Uid, nil
+}
+
+func validateDaemonPathUID(path string, ownerUID, daemonUID uint32) error {
+	return validateRootOrDaemonPathUID("self-update", path, ownerUID, daemonUID)
+}
+
+func validateRootOrDaemonPathUID(pathName, path string, ownerUID, daemonUID uint32) error {
+	if ownerUID != 0 && ownerUID != daemonUID {
+		return fmt.Errorf("%s path component %q is owned by untrusted UID %d", pathName, path, ownerUID)
+	}
+	return nil
+}
+
+func validateDaemonPathOwner(path string, info os.FileInfo) error {
+	uid, err := updaterPathOwnerUID(path, "self-update path", info)
+	if err != nil {
+		return err
+	}
+	return validateDaemonPathUID(path, uid, uint32(os.Geteuid())) //nolint:gosec // Effective UIDs are non-negative on supported Unix hosts.
+}
+
+func validateSelfUpdateExecutable(path string, info os.FileInfo) error {
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("self-update path must not be a symlink: %q", path)
+	}
+	if !info.Mode().IsRegular() || info.Size() == 0 || info.Mode().Perm()&0o111 == 0 {
+		return fmt.Errorf("self-update path must be a non-empty executable regular file: %q", path)
+	}
+	if err := validateDaemonPathOwner(path, info); err != nil {
+		return err
+	}
+	if info.Mode().Perm()&0o022 != 0 {
+		return fmt.Errorf("self-update path must not be group- or world-writable: %q", path)
+	}
+	return nil
 }
 
 func openOperationLogRoot(stateDir string) (*os.Root, error) {
@@ -391,6 +554,18 @@ func NewManager(cfg Config) (*Manager, error) {
 	if cfg.PreflightTimeout < 0 || cfg.ActivationTimeout < 0 || cfg.CleanupTimeout < 0 {
 		return nil, fmt.Errorf("updater phase timeouts must be positive")
 	}
+	canonicalInstallRoot, err := ensureTrustedInstallRoot(cfg.InstallRoot)
+	if err != nil {
+		return nil, err
+	}
+	cfg.InstallRoot = canonicalInstallRoot
+	if cfg.SelfUpdatePath != "" {
+		canonicalSelfUpdatePath, err := ensureTrustedSelfUpdatePath(cfg.SelfUpdatePath)
+		if err != nil {
+			return nil, err
+		}
+		cfg.SelfUpdatePath = canonicalSelfUpdatePath
+	}
 	canonicalStateDir, err := ensureUpdaterStateDirectory(cfg.StateDir)
 	if err != nil {
 		return nil, err
@@ -408,7 +583,7 @@ func NewManager(cfg Config) (*Manager, error) {
 
 	m := &Manager{
 		cfg:             cfg,
-		selfUpdateReady: make(chan struct{}, 1),
+		selfUpdateReady: make(chan string, 1),
 		processLock:     processLock,
 		logRoot:         logRoot,
 	}
@@ -438,10 +613,11 @@ func (m *Manager) Close() error {
 	return m.Shutdown(context.Background())
 }
 
-// SelfUpdateReady is signaled once the replacement executable and successful
-// terminal state are both durable. The command process owns listener draining,
-// lock release, and exec so the manager remains independent of any supervisor.
-func (m *Manager) SelfUpdateReady() <-chan struct{} {
+// SelfUpdateReady yields the validated canonical executable path once the
+// replacement and successful terminal state are both durable. The command
+// process owns listener draining, lock release, and exec so the manager remains
+// independent of any supervisor.
+func (m *Manager) SelfUpdateReady() <-chan string {
 	return m.selfUpdateReady
 }
 
@@ -847,7 +1023,7 @@ func (m *Manager) run(ctx context.Context, operationID, targetVersion string) {
 	}
 	if selfUpdateSucceeded {
 		select {
-		case m.selfUpdateReady <- struct{}{}:
+		case m.selfUpdateReady <- m.cfg.SelfUpdatePath:
 		default:
 		}
 	}

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -59,6 +59,7 @@ const (
 	processLockFilename      = "updater.lock"
 	activationMarkerFilename = "activation-swap.json"
 	activationMarkerTempName = ".activation-swap.json.tmp"
+	preflightProofFilename   = ".update-preflight-complete"
 	operationArtifactPrefix  = ".proto-fleet-upgrade-"
 	selfUpdateBackupSuffix   = ".previous"
 	stateTempPrefix          = ".state-"
@@ -1140,7 +1141,16 @@ func (m *Manager) run(ctx context.Context, operationID, targetVersion string) {
 		// run-fleet may have applied forward-only migrations before returning an
 		// error. Keep the new deployment active for forward recovery; restoring
 		// the previous binaries could make the schema and application incompatible.
-		m.fail(operationID, fmt.Errorf("new stack failed to start: %w", err), recovery)
+		activationErr := fmt.Errorf("new stack failed to start: %w", err)
+		failureRecovery, recoveryErr := activationRecoveryCommandAfterFailure(currentDeployment)
+		if recoveryErr != nil {
+			activationErr = errors.Join(
+				activationErr,
+				fmt.Errorf("derive activation recovery command: %w", recoveryErr),
+			)
+			failureRecovery = ""
+		}
+		m.fail(operationID, activationErr, failureRecovery)
 		return
 	}
 	successMessage := fmt.Sprintf("Fleet %s is running", targetVersion)
@@ -1756,7 +1766,33 @@ func (m *Manager) loadState() error {
 		}
 	}
 	m.operation = &op
-	return m.persistLocked()
+	return m.persistReconciledState()
+}
+
+// persistReconciledState normally preserves the ordering of reconciliation,
+// durable state, then stale-artifact cleanup. If the state write itself proves
+// the filesystem is full, the exact reserved-name artifacts are the only safe
+// source of space to reclaim: layout reconciliation has already succeeded, so
+// clean them and retry the small state write once. Other persistence failures
+// leave the artifacts untouched for diagnosis.
+func (m *Manager) persistReconciledState() error {
+	persistErr := m.persistLocked()
+	if persistErr == nil || !errors.Is(persistErr, syscall.ENOSPC) {
+		return persistErr
+	}
+	if cleanupErr := m.cleanupStaleArtifacts(); cleanupErr != nil {
+		return errors.Join(
+			persistErr,
+			fmt.Errorf("clean stale upgrade artifacts after updater state exhausted storage: %w", cleanupErr),
+		)
+	}
+	if retryErr := m.persistLocked(); retryErr != nil {
+		return errors.Join(
+			persistErr,
+			fmt.Errorf("persist reconciled updater state after stale artifact cleanup: %w", retryErr),
+		)
+	}
+	return nil
 }
 
 // reconcileDeploymentLayout validates the active layout and repairs the
@@ -1783,7 +1819,7 @@ func (m *Manager) reconcileDeploymentLayout(
 		if deriveForwardRecovery {
 			op.RecoveryCommand = ""
 			if version == op.TargetVersion {
-				markerInfo, markerErr := os.Lstat(filepath.Join(current, ".update-preflight-complete"))
+				markerInfo, markerErr := os.Lstat(filepath.Join(current, preflightProofFilename))
 				if markerErr == nil {
 					if !markerInfo.Mode().IsRegular() {
 						return false, fmt.Errorf("activation preflight proof is not a regular file")
@@ -2734,6 +2770,28 @@ func shellQuote(value string) string {
 
 func activationRecoveryCommand(deploymentPath string) string {
 	return fmt.Sprintf("cd %s && ./run-fleet.sh --non-interactive --skip-build", shellQuote(deploymentPath))
+}
+
+func activationPreflightRecoveryCommand(deploymentPath string) string {
+	return fmt.Sprintf(
+		"cd %s && ./run-fleet.sh --non-interactive --preflight-only && ./run-fleet.sh --non-interactive --skip-build",
+		shellQuote(deploymentPath),
+	)
+}
+
+func activationRecoveryCommandAfterFailure(deploymentPath string) (string, error) {
+	proofPath := filepath.Join(deploymentPath, preflightProofFilename)
+	info, err := os.Lstat(proofPath)
+	if err == nil {
+		if !info.Mode().IsRegular() {
+			return "", fmt.Errorf("activation preflight proof is not a regular file")
+		}
+		return activationRecoveryCommand(deploymentPath), nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return activationPreflightRecoveryCommand(deploymentPath), nil
+	}
+	return "", fmt.Errorf("inspect activation preflight proof: %w", err)
 }
 
 func activationRestoreCommand(current, previous string) string {

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -631,6 +631,21 @@ func (m *Manager) RollbackSelfUpdate() error {
 	return restorePreviousExecutable(m.cfg.SelfUpdatePath)
 }
 
+// RollbackSelfUpdateExecutable validates the installed executable trust chain
+// before restoring its retained sibling backup. The command uses this during
+// the replacement process's one-shot startup window, including failures that
+// happen before a Manager can be constructed.
+func RollbackSelfUpdateExecutable(selfUpdatePath string) error {
+	if selfUpdatePath == "" {
+		return fmt.Errorf("self-update path is not configured")
+	}
+	canonicalPath, err := ensureTrustedSelfUpdatePath(selfUpdatePath)
+	if err != nil {
+		return fmt.Errorf("validate self-update rollback path: %w", err)
+	}
+	return restorePreviousExecutable(canonicalPath)
+}
+
 // Shutdown rejects future triggers, cancels work that has not crossed the
 // activation boundary, waits for the operation to persist a terminal state,
 // and only then releases the daemon lock. An active forward migration is not

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -120,6 +120,9 @@ type Config struct {
 	// Tests inject an httptest TLS endpoint without opening a production
 	// configuration path for alternate release mirrors.
 	allowTestDownloadBaseURL bool
+	// Tests inject deterministic state-write failures without weakening the
+	// production state-directory trust boundary.
+	beforePersistState func(updaterapi.Operation) error
 }
 
 type activationMarker struct {
@@ -833,9 +836,16 @@ func (m *Manager) run(ctx context.Context, operationID, targetVersion string) {
 	}
 
 	if err := m.succeed(operationID, successMessage, selfUpdateSucceeded); err != nil {
-		_, _ = fmt.Fprintf(logFile, "[%s] warning: persist successful terminal state: %v\n", m.cfg.Now().UTC().Format(time.RFC3339), err)
-		log.Printf("persist successful upgrade state: %v", err)
-	} else if selfUpdateSucceeded {
+		_, _ = fmt.Fprintf(
+			logFile,
+			"[%s] error: Fleet is running, but updater completion was not persisted; further upgrades remain blocked until startup reconciliation: %v\n",
+			m.cfg.Now().UTC().Format(time.RFC3339),
+			err,
+		)
+		log.Printf("persist successful upgrade state; further upgrades remain blocked until startup reconciliation: %v", err)
+		return
+	}
+	if selfUpdateSucceeded {
 		select {
 		case m.selfUpdateReady <- struct{}{}:
 		default:
@@ -1285,6 +1295,7 @@ func (m *Manager) succeed(id, message string, closeForSelfUpdate bool) error {
 	if m.operation == nil || m.operation.ID != id {
 		return fmt.Errorf("operation %s is no longer current", id)
 	}
+	previous := *m.operation
 	now := m.cfg.Now().UTC()
 	m.operation.Phase = updaterapi.PhaseSucceeded
 	m.operation.Message = message
@@ -1292,6 +1303,10 @@ func (m *Manager) succeed(id, message string, closeForSelfUpdate bool) error {
 	m.operation.UpdatedAt = now
 	m.operation.CompletedAt = &now
 	if err := m.persistLocked(); err != nil {
+		// Keep the last durable, non-terminal activation state (including its
+		// recovery command) visible in memory. That fails closed: Trigger rejects
+		// another upgrade until a restart reconciles and persists the outcome.
+		*m.operation = previous
 		return err
 	}
 	if closeForSelfUpdate {
@@ -1724,6 +1739,11 @@ func cleanupStaleStageDirectories(installRoot string) (bool, error) {
 func (m *Manager) persistLocked() error {
 	if m.operation == nil {
 		return nil
+	}
+	if m.cfg.beforePersistState != nil {
+		if err := m.cfg.beforePersistState(*m.operation); err != nil {
+			return fmt.Errorf("persist updater state: %w", err)
+		}
 	}
 	data, err := json.MarshalIndent(m.operation, "", "  ")
 	if err != nil {

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -159,6 +159,9 @@ type Config struct {
 	// Tests observe ownership restoration ordering around preflight-generated
 	// artifacts without requiring the test process to run as root.
 	preserveDeploymentOwnership func(context.Context, string, string) error
+	// Tests pause a trigger after unlocked prechecks but before serialized
+	// admission so a completed concurrent upgrade can change the installed version.
+	beforeTriggerAdmission func(string)
 }
 
 type activationMarker struct {
@@ -859,21 +862,8 @@ func (m *Manager) trigger(targetVersion, operationID string, idempotent bool) (u
 			),
 		)
 	}
-	currentVersion, err := readInstalledVersion(filepath.Join(m.cfg.InstallRoot, "deployment", "version.txt"))
-	if err != nil {
-		return updaterapi.Operation{}, err
-	}
-	if !semver.IsValid(currentVersion) {
-		return updaterapi.Operation{}, newTriggerError(
-			errTriggerPrecondition,
-			fmt.Sprintf("installed version %q is not upgradeable", currentVersion),
-		)
-	}
-	if semver.Compare(targetVersion, currentVersion) <= 0 {
-		return updaterapi.Operation{}, newTriggerError(
-			errTriggerPrecondition,
-			fmt.Sprintf("target version %s must be newer than installed version %s", targetVersion, currentVersion),
-		)
+	if m.cfg.beforeTriggerAdmission != nil {
+		m.cfg.beforeTriggerAdmission(targetVersion)
 	}
 
 	m.mu.Lock()
@@ -900,6 +890,25 @@ func (m *Manager) trigger(targetVersion, operationID string, idempotent bool) (u
 		return updaterapi.Operation{}, newTriggerError(
 			errTriggerBusy,
 			"the previous upgrade is still completing cleanup",
+		)
+	}
+	// The installed deployment can change while an earlier trigger is running.
+	// Validate the monotonic-version precondition while admission is serialized,
+	// after the prior worker has fully finished and before this one is accepted.
+	currentVersion, err := readInstalledVersion(filepath.Join(m.cfg.InstallRoot, "deployment", "version.txt"))
+	if err != nil {
+		return updaterapi.Operation{}, err
+	}
+	if !semver.IsValid(currentVersion) {
+		return updaterapi.Operation{}, newTriggerError(
+			errTriggerPrecondition,
+			fmt.Sprintf("installed version %q is not upgradeable", currentVersion),
+		)
+	}
+	if semver.Compare(targetVersion, currentVersion) <= 0 {
+		return updaterapi.Operation{}, newTriggerError(
+			errTriggerPrecondition,
+			fmt.Sprintf("target version %s must be newer than installed version %s", targetVersion, currentVersion),
 		)
 	}
 	if err := m.cleanupStaleArtifacts(); err != nil {

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -143,18 +143,137 @@ type Manager struct {
 	closeErr         error
 }
 
-func ensureUpdaterStateDirectory(stateDir string) error {
-	if err := os.MkdirAll(stateDir, 0o700); err != nil {
-		return fmt.Errorf("create updater state directory: %w", err)
+// ensureUpdaterStateDirectory establishes the trust boundary that permits the
+// updater to reopen state and downloaded artifacts by pathname. Every path
+// component must be owned by root or the current effective user. Group- and
+// world-writable components are rejected except for sticky shared ancestors
+// (for example /tmp), where an untrusted user cannot replace a trusted-owned
+// child. The state directory itself is never allowed to be group- or
+// world-writable.
+func ensureUpdaterStateDirectory(stateDir string) (string, error) {
+	stateDir = filepath.Clean(stateDir)
+
+	existingPath, err := nearestExistingPath(stateDir)
+	if err != nil {
+		return "", err
 	}
+	existingIsStateDir := existingPath == stateDir
+	if err := validateTrustedUpdaterPath(existingPath, existingIsStateDir); err != nil {
+		return "", err
+	}
+	existingCanonical, err := filepath.EvalSymlinks(existingPath)
+	if err != nil {
+		return "", fmt.Errorf("resolve existing updater state ancestor: %w", err)
+	}
+	if err := validateTrustedUpdaterPath(existingCanonical, existingIsStateDir); err != nil {
+		return "", err
+	}
+
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		return "", fmt.Errorf("create updater state directory: %w", err)
+	}
+	if err := validateTrustedUpdaterPath(stateDir, true); err != nil {
+		return "", err
+	}
+	canonicalStateDir, err := filepath.EvalSymlinks(stateDir)
+	if err != nil {
+		return "", fmt.Errorf("resolve updater state directory: %w", err)
+	}
+	if err := validateTrustedUpdaterPath(canonicalStateDir, true); err != nil {
+		return "", err
+	}
+
 	stateInfo, err := os.Lstat(stateDir)
 	if err != nil {
-		return fmt.Errorf("inspect updater state directory: %w", err)
+		return "", fmt.Errorf("inspect updater state directory: %w", err)
 	}
-	if !stateInfo.IsDir() {
-		return fmt.Errorf("updater state path is not a directory")
+	canonicalInfo, err := os.Lstat(canonicalStateDir)
+	if err != nil {
+		return "", fmt.Errorf("inspect canonical updater state directory: %w", err)
+	}
+	if !os.SameFile(stateInfo, canonicalInfo) {
+		return "", fmt.Errorf("updater state directory changed while it was validated")
+	}
+	return canonicalStateDir, nil
+}
+
+func nearestExistingPath(path string) (string, error) {
+	for candidate := path; ; candidate = filepath.Dir(candidate) {
+		_, err := os.Lstat(candidate)
+		if err == nil {
+			return candidate, nil
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf("inspect updater state ancestor %q: %w", candidate, err)
+		}
+		if parent := filepath.Dir(candidate); parent == candidate {
+			return "", fmt.Errorf("find existing updater state ancestor for %q", path)
+		}
+	}
+}
+
+func validateTrustedUpdaterPath(path string, finalIsStateDir bool) error {
+	components := pathComponents(path)
+	for index, component := range components {
+		info, err := os.Lstat(component)
+		if err != nil {
+			return fmt.Errorf("inspect updater state path component %q: %w", component, err)
+		}
+		isFinal := index == len(components)-1
+		if info.Mode()&os.ModeSymlink != 0 {
+			if finalIsStateDir && isFinal {
+				return fmt.Errorf("updater state directory must not be a symlink: %q", component)
+			}
+			if err := validateTrustedUpdaterOwner(component, info); err != nil {
+				return err
+			}
+			continue
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("updater state path component is not a directory: %q", component)
+		}
+		if err := validateTrustedUpdaterOwner(component, info); err != nil {
+			return err
+		}
+		if info.Mode().Perm()&0o022 == 0 {
+			continue
+		}
+		if finalIsStateDir && isFinal {
+			return fmt.Errorf("updater state directory must not be group- or world-writable: %q", component)
+		}
+		if info.Mode()&os.ModeSticky == 0 {
+			return fmt.Errorf("updater state ancestor is group- or world-writable without the sticky bit: %q", component)
+		}
 	}
 	return nil
+}
+
+func validateTrustedUpdaterOwner(path string, info os.FileInfo) error {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return fmt.Errorf("inspect owner of updater state path component %q", path)
+	}
+	euid := uint32(os.Geteuid()) //nolint:gosec // Effective UIDs are non-negative on supported Unix hosts.
+	if stat.Uid != 0 && stat.Uid != euid {
+		return fmt.Errorf("updater state path component %q is owned by untrusted UID %d", path, stat.Uid)
+	}
+	return nil
+}
+
+func pathComponents(path string) []string {
+	var reversed []string
+	for component := filepath.Clean(path); ; component = filepath.Dir(component) {
+		reversed = append(reversed, component)
+		parent := filepath.Dir(component)
+		if parent == component {
+			break
+		}
+	}
+	components := make([]string, len(reversed))
+	for index := range reversed {
+		components[index] = reversed[len(reversed)-1-index]
+	}
+	return components
 }
 
 func openOperationLogRoot(stateDir string) (*os.Root, error) {
@@ -269,9 +388,11 @@ func NewManager(cfg Config) (*Manager, error) {
 	if cfg.PreflightTimeout < 0 || cfg.ActivationTimeout < 0 || cfg.CleanupTimeout < 0 {
 		return nil, fmt.Errorf("updater phase timeouts must be positive")
 	}
-	if err := ensureUpdaterStateDirectory(cfg.StateDir); err != nil {
+	canonicalStateDir, err := ensureUpdaterStateDirectory(cfg.StateDir)
+	if err != nil {
 		return nil, err
 	}
+	cfg.StateDir = canonicalStateDir
 	processLock, err := acquireProcessLock(cfg.StateDir)
 	if err != nil {
 		return nil, err

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -149,7 +149,7 @@ func TestManagerUpgradeStagesBeforeActivationAndPreservesConfiguration(t *testin
 	require.Len(t, commands, 2)
 	assert.Equal(t, []string{"./run-fleet.sh", "--non-interactive", "--preflight-only"}, commands[0].Args)
 	assert.Contains(t, commands[0].Dir, ".proto-fleet-upgrade-")
-	assert.Equal(t, filepath.Join(installRoot, "deployment"), commands[1].Dir)
+	assert.Equal(t, filepath.Join(manager.cfg.InstallRoot, "deployment"), commands[1].Dir)
 	assert.Equal(t, []string{"./run-fleet.sh", "--non-interactive", "--skip-build"}, commands[1].Args)
 	assert.FileExists(t, completed.LogPath)
 	assert.Empty(t, completed.RecoveryCommand)
@@ -188,8 +188,18 @@ func TestManagerSelfUpdateUsesVerifiedArchiveCopy(t *testing.T) {
 
 	installRoot := t.TempDir()
 	writeCurrentDeployment(t, installRoot, "v1.0.0")
-	installedUpdater := filepath.Join(t.TempDir(), "proto-fleet-updater")
+	updaterRoot := t.TempDir()
+	originalParent := filepath.Join(updaterRoot, "original")
+	replacementParent := filepath.Join(updaterRoot, "replacement")
+	require.NoError(t, os.Mkdir(originalParent, 0o700))
+	require.NoError(t, os.Mkdir(replacementParent, 0o700))
+	installedUpdater := filepath.Join(originalParent, "proto-fleet-updater")
+	replacementUpdater := filepath.Join(replacementParent, "proto-fleet-updater")
 	require.NoError(t, os.WriteFile(installedUpdater, []byte("old updater"), 0o755))
+	require.NoError(t, os.WriteFile(replacementUpdater, []byte("replacement path"), 0o755))
+	linkedParent := filepath.Join(updaterRoot, "linked")
+	require.NoError(t, os.Symlink(originalParent, linkedParent))
+	configuredUpdater := filepath.Join(linkedParent, "proto-fleet-updater")
 	bundle := releaseBundle(t, "v1.1.0")
 	server := releaseServer(t, "v1.1.0", "amd64", bundle, "")
 	runner := &recordingRunner{
@@ -199,10 +209,12 @@ func TestManagerSelfUpdateUsesVerifiedArchiveCopy(t *testing.T) {
 				[]byte("operator replacement"),
 				0o755,
 			))
+			require.NoError(t, os.Remove(linkedParent))
+			require.NoError(t, os.Symlink(replacementParent, linkedParent))
 		},
 	}
 	manager := newTestManagerWithConfig(t, installRoot, server, runner, func(cfg *Config) {
-		cfg.SelfUpdatePath = installedUpdater
+		cfg.SelfUpdatePath = configuredUpdater
 	})
 
 	_, err := manager.Trigger("v1.1.0")
@@ -211,9 +223,12 @@ func TestManagerSelfUpdateUsesVerifiedArchiveCopy(t *testing.T) {
 
 	require.Equal(t, updaterapi.PhaseSucceeded, completed.Phase, completed.Error)
 	assert.Equal(t, "updater", mustReadFile(t, installedUpdater))
+	assert.Equal(t, "replacement path", mustReadFile(t, replacementUpdater))
 	assert.Equal(t, "old updater", mustReadFile(t, installedUpdater+selfUpdateBackupSuffix))
 	select {
-	case <-manager.SelfUpdateReady():
+	case readyPath := <-manager.SelfUpdateReady():
+		assert.Equal(t, manager.cfg.SelfUpdatePath, readyPath)
+		assert.NotEqual(t, configuredUpdater, readyPath)
 	case <-time.After(time.Second):
 		t.Fatal("successful updater replacement did not request a self-restart")
 	}
@@ -334,10 +349,15 @@ func TestManagerSelfUpdateFailureIsADegradedSuccess(t *testing.T) {
 	writeCurrentDeployment(t, installRoot, "v1.0.0")
 	bundle := releaseBundle(t, "v1.1.0")
 	server := releaseServer(t, "v1.1.0", "amd64", bundle, "")
-	runner := &recordingRunner{}
-	missingParent := filepath.Join(t.TempDir(), "missing", "proto-fleet-updater")
+	updaterParent := filepath.Join(t.TempDir(), "updater")
+	require.NoError(t, os.Mkdir(updaterParent, 0o700))
+	installedUpdater := filepath.Join(updaterParent, "proto-fleet-updater")
+	require.NoError(t, os.WriteFile(installedUpdater, []byte("old updater"), 0o755))
+	runner := &recordingRunner{activationHook: func(string) {
+		require.NoError(t, os.RemoveAll(updaterParent))
+	}}
 	manager := newTestManagerWithConfig(t, installRoot, server, runner, func(cfg *Config) {
-		cfg.SelfUpdatePath = missingParent
+		cfg.SelfUpdatePath = installedUpdater
 	})
 
 	_, err := manager.Trigger("v1.1.0")
@@ -348,7 +368,7 @@ func TestManagerSelfUpdateFailureIsADegradedSuccess(t *testing.T) {
 	assert.Equal(t, "v1.1.0", mustReadVersion(t, filepath.Join(installRoot, "deployment", "version.txt")))
 	assert.Contains(t, completed.Message, "host updater refresh needs attention")
 	assert.Contains(t, mustReadFile(t, completed.LogPath), "host updater binary was not refreshed")
-	assert.NoFileExists(t, missingParent)
+	assert.NoFileExists(t, installedUpdater)
 	select {
 	case <-manager.SelfUpdateReady():
 		t.Fatal("failed updater replacement must not request a self-restart")
@@ -1465,6 +1485,301 @@ func TestManagerRejectsUnrecoverableInterruptedActivationLayout(t *testing.T) {
 		GOARCH:      "amd64",
 	})
 	require.ErrorContains(t, err, "both deployment and deployment.previous are missing")
+}
+
+func TestInstallRootTrustAllowsOnlyOneNonRootAdmin(t *testing.T) {
+	t.Parallel()
+
+	rootAndB := &installRootTrust{}
+	require.NoError(t, rootAndB.validateUID("/", 0))
+	require.NoError(t, rootAndB.validateUID("/srv/fleet/deployment", 1002))
+
+	aAndB := &installRootTrust{}
+	require.NoError(t, aAndB.validateUID("/srv/admin-a", 1001))
+	require.ErrorContains(t, aAndB.validateUID("/srv/fleet/deployment", 1002), "trusted install-admin UID is 1001")
+}
+
+func TestManagerRejectsUnsafeInstallRoot(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name      string
+		prepare   func(*testing.T) string
+		wantError string
+	}{
+		{
+			name: "missing",
+			prepare: func(t *testing.T) string {
+				return filepath.Join(t.TempDir(), "missing")
+			},
+			wantError: "install root path component",
+		},
+		{
+			name: "regular file",
+			prepare: func(t *testing.T) string {
+				path := filepath.Join(t.TempDir(), "install")
+				require.NoError(t, os.WriteFile(path, []byte("not a directory"), 0o600))
+				return path
+			},
+			wantError: "install root path component is not a directory",
+		},
+		{
+			name: "final symlink",
+			prepare: func(t *testing.T) string {
+				root := t.TempDir()
+				target := filepath.Join(root, "target")
+				require.NoError(t, os.Mkdir(target, 0o700))
+				path := filepath.Join(root, "install")
+				require.NoError(t, os.Symlink(target, path))
+				return path
+			},
+			wantError: "install root must not be a symlink",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := NewManager(Config{
+				InstallRoot: test.prepare(t),
+				StateDir:    filepath.Join(t.TempDir(), "state"),
+				GOARCH:      "amd64",
+			})
+			require.ErrorContains(t, err, test.wantError)
+		})
+	}
+}
+
+func TestManagerRejectsWritableInstallRoot(t *testing.T) {
+	t.Parallel()
+
+	for _, mode := range []os.FileMode{0o770, 0o707, os.ModeSticky | 0o707} {
+		installRoot := t.TempDir()
+		require.NoError(t, os.Chmod(installRoot, mode))
+		_, err := NewManager(Config{
+			InstallRoot: installRoot,
+			StateDir:    filepath.Join(t.TempDir(), "state"),
+			GOARCH:      "amd64",
+		})
+		require.ErrorContains(t, err, "install root must not be group- or world-writable")
+	}
+}
+
+func TestManagerRejectsWritableInstallRootAncestor(t *testing.T) {
+	t.Parallel()
+
+	unsafeAncestor := filepath.Join(t.TempDir(), "unsafe")
+	require.NoError(t, os.Mkdir(unsafeAncestor, 0o700))
+	require.NoError(t, os.Chmod(unsafeAncestor, 0o770)) //nolint:gosec // Deliberately unsafe mode exercises fail-closed validation.
+	t.Cleanup(func() {
+		// #nosec G302 -- directories require execute permission for cleanup.
+		assert.NoError(t, os.Chmod(unsafeAncestor, 0o700))
+	})
+	installRoot := filepath.Join(unsafeAncestor, "install")
+	require.NoError(t, os.Mkdir(installRoot, 0o700))
+
+	_, err := NewManager(Config{
+		InstallRoot: installRoot,
+		StateDir:    filepath.Join(t.TempDir(), "state"),
+		GOARCH:      "amd64",
+	})
+	require.ErrorContains(t, err, "install root ancestor is group- or world-writable")
+}
+
+func TestManagerRejectsUnsafeExistingDeploymentDirectory(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"deployment", "deployment.previous"} {
+		t.Run(name+" symlink", func(t *testing.T) {
+			t.Parallel()
+			installRoot := t.TempDir()
+			target := filepath.Join(t.TempDir(), "target")
+			require.NoError(t, os.Mkdir(target, 0o700))
+			require.NoError(t, os.Symlink(target, filepath.Join(installRoot, name)))
+			_, err := NewManager(Config{InstallRoot: installRoot, StateDir: filepath.Join(t.TempDir(), "state"), GOARCH: "amd64"})
+			require.ErrorContains(t, err, name+" directory must not be a symlink")
+		})
+		t.Run(name+" writable", func(t *testing.T) {
+			t.Parallel()
+			installRoot := t.TempDir()
+			path := filepath.Join(installRoot, name)
+			require.NoError(t, os.Mkdir(path, 0o700))
+			require.NoError(t, os.Chmod(path, 0o770)) //nolint:gosec // Deliberately unsafe mode exercises fail-closed validation.
+			_, err := NewManager(Config{InstallRoot: installRoot, StateDir: filepath.Join(t.TempDir(), "state"), GOARCH: "amd64"})
+			require.ErrorContains(t, err, name+" directory must not be group- or world-writable")
+		})
+	}
+}
+
+func TestManagerCanonicalizesTrustedInstallRootAncestor(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	originalParent := filepath.Join(root, "original")
+	replacementParent := filepath.Join(root, "replacement")
+	for _, parent := range []string{originalParent, replacementParent} {
+		require.NoError(t, os.Mkdir(parent, 0o700))
+	}
+	originalRoot := filepath.Join(originalParent, "install")
+	require.NoError(t, os.Mkdir(originalRoot, 0o700))
+	writeCurrentDeployment(t, originalRoot, "v1.0.0")
+	replacementRoot := filepath.Join(replacementParent, "install")
+	require.NoError(t, os.Mkdir(replacementRoot, 0o700))
+	writeCurrentDeployment(t, replacementRoot, "v9.9.9")
+	linkedParent := filepath.Join(root, "linked")
+	require.NoError(t, os.Symlink(originalParent, linkedParent))
+
+	manager, err := NewManager(Config{
+		InstallRoot: filepath.Join(linkedParent, "install"),
+		StateDir:    filepath.Join(t.TempDir(), "state"),
+		GOARCH:      "amd64",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, manager.Close()) })
+	canonicalRoot, err := filepath.EvalSymlinks(originalRoot)
+	require.NoError(t, err)
+	require.Equal(t, canonicalRoot, manager.cfg.InstallRoot)
+
+	require.NoError(t, os.Remove(linkedParent))
+	require.NoError(t, os.Symlink(replacementParent, linkedParent))
+	assert.Equal(t, "v1.0.0", mustReadVersion(t, filepath.Join(manager.cfg.InstallRoot, "deployment", "version.txt")))
+}
+
+func TestManagerRejectsUnsafeSelfUpdatePath(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name      string
+		prepare   func(*testing.T) string
+		wantError string
+	}{
+		{
+			name: "missing",
+			prepare: func(t *testing.T) string {
+				return filepath.Join(t.TempDir(), "missing")
+			},
+			wantError: "inspect self-update path",
+		},
+		{
+			name: "non-executable",
+			prepare: func(t *testing.T) string {
+				path := filepath.Join(t.TempDir(), "updater")
+				require.NoError(t, os.WriteFile(path, []byte("updater"), 0o600))
+				return path
+			},
+			wantError: "executable regular file",
+		},
+		{
+			name: "writable executable",
+			prepare: func(t *testing.T) string {
+				path := filepath.Join(t.TempDir(), "updater")
+				require.NoError(t, os.WriteFile(path, []byte("updater"), 0o755))
+				require.NoError(t, os.Chmod(path, 0o775)) //nolint:gosec // Deliberately unsafe mode exercises fail-closed validation.
+				return path
+			},
+			wantError: "must not be group- or world-writable",
+		},
+		{
+			name: "writable parent",
+			prepare: func(t *testing.T) string {
+				parent := filepath.Join(t.TempDir(), "updater-parent")
+				require.NoError(t, os.Mkdir(parent, 0o700))
+				require.NoError(t, os.Chmod(parent, 0o770)) //nolint:gosec // Deliberately unsafe mode exercises fail-closed validation.
+				path := filepath.Join(parent, "updater")
+				require.NoError(t, os.WriteFile(path, []byte("updater"), 0o755))
+				return path
+			},
+			wantError: "self-update path ancestor is group- or world-writable",
+		},
+		{
+			name: "final symlink",
+			prepare: func(t *testing.T) string {
+				root := t.TempDir()
+				target := filepath.Join(root, "target")
+				require.NoError(t, os.WriteFile(target, []byte("updater"), 0o755))
+				path := filepath.Join(root, "updater")
+				require.NoError(t, os.Symlink(target, path))
+				return path
+			},
+			wantError: "self-update path must not be a symlink",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			installRoot := t.TempDir()
+			writeCurrentDeployment(t, installRoot, "v1.0.0")
+			_, err := NewManager(Config{
+				InstallRoot:    installRoot,
+				StateDir:       filepath.Join(t.TempDir(), "state"),
+				SelfUpdatePath: test.prepare(t),
+				GOARCH:         "amd64",
+			})
+			require.ErrorContains(t, err, test.wantError)
+		})
+	}
+}
+
+func TestSelfUpdateTrustRejectsUntrustedOwner(t *testing.T) {
+	t.Parallel()
+
+	require.ErrorContains(t, validateDaemonPathUID("/usr/local/bin/updater", 1002, 1001), "untrusted UID 1002")
+}
+
+func TestManagerAllowsStickySharedSelfUpdateAncestor(t *testing.T) {
+	t.Parallel()
+
+	sharedParent := filepath.Join(t.TempDir(), "shared")
+	require.NoError(t, os.Mkdir(sharedParent, 0o700))
+	require.NoError(t, os.Chmod(sharedParent, os.ModeSticky|0o777))
+	installedUpdater := filepath.Join(sharedParent, "updater")
+	require.NoError(t, os.WriteFile(installedUpdater, []byte("updater"), 0o755))
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+
+	manager, err := NewManager(Config{
+		InstallRoot:    installRoot,
+		StateDir:       filepath.Join(t.TempDir(), "state"),
+		SelfUpdatePath: installedUpdater,
+		GOARCH:         "amd64",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, manager.Close()) })
+}
+
+func TestManagerCanonicalizesTrustedSelfUpdateAncestor(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	originalParent := filepath.Join(root, "original")
+	replacementParent := filepath.Join(root, "replacement")
+	for _, parent := range []string{originalParent, replacementParent} {
+		require.NoError(t, os.Mkdir(parent, 0o700))
+		require.NoError(t, os.WriteFile(filepath.Join(parent, "updater"), []byte("current"), 0o755))
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(originalParent, "updater.previous"), []byte("previous"), 0o755))
+	linkedParent := filepath.Join(root, "linked")
+	require.NoError(t, os.Symlink(originalParent, linkedParent))
+	configuredPath := filepath.Join(linkedParent, "updater")
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+
+	manager, err := NewManager(Config{
+		InstallRoot:    installRoot,
+		StateDir:       filepath.Join(t.TempDir(), "state"),
+		SelfUpdatePath: configuredPath,
+		GOARCH:         "amd64",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, manager.Close()) })
+	configuredInfo, err := os.Lstat(configuredPath)
+	require.NoError(t, err)
+	canonicalInfo, err := os.Lstat(manager.cfg.SelfUpdatePath)
+	require.NoError(t, err)
+	require.True(t, os.SameFile(configuredInfo, canonicalInfo))
+
+	require.NoError(t, os.Remove(linkedParent))
+	require.NoError(t, os.Symlink(replacementParent, linkedParent))
+	require.NoError(t, manager.RollbackSelfUpdate())
+	assert.Equal(t, "previous", mustReadFile(t, filepath.Join(originalParent, "updater")))
+	assert.Equal(t, "current", mustReadFile(t, filepath.Join(replacementParent, "updater")))
 }
 
 func TestManagerRejectsWritableStateDirectory(t *testing.T) {

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -1,0 +1,368 @@
+package updater
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/proto-fleet/server/internal/updaterapi"
+)
+
+type recordedCommand struct {
+	Dir  string
+	Name string
+	Args []string
+}
+
+type recordingRunner struct {
+	mu          sync.Mutex
+	commands    []recordedCommand
+	preflight   error
+	activation  error
+	preflightAt chan struct{}
+	release     chan struct{}
+}
+
+const operatorEnv = `DB_PASSWORD=secret
+ENABLE_BETA_ALERTS=true
+ENABLE_SYSTEM_MONITORING=true
+ENABLE_TRACING=true
+ENABLE_ONE_CLICK_UPDATES=true
+`
+
+func (r *recordingRunner) Run(_ context.Context, dir string, _ io.Writer, name string, args ...string) error {
+	r.mu.Lock()
+	r.commands = append(r.commands, recordedCommand{Dir: dir, Name: name, Args: append([]string(nil), args...)})
+	call := len(r.commands)
+	r.mu.Unlock()
+
+	if call == 1 {
+		if r.preflightAt != nil {
+			close(r.preflightAt)
+		}
+		if r.release != nil {
+			<-r.release
+		}
+		return r.preflight
+	}
+	return r.activation
+}
+
+func (r *recordingRunner) Commands() []recordedCommand {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]recordedCommand(nil), r.commands...)
+}
+
+func TestManagerUpgradeStagesBeforeActivationAndPreservesConfiguration(t *testing.T) {
+	t.Parallel()
+
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	bundle := releaseBundle(t, "v1.1.0")
+	server := releaseServer(t, "v1.1.0", "amd64", bundle, "")
+	runner := &recordingRunner{}
+	manager := newTestManager(t, installRoot, server, runner)
+
+	operation, err := manager.Trigger("v1.1.0")
+	require.NoError(t, err)
+	assert.Equal(t, updaterapi.PhaseQueued, operation.Phase)
+
+	completed := waitForTerminal(t, manager)
+	require.Equal(t, updaterapi.PhaseSucceeded, completed.Phase, completed.Error)
+	assert.Equal(t, "v1.1.0", mustReadVersion(t, filepath.Join(installRoot, "deployment", "version.txt")))
+	assert.Equal(t, "v1.0.0", mustReadVersion(t, filepath.Join(installRoot, "deployment.previous", "version.txt")))
+	assert.Equal(t, operatorEnv, mustReadFile(t, filepath.Join(installRoot, "deployment", ".env")))
+	assert.Equal(t, "certificate\n", mustReadFile(t, filepath.Join(installRoot, "deployment", "ssl", "cert.pem")))
+	assert.Equal(t, "influx-secret\n", mustReadFile(t, filepath.Join(installRoot, "deployment", "server", "influx_config", ".env")))
+
+	commands := runner.Commands()
+	require.Len(t, commands, 2)
+	assert.Equal(t, []string{"./run-fleet.sh", "--non-interactive", "--preflight-only"}, commands[0].Args)
+	assert.Contains(t, commands[0].Dir, ".proto-fleet-upgrade-")
+	assert.Equal(t, filepath.Join(installRoot, "deployment"), commands[1].Dir)
+	assert.Equal(t, []string{"./run-fleet.sh", "--non-interactive", "--skip-build"}, commands[1].Args)
+	assert.FileExists(t, completed.LogPath)
+	assert.Contains(t, completed.RecoveryCommand, "./run-fleet.sh --non-interactive --skip-build")
+}
+
+func TestManagerChecksumFailureLeavesCurrentDeploymentUntouched(t *testing.T) {
+	t.Parallel()
+
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	bundle := releaseBundle(t, "v1.1.0")
+	server := releaseServer(t, "v1.1.0", "amd64", bundle, strings.Repeat("0", sha256.Size*2))
+	runner := &recordingRunner{}
+	manager := newTestManager(t, installRoot, server, runner)
+
+	_, err := manager.Trigger("v1.1.0")
+	require.NoError(t, err)
+	completed := waitForTerminal(t, manager)
+
+	assert.Equal(t, updaterapi.PhaseFailed, completed.Phase)
+	assert.Contains(t, completed.Error, "checksum verification failed")
+	assert.Equal(t, "v1.0.0", mustReadVersion(t, filepath.Join(installRoot, "deployment", "version.txt")))
+	assert.NoDirExists(t, filepath.Join(installRoot, "deployment.previous"))
+	assert.Empty(t, runner.Commands())
+}
+
+func TestManagerPreflightFailureNeverTakesTheRunningDeploymentOffline(t *testing.T) {
+	t.Parallel()
+
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	bundle := releaseBundle(t, "v1.1.0")
+	server := releaseServer(t, "v1.1.0", "amd64", bundle, "")
+	runner := &recordingRunner{preflight: assert.AnError}
+	manager := newTestManager(t, installRoot, server, runner)
+
+	_, err := manager.Trigger("v1.1.0")
+	require.NoError(t, err)
+	completed := waitForTerminal(t, manager)
+
+	assert.Equal(t, updaterapi.PhaseFailed, completed.Phase)
+	assert.Contains(t, completed.Error, "preflight failed")
+	assert.Equal(t, "v1.0.0", mustReadVersion(t, filepath.Join(installRoot, "deployment", "version.txt")))
+	assert.NoDirExists(t, filepath.Join(installRoot, "deployment.previous"))
+	require.Len(t, runner.Commands(), 1)
+}
+
+func TestManagerRejectsASecondUpgradeWhileOneIsRunning(t *testing.T) {
+	t.Parallel()
+
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	bundle := releaseBundle(t, "v1.1.0")
+	server := releaseServer(t, "v1.1.0", "amd64", bundle, "")
+	runner := &recordingRunner{
+		preflightAt: make(chan struct{}),
+		release:     make(chan struct{}),
+	}
+	manager := newTestManager(t, installRoot, server, runner)
+
+	_, err := manager.Trigger("v1.1.0")
+	require.NoError(t, err)
+	select {
+	case <-runner.preflightAt:
+	case <-time.After(5 * time.Second):
+		t.Fatal("upgrade never reached preflight")
+	}
+
+	_, err = manager.Trigger("v1.2.0")
+	require.ErrorContains(t, err, "already in progress")
+	close(runner.release)
+	assert.Equal(t, updaterapi.PhaseSucceeded, waitForTerminal(t, manager).Phase)
+}
+
+func TestManagerMarksAnInterruptedPersistedOperationFailed(t *testing.T) {
+	t.Parallel()
+
+	installRoot := t.TempDir()
+	stateDir := filepath.Join(t.TempDir(), "state")
+	require.NoError(t, os.MkdirAll(stateDir, 0o700))
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	started := time.Date(2026, 7, 29, 8, 0, 0, 0, time.UTC)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(stateDir, stateFilename),
+		[]byte(fmt.Sprintf(`{"id":"old","target_version":"v1.1.0","phase":"activating","started_at":%q,"updated_at":%q}`, started.Format(time.RFC3339Nano), started.Format(time.RFC3339Nano))),
+		0o600,
+	))
+
+	manager, err := NewManager(Config{
+		InstallRoot:     installRoot,
+		StateDir:        stateDir,
+		DownloadBaseURL: "https://example.invalid",
+		GOARCH:          "amd64",
+		Now:             func() time.Time { return started.Add(time.Minute) },
+	})
+	require.NoError(t, err)
+
+	operation := manager.Status().Operation
+	require.NotNil(t, operation)
+	assert.Equal(t, updaterapi.PhaseFailed, operation.Phase)
+	assert.Contains(t, operation.Error, "updater restarted")
+	require.NotNil(t, operation.CompletedAt)
+}
+
+func TestManagerRejectsUnsafeDownloadBaseURLs(t *testing.T) {
+	t.Parallel()
+
+	for _, rawURL := range []string{
+		"http://example.com/releases",
+		"https://",
+		"https://user@example.com/releases",
+		"https://example.com/releases?channel=test",
+		"https://example.com/releases#fragment",
+	} {
+		_, err := NewManager(Config{
+			InstallRoot:     t.TempDir(),
+			StateDir:        filepath.Join(t.TempDir(), "state"),
+			DownloadBaseURL: rawURL,
+			GOARCH:          "amd64",
+		})
+		require.Error(t, err, rawURL)
+	}
+}
+
+func TestExtractArchiveRejectsTraversal(t *testing.T) {
+	t.Parallel()
+
+	archive := filepath.Join(t.TempDir(), "unsafe.tar.gz")
+	var buffer bytes.Buffer
+	gzipWriter := gzip.NewWriter(&buffer)
+	tarWriter := tar.NewWriter(gzipWriter)
+	require.NoError(t, tarWriter.WriteHeader(&tar.Header{Name: "../escape", Mode: 0o644, Size: 1, Typeflag: tar.TypeReg}))
+	_, err := tarWriter.Write([]byte("x"))
+	require.NoError(t, err)
+	require.NoError(t, tarWriter.Close())
+	require.NoError(t, gzipWriter.Close())
+	require.NoError(t, os.WriteFile(archive, buffer.Bytes(), 0o600))
+
+	err = extractArchive(archive, t.TempDir())
+	require.ErrorContains(t, err, "unsafe path")
+}
+
+func TestAtomicReplaceExecutableRefreshesTheInstalledUpdater(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	source := filepath.Join(root, "staged-updater")
+	destination := filepath.Join(root, "installed", "proto-fleet-updater")
+	require.NoError(t, os.WriteFile(source, []byte("new updater"), 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Dir(destination), 0o750))
+	require.NoError(t, os.WriteFile(destination, []byte("old updater"), 0o755))
+
+	require.NoError(t, atomicReplaceExecutable(source, destination))
+	assert.Equal(t, "new updater", mustReadFile(t, destination))
+	info, err := os.Stat(destination)
+	require.NoError(t, err)
+	assert.NotZero(t, info.Mode().Perm()&0o111)
+}
+
+func newTestManager(t *testing.T, installRoot string, server *httptest.Server, runner CommandRunner) *Manager {
+	t.Helper()
+	manager, err := NewManager(Config{
+		InstallRoot:     installRoot,
+		StateDir:        filepath.Join(t.TempDir(), "state"),
+		DownloadBaseURL: server.URL,
+		HTTPClient:      server.Client(),
+		Runner:          runner,
+		GOARCH:          "amd64",
+		NewID:           func() string { return "test-operation" },
+	})
+	require.NoError(t, err)
+	return manager
+}
+
+func releaseServer(t *testing.T, version, arch string, bundle []byte, checksumOverride string) *httptest.Server {
+	t.Helper()
+	archiveName := fmt.Sprintf("proto-fleet-%s-%s.tar.gz", version, arch)
+	checksum := fmt.Sprintf("%x", sha256.Sum256(bundle))
+	if checksumOverride != "" {
+		checksum = checksumOverride
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/"+version+"/"+archiveName, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(bundle)
+	})
+	mux.HandleFunc("/"+version+"/"+archiveName+".sha256", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprintf(w, "%s  %s\n", checksum, archiveName)
+	})
+	server := httptest.NewTLSServer(mux)
+	t.Cleanup(server.Close)
+	return server
+}
+
+func releaseBundle(t *testing.T, version string) []byte {
+	t.Helper()
+	files := map[string]string{
+		"deployment/version.txt":                         "version: " + version + "\n",
+		"deployment/docker-compose.yaml":                 "services: {}\n",
+		"deployment/run-fleet.sh":                        "#!/usr/bin/env bash\n",
+		"deployment/server/fleetd":                       "fleetd",
+		"deployment/server/proto-plugin":                 "plugin",
+		"deployment/server/antminer-plugin":              "plugin",
+		"deployment/server/asicrs-plugin":                "plugin",
+		"deployment/updater/proto-fleet-updater":         "updater",
+		"deployment/updater/proto-fleet-updater.service": "[Service]\n",
+	}
+	var buffer bytes.Buffer
+	gzipWriter := gzip.NewWriter(&buffer)
+	tarWriter := tar.NewWriter(gzipWriter)
+	for name, contents := range files {
+		mode := int64(0o644)
+		if strings.HasSuffix(name, "run-fleet.sh") || strings.HasSuffix(name, "fleetd") || strings.HasSuffix(name, "-plugin") || strings.HasSuffix(name, "proto-fleet-updater") {
+			mode = 0o755
+		}
+		require.NoError(t, tarWriter.WriteHeader(&tar.Header{
+			Name:     name,
+			Mode:     mode,
+			Size:     int64(len(contents)),
+			Typeflag: tar.TypeReg,
+		}))
+		_, err := tarWriter.Write([]byte(contents))
+		require.NoError(t, err)
+	}
+	require.NoError(t, tarWriter.Close())
+	require.NoError(t, gzipWriter.Close())
+	return buffer.Bytes()
+}
+
+func writeCurrentDeployment(t *testing.T, installRoot, version string) {
+	t.Helper()
+	files := map[string]string{
+		"version.txt":               "version: " + version + "\n",
+		".env":                      operatorEnv,
+		"ssl/cert.pem":              "certificate\n",
+		"server/influx_config/.env": "influx-secret\n",
+	}
+	for name, contents := range files {
+		path := filepath.Join(installRoot, "deployment", name)
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o750))
+		require.NoError(t, os.WriteFile(path, []byte(contents), 0o600))
+	}
+}
+
+func waitForTerminal(t *testing.T, manager *Manager) updaterapi.Operation {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		status := manager.Status()
+		if status.Operation != nil && status.Operation.Phase.Terminal() {
+			return *status.Operation
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("upgrade did not reach a terminal state")
+	return updaterapi.Operation{}
+}
+
+func mustReadVersion(t *testing.T, path string) string {
+	t.Helper()
+	version, err := readInstalledVersion(path)
+	require.NoError(t, err)
+	return version
+}
+
+func mustReadFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return string(data)
+}

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -128,6 +128,9 @@ func TestManagerUpgradeStagesBeforeActivationAndPreservesConfiguration(t *testin
 
 	installRoot := t.TempDir()
 	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	haNodeEnvPath := filepath.Join(installRoot, "deployment", "ha", "node.env")
+	require.NoError(t, os.MkdirAll(filepath.Dir(haNodeEnvPath), 0o750))
+	require.NoError(t, os.WriteFile(haNodeEnvPath, []byte("HA_NODE_NAME=ha-a\n"), 0o600))
 	bundle := releaseBundle(t, "v1.1.0")
 	server := releaseServer(t, "v1.1.0", "amd64", bundle, "")
 	runner := &recordingRunner{}
@@ -144,6 +147,10 @@ func TestManagerUpgradeStagesBeforeActivationAndPreservesConfiguration(t *testin
 	assert.Equal(t, operatorEnv, mustReadFile(t, filepath.Join(installRoot, "deployment", ".env")))
 	assert.Equal(t, "certificate\n", mustReadFile(t, filepath.Join(installRoot, "deployment", "ssl", "cert.pem")))
 	assert.Equal(t, "influx-secret\n", mustReadFile(t, filepath.Join(installRoot, "deployment", "server", "influx_config", ".env")))
+	assert.Equal(t, "HA_NODE_NAME=ha-a\n", mustReadFile(t, filepath.Join(installRoot, "deployment", "ha", "node.env")))
+	haNodeEnv, err := os.Stat(filepath.Join(installRoot, "deployment", "ha", "node.env"))
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), haNodeEnv.Mode().Perm())
 
 	commands := runner.Commands()
 	require.Len(t, commands, 2)
@@ -154,6 +161,18 @@ func TestManagerUpgradeStagesBeforeActivationAndPreservesConfiguration(t *testin
 	assert.FileExists(t, completed.LogPath)
 	assert.Empty(t, completed.RecoveryCommand)
 	assert.NoFileExists(t, filepath.Join(manager.cfg.StateDir, activationMarkerFilename))
+}
+
+func TestPreserveDeploymentStateRejectsDanglingSymlink(t *testing.T) {
+	t.Parallel()
+
+	current := t.TempDir()
+	staged := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(current, "ha"), 0o750))
+	require.NoError(t, os.Symlink("missing-node.env", filepath.Join(current, "ha", "node.env")))
+
+	err := preserveDeploymentState(context.Background(), current, staged)
+	require.ErrorContains(t, err, "refusing to copy non-regular file")
 }
 
 func TestManagerDefersSelfUpdateUntilActivationSucceeds(t *testing.T) {

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -1403,6 +1403,134 @@ func TestManagerRejectsUnrecoverableInterruptedActivationLayout(t *testing.T) {
 	require.ErrorContains(t, err, "both deployment and deployment.previous are missing")
 }
 
+func TestManagerRejectsWritableStateDirectory(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name string
+		mode os.FileMode
+	}{
+		{name: "group writable", mode: 0o770},
+		{name: "world writable", mode: 0o707},
+		{name: "sticky world writable", mode: os.ModeSticky | 0o707},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			stateDir := filepath.Join(t.TempDir(), "state")
+			require.NoError(t, os.Mkdir(stateDir, 0o700))
+			require.NoError(t, os.Chmod(stateDir, test.mode))
+
+			_, err := NewManager(Config{
+				InstallRoot: t.TempDir(),
+				StateDir:    stateDir,
+				GOARCH:      "amd64",
+			})
+			require.ErrorContains(t, err, "state directory must not be group- or world-writable")
+		})
+	}
+}
+
+func TestManagerRejectsWritableStateDirectoryAncestor(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name string
+		mode os.FileMode
+	}{
+		{name: "group writable", mode: 0o770},
+		{name: "world writable", mode: 0o707},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			unsafeAncestor := filepath.Join(t.TempDir(), "unsafe")
+			require.NoError(t, os.Mkdir(unsafeAncestor, 0o700))
+			require.NoError(t, os.Chmod(unsafeAncestor, test.mode))
+			t.Cleanup(func() {
+				// #nosec G302 -- directories require execute permission for cleanup.
+				assert.NoError(t, os.Chmod(unsafeAncestor, 0o700))
+			})
+
+			_, err := NewManager(Config{
+				InstallRoot: t.TempDir(),
+				StateDir:    filepath.Join(unsafeAncestor, "nested", "state"),
+				GOARCH:      "amd64",
+			})
+			require.ErrorContains(t, err, "state ancestor is group- or world-writable without the sticky bit")
+		})
+	}
+}
+
+func TestManagerAllowsStickySharedStateDirectoryAncestor(t *testing.T) {
+	t.Parallel()
+
+	sharedAncestor := filepath.Join(t.TempDir(), "shared")
+	require.NoError(t, os.Mkdir(sharedAncestor, 0o700))
+	require.NoError(t, os.Chmod(sharedAncestor, os.ModeSticky|0o777))
+	t.Cleanup(func() {
+		// #nosec G302 -- directories require execute permission for cleanup.
+		assert.NoError(t, os.Chmod(sharedAncestor, 0o700))
+	})
+	stateDir := filepath.Join(sharedAncestor, "owned", "state")
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+
+	manager, err := NewManager(Config{
+		InstallRoot: installRoot,
+		StateDir:    stateDir,
+		GOARCH:      "amd64",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, manager.Close()) })
+
+	info, err := os.Stat(stateDir)
+	require.NoError(t, err)
+	assert.Zero(t, info.Mode().Perm()&0o077)
+}
+
+func TestManagerRejectsStateDirectorySymlink(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	target := filepath.Join(root, "target")
+	require.NoError(t, os.Mkdir(target, 0o700))
+	stateDir := filepath.Join(root, "state")
+	require.NoError(t, os.Symlink(target, stateDir))
+
+	_, err := NewManager(Config{
+		InstallRoot: t.TempDir(),
+		StateDir:    stateDir,
+		GOARCH:      "amd64",
+	})
+	require.ErrorContains(t, err, "state directory must not be a symlink")
+}
+
+func TestManagerCanonicalizesTrustedStateDirectorySymlinkAncestor(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	realParent := filepath.Join(root, "real")
+	require.NoError(t, os.Mkdir(realParent, 0o700))
+	linkedParent := filepath.Join(root, "linked")
+	require.NoError(t, os.Symlink(realParent, linkedParent))
+	stateDir := filepath.Join(linkedParent, "state")
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+
+	manager, err := NewManager(Config{
+		InstallRoot: installRoot,
+		StateDir:    stateDir,
+		GOARCH:      "amd64",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, manager.Close()) })
+
+	canonicalStateDir, err := filepath.EvalSymlinks(stateDir)
+	require.NoError(t, err)
+	assert.Equal(t, canonicalStateDir, manager.cfg.StateDir)
+}
+
 func TestManagerRejectsUnsafeDownloadBaseURLs(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -34,6 +34,7 @@ type recordingRunner struct {
 	commands    []recordedCommand
 	preflight   error
 	activation  error
+	cleanup     error
 	preflightAt chan struct{}
 	release     chan struct{}
 }
@@ -48,10 +49,9 @@ ENABLE_ONE_CLICK_UPDATES=true
 func (r *recordingRunner) Run(_ context.Context, dir string, _ io.Writer, name string, args ...string) error {
 	r.mu.Lock()
 	r.commands = append(r.commands, recordedCommand{Dir: dir, Name: name, Args: append([]string(nil), args...)})
-	call := len(r.commands)
 	r.mu.Unlock()
 
-	if call == 1 {
+	if name == "/bin/bash" && len(args) > 0 && args[len(args)-1] == "--preflight-only" {
 		if r.preflightAt != nil {
 			close(r.preflightAt)
 		}
@@ -59,6 +59,9 @@ func (r *recordingRunner) Run(_ context.Context, dir string, _ io.Writer, name s
 			<-r.release
 		}
 		return r.preflight
+	}
+	if name == "docker" {
+		return r.cleanup
 	}
 	return r.activation
 }
@@ -140,7 +143,35 @@ func TestManagerPreflightFailureNeverTakesTheRunningDeploymentOffline(t *testing
 	assert.Contains(t, completed.Error, "preflight failed")
 	assert.Equal(t, "v1.0.0", mustReadVersion(t, filepath.Join(installRoot, "deployment", "version.txt")))
 	assert.NoDirExists(t, filepath.Join(installRoot, "deployment.previous"))
-	require.Len(t, runner.Commands(), 1)
+	commands := runner.Commands()
+	require.Len(t, commands, 1+len(releaseImageRepositories))
+	assert.Equal(t, []string{"./run-fleet.sh", "--non-interactive", "--preflight-only"}, commands[0].Args)
+	for i, repository := range releaseImageRepositories {
+		cleanup := commands[i+1]
+		assert.Equal(t, "docker", cleanup.Name)
+		assert.Equal(t, []string{"image", "rm", repository + ":v1.1.0"}, cleanup.Args)
+		assert.Contains(t, cleanup.Dir, ".proto-fleet-upgrade-")
+	}
+}
+
+func TestManagerFailedPreflightImageCleanupIsBestEffort(t *testing.T) {
+	t.Parallel()
+
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	bundle := releaseBundle(t, "v1.1.0")
+	server := releaseServer(t, "v1.1.0", "amd64", bundle, "")
+	runner := &recordingRunner{preflight: assert.AnError, cleanup: assert.AnError}
+	manager := newTestManager(t, installRoot, server, runner)
+
+	_, err := manager.Trigger("v1.1.0")
+	require.NoError(t, err)
+	completed := waitForTerminal(t, manager)
+
+	assert.Equal(t, updaterapi.PhaseFailed, completed.Phase)
+	assert.Contains(t, completed.Error, "preflight failed")
+	assert.Equal(t, "v1.0.0", mustReadVersion(t, filepath.Join(installRoot, "deployment", "version.txt")))
+	assert.Contains(t, mustReadFile(t, completed.LogPath), "warning: could not remove failed preflight image proto-fleet-api:v1.1.0")
 }
 
 func TestManagerRejectsASecondUpgradeWhileOneIsRunning(t *testing.T) {

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -43,6 +43,7 @@ type recordingRunner struct {
 	releaseActivation    chan struct{}
 	waitForCleanupCancel bool
 	releaseCleanup       chan struct{}
+	preflightHook        func(string) error
 	activationHook       func(string)
 	candidateVersion     string
 	candidateError       error
@@ -86,6 +87,11 @@ func (r *recordingRunner) Run(ctx context.Context, dir string, output io.Writer,
 			case <-r.release:
 			case <-ctx.Done():
 				return fmt.Errorf("preflight canceled: %w", ctx.Err())
+			}
+		}
+		if r.preflightHook != nil {
+			if err := r.preflightHook(dir); err != nil {
+				return err
 			}
 		}
 		return r.preflight
@@ -253,6 +259,7 @@ func TestManagerSelfUpdateUsesVerifiedArchiveCopy(t *testing.T) {
 	}
 	_, err = manager.Trigger("v1.2.0")
 	require.ErrorContains(t, err, "updater is shutting down")
+	require.ErrorIs(t, err, errTriggerClosing)
 	var persisted updaterapi.Operation
 	require.NoError(t, json.Unmarshal([]byte(mustReadFile(t, filepath.Join(manager.cfg.StateDir, stateFilename))), &persisted))
 	assert.Equal(t, updaterapi.PhaseSucceeded, persisted.Phase)
@@ -318,6 +325,7 @@ func TestManagerFailsClosedWhenSuccessfulStateCannotPersist(t *testing.T) {
 
 	_, err = manager.Trigger("v1.2.0")
 	require.ErrorContains(t, err, "already in progress")
+	require.ErrorIs(t, err, errTriggerBusy)
 
 	// A restart reconciles the durable activation state into a terminal failure;
 	// until then, both the in-memory and persisted non-terminal state fail closed.
@@ -497,6 +505,69 @@ func TestManagerPreflightFailureNeverTakesTheRunningDeploymentOffline(t *testing
 		assert.Equal(t, []string{"image", "rm", repository + ":v1.1.0"}, cleanup.Args)
 		assert.Contains(t, cleanup.Dir, ".proto-fleet-upgrade-")
 	}
+}
+
+func TestManagerRestoresDeploymentOwnershipAfterPreflightBeforeStagedSync(t *testing.T) {
+	t.Parallel()
+
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	canonicalInstallRoot, err := filepath.EvalSymlinks(installRoot)
+	require.NoError(t, err)
+	bundle := releaseBundle(t, "v1.1.0")
+	server := releaseServer(t, "v1.1.0", "amd64", bundle, "")
+	var events []string
+	markerFilename := ".update-preflight-complete"
+	runner := &recordingRunner{
+		preflightHook: func(dir string) error {
+			events = append(events, "preflight")
+			return os.WriteFile(filepath.Join(dir, markerFilename), []byte("proof"), 0o600)
+		},
+		activationHook: func(string) {
+			events = append(events, "activation")
+		},
+	}
+	manager := newTestManagerWithConfig(t, installRoot, server, runner, func(cfg *Config) {
+		cfg.preserveDeploymentOwnership = func(_ context.Context, current, staged string) error {
+			events = append(events, "ownership")
+			if current != filepath.Join(canonicalInstallRoot, "deployment") {
+				return fmt.Errorf("unexpected current deployment %s", current)
+			}
+			info, err := os.Stat(filepath.Join(staged, markerFilename))
+			if err != nil {
+				return fmt.Errorf("inspect preflight proof during ownership restoration: %w", err)
+			}
+			if !info.Mode().IsRegular() {
+				return fmt.Errorf("preflight proof is not regular")
+			}
+			return nil
+		}
+		cfg.syncStagedDeployment = func(ctx context.Context, staged string) error {
+			events = append(events, "sync")
+			return syncStagedDeployment(ctx, staged)
+		}
+	})
+
+	_, err = manager.Trigger("v1.1.0")
+	require.NoError(t, err)
+	completed := waitForTerminal(t, manager)
+
+	require.Equal(t, updaterapi.PhaseSucceeded, completed.Phase, completed.Error)
+	assert.Equal(t, []string{"preflight", "ownership", "sync", "activation"}, events)
+	assert.Equal(t, "proof", mustReadFile(t, filepath.Join(installRoot, "deployment", markerFilename)))
+}
+
+func TestSetDeploymentTreeOwnershipRejectsNonRegularEntries(t *testing.T) {
+	t.Parallel()
+
+	staged := t.TempDir()
+	target := filepath.Join(t.TempDir(), "external-target")
+	require.NoError(t, os.WriteFile(target, []byte("unchanged"), 0o600))
+	require.NoError(t, os.Symlink(target, filepath.Join(staged, "preflight-generated-link")))
+
+	err := setDeploymentTreeOwnership(context.Background(), staged, os.Geteuid(), os.Getegid())
+	require.ErrorContains(t, err, "refusing to preserve ownership of non-regular staged entry")
+	assert.Equal(t, "unchanged", mustReadFile(t, target))
 }
 
 func TestManagerFailedPreflightImageCleanupIsBestEffort(t *testing.T) {
@@ -709,6 +780,7 @@ func TestManagerRejectsAnotherUpgradeWhileActivationRecoveryIsPending(t *testing
 
 	_, err = manager.Trigger("v1.2.0")
 	require.ErrorContains(t, err, "activation recovery for operation pending-recovery is pending")
+	require.ErrorIs(t, err, errTriggerBusy)
 	operation := manager.Status().Operation
 	require.NotNil(t, operation)
 	assert.Equal(t, "pending-recovery", operation.ID)
@@ -939,6 +1011,7 @@ func TestManagerShutdownCancelsPreActivationWorkAndWaits(t *testing.T) {
 	assert.Contains(t, completed.Error, context.Canceled.Error())
 	_, err = manager.Trigger("v1.2.0")
 	require.ErrorContains(t, err, "updater is shutting down")
+	require.ErrorIs(t, err, errTriggerClosing)
 }
 
 func TestManagerShutdownDuringActivationRetainsTheProcessLockUntilCompletion(t *testing.T) {

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -232,6 +232,70 @@ func TestManagerSelfUpdateUsesVerifiedArchiveCopy(t *testing.T) {
 	assert.Equal(t, "old updater", mustReadFile(t, installedUpdater+selfUpdateBackupSuffix))
 }
 
+func TestManagerFailsClosedWhenSuccessfulStateCannotPersist(t *testing.T) {
+	t.Parallel()
+
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	installedUpdater := filepath.Join(t.TempDir(), "proto-fleet-updater")
+	require.NoError(t, os.WriteFile(installedUpdater, []byte("old updater"), 0o755))
+	bundle := releaseBundle(t, "v1.1.0")
+	server := releaseServer(t, "v1.1.0", "amd64", bundle, "")
+	manager := newTestManagerWithConfig(t, installRoot, server, &recordingRunner{}, func(cfg *Config) {
+		cfg.SelfUpdatePath = installedUpdater
+		cfg.beforePersistState = func(operation updaterapi.Operation) error {
+			if operation.Phase == updaterapi.PhaseSucceeded {
+				return assert.AnError
+			}
+			return nil
+		}
+	})
+
+	_, err := manager.Trigger("v1.1.0")
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		manager.mu.RLock()
+		defer manager.mu.RUnlock()
+		return !manager.operationRunning
+	}, 5*time.Second, 10*time.Millisecond, "upgrade worker did not finish")
+
+	operation := manager.Status().Operation
+	require.NotNil(t, operation)
+	assert.Equal(t, updaterapi.PhaseActivating, operation.Phase)
+	assert.NotEmpty(t, operation.RecoveryCommand)
+	assert.Nil(t, operation.CompletedAt)
+	assert.NotContains(t, operation.Message, "is running")
+	assert.Equal(t, "updater", mustReadFile(t, installedUpdater), "self-update must reach the signal gate")
+	assert.Contains(t, mustReadFile(t, operation.LogPath), "further upgrades remain blocked")
+	select {
+	case <-manager.SelfUpdateReady():
+		t.Fatal("non-durable success must not request a self-restart")
+	default:
+	}
+
+	var persisted updaterapi.Operation
+	require.NoError(t, json.Unmarshal(
+		[]byte(mustReadFile(t, filepath.Join(manager.cfg.StateDir, stateFilename))),
+		&persisted,
+	))
+	assert.Equal(t, updaterapi.PhaseActivating, persisted.Phase)
+	assert.Equal(t, operation.RecoveryCommand, persisted.RecoveryCommand)
+	assert.Nil(t, persisted.CompletedAt)
+
+	_, err = manager.Trigger("v1.2.0")
+	require.ErrorContains(t, err, "already in progress")
+
+	// A restart reconciles the durable activation state into a terminal failure;
+	// until then, both the in-memory and persisted non-terminal state fail closed.
+	require.NoError(t, manager.Close())
+	restarted, err := NewManager(manager.cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, restarted.Close()) })
+	restartedOperation := restarted.Status().Operation
+	require.NotNil(t, restartedOperation)
+	assert.Equal(t, updaterapi.PhaseFailed, restartedOperation.Phase)
+}
+
 func TestManagerRejectsUpdaterCandidateWithUnexpectedVersionBeforeReplacement(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -230,6 +230,94 @@ func TestManagerTriggerWithIDDeduplicatesConcurrentAdmission(t *testing.T) {
 	assert.Len(t, runner.Commands(), 2, "concurrent same-ID admission must launch exactly one upgrade worker")
 }
 
+func TestManagerTriggerRevalidatesInstalledVersionDuringSerializedAdmission(t *testing.T) {
+	t.Parallel()
+
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	bundle := releaseBundle(t, "v1.2.0")
+	server := releaseServer(t, "v1.2.0", "amd64", bundle, "")
+	runner := &recordingRunner{}
+	firstSyncStarted := make(chan struct{})
+	releaseFirstSync := make(chan struct{})
+	staleTriggerAtAdmission := make(chan struct{})
+	releaseStaleTrigger := make(chan struct{})
+	var pauseFirstSync sync.Once
+	var releaseFirstSyncOnce sync.Once
+	var releaseStaleTriggerOnce sync.Once
+	manager := newTestManagerWithConfig(t, installRoot, server, runner, func(cfg *Config) {
+		cfg.syncStagedDeployment = func(ctx context.Context, staged string) error {
+			pause := false
+			pauseFirstSync.Do(func() {
+				pause = true
+				close(firstSyncStarted)
+			})
+			if pause {
+				select {
+				case <-releaseFirstSync:
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			}
+			return syncStagedDeployment(ctx, staged)
+		}
+		cfg.beforeTriggerAdmission = func(targetVersion string) {
+			if targetVersion != "v1.1.0" {
+				return
+			}
+			close(staleTriggerAtAdmission)
+			<-releaseStaleTrigger
+		}
+	})
+	releaseFirst := func() { releaseFirstSyncOnce.Do(func() { close(releaseFirstSync) }) }
+	releaseStale := func() { releaseStaleTriggerOnce.Do(func() { close(releaseStaleTrigger) }) }
+	t.Cleanup(releaseFirst)
+	t.Cleanup(releaseStale)
+
+	firstOperationID := "11111111-1111-4111-8111-111111111111"
+	_, err := manager.TriggerWithID("v1.2.0", firstOperationID)
+	require.NoError(t, err)
+	select {
+	case <-firstSyncStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first upgrade never reached staged-tree sync")
+	}
+
+	staleResult := make(chan error, 1)
+	go func() {
+		_, triggerErr := manager.TriggerWithID(
+			"v1.1.0",
+			"22222222-2222-4222-8222-222222222222",
+		)
+		staleResult <- triggerErr
+	}()
+	select {
+	case <-staleTriggerAtAdmission:
+	case <-time.After(5 * time.Second):
+		t.Fatal("second trigger never reached final admission")
+	}
+
+	releaseFirst()
+	completed := waitForTerminal(t, manager)
+	require.Equal(t, updaterapi.PhaseSucceeded, completed.Phase, completed.Error)
+	require.Eventually(t, func() bool {
+		manager.mu.RLock()
+		defer manager.mu.RUnlock()
+		return !manager.operationRunning
+	}, 5*time.Second, 10*time.Millisecond, "first upgrade worker did not finish")
+
+	releaseStale()
+	select {
+	case err = <-staleResult:
+	case <-time.After(5 * time.Second):
+		t.Fatal("second trigger did not complete admission")
+	}
+	require.ErrorIs(t, err, errTriggerPrecondition)
+	assert.ErrorContains(t, err, "target version v1.1.0 must be newer than installed version v1.2.0")
+	assert.Equal(t, firstOperationID, manager.Status().Operation.ID)
+	assert.Len(t, runner.Commands(), 2, "stale trigger must not launch a downgrade worker")
+}
+
 func TestPreserveDeploymentStateRejectsDanglingSymlink(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -792,6 +792,84 @@ func TestManagerPreflightDeadlineFailsTheOperation(t *testing.T) {
 	assert.Contains(t, completed.Error, context.DeadlineExceeded.Error())
 }
 
+func TestManagerShutdownCancelsStagedTreeSyncBeforeActivation(t *testing.T) {
+	t.Parallel()
+
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	bundle := releaseBundle(t, "v1.1.0")
+	server := releaseServer(t, "v1.1.0", "amd64", bundle, "")
+	syncStarted := make(chan struct{})
+	manager := newTestManagerWithConfig(t, installRoot, server, &recordingRunner{}, func(cfg *Config) {
+		cfg.ActivationTimeout = time.Hour
+		cfg.syncStagedDeployment = func(ctx context.Context, _ string) error {
+			close(syncStarted)
+			<-ctx.Done()
+			return ctx.Err()
+		}
+	})
+
+	_, err := manager.Trigger("v1.1.0")
+	require.NoError(t, err)
+	select {
+	case <-syncStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("upgrade never reached staged-tree sync")
+	}
+	operation := manager.Status().Operation
+	require.NotNil(t, operation)
+	assert.Equal(t, updaterapi.PhasePreflight, operation.Phase)
+	assert.NoFileExists(t, filepath.Join(manager.cfg.StateDir, activationMarkerFilename))
+	assert.NoDirExists(t, filepath.Join(installRoot, "deployment.previous"))
+	assert.Equal(t, "v1.0.0", mustReadVersion(t, filepath.Join(installRoot, "deployment", "version.txt")))
+
+	shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancelShutdown()
+	require.NoError(t, manager.Shutdown(shutdownCtx))
+	completed := manager.Status().Operation
+	require.NotNil(t, completed)
+	assert.Equal(t, updaterapi.PhaseFailed, completed.Phase)
+	assert.Contains(t, completed.Error, context.Canceled.Error())
+	assert.NoFileExists(t, filepath.Join(manager.cfg.StateDir, activationMarkerFilename))
+	assert.NoDirExists(t, filepath.Join(installRoot, "deployment.previous"))
+	assert.Equal(t, "v1.0.0", mustReadVersion(t, filepath.Join(installRoot, "deployment", "version.txt")))
+}
+
+func TestManagerStagedTreeSyncUsesActivationDeadlineBeforeSwap(t *testing.T) {
+	t.Parallel()
+
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	bundle := releaseBundle(t, "v1.1.0")
+	server := releaseServer(t, "v1.1.0", "amd64", bundle, "")
+	manager := newTestManagerWithConfig(t, installRoot, server, &recordingRunner{}, func(cfg *Config) {
+		cfg.ActivationTimeout = 25 * time.Millisecond
+		cfg.syncStagedDeployment = func(ctx context.Context, _ string) error {
+			<-ctx.Done()
+			return ctx.Err()
+		}
+	})
+
+	_, err := manager.Trigger("v1.1.0")
+	require.NoError(t, err)
+	completed := waitForTerminal(t, manager)
+	assert.Equal(t, updaterapi.PhaseFailed, completed.Phase)
+	assert.Contains(t, completed.Error, context.DeadlineExceeded.Error())
+	assert.NoFileExists(t, filepath.Join(manager.cfg.StateDir, activationMarkerFilename))
+	assert.NoDirExists(t, filepath.Join(installRoot, "deployment.previous"))
+	assert.Equal(t, "v1.0.0", mustReadVersion(t, filepath.Join(installRoot, "deployment", "version.txt")))
+}
+
+func TestSyncTreeStopsBeforeWalkingCanceledContext(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "file"), []byte("data"), 0o600))
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.ErrorIs(t, syncTree(ctx, root), context.Canceled)
+}
+
 func TestManagerActivationDeadlineLetsShutdownFinishWithoutRollback(t *testing.T) {
 	t.Parallel()
 
@@ -1825,9 +1903,13 @@ func TestManagerCanonicalizesTrustedSelfUpdateAncestor(t *testing.T) {
 	replacementParent := filepath.Join(root, "replacement")
 	for _, parent := range []string{originalParent, replacementParent} {
 		require.NoError(t, os.Mkdir(parent, 0o700))
-		require.NoError(t, os.WriteFile(filepath.Join(parent, "updater"), []byte("current"), 0o755))
 	}
-	require.NoError(t, os.WriteFile(filepath.Join(originalParent, "updater.previous"), []byte("previous"), 0o755))
+	originalUpdater := filepath.Join(originalParent, "updater")
+	require.NoError(t, os.WriteFile(originalUpdater, []byte("previous"), 0o755))
+	candidateUpdater := filepath.Join(originalParent, "updater.candidate")
+	require.NoError(t, os.WriteFile(candidateUpdater, []byte("current"), 0o755))
+	require.NoError(t, installExecutableCandidate(candidateUpdater, originalUpdater))
+	require.NoError(t, os.WriteFile(filepath.Join(replacementParent, "updater"), []byte("current"), 0o755))
 	linkedParent := filepath.Join(root, "linked")
 	require.NoError(t, os.Symlink(originalParent, linkedParent))
 	configuredPath := filepath.Join(linkedParent, "updater")
@@ -2052,13 +2134,15 @@ func TestInstallExecutableCandidateRetainsAndRestoresThePreviousUpdater(t *testi
 	require.NoError(t, installExecutableCandidate(candidatePath, destination))
 	assert.Equal(t, "new updater", mustReadFile(t, destination))
 	assert.Equal(t, "old updater", mustReadFile(t, destination+selfUpdateBackupSuffix))
+	assert.FileExists(t, destination+selfUpdateHandoffSuffix)
 	info, err := os.Stat(destination)
 	require.NoError(t, err)
 	assert.NotZero(t, info.Mode().Perm()&0o111)
 
-	require.NoError(t, restorePreviousExecutable(destination))
+	require.NoError(t, rollbackPendingSelfUpdate(destination))
 	assert.Equal(t, "old updater", mustReadFile(t, destination))
-	assert.NoFileExists(t, destination+selfUpdateBackupSuffix)
+	assert.Equal(t, "old updater", mustReadFile(t, destination+selfUpdateBackupSuffix))
+	assert.NoFileExists(t, destination+selfUpdateHandoffSuffix)
 }
 
 func TestValidateUpdaterCandidateRejectsAnUnrunnablePayload(t *testing.T) {

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -142,8 +142,10 @@ func TestManagerUpgradeStagesBeforeActivationAndPreservesConfiguration(t *testin
 	runner := &recordingRunner{}
 	manager := newTestManager(t, installRoot, server, runner)
 
-	operation, err := manager.Trigger("v1.1.0")
+	operationID := "11111111-1111-4111-8111-111111111111"
+	operation, err := manager.TriggerWithID("v1.1.0", operationID)
 	require.NoError(t, err)
+	assert.Equal(t, operationID, operation.ID)
 	assert.Equal(t, updaterapi.PhaseQueued, operation.Phase)
 
 	completed := waitForTerminal(t, manager)
@@ -167,6 +169,64 @@ func TestManagerUpgradeStagesBeforeActivationAndPreservesConfiguration(t *testin
 	assert.FileExists(t, completed.LogPath)
 	assert.Empty(t, completed.RecoveryCommand)
 	assert.NoFileExists(t, filepath.Join(manager.cfg.StateDir, activationMarkerFilename))
+
+	// A lost-response retry returns the durable operation even after the
+	// installed version changed, while ID reuse for another target is rejected.
+	retried, err := manager.TriggerWithID("v1.1.0", operationID)
+	require.NoError(t, err)
+	assert.Equal(t, updaterapi.PhaseSucceeded, retried.Phase)
+	_, err = manager.TriggerWithID("v1.2.0", operationID)
+	require.ErrorIs(t, err, errTriggerInvalid)
+}
+
+func TestManagerTriggerWithIDDeduplicatesConcurrentAdmission(t *testing.T) {
+	t.Parallel()
+
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	bundle := releaseBundle(t, "v1.1.0")
+	server := releaseServer(t, "v1.1.0", "amd64", bundle, "")
+	runner := &recordingRunner{}
+	admissionStarted := make(chan struct{})
+	releaseAdmission := make(chan struct{})
+	var blockQueuedPersist sync.Once
+	manager := newTestManagerWithConfig(t, installRoot, server, runner, func(cfg *Config) {
+		cfg.beforePersistState = func(operation updaterapi.Operation) error {
+			if operation.Phase == updaterapi.PhaseQueued {
+				blockQueuedPersist.Do(func() {
+					close(admissionStarted)
+					<-releaseAdmission
+				})
+			}
+			return nil
+		}
+	})
+
+	type triggerResult struct {
+		operation updaterapi.Operation
+		err       error
+	}
+	results := make(chan triggerResult, 2)
+	operationID := "11111111-1111-4111-8111-111111111111"
+	trigger := func() {
+		operation, err := manager.TriggerWithID("v1.1.0", operationID)
+		results <- triggerResult{operation: operation, err: err}
+	}
+	go trigger()
+	<-admissionStarted
+	go trigger()
+	close(releaseAdmission)
+
+	first := <-results
+	second := <-results
+	require.NoError(t, first.err)
+	require.NoError(t, second.err)
+	assert.Equal(t, first.operation, second.operation)
+	assert.Equal(t, operationID, first.operation.ID)
+
+	completed := waitForTerminal(t, manager)
+	require.Equal(t, updaterapi.PhaseSucceeded, completed.Phase, completed.Error)
+	assert.Len(t, runner.Commands(), 2, "concurrent same-ID admission must launch exactly one upgrade worker")
 }
 
 func TestPreserveDeploymentStateRejectsDanglingSymlink(t *testing.T) {

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -44,6 +44,8 @@ type recordingRunner struct {
 	waitForCleanupCancel bool
 	releaseCleanup       chan struct{}
 	activationHook       func(string)
+	candidateVersion     string
+	candidateError       error
 }
 
 const operatorEnv = `DB_PASSWORD=secret
@@ -53,10 +55,23 @@ ENABLE_TRACING=true
 ENABLE_ONE_CLICK_UPDATES=true
 `
 
-func (r *recordingRunner) Run(ctx context.Context, dir string, _ io.Writer, name string, args ...string) error {
+func (r *recordingRunner) Run(ctx context.Context, dir string, output io.Writer, name string, args ...string) error {
 	r.mu.Lock()
 	r.commands = append(r.commands, recordedCommand{Dir: dir, Name: name, Args: append([]string(nil), args...)})
 	r.mu.Unlock()
+	if len(args) == 1 && args[0] == "--version" && name != "/bin/bash" {
+		if r.candidateError != nil {
+			return r.candidateError
+		}
+		candidateVersion := r.candidateVersion
+		if candidateVersion == "" {
+			candidateVersion = "v1.1.0"
+		}
+		if _, err := fmt.Fprintln(output, candidateVersion); err != nil {
+			return fmt.Errorf("write candidate version: %w", err)
+		}
+		return nil
+	}
 
 	if name == "/bin/bash" && len(args) > 0 && args[len(args)-1] == "--preflight-only" {
 		if r.preflightAt != nil {
@@ -196,6 +211,7 @@ func TestManagerSelfUpdateUsesVerifiedArchiveCopy(t *testing.T) {
 
 	require.Equal(t, updaterapi.PhaseSucceeded, completed.Phase, completed.Error)
 	assert.Equal(t, "updater", mustReadFile(t, installedUpdater))
+	assert.Equal(t, "old updater", mustReadFile(t, installedUpdater+selfUpdateBackupSuffix))
 	select {
 	case <-manager.SelfUpdateReady():
 	case <-time.After(time.Second):
@@ -213,6 +229,38 @@ func TestManagerSelfUpdateUsesVerifiedArchiveCopy(t *testing.T) {
 	restartedOperation := restarted.Status().Operation
 	require.NotNil(t, restartedOperation)
 	assert.Equal(t, updaterapi.PhaseSucceeded, restartedOperation.Phase)
+	assert.Equal(t, "old updater", mustReadFile(t, installedUpdater+selfUpdateBackupSuffix))
+}
+
+func TestManagerRejectsUpdaterCandidateWithUnexpectedVersionBeforeReplacement(t *testing.T) {
+	t.Parallel()
+
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	installedUpdater := filepath.Join(t.TempDir(), "proto-fleet-updater")
+	require.NoError(t, os.WriteFile(installedUpdater, []byte("old updater"), 0o755))
+	bundle := releaseBundle(t, "v1.1.0")
+	server := releaseServer(t, "v1.1.0", "amd64", bundle, "")
+	runner := &recordingRunner{candidateVersion: "v9.9.9"}
+	manager := newTestManagerWithConfig(t, installRoot, server, runner, func(cfg *Config) {
+		cfg.SelfUpdatePath = installedUpdater
+	})
+
+	_, err := manager.Trigger("v1.1.0")
+	require.NoError(t, err)
+	completed := waitForTerminal(t, manager)
+
+	require.Equal(t, updaterapi.PhaseSucceeded, completed.Phase, completed.Error)
+	assert.Equal(t, "old updater", mustReadFile(t, installedUpdater))
+	assert.NoFileExists(t, installedUpdater+selfUpdateBackupSuffix)
+	assert.NoFileExists(t, installedUpdater+".candidate")
+	assert.Contains(t, completed.Message, "host updater refresh needs attention")
+	assert.Contains(t, mustReadFile(t, completed.LogPath), "reported version")
+	select {
+	case <-manager.SelfUpdateReady():
+		t.Fatal("invalid updater candidate must not request a self-restart")
+	default:
+	}
 }
 
 func TestManagerSelfUpdateFailureIsADegradedSuccess(t *testing.T) {
@@ -718,8 +766,12 @@ func TestManagerShutdownDuringActivationRetainsTheProcessLockUntilCompletion(t *
 	require.NoError(t, manager.Shutdown(finalShutdownCtx))
 	cancelFinalShutdown()
 
-	replacement, err := NewManager(config)
-	require.NoError(t, err)
+	var replacement *Manager
+	require.Eventually(t, func() bool {
+		var replacementErr error
+		replacement, replacementErr = NewManager(config)
+		return replacementErr == nil
+	}, 2*time.Second, 10*time.Millisecond, "replacement manager did not reacquire the released process lock")
 	t.Cleanup(func() { assert.NoError(t, replacement.Close()) })
 }
 
@@ -925,6 +977,264 @@ func TestManagerCleansCrashAbandonedArtifactsOnStartup(t *testing.T) {
 	}
 	assert.NoDirExists(t, stageRoot)
 	assert.FileExists(t, keepPath)
+}
+
+func TestManagerRejectsSymlinkedLogDirectoryWithoutTouchingItsTarget(t *testing.T) {
+	t.Parallel()
+
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	stateDir := filepath.Join(t.TempDir(), "state")
+	require.NoError(t, os.MkdirAll(stateDir, 0o700))
+	externalLogDir := t.TempDir()
+	externalLog := filepath.Join(externalLogDir, operationLogFilename("external"))
+	require.NoError(t, os.WriteFile(externalLog, []byte("keep"), 0o600))
+	require.NoError(t, os.Symlink(externalLogDir, filepath.Join(stateDir, "logs")))
+
+	manager, err := NewManager(Config{
+		InstallRoot: installRoot,
+		StateDir:    stateDir,
+		GOARCH:      "amd64",
+	})
+	if manager != nil {
+		_ = manager.Close()
+	}
+	require.ErrorContains(t, err, "updater log path is not a directory")
+	assert.Equal(t, "keep", mustReadFile(t, externalLog))
+}
+
+func TestPruneOperationLogsRetainsCurrentAndNewestWithinBounds(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name         string
+		maxFiles     int
+		maxBytes     int64
+		reserveFiles int
+		reserveBytes int64
+		wantRemoved  []string
+		wantRetained []string
+	}{
+		{
+			name:         "count",
+			maxFiles:     3,
+			maxBytes:     100,
+			wantRemoved:  []string{"oldest"},
+			wantRetained: []string{"current", "middle", "newest"},
+		},
+		{
+			name:         "bytes",
+			maxFiles:     10,
+			maxBytes:     8,
+			wantRemoved:  []string{"oldest", "middle"},
+			wantRetained: []string{"current", "newest"},
+		},
+		{
+			name:         "reserved next operation",
+			maxFiles:     4,
+			maxBytes:     16,
+			reserveFiles: 1,
+			reserveBytes: 4,
+			wantRemoved:  []string{"oldest"},
+			wantRetained: []string{"current", "middle", "newest"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			logDir := t.TempDir()
+			baseTime := time.Date(2026, 8, 5, 8, 0, 0, 0, time.UTC)
+			for index, id := range []string{"current", "oldest", "middle", "newest"} {
+				path := filepath.Join(logDir, operationLogFilename(id))
+				require.NoError(t, os.WriteFile(path, []byte("1234"), 0o600))
+				modified := baseTime.Add(time.Duration(index) * time.Minute)
+				require.NoError(t, os.Chtimes(path, modified, modified))
+			}
+
+			require.NoError(t, pruneOperationLogs(
+				logDir,
+				operationLogFilename("current"),
+				test.maxFiles,
+				test.maxBytes,
+				test.reserveFiles,
+				test.reserveBytes,
+			))
+
+			for _, id := range test.wantRemoved {
+				assert.NoFileExists(t, filepath.Join(logDir, operationLogFilename(id)))
+			}
+			for _, id := range test.wantRetained {
+				assert.FileExists(t, filepath.Join(logDir, operationLogFilename(id)))
+			}
+		})
+	}
+}
+
+func TestPruneOperationLogsIgnoresUnownedAndNonRegularEntries(t *testing.T) {
+	t.Parallel()
+
+	logDir := t.TempDir()
+	unrelated := filepath.Join(logDir, "operator-notes.log")
+	require.NoError(t, os.WriteFile(unrelated, []byte("keep"), 0o600))
+
+	external := filepath.Join(t.TempDir(), "external.log")
+	require.NoError(t, os.WriteFile(external, []byte("keep"), 0o600))
+	symlinkPath := filepath.Join(logDir, operationLogFilename("symlink"))
+	require.NoError(t, os.Symlink(external, symlinkPath))
+
+	directoryPath := filepath.Join(logDir, operationLogFilename("directory"))
+	require.NoError(t, os.Mkdir(directoryPath, 0o700))
+	sentinel := filepath.Join(directoryPath, "sentinel")
+	require.NoError(t, os.WriteFile(sentinel, []byte("keep"), 0o600))
+
+	require.NoError(t, pruneOperationLogs(logDir, "", 0, 0, 0, 0))
+
+	assert.FileExists(t, unrelated)
+	_, err := os.Lstat(symlinkPath)
+	assert.NoError(t, err)
+	assert.Equal(t, "keep", mustReadFile(t, external))
+	assert.FileExists(t, sentinel)
+}
+
+func TestSaturatingLogBytesCannotOverflowBelowTheQuota(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, int64(11), saturatingLogBytes(9, 2, 10))
+	assert.Equal(t, int64(11), saturatingLogBytes(0, int64(^uint64(0)>>1), 10))
+}
+
+func TestManagerRejectsTriggerWhenCurrentLogConsumesReservedCapacity(t *testing.T) {
+	t.Parallel()
+
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	stateDir := filepath.Join(t.TempDir(), "state")
+	logDir := filepath.Join(stateDir, "logs")
+	require.NoError(t, os.MkdirAll(logDir, 0o700))
+	now := time.Date(2026, 8, 5, 8, 0, 0, 0, time.UTC)
+	operation := updaterapi.Operation{
+		ID:            "current-operation",
+		TargetVersion: "v1.0.0",
+		Phase:         updaterapi.PhaseSucceeded,
+		StartedAt:     now,
+		UpdatedAt:     now,
+		CompletedAt:   &now,
+	}
+	operation.LogPath = filepath.Join(logDir, operationLogFilename(operation.ID))
+	data, err := json.Marshal(operation)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(stateDir, stateFilename), data, 0o600))
+	require.NoError(t, os.WriteFile(operation.LogPath, nil, 0o600))
+	require.NoError(t, os.Truncate(
+		operation.LogPath,
+		maxRetainedLogBytes-maxCommandLogBytes+1,
+	))
+
+	manager, err := NewManager(Config{
+		InstallRoot: installRoot,
+		StateDir:    stateDir,
+		GOARCH:      "amd64",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, manager.Close()) })
+
+	_, err = manager.Trigger("v1.1.0")
+	require.ErrorContains(t, err, "reserve updater operation log capacity")
+	require.ErrorContains(t, err, "current updater operation log leaves insufficient retained capacity")
+	assert.Equal(t, updaterapi.PhaseSucceeded, manager.Status().Operation.Phase)
+	assert.FileExists(t, operation.LogPath)
+}
+
+func TestManagerPreservesTerminalStatusWhenQueuedStateCannotPersist(t *testing.T) {
+	t.Parallel()
+
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	stateDir := filepath.Join(t.TempDir(), "state")
+	logDir := filepath.Join(stateDir, "logs")
+	require.NoError(t, os.MkdirAll(logDir, 0o700))
+	now := time.Date(2026, 8, 5, 8, 0, 0, 0, time.UTC)
+	previous := updaterapi.Operation{
+		ID:            "previous-operation",
+		TargetVersion: "v1.0.0",
+		Phase:         updaterapi.PhaseSucceeded,
+		StartedAt:     now,
+		UpdatedAt:     now,
+		CompletedAt:   &now,
+	}
+	previous.LogPath = filepath.Join(logDir, operationLogFilename(previous.ID))
+	data, err := json.Marshal(previous)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(stateDir, stateFilename), data, 0o600))
+	require.NoError(t, os.WriteFile(previous.LogPath, []byte("previous log"), 0o600))
+
+	manager, err := NewManager(Config{
+		InstallRoot: installRoot,
+		StateDir:    stateDir,
+		GOARCH:      "amd64",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, manager.Close()) })
+	// #nosec G302 -- these are restrictive directory modes used to force a
+	// persistence failure; no file is made group/world accessible.
+	require.NoError(t, os.Chmod(stateDir, 0o500))
+	t.Cleanup(func() {
+		// #nosec G302 -- restore owner-only directory access for TempDir cleanup.
+		_ = os.Chmod(stateDir, 0o700)
+	})
+
+	_, err = manager.Trigger("v1.1.0")
+	require.ErrorContains(t, err, "create updater state temp file")
+	status := manager.Status().Operation
+	require.NotNil(t, status)
+	assert.Equal(t, previous.ID, status.ID)
+	assert.Equal(t, updaterapi.PhaseSucceeded, status.Phase)
+}
+
+func TestManagerPostCompletionLogPruneFailureDoesNotChangeTerminalState(t *testing.T) {
+	t.Parallel()
+
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	bundle := releaseBundle(t, "v1.1.0")
+	server := releaseServer(t, "v1.1.0", "amd64", bundle, "")
+	stateDir := filepath.Join(t.TempDir(), "state")
+	operationID := "oversized-current-log"
+	runner := &recordingRunner{
+		activationHook: func(string) {
+			require.NoError(t, os.Truncate(
+				filepath.Join(stateDir, "logs", operationLogFilename(operationID)),
+				maxRetainedLogBytes+1,
+			))
+		},
+	}
+	manager, err := NewManager(Config{
+		InstallRoot:              installRoot,
+		StateDir:                 stateDir,
+		DownloadBaseURL:          server.URL,
+		HTTPClient:               server.Client(),
+		Runner:                   runner,
+		GOARCH:                   "amd64",
+		NewID:                    func() string { return operationID },
+		allowTestDownloadBaseURL: true,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, manager.Close()) })
+
+	_, err = manager.Trigger("v1.1.0")
+	require.NoError(t, err)
+	completed := waitForTerminal(t, manager)
+	require.Eventually(t, func() bool {
+		manager.mu.RLock()
+		defer manager.mu.RUnlock()
+		return !manager.operationRunning
+	}, 5*time.Second, 10*time.Millisecond)
+
+	assert.Equal(t, updaterapi.PhaseSucceeded, completed.Phase, completed.Error)
+	info, err := os.Stat(completed.LogPath)
+	require.NoError(t, err)
+	assert.Greater(t, info.Size(), maxRetainedLogBytes)
+	assert.Equal(t, updaterapi.PhaseSucceeded, manager.Status().Operation.Phase)
 }
 
 func TestManagerCleansDeferredArtifactsBeforeAcceptingAnotherUpgrade(t *testing.T) {
@@ -1144,7 +1454,7 @@ func TestExtractArchiveRejectsTraversal(t *testing.T) {
 	require.ErrorContains(t, err, "unsafe path")
 }
 
-func TestAtomicReplaceExecutableRefreshesTheInstalledUpdater(t *testing.T) {
+func TestInstallExecutableCandidateRetainsAndRestoresThePreviousUpdater(t *testing.T) {
 	t.Parallel()
 
 	root := t.TempDir()
@@ -1154,11 +1464,32 @@ func TestAtomicReplaceExecutableRefreshesTheInstalledUpdater(t *testing.T) {
 	require.NoError(t, os.MkdirAll(filepath.Dir(destination), 0o750))
 	require.NoError(t, os.WriteFile(destination, []byte("old updater"), 0o755))
 
-	require.NoError(t, atomicReplaceExecutable(source, destination))
+	in, err := os.Open(source)
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, in.Close()) })
+	candidatePath, err := stageExecutableCandidate(in, destination)
+	require.NoError(t, err)
+	require.NoError(t, installExecutableCandidate(candidatePath, destination))
 	assert.Equal(t, "new updater", mustReadFile(t, destination))
+	assert.Equal(t, "old updater", mustReadFile(t, destination+selfUpdateBackupSuffix))
 	info, err := os.Stat(destination)
 	require.NoError(t, err)
 	assert.NotZero(t, info.Mode().Perm()&0o111)
+
+	require.NoError(t, restorePreviousExecutable(destination))
+	assert.Equal(t, "old updater", mustReadFile(t, destination))
+	assert.NoFileExists(t, destination+selfUpdateBackupSuffix)
+}
+
+func TestValidateUpdaterCandidateRejectsAnUnrunnablePayload(t *testing.T) {
+	t.Parallel()
+
+	candidatePath := filepath.Join(t.TempDir(), "proto-fleet-updater.candidate")
+	require.NoError(t, os.WriteFile(candidatePath, []byte("not an executable format"), 0o755))
+	manager := &Manager{cfg: Config{Runner: execRunner{}}}
+
+	err := manager.validateUpdaterCandidate(context.Background(), candidatePath, "v1.1.0")
+	require.ErrorContains(t, err, "smoke-test updater candidate")
 }
 
 func TestActivationRestoreCommandQuotesEveryPathUse(t *testing.T) {

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -6,6 +6,7 @@ import (
 	"compress/gzip"
 	"context"
 	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -305,6 +306,56 @@ func TestManagerRejectsASecondUpgradeWhileOneIsRunning(t *testing.T) {
 	assert.Equal(t, updaterapi.PhaseSucceeded, waitForTerminal(t, manager).Phase)
 }
 
+func TestManagerProcessLockPreventsASecondDaemonFromMutatingState(t *testing.T) {
+	t.Parallel()
+
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	bundle := releaseBundle(t, "v1.1.0")
+	server := releaseServer(t, "v1.1.0", "amd64", bundle, "")
+	stateDir := filepath.Join(t.TempDir(), "state")
+	runner := &recordingRunner{
+		preflightAt: make(chan struct{}),
+		release:     make(chan struct{}),
+	}
+	config := Config{
+		InstallRoot:              installRoot,
+		StateDir:                 stateDir,
+		DownloadBaseURL:          server.URL,
+		HTTPClient:               server.Client(),
+		Runner:                   runner,
+		GOARCH:                   "amd64",
+		NewID:                    func() string { return "locked-operation" },
+		allowTestDownloadBaseURL: true,
+	}
+	manager, err := NewManager(config)
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, manager.Close()) })
+	_, err = manager.Trigger("v1.1.0")
+	require.NoError(t, err)
+	select {
+	case <-runner.preflightAt:
+	case <-time.After(5 * time.Second):
+		t.Fatal("upgrade never reached preflight")
+	}
+
+	_, err = NewManager(config)
+	require.ErrorContains(t, err, "another updater process is already running")
+	operation := manager.Status().Operation
+	require.NotNil(t, operation)
+	assert.False(t, operation.Phase.Terminal())
+	var persisted updaterapi.Operation
+	require.NoError(t, json.Unmarshal([]byte(mustReadFile(t, filepath.Join(stateDir, stateFilename))), &persisted))
+	assert.False(t, persisted.Phase.Terminal())
+
+	close(runner.release)
+	assert.Equal(t, updaterapi.PhaseSucceeded, waitForTerminal(t, manager).Phase)
+	require.NoError(t, manager.Close())
+	replacement, err := NewManager(config)
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, replacement.Close()) })
+}
+
 func TestManagerMarksAnInterruptedPersistedOperationFailed(t *testing.T) {
 	t.Parallel()
 
@@ -326,6 +377,7 @@ func TestManagerMarksAnInterruptedPersistedOperationFailed(t *testing.T) {
 		Now:         func() time.Time { return started.Add(time.Minute) },
 	})
 	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, manager.Close()) })
 
 	operation := manager.Status().Operation
 	require.NotNil(t, operation)
@@ -352,6 +404,7 @@ func TestManagerRestoresPreviousDeploymentAfterInterruptedSwap(t *testing.T) {
 		GOARCH:      "amd64",
 	})
 	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, manager.Close()) })
 
 	operation := manager.Status().Operation
 	require.NotNil(t, operation)
@@ -394,6 +447,7 @@ func TestManagerKeepsForwardDeploymentAfterInterruptedActivation(t *testing.T) {
 				GOARCH:      "amd64",
 			})
 			require.NoError(t, err)
+			t.Cleanup(func() { assert.NoError(t, manager.Close()) })
 
 			operation := manager.Status().Operation
 			require.NotNil(t, operation)
@@ -518,6 +572,7 @@ func newTestManagerWithConfig(
 	}
 	manager, err := NewManager(cfg)
 	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, manager.Close()) })
 	return manager
 }
 

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -138,6 +138,7 @@ func TestManagerUpgradeStagesBeforeActivationAndPreservesConfiguration(t *testin
 	assert.Equal(t, []string{"./run-fleet.sh", "--non-interactive", "--skip-build"}, commands[1].Args)
 	assert.FileExists(t, completed.LogPath)
 	assert.Empty(t, completed.RecoveryCommand)
+	assert.NoFileExists(t, filepath.Join(manager.cfg.StateDir, activationMarkerFilename))
 }
 
 func TestManagerDefersSelfUpdateUntilActivationSucceeds(t *testing.T) {
@@ -160,6 +161,11 @@ func TestManagerDefersSelfUpdateUntilActivationSucceeds(t *testing.T) {
 
 	assert.Equal(t, updaterapi.PhaseFailed, completed.Phase)
 	assert.Equal(t, "old updater", mustReadFile(t, installedUpdater))
+	select {
+	case <-manager.SelfUpdateReady():
+		t.Fatal("failed activation must not request a self-restart")
+	default:
+	}
 }
 
 func TestManagerSelfUpdateUsesVerifiedArchiveCopy(t *testing.T) {
@@ -190,6 +196,23 @@ func TestManagerSelfUpdateUsesVerifiedArchiveCopy(t *testing.T) {
 
 	require.Equal(t, updaterapi.PhaseSucceeded, completed.Phase, completed.Error)
 	assert.Equal(t, "updater", mustReadFile(t, installedUpdater))
+	select {
+	case <-manager.SelfUpdateReady():
+	case <-time.After(time.Second):
+		t.Fatal("successful updater replacement did not request a self-restart")
+	}
+	_, err = manager.Trigger("v1.2.0")
+	require.ErrorContains(t, err, "updater is shutting down")
+	var persisted updaterapi.Operation
+	require.NoError(t, json.Unmarshal([]byte(mustReadFile(t, filepath.Join(manager.cfg.StateDir, stateFilename))), &persisted))
+	assert.Equal(t, updaterapi.PhaseSucceeded, persisted.Phase)
+	require.NoError(t, manager.Shutdown(context.Background()))
+	restarted, err := NewManager(manager.cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, restarted.Close()) })
+	restartedOperation := restarted.Status().Operation
+	require.NotNil(t, restartedOperation)
+	assert.Equal(t, updaterapi.PhaseSucceeded, restartedOperation.Phase)
 }
 
 func TestManagerSelfUpdateFailureIsADegradedSuccess(t *testing.T) {
@@ -214,6 +237,11 @@ func TestManagerSelfUpdateFailureIsADegradedSuccess(t *testing.T) {
 	assert.Contains(t, completed.Message, "host updater refresh needs attention")
 	assert.Contains(t, mustReadFile(t, completed.LogPath), "host updater binary was not refreshed")
 	assert.NoFileExists(t, missingParent)
+	select {
+	case <-manager.SelfUpdateReady():
+		t.Fatal("failed updater replacement must not request a self-restart")
+	default:
+	}
 }
 
 func TestManagerChecksumFailureLeavesCurrentDeploymentUntouched(t *testing.T) {
@@ -338,6 +366,83 @@ func TestManagerActivationFailurePreservesForwardRecovery(t *testing.T) {
 	assert.Equal(t, []string{"./run-fleet.sh", "--non-interactive", "--skip-build"}, commands[1].Args)
 }
 
+func TestManagerFailsActivationOnlyAfterRestoringPreviousDeployment(t *testing.T) {
+	t.Parallel()
+
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	stateDir := filepath.Join(t.TempDir(), "state")
+	manager, err := NewManager(Config{
+		InstallRoot: installRoot,
+		StateDir:    stateDir,
+		GOARCH:      "amd64",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, manager.Close()) })
+	started := time.Date(2026, 8, 5, 8, 0, 0, 0, time.UTC)
+	manager.mu.Lock()
+	manager.operation = &updaterapi.Operation{
+		ID:              "activation-error",
+		TargetVersion:   "v1.1.0",
+		Phase:           updaterapi.PhaseActivating,
+		RecoveryCommand: "stale",
+		StartedAt:       started,
+		UpdatedAt:       started,
+	}
+	require.NoError(t, manager.persistLocked())
+	manager.mu.Unlock()
+	require.NoError(t, manager.writeActivationMarker(activationMarker{
+		OperationID:   "activation-error",
+		TargetVersion: "v1.1.0",
+	}))
+	require.NoError(t, os.Rename(
+		filepath.Join(installRoot, "deployment"),
+		filepath.Join(installRoot, "deployment.previous"),
+	))
+
+	manager.failActivation("activation-error", "v1.1.0", assert.AnError, io.Discard)
+
+	operation := manager.Status().Operation
+	require.NotNil(t, operation)
+	assert.Equal(t, updaterapi.PhaseFailed, operation.Phase)
+	assert.Contains(t, operation.Error, assert.AnError.Error())
+	assert.Empty(t, operation.RecoveryCommand)
+	assert.Equal(t, "v1.0.0", mustReadVersion(t, filepath.Join(installRoot, "deployment", "version.txt")))
+	assert.NoDirExists(t, filepath.Join(installRoot, "deployment.previous"))
+	var persisted updaterapi.Operation
+	require.NoError(t, json.Unmarshal([]byte(mustReadFile(t, filepath.Join(stateDir, stateFilename))), &persisted))
+	assert.Equal(t, updaterapi.PhaseFailed, persisted.Phase)
+	assert.Empty(t, persisted.RecoveryCommand)
+}
+
+func TestActivationMarkerWriteIsAtomicAndExclusive(t *testing.T) {
+	t.Parallel()
+
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	manager, err := NewManager(Config{
+		InstallRoot: installRoot,
+		StateDir:    filepath.Join(t.TempDir(), "state"),
+		GOARCH:      "amd64",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, manager.Close()) })
+
+	marker := activationMarker{OperationID: "atomic-marker", TargetVersion: "v1.1.0"}
+	require.NoError(t, manager.writeActivationMarker(marker))
+	assert.NoFileExists(t, filepath.Join(manager.cfg.StateDir, activationMarkerTempName))
+	persisted, err := manager.readActivationMarker()
+	require.NoError(t, err)
+	require.NotNil(t, persisted)
+	assert.Equal(t, marker, *persisted)
+	original := mustReadFile(t, filepath.Join(manager.cfg.StateDir, activationMarkerFilename))
+
+	err = manager.writeActivationMarker(activationMarker{OperationID: "replacement", TargetVersion: "v1.2.0"})
+	require.ErrorContains(t, err, "already exists")
+	assert.Equal(t, original, mustReadFile(t, filepath.Join(manager.cfg.StateDir, activationMarkerFilename)))
+	assert.NoFileExists(t, filepath.Join(manager.cfg.StateDir, activationMarkerTempName))
+}
+
 func TestManagerRejectsASecondUpgradeWhileOneIsRunning(t *testing.T) {
 	t.Parallel()
 
@@ -363,6 +468,48 @@ func TestManagerRejectsASecondUpgradeWhileOneIsRunning(t *testing.T) {
 	require.ErrorContains(t, err, "already in progress")
 	close(runner.release)
 	assert.Equal(t, updaterapi.PhaseSucceeded, waitForTerminal(t, manager).Phase)
+}
+
+func TestManagerRejectsAnotherUpgradeWhileActivationRecoveryIsPending(t *testing.T) {
+	t.Parallel()
+
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	stateDir := filepath.Join(t.TempDir(), "state")
+	manager, err := NewManager(Config{
+		InstallRoot: installRoot,
+		StateDir:    stateDir,
+		GOARCH:      "amd64",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, manager.Close()) })
+	now := time.Date(2026, 8, 5, 8, 0, 0, 0, time.UTC)
+	manager.mu.Lock()
+	manager.operation = &updaterapi.Operation{
+		ID:            "pending-recovery",
+		TargetVersion: "v1.1.0",
+		Phase:         updaterapi.PhaseFailed,
+		Message:       "Activation layout requires manual recovery",
+		StartedAt:     now,
+		UpdatedAt:     now,
+		CompletedAt:   &now,
+	}
+	require.NoError(t, manager.persistLocked())
+	manager.mu.Unlock()
+	require.NoError(t, manager.writeActivationMarker(activationMarker{
+		OperationID:   "pending-recovery",
+		TargetVersion: "v1.1.0",
+	}))
+	stateBefore := mustReadFile(t, filepath.Join(stateDir, stateFilename))
+
+	_, err = manager.Trigger("v1.2.0")
+	require.ErrorContains(t, err, "activation recovery for operation pending-recovery is pending")
+	operation := manager.Status().Operation
+	require.NotNil(t, operation)
+	assert.Equal(t, "pending-recovery", operation.ID)
+	assert.Equal(t, updaterapi.PhaseFailed, operation.Phase)
+	assert.Equal(t, stateBefore, mustReadFile(t, filepath.Join(stateDir, stateFilename)))
+	assert.FileExists(t, filepath.Join(stateDir, activationMarkerFilename))
 }
 
 func TestManagerProcessLockPreventsASecondDaemonFromMutatingState(t *testing.T) {
@@ -397,9 +544,12 @@ func TestManagerProcessLockPreventsASecondDaemonFromMutatingState(t *testing.T) 
 	case <-time.After(5 * time.Second):
 		t.Fatal("upgrade never reached preflight")
 	}
+	contestedArtifact := filepath.Join(stateDir, operationArtifactBase("contested-cleanup")+".updater")
+	require.NoError(t, os.WriteFile(contestedArtifact, []byte("still owned by the live daemon"), 0o600))
 
 	_, err = NewManager(config)
 	require.ErrorContains(t, err, "another updater process is already running")
+	assert.FileExists(t, contestedArtifact, "a lock contender must not mutate updater state")
 	operation := manager.Status().Operation
 	require.NotNil(t, operation)
 	assert.False(t, operation.Phase.Terminal())
@@ -413,6 +563,7 @@ func TestManagerProcessLockPreventsASecondDaemonFromMutatingState(t *testing.T) 
 	replacement, err := NewManager(config)
 	require.NoError(t, err)
 	t.Cleanup(func() { assert.NoError(t, replacement.Close()) })
+	assert.NoFileExists(t, contestedArtifact)
 }
 
 func TestManagerPreflightDeadlineFailsTheOperation(t *testing.T) {
@@ -629,6 +780,251 @@ func TestManagerRestoresPreviousDeploymentAfterInterruptedSwap(t *testing.T) {
 	assert.Empty(t, operation.RecoveryCommand)
 	assert.Equal(t, "v1.0.0", mustReadVersion(t, filepath.Join(installRoot, "deployment", "version.txt")))
 	assert.NoDirExists(t, filepath.Join(installRoot, "deployment.previous"))
+	assert.NoFileExists(t, filepath.Join(stateDir, activationMarkerFilename))
+}
+
+func TestManagerReconcilesTerminalFailedActivationBeforeCleaningArtifacts(t *testing.T) {
+	t.Parallel()
+
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	require.NoError(t, os.Rename(
+		filepath.Join(installRoot, "deployment"),
+		filepath.Join(installRoot, "deployment.previous"),
+	))
+	stageRoot := filepath.Join(installRoot, operationArtifactBase("failed-operation"))
+	require.NoError(t, os.MkdirAll(filepath.Join(stageRoot, "deployment"), 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(stageRoot, "deployment", "partial"), []byte("stale"), 0o600))
+
+	stateDir := filepath.Join(t.TempDir(), "state")
+	require.NoError(t, os.MkdirAll(stateDir, 0o700))
+	started := time.Date(2026, 8, 5, 8, 0, 0, 0, time.UTC)
+	completed := started.Add(time.Minute)
+	persisted := updaterapi.Operation{
+		ID:              "failed-operation",
+		TargetVersion:   "v1.1.0",
+		Phase:           updaterapi.PhaseFailed,
+		Message:         "Upgrade failed",
+		Error:           "activate staged deployment: input/output error",
+		RecoveryCommand: "stale",
+		StartedAt:       started,
+		UpdatedAt:       completed,
+		CompletedAt:     &completed,
+	}
+	data, err := json.Marshal(persisted)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(stateDir, stateFilename), data, 0o600))
+	marker, err := json.Marshal(activationMarker{
+		OperationID:   persisted.ID,
+		TargetVersion: persisted.TargetVersion,
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(stateDir, activationMarkerFilename), marker, 0o600))
+
+	manager, err := NewManager(Config{
+		InstallRoot: installRoot,
+		StateDir:    stateDir,
+		GOARCH:      "amd64",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, manager.Close()) })
+
+	operation := manager.Status().Operation
+	require.NotNil(t, operation)
+	assert.Equal(t, updaterapi.PhaseFailed, operation.Phase)
+	assert.Contains(t, operation.Error, "input/output error")
+	assert.Contains(t, operation.Error, "restored the validated previous deployment")
+	assert.Contains(t, operation.Message, "Previous deployment restored")
+	assert.Equal(t, completed, *operation.CompletedAt)
+	assert.Empty(t, operation.RecoveryCommand)
+	assert.Equal(t, "v1.0.0", mustReadVersion(t, filepath.Join(installRoot, "deployment", "version.txt")))
+	assert.NoDirExists(t, filepath.Join(installRoot, "deployment.previous"))
+	assert.NoDirExists(t, stageRoot)
+}
+
+func TestManagerDoesNotRestorePreviousWithoutAPendingSwapMarker(t *testing.T) {
+	t.Parallel()
+
+	for _, phase := range []updaterapi.Phase{
+		updaterapi.PhaseFailed,
+		updaterapi.PhaseSucceeded,
+	} {
+		t.Run(string(phase), func(t *testing.T) {
+			t.Parallel()
+
+			installRoot := t.TempDir()
+			writeCurrentDeployment(t, installRoot, "v1.0.0")
+			require.NoError(t, os.Rename(
+				filepath.Join(installRoot, "deployment"),
+				filepath.Join(installRoot, "deployment.previous"),
+			))
+			stateDir := filepath.Join(t.TempDir(), "state")
+			require.NoError(t, os.MkdirAll(stateDir, 0o700))
+			now := time.Date(2026, 8, 5, 8, 0, 0, 0, time.UTC)
+			operation := updaterapi.Operation{
+				ID:            "historical-operation",
+				TargetVersion: "v1.1.0",
+				Phase:         phase,
+				StartedAt:     now,
+				UpdatedAt:     now,
+				CompletedAt:   &now,
+			}
+			data, err := json.Marshal(operation)
+			require.NoError(t, err)
+			require.NoError(t, os.WriteFile(filepath.Join(stateDir, stateFilename), data, 0o600))
+
+			_, err = NewManager(Config{
+				InstallRoot: installRoot,
+				StateDir:    stateDir,
+				GOARCH:      "amd64",
+			})
+			require.ErrorContains(t, err, "without a pending activation swap")
+			assert.NoDirExists(t, filepath.Join(installRoot, "deployment"))
+			assert.Equal(t, "v1.0.0", mustReadVersion(t, filepath.Join(installRoot, "deployment.previous", "version.txt")))
+		})
+	}
+}
+
+func TestManagerCleansCrashAbandonedArtifactsOnStartup(t *testing.T) {
+	t.Parallel()
+
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	stateDir := filepath.Join(t.TempDir(), "state")
+	require.NoError(t, os.MkdirAll(stateDir, 0o700))
+	artifactBase := operationArtifactBase("../../path-like-operation-id")
+	assert.True(t, staleStagingArtifactName.MatchString(artifactBase))
+	assert.NotContains(t, artifactBase, string(os.PathSeparator))
+
+	staleStatePaths := []string{
+		filepath.Join(stateDir, artifactBase+".tar.gz"),
+		filepath.Join(stateDir, artifactBase+".sha256"),
+		filepath.Join(stateDir, artifactBase+".updater"),
+		filepath.Join(stateDir, stateTempPrefix+"abandoned"),
+		filepath.Join(stateDir, activationMarkerTempName),
+	}
+	for _, path := range staleStatePaths {
+		require.NoError(t, os.WriteFile(path, []byte("stale"), 0o600))
+	}
+	keepPath := filepath.Join(stateDir, ".proto-fleet-upgrade-lookalike.tar.gz")
+	require.NoError(t, os.WriteFile(keepPath, []byte("keep"), 0o600))
+	stageRoot := filepath.Join(installRoot, artifactBase)
+	require.NoError(t, os.MkdirAll(filepath.Join(stageRoot, "deployment", "nested"), 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(stageRoot, "deployment", "nested", "file"), []byte("stale"), 0o600))
+
+	manager, err := NewManager(Config{
+		InstallRoot: installRoot,
+		StateDir:    stateDir,
+		GOARCH:      "amd64",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, manager.Close()) })
+
+	for _, path := range staleStatePaths {
+		assert.NoFileExists(t, path)
+	}
+	assert.NoDirExists(t, stageRoot)
+	assert.FileExists(t, keepPath)
+}
+
+func TestManagerCleansDeferredArtifactsBeforeAcceptingAnotherUpgrade(t *testing.T) {
+	t.Parallel()
+
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	bundle := releaseBundle(t, "v1.1.0")
+	server := releaseServer(t, "v1.1.0", "amd64", bundle, "")
+	manager := newTestManager(t, installRoot, server, &recordingRunner{})
+	staleArtifact := filepath.Join(manager.cfg.StateDir, operationArtifactBase("previous-operation")+".updater")
+	require.NoError(t, os.WriteFile(staleArtifact, []byte("stale"), 0o600))
+
+	_, err := manager.Trigger("v1.1.0")
+	require.NoError(t, err)
+	completed := waitForTerminal(t, manager)
+	require.Equal(t, updaterapi.PhaseSucceeded, completed.Phase, completed.Error)
+	assert.NoFileExists(t, staleArtifact)
+}
+
+func TestManagerStaleArtifactCleanupDoesNotFollowSymlinks(t *testing.T) {
+	t.Parallel()
+
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	stateDir := filepath.Join(t.TempDir(), "state")
+	require.NoError(t, os.MkdirAll(stateDir, 0o700))
+	externalRoot := t.TempDir()
+	externalFile := filepath.Join(externalRoot, "updater")
+	externalStageFile := filepath.Join(externalRoot, "deployment-data")
+	require.NoError(t, os.WriteFile(externalFile, []byte("keep"), 0o600))
+	require.NoError(t, os.WriteFile(externalStageFile, []byte("keep"), 0o600))
+	artifactBase := operationArtifactBase("symlink-operation")
+	stateLink := filepath.Join(stateDir, artifactBase+".updater")
+	stageLink := filepath.Join(installRoot, artifactBase)
+	require.NoError(t, os.Symlink(externalFile, stateLink))
+	require.NoError(t, os.Symlink(externalRoot, stageLink))
+
+	manager, err := NewManager(Config{
+		InstallRoot: installRoot,
+		StateDir:    stateDir,
+		GOARCH:      "amd64",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, manager.Close()) })
+
+	_, err = os.Lstat(stateLink)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+	_, err = os.Lstat(stageLink)
+	assert.ErrorIs(t, err, os.ErrNotExist)
+	assert.Equal(t, "keep", mustReadFile(t, externalFile))
+	assert.Equal(t, "keep", mustReadFile(t, externalStageFile))
+}
+
+func TestManagerRefusesAStaleStateDirectoryInAFileSlot(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{
+		operationArtifactBase("directory-operation") + ".updater",
+		activationMarkerTempName,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			installRoot := t.TempDir()
+			writeCurrentDeployment(t, installRoot, "v1.0.0")
+			stateDir := filepath.Join(t.TempDir(), "state")
+			unexpectedDirectory := filepath.Join(stateDir, name)
+			require.NoError(t, os.MkdirAll(unexpectedDirectory, 0o700))
+			sentinel := filepath.Join(unexpectedDirectory, "evidence")
+			require.NoError(t, os.WriteFile(sentinel, []byte("keep"), 0o600))
+
+			_, err := NewManager(Config{
+				InstallRoot: installRoot,
+				StateDir:    stateDir,
+				GOARCH:      "amd64",
+			})
+			require.ErrorContains(t, err, "state directory from file slot")
+			assert.FileExists(t, sentinel)
+		})
+	}
+}
+
+func TestManagerLeavesStagingEvidenceWhenDeploymentCannotBeReconciled(t *testing.T) {
+	t.Parallel()
+
+	installRoot := t.TempDir()
+	artifactBase := operationArtifactBase("unrecoverable-operation")
+	stageRoot := filepath.Join(installRoot, artifactBase)
+	require.NoError(t, os.MkdirAll(stageRoot, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(stageRoot, "evidence"), []byte("keep"), 0o600))
+	stateDir := filepath.Join(t.TempDir(), "state")
+
+	_, err := NewManager(Config{
+		InstallRoot: installRoot,
+		StateDir:    stateDir,
+		GOARCH:      "amd64",
+	})
+	require.ErrorContains(t, err, "active deployment is missing without a pending activation swap")
+	assert.FileExists(t, filepath.Join(stageRoot, "evidence"))
 }
 
 func TestManagerKeepsForwardDeploymentAfterInterruptedActivation(t *testing.T) {
@@ -637,10 +1033,12 @@ func TestManagerKeepsForwardDeploymentAfterInterruptedActivation(t *testing.T) {
 	for _, test := range []struct {
 		name             string
 		withProof        bool
+		withSwapMarker   bool
 		wantRecoveryHint bool
 	}{
-		{name: "preflight proof remains", withProof: true, wantRecoveryHint: true},
-		{name: "preflight proof was consumed", withProof: false, wantRecoveryHint: false},
+		{name: "swap pending and preflight proof remains", withProof: true, withSwapMarker: true, wantRecoveryHint: true},
+		{name: "swap completed and preflight proof remains", withProof: true, withSwapMarker: false, wantRecoveryHint: true},
+		{name: "preflight proof was consumed", withProof: false, withSwapMarker: false, wantRecoveryHint: false},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
@@ -656,6 +1054,9 @@ func TestManagerKeepsForwardDeploymentAfterInterruptedActivation(t *testing.T) {
 			}
 			stateDir := filepath.Join(t.TempDir(), "state")
 			writeInterruptedOperationState(t, stateDir, "v1.1.0")
+			if !test.withSwapMarker {
+				require.NoError(t, os.Remove(filepath.Join(stateDir, activationMarkerFilename)))
+			}
 
 			manager, err := NewManager(Config{
 				InstallRoot: installRoot,
@@ -758,6 +1159,19 @@ func TestAtomicReplaceExecutableRefreshesTheInstalledUpdater(t *testing.T) {
 	info, err := os.Stat(destination)
 	require.NoError(t, err)
 	assert.NotZero(t, info.Mode().Perm()&0o111)
+}
+
+func TestActivationRestoreCommandQuotesEveryPathUse(t *testing.T) {
+	t.Parallel()
+
+	current := "/opt/proto fleet/deploy'ment"
+	previous := "/opt/proto fleet/previous'copy"
+	command := activationRestoreCommand(current, previous)
+
+	assert.Contains(t, command, "test ! -e "+shellQuote(current))
+	assert.Contains(t, command, "test ! -L "+shellQuote(current))
+	assert.Contains(t, command, "test -d "+shellQuote(previous))
+	assert.Contains(t, command, "mv -- "+shellQuote(previous)+" "+shellQuote(current))
 }
 
 func TestCappedWriterDiscardsExcessWhileLeavingTheLogWritable(t *testing.T) {
@@ -916,6 +1330,16 @@ func writeInterruptedOperationState(t *testing.T, stateDir, targetVersion string
 			started.Format(time.RFC3339Nano),
 			started.Format(time.RFC3339Nano),
 		)),
+		0o600,
+	))
+	marker, err := json.Marshal(activationMarker{
+		OperationID:   "interrupted",
+		TargetVersion: targetVersion,
+	})
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(stateDir, activationMarkerFilename),
+		marker,
 		0o600,
 	))
 }

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -30,13 +30,14 @@ type recordedCommand struct {
 }
 
 type recordingRunner struct {
-	mu          sync.Mutex
-	commands    []recordedCommand
-	preflight   error
-	activation  error
-	cleanup     error
-	preflightAt chan struct{}
-	release     chan struct{}
+	mu             sync.Mutex
+	commands       []recordedCommand
+	preflight      error
+	activation     error
+	cleanup        error
+	preflightAt    chan struct{}
+	release        chan struct{}
+	activationHook func(string)
 }
 
 const operatorEnv = `DB_PASSWORD=secret
@@ -62,6 +63,9 @@ func (r *recordingRunner) Run(_ context.Context, dir string, _ io.Writer, name s
 	}
 	if name == "docker" {
 		return r.cleanup
+	}
+	if r.activationHook != nil {
+		r.activationHook(dir)
 	}
 	return r.activation
 }
@@ -102,6 +106,82 @@ func TestManagerUpgradeStagesBeforeActivationAndPreservesConfiguration(t *testin
 	assert.Equal(t, []string{"./run-fleet.sh", "--non-interactive", "--skip-build"}, commands[1].Args)
 	assert.FileExists(t, completed.LogPath)
 	assert.Contains(t, completed.RecoveryCommand, "./run-fleet.sh --non-interactive --skip-build")
+}
+
+func TestManagerDefersSelfUpdateUntilActivationSucceeds(t *testing.T) {
+	t.Parallel()
+
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	installedUpdater := filepath.Join(t.TempDir(), "proto-fleet-updater")
+	require.NoError(t, os.WriteFile(installedUpdater, []byte("old updater"), 0o755))
+	bundle := releaseBundle(t, "v1.1.0")
+	server := releaseServer(t, "v1.1.0", "amd64", bundle, "")
+	runner := &recordingRunner{activation: assert.AnError}
+	manager := newTestManagerWithConfig(t, installRoot, server, runner, func(cfg *Config) {
+		cfg.SelfUpdatePath = installedUpdater
+	})
+
+	_, err := manager.Trigger("v1.1.0")
+	require.NoError(t, err)
+	completed := waitForTerminal(t, manager)
+
+	assert.Equal(t, updaterapi.PhaseFailed, completed.Phase)
+	assert.Equal(t, "old updater", mustReadFile(t, installedUpdater))
+}
+
+func TestManagerSelfUpdateUsesVerifiedArchiveCopy(t *testing.T) {
+	t.Parallel()
+
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	installedUpdater := filepath.Join(t.TempDir(), "proto-fleet-updater")
+	require.NoError(t, os.WriteFile(installedUpdater, []byte("old updater"), 0o755))
+	bundle := releaseBundle(t, "v1.1.0")
+	server := releaseServer(t, "v1.1.0", "amd64", bundle, "")
+	runner := &recordingRunner{
+		activationHook: func(dir string) {
+			require.NoError(t, os.WriteFile(
+				filepath.Join(dir, "updater", "proto-fleet-updater"),
+				[]byte("operator replacement"),
+				0o755,
+			))
+		},
+	}
+	manager := newTestManagerWithConfig(t, installRoot, server, runner, func(cfg *Config) {
+		cfg.SelfUpdatePath = installedUpdater
+	})
+
+	_, err := manager.Trigger("v1.1.0")
+	require.NoError(t, err)
+	completed := waitForTerminal(t, manager)
+
+	require.Equal(t, updaterapi.PhaseSucceeded, completed.Phase, completed.Error)
+	assert.Equal(t, "updater", mustReadFile(t, installedUpdater))
+}
+
+func TestManagerSelfUpdateFailureIsADegradedSuccess(t *testing.T) {
+	t.Parallel()
+
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	bundle := releaseBundle(t, "v1.1.0")
+	server := releaseServer(t, "v1.1.0", "amd64", bundle, "")
+	runner := &recordingRunner{}
+	missingParent := filepath.Join(t.TempDir(), "missing", "proto-fleet-updater")
+	manager := newTestManagerWithConfig(t, installRoot, server, runner, func(cfg *Config) {
+		cfg.SelfUpdatePath = missingParent
+	})
+
+	_, err := manager.Trigger("v1.1.0")
+	require.NoError(t, err)
+	completed := waitForTerminal(t, manager)
+
+	require.Equal(t, updaterapi.PhaseSucceeded, completed.Phase, completed.Error)
+	assert.Equal(t, "v1.1.0", mustReadVersion(t, filepath.Join(installRoot, "deployment", "version.txt")))
+	assert.Contains(t, completed.Message, "host updater refresh needs attention")
+	assert.Contains(t, mustReadFile(t, completed.LogPath), "host updater binary was not refreshed")
+	assert.NoFileExists(t, missingParent)
 }
 
 func TestManagerChecksumFailureLeavesCurrentDeploymentUntouched(t *testing.T) {
@@ -240,11 +320,10 @@ func TestManagerMarksAnInterruptedPersistedOperationFailed(t *testing.T) {
 	))
 
 	manager, err := NewManager(Config{
-		InstallRoot:     installRoot,
-		StateDir:        stateDir,
-		DownloadBaseURL: "https://example.invalid",
-		GOARCH:          "amd64",
-		Now:             func() time.Time { return started.Add(time.Minute) },
+		InstallRoot: installRoot,
+		StateDir:    stateDir,
+		GOARCH:      "amd64",
+		Now:         func() time.Time { return started.Add(time.Minute) },
 	})
 	require.NoError(t, err)
 
@@ -266,13 +345,26 @@ func TestManagerRejectsUnsafeDownloadBaseURLs(t *testing.T) {
 		"https://example.com/releases#fragment",
 	} {
 		_, err := NewManager(Config{
-			InstallRoot:     t.TempDir(),
-			StateDir:        filepath.Join(t.TempDir(), "state"),
-			DownloadBaseURL: rawURL,
-			GOARCH:          "amd64",
+			InstallRoot:              t.TempDir(),
+			StateDir:                 filepath.Join(t.TempDir(), "state"),
+			DownloadBaseURL:          rawURL,
+			GOARCH:                   "amd64",
+			allowTestDownloadBaseURL: true,
 		})
 		require.Error(t, err, rawURL)
 	}
+}
+
+func TestManagerRejectsProductionDownloadBaseOverride(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewManager(Config{
+		InstallRoot:     t.TempDir(),
+		StateDir:        filepath.Join(t.TempDir(), "state"),
+		DownloadBaseURL: "https://mirror.example.com/proto-fleet",
+		GOARCH:          "amd64",
+	})
+	require.ErrorContains(t, err, "official GitHub Releases URL")
 }
 
 func TestExtractArchiveRejectsTraversal(t *testing.T) {
@@ -312,15 +404,31 @@ func TestAtomicReplaceExecutableRefreshesTheInstalledUpdater(t *testing.T) {
 
 func newTestManager(t *testing.T, installRoot string, server *httptest.Server, runner CommandRunner) *Manager {
 	t.Helper()
-	manager, err := NewManager(Config{
-		InstallRoot:     installRoot,
-		StateDir:        filepath.Join(t.TempDir(), "state"),
-		DownloadBaseURL: server.URL,
-		HTTPClient:      server.Client(),
-		Runner:          runner,
-		GOARCH:          "amd64",
-		NewID:           func() string { return "test-operation" },
-	})
+	return newTestManagerWithConfig(t, installRoot, server, runner, nil)
+}
+
+func newTestManagerWithConfig(
+	t *testing.T,
+	installRoot string,
+	server *httptest.Server,
+	runner CommandRunner,
+	configure func(*Config),
+) *Manager {
+	t.Helper()
+	cfg := Config{
+		InstallRoot:              installRoot,
+		StateDir:                 filepath.Join(t.TempDir(), "state"),
+		DownloadBaseURL:          server.URL,
+		HTTPClient:               server.Client(),
+		Runner:                   runner,
+		GOARCH:                   "amd64",
+		NewID:                    func() string { return "test-operation" },
+		allowTestDownloadBaseURL: true,
+	}
+	if configure != nil {
+		configure(&cfg)
+	}
+	manager, err := NewManager(cfg)
 	require.NoError(t, err)
 	return manager
 }

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -2189,6 +2189,28 @@ func TestExtractArchiveRejectsTraversal(t *testing.T) {
 	require.ErrorContains(t, err, "unsafe path")
 }
 
+func TestExtractArchiveRejectsExcessiveEntryCount(t *testing.T) {
+	t.Parallel()
+
+	archive := filepath.Join(t.TempDir(), "too-many-entries.tar.gz")
+	var buffer bytes.Buffer
+	gzipWriter := gzip.NewWriter(&buffer)
+	tarWriter := tar.NewWriter(gzipWriter)
+	for range maxArchiveEntries + 1 {
+		require.NoError(t, tarWriter.WriteHeader(&tar.Header{
+			Name:     "deployment/repeated-directory",
+			Mode:     0o755,
+			Typeflag: tar.TypeDir,
+		}))
+	}
+	require.NoError(t, tarWriter.Close())
+	require.NoError(t, gzipWriter.Close())
+	require.NoError(t, os.WriteFile(archive, buffer.Bytes(), 0o600))
+
+	err := extractArchive(archive, t.TempDir())
+	require.ErrorContains(t, err, fmt.Sprintf("archive contains more than %d entries", maxArchiveEntries))
+}
+
 func TestInstallExecutableCandidateRetainsAndRestoresThePreviousUpdater(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -31,14 +31,19 @@ type recordedCommand struct {
 }
 
 type recordingRunner struct {
-	mu             sync.Mutex
-	commands       []recordedCommand
-	preflight      error
-	activation     error
-	cleanup        error
-	preflightAt    chan struct{}
-	release        chan struct{}
-	activationHook func(string)
+	mu                   sync.Mutex
+	commands             []recordedCommand
+	preflight            error
+	activation           error
+	cleanup              error
+	preflightAt          chan struct{}
+	release              chan struct{}
+	waitForCancel        bool
+	activationAt         chan struct{}
+	releaseActivation    chan struct{}
+	waitForCleanupCancel bool
+	releaseCleanup       chan struct{}
+	activationHook       func(string)
 }
 
 const operatorEnv = `DB_PASSWORD=secret
@@ -48,7 +53,7 @@ ENABLE_TRACING=true
 ENABLE_ONE_CLICK_UPDATES=true
 `
 
-func (r *recordingRunner) Run(_ context.Context, dir string, _ io.Writer, name string, args ...string) error {
+func (r *recordingRunner) Run(ctx context.Context, dir string, _ io.Writer, name string, args ...string) error {
 	r.mu.Lock()
 	r.commands = append(r.commands, recordedCommand{Dir: dir, Name: name, Args: append([]string(nil), args...)})
 	r.mu.Unlock()
@@ -57,13 +62,39 @@ func (r *recordingRunner) Run(_ context.Context, dir string, _ io.Writer, name s
 		if r.preflightAt != nil {
 			close(r.preflightAt)
 		}
+		if r.waitForCancel {
+			<-ctx.Done()
+			return fmt.Errorf("preflight canceled: %w", ctx.Err())
+		}
 		if r.release != nil {
-			<-r.release
+			select {
+			case <-r.release:
+			case <-ctx.Done():
+				return fmt.Errorf("preflight canceled: %w", ctx.Err())
+			}
 		}
 		return r.preflight
 	}
 	if name == "docker" {
+		if r.waitForCleanupCancel {
+			select {
+			case <-ctx.Done():
+				return fmt.Errorf("cleanup canceled: %w", ctx.Err())
+			case <-r.releaseCleanup:
+				return fmt.Errorf("cleanup released before cancellation")
+			}
+		}
 		return r.cleanup
+	}
+	if r.activationAt != nil {
+		close(r.activationAt)
+	}
+	if r.releaseActivation != nil {
+		select {
+		case <-r.releaseActivation:
+		case <-ctx.Done():
+			return fmt.Errorf("activation canceled: %w", ctx.Err())
+		}
 	}
 	if r.activationHook != nil {
 		r.activationHook(dir)
@@ -106,7 +137,7 @@ func TestManagerUpgradeStagesBeforeActivationAndPreservesConfiguration(t *testin
 	assert.Equal(t, filepath.Join(installRoot, "deployment"), commands[1].Dir)
 	assert.Equal(t, []string{"./run-fleet.sh", "--non-interactive", "--skip-build"}, commands[1].Args)
 	assert.FileExists(t, completed.LogPath)
-	assert.Contains(t, completed.RecoveryCommand, "./run-fleet.sh --non-interactive --skip-build")
+	assert.Empty(t, completed.RecoveryCommand)
 }
 
 func TestManagerDefersSelfUpdateUntilActivationSucceeds(t *testing.T) {
@@ -255,6 +286,34 @@ func TestManagerFailedPreflightImageCleanupIsBestEffort(t *testing.T) {
 	assert.Contains(t, mustReadFile(t, completed.LogPath), "warning: could not remove failed preflight image proto-fleet-api:v1.1.0")
 }
 
+func TestManagerFailedPreflightImageCleanupHasABoundedDeadline(t *testing.T) {
+	t.Parallel()
+
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	bundle := releaseBundle(t, "v1.1.0")
+	server := releaseServer(t, "v1.1.0", "amd64", bundle, "")
+	releaseCleanup := make(chan struct{})
+	runner := &recordingRunner{
+		preflight:            assert.AnError,
+		waitForCleanupCancel: true,
+		releaseCleanup:       releaseCleanup,
+	}
+	manager := newTestManagerWithConfig(t, installRoot, server, runner, func(cfg *Config) {
+		cfg.CleanupTimeout = 25 * time.Millisecond
+	})
+	t.Cleanup(func() { close(releaseCleanup) })
+
+	_, err := manager.Trigger("v1.1.0")
+	require.NoError(t, err)
+	completed := waitForTerminal(t, manager)
+
+	assert.Equal(t, updaterapi.PhaseFailed, completed.Phase)
+	assert.Contains(t, completed.Error, "preflight failed")
+	assert.NotContains(t, completed.Error, "cleanup canceled")
+	assert.Contains(t, mustReadFile(t, completed.LogPath), context.DeadlineExceeded.Error())
+}
+
 func TestManagerActivationFailurePreservesForwardRecovery(t *testing.T) {
 	t.Parallel()
 
@@ -351,6 +410,163 @@ func TestManagerProcessLockPreventsASecondDaemonFromMutatingState(t *testing.T) 
 	close(runner.release)
 	assert.Equal(t, updaterapi.PhaseSucceeded, waitForTerminal(t, manager).Phase)
 	require.NoError(t, manager.Close())
+	replacement, err := NewManager(config)
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, replacement.Close()) })
+}
+
+func TestManagerPreflightDeadlineFailsTheOperation(t *testing.T) {
+	t.Parallel()
+
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	bundle := releaseBundle(t, "v1.1.0")
+	server := releaseServer(t, "v1.1.0", "amd64", bundle, "")
+	runner := &recordingRunner{waitForCancel: true}
+	manager := newTestManagerWithConfig(t, installRoot, server, runner, func(cfg *Config) {
+		cfg.PreflightTimeout = 25 * time.Millisecond
+	})
+
+	_, err := manager.Trigger("v1.1.0")
+	require.NoError(t, err)
+	completed := waitForTerminal(t, manager)
+
+	assert.Equal(t, updaterapi.PhaseFailed, completed.Phase)
+	assert.Contains(t, completed.Error, "phase deadline")
+	assert.Contains(t, completed.Error, context.DeadlineExceeded.Error())
+}
+
+func TestManagerActivationDeadlineLetsShutdownFinishWithoutRollback(t *testing.T) {
+	t.Parallel()
+
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	bundle := releaseBundle(t, "v1.1.0")
+	server := releaseServer(t, "v1.1.0", "amd64", bundle, "")
+	activationAt := make(chan struct{})
+	runner := &recordingRunner{
+		activationAt:      activationAt,
+		releaseActivation: make(chan struct{}),
+	}
+	manager := newTestManagerWithConfig(t, installRoot, server, runner, func(cfg *Config) {
+		cfg.ActivationTimeout = 250 * time.Millisecond
+	})
+
+	_, err := manager.Trigger("v1.1.0")
+	require.NoError(t, err)
+	select {
+	case <-activationAt:
+	case <-time.After(5 * time.Second):
+		t.Fatal("upgrade never reached activation")
+	}
+
+	shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancelShutdown()
+	require.NoError(t, manager.Shutdown(shutdownCtx))
+	completed := manager.Status().Operation
+	require.NotNil(t, completed)
+	assert.Equal(t, updaterapi.PhaseFailed, completed.Phase)
+	assert.Contains(t, completed.Error, "phase deadline")
+	assert.Contains(t, completed.Error, context.DeadlineExceeded.Error())
+	assert.NotContains(t, completed.Error, context.Canceled.Error())
+	assert.Equal(t, "v1.1.0", mustReadVersion(t, filepath.Join(installRoot, "deployment", "version.txt")))
+	assert.Equal(t, "v1.0.0", mustReadVersion(t, filepath.Join(installRoot, "deployment.previous", "version.txt")))
+	assert.Contains(t, completed.RecoveryCommand, "./run-fleet.sh --non-interactive --skip-build")
+}
+
+func TestManagerShutdownCancelsPreActivationWorkAndWaits(t *testing.T) {
+	t.Parallel()
+
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	bundle := releaseBundle(t, "v1.1.0")
+	server := releaseServer(t, "v1.1.0", "amd64", bundle, "")
+	runner := &recordingRunner{
+		preflightAt:   make(chan struct{}),
+		waitForCancel: true,
+	}
+	manager := newTestManagerWithConfig(t, installRoot, server, runner, func(cfg *Config) {
+		cfg.PreflightTimeout = time.Hour
+	})
+	_, err := manager.Trigger("v1.1.0")
+	require.NoError(t, err)
+	select {
+	case <-runner.preflightAt:
+	case <-time.After(5 * time.Second):
+		t.Fatal("upgrade never reached preflight")
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	require.NoError(t, manager.Shutdown(shutdownCtx))
+	completed := manager.Status().Operation
+	require.NotNil(t, completed)
+	assert.Equal(t, updaterapi.PhaseFailed, completed.Phase)
+	assert.Contains(t, completed.Error, context.Canceled.Error())
+	_, err = manager.Trigger("v1.2.0")
+	require.ErrorContains(t, err, "updater is shutting down")
+}
+
+func TestManagerShutdownDuringActivationRetainsTheProcessLockUntilCompletion(t *testing.T) {
+	t.Parallel()
+
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	bundle := releaseBundle(t, "v1.1.0")
+	server := releaseServer(t, "v1.1.0", "amd64", bundle, "")
+	stateDir := filepath.Join(t.TempDir(), "state")
+	activationAt := make(chan struct{})
+	releaseActivation := make(chan struct{})
+	var releaseOnce sync.Once
+	runner := &recordingRunner{
+		activationAt:      activationAt,
+		releaseActivation: releaseActivation,
+	}
+	config := Config{
+		InstallRoot:              installRoot,
+		StateDir:                 stateDir,
+		DownloadBaseURL:          server.URL,
+		HTTPClient:               server.Client(),
+		Runner:                   runner,
+		GOARCH:                   "amd64",
+		NewID:                    func() string { return "activating-operation" },
+		ActivationTimeout:        time.Hour,
+		allowTestDownloadBaseURL: true,
+	}
+	manager, err := NewManager(config)
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, manager.Close()) })
+	t.Cleanup(func() { releaseOnce.Do(func() { close(releaseActivation) }) })
+
+	_, err = manager.Trigger("v1.1.0")
+	require.NoError(t, err)
+	select {
+	case <-activationAt:
+	case <-time.After(5 * time.Second):
+		t.Fatal("upgrade never reached activation")
+	}
+
+	shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	err = manager.Shutdown(shutdownCtx)
+	cancelShutdown()
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	operation := manager.Status().Operation
+	require.NotNil(t, operation)
+	assert.Equal(t, updaterapi.PhaseActivating, operation.Phase)
+
+	contender, contenderErr := NewManager(config)
+	if contender != nil {
+		_ = contender.Close()
+	}
+	require.ErrorContains(t, contenderErr, "another updater process is already running")
+
+	releaseOnce.Do(func() { close(releaseActivation) })
+	completed := waitForTerminal(t, manager)
+	require.Equal(t, updaterapi.PhaseSucceeded, completed.Phase, completed.Error)
+	finalShutdownCtx, cancelFinalShutdown := context.WithTimeout(context.Background(), 5*time.Second)
+	require.NoError(t, manager.Shutdown(finalShutdownCtx))
+	cancelFinalShutdown()
+
 	replacement, err := NewManager(config)
 	require.NoError(t, err)
 	t.Cleanup(func() { assert.NoError(t, replacement.Close()) })
@@ -542,6 +758,64 @@ func TestAtomicReplaceExecutableRefreshesTheInstalledUpdater(t *testing.T) {
 	info, err := os.Stat(destination)
 	require.NoError(t, err)
 	assert.NotZero(t, info.Mode().Perm()&0o111)
+}
+
+func TestCappedWriterDiscardsExcessWhileLeavingTheLogWritable(t *testing.T) {
+	t.Parallel()
+
+	var log bytes.Buffer
+	commandOutput := newCappedWriter(&log, 4)
+	written, err := commandOutput.Write([]byte("abcdefgh"))
+	require.NoError(t, err)
+	assert.Equal(t, 8, written)
+	written, err = commandOutput.Write([]byte("discarded"))
+	require.NoError(t, err)
+	assert.Equal(t, len("discarded"), written)
+	_, err = io.WriteString(&log, "terminal message\n")
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, strings.Count(log.String(), "command output truncated"))
+	assert.Contains(t, log.String(), "abcd")
+	assert.NotContains(t, log.String(), "efgh")
+	assert.Contains(t, log.String(), "terminal message")
+}
+
+func TestExecRunnerCancellationKillsBackgroundDescendants(t *testing.T) {
+	t.Parallel()
+
+	directory := t.TempDir()
+	childStarted := filepath.Join(directory, "child-started")
+	delayedMarker := filepath.Join(directory, "delayed-marker")
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	done := make(chan error, 1)
+	go func() {
+		done <- (execRunner{}).Run(
+			ctx,
+			directory,
+			io.Discard,
+			"/bin/bash",
+			"-c",
+			`(printf child-started > "$1"; sleep 0.25; printf survived > "$2") & wait`,
+			"bash",
+			childStarted,
+			delayedMarker,
+		)
+	}()
+	require.Eventually(t, func() bool {
+		_, err := os.Stat(childStarted)
+		return err == nil
+	}, 5*time.Second, 10*time.Millisecond, "background child never started")
+
+	cancel()
+	select {
+	case err := <-done:
+		require.Error(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("exec runner did not return after cancellation")
+	}
+	time.Sleep(350 * time.Millisecond)
+	assert.NoFileExists(t, delayedMarker, "background descendant survived command cancellation")
 }
 
 func newTestManager(t *testing.T, installRoot string, server *httptest.Server, runner CommandRunner) *Manager {

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -174,6 +174,30 @@ func TestManagerFailedPreflightImageCleanupIsBestEffort(t *testing.T) {
 	assert.Contains(t, mustReadFile(t, completed.LogPath), "warning: could not remove failed preflight image proto-fleet-api:v1.1.0")
 }
 
+func TestManagerActivationFailurePreservesForwardRecovery(t *testing.T) {
+	t.Parallel()
+
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	bundle := releaseBundle(t, "v1.1.0")
+	server := releaseServer(t, "v1.1.0", "amd64", bundle, "")
+	runner := &recordingRunner{activation: assert.AnError}
+	manager := newTestManager(t, installRoot, server, runner)
+
+	_, err := manager.Trigger("v1.1.0")
+	require.NoError(t, err)
+	completed := waitForTerminal(t, manager)
+
+	assert.Equal(t, updaterapi.PhaseFailed, completed.Phase)
+	assert.Contains(t, completed.Error, "new stack failed to start")
+	assert.Equal(t, "v1.1.0", mustReadVersion(t, filepath.Join(installRoot, "deployment", "version.txt")))
+	assert.Equal(t, "v1.0.0", mustReadVersion(t, filepath.Join(installRoot, "deployment.previous", "version.txt")))
+	assert.Contains(t, completed.RecoveryCommand, "./run-fleet.sh --non-interactive --skip-build")
+	commands := runner.Commands()
+	require.Len(t, commands, 2)
+	assert.Equal(t, []string{"./run-fleet.sh", "--non-interactive", "--skip-build"}, commands[1].Args)
+}
+
 func TestManagerRejectsASecondUpgradeWhileOneIsRunning(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -330,6 +330,60 @@ func TestManagerFailsClosedWhenSuccessfulStateCannotPersist(t *testing.T) {
 	assert.Equal(t, updaterapi.PhaseFailed, restartedOperation.Phase)
 }
 
+func TestManagerFailsClosedWhenFailedStateCannotPersist(t *testing.T) {
+	t.Parallel()
+
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	bundle := releaseBundle(t, "v1.1.0")
+	server := releaseServer(t, "v1.1.0", "amd64", bundle, "")
+	rejectFailedStateOnce := true
+	manager := newTestManagerWithConfig(t, installRoot, server, &recordingRunner{activation: assert.AnError}, func(cfg *Config) {
+		cfg.beforePersistState = func(operation updaterapi.Operation) error {
+			if operation.Phase == updaterapi.PhaseFailed && rejectFailedStateOnce {
+				rejectFailedStateOnce = false
+				return assert.AnError
+			}
+			return nil
+		}
+	})
+
+	_, err := manager.Trigger("v1.1.0")
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		manager.mu.RLock()
+		defer manager.mu.RUnlock()
+		return !manager.operationRunning
+	}, 5*time.Second, 10*time.Millisecond, "upgrade worker did not finish")
+
+	operation := manager.Status().Operation
+	require.NotNil(t, operation)
+	assert.Equal(t, updaterapi.PhaseActivating, operation.Phase)
+	assert.NotEmpty(t, operation.RecoveryCommand)
+	assert.Nil(t, operation.CompletedAt)
+	assert.NotContains(t, mustReadFile(t, operation.LogPath), "terminal phase=failed")
+
+	var persisted updaterapi.Operation
+	require.NoError(t, json.Unmarshal(
+		[]byte(mustReadFile(t, filepath.Join(manager.cfg.StateDir, stateFilename))),
+		&persisted,
+	))
+	assert.Equal(t, updaterapi.PhaseActivating, persisted.Phase)
+	assert.Equal(t, operation.RecoveryCommand, persisted.RecoveryCommand)
+	assert.Nil(t, persisted.CompletedAt)
+
+	_, err = manager.Trigger("v1.2.0")
+	require.ErrorContains(t, err, "already in progress")
+
+	require.NoError(t, manager.Close())
+	restarted, err := NewManager(manager.cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, restarted.Close()) })
+	restartedOperation := restarted.Status().Operation
+	require.NotNil(t, restartedOperation)
+	assert.Equal(t, updaterapi.PhaseFailed, restartedOperation.Phase)
+}
+
 func TestManagerRejectsUpdaterCandidateWithUnexpectedVersionBeforeReplacement(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -678,28 +679,72 @@ func TestManagerFailedPreflightImageCleanupHasABoundedDeadline(t *testing.T) {
 	assert.Contains(t, mustReadFile(t, completed.LogPath), context.DeadlineExceeded.Error())
 }
 
-func TestManagerActivationFailurePreservesForwardRecovery(t *testing.T) {
+func TestManagerActivationFailurePersistsProofAwareForwardRecovery(t *testing.T) {
 	t.Parallel()
 
-	installRoot := t.TempDir()
-	writeCurrentDeployment(t, installRoot, "v1.0.0")
-	bundle := releaseBundle(t, "v1.1.0")
-	server := releaseServer(t, "v1.1.0", "amd64", bundle, "")
-	runner := &recordingRunner{activation: assert.AnError}
-	manager := newTestManager(t, installRoot, server, runner)
+	for _, test := range []struct {
+		name       string
+		proofState string
+	}{
+		{name: "retained proof uses prepared images", proofState: "retained"},
+		{name: "removed proof reruns preflight", proofState: "removed"},
+		{name: "non-regular proof fails closed", proofState: "non-regular"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 
-	_, err := manager.Trigger("v1.1.0")
-	require.NoError(t, err)
-	completed := waitForTerminal(t, manager)
+			installRoot := t.TempDir()
+			writeCurrentDeployment(t, installRoot, "v1.0.0")
+			bundle := releaseBundle(t, "v1.1.0")
+			server := releaseServer(t, "v1.1.0", "amd64", bundle, "")
+			runner := &recordingRunner{
+				activation: assert.AnError,
+				preflightHook: func(dir string) error {
+					return os.WriteFile(filepath.Join(dir, preflightProofFilename), []byte("proof\n"), 0o600)
+				},
+				activationHook: func(dir string) {
+					proofPath := filepath.Join(dir, preflightProofFilename)
+					switch test.proofState {
+					case "removed":
+						_ = os.Remove(proofPath)
+					case "non-regular":
+						_ = os.Remove(proofPath)
+						_ = os.Mkdir(proofPath, 0o700)
+					}
+				},
+			}
+			manager := newTestManager(t, installRoot, server, runner)
 
-	assert.Equal(t, updaterapi.PhaseFailed, completed.Phase)
-	assert.Contains(t, completed.Error, "new stack failed to start")
-	assert.Equal(t, "v1.1.0", mustReadVersion(t, filepath.Join(installRoot, "deployment", "version.txt")))
-	assert.Equal(t, "v1.0.0", mustReadVersion(t, filepath.Join(installRoot, "deployment.previous", "version.txt")))
-	assert.Contains(t, completed.RecoveryCommand, "./run-fleet.sh --non-interactive --skip-build")
-	commands := runner.Commands()
-	require.Len(t, commands, 2)
-	assert.Equal(t, []string{"./run-fleet.sh", "--non-interactive", "--skip-build"}, commands[1].Args)
+			_, err := manager.Trigger("v1.1.0")
+			require.NoError(t, err)
+			completed := waitForTerminal(t, manager)
+
+			assert.Equal(t, updaterapi.PhaseFailed, completed.Phase)
+			assert.Contains(t, completed.Error, "new stack failed to start")
+			assert.Equal(t, "v1.1.0", mustReadVersion(t, filepath.Join(installRoot, "deployment", "version.txt")))
+			assert.Equal(t, "v1.0.0", mustReadVersion(t, filepath.Join(installRoot, "deployment.previous", "version.txt")))
+			currentDeployment := filepath.Join(manager.cfg.InstallRoot, "deployment")
+			switch test.proofState {
+			case "retained":
+				assert.Equal(t, activationRecoveryCommand(currentDeployment), completed.RecoveryCommand)
+			case "removed":
+				assert.Equal(t, activationPreflightRecoveryCommand(currentDeployment), completed.RecoveryCommand)
+			case "non-regular":
+				assert.Empty(t, completed.RecoveryCommand)
+				assert.Contains(t, completed.Error, "activation preflight proof is not a regular file")
+			}
+
+			var persisted updaterapi.Operation
+			require.NoError(t, json.Unmarshal(
+				[]byte(mustReadFile(t, filepath.Join(manager.cfg.StateDir, stateFilename))),
+				&persisted,
+			))
+			assert.Equal(t, completed.RecoveryCommand, persisted.RecoveryCommand)
+			commands := runner.Commands()
+			require.Len(t, commands, 2)
+			assert.Equal(t, []string{"./run-fleet.sh", "--non-interactive", "--skip-build"}, commands[1].Args)
+		})
+	}
 }
 
 func TestManagerFailsActivationOnlyAfterRestoringPreviousDeployment(t *testing.T) {
@@ -1171,6 +1216,86 @@ func TestManagerMarksAnInterruptedPersistedOperationFailed(t *testing.T) {
 	assert.Equal(t, updaterapi.PhaseFailed, operation.Phase)
 	assert.Contains(t, operation.Error, "updater restarted")
 	require.NotNil(t, operation.CompletedAt)
+}
+
+func TestManagerOnlyCleansStaleArtifactsToRetryReconciledStateAfterENOSPC(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name          string
+		persistErr    error
+		wantStarted   bool
+		wantAttempts  int
+		wantStaleFile bool
+	}{
+		{
+			name:         "ENOSPC cleans and retries once",
+			persistErr:   fmt.Errorf("state filesystem full: %w", syscall.ENOSPC),
+			wantStarted:  true,
+			wantAttempts: 2,
+		},
+		{
+			name:          "other error preserves evidence without retry",
+			persistErr:    assert.AnError,
+			wantAttempts:  1,
+			wantStaleFile: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			installRoot := t.TempDir()
+			writeCurrentDeployment(t, installRoot, "v1.0.0")
+			stateDir := filepath.Join(t.TempDir(), "state")
+			require.NoError(t, os.MkdirAll(stateDir, 0o700))
+			started := time.Date(2026, 8, 5, 8, 0, 0, 0, time.UTC)
+			interrupted := updaterapi.Operation{
+				ID:            "interrupted-before-activation",
+				TargetVersion: "v1.1.0",
+				Phase:         updaterapi.PhaseStaging,
+				Message:       "Staging release",
+				StartedAt:     started,
+				UpdatedAt:     started,
+			}
+			data, err := json.Marshal(interrupted)
+			require.NoError(t, err)
+			require.NoError(t, os.WriteFile(filepath.Join(stateDir, stateFilename), data, 0o600))
+			staleArtifact := filepath.Join(stateDir, operationArtifactBase(interrupted.ID)+".tar.gz")
+			require.NoError(t, os.WriteFile(staleArtifact, []byte("crash artifact"), 0o600))
+
+			attempts := 0
+			manager, err := NewManager(Config{
+				InstallRoot: installRoot,
+				StateDir:    stateDir,
+				GOARCH:      "amd64",
+				beforePersistState: func(updaterapi.Operation) error {
+					attempts++
+					if _, statErr := os.Lstat(staleArtifact); statErr == nil {
+						return test.persistErr
+					}
+					return nil
+				},
+			})
+			assert.Equal(t, test.wantAttempts, attempts)
+			if test.wantStarted {
+				require.NoError(t, err)
+				t.Cleanup(func() { assert.NoError(t, manager.Close()) })
+				operation := manager.Status().Operation
+				require.NotNil(t, operation)
+				assert.Equal(t, updaterapi.PhaseFailed, operation.Phase)
+				assert.NoFileExists(t, staleArtifact)
+				return
+			}
+
+			if manager != nil {
+				_ = manager.Close()
+			}
+			require.Error(t, err)
+			if test.wantStaleFile {
+				assert.FileExists(t, staleArtifact)
+			}
+		})
+	}
 }
 
 func TestManagerRestoresPreviousDeploymentAfterInterruptedSwap(t *testing.T) {

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -334,6 +334,94 @@ func TestManagerMarksAnInterruptedPersistedOperationFailed(t *testing.T) {
 	require.NotNil(t, operation.CompletedAt)
 }
 
+func TestManagerRestoresPreviousDeploymentAfterInterruptedSwap(t *testing.T) {
+	t.Parallel()
+
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	require.NoError(t, os.Rename(
+		filepath.Join(installRoot, "deployment"),
+		filepath.Join(installRoot, "deployment.previous"),
+	))
+	stateDir := filepath.Join(t.TempDir(), "state")
+	writeInterruptedOperationState(t, stateDir, "v1.1.0")
+
+	manager, err := NewManager(Config{
+		InstallRoot: installRoot,
+		StateDir:    stateDir,
+		GOARCH:      "amd64",
+	})
+	require.NoError(t, err)
+
+	operation := manager.Status().Operation
+	require.NotNil(t, operation)
+	assert.Equal(t, updaterapi.PhaseFailed, operation.Phase)
+	assert.Contains(t, operation.Message, "previous deployment restored")
+	assert.Empty(t, operation.RecoveryCommand)
+	assert.Equal(t, "v1.0.0", mustReadVersion(t, filepath.Join(installRoot, "deployment", "version.txt")))
+	assert.NoDirExists(t, filepath.Join(installRoot, "deployment.previous"))
+}
+
+func TestManagerKeepsForwardDeploymentAfterInterruptedActivation(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name             string
+		withProof        bool
+		wantRecoveryHint bool
+	}{
+		{name: "preflight proof remains", withProof: true, wantRecoveryHint: true},
+		{name: "preflight proof was consumed", withProof: false, wantRecoveryHint: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			installRoot := t.TempDir()
+			writeCurrentDeployment(t, installRoot, "v1.1.0")
+			if test.withProof {
+				require.NoError(t, os.WriteFile(
+					filepath.Join(installRoot, "deployment", ".update-preflight-complete"),
+					[]byte("proof\n"),
+					0o600,
+				))
+			}
+			stateDir := filepath.Join(t.TempDir(), "state")
+			writeInterruptedOperationState(t, stateDir, "v1.1.0")
+
+			manager, err := NewManager(Config{
+				InstallRoot: installRoot,
+				StateDir:    stateDir,
+				GOARCH:      "amd64",
+			})
+			require.NoError(t, err)
+
+			operation := manager.Status().Operation
+			require.NotNil(t, operation)
+			assert.Equal(t, updaterapi.PhaseFailed, operation.Phase)
+			assert.Equal(t, "v1.1.0", mustReadVersion(t, filepath.Join(installRoot, "deployment", "version.txt")))
+			if test.wantRecoveryHint {
+				assert.Contains(t, operation.RecoveryCommand, "--skip-build")
+			} else {
+				assert.Empty(t, operation.RecoveryCommand)
+			}
+		})
+	}
+}
+
+func TestManagerRejectsUnrecoverableInterruptedActivationLayout(t *testing.T) {
+	t.Parallel()
+
+	stateDir := filepath.Join(t.TempDir(), "state")
+	writeInterruptedOperationState(t, stateDir, "v1.1.0")
+
+	_, err := NewManager(Config{
+		InstallRoot: t.TempDir(),
+		StateDir:    stateDir,
+		GOARCH:      "amd64",
+	})
+	require.ErrorContains(t, err, "both deployment and deployment.previous are missing")
+}
+
 func TestManagerRejectsUnsafeDownloadBaseURLs(t *testing.T) {
 	t.Parallel()
 
@@ -485,6 +573,22 @@ func releaseBundle(t *testing.T, version string) []byte {
 	require.NoError(t, tarWriter.Close())
 	require.NoError(t, gzipWriter.Close())
 	return buffer.Bytes()
+}
+
+func writeInterruptedOperationState(t *testing.T, stateDir, targetVersion string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(stateDir, 0o700))
+	started := time.Date(2026, 8, 5, 8, 0, 0, 0, time.UTC)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(stateDir, stateFilename),
+		[]byte(fmt.Sprintf(
+			`{"id":"interrupted","target_version":%q,"phase":"activating","started_at":%q,"updated_at":%q,"recovery_command":"stale"}`,
+			targetVersion,
+			started.Format(time.RFC3339Nano),
+			started.Format(time.RFC3339Nano),
+		)),
+		0o600,
+	))
 }
 
 func writeCurrentDeployment(t *testing.T, installRoot, version string) {

--- a/server/internal/updater/self_update_handoff.go
+++ b/server/internal/updater/self_update_handoff.go
@@ -1,0 +1,313 @@
+package updater
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+const (
+	selfUpdateHandoffSuffix     = ".handoff"
+	selfUpdateHandoffTempSuffix = ".handoff.tmp"
+	selfUpdateRestoreTempSuffix = ".restore"
+	maxSelfUpdateHandoffBytes   = 4096
+)
+
+// ErrInterruptedSelfUpdateRestored tells the command to exit nonzero so its
+// supervisor starts the executable that was restored before initialization.
+var ErrInterruptedSelfUpdateRestored = errors.New("interrupted self-update restored; restart required")
+
+type selfUpdateHandoffMarker struct {
+	ExecutablePath string `json:"executable_path"`
+}
+
+// SelfUpdateStartup is the one-shot authority carried by the first replacement
+// process. A durable sibling marker preserves that authority if this process is
+// interrupted before it binds the secured production socket.
+type SelfUpdateStartup struct {
+	executablePath string
+	active         bool
+}
+
+// PrepareSelfUpdateStartup reconciles an interrupted replacement before the
+// manager touches StateDir. A matching argv handoff identifies the first
+// replacement attempt; a durable marker without that argv means a supervisor
+// restarted an attempt that never reached readiness, so the previous binary is
+// restored before initialization continues.
+func PrepareSelfUpdateStartup(configuredPath, handoffPath string) (*SelfUpdateStartup, error) {
+	if configuredPath == "" {
+		if handoffPath != "" {
+			return nil, fmt.Errorf("self-update handoff provided without a configured executable path")
+		}
+		return nil, nil
+	}
+	canonicalPath, err := ensureTrustedSelfUpdateLocation(configuredPath)
+	if err != nil {
+		return nil, fmt.Errorf("validate self-update startup location: %w", err)
+	}
+	marker, exists, err := readSelfUpdateHandoffMarker(canonicalPath)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		if handoffPath != "" {
+			return nil, fmt.Errorf("self-update handoff marker is missing")
+		}
+		if _, err := ensureTrustedSelfUpdatePath(configuredPath); err != nil {
+			return nil, fmt.Errorf("validate self-update startup path: %w", err)
+		}
+		return nil, nil
+	}
+	if marker.ExecutablePath != canonicalPath {
+		return nil, fmt.Errorf("self-update handoff marker path does not match configured executable")
+	}
+	if handoffPath != "" {
+		validatedPath, err := ensureTrustedSelfUpdatePath(configuredPath)
+		if err != nil {
+			return nil, fmt.Errorf("validate replacement updater executable: %w", err)
+		}
+		if validatedPath != canonicalPath {
+			return nil, fmt.Errorf("validated replacement path does not match durable marker")
+		}
+		canonicalHandoff, err := canonicalSelfUpdateDestination(handoffPath)
+		if err != nil {
+			return nil, fmt.Errorf("resolve self-update handoff argument: %w", err)
+		}
+		if !filepath.IsAbs(handoffPath) || canonicalHandoff != canonicalPath {
+			return nil, fmt.Errorf("self-update handoff argument does not match durable marker")
+		}
+		return &SelfUpdateStartup{executablePath: canonicalPath, active: true}, nil
+	}
+	if err := rollbackPendingSelfUpdate(canonicalPath); err != nil {
+		return nil, fmt.Errorf("restore interrupted self-update: %w", err)
+	}
+	return nil, ErrInterruptedSelfUpdateRestored
+}
+
+// Commit durably removes rollback eligibility after the real manager has
+// initialized and the production socket has been bound and secured.
+func (startup *SelfUpdateStartup) Commit() error {
+	if startup == nil || !startup.active {
+		return nil
+	}
+	if err := clearSelfUpdateHandoffMarker(startup.executablePath); err != nil {
+		return err
+	}
+	startup.active = false
+	return nil
+}
+
+// Rollback atomically restores the retained executable without consuming the
+// backup, then durably clears the marker. Retaining the hard link makes the
+// operation idempotent across a crash between restoration and marker removal.
+func (startup *SelfUpdateStartup) Rollback() error {
+	if startup == nil || !startup.active {
+		return nil
+	}
+	_, markerExists, err := readSelfUpdateHandoffMarker(startup.executablePath)
+	if err != nil {
+		return err
+	}
+	if markerExists {
+		err = rollbackPendingSelfUpdate(startup.executablePath)
+	} else {
+		// Commit may have unlinked the marker before its parent fsync failed.
+		// The in-memory token still authorizes a conservative restoration.
+		err = restorePreviousExecutable(startup.executablePath)
+	}
+	if err != nil {
+		return err
+	}
+	startup.active = false
+	return nil
+}
+
+func writeSelfUpdateHandoffMarker(destination string) error {
+	canonicalDestination, err := canonicalSelfUpdateDestination(destination)
+	if err != nil {
+		return err
+	}
+	destination = canonicalDestination
+	destinationInfo, err := os.Lstat(destination)
+	if err != nil {
+		return fmt.Errorf("inspect updater destination before handoff: %w", err)
+	}
+	backupInfo, err := os.Lstat(destination + selfUpdateBackupSuffix)
+	if err != nil {
+		return fmt.Errorf("inspect updater backup before handoff: %w", err)
+	}
+	if !os.SameFile(destinationInfo, backupInfo) {
+		return fmt.Errorf("updater backup does not retain the current executable")
+	}
+
+	markerPath := destination + selfUpdateHandoffSuffix
+	if _, err := os.Lstat(markerPath); err == nil {
+		return fmt.Errorf("self-update handoff marker already exists")
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("inspect self-update handoff marker: %w", err)
+	}
+	tempPath := destination + selfUpdateHandoffTempSuffix
+	if removed, err := unlinkExecutableSlot(tempPath); err != nil {
+		return fmt.Errorf("clean stale self-update handoff temp file: %w", err)
+	} else if removed {
+		if err := syncDirectory(filepath.Dir(destination)); err != nil {
+			return fmt.Errorf("persist stale handoff temp cleanup: %w", err)
+		}
+	}
+
+	data, err := json.Marshal(selfUpdateHandoffMarker{ExecutablePath: destination})
+	if err != nil {
+		return fmt.Errorf("encode self-update handoff marker: %w", err)
+	}
+	fd, err := syscall.Open(
+		tempPath,
+		syscall.O_CREAT|syscall.O_EXCL|syscall.O_WRONLY|syscall.O_CLOEXEC|syscall.O_NOFOLLOW,
+		0o600,
+	)
+	if err != nil {
+		return fmt.Errorf("create self-update handoff temp file: %w", err)
+	}
+	file := os.NewFile(uintptr(fd), tempPath)
+	if file == nil {
+		_ = syscall.Close(fd)
+		return fmt.Errorf("create self-update handoff temp file")
+	}
+	installed := false
+	defer func() {
+		if !installed {
+			_ = os.Remove(tempPath)
+		}
+	}()
+	if _, err := file.Write(data); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("write self-update handoff marker: %w", err)
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("sync self-update handoff marker: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close self-update handoff marker: %w", err)
+	}
+	if err := os.Rename(tempPath, markerPath); err != nil {
+		return fmt.Errorf("install self-update handoff marker: %w", err)
+	}
+	installed = true
+	if err := syncDirectory(filepath.Dir(destination)); err != nil {
+		return fmt.Errorf("persist self-update handoff marker: %w", err)
+	}
+	return nil
+}
+
+func readSelfUpdateHandoffMarker(destination string) (selfUpdateHandoffMarker, bool, error) {
+	canonicalDestination, err := canonicalSelfUpdateDestination(destination)
+	if err != nil {
+		return selfUpdateHandoffMarker{}, false, err
+	}
+	destination = canonicalDestination
+	markerPath := destination + selfUpdateHandoffSuffix
+	fd, err := syscall.Open(markerPath, syscall.O_RDONLY|syscall.O_CLOEXEC|syscall.O_NOFOLLOW, 0)
+	if errors.Is(err, os.ErrNotExist) {
+		return selfUpdateHandoffMarker{}, false, nil
+	}
+	if err != nil {
+		return selfUpdateHandoffMarker{}, false, fmt.Errorf("open self-update handoff marker: %w", err)
+	}
+	file := os.NewFile(uintptr(fd), markerPath)
+	if file == nil {
+		_ = syscall.Close(fd)
+		return selfUpdateHandoffMarker{}, false, fmt.Errorf("open self-update handoff marker")
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return selfUpdateHandoffMarker{}, false, fmt.Errorf("inspect self-update handoff marker: %w", err)
+	}
+	if !info.Mode().IsRegular() || info.Mode().Perm()&0o022 != 0 {
+		return selfUpdateHandoffMarker{}, false, fmt.Errorf("self-update handoff marker must be a protected regular file")
+	}
+	if err := validateDaemonPathOwner(markerPath, info); err != nil {
+		return selfUpdateHandoffMarker{}, false, err
+	}
+	data, err := io.ReadAll(io.LimitReader(file, maxSelfUpdateHandoffBytes+1))
+	if err != nil {
+		return selfUpdateHandoffMarker{}, false, fmt.Errorf("read self-update handoff marker: %w", err)
+	}
+	if len(data) > maxSelfUpdateHandoffBytes {
+		return selfUpdateHandoffMarker{}, false, fmt.Errorf("self-update handoff marker exceeds %d bytes", maxSelfUpdateHandoffBytes)
+	}
+	var marker selfUpdateHandoffMarker
+	if err := json.Unmarshal(data, &marker); err != nil {
+		return selfUpdateHandoffMarker{}, false, fmt.Errorf("decode self-update handoff marker: %w", err)
+	}
+	if marker.ExecutablePath == "" || !filepath.IsAbs(marker.ExecutablePath) || filepath.Clean(marker.ExecutablePath) != marker.ExecutablePath {
+		return selfUpdateHandoffMarker{}, false, fmt.Errorf("self-update handoff marker contains an invalid executable path")
+	}
+	return marker, true, nil
+}
+
+func rollbackPendingSelfUpdate(destination string) error {
+	canonicalDestination, err := canonicalSelfUpdateDestination(destination)
+	if err != nil {
+		return err
+	}
+	destination = canonicalDestination
+	marker, exists, err := readSelfUpdateHandoffMarker(destination)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return fmt.Errorf("self-update handoff marker is missing")
+	}
+	if marker.ExecutablePath != destination {
+		return fmt.Errorf("self-update handoff marker path does not match executable")
+	}
+	if err := restorePreviousExecutable(destination); err != nil {
+		return err
+	}
+	return clearSelfUpdateHandoffMarker(destination)
+}
+
+func clearSelfUpdateHandoffMarker(destination string) error {
+	canonicalDestination, err := canonicalSelfUpdateDestination(destination)
+	if err != nil {
+		return err
+	}
+	destination = canonicalDestination
+	marker, exists, err := readSelfUpdateHandoffMarker(destination)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return fmt.Errorf("self-update handoff marker is missing")
+	}
+	if marker.ExecutablePath != destination {
+		return fmt.Errorf("self-update handoff marker path does not match executable")
+	}
+	if err := syscall.Unlink(destination + selfUpdateHandoffSuffix); err != nil {
+		return fmt.Errorf("remove self-update handoff marker: %w", err)
+	}
+	if err := syncDirectory(filepath.Dir(destination)); err != nil {
+		return fmt.Errorf("persist self-update handoff marker removal: %w", err)
+	}
+	return nil
+}
+
+func canonicalSelfUpdateDestination(destination string) (string, error) {
+	canonicalPath, err := filepath.EvalSymlinks(destination)
+	if err == nil {
+		return canonicalPath, nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return "", fmt.Errorf("resolve self-update executable path: %w", err)
+	}
+	canonicalParent, parentErr := filepath.EvalSymlinks(filepath.Dir(destination))
+	if parentErr != nil {
+		return "", fmt.Errorf("resolve self-update executable parent: %w", parentErr)
+	}
+	return filepath.Join(canonicalParent, filepath.Base(destination)), nil
+}

--- a/server/internal/updater/self_update_handoff.go
+++ b/server/internal/updater/self_update_handoff.go
@@ -39,6 +39,12 @@ type SelfUpdateStartup struct {
 // restarted an attempt that never reached readiness, so the previous binary is
 // restored before initialization continues.
 func PrepareSelfUpdateStartup(configuredPath, handoffPath string) (*SelfUpdateStartup, error) {
+	if configuredPath != "" && !filepath.IsAbs(configuredPath) {
+		return nil, fmt.Errorf("self-update path must be absolute")
+	}
+	if handoffPath != "" && !filepath.IsAbs(handoffPath) {
+		return nil, fmt.Errorf("self-update handoff path must be absolute")
+	}
 	if configuredPath == "" {
 		if handoffPath != "" {
 			return nil, fmt.Errorf("self-update handoff provided without a configured executable path")
@@ -77,7 +83,7 @@ func PrepareSelfUpdateStartup(configuredPath, handoffPath string) (*SelfUpdateSt
 		if err != nil {
 			return nil, fmt.Errorf("resolve self-update handoff argument: %w", err)
 		}
-		if !filepath.IsAbs(handoffPath) || canonicalHandoff != canonicalPath {
+		if canonicalHandoff != canonicalPath {
 			return nil, fmt.Errorf("self-update handoff argument does not match durable marker")
 		}
 		return &SelfUpdateStartup{executablePath: canonicalPath, active: true}, nil

--- a/server/internal/updater/self_update_handoff_test.go
+++ b/server/internal/updater/self_update_handoff_test.go
@@ -9,6 +9,37 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestPrepareSelfUpdateStartupRejectsRelativePathsBeforeFilesystemAccess(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name           string
+		configuredPath string
+		handoffPath    string
+		wantError      string
+	}{
+		{
+			name:           "configured executable",
+			configuredPath: filepath.Join("missing", "proto-fleet-updater"),
+			wantError:      "self-update path must be absolute",
+		},
+		{
+			name:           "handoff executable",
+			configuredPath: filepath.Join(t.TempDir(), "missing-updater"),
+			handoffPath:    filepath.Join("missing", "proto-fleet-updater"),
+			wantError:      "self-update handoff path must be absolute",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			startup, err := PrepareSelfUpdateStartup(test.configuredPath, test.handoffPath)
+			require.ErrorContains(t, err, test.wantError)
+			assert.Nil(t, startup)
+		})
+	}
+}
+
 func TestSelfUpdateHandoffCommitsOnlyAfterReplacementReadiness(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/updater/self_update_handoff_test.go
+++ b/server/internal/updater/self_update_handoff_test.go
@@ -1,0 +1,137 @@
+package updater
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSelfUpdateHandoffCommitsOnlyAfterReplacementReadiness(t *testing.T) {
+	t.Parallel()
+
+	destination := installSelfUpdateForHandoffTest(t)
+	startup, err := PrepareSelfUpdateStartup(destination, destination)
+	require.NoError(t, err)
+	require.NotNil(t, startup)
+	assert.FileExists(t, destination+selfUpdateHandoffSuffix)
+
+	require.NoError(t, startup.Commit())
+	assert.NoFileExists(t, destination+selfUpdateHandoffSuffix)
+	assert.Equal(t, "new updater", mustReadFile(t, destination))
+	assert.Equal(t, "old updater", mustReadFile(t, destination+selfUpdateBackupSuffix))
+
+	ordinaryStartup, err := PrepareSelfUpdateStartup(destination, "")
+	require.NoError(t, err)
+	assert.Nil(t, ordinaryStartup)
+}
+
+func TestSelfUpdateHandoffRestoresInterruptedReplacementWithoutArgv(t *testing.T) {
+	t.Parallel()
+
+	destination := installSelfUpdateForHandoffTest(t)
+	startup, err := PrepareSelfUpdateStartup(destination, "")
+	require.ErrorIs(t, err, ErrInterruptedSelfUpdateRestored)
+	assert.Nil(t, startup)
+	assert.Equal(t, "old updater", mustReadFile(t, destination))
+	assert.Equal(t, "old updater", mustReadFile(t, destination+selfUpdateBackupSuffix))
+	assert.NoFileExists(t, destination+selfUpdateHandoffSuffix)
+}
+
+func TestSelfUpdateHandoffRollbackRestoresReturnedStartupFailure(t *testing.T) {
+	t.Parallel()
+
+	destination := installSelfUpdateForHandoffTest(t)
+	startup, err := PrepareSelfUpdateStartup(destination, destination)
+	require.NoError(t, err)
+	require.NoError(t, startup.Rollback())
+	assert.Equal(t, "old updater", mustReadFile(t, destination))
+	assert.Equal(t, "old updater", mustReadFile(t, destination+selfUpdateBackupSuffix))
+	assert.NoFileExists(t, destination+selfUpdateHandoffSuffix)
+}
+
+func TestSelfUpdateHandoffReconcilesCrashBeforeCandidateRename(t *testing.T) {
+	t.Parallel()
+
+	directory := t.TempDir()
+	destination := filepath.Join(directory, "proto-fleet-updater")
+	require.NoError(t, os.WriteFile(destination, []byte("old updater"), 0o755))
+	require.NoError(t, os.Link(destination, destination+selfUpdateBackupSuffix))
+	require.NoError(t, writeSelfUpdateHandoffMarker(destination))
+
+	startup, err := PrepareSelfUpdateStartup(destination, "")
+	require.ErrorIs(t, err, ErrInterruptedSelfUpdateRestored)
+	assert.Nil(t, startup)
+	assert.Equal(t, "old updater", mustReadFile(t, destination))
+	assert.Equal(t, "old updater", mustReadFile(t, destination+selfUpdateBackupSuffix))
+	assert.NoFileExists(t, destination+selfUpdateHandoffSuffix)
+}
+
+func TestSelfUpdateHandoffReconcilesCrashAfterExecutableRestoration(t *testing.T) {
+	t.Parallel()
+
+	destination := installSelfUpdateForHandoffTest(t)
+	require.NoError(t, restorePreviousExecutable(destination))
+	assert.FileExists(t, destination+selfUpdateHandoffSuffix)
+
+	startup, err := PrepareSelfUpdateStartup(destination, "")
+	require.ErrorIs(t, err, ErrInterruptedSelfUpdateRestored)
+	assert.Nil(t, startup)
+	assert.Equal(t, "old updater", mustReadFile(t, destination))
+	assert.Equal(t, "old updater", mustReadFile(t, destination+selfUpdateBackupSuffix))
+	assert.NoFileExists(t, destination+selfUpdateHandoffSuffix)
+}
+
+func TestSelfUpdateHandoffRestoresMissingExecutableEntry(t *testing.T) {
+	t.Parallel()
+
+	destination := installSelfUpdateForHandoffTest(t)
+	require.NoError(t, os.Remove(destination))
+	assert.NoFileExists(t, destination)
+
+	startup, err := PrepareSelfUpdateStartup(destination, "")
+	require.ErrorIs(t, err, ErrInterruptedSelfUpdateRestored)
+	assert.Nil(t, startup)
+	assert.Equal(t, "old updater", mustReadFile(t, destination))
+	assert.Equal(t, "old updater", mustReadFile(t, destination+selfUpdateBackupSuffix))
+	assert.NoFileExists(t, destination+selfUpdateHandoffSuffix)
+}
+
+func TestSelfUpdateHandoffMismatchFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	destination := installSelfUpdateForHandoffTest(t)
+	startup, err := PrepareSelfUpdateStartup(destination, filepath.Join(filepath.Dir(destination), "different-updater"))
+	require.ErrorContains(t, err, "does not match durable marker")
+	assert.Nil(t, startup)
+	assert.Equal(t, "new updater", mustReadFile(t, destination))
+	assert.Equal(t, "old updater", mustReadFile(t, destination+selfUpdateBackupSuffix))
+	assert.FileExists(t, destination+selfUpdateHandoffSuffix)
+}
+
+func TestSelfUpdateHandoffRejectsSymlinkMarker(t *testing.T) {
+	t.Parallel()
+
+	destination := installSelfUpdateForHandoffTest(t)
+	markerPath := destination + selfUpdateHandoffSuffix
+	require.NoError(t, os.Remove(markerPath))
+	require.NoError(t, os.Symlink(destination+selfUpdateBackupSuffix, markerPath))
+
+	startup, err := PrepareSelfUpdateStartup(destination, destination)
+	require.Error(t, err)
+	assert.Nil(t, startup)
+	assert.Equal(t, "new updater", mustReadFile(t, destination))
+}
+
+func installSelfUpdateForHandoffTest(t *testing.T) string {
+	t.Helper()
+	directory := t.TempDir()
+	destination := filepath.Join(directory, "proto-fleet-updater")
+	candidate := filepath.Join(directory, "proto-fleet-updater.candidate")
+	require.NoError(t, os.WriteFile(destination, []byte("old updater"), 0o755))
+	require.NoError(t, os.WriteFile(candidate, []byte("new updater"), 0o755))
+	require.NoError(t, installExecutableCandidate(candidate, destination))
+	return destination
+}

--- a/server/internal/updater/server.go
+++ b/server/internal/updater/server.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"syscall"
 	"time"
 
 	"github.com/block/proto-fleet/server/internal/updaterapi"
@@ -38,12 +39,9 @@ func (s *Server) Serve(socketPath string) error {
 	if err := os.MkdirAll(filepath.Dir(socketPath), 0o750); err != nil {
 		return fmt.Errorf("create updater socket directory: %w", err)
 	}
-	if err := os.Remove(socketPath); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("remove stale updater socket: %w", err)
-	}
-	listener, err := net.Listen("unix", socketPath)
+	listener, err := listenUpdaterSocket(socketPath)
 	if err != nil {
-		return fmt.Errorf("listen on updater socket: %w", err)
+		return err
 	}
 	// #nosec G302 -- root fleet-api needs read/write access through the
 	// bind-mounted Unix socket; the parent directory remains root-only.
@@ -55,6 +53,42 @@ func (s *Server) Serve(socketPath string) error {
 		return fmt.Errorf("serve updater API: %w", err)
 	}
 	return nil
+}
+
+func listenUpdaterSocket(socketPath string) (*net.UnixListener, error) {
+	address := &net.UnixAddr{Name: socketPath, Net: "unix"}
+	listener, err := net.ListenUnix("unix", address)
+	if err == nil {
+		listener.SetUnlinkOnClose(true)
+		return listener, nil
+	}
+	if !errors.Is(err, syscall.EADDRINUSE) {
+		return nil, fmt.Errorf("listen on updater socket: %w", err)
+	}
+	info, statErr := os.Lstat(socketPath)
+	if statErr != nil {
+		return nil, fmt.Errorf("inspect occupied updater socket path: %w", statErr)
+	}
+	if info.Mode()&os.ModeSocket == 0 {
+		return nil, fmt.Errorf("refusing to replace non-socket path at updater socket location")
+	}
+	connection, dialErr := net.DialTimeout("unix", socketPath, 250*time.Millisecond)
+	if dialErr == nil {
+		_ = connection.Close()
+		return nil, fmt.Errorf("another updater is already listening on the configured socket")
+	}
+	if !errors.Is(dialErr, syscall.ECONNREFUSED) {
+		return nil, fmt.Errorf("refusing to replace updater socket with ambiguous owner: %w", dialErr)
+	}
+	if err := os.Remove(socketPath); err != nil {
+		return nil, fmt.Errorf("remove stale updater socket: %w", err)
+	}
+	listener, err = net.ListenUnix("unix", address)
+	if err != nil {
+		return nil, fmt.Errorf("listen on updater socket after stale cleanup: %w", err)
+	}
+	listener.SetUnlinkOnClose(true)
+	return listener, nil
 }
 
 func (s *Server) Shutdown() error {

--- a/server/internal/updater/server.go
+++ b/server/internal/updater/server.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -244,23 +245,44 @@ func (s *Server) handleUpgrade(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	defer r.Body.Close()
-	var request updaterapi.TriggerRequest
-	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4096))
-	decoder.DisallowUnknownFields()
-	if err := decoder.Decode(&request); err != nil {
+	request, err := decodeTriggerRequest(http.MaxBytesReader(w, r.Body, 4096))
+	if err != nil {
 		writeJSON(w, http.StatusBadRequest, updaterapi.ErrorResponse{Error: "invalid request body"})
 		return
 	}
 	operation, err := s.manager.Trigger(request.TargetVersion)
 	if err != nil {
-		status := http.StatusBadRequest
-		if current := s.manager.Status().Operation; current != nil && !current.Phase.Terminal() {
-			status = http.StatusConflict
-		}
-		writeJSON(w, status, updaterapi.ErrorResponse{Error: err.Error()})
+		writeJSON(w, triggerErrorHTTPStatus(err), updaterapi.ErrorResponse{Error: err.Error()})
 		return
 	}
 	writeJSON(w, http.StatusAccepted, updaterapi.TriggerResponse{Operation: operation})
+}
+
+func decodeTriggerRequest(body io.Reader) (updaterapi.TriggerRequest, error) {
+	var request updaterapi.TriggerRequest
+	decoder := json.NewDecoder(body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&request); err != nil {
+		return updaterapi.TriggerRequest{}, fmt.Errorf("decode request body: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return updaterapi.TriggerRequest{}, fmt.Errorf("request body must contain exactly one JSON value")
+		}
+		return updaterapi.TriggerRequest{}, fmt.Errorf("decode trailing request body: %w", err)
+	}
+	return request, nil
+}
+
+func triggerErrorHTTPStatus(err error) int {
+	switch {
+	case errors.Is(err, errTriggerClosing):
+		return http.StatusServiceUnavailable
+	case errors.Is(err, errTriggerBusy):
+		return http.StatusConflict
+	default:
+		return http.StatusBadRequest
+	}
 }
 
 func writeJSON(w http.ResponseWriter, status int, value any) {

--- a/server/internal/updater/server.go
+++ b/server/internal/updater/server.go
@@ -1,6 +1,7 @@
 package updater
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -91,9 +92,13 @@ func listenUpdaterSocket(socketPath string) (*net.UnixListener, error) {
 	return listener, nil
 }
 
-func (s *Server) Shutdown() error {
-	if err := s.http.Close(); err != nil {
-		return fmt.Errorf("close updater API: %w", err)
+func (s *Server) Shutdown(ctx context.Context) error {
+	if err := s.http.Shutdown(ctx); err != nil {
+		closeErr := s.http.Close()
+		return errors.Join(
+			fmt.Errorf("shut down updater API: %w", err),
+			closeErr,
+		)
 	}
 	return nil
 }

--- a/server/internal/updater/server.go
+++ b/server/internal/updater/server.go
@@ -37,14 +37,15 @@ func (s *Server) Serve(socketPath string) error {
 	if !filepath.IsAbs(socketPath) {
 		return fmt.Errorf("socket path must be absolute")
 	}
-	if err := prepareUpdaterSocketDirectory(socketPath); err != nil {
-		return err
-	}
-	listener, err := listenUpdaterSocket(socketPath)
+	canonicalSocketPath, err := prepareUpdaterSocketDirectory(socketPath)
 	if err != nil {
 		return err
 	}
-	if err := secureUpdaterSocket(socketPath); err != nil {
+	listener, err := listenUpdaterSocket(canonicalSocketPath)
+	if err != nil {
+		return err
+	}
+	if err := secureUpdaterSocket(canonicalSocketPath); err != nil {
 		listener.Close()
 		return err
 	}
@@ -58,39 +59,54 @@ func (s *Server) Serve(socketPath string) error {
 // boundary for the updater API. The socket is not network-reachable and its
 // intended caller is the root fleet-api process, so a trusted directory chain
 // plus a daemon-owned 0660 socket is sufficient without a second application
-// authentication protocol.
-func prepareUpdaterSocketDirectory(socketPath string) error {
+// authentication protocol. It returns a canonical path so binding and
+// permission changes never resolve configured ancestor symlinks again.
+func prepareUpdaterSocketDirectory(socketPath string) (string, error) {
+	socketPath = filepath.Clean(socketPath)
 	socketDir := filepath.Dir(socketPath)
 	if err := os.MkdirAll(socketDir, 0o750); err != nil {
-		return fmt.Errorf("create updater socket directory: %w", err)
+		return "", fmt.Errorf("create updater socket directory: %w", err)
 	}
-	if err := validateUpdaterSocketDirectoryChain(socketDir); err != nil {
-		return fmt.Errorf("validate updater socket directory: %w", err)
+	canonicalSocketDir, err := validateUpdaterSocketDirectoryChain(socketDir)
+	if err != nil {
+		return "", fmt.Errorf("validate updater socket directory: %w", err)
 	}
-	return nil
+	return filepath.Join(canonicalSocketDir, filepath.Base(socketPath)), nil
 }
 
 // validateUpdaterSocketDirectoryChain checks both the configured and resolved
 // paths. A protected symlink in an ancestor (for example, /tmp on macOS) is
 // safe once its containing and target directory chains are both trusted, but
 // the socket directory itself must never be a symlink.
-func validateUpdaterSocketDirectoryChain(socketDir string) error {
-	if err := walkUpdaterSocketDirectoryChain(socketDir, true); err != nil {
-		return err
+func validateUpdaterSocketDirectoryChain(socketDir string) (string, error) {
+	if err := walkUpdaterSocketDirectoryChain(socketDir); err != nil {
+		return "", err
 	}
 	resolvedDir, err := filepath.EvalSymlinks(socketDir)
 	if err != nil {
-		return fmt.Errorf("resolve %s: %w", socketDir, err)
+		return "", fmt.Errorf("resolve %s: %w", socketDir, err)
 	}
 	if resolvedDir != socketDir {
-		if err := walkUpdaterSocketDirectoryChain(resolvedDir, true); err != nil {
-			return err
+		if err := walkUpdaterSocketDirectoryChain(resolvedDir); err != nil {
+			return "", err
 		}
 	}
-	return nil
+
+	configuredInfo, err := os.Lstat(socketDir)
+	if err != nil {
+		return "", fmt.Errorf("inspect configured socket directory: %w", err)
+	}
+	canonicalInfo, err := os.Lstat(resolvedDir)
+	if err != nil {
+		return "", fmt.Errorf("inspect canonical socket directory: %w", err)
+	}
+	if !os.SameFile(configuredInfo, canonicalInfo) {
+		return "", fmt.Errorf("updater socket directory changed while it was validated")
+	}
+	return resolvedDir, nil
 }
 
-func walkUpdaterSocketDirectoryChain(path string, rejectFirstSymlink bool) error {
+func walkUpdaterSocketDirectoryChain(path string) error {
 	euid := uint32(os.Geteuid()) //nolint:gosec // Effective UIDs are non-negative on supported Unix hosts.
 	current := filepath.Clean(path)
 	first := true
@@ -99,27 +115,12 @@ func walkUpdaterSocketDirectoryChain(path string, rejectFirstSymlink bool) error
 		if err != nil {
 			return fmt.Errorf("inspect path component %s: %w", current, err)
 		}
-		if info.Mode()&os.ModeSymlink != 0 {
-			if first && rejectFirstSymlink {
-				return fmt.Errorf("socket directory %s must not be a symlink", current)
-			}
-			// The containing directory is checked below and the symlink target
-			// is checked by the resolved-path walk above.
-		} else {
-			if !info.IsDir() {
-				return fmt.Errorf("path component %s is not a directory", current)
-			}
-			stat, ok := info.Sys().(*syscall.Stat_t)
-			if !ok {
-				return fmt.Errorf("path component %s has unsupported stat type %T", current, info.Sys())
-			}
-			if stat.Uid != 0 && stat.Uid != euid {
-				return fmt.Errorf("path component %s owner uid %d must be root or daemon uid %d", current, stat.Uid, euid)
-			}
-			mode := info.Mode()
-			if mode.Perm()&0o022 != 0 && (first || mode&os.ModeSticky == 0) {
-				return fmt.Errorf("path component %s mode %#o must not be group- or world-writable", current, mode.Perm())
-			}
+		stat, ok := info.Sys().(*syscall.Stat_t)
+		if !ok {
+			return fmt.Errorf("path component %s has unsupported stat type %T", current, info.Sys())
+		}
+		if err := validateUpdaterSocketPathComponent(current, info.Mode(), stat.Uid, euid, first); err != nil {
+			return err
 		}
 
 		parent := filepath.Dir(current)
@@ -128,6 +129,27 @@ func walkUpdaterSocketDirectoryChain(path string, rejectFirstSymlink bool) error
 		}
 		current = parent
 		first = false
+	}
+	return nil
+}
+
+func validateUpdaterSocketPathComponent(path string, mode os.FileMode, ownerUID, daemonUID uint32, isSocketDirectory bool) error {
+	if ownerUID != 0 && ownerUID != daemonUID {
+		return fmt.Errorf("path component %s owner uid %d must be root or daemon uid %d", path, ownerUID, daemonUID)
+	}
+	if mode&os.ModeSymlink != 0 {
+		if isSocketDirectory {
+			return fmt.Errorf("socket directory %s must not be a symlink", path)
+		}
+		// The containing directory is checked by this walk and the symlink
+		// target is checked by the resolved-path walk above.
+		return nil
+	}
+	if !mode.IsDir() {
+		return fmt.Errorf("path component %s is not a directory", path)
+	}
+	if mode.Perm()&0o022 != 0 && (isSocketDirectory || mode&os.ModeSticky == 0) {
+		return fmt.Errorf("path component %s mode %#o must not be group- or world-writable", path, mode.Perm())
 	}
 	return nil
 }

--- a/server/internal/updater/server.go
+++ b/server/internal/updater/server.go
@@ -37,21 +37,113 @@ func (s *Server) Serve(socketPath string) error {
 	if !filepath.IsAbs(socketPath) {
 		return fmt.Errorf("socket path must be absolute")
 	}
-	if err := os.MkdirAll(filepath.Dir(socketPath), 0o750); err != nil {
-		return fmt.Errorf("create updater socket directory: %w", err)
+	if err := prepareUpdaterSocketDirectory(socketPath); err != nil {
+		return err
 	}
 	listener, err := listenUpdaterSocket(socketPath)
 	if err != nil {
 		return err
 	}
-	// #nosec G302 -- root fleet-api needs read/write access through the
-	// bind-mounted Unix socket; the parent directory remains root-only.
-	if err := os.Chmod(socketPath, 0o660); err != nil {
+	if err := secureUpdaterSocket(socketPath); err != nil {
 		listener.Close()
-		return fmt.Errorf("set updater socket permissions: %w", err)
+		return err
 	}
 	if err := s.http.Serve(listener); err != nil {
 		return fmt.Errorf("serve updater API: %w", err)
+	}
+	return nil
+}
+
+// prepareUpdaterSocketDirectory establishes the filesystem authentication
+// boundary for the updater API. The socket is not network-reachable and its
+// intended caller is the root fleet-api process, so a trusted directory chain
+// plus a daemon-owned 0660 socket is sufficient without a second application
+// authentication protocol.
+func prepareUpdaterSocketDirectory(socketPath string) error {
+	socketDir := filepath.Dir(socketPath)
+	if err := os.MkdirAll(socketDir, 0o750); err != nil {
+		return fmt.Errorf("create updater socket directory: %w", err)
+	}
+	if err := validateUpdaterSocketDirectoryChain(socketDir); err != nil {
+		return fmt.Errorf("validate updater socket directory: %w", err)
+	}
+	return nil
+}
+
+// validateUpdaterSocketDirectoryChain checks both the configured and resolved
+// paths. A protected symlink in an ancestor (for example, /tmp on macOS) is
+// safe once its containing and target directory chains are both trusted, but
+// the socket directory itself must never be a symlink.
+func validateUpdaterSocketDirectoryChain(socketDir string) error {
+	if err := walkUpdaterSocketDirectoryChain(socketDir, true); err != nil {
+		return err
+	}
+	resolvedDir, err := filepath.EvalSymlinks(socketDir)
+	if err != nil {
+		return fmt.Errorf("resolve %s: %w", socketDir, err)
+	}
+	if resolvedDir != socketDir {
+		if err := walkUpdaterSocketDirectoryChain(resolvedDir, true); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func walkUpdaterSocketDirectoryChain(path string, rejectFirstSymlink bool) error {
+	euid := uint32(os.Geteuid()) //nolint:gosec // Effective UIDs are non-negative on supported Unix hosts.
+	current := filepath.Clean(path)
+	first := true
+	for {
+		info, err := os.Lstat(current)
+		if err != nil {
+			return fmt.Errorf("inspect path component %s: %w", current, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			if first && rejectFirstSymlink {
+				return fmt.Errorf("socket directory %s must not be a symlink", current)
+			}
+			// The containing directory is checked below and the symlink target
+			// is checked by the resolved-path walk above.
+		} else {
+			if !info.IsDir() {
+				return fmt.Errorf("path component %s is not a directory", current)
+			}
+			stat, ok := info.Sys().(*syscall.Stat_t)
+			if !ok {
+				return fmt.Errorf("path component %s has unsupported stat type %T", current, info.Sys())
+			}
+			if stat.Uid != 0 && stat.Uid != euid {
+				return fmt.Errorf("path component %s owner uid %d must be root or daemon uid %d", current, stat.Uid, euid)
+			}
+			mode := info.Mode()
+			if mode.Perm()&0o022 != 0 && (first || mode&os.ModeSticky == 0) {
+				return fmt.Errorf("path component %s mode %#o must not be group- or world-writable", current, mode.Perm())
+			}
+		}
+
+		parent := filepath.Dir(current)
+		if parent == current {
+			break
+		}
+		current = parent
+		first = false
+	}
+	return nil
+}
+
+func secureUpdaterSocket(socketPath string) error {
+	// A setgid socket directory can otherwise make a newly bound socket
+	// inherit an unintended group. Set both IDs explicitly before chmod because
+	// chown is permitted to clear mode bits on supported Unix hosts.
+	if err := os.Chown(socketPath, os.Geteuid(), os.Getegid()); err != nil {
+		return fmt.Errorf("set updater socket ownership: %w", err)
+	}
+	// #nosec G302 -- the root fleet-api caller needs read/write access through
+	// the bind-mounted Unix socket; the validated parent directory is 0750 or
+	// stricter and every writable ancestor is protected by the sticky bit.
+	if err := os.Chmod(socketPath, 0o660); err != nil {
+		return fmt.Errorf("set updater socket permissions: %w", err)
 	}
 	return nil
 }

--- a/server/internal/updater/server.go
+++ b/server/internal/updater/server.go
@@ -250,15 +250,7 @@ func (s *Server) handleUpgrade(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, updaterapi.ErrorResponse{Error: "invalid request body"})
 		return
 	}
-	var operation updaterapi.Operation
-	if request.OperationID == "" {
-		// Backward compatibility for an older fleetd paired with a newer host
-		// updater. New callers always supply an operation ID for exact
-		// lost-response reconciliation.
-		operation, err = s.manager.Trigger(request.TargetVersion)
-	} else {
-		operation, err = s.manager.TriggerWithID(request.TargetVersion, request.OperationID)
-	}
+	operation, err := s.manager.TriggerWithID(request.TargetVersion, request.OperationID)
 	if err != nil {
 		status := triggerErrorHTTPStatus(err)
 		message := err.Error()

--- a/server/internal/updater/server.go
+++ b/server/internal/updater/server.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sync"
 	"syscall"
 	"time"
 
@@ -17,12 +18,14 @@ import (
 )
 
 type Server struct {
-	manager *Manager
-	http    *http.Server
+	manager   *Manager
+	http      *http.Server
+	ready     chan struct{}
+	readyOnce sync.Once
 }
 
 func NewServer(manager *Manager) *Server {
-	server := &Server{manager: manager}
+	server := &Server{manager: manager, ready: make(chan struct{})}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v1/status", server.handleStatus)
 	mux.HandleFunc("/v1/upgrade", server.handleUpgrade)
@@ -49,10 +52,18 @@ func (s *Server) Serve(socketPath string) error {
 		listener.Close()
 		return err
 	}
+	s.readyOnce.Do(func() { close(s.ready) })
 	if err := s.http.Serve(listener); err != nil {
 		return fmt.Errorf("serve updater API: %w", err)
 	}
 	return nil
+}
+
+// Ready closes only after the Unix socket is bound and its ownership and mode
+// establish the local authentication boundary. Callers can use it as the
+// startup-commit point for a one-shot updater handoff.
+func (s *Server) Ready() <-chan struct{} {
+	return s.ready
 }
 
 // prepareUpdaterSocketDirectory establishes the filesystem authentication

--- a/server/internal/updater/server.go
+++ b/server/internal/updater/server.go
@@ -1,0 +1,108 @@
+package updater
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/block/proto-fleet/server/internal/updaterapi"
+)
+
+type Server struct {
+	manager *Manager
+	http    *http.Server
+}
+
+func NewServer(manager *Manager) *Server {
+	server := &Server{manager: manager}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/status", server.handleStatus)
+	mux.HandleFunc("/v1/upgrade", server.handleUpgrade)
+	server.http = &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 3 * time.Second,
+	}
+	return server
+}
+
+func (s *Server) Serve(socketPath string) error {
+	if !filepath.IsAbs(socketPath) {
+		return fmt.Errorf("socket path must be absolute")
+	}
+	if err := os.MkdirAll(filepath.Dir(socketPath), 0o750); err != nil {
+		return fmt.Errorf("create updater socket directory: %w", err)
+	}
+	if err := os.Remove(socketPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("remove stale updater socket: %w", err)
+	}
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		return fmt.Errorf("listen on updater socket: %w", err)
+	}
+	// #nosec G302 -- root fleet-api needs read/write access through the
+	// bind-mounted Unix socket; the parent directory remains root-only.
+	if err := os.Chmod(socketPath, 0o660); err != nil {
+		listener.Close()
+		return fmt.Errorf("set updater socket permissions: %w", err)
+	}
+	if err := s.http.Serve(listener); err != nil {
+		return fmt.Errorf("serve updater API: %w", err)
+	}
+	return nil
+}
+
+func (s *Server) Shutdown() error {
+	if err := s.http.Close(); err != nil {
+		return fmt.Errorf("close updater API: %w", err)
+	}
+	return nil
+}
+
+func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		writeJSON(w, http.StatusMethodNotAllowed, updaterapi.ErrorResponse{Error: "method not allowed"})
+		return
+	}
+	writeJSON(w, http.StatusOK, s.manager.Status())
+}
+
+func (s *Server) handleUpgrade(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		writeJSON(w, http.StatusMethodNotAllowed, updaterapi.ErrorResponse{Error: "method not allowed"})
+		return
+	}
+	defer r.Body.Close()
+	var request updaterapi.TriggerRequest
+	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, 4096))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&request); err != nil {
+		writeJSON(w, http.StatusBadRequest, updaterapi.ErrorResponse{Error: "invalid request body"})
+		return
+	}
+	operation, err := s.manager.Trigger(request.TargetVersion)
+	if err != nil {
+		status := http.StatusBadRequest
+		if current := s.manager.Status().Operation; current != nil && !current.Phase.Terminal() {
+			status = http.StatusConflict
+		}
+		writeJSON(w, status, updaterapi.ErrorResponse{Error: err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusAccepted, updaterapi.TriggerResponse{Operation: operation})
+}
+
+func writeJSON(w http.ResponseWriter, status int, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(value); err != nil {
+		log.Printf("encode updater response: %v", err)
+	}
+}

--- a/server/internal/updater/server.go
+++ b/server/internal/updater/server.go
@@ -250,9 +250,25 @@ func (s *Server) handleUpgrade(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, updaterapi.ErrorResponse{Error: "invalid request body"})
 		return
 	}
-	operation, err := s.manager.Trigger(request.TargetVersion)
+	var operation updaterapi.Operation
+	if request.OperationID == "" {
+		// Backward compatibility for an older fleetd paired with a newer host
+		// updater. New callers always supply an operation ID for exact
+		// lost-response reconciliation.
+		operation, err = s.manager.Trigger(request.TargetVersion)
+	} else {
+		operation, err = s.manager.TriggerWithID(request.TargetVersion, request.OperationID)
+	}
 	if err != nil {
-		writeJSON(w, triggerErrorHTTPStatus(err), updaterapi.ErrorResponse{Error: err.Error()})
+		status := triggerErrorHTTPStatus(err)
+		message := err.Error()
+		if status == http.StatusInternalServerError {
+			// Manager errors can contain privileged host paths and filesystem
+			// details. Keep those in daemon logs, not the Fleet API response.
+			log.Printf("trigger updater operation: %v", err)
+			message = "host updater failed to start upgrade"
+		}
+		writeJSON(w, status, updaterapi.ErrorResponse{Error: message})
 		return
 	}
 	writeJSON(w, http.StatusAccepted, updaterapi.TriggerResponse{Operation: operation})
@@ -276,12 +292,16 @@ func decodeTriggerRequest(body io.Reader) (updaterapi.TriggerRequest, error) {
 
 func triggerErrorHTTPStatus(err error) int {
 	switch {
+	case errors.Is(err, errTriggerInvalid):
+		return http.StatusBadRequest
+	case errors.Is(err, errTriggerPrecondition):
+		return http.StatusPreconditionFailed
 	case errors.Is(err, errTriggerClosing):
 		return http.StatusServiceUnavailable
 	case errors.Is(err, errTriggerBusy):
 		return http.StatusConflict
 	default:
-		return http.StatusBadRequest
+		return http.StatusInternalServerError
 	}
 }
 

--- a/server/internal/updater/server_test.go
+++ b/server/internal/updater/server_test.go
@@ -2,17 +2,132 @@ package updater
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
 
+	"github.com/block/proto-fleet/server/internal/updaterapi"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestHandleUpgradeRejectsTrailingContentAndAllowsWhitespace(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name      string
+		body      string
+		wantError string
+	}{
+		{
+			name:      "second JSON value",
+			body:      `{"target_version":"v1.2.3"}{}`,
+			wantError: "invalid request body",
+		},
+		{
+			name:      "trailing junk",
+			body:      `{"target_version":"v1.2.3"} trailing`,
+			wantError: "invalid request body",
+		},
+		{
+			name:      "trailing whitespace",
+			body:      "{\"target_version\":\"invalid\"}\n\t ",
+			wantError: "target version must be a stable or RC release tag",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			recorder := httptest.NewRecorder()
+			request := httptest.NewRequest(http.MethodPost, "/v1/upgrade", strings.NewReader(test.body))
+			NewServer(&Manager{}).handleUpgrade(recorder, request)
+
+			assert.Equal(t, http.StatusBadRequest, recorder.Code)
+			assert.Contains(t, recorder.Body.String(), test.wantError)
+		})
+	}
+}
+
+func TestHandleUpgradeMapsManagerStateWithoutStatusSnapshot(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name             string
+		targetVersion    string
+		phase            updaterapi.Phase
+		operationRunning bool
+		closing          bool
+		wantStatus       int
+	}{
+		{
+			name:             "active operation",
+			targetVersion:    "v1.2.0",
+			phase:            updaterapi.PhasePreflight,
+			operationRunning: true,
+			wantStatus:       http.StatusConflict,
+		},
+		{
+			name:             "terminal operation still cleaning up",
+			targetVersion:    "v1.2.0",
+			phase:            updaterapi.PhaseSucceeded,
+			operationRunning: true,
+			wantStatus:       http.StatusConflict,
+		},
+		{
+			name:          "updater closing",
+			targetVersion: "v1.2.0",
+			closing:       true,
+			wantStatus:    http.StatusServiceUnavailable,
+		},
+		{
+			name:             "invalid target while operation active",
+			targetVersion:    "invalid",
+			phase:            updaterapi.PhasePreflight,
+			operationRunning: true,
+			wantStatus:       http.StatusBadRequest,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			installRoot := t.TempDir()
+			writeCurrentDeployment(t, installRoot, "v1.0.0")
+			manager, err := NewManager(Config{
+				InstallRoot: installRoot,
+				StateDir:    filepath.Join(t.TempDir(), "state"),
+				GOARCH:      "amd64",
+			})
+			require.NoError(t, err)
+			t.Cleanup(func() { assert.NoError(t, manager.Close()) })
+
+			manager.mu.Lock()
+			if test.phase != "" {
+				manager.operation = &updaterapi.Operation{
+					TargetVersion: "v1.1.0",
+					Phase:         test.phase,
+				}
+			}
+			manager.operationRunning = test.operationRunning
+			manager.closing = test.closing
+			manager.mu.Unlock()
+
+			recorder := httptest.NewRecorder()
+			body := fmt.Sprintf(`{"target_version":%q}`, test.targetVersion)
+			request := httptest.NewRequest(http.MethodPost, "/v1/upgrade", strings.NewReader(body))
+			NewServer(manager).handleUpgrade(recorder, request)
+
+			assert.Equal(t, test.wantStatus, recorder.Code)
+		})
+	}
+}
 
 func TestServerReadyAfterSocketIsBoundAndSecured(t *testing.T) {
 	t.Parallel()

--- a/server/internal/updater/server_test.go
+++ b/server/internal/updater/server_test.go
@@ -1,0 +1,62 @@
+package updater
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListenUpdaterSocketRefusesLiveListener(t *testing.T) {
+	t.Parallel()
+
+	socketPath := shortSocketPath(t)
+	existing, err := net.ListenUnix("unix", &net.UnixAddr{Name: socketPath, Net: "unix"})
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, existing.Close()) })
+
+	_, err = listenUpdaterSocket(socketPath)
+	require.ErrorContains(t, err, "another updater is already listening")
+	connection, err := net.DialTimeout("unix", socketPath, time.Second)
+	require.NoError(t, err, "the live listener path must not be unlinked")
+	require.NoError(t, connection.Close())
+}
+
+func TestListenUpdaterSocketReclaimsStaleSocket(t *testing.T) {
+	t.Parallel()
+
+	socketPath := shortSocketPath(t)
+	stale, err := net.ListenUnix("unix", &net.UnixAddr{Name: socketPath, Net: "unix"})
+	require.NoError(t, err)
+	stale.SetUnlinkOnClose(false)
+	require.NoError(t, stale.Close())
+	assert.FileExists(t, socketPath)
+
+	listener, err := listenUpdaterSocket(socketPath)
+	require.NoError(t, err)
+	require.NoError(t, listener.Close())
+	assert.NoFileExists(t, socketPath)
+}
+
+func TestListenUpdaterSocketRefusesNonSocketPath(t *testing.T) {
+	t.Parallel()
+
+	socketPath := shortSocketPath(t)
+	require.NoError(t, os.WriteFile(socketPath, []byte("not a socket"), 0o600))
+
+	_, err := listenUpdaterSocket(socketPath)
+	require.ErrorContains(t, err, "refusing to replace non-socket path")
+	assert.Equal(t, "not a socket", mustReadFile(t, socketPath))
+}
+
+func shortSocketPath(t *testing.T) string {
+	t.Helper()
+	directory, err := os.MkdirTemp("/tmp", "proto-fleet-updater-test-")
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, os.RemoveAll(directory)) })
+	return filepath.Join(directory, "updater.sock")
+}

--- a/server/internal/updater/server_test.go
+++ b/server/internal/updater/server_test.go
@@ -1,7 +1,9 @@
 package updater
 
 import (
+	"context"
 	"net"
+	"net/http"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -11,6 +13,42 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestServerReadyAfterSocketIsBoundAndSecured(t *testing.T) {
+	t.Parallel()
+
+	socketPath := shortSocketPath(t)
+	server := NewServer(nil)
+	done := make(chan error, 1)
+	go func() { done <- server.Serve(socketPath) }()
+
+	select {
+	case <-server.Ready():
+	case <-time.After(2 * time.Second):
+		t.Fatal("server did not report readiness")
+	}
+	info, err := os.Lstat(socketPath)
+	require.NoError(t, err)
+	assert.NotZero(t, info.Mode()&os.ModeSocket)
+	assert.Equal(t, os.FileMode(0o660), info.Mode().Perm())
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	require.NoError(t, server.Shutdown(shutdownCtx))
+	require.ErrorIs(t, <-done, http.ErrServerClosed)
+}
+
+func TestServerDoesNotReportReadinessWhenSocketSetupFails(t *testing.T) {
+	t.Parallel()
+
+	server := NewServer(nil)
+	require.ErrorContains(t, server.Serve("relative.sock"), "socket path must be absolute")
+	select {
+	case <-server.Ready():
+		t.Fatal("failed server startup reported readiness")
+	default:
+	}
+}
 
 func TestListenUpdaterSocketRefusesLiveListener(t *testing.T) {
 	t.Parallel()

--- a/server/internal/updater/server_test.go
+++ b/server/internal/updater/server_test.go
@@ -40,7 +40,7 @@ func TestHandleUpgradeRejectsTrailingContentAndAllowsWhitespace(t *testing.T) {
 		},
 		{
 			name:      "trailing whitespace",
-			body:      "{\"target_version\":\"invalid\"}\n\t ",
+			body:      "{\"operation_id\":\"11111111-1111-4111-8111-111111111111\",\"target_version\":\"invalid\"}\n\t ",
 			wantError: "target version must be a stable or RC release tag",
 		},
 	} {
@@ -121,7 +121,10 @@ func TestHandleUpgradeMapsManagerStateWithoutStatusSnapshot(t *testing.T) {
 			manager.mu.Unlock()
 
 			recorder := httptest.NewRecorder()
-			body := fmt.Sprintf(`{"target_version":%q}`, test.targetVersion)
+			body := fmt.Sprintf(
+				`{"operation_id":"11111111-1111-4111-8111-111111111111","target_version":%q}`,
+				test.targetVersion,
+			)
 			request := httptest.NewRequest(http.MethodPost, "/v1/upgrade", strings.NewReader(body))
 			NewServer(manager).handleUpgrade(recorder, request)
 
@@ -168,6 +171,22 @@ func TestHandleUpgradeRejectsInvalidOperationID(t *testing.T) {
 	assert.Contains(t, recorder.Body.String(), "operation id must be a canonical UUID")
 }
 
+func TestHandleUpgradeRequiresOperationID(t *testing.T) {
+	t.Parallel()
+
+	for _, body := range []string{
+		`{"target_version":"v1.1.0"}`,
+		`{"operation_id":"","target_version":"v1.1.0"}`,
+	} {
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest(http.MethodPost, "/v1/upgrade", strings.NewReader(body))
+		NewServer(&Manager{}).handleUpgrade(recorder, request)
+
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+		assert.Contains(t, recorder.Body.String(), "operation id must be a canonical UUID")
+	}
+}
+
 func TestTriggerErrorHTTPStatus(t *testing.T) {
 	t.Parallel()
 
@@ -196,10 +215,13 @@ func TestHandleUpgradeSanitizesInternalManagerError(t *testing.T) {
 	manager := &Manager{cfg: Config{
 		InstallRoot: missingInstallRoot,
 		StateDir:    t.TempDir(),
-		NewID:       func() string { return "test-operation" },
 	}}
 	recorder := httptest.NewRecorder()
-	request := httptest.NewRequest(http.MethodPost, "/v1/upgrade", strings.NewReader(`{"target_version":"v1.1.0"}`))
+	request := httptest.NewRequest(
+		http.MethodPost,
+		"/v1/upgrade",
+		strings.NewReader(`{"operation_id":"11111111-1111-4111-8111-111111111111","target_version":"v1.1.0"}`),
+	)
 	NewServer(manager).handleUpgrade(recorder, request)
 
 	assert.Equal(t, http.StatusInternalServerError, recorder.Code)

--- a/server/internal/updater/server_test.go
+++ b/server/internal/updater/server_test.go
@@ -55,7 +55,8 @@ func TestListenUpdaterSocketRefusesNonSocketPath(t *testing.T) {
 
 func shortSocketPath(t *testing.T) string {
 	t.Helper()
-	directory, err := os.MkdirTemp("/tmp", "proto-fleet-updater-test-")
+	// /tmp keeps the path below macOS's short Unix-domain socket limit.
+	directory, err := os.MkdirTemp("/tmp", "proto-fleet-updater-test-") //nolint:usetesting
 	require.NoError(t, err)
 	t.Cleanup(func() { assert.NoError(t, os.RemoveAll(directory)) })
 	return filepath.Join(directory, "updater.sock")

--- a/server/internal/updater/server_test.go
+++ b/server/internal/updater/server_test.go
@@ -2,6 +2,7 @@ package updater
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
@@ -127,6 +128,83 @@ func TestHandleUpgradeMapsManagerStateWithoutStatusSnapshot(t *testing.T) {
 			assert.Equal(t, test.wantStatus, recorder.Code)
 		})
 	}
+}
+
+func TestHandleUpgradeUsesCallerOperationID(t *testing.T) {
+	t.Parallel()
+
+	operationID := "11111111-1111-4111-8111-111111111111"
+	manager := &Manager{operation: &updaterapi.Operation{
+		ID:            operationID,
+		TargetVersion: "v1.1.0",
+		Phase:         updaterapi.PhaseQueued,
+	}}
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(
+		http.MethodPost,
+		"/v1/upgrade",
+		strings.NewReader(fmt.Sprintf(`{"operation_id":%q,"target_version":"v1.1.0"}`, operationID)),
+	)
+	NewServer(manager).handleUpgrade(recorder, request)
+
+	assert.Equal(t, http.StatusAccepted, recorder.Code)
+	var response updaterapi.TriggerResponse
+	require.NoError(t, json.NewDecoder(recorder.Body).Decode(&response))
+	assert.Equal(t, operationID, response.Operation.ID)
+}
+
+func TestHandleUpgradeRejectsInvalidOperationID(t *testing.T) {
+	t.Parallel()
+
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(
+		http.MethodPost,
+		"/v1/upgrade",
+		strings.NewReader(`{"operation_id":"not-a-uuid","target_version":"v1.1.0"}`),
+	)
+	NewServer(&Manager{}).handleUpgrade(recorder, request)
+
+	assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	assert.Contains(t, recorder.Body.String(), "operation id must be a canonical UUID")
+}
+
+func TestTriggerErrorHTTPStatus(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name string
+		err  error
+		want int
+	}{
+		{name: "invalid", err: newTriggerError(errTriggerInvalid, "invalid"), want: http.StatusBadRequest},
+		{name: "precondition", err: newTriggerError(errTriggerPrecondition, "precondition"), want: http.StatusPreconditionFailed},
+		{name: "busy", err: newTriggerError(errTriggerBusy, "busy"), want: http.StatusConflict},
+		{name: "closing", err: errTriggerClosing, want: http.StatusServiceUnavailable},
+		{name: "internal", err: assert.AnError, want: http.StatusInternalServerError},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, test.want, triggerErrorHTTPStatus(test.err))
+		})
+	}
+}
+
+func TestHandleUpgradeSanitizesInternalManagerError(t *testing.T) {
+	t.Parallel()
+
+	missingInstallRoot := filepath.Join(t.TempDir(), "privileged-host-path")
+	manager := &Manager{cfg: Config{
+		InstallRoot: missingInstallRoot,
+		StateDir:    t.TempDir(),
+		NewID:       func() string { return "test-operation" },
+	}}
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/v1/upgrade", strings.NewReader(`{"target_version":"v1.1.0"}`))
+	NewServer(manager).handleUpgrade(recorder, request)
+
+	assert.Equal(t, http.StatusInternalServerError, recorder.Code)
+	assert.Contains(t, recorder.Body.String(), "host updater failed to start upgrade")
+	assert.NotContains(t, recorder.Body.String(), missingInstallRoot)
 }
 
 func TestServerReadyAfterSocketIsBoundAndSecured(t *testing.T) {

--- a/server/internal/updater/server_test.go
+++ b/server/internal/updater/server_test.go
@@ -71,7 +71,7 @@ func TestPrepareUpdaterSocketDirectoryRefusesSymlink(t *testing.T) {
 	symlinkDirectory := filepath.Join(root, "socket-dir")
 	require.NoError(t, os.Symlink(realDirectory, symlinkDirectory))
 
-	err = prepareUpdaterSocketDirectory(filepath.Join(symlinkDirectory, "updater.sock"))
+	_, err = prepareUpdaterSocketDirectory(filepath.Join(symlinkDirectory, "updater.sock"))
 	require.ErrorContains(t, err, "must not be a symlink")
 }
 
@@ -91,7 +91,7 @@ func TestPrepareUpdaterSocketDirectoryRefusesWritableDirectory(t *testing.T) {
 			socketPath := shortSocketPath(t)
 			require.NoError(t, os.Chmod(filepath.Dir(socketPath), test.mode))
 
-			err := prepareUpdaterSocketDirectory(socketPath)
+			_, err := prepareUpdaterSocketDirectory(socketPath)
 			require.ErrorContains(t, err, "must not be group- or world-writable")
 		})
 	}
@@ -109,7 +109,60 @@ func TestPrepareUpdaterSocketDirectoryAllowsStickySharedAncestor(t *testing.T) {
 	socketDirectory := filepath.Join(sharedDirectory, "socket-dir")
 	require.NoError(t, os.Mkdir(socketDirectory, 0o700))
 
-	require.NoError(t, prepareUpdaterSocketDirectory(filepath.Join(socketDirectory, "updater.sock")))
+	_, err = prepareUpdaterSocketDirectory(filepath.Join(socketDirectory, "updater.sock"))
+	require.NoError(t, err)
+}
+
+func TestValidateUpdaterSocketPathComponentRefusesUntrustedAncestorSymlink(t *testing.T) {
+	t.Parallel()
+
+	daemonUID := uint32(os.Geteuid()) //nolint:gosec // Effective UIDs are non-negative on supported Unix hosts.
+	untrustedUID := uint32(1)
+	if daemonUID == untrustedUID {
+		untrustedUID++
+	}
+
+	err := validateUpdaterSocketPathComponent(
+		"/shared/attacker-link",
+		os.ModeSymlink,
+		untrustedUID,
+		daemonUID,
+		false,
+	)
+	require.ErrorContains(t, err, "owner uid")
+}
+
+func TestPrepareUpdaterSocketDirectoryReturnsCanonicalPath(t *testing.T) {
+	t.Parallel()
+
+	root, err := os.MkdirTemp("/tmp", "proto-fleet-updater-dir-test-") //nolint:usetesting
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, os.RemoveAll(root)) })
+	originalParent := filepath.Join(root, "original")
+	replacementParent := filepath.Join(root, "replacement")
+	for _, parent := range []string{originalParent, replacementParent} {
+		require.NoError(t, os.MkdirAll(filepath.Join(parent, "socket-dir"), 0o700))
+	}
+	linkedParent := filepath.Join(root, "linked")
+	require.NoError(t, os.Symlink(originalParent, linkedParent))
+	configuredSocketPath := filepath.Join(linkedParent, "socket-dir", "updater.sock")
+
+	canonicalSocketPath, err := prepareUpdaterSocketDirectory(configuredSocketPath)
+	require.NoError(t, err)
+	canonicalOriginalDirectory, err := filepath.EvalSymlinks(filepath.Join(originalParent, "socket-dir"))
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(canonicalOriginalDirectory, "updater.sock"), canonicalSocketPath)
+
+	// Once validation is complete, later operations use the canonical path and
+	// cannot be redirected by resolving the configured symlink again.
+	require.NoError(t, os.Remove(linkedParent))
+	require.NoError(t, os.Symlink(replacementParent, linkedParent))
+	listener, err := listenUpdaterSocket(canonicalSocketPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, listener.Close()) })
+	require.NoError(t, secureUpdaterSocket(canonicalSocketPath))
+	assert.FileExists(t, filepath.Join(canonicalOriginalDirectory, "updater.sock"))
+	assert.NoFileExists(t, filepath.Join(replacementParent, "socket-dir", "updater.sock"))
 }
 
 func TestSecureUpdaterSocketOverridesSetgidDirectoryAndSetsMode(t *testing.T) {
@@ -123,21 +176,22 @@ func TestSecureUpdaterSocketOverridesSetgidDirectoryAndSetsMode(t *testing.T) {
 	directoryInfo, err := os.Lstat(directory)
 	require.NoError(t, err)
 	require.NotZero(t, directoryInfo.Mode()&os.ModeSetgid)
-	require.NoError(t, prepareUpdaterSocketDirectory(socketPath))
+	canonicalSocketPath, err := prepareUpdaterSocketDirectory(socketPath)
+	require.NoError(t, err)
 
-	listener, err := listenUpdaterSocket(socketPath)
+	listener, err := listenUpdaterSocket(canonicalSocketPath)
 	require.NoError(t, err)
 	t.Cleanup(func() { assert.NoError(t, listener.Close()) })
 	if inheritedGID != os.Getegid() {
-		inheritedInfo, err := os.Lstat(socketPath)
+		inheritedInfo, err := os.Lstat(canonicalSocketPath)
 		require.NoError(t, err)
 		inheritedStat, ok := inheritedInfo.Sys().(*syscall.Stat_t)
 		require.True(t, ok)
 		require.Equal(t, uint32(inheritedGID), inheritedStat.Gid) //nolint:gosec // Test GIDs are non-negative.
 	}
 
-	require.NoError(t, secureUpdaterSocket(socketPath))
-	info, err := os.Lstat(socketPath)
+	require.NoError(t, secureUpdaterSocket(canonicalSocketPath))
+	info, err := os.Lstat(canonicalSocketPath)
 	require.NoError(t, err)
 	assert.Equal(t, os.FileMode(0o660), info.Mode().Perm())
 	stat, ok := info.Sys().(*syscall.Stat_t)

--- a/server/internal/updater/server_test.go
+++ b/server/internal/updater/server_test.go
@@ -4,6 +4,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 	"time"
 
@@ -57,6 +58,112 @@ func TestListenUpdaterSocketRefusesNonSocketPath(t *testing.T) {
 	_, err := listenUpdaterSocket(socketPath)
 	require.ErrorContains(t, err, "refusing to replace non-socket path")
 	assert.Equal(t, "not a socket", mustReadFile(t, socketPath))
+}
+
+func TestPrepareUpdaterSocketDirectoryRefusesSymlink(t *testing.T) {
+	t.Parallel()
+
+	root, err := os.MkdirTemp("/tmp", "proto-fleet-updater-dir-test-") //nolint:usetesting
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, os.RemoveAll(root)) })
+	realDirectory := filepath.Join(root, "real")
+	require.NoError(t, os.Mkdir(realDirectory, 0o700))
+	symlinkDirectory := filepath.Join(root, "socket-dir")
+	require.NoError(t, os.Symlink(realDirectory, symlinkDirectory))
+
+	err = prepareUpdaterSocketDirectory(filepath.Join(symlinkDirectory, "updater.sock"))
+	require.ErrorContains(t, err, "must not be a symlink")
+}
+
+func TestPrepareUpdaterSocketDirectoryRefusesWritableDirectory(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name string
+		mode os.FileMode
+	}{
+		{name: "group writable", mode: 0o770},
+		{name: "world writable even when sticky", mode: 0o777 | os.ModeSticky},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			socketPath := shortSocketPath(t)
+			require.NoError(t, os.Chmod(filepath.Dir(socketPath), test.mode))
+
+			err := prepareUpdaterSocketDirectory(socketPath)
+			require.ErrorContains(t, err, "must not be group- or world-writable")
+		})
+	}
+}
+
+func TestPrepareUpdaterSocketDirectoryAllowsStickySharedAncestor(t *testing.T) {
+	t.Parallel()
+
+	root, err := os.MkdirTemp("/tmp", "proto-fleet-updater-dir-test-") //nolint:usetesting
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, os.RemoveAll(root)) })
+	sharedDirectory := filepath.Join(root, "shared")
+	require.NoError(t, os.Mkdir(sharedDirectory, 0o700))
+	require.NoError(t, os.Chmod(sharedDirectory, 0o777|os.ModeSticky))
+	socketDirectory := filepath.Join(sharedDirectory, "socket-dir")
+	require.NoError(t, os.Mkdir(socketDirectory, 0o700))
+
+	require.NoError(t, prepareUpdaterSocketDirectory(filepath.Join(socketDirectory, "updater.sock")))
+}
+
+func TestSecureUpdaterSocketOverridesSetgidDirectoryAndSetsMode(t *testing.T) {
+	t.Parallel()
+
+	socketPath := shortSocketPath(t)
+	directory := filepath.Dir(socketPath)
+	inheritedGID := alternateOwnedGroup(t)
+	require.NoError(t, os.Chown(directory, os.Geteuid(), inheritedGID))
+	require.NoError(t, os.Chmod(directory, 0o750|os.ModeSetgid))
+	directoryInfo, err := os.Lstat(directory)
+	require.NoError(t, err)
+	require.NotZero(t, directoryInfo.Mode()&os.ModeSetgid)
+	require.NoError(t, prepareUpdaterSocketDirectory(socketPath))
+
+	listener, err := listenUpdaterSocket(socketPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, listener.Close()) })
+	if inheritedGID != os.Getegid() {
+		inheritedInfo, err := os.Lstat(socketPath)
+		require.NoError(t, err)
+		inheritedStat, ok := inheritedInfo.Sys().(*syscall.Stat_t)
+		require.True(t, ok)
+		require.Equal(t, uint32(inheritedGID), inheritedStat.Gid) //nolint:gosec // Test GIDs are non-negative.
+	}
+
+	require.NoError(t, secureUpdaterSocket(socketPath))
+	info, err := os.Lstat(socketPath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o660), info.Mode().Perm())
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	require.True(t, ok)
+	assert.Equal(t, uint32(os.Geteuid()), stat.Uid) //nolint:gosec // Effective UIDs are non-negative on supported Unix hosts.
+	assert.Equal(t, uint32(os.Getegid()), stat.Gid) //nolint:gosec // Effective GIDs are non-negative on supported Unix hosts.
+}
+
+func alternateOwnedGroup(t *testing.T) int {
+	t.Helper()
+	for _, gid := range mustGetgroups(t) {
+		if gid != os.Getegid() {
+			return gid
+		}
+	}
+	if os.Geteuid() == 0 {
+		return os.Getegid() + 1
+	}
+	return os.Getegid()
+}
+
+func mustGetgroups(t *testing.T) []int {
+	t.Helper()
+	groups, err := os.Getgroups()
+	require.NoError(t, err)
+	return groups
 }
 
 func shortSocketPath(t *testing.T) string {

--- a/server/internal/updater/server_test.go
+++ b/server/internal/updater/server_test.go
@@ -36,8 +36,14 @@ func TestListenUpdaterSocketReclaimsStaleSocket(t *testing.T) {
 	require.NoError(t, stale.Close())
 	assert.FileExists(t, socketPath)
 
-	listener, err := listenUpdaterSocket(socketPath)
-	require.NoError(t, err)
+	var listener *net.UnixListener
+	// Darwin can briefly continue accepting connects immediately after Close.
+	// The production code correctly treats that ambiguity as live, so retry the
+	// proof rather than weakening its fail-closed behavior.
+	require.Eventually(t, func() bool {
+		listener, err = listenUpdaterSocket(socketPath)
+		return err == nil
+	}, 2*time.Second, 10*time.Millisecond)
 	require.NoError(t, listener.Close())
 	assert.NoFileExists(t, socketPath)
 }

--- a/server/internal/updaterapi/types.go
+++ b/server/internal/updaterapi/types.go
@@ -41,7 +41,7 @@ type StatusResponse struct {
 }
 
 type TriggerRequest struct {
-	OperationID   string `json:"operation_id,omitempty"`
+	OperationID   string `json:"operation_id"`
 	TargetVersion string `json:"target_version"`
 }
 

--- a/server/internal/updaterapi/types.go
+++ b/server/internal/updaterapi/types.go
@@ -1,0 +1,53 @@
+// Package updaterapi defines the narrow local protocol shared by fleetd and
+// the privileged host updater. The transport is an HTTP server on a Unix
+// socket; this package intentionally contains data types only so neither side
+// can accidentally share privileged implementation code.
+package updaterapi
+
+import "time"
+
+type Phase string
+
+const (
+	PhaseQueued      Phase = "queued"
+	PhaseDownloading Phase = "downloading"
+	PhaseVerifying   Phase = "verifying"
+	PhaseStaging     Phase = "staging"
+	PhasePreflight   Phase = "preflight"
+	PhaseActivating  Phase = "activating"
+	PhaseSucceeded   Phase = "succeeded"
+	PhaseFailed      Phase = "failed"
+)
+
+func (p Phase) Terminal() bool {
+	return p == PhaseSucceeded || p == PhaseFailed
+}
+
+type Operation struct {
+	ID              string     `json:"id"`
+	TargetVersion   string     `json:"target_version"`
+	Phase           Phase      `json:"phase"`
+	Message         string     `json:"message,omitempty"`
+	StartedAt       time.Time  `json:"started_at"`
+	UpdatedAt       time.Time  `json:"updated_at"`
+	CompletedAt     *time.Time `json:"completed_at,omitempty"`
+	Error           string     `json:"error,omitempty"`
+	RecoveryCommand string     `json:"recovery_command,omitempty"`
+	LogPath         string     `json:"log_path,omitempty"`
+}
+
+type StatusResponse struct {
+	Operation *Operation `json:"operation,omitempty"`
+}
+
+type TriggerRequest struct {
+	TargetVersion string `json:"target_version"`
+}
+
+type TriggerResponse struct {
+	Operation Operation `json:"operation"`
+}
+
+type ErrorResponse struct {
+	Error string `json:"error"`
+}

--- a/server/internal/updaterapi/types.go
+++ b/server/internal/updaterapi/types.go
@@ -41,6 +41,7 @@ type StatusResponse struct {
 }
 
 type TriggerRequest struct {
+	OperationID   string `json:"operation_id,omitempty"`
 	TargetVersion string `json:"target_version"`
 }
 


### PR DESCRIPTION
Reviewable diff: +3633/-0 across 5 files (excludes generated, test, and story files).

## Summary

Adds the dormant host updater engine that will power one-click upgrades: a single-flight daemon, durable operation state, and a narrow Unix-socket HTTP interface. Its trigger contract accepts optional caller-generated operation IDs, making same-ID retries idempotent while retaining target-only compatibility for older callers. It stages and preflights a release while Fleet remains online, then crosses a marker-protected activation boundary with bounded commands, crash recovery, and coordinated updater self-restart. The binary is not packaged, installed, or connected to Fleet API in this PR, so merging it exposes no operator-facing behavior.

*Stack:* The update-notification foundation [#841](https://github.com/block/proto-fleet/pull/841) → [#842](https://github.com/block/proto-fleet/pull/842) → [#843](https://github.com/block/proto-fleet/pull/843) → [#844](https://github.com/block/proto-fleet/pull/844) → [#845](https://github.com/block/proto-fleet/pull/845) is merged. The one-click phase is [#835](https://github.com/block/proto-fleet/pull/835) (merged) → **#836** → [#837](https://github.com/block/proto-fleet/pull/837) → [#838](https://github.com/block/proto-fleet/pull/838) → [#839](https://github.com/block/proto-fleet/pull/839) → [#840](https://github.com/block/proto-fleet/pull/840). This is **2/6** and its diff is relative to `main`; #835 supplies release metadata plus the preflight/activation contract. Fleet API bridging, packaging, installation, and client exposure remain in #837–#840.

## How it works

At startup, the daemon validates and canonicalizes every component of its state, install, executable, and socket trust boundaries before loading or binding anything. The install chain may contain root plus one consistent deployment-admin UID—the owner #839 has already verified controls the same rootful Docker daemon—while the updater executable remains root/daemon-controlled. It then takes a lifetime advisory lock, reconciles only activation swaps proven by a durable marker, and removes crash-abandoned artifacts whose exact names are derived from the operation ID. Operation logs are confined and retained within fixed count/byte bounds; the local API refuses live or ambiguous socket owners and explicitly sets the bound socket identity and mode. A trigger accepts only a stable or RC tag, binds an optional canonical operation ID to that target, deduplicates concurrent same-ID admission, and constructs artifact URLs from the fixed Proto Fleet GitHub Releases origin.

The manager downloads the archive and SHA-256 sidecar, verifies transfer integrity, safely extracts bounded regular-file content, retains the updater payload through a private file descriptor, and preserves deployment configuration including the operator-owned HA node identity. Commands have phase deadlines, whole-process-group cancellation, and bounded output. After preflight, the staged tree and its parent are synchronized under a cancellable activation-length preparation deadline while the operation is still in `Preflight`; only then can the marker-backed, non-cancelable swap begin. Shutdown cancels pre-activation work and waits for terminal state before releasing the daemon lock.

After #835's preflight succeeds with Fleet still online and the staged tree is durable, the manager atomically persists an activation marker and rotates `deployment` to `deployment.previous` before installing the new tree. Pre-command failures are reconciled before terminal state is written; a restart restores the previous tree only when the marker proves the two-rename gap, never merely because an old backup exists. Success and failure become terminal only after that exact transition is durable; if the state write fails, memory retains the last nonterminal recovery context and blocks retriggers until startup reconciliation. Once Fleet is healthy, the protected updater candidate must execute `--version` successfully on the host and report the exact target tag. Before replacement, the manager hard-links the working executable into a retained rollback slot and durably writes a protected sibling handoff marker. The matching argv identifies the first candidate attempt; returned startup errors restore `.previous`, while a signal, kill, or power loss leaves the marker for the next supervisor start to reconcile before manager initialization. Secured-socket readiness durably removes the marker. Failed `exec`, missing destination entries, and restore/marker-clear crash windows are idempotently recoverable without consuming the backup; ordinary starts and post-ready failures cannot downgrade the updater.

```mermaid
flowchart LR
  C["Local Unix-socket caller"] --> A["Bounded updater API"]
  A --> M["Single-flight manager"]
  M --> G["Pinned GitHub Releases origin"]
  M --> S["Durable state, marker, lock, and retained logs"]
  M --> D["Staged, active, and previous deployments"]
  M --> R["run-fleet.sh preflight and activation"]
  M --> X["Verified replacement and durable startup handoff"]
```

```mermaid
sequenceDiagram
  participant C as Local caller
  participant U as Host updater
  participant G as GitHub Releases
  participant R as run-fleet.sh

  U->>U: Acquire daemon lock
  U->>U: Reconcile marker-proven swap, then clean stale artifacts
  C->>U: POST /v1/upgrade with target tag
  U->>G: Download archive and SHA-256 sidecar
  U->>U: Verify, safely extract, and preserve configuration
  U->>R: --preflight-only with deadline

  alt Preflight fails or shutdown begins
    U->>U: Bounded cleanup and persisted failure
  else Preflight passes
    U->>U: Sync staged tree under cancellable deadline
    U->>U: Persist swap marker and activating state
    U->>U: Fsync and rotate deployment directories
    alt Pre-command swap fails or process stops
      U->>U: Reconcile only the marker-proven layout
    else Swap is durable
      U->>U: Persist recovery command and consume marker
      U->>R: --skip-build with activation deadline
      alt Fleet fails to become healthy
        U->>U: Keep forward deployment and recovery details
      else Fleet is healthy
        U->>U: Smoke-test updater and retain rollback binary
        U->>U: Persist handoff marker, replace updater, and persist success
        U->>U: Drain API, release lock, and exec with one-shot handoff
        alt Exec fails, startup returns, or restart finds pending marker
          U->>U: Restore previous updater and exit nonzero
        else Manager initializes and secured socket binds
          U->>U: Consume rollback eligibility
        end
      end
    end
  end

  C->>U: GET /v1/status
  U-->>C: Persisted operation status
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
|---|---|---|
| `server/internal/updaterapi` | Transport-neutral operation and error types | Defines the complete local privilege-boundary contract |
| `server/internal/updater/manager.go` | Validation, download, staging, marker-gated activation recovery, locking, deadlines, confined log retention, exact stale-artifact cleanup, and self-refresh | Primary security, durability, and lifecycle review surface |
| `server/internal/updater/self_update_handoff.go` | Protected sibling marker plus idempotent executable restoration/commit state machine | Review crash ordering across replacement, supervisor restart, and secured-socket readiness |
| `server/internal/updater/server.go` | Bounded HTTP API plus validated socket-directory ownership and explicit socket identity/mode | Review request limits, local filesystem authentication, and duplicate-daemon behavior |
| `server/cmd/fleet-updater` | Signal handling, graceful draining, production configuration, and canonical replacement-process exec | Pins production downloads and coordinates listener/operation/lock handoff without re-resolving configured symlinks |
| `server/internal/updater/*_test.go` | Adversarial archive, activation, locking, socket, deadline, cleanup, process-group, and recovery coverage | Tests — review alongside the manager invariants |

## Key technical decisions & trade-offs

- **Publisher trust:** Production is pinned to the official GitHub Releases origin. The sidecar detects corruption, not an independently compromised publisher; independent signing needs a separate release-key custody, rotation, revocation, and bootstrap design rather than a same-origin key added only here.
- **Activation provenance:** A file-fsynced, atomically installed marker exists only around the two-rename/pre-command window. Automatic restoration requires that marker; terminal state or the mere presence of `deployment.previous` is insufficient because forward migrations may already exist.
- **Crash cleanup:** Operation artifacts use exact SHA-256-derived direct-child names. Startup and pre-trigger sweeps run under the daemon lock, after layout reconciliation, unlink non-directories without following them, and recursively remove only exact reserved staging directories.
- **Forward recovery:** Once the activation command begins, shutdown waits instead of canceling because `run-fleet.sh` may have applied forward-only migrations. A 45-minute deadline is the liveness bound, and failed starts keep the new deployment plus an actionable recovery command.
- **Daemon serialization:** A host-state advisory lock is acquired before state load and held through operation drain; socket cleanup occurs only after proving `ECONNREFUSED` on an existing socket.
- **Filesystem trust:** State, install, executable, and socket chains reject unrelated owners and unsafe write modes, validate configured plus resolved paths, and continue through canonical paths. Install content may be owned by root plus one consistent rootful-Docker admin; state/socket/executable paths remain root/daemon-controlled. Protected final nodes cannot be symlinks, and the bound socket receives the daemon's explicit UID/GID and mode `0660`.
- **Durable completion:** Success or failure is published as terminal—and can make the manager reusable—only after that exact state is durable. A write failure restores the last nonterminal state and recovery command, blocking another upgrade or self-restart until startup reconciliation.
- **Release asset contract:** #838 builds the versioned updater into `deployment/updater/proto-fleet-updater` and publishes a `.sha256` sidecar for every architecture archive; #839 installs that payload and service. The production-bundle contract test belongs with that packaging workflow rather than this dormant engine.
- **Resource bounds:** Preflight, staged-tree durability, activation, and cleanup have bounded phases; cancellation kills the command process group and is checked between file/directory syncs before the non-cancelable swap. An individual kernel `fsync` remains inherently non-preemptible. Command output is capped at 64 MiB, while confined retention keeps the current plus newest prior logs within eight files and 256 MiB.
- **Self-refresh ordering:** The protected updater payload replaces the installed binary only after Fleet is healthy and the host kernel executes its exact-version smoke test. A hard-linked previous binary and fsynced sibling marker are installed before replacement; a canonical argv value distinguishes the first candidate attempt, and the marker survives signals, kills, power loss, missing destination entries, and supervisor restarts. Restoration retains the backup and is idempotent across crashes. Only real manager initialization plus secured production-socket readiness durably removes rollback eligibility—without adding a second supervisor or a duplicate startup probe.
- **Execution privilege:** Supported one-click installs already grant the deployment owner rootful Docker administration, which is host-administrator-equivalent. Any future relaxation of #839's eligibility gate must revisit this boundary.
- **Downstream service lifecycle:** #839 must set systemd `TimeoutStopSec` above the 45-minute activation bound (with margin or infinity) so service shutdown preserves this PR's graceful-wait contract.

## Testing & validation

- `DB_PASSWORD=fleet GOWORK=off go test ./...`
- `GOWORK=off go test ./cmd/fleet-updater ./internal/updater`
- `GOWORK=off go test -race ./cmd/fleet-updater ./internal/updater`
- `GOWORK=off go vet ./cmd/fleet-updater ./internal/updater`
- `golangci-lint run -c .golangci.yaml`
- Linux `amd64` static build and `git diff --check`
- Coverage includes traversal/size rejection, checksum failure, preserved secrets/TLS/HA node configuration and restrictive mode, failed-preflight cleanup deadlines, cancellable/deadline-bounded staged-tree durability before marker creation, marker write atomicity, pre-command rollback provenance, terminal-state reconciliation, crash-abandoned artifact cleanup/confinement, state/install/deployment/executable/socket ownership and mode policies, symlink rejection/canonical retarget resistance, canonical self-exec signaling, explicit socket identity, symlink-safe log confinement and count/byte retention, queued/terminal-state persistence failures, daemon-lock retention, live/stale socket handling, shutdown races, activation deadlines, real descendant-process termination, candidate version/format rejection, protected handoff/argv mismatch rejection, pre-rename and post-restore crash reconciliation, missing executable restoration, readiness commit, degraded self-refresh, and supervisor restart handoff.
- Fleet API integration, systemd packaging, installer eligibility, and browser behavior are intentionally deferred to #837–#840.
