### PR TITLE
build(updates): package host updater artifacts

### DIFF
--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -142,6 +142,25 @@ jobs:
       - name: List nightly assets
         run: find /tmp/nightly-assets -type f | sort
 
+      - name: Verify deployment bundle checksums
+        run: |
+          cd /tmp/nightly-assets/bundles
+          for arch in amd64 arm64; do
+            bundle="proto-fleet-${VERSION}-${arch}.tar.gz"
+            if [[ ! -f "$bundle" || ! -f "$bundle.sha256" ]]; then
+              echo "::error::Missing deployment bundle or checksum for $arch"
+              exit 1
+            fi
+            # Bind both the digest and filename; sha256sum -c trusts the
+            # filename stored inside the sidecar.
+            expected_sidecar="$RUNNER_TEMP/proto-fleet-${arch}.sha256"
+            sha256sum "$bundle" > "$expected_sidecar"
+            if ! cmp -s "$expected_sidecar" "$bundle.sha256"; then
+              echo "::error::Deployment bundle checksum is not bound to $bundle"
+              exit 1
+            fi
+          done
+
       - name: Create release notes
         run: |
           cat > /tmp/nightly-release-notes.md <<EOF
@@ -179,6 +198,7 @@ jobs:
         run: |
           gh release create "$VERSION" \
             /tmp/nightly-assets/bundles/proto-fleet-${VERSION}-*.tar.gz \
+            /tmp/nightly-assets/bundles/proto-fleet-${VERSION}-*.tar.gz.sha256 \
             /tmp/nightly-assets/windows/installer.exe \
             /tmp/nightly-assets/windows/uninstall.exe \
             /tmp/nightly-assets/server/proto-fleet-server-${VERSION}-*.tar.gz \
@@ -198,6 +218,7 @@ jobs:
         run: |
           gh release upload "$VERSION" \
             /tmp/nightly-assets/bundles/proto-fleet-${VERSION}-*.tar.gz \
+            /tmp/nightly-assets/bundles/proto-fleet-${VERSION}-*.tar.gz.sha256 \
             /tmp/nightly-assets/windows/installer.exe \
             /tmp/nightly-assets/windows/uninstall.exe \
             /tmp/nightly-assets/server/proto-fleet-server-${VERSION}-*.tar.gz \

--- a/.github/workflows/proto-fleet-artifact-build.yml
+++ b/.github/workflows/proto-fleet-artifact-build.yml
@@ -170,6 +170,21 @@ jobs:
           go mod download
           go build -v -ldflags "-X main.version=$VERSION" -o fleetd-${{ matrix.arch }} ./cmd/fleetd
           go build -v -o fleet-ha-${{ matrix.arch }} ./cmd/fleet-ha
+          updater_binary="proto-fleet-updater-${{ matrix.arch }}"
+          CGO_ENABLED=0 go build -v -ldflags "-X main.version=$VERSION" -o "$updater_binary" ./cmd/fleet-updater
+          if ! command -v readelf >/dev/null || ! readelf -h "$updater_binary" >/dev/null; then
+            echo "::error::Unable to inspect the host updater ELF binary"
+            exit 1
+          fi
+          if readelf -l "$updater_binary" | grep INTERP >/dev/null || readelf -d "$updater_binary" | grep NEEDED >/dev/null; then
+            echo "::error::Host updater must be statically linked for supported Linux hosts"
+            exit 1
+          fi
+          updater_version=$("./$updater_binary" --version)
+          if [[ "$updater_version" != "$VERSION" ]]; then
+            echo "::error::Host updater reports version '$updater_version', expected '$VERSION'"
+            exit 1
+          fi
           echo "version: $VERSION" > version.txt
           echo "is_prerelease: $IS_PRERELEASE" >> version.txt
           echo "build_date: $BUILD_DATE" >> version.txt
@@ -206,6 +221,7 @@ jobs:
           tar -czf "proto-fleet-server-${VERSION}-${{ matrix.arch }}.tar.gz" \
             fleetd-${{ matrix.arch }} \
             fleet-ha-${{ matrix.arch }} \
+            proto-fleet-updater-${{ matrix.arch }} \
             proto-plugin-${{ matrix.arch }} \
             antminer-plugin-${{ matrix.arch }} \
             virtual-plugin-${{ matrix.arch }} \
@@ -459,6 +475,8 @@ jobs:
           cd deployment/server
           mv fleetd-${{ matrix.arch }} fleetd
           mv fleet-ha-${{ matrix.arch }} fleet-ha
+          mkdir -p ../updater
+          mv proto-fleet-updater-${{ matrix.arch }} ../updater/proto-fleet-updater
           mv proto-plugin-${{ matrix.arch }} proto-plugin
           mv antminer-plugin-${{ matrix.arch }} antminer-plugin
           mv virtual-plugin-${{ matrix.arch }} virtual-plugin
@@ -488,6 +506,8 @@ jobs:
           cp deployment-files/docker-compose.alerts.yaml deployment/
           cp deployment-files/docker-compose.system-monitoring.yaml deployment/
           cp deployment-files/docker-compose.tracing.yaml deployment/
+          cp deployment-files/docker-compose.updater.yaml deployment/
+          cp deployment-files/updater/proto-fleet-updater.service deployment/updater/
           cp -a server/monitoring deployment/server/
           cp server/docker-compose.base.yaml deployment/server/
           cp deployment-files/run-fleet.sh deployment/
@@ -498,6 +518,7 @@ jobs:
           mv deployment/server/fleet-ha deployment/ha/fleet-ha
           chmod +x deployment/run-fleet.sh deployment/uninstall.sh deployment/scripts/*.sh
           chmod +x deployment/ha/scripts/*.sh deployment/ha/tests/*.sh
+          chmod +x deployment/updater/proto-fleet-updater
 
           mkdir -p deployment/images
           cp /tmp/timescaledb-images/timescaledb-${{ matrix.arch }}.tar.gz deployment/images/timescaledb.tar.gz
@@ -529,11 +550,27 @@ jobs:
 
       - name: Package ProtoFleet deployment bundle
         run: |
-          tar -czf "proto-fleet-${VERSION}-${{ matrix.arch }}.tar.gz" deployment
+          bundle="proto-fleet-${VERSION}-${{ matrix.arch }}.tar.gz"
+          tar -czf "$bundle" deployment
+          sha256sum "$bundle" > "$bundle.sha256"
+          sha256sum -c "$bundle.sha256"
+
+          tar -tzf "$bundle" > "$RUNNER_TEMP/deployment-bundle-contents.txt"
+          for required_path in \
+            deployment/docker-compose.updater.yaml \
+            deployment/updater/proto-fleet-updater \
+            deployment/updater/proto-fleet-updater.service; do
+            if ! grep -Fxq "$required_path" "$RUNNER_TEMP/deployment-bundle-contents.txt"; then
+              echo "::error::Deployment bundle is missing $required_path"
+              exit 1
+            fi
+          done
 
       - name: Upload deployment bundle artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: proto-fleet-deployment-bundle-${{ matrix.arch }}
-          path: proto-fleet-${{ needs.metadata.outputs.version }}-${{ matrix.arch }}.tar.gz
+          path: |
+            proto-fleet-${{ needs.metadata.outputs.version }}-${{ matrix.arch }}.tar.gz
+            proto-fleet-${{ needs.metadata.outputs.version }}-${{ matrix.arch }}.tar.gz.sha256
           retention-days: ${{ inputs.retention_days }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,27 @@ jobs:
       - name: List all release assets
         run: find /tmp/release-assets -type f | sort
 
+      - name: Verify deployment bundle checksums
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          cd /tmp/release-assets/bundles
+          for arch in amd64 arm64; do
+            bundle="proto-fleet-${VERSION}-${arch}.tar.gz"
+            if [[ ! -f "$bundle" || ! -f "$bundle.sha256" ]]; then
+              echo "::error::Missing deployment bundle or checksum for $arch"
+              exit 1
+            fi
+            # Bind both the digest and filename; sha256sum -c trusts the
+            # filename stored inside the sidecar.
+            expected_sidecar="$RUNNER_TEMP/proto-fleet-${arch}.sha256"
+            sha256sum "$bundle" > "$expected_sidecar"
+            if ! cmp -s "$expected_sidecar" "$bundle.sha256"; then
+              echo "::error::Deployment bundle checksum is not bound to $bundle"
+              exit 1
+            fi
+          done
+
       - name: Create or refresh draft release and upload assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -117,6 +138,7 @@ jobs:
           shopt -s failglob
           files=(
             /tmp/release-assets/bundles/proto-fleet-"$TAG_NAME"-*.tar.gz
+            /tmp/release-assets/bundles/proto-fleet-"$TAG_NAME"-*.tar.gz.sha256
             /tmp/release-assets/windows/installer.exe
             /tmp/release-assets/windows/uninstall.exe
             /tmp/release-assets/server/proto-fleet-server-"$TAG_NAME"-*.tar.gz

--- a/deployment-files/docker-compose.updater.yaml
+++ b/deployment-files/docker-compose.updater.yaml
@@ -1,0 +1,9 @@
+services:
+  fleet-api:
+    environment:
+      UPDATES_UPDATER_SOCKET_PATH: "/run/proto-fleet-updater/updater.sock"
+    volumes:
+      # Mount only the updater's narrow Unix-socket API. Never mount the host
+      # Docker socket into fleet-api: that would turn an application
+      # compromise into unrestricted host root access.
+      - /run/proto-fleet-updater:/run/proto-fleet-updater:ro

--- a/deployment-files/updater/proto-fleet-updater.service
+++ b/deployment-files/updater/proto-fleet-updater.service
@@ -1,0 +1,38 @@
+[Unit]
+Description=Proto Fleet host updater
+Documentation=https://github.com/block/proto-fleet
+After=docker.service network-online.target
+# Docker is needed only when an upgrade runs; keep status available while the
+# daemon is down and recover automatically when Docker returns.
+Wants=docker.service network-online.target
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/proto-fleet/updater.env
+ExecStart=/usr/local/libexec/proto-fleet/proto-fleet-updater
+Restart=on-failure
+RestartSec=5s
+# Signal only the daemon first so it can safely drain an activation that has
+# already stopped Fleet. Its internal activation deadline is 45 minutes.
+KillMode=mixed
+TimeoutStopSec=50min
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=full
+ReadWritePaths=/usr/local/libexec/proto-fleet
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+LockPersonality=true
+StateDirectory=proto-fleet-updater
+StateDirectoryMode=0700
+RuntimeDirectory=proto-fleet-updater
+RuntimeDirectoryMode=0750
+# Keep Docker's bind mount attached to the same directory inode across service
+# stops and restarts. /run still clears the directory on host reboot.
+RuntimeDirectoryPreserve=yes
+UMask=0077
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Reviewable diff: +129/-2 across 5 files (excludes generated, test, and story files).

## Summary

Packages the host updater into amd64 and arm64 deployment artifacts, publishes paired SHA-256 sidecars, and includes the hardened systemd unit plus narrow socket overlay required by the merged Fleet API bridge. The host binary is statically linked and verified before packaging, while release publication fails closed unless both architecture bundles and correctly bound checksums are present. These assets remain dormant until installer activation lands in #839.

*Stack:* Prerequisites [#841](https://github.com/block/proto-fleet/pull/841) → [#842](https://github.com/block/proto-fleet/pull/842) → [#843](https://github.com/block/proto-fleet/pull/843) → [#844](https://github.com/block/proto-fleet/pull/844) → [#845](https://github.com/block/proto-fleet/pull/845) → [#835](https://github.com/block/proto-fleet/pull/835) → [#836](https://github.com/block/proto-fleet/pull/836) → [#837](https://github.com/block/proto-fleet/pull/837) are merged. This is **4/6**, and its diff is relative to `main`. Remaining descendants are [#839](https://github.com/block/proto-fleet/pull/839) → [#840](https://github.com/block/proto-fleet/pull/840): #839 installs and activates these assets, while #840 exposes one-click execution in the client.

## How it works

The artifact workflow builds a CGO-disabled `fleet-updater` on each native architecture runner, rejects dynamically linked output, and verifies the embedded version. The server artifact carries that binary into the deployment bundle, where it is placed beside its systemd unit and a Compose overlay that exposes only the updater Unix-socket directory to fleet-api.

Before upload, the workflow verifies the bundle checksum and required updater paths. Stable/RC and nightly publishers then require both amd64 and arm64 pairs, regenerate the expected sidecar for each explicit bundle, and compare the complete digest-and-filename line before creating or updating a GitHub release. The service unit preserves the socket directory inode across stops and restarts, remains available through Docker outages, and gives an in-progress activation enough bounded time to drain safely.

```mermaid
flowchart LR
  B["Build static fleet-updater per architecture"] --> V["Verify ELF linkage and embedded version"]
  V --> S["Server artifact"]
  S --> D["Deployment bundle with unit and socket overlay"]
  D --> C["Verify required paths and SHA-256 sidecar"]
  C --> A["Upload amd64 and arm64 artifacts"]
  A --> P["Release/nightly publisher re-verifies each explicit pair"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
|---|---|---|
| `.github/workflows/proto-fleet-artifact-build.yml` | Builds and validates the static updater, packages runtime assets, creates and checks sidecars | Review architecture naming, static-host portability, and the bundle contract |
| `.github/workflows/release.yml`, `nightly-builds.yml` | Require both architecture pairs and bind each sidecar to its explicit bundle before publication | Prevents partial, mismatched, or swapped release assets |
| `deployment-files/docker-compose.updater.yaml` | Mounts only the read-only updater socket directory into fleet-api | Security boundary preventing Docker-socket exposure |
| `deployment-files/updater/proto-fleet-updater.service` | Defines hardening, soft Docker ordering, bounded activation drain, and runtime-directory preservation | Review root-service permissions, recovery, and lifecycle behavior |

## Key technical decisions & trade-offs

- Build the host updater with `CGO_ENABLED=0` and inspect its ELF headers, avoiding host glibc coupling at the cost of requiring pure-Go dependencies.
- Publish same-name `.sha256` sidecars and compare their full content against each explicit amd64/arm64 bundle, keeping updater discovery deterministic and failing closed on partial or swapped artifacts.
- Treat SHA-256 sidecars as corruption and pairing checks, not independent publisher authentication; the GitHub release origin remains the trust anchor, while separately pinned release signing is intentionally out of scope.
- Use `KillMode=mixed` with a 50-minute stop bound so systemd signals the daemon first and preserves the updater's 45-minute activation safety window.
- Preserve the runtime directory across service stops and restarts so Docker's bind mount stays attached to the socket directory inode.
- Soft-order the updater after Docker instead of requiring Docker continuously; trigger-time preflight remains the authority for daemon readiness.
- Keep packaging separate from activation so this PR remains merge-safe; installation and enablement are isolated in #839.

## Testing & validation

- `go test ./cmd/fleet-updater ./internal/updater`
- CGO-disabled build and embedded-version smoke check
- Host profile, HA profile, and complete non-interactive upgrade-safety harnesses
- Base plus updater Compose rendering
- Workflow/Compose YAML parsing, positive checksum-pair simulation, swapped-sidecar rejection, required-path checks, and `git diff --check`
- Pre-push client typecheck plus server and plugin lint hooks; final review-fix push reran server lint

End-to-end deployment artifact assembly is not run by PR CI; the reusable workflow executes only for release and nightly builds. The new in-workflow assertions make that explicit path fail before publication, but a real release/nightly run remains the integration coverage.