### PR TITLE
feat(updates): bootstrap host updater installs

### DIFF
--- a/.github/workflows/deployment-config-checks.yml
+++ b/.github/workflows/deployment-config-checks.yml
@@ -14,6 +14,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: Validate deployment shell syntax
+        run: |
+          for script in \
+            deployment-files/install.sh \
+            deployment-files/run-fleet.sh \
+            deployment-files/uninstall.sh \
+            deployment-files/tests/test-install-overlay-migration.sh \
+            deployment-files/tests/test-profiles.sh \
+            deployment-files/tests/test-run-fleet-upgrade.sh; do
+            bash -n "$script"
+          done
+
       - name: Validate host profiles and compose interpolation
         run: ./deployment-files/tests/test-profiles.sh
 

--- a/.github/workflows/deployment-config-checks.yml
+++ b/.github/workflows/deployment-config-checks.yml
@@ -22,7 +22,8 @@ jobs:
             deployment-files/uninstall.sh \
             deployment-files/tests/test-install-overlay-migration.sh \
             deployment-files/tests/test-profiles.sh \
-            deployment-files/tests/test-run-fleet-upgrade.sh; do
+            deployment-files/tests/test-run-fleet-upgrade.sh \
+            deployment-files/tests/test-uninstall-updater-cleanup.sh; do
             bash -n "$script"
           done
 
@@ -37,3 +38,6 @@ jobs:
 
       - name: Validate installer overlay migration
         run: ./deployment-files/tests/test-install-overlay-migration.sh
+
+      - name: Validate uninstaller updater cleanup
+        run: ./deployment-files/tests/test-uninstall-updater-cleanup.sh

--- a/.github/workflows/deployment-config-checks.yml
+++ b/.github/workflows/deployment-config-checks.yml
@@ -22,3 +22,6 @@ jobs:
 
       - name: Validate non-interactive upgrade safety
         run: ./deployment-files/tests/test-run-fleet-upgrade.sh
+
+      - name: Validate installer overlay migration
+        run: ./deployment-files/tests/test-install-overlay-migration.sh

--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ bash <(curl -fsSL https://fleet.proto.xyz/install.sh)
 bash <(curl -fsSL https://fleet.proto.xyz/install.sh) v0.1.0
 ```
 
+On Linux/systemd hosts with rootful Docker, this install also bootstraps the
+host updater. Future eligible releases can then be confirmed and installed
+from ProtoFleet's update prompt; unsupported hosts keep the copy-paste command
+fallback. See [deployment-files/README.md](deployment-files/README.md#one-click-upgrades)
+for supported hosts, validation behavior, logs, and recovery.
+
 #### Uninstall
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ bash <(curl -fsSL https://fleet.proto.xyz/install.sh)
 #### Specific Version
 
 ```bash
-bash <(curl -fsSL https://fleet.proto.xyz/install.sh) v0.1.0
+VERSION=v0.2.10-rc.2
+bash <(curl -fsSL "https://github.com/block/proto-fleet/releases/download/${VERSION}/install.sh") "${VERSION}"
 ```
 
 On Linux/systemd hosts with rootful Docker, this install also bootstraps the

--- a/deployment-files/README.md
+++ b/deployment-files/README.md
@@ -22,10 +22,14 @@ The `install.sh` script sets up the Proto Fleet server components.
 ### Proto Fleet Installation Options
 
 ```bash
-Usage: install.sh [VERSION]
+Usage: install.sh [options] [VERSION]
 
 If you omit VERSION or pass "latest", installs the latest GitHub release.
 Pass "nightly" to install the latest successful nightly prerelease.
+Options:
+  --install-dir PATH       Use PATH without prompting.
+  --non-interactive        Fail instead of prompting; for an existing install
+                           with a complete deployment .env.
 You can override by doing, e.g.:
   install.sh v0.1.0-beta-5
   install.sh nightly
@@ -38,7 +42,8 @@ Examples:
 bash <(curl -fsSL https://github.com/block/proto-fleet/releases/latest/download/install.sh)
 
 # Install a specific version
-bash <(curl -fsSL https://github.com/block/proto-fleet/releases/latest/download/install.sh) v0.1.0-beta-5
+VERSION=v0.2.10-rc.2
+bash <(curl -fsSL "https://github.com/block/proto-fleet/releases/download/$VERSION/install.sh") "$VERSION"
 
 # Install the latest nightly prerelease (installer is fetched from the resolved
 # nightly release asset, not from the mutable nightly-channel branch)
@@ -76,6 +81,11 @@ Only then does it swap the staged deployment into place and restart the stack.
 The previous deployment remains at `<install-root>/deployment.previous` for
 operator inspection. Automatic rollback is deliberately disabled because
 database migrations are forward-only.
+
+The checksum sidecar detects transfer corruption and binds the expected asset
+name to its digest. Because the bundle and sidecar share the same GitHub
+Release origin, GitHub remains the publisher trust anchor; independent release
+signing is intentionally outside this phase.
 
 One-click upgrades are enabled on Linux hosts with systemd and rootful Docker,
 including WSL distributions configured with systemd. macOS, rootless Docker,

--- a/deployment-files/README.md
+++ b/deployment-files/README.md
@@ -49,9 +49,61 @@ bash <(curl -fsSL "https://github.com/block/proto-fleet/releases/download/$VERSI
 The script will:
 
 - Check system compatibility (page size)
-- Download and extract the specified version
-- Preserve existing configuration files if present
+- Download the specified version and verify its published SHA-256 checksum
+- Extract the release and preserve existing configuration files
+- On Linux/systemd with rootful Docker, install the host updater used for
+  in-product one-click upgrades
 - Run the deployment script automatically
+
+## One-click upgrades
+
+After one manual install of a release that includes the host updater,
+permission-holding operators can upgrade an eligible stable or release
+candidate from the ProtoFleet update prompt. The confirmation explains the
+restart window and adds a no-downgrade warning for release candidates.
+
+The updater runs as `proto-fleet-updater.service`, outside the Docker Compose
+stack it restarts. Fleet API talks to it over
+`/run/proto-fleet-updater/updater.sock`; the application container is never
+given the host Docker socket. Before stopping Fleet, the updater:
+
+1. downloads the target bundle and its checksum over HTTPS;
+2. verifies the SHA-256 digest and safely extracts the archive;
+3. preserves `.env`, `ssl/`, and `server/influx_config/.env`;
+4. builds and validates the staged deployment with Fleet still running.
+
+Only then does it swap the staged deployment into place and restart the stack.
+The previous deployment remains at `<install-root>/deployment.previous` for
+operator inspection. Automatic rollback is deliberately disabled because
+database migrations are forward-only.
+
+One-click upgrades are enabled on Linux hosts with systemd and rootful Docker,
+including WSL distributions configured with systemd. macOS, rootless Docker,
+and Linux hosts without systemd continue to show the exact manual upgrade
+command.
+
+### Failure recovery
+
+The client shows the terminal error, host log path, and a recovery command
+when Fleet is reachable. The same durable details remain on the host:
+
+```text
+/var/lib/proto-fleet-updater/state.json
+/var/lib/proto-fleet-updater/logs/<operation-id>.log
+```
+
+Inspect the service and latest operation with:
+
+```bash
+sudo systemctl status proto-fleet-updater.service
+sudo journalctl -u proto-fleet-updater.service
+sudo cat /var/lib/proto-fleet-updater/state.json
+```
+
+If activation failed, run the `recovery_command` from `state.json` as root.
+Do not replace the active deployment with `deployment.previous` after
+migrations may have started; an older binary may be incompatible with the
+newer schema.
 
 ## Optional Virtual Miners
 

--- a/deployment-files/install.sh
+++ b/deployment-files/install.sh
@@ -1105,10 +1105,11 @@ complete_disabled_updater_fallback_after_run() {
 
 reconcile_updater_after_failed_deployment() {
   local env_file="$1"
-  local expected_state="$2"
-  local reenable_after_failure="$3"
-  local restart_after_failure="$4"
-  shift 4
+  local previous_state="$2"
+  local desired_state="$3"
+  local reenable_after_failure="$4"
+  local restart_after_failure="$5"
+  shift 5
   local privilege=("$@")
   local restored_state
 
@@ -1129,8 +1130,9 @@ reconcile_updater_after_failed_deployment() {
     return 1
   fi
   [ "$restored_state" != "missing" ] || restored_state=false
-  if [ "$restored_state" != "$expected_state" ]; then
-    echo "❌ The failed deployment did not restore the prior one-click update setting." >&2
+  if [ "$restored_state" != "$previous_state" ] \
+    && [ "$restored_state" != "$desired_state" ]; then
+    echo "❌ The failed deployment left an unknown one-click update setting." >&2
     disable_updater_service_with \
       ${privilege[@]+"${privilege[@]}"} || true
     return 1
@@ -1140,7 +1142,16 @@ reconcile_updater_after_failed_deployment() {
       ${privilege[@]+"${privilege[@]}"}; then
     return 1
   fi
-  if [ "$expected_state" = "true" ]; then
+  if [ "$restored_state" = "$desired_state" ] \
+    && [ "$desired_state" != "$previous_state" ]; then
+    if ! ${privilege[@]+"${privilege[@]}"} systemctl enable \
+        proto-fleet-updater.service >/dev/null 2>&1 \
+      || ! restart_updater_service_with "$UPDATER_SOCKET_PATH" \
+        ${privilege[@]+"${privilege[@]}"}; then
+      echo "❌ Could not retain the host updater after the deployment topology changed." >&2
+      return 1
+    fi
+  elif [ "$previous_state" = "true" ]; then
     if [ "$reenable_after_failure" = "1" ] \
       && ! ${privilege[@]+"${privilege[@]}"} systemctl enable \
         proto-fleet-updater.service >/dev/null 2>&1; then
@@ -2084,7 +2095,8 @@ if [ "$NON_INTERACTIVE" = "1" ]; then
   RUN_FLEET_ARGS+=(--non-interactive)
 fi
 RUN_FLEET_STATUS=0
-if ./run-fleet.sh "${RUN_FLEET_ARGS[@]}"; then
+if PROTO_FLEET_INSTALLER_MANAGED_RUN=1 \
+  ./run-fleet.sh "${RUN_FLEET_ARGS[@]}"; then
   RUN_FLEET_STATUS=0
 else
   RUN_FLEET_STATUS=$?
@@ -2111,6 +2123,7 @@ if [ "$RUN_FLEET_STATUS" -ne 0 ]; then
     && ! reconcile_updater_after_failed_deployment \
       "$INSTALL_DIR/$DEPLOYMENT_DIR/.env" \
       "$PREVIOUS_ONE_CLICK_UPDATES" \
+      true \
       "$UPDATER_REENABLE_AFTER_FAILED_RUN" \
       "$UPDATER_RESTART_AFTER_FAILED_RUN" \
       ${UPDATER_PRIVILEGE[@]+"${UPDATER_PRIVILEGE[@]}"}; then

--- a/deployment-files/install.sh
+++ b/deployment-files/install.sh
@@ -8,6 +8,7 @@ UPDATER_CLEANUP_FAILED=0
 UPDATER_PRIVILEGE=()
 UPDATER_PRIVILEGE_AVAILABLE=1
 UPDATER_DISABLE_ON_EXIT=0
+UPDATER_REENABLE_ON_EXIT=0
 UPDATER_RESTART_ON_EXIT=0
 UPDATER_SOCKET_PATH="/run/proto-fleet-updater/updater.sock"
 UPDATER_VALIDATION_SOCKET_PATH="/run/proto-fleet-updater/installer-validation.sock"
@@ -625,6 +626,52 @@ prepare_fresh_install_path() {
   printf '%s\n' "$canonical"
 }
 
+# Recognize an explicitly selected, stopped deployment without weakening the
+# fresh-install path boundary. Docker cannot identify a deployment after its
+# containers have been removed, so the on-disk marker is accepted only after
+# the root, deployment directory, and marker have all passed the same trusted
+# owner and non-symlink checks used by the privileged updater.
+canonical_existing_install_path() {
+  local selected="$1"
+  local normalized canonical trusted_uid deployment_dir marker metadata owner_uid mode
+  normalized=$(lexical_absolute_path "$selected") || return 1
+  reject_dangerous_install_root "$normalized" || return 1
+  if [ -L "$normalized" ] || [ ! -d "$normalized" ]; then
+    echo "❌ Existing installation root must be a real directory, not a symlink: $normalized" >&2
+    return 1
+  fi
+
+  canonical=$(cd "$normalized" 2>/dev/null && pwd -P) || {
+    echo "❌ Existing installation root cannot be accessed: $normalized" >&2
+    return 1
+  }
+  reject_dangerous_install_root "$canonical" || return 1
+  trusted_uid=$(install_admin_uid) || {
+    echo "❌ Could not determine the invoking installation administrator." >&2
+    return 1
+  }
+  validate_install_directory_chain "$canonical" "$trusted_uid" 1 || return 1
+
+  deployment_dir="$canonical/$DEPLOYMENT_DIR"
+  marker="$deployment_dir/docker-compose.yaml"
+  if [ -L "$deployment_dir" ] || [ ! -d "$deployment_dir" ]; then
+    echo "❌ Existing deployment directory must be a real directory, not a symlink: $deployment_dir" >&2
+    return 1
+  fi
+  validate_install_directory_chain "$deployment_dir" "$trusted_uid" 1 || return 1
+  if [ -L "$marker" ] || [ ! -f "$marker" ]; then
+    echo "❌ Existing deployment marker must be a regular, non-symlink file: $marker" >&2
+    return 1
+  fi
+  metadata=$(install_path_metadata "$marker") || {
+    echo "❌ Could not inspect existing deployment marker metadata: $marker" >&2
+    return 1
+  }
+  read -r owner_uid mode <<< "$metadata"
+  validate_install_path_metadata "$marker" "$owner_uid" "$mode" "$trusted_uid" 1 || return 1
+  printf '%s\n' "$canonical"
+}
+
 resolve_selected_install_path() {
   local selected="$1"
   local discovered="${2:-}"
@@ -775,6 +822,17 @@ resolve_updater_privilege() {
   fi
 }
 
+arm_existing_updater_restoration() {
+  local active_state="$1"
+  local unit_file_state="$2"
+  case "$unit_file_state" in
+    enabled|enabled-runtime) UPDATER_REENABLE_ON_EXIT=1 ;;
+  esac
+  case "$active_state" in
+    active|activating|reloading) UPDATER_RESTART_ON_EXIT=1 ;;
+  esac
+}
+
 # Stop the existing updater before the release tree can be replaced. systemd's
 # inactive state proves the supervised process has exited, which also releases
 # the updater's lifetime flock. A missing unit needs no privilege or prompt.
@@ -785,7 +843,7 @@ prepare_existing_updater_service() {
     return 0
   fi
 
-  local load_state
+  local load_state active_state unit_file_state
   if ! load_state=$(systemctl show --property=LoadState --value \
       proto-fleet-updater.service 2>/dev/null); then
     echo "❌ Could not inspect the existing host updater before installation." >&2
@@ -800,7 +858,23 @@ prepare_existing_updater_service() {
     UPDATER_CLEANUP_FAILED=1
     return 1
   fi
-  disable_updater_service_with ${UPDATER_PRIVILEGE[@]+"${UPDATER_PRIVILEGE[@]}"}
+  if ! active_state=$(systemctl show --property=ActiveState --value \
+      proto-fleet-updater.service 2>/dev/null) \
+    || ! unit_file_state=$(systemctl show --property=UnitFileState --value \
+      proto-fleet-updater.service 2>/dev/null); then
+    echo "❌ Could not inspect the existing host updater state before installation." >&2
+    UPDATER_CLEANUP_FAILED=1
+    return 1
+  fi
+  # Arm restoration before the stop/disable call. Even if its final-state
+  # verification fails after systemd performed the mutation, EXIT cleanup can
+  # still return the service to the state observed above.
+  arm_existing_updater_restoration "$active_state" "$unit_file_state"
+  if ! disable_updater_service_with \
+      ${UPDATER_PRIVILEGE[@]+"${UPDATER_PRIVILEGE[@]}"}; then
+    return 1
+  fi
+  return 0
 }
 
 write_updater_environment_file() {
@@ -887,6 +961,14 @@ installer_exit_cleanup() {
     echo "🔒 Disabling the host updater after interrupted validation..." >&2
     if ! disable_updater_service_with \
       ${UPDATER_PRIVILEGE[@]+"${UPDATER_PRIVILEGE[@]}"}; then
+      status=1
+    fi
+  fi
+  if [ "${UPDATER_REENABLE_ON_EXIT:-0}" = "1" ]; then
+    echo "🔄 Restoring host updater boot enablement after the interrupted installation..." >&2
+    if ! ${UPDATER_PRIVILEGE[@]+"${UPDATER_PRIVILEGE[@]}"} systemctl enable \
+        proto-fleet-updater.service >/dev/null 2>&1; then
+      echo "❌ Could not restore host updater boot enablement." >&2
       status=1
     fi
   fi
@@ -1260,9 +1342,19 @@ fi
 # this really is a ProtoFleet install (and not some unrelated 'deployment/'
 # tree the user happened to create).
 if [ -z "${PREVIOUS_INSTALL_DIR:-}" ] \
+  && [ -n "$REQUESTED_INSTALL_DIR" ] \
+  && { [ -e "${REQUESTED_INSTALL_DIR%/}/${DEPLOYMENT_DIR}/docker-compose.yaml" ] \
+    || [ -L "${REQUESTED_INSTALL_DIR%/}/${DEPLOYMENT_DIR}/docker-compose.yaml" ]; }; then
+  if ! PREVIOUS_INSTALL_DIR=$(canonical_existing_install_path "$REQUESTED_INSTALL_DIR"); then
+    exit 1
+  fi
+  echo "📁 No running fleet containers, but found requested install on disk at: ${PREVIOUS_INSTALL_DIR}"
+elif [ -z "${PREVIOUS_INSTALL_DIR:-}" ] \
   && [ -d "${DEFAULT_INSTALL_DIR}/${DEPLOYMENT_DIR}" ] \
   && [ -f "${DEFAULT_INSTALL_DIR}/${DEPLOYMENT_DIR}/docker-compose.yaml" ]; then
-  PREVIOUS_INSTALL_DIR="$DEFAULT_INSTALL_DIR"
+  if ! PREVIOUS_INSTALL_DIR=$(canonical_existing_install_path "$DEFAULT_INSTALL_DIR"); then
+    exit 1
+  fi
   echo "📁 No running fleet containers, but found existing install on disk at: ${PREVIOUS_INSTALL_DIR}"
 fi
 
@@ -1466,6 +1558,9 @@ install_updater_service() {
     disable_updater_service_with ${privilege[@]+"${privilege[@]}"} || true
     return 1
   fi
+  # The replacement unit now owns its boot enablement. EXIT cleanup only
+  # needs to stop a failed validation or restart the validated service.
+  UPDATER_REENABLE_ON_EXIT=0
   UPDATER_DISABLE_ON_EXIT=1
   if ! restart_updater_service_with "$UPDATER_VALIDATION_SOCKET_PATH" \
     ${privilege[@]+"${privilege[@]}"}; then
@@ -1525,6 +1620,8 @@ else
     exit 1
   fi
   UPDATER_DISABLE_ON_EXIT=0
+  UPDATER_REENABLE_ON_EXIT=0
+  UPDATER_RESTART_ON_EXIT=0
   echo "ℹ️  One-click upgrades are unavailable; the in-product copy command remains usable."
   RUN_FLEET_ARGS+=(--disable-one-click-updates)
 fi
@@ -1546,6 +1643,7 @@ if [ "$UPDATER_RESTART_ON_EXIT" = "1" ]; then
   # run-fleet is finished, so the old API can no longer race this deployment.
   # systemd owns the service lifecycle once the restart is issued.
   UPDATER_RESTART_ON_EXIT=0
+  UPDATER_REENABLE_ON_EXIT=0
   if restart_updater_service_with "$UPDATER_SOCKET_PATH" \
     ${UPDATER_PRIVILEGE[@]+"${UPDATER_PRIVILEGE[@]}"}; then
     :

--- a/deployment-files/install.sh
+++ b/deployment-files/install.sh
@@ -8,11 +8,11 @@ UPDATER_CLEANUP_FAILED=0
 UPDATER_PRIVILEGE=()
 UPDATER_PRIVILEGE_AVAILABLE=1
 UPDATER_DISABLE_ON_EXIT=0
-UPDATER_REENABLE_ON_EXIT=0
+UPDATER_REENABLE_ON_EXIT=disabled
 UPDATER_RESTART_ON_EXIT=0
 UPDATER_START_AFTER_RUN=0
 UPDATER_DEPLOYMENT_COMMITTED=0
-UPDATER_REENABLE_AFTER_FAILED_RUN=0
+UPDATER_REENABLE_AFTER_FAILED_RUN=disabled
 UPDATER_RESTART_AFTER_FAILED_RUN=0
 UPDATER_FALLBACK_PENDING=0
 UPDATER_ENV_PATH="/etc/proto-fleet/updater.env"
@@ -902,10 +902,32 @@ arm_existing_updater_restoration() {
   local active_state="$1"
   local unit_file_state="$2"
   case "$unit_file_state" in
-    enabled|enabled-runtime) UPDATER_REENABLE_ON_EXIT=1 ;;
+    enabled|enabled-runtime) UPDATER_REENABLE_ON_EXIT="$unit_file_state" ;;
   esac
   case "$active_state" in
     active|activating|reloading) UPDATER_RESTART_ON_EXIT=1 ;;
+  esac
+}
+
+restore_updater_enablement_with() {
+  local enablement="$1"
+  shift
+  local privilege=("$@")
+
+  case "$enablement" in
+    disabled) return 0 ;;
+    enabled)
+      ${privilege[@]+"${privilege[@]}"} systemctl enable \
+        proto-fleet-updater.service >/dev/null 2>&1
+      ;;
+    enabled-runtime)
+      ${privilege[@]+"${privilege[@]}"} systemctl enable --runtime \
+        proto-fleet-updater.service >/dev/null 2>&1
+      ;;
+    *)
+      echo "❌ Cannot restore unsupported updater enablement state: $enablement" >&2
+      return 1
+      ;;
   esac
 }
 
@@ -1084,7 +1106,7 @@ finalize_disabled_updater_fallback_if_persisted() {
   state=$(deployment_boolean_state "$env_file" ENABLE_ONE_CLICK_UPDATES) || return 1
   [ "$state" = "false" ] || return 1
   UPDATER_DISABLE_ON_EXIT=0
-  UPDATER_REENABLE_ON_EXIT=0
+  UPDATER_REENABLE_ON_EXIT=disabled
   UPDATER_RESTART_ON_EXIT=0
   UPDATER_ENV_RESTORE_FILE=""
   UPDATER_BINARY_RESTORE_FILE=""
@@ -1156,7 +1178,7 @@ reconcile_committed_updater_enablement() {
       ${UPDATER_PRIVILEGE[@]+"${UPDATER_PRIVILEGE[@]}"}; then
     UPDATER_DISABLE_ON_EXIT=0
     UPDATER_RESTART_ON_EXIT=0
-    UPDATER_REENABLE_ON_EXIT=0
+    UPDATER_REENABLE_ON_EXIT=disabled
     UPDATER_START_AFTER_RUN=0
     UPDATER_DEPLOYMENT_COMMITTED=0
     return 0
@@ -1167,7 +1189,7 @@ reconcile_committed_updater_enablement() {
     ${UPDATER_PRIVILEGE[@]+"${UPDATER_PRIVILEGE[@]}"} || true
   # Keep disablement armed until the copy-command fallback is active.
   UPDATER_RESTART_ON_EXIT=0
-  UPDATER_REENABLE_ON_EXIT=0
+  UPDATER_REENABLE_ON_EXIT=disabled
   UPDATER_START_AFTER_RUN=0
   UPDATER_DISABLE_ON_EXIT=1
   if ! run_disabled_updater_fallback "$runner" "$env_file" \
@@ -1183,14 +1205,14 @@ reconcile_updater_after_failed_deployment() {
   local env_file="$1"
   local previous_state="$2"
   local desired_state="$3"
-  local reenable_after_failure="$4"
+  local enablement_after_failure="$4"
   local restart_after_failure="$5"
   shift 5
   local privilege=("$@")
   local restored_state
 
   # Keep the replacement fail-closed while restoring prior state.
-  UPDATER_REENABLE_ON_EXIT=0
+  UPDATER_REENABLE_ON_EXIT=disabled
   UPDATER_RESTART_ON_EXIT=0
   UPDATER_START_AFTER_RUN=0
   UPDATER_DISABLE_ON_EXIT=1
@@ -1225,9 +1247,8 @@ reconcile_updater_after_failed_deployment() {
       return 1
     fi
   elif [ "$previous_state" = "true" ]; then
-    if [ "$reenable_after_failure" = "1" ] \
-      && ! ${privilege[@]+"${privilege[@]}"} systemctl enable \
-        proto-fleet-updater.service >/dev/null 2>&1; then
+    if ! restore_updater_enablement_with "$enablement_after_failure" \
+        ${privilege[@]+"${privilege[@]}"}; then
       echo "❌ Could not restore host updater boot enablement after deployment failure." >&2
       return 1
     fi
@@ -1470,15 +1491,15 @@ installer_exit_cleanup() {
     if ! restore_updater_artifacts_with \
         ${UPDATER_PRIVILEGE[@]+"${UPDATER_PRIVILEGE[@]}"}; then
       echo "❌ Could not restore the prior host updater artifacts." >&2
-      UPDATER_REENABLE_ON_EXIT=0
+      UPDATER_REENABLE_ON_EXIT=disabled
       UPDATER_RESTART_ON_EXIT=0
       status=1
     fi
   fi
-  if [ "${UPDATER_REENABLE_ON_EXIT:-0}" = "1" ]; then
+  if [ "${UPDATER_REENABLE_ON_EXIT:-disabled}" != "disabled" ]; then
     echo "🔄 Restoring host updater boot enablement after the interrupted installation..." >&2
-    if ! ${UPDATER_PRIVILEGE[@]+"${UPDATER_PRIVILEGE[@]}"} systemctl enable \
-        proto-fleet-updater.service >/dev/null 2>&1; then
+    if ! restore_updater_enablement_with "$UPDATER_REENABLE_ON_EXIT" \
+        ${UPDATER_PRIVILEGE[@]+"${UPDATER_PRIVILEGE[@]}"}; then
       echo "❌ Could not restore host updater boot enablement." >&2
       status=1
     fi

--- a/deployment-files/install.sh
+++ b/deployment-files/install.sh
@@ -150,8 +150,8 @@ detect_previous_install() {
 
 parse_compose_env_value() {
   local value="$1"
-  local double_quoted='^"(.*)"[[:space:]]*(#.*)?$'
-  local single_quoted="^'(.*)'[[:space:]]*(#.*)?$"
+  local double_quoted='^"([^"\\]*)"[[:space:]]*(#.*)?$'
+  local single_quoted="^'([^']*)'[[:space:]]*(#.*)?$"
 
   value=$(printf '%s' "$value" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
   case "$value" in
@@ -429,8 +429,6 @@ Options:
   --install-dir PATH       Use PATH without prompting.
   --non-interactive        Fail instead of prompting; for an existing install
                            with a complete deployment .env.
-  --skip-updater-service   Do not install/reconfigure the host updater.
-                           Reserved for updater-driven internal workflows.
 You can override by doing, e.g.:
   install.sh v0.1.0-beta-5
   install.sh nightly
@@ -490,6 +488,16 @@ resolve_latest_nightly_version() {
   echo "${nightly_version}"
 }
 
+validate_release_version() {
+  local version="$1"
+  if [[ "$version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z]+)*$ ]] \
+    || [[ "$version" =~ ^nightly-[0-9]{8}-[0-9a-f]{12}$ ]]; then
+    return 0
+  fi
+  echo "❌ Invalid Proto Fleet release version: $version" >&2
+  exit 1
+}
+
 check_page_size() {
   local page_size=$(getconf PAGE_SIZE)
   local os_type=$(uname -s)
@@ -521,7 +529,6 @@ check_page_size() {
 }
 
 NON_INTERACTIVE=0
-SKIP_UPDATER_SERVICE=0
 REQUESTED_INSTALL_DIR=""
 REQUESTED_VERSION=""
 
@@ -534,10 +541,6 @@ while [ "$#" -gt 0 ]; do
       ;;
     --non-interactive)
       NON_INTERACTIVE=1
-      shift
-      ;;
-    --skip-updater-service)
-      SKIP_UPDATER_SERVICE=1
       shift
       ;;
     -h|--help)
@@ -585,6 +588,7 @@ case "${REQUESTED_VERSION:-latest}" in
     VERSION="$REQUESTED_VERSION"
     ;;
 esac
+validate_release_version "$VERSION"
 
 # Detect architecture
 case "$(uname -m)" in
@@ -595,24 +599,29 @@ esac
 
 TAR_NAME="proto-fleet-${VERSION}-${ARCH}.tar.gz"
 URL="${GITHUB_RELEASES_URL}/download/${VERSION}/${TAR_NAME}"
-
-# Clean up the downloaded tarball on any exit path. extract_and_cd also rm's
-# it on the happy path, but early-exit paths (download retry, sudo-mismatch
-# abort, future guards added below) would otherwise leak release-sized files
-# into /tmp on every aborted attempt.
-trap 'rm -f "/tmp/${TAR_NAME}"' EXIT
+DOWNLOAD_DIR=$(mktemp -d /tmp/proto-fleet-install.XXXXXX) || {
+  echo "❌ Could not create a private release-download directory." >&2
+  exit 1
+}
+trap 'rm -rf -- "$DOWNLOAD_DIR"' EXIT
+chmod 700 "$DOWNLOAD_DIR" || {
+  echo "❌ Could not secure the release-download directory." >&2
+  exit 1
+}
+TAR_PATH="${DOWNLOAD_DIR}/${TAR_NAME}"
 
 echo "🛰  Fetching proto-fleet ${VERSION} from ${URL}"
-if ! curl -fsSL "${URL}" -o "/tmp/${TAR_NAME}"; then
+if ! curl -fsSL "${URL}" -o "$TAR_PATH"; then
   echo "❌ Failed to download ${TAR_NAME} from GitHub Releases — does that release asset exist?"
   usage
 fi
 
-CHECKSUM_PATH="/tmp/${TAR_NAME}.sha256"
-trap 'rm -f "/tmp/${TAR_NAME}" "${CHECKSUM_PATH}"' EXIT
+CHECKSUM_PATH="${DOWNLOAD_DIR}/${TAR_NAME}.sha256"
 echo "🔐 Fetching and verifying ${TAR_NAME}.sha256"
 if ! curl -fsSL "${URL}.sha256" -o "${CHECKSUM_PATH}"; then
   echo "❌ This release does not provide the required SHA-256 integrity file."
+  echo "   For a legacy release, run the installer published with that exact tag:"
+  echo "   bash <(curl -fsSL ${GITHUB_RELEASES_URL}/download/${VERSION}/install.sh) ${VERSION}"
   exit 1
 fi
 checksum_fields=$(wc -w < "${CHECKSUM_PATH}" | tr -d '[:space:]')
@@ -622,10 +631,10 @@ if [ "$checksum_fields" != "2" ] || [ "$checksum_name" != "$TAR_NAME" ]; then
   exit 1
 fi
 if command -v sha256sum >/dev/null 2>&1; then
-  (cd /tmp && sha256sum -c "${TAR_NAME}.sha256")
+  (cd "$DOWNLOAD_DIR" && sha256sum -c "${TAR_NAME}.sha256")
 elif command -v shasum >/dev/null 2>&1; then
   expected_checksum=$(awk '{print $1}' "${CHECKSUM_PATH}")
-  actual_checksum=$(shasum -a 256 "/tmp/${TAR_NAME}" | awk '{print $1}')
+  actual_checksum=$(shasum -a 256 "$TAR_PATH" | awk '{print $1}')
   [ "$expected_checksum" = "$actual_checksum" ] || { echo "❌ Release checksum verification failed."; exit 1; }
 else
   echo "❌ Neither sha256sum nor shasum is available to verify the release."
@@ -785,7 +794,7 @@ if ! capture_previous_run_options "$INSTALL_DIR" "$EXISTING_DEPLOYMENT" \
   exit 1
 fi
 
-extract_and_cd "/tmp/${TAR_NAME}" "$INSTALL_DIR"
+extract_and_cd "$TAR_PATH" "$INSTALL_DIR"
 # The system service starts with / as its working directory, so persist the
 # canonical absolute install root even when the interactive installer was
 # given a relative path.
@@ -816,8 +825,57 @@ for plugin in "${REQUIRED_PLUGINS[@]}"; do
 done
 echo "✅ Plugin binaries validated"
 
+UPDATER_CLEANUP_FAILED=0
+
+disable_updater_service_with() {
+  local privilege=("$@")
+  local load_state active_state unit_file_state
+  command -v systemctl >/dev/null 2>&1 || return 0
+
+  # A missing unit is already safe. For a known unit, query final state with
+  # checked commands so a sudo/systemctl failure cannot masquerade as
+  # inactive merely because `is-active` returned nonzero.
+  if ! load_state=$(${privilege[@]+"${privilege[@]}"} systemctl show \
+      --property=LoadState --value proto-fleet-updater.service 2>/dev/null); then
+    echo "❌ Could not inspect the host updater while disabling it." >&2
+    UPDATER_CLEANUP_FAILED=1
+    return 1
+  fi
+  if [ "$load_state" = "not-found" ]; then
+    return 0
+  fi
+
+  ${privilege[@]+"${privilege[@]}"} systemctl disable --now \
+    proto-fleet-updater.service >/dev/null 2>&1 || true
+  if ! active_state=$(${privilege[@]+"${privilege[@]}"} systemctl show \
+      --property=ActiveState --value proto-fleet-updater.service 2>/dev/null) \
+    || ! unit_file_state=$(${privilege[@]+"${privilege[@]}"} systemctl show \
+      --property=UnitFileState --value proto-fleet-updater.service 2>/dev/null); then
+    echo "❌ Could not stop and disable the host updater safely." >&2
+    UPDATER_CLEANUP_FAILED=1
+    return 1
+  fi
+  case "$active_state" in
+    inactive|failed) ;;
+    *)
+      echo "❌ Could not stop and disable the host updater safely." >&2
+      UPDATER_CLEANUP_FAILED=1
+      return 1
+      ;;
+  esac
+  case "$unit_file_state" in
+    disabled|masked|masked-runtime|static) ;;
+    *)
+      echo "❌ Could not stop and disable the host updater safely." >&2
+      UPDATER_CLEANUP_FAILED=1
+      return 1
+      ;;
+  esac
+  return 0
+}
+
 install_updater_service() {
-  if [ "$SKIP_UPDATER_SERVICE" = "1" ] || [ "$(uname -s)" != "Linux" ]; then
+  if [ "$(uname -s)" != "Linux" ]; then
     return 1
   fi
   if ! command -v systemctl >/dev/null 2>&1 || [ ! -d /run/systemd/system ]; then
@@ -851,45 +909,92 @@ install_updater_service() {
   # The service runs as root. Only enable it when root sees the same Docker
   # daemon as the current installation; rootless Docker needs a future
   # user-service adapter and must keep the manual fallback.
-  local current_docker_id root_docker_id
+  local current_docker_id root_docker_id attempt
   current_docker_id=$(docker info --format '{{.ID}}' 2>/dev/null || true)
+  if [ -z "$current_docker_id" ] && command -v docker >/dev/null 2>&1; then
+    # Docker is an installer prerequisite, but tolerate an installed rootful
+    # daemon that is merely stopped so a single manual install still enables
+    # one-click upgrades. A rootless DOCKER_HOST remains distinct and will
+    # fail the daemon-identity comparison below.
+    ${privilege[@]+"${privilege[@]}"} systemctl start docker.service >/dev/null 2>&1 || true
+    for attempt in {1..20}; do
+      current_docker_id=$(docker info --format '{{.ID}}' 2>/dev/null || true)
+      [ -z "$current_docker_id" ] || break
+      sleep 0.25
+    done
+  fi
   root_docker_id=$(${privilege[@]+"${privilege[@]}"} docker info --format '{{.ID}}' 2>/dev/null || true)
   if [ -z "$current_docker_id" ] || [ "$current_docker_id" != "$root_docker_id" ]; then
     echo "ℹ️  Root does not manage this installation's Docker daemon; keeping copy-command upgrades."
+    disable_updater_service_with ${privilege[@]+"${privilege[@]}"} || true
     return 1
   fi
 
   local env_temp escaped_install escaped_download
-  env_temp=$(mktemp)
+  if ! env_temp=$(mktemp); then
+    echo "⚠️  Could not create the host updater environment file." >&2
+    disable_updater_service_with ${privilege[@]+"${privilege[@]}"} || true
+    return 1
+  fi
   escaped_install=${INSTALL_DIR//\\/\\\\}
   escaped_install=${escaped_install//\"/\\\"}
   escaped_download=${GITHUB_RELEASES_URL//\\/\\\\}
   escaped_download=${escaped_download//\"/\\\"}
-  {
+  if ! {
     printf 'PROTO_FLEET_INSTALL_ROOT="%s"\n' "$escaped_install"
     printf 'PROTO_FLEET_DOWNLOAD_BASE_URL="%s/download"\n' "$escaped_download"
     printf 'PROTO_FLEET_UPDATER_STATE_DIR="/var/lib/proto-fleet-updater"\n'
     printf 'PROTO_FLEET_UPDATER_SOCKET_PATH="/run/proto-fleet-updater/updater.sock"\n'
     printf 'PROTO_FLEET_UPDATER_BINARY_PATH="/usr/local/libexec/proto-fleet/proto-fleet-updater"\n'
-  } > "$env_temp"
+  } > "$env_temp"; then
+    echo "⚠️  Could not write the host updater environment file." >&2
+    rm -f "$env_temp"
+    disable_updater_service_with ${privilege[@]+"${privilege[@]}"} || true
+    return 1
+  fi
 
   if ! ${privilege[@]+"${privilege[@]}"} install -d -m 0755 /usr/local/libexec/proto-fleet /etc/proto-fleet; then
     rm -f "$env_temp"
+    disable_updater_service_with ${privilege[@]+"${privilege[@]}"} || true
     return 1
   fi
   if ! ${privilege[@]+"${privilege[@]}"} install -m 0755 updater/proto-fleet-updater /usr/local/libexec/proto-fleet/proto-fleet-updater \
     || ! ${privilege[@]+"${privilege[@]}"} install -m 0644 updater/proto-fleet-updater.service /etc/systemd/system/proto-fleet-updater.service \
     || ! ${privilege[@]+"${privilege[@]}"} install -m 0600 "$env_temp" /etc/proto-fleet/updater.env; then
     rm -f "$env_temp"
+    disable_updater_service_with ${privilege[@]+"${privilege[@]}"} || true
     return 1
   fi
   rm -f "$env_temp"
-  ${privilege[@]+"${privilege[@]}"} systemctl daemon-reload
-  ${privilege[@]+"${privilege[@]}"} systemctl enable proto-fleet-updater.service
+  if ! ${privilege[@]+"${privilege[@]}"} systemctl daemon-reload \
+    || ! ${privilege[@]+"${privilege[@]}"} systemctl enable proto-fleet-updater.service; then
+    disable_updater_service_with ${privilege[@]+"${privilege[@]}"} || true
+    return 1
+  fi
   # A manual install can safely restart an already-running updater; the
   # updater-driven path never invokes install.sh and refreshes its on-disk
   # binary for the next service start instead.
-  ${privilege[@]+"${privilege[@]}"} systemctl restart proto-fleet-updater.service
+  if ! ${privilege[@]+"${privilege[@]}"} systemctl restart proto-fleet-updater.service; then
+    disable_updater_service_with ${privilege[@]+"${privilege[@]}"} || true
+    return 1
+  fi
+
+  # Type=simple reports the restart as soon as the process is spawned. Wait
+  # for the updater to finish validating its privileged configuration and
+  # bind the secured API socket before exposing that socket to fleet-api.
+  local ready_deadline=$((SECONDS + 60))
+  while [ "$SECONDS" -lt "$ready_deadline" ]; do
+    if ${privilege[@]+"${privilege[@]}"} curl -fsS --max-time 1 \
+      --unix-socket /run/proto-fleet-updater/updater.sock \
+      http://localhost/v1/status >/dev/null 2>&1 \
+      && ${privilege[@]+"${privilege[@]}"} systemctl is-active --quiet proto-fleet-updater.service; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "⚠️  Host updater did not become ready; keeping copy-command upgrades." >&2
+  disable_updater_service_with ${privilege[@]+"${privilege[@]}"} || true
+  return 1
 }
 
 RUN_FLEET_ARGS=()
@@ -906,11 +1011,22 @@ if install_updater_service; then
   echo "✅ Host updater installed; one-click upgrades are enabled."
   RUN_FLEET_ARGS+=(--enable-one-click-updates)
 else
+  if [ "$UPDATER_CLEANUP_FAILED" = "1" ]; then
+    echo "❌ Installation stopped because the host updater could not be left in a safe state." >&2
+    exit 1
+  fi
   echo "ℹ️  One-click upgrades are unavailable; the in-product copy command remains usable."
+  RUN_FLEET_ARGS+=(--disable-one-click-updates)
 fi
 
 echo "🔧 Running deployment script..."
 if [ "$NON_INTERACTIVE" = "1" ]; then
   RUN_FLEET_ARGS+=(--non-interactive)
 fi
+# run-fleet persists the selected overlay before later build/start work. If a
+# later deployment step fails, keep the already-verified updater service ready
+# so that persisted true state never points fleet-api at a dead socket. A fresh
+# installation cannot expose the socket until run-fleet successfully starts
+# the overlay; an existing socket-enabled deployment already owned this
+# service before the manual retry.
 ./run-fleet.sh "${RUN_FLEET_ARGS[@]}"

--- a/deployment-files/install.sh
+++ b/deployment-files/install.sh
@@ -10,6 +10,7 @@ UPDATER_PRIVILEGE_AVAILABLE=1
 UPDATER_DISABLE_ON_EXIT=0
 UPDATER_REENABLE_ON_EXIT=0
 UPDATER_RESTART_ON_EXIT=0
+UPDATER_FALLBACK_PENDING=0
 UPDATER_ENV_PATH="/etc/proto-fleet/updater.env"
 UPDATER_ENV_RESTORE_FILE=""
 UPDATER_BINARY_RESTORE_FILE=""
@@ -17,12 +18,22 @@ UPDATER_UNIT_RESTORE_FILE=""
 UPDATER_ARTIFACT_RESTORE_PENDING=0
 UPDATER_BINARY_PATH="/usr/local/libexec/proto-fleet/proto-fleet-updater"
 UPDATER_UNIT_PATH="/etc/systemd/system/proto-fleet-updater.service"
+UPDATER_STATE_DIR="/var/lib/proto-fleet-updater"
 UPDATER_RUNTIME_DIR="/run/proto-fleet-updater"
+UPDATER_SYSTEMD_RUNTIME_DIR="/run/systemd/system"
 UPDATER_SOCKET_PATH="$UPDATER_RUNTIME_DIR/updater.sock"
 UPDATER_VALIDATION_RUNTIME_DIR="/run/proto-fleet-updater-validation"
 UPDATER_VALIDATION_SOCKET_PATH="$UPDATER_VALIDATION_RUNTIME_DIR/updater.sock"
 UPDATER_VALIDATION_RUNTIME_ON_EXIT=0
 UPDATER_DOCKER_HOST="unix:///var/run/docker.sock"
+UPDATER_SELF_UPDATE_SUFFIXES=(
+  ""
+  .previous
+  .candidate
+  .handoff
+  .handoff.tmp
+  .restore
+)
 
 # Probe docker for an existing fleet-api container and return the install
 # directory inferred from its bind mount. Echoes the path on success; returns
@@ -786,11 +797,10 @@ disable_updater_service_with() {
   local load_state active_state unit_file_state
   command -v systemctl >/dev/null 2>&1 || return 0
 
-  # A missing unit is already safe and LoadState is readable without
-  # privilege. Check it directly before invoking sudo so a non-interactive
-  # fallback does not turn a previously proven missing unit into a fatal
-  # cleanup failure merely because sudo would require a password. For a known
-  # unit, all mutation and final-state checks still use the resolved privilege.
+  # LoadState and ActiveState are readable without privilege. A deleted unit
+  # can still have a supervised process, so not-found is safe only after the
+  # process state is also inactive. Privilege is needed only when a stop is
+  # actually required.
   if ! load_state=$(systemctl show \
       --property=LoadState --value proto-fleet-updater.service 2>/dev/null); then
     echo "❌ Could not inspect the host updater while disabling it." >&2
@@ -798,7 +808,37 @@ disable_updater_service_with() {
     return 1
   fi
   if [ "$load_state" = "not-found" ]; then
-    return 0
+    if ! active_state=$(systemctl show \
+        --property=ActiveState --value proto-fleet-updater.service 2>/dev/null); then
+      echo "❌ Could not inspect the host updater process while disabling it." >&2
+      UPDATER_CLEANUP_FAILED=1
+      return 1
+    fi
+    case "$active_state" in
+      inactive|failed) return 0 ;;
+      active|activating|reloading|deactivating) ;;
+      *)
+        echo "❌ The host updater has an unexpected active state: $active_state" >&2
+        UPDATER_CLEANUP_FAILED=1
+        return 1
+        ;;
+    esac
+    if ! ${privilege[@]+"${privilege[@]}"} systemctl stop \
+        proto-fleet-updater.service \
+      || ! active_state=$(systemctl show \
+        --property=ActiveState --value proto-fleet-updater.service 2>/dev/null); then
+      echo "❌ Could not stop the host updater process safely." >&2
+      UPDATER_CLEANUP_FAILED=1
+      return 1
+    fi
+    case "$active_state" in
+      inactive|failed) return 0 ;;
+      *)
+        echo "❌ Could not stop the host updater process safely." >&2
+        UPDATER_CLEANUP_FAILED=1
+        return 1
+        ;;
+    esac
   fi
 
   ${privilege[@]+"${privilege[@]}"} systemctl disable --now \
@@ -1005,6 +1045,43 @@ restore_updater_artifacts_with() {
   UPDATER_ARTIFACT_RESTORE_PENDING=0
 }
 
+updater_durable_artifacts_present() {
+  local path suffix
+
+  for path in \
+    "$UPDATER_ENV_PATH" \
+    "$UPDATER_UNIT_PATH" \
+    "$UPDATER_STATE_DIR" \
+    "$UPDATER_RUNTIME_DIR"; do
+    if [ -e "$path" ] || [ -L "$path" ]; then
+      return 0
+    fi
+  done
+  for suffix in "${UPDATER_SELF_UPDATE_SUFFIXES[@]}"; do
+    path="${UPDATER_BINARY_PATH}${suffix}"
+    if [ -e "$path" ] || [ -L "$path" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+finalize_disabled_updater_fallback_if_persisted() {
+  local env_file="$1"
+  local state
+
+  state=$(deployment_boolean_state "$env_file" ENABLE_ONE_CLICK_UPDATES) || return 1
+  [ "$state" = "false" ] || return 1
+  UPDATER_DISABLE_ON_EXIT=0
+  UPDATER_REENABLE_ON_EXIT=0
+  UPDATER_RESTART_ON_EXIT=0
+  UPDATER_ENV_RESTORE_FILE=""
+  UPDATER_BINARY_RESTORE_FILE=""
+  UPDATER_UNIT_RESTORE_FILE=""
+  UPDATER_ARTIFACT_RESTORE_PENDING=0
+  UPDATER_FALLBACK_PENDING=0
+}
+
 install_updater_bootstrap_files_with() {
   local env_source="$1"
   shift
@@ -1062,7 +1139,7 @@ prepare_existing_updater_service() {
   local selected_root="$1"
   if [ "$(uname -s)" != "Linux" ] \
     || ! command -v systemctl >/dev/null 2>&1 \
-    || [ ! -d /run/systemd/system ]; then
+    || [ ! -d "$UPDATER_SYSTEMD_RUNTIME_DIR" ]; then
     return 0
   fi
 
@@ -1073,7 +1150,11 @@ prepare_existing_updater_service() {
     UPDATER_CLEANUP_FAILED=1
     return 1
   fi
-  if [ "$load_state" = "not-found" ]; then
+  local durable_artifacts=false
+  if updater_durable_artifacts_present; then
+    durable_artifacts=true
+  fi
+  if [ "$load_state" = "not-found" ] && [ "$durable_artifacts" != "true" ]; then
     return 0
   fi
   if [ "$UPDATER_PRIVILEGE_AVAILABLE" != "1" ]; then
@@ -1085,6 +1166,16 @@ prepare_existing_updater_service() {
       ${UPDATER_PRIVILEGE[@]+"${UPDATER_PRIVILEGE[@]}"}; then
     UPDATER_CLEANUP_FAILED=1
     return 1
+  fi
+  if [ "$load_state" = "not-found" ]; then
+    if ! disable_updater_service_with \
+        ${UPDATER_PRIVILEGE[@]+"${UPDATER_PRIVILEGE[@]}"}; then
+      return 1
+    fi
+    # Matching durable artifacts without a loaded unit are a recoverable
+    # partial bootstrap/uninstall. There is no complete service to back up;
+    # the new bootstrap may repair it, but ownership cannot silently transfer.
+    return 0
   fi
   if ! active_state=$(systemctl show --property=ActiveState --value \
       proto-fleet-updater.service 2>/dev/null) \
@@ -1128,7 +1219,7 @@ write_updater_environment_file() {
   {
     printf 'PROTO_FLEET_INSTALL_ROOT="%s"\n' "$escaped_install"
     printf 'PROTO_FLEET_DOWNLOAD_BASE_URL="%s/download"\n' "$escaped_download"
-    printf 'PROTO_FLEET_UPDATER_STATE_DIR="/var/lib/proto-fleet-updater"\n'
+    printf 'PROTO_FLEET_UPDATER_STATE_DIR="%s"\n' "$UPDATER_STATE_DIR"
     printf 'PROTO_FLEET_UPDATER_SOCKET_PATH="%s"\n' "$escaped_socket"
     printf 'PROTO_FLEET_UPDATER_BINARY_PATH="%s"\n' "$UPDATER_BINARY_PATH"
   } > "$target"
@@ -1727,7 +1818,7 @@ install_updater_service() {
   if [ "$(uname -s)" != "Linux" ]; then
     return 1
   fi
-  if ! command -v systemctl >/dev/null 2>&1 || [ ! -d /run/systemd/system ]; then
+  if ! command -v systemctl >/dev/null 2>&1 || [ ! -d "$UPDATER_SYSTEMD_RUNTIME_DIR" ]; then
     echo "ℹ️  systemd is unavailable; keeping copy-command upgrades on this host."
     return 1
   fi
@@ -1891,16 +1982,16 @@ else
   # updater to reconcile.
   if [ "$(uname -s)" = "Linux" ] \
     && command -v systemctl >/dev/null 2>&1 \
-    && [ -d /run/systemd/system ]; then
+    && [ -d "$UPDATER_SYSTEMD_RUNTIME_DIR" ]; then
     disable_updater_service_with ${UPDATER_PRIVILEGE[@]+"${UPDATER_PRIVILEGE[@]}"} || true
   fi
   if [ "$UPDATER_CLEANUP_FAILED" = "1" ]; then
     echo "❌ Installation stopped because the host updater could not be left in a safe state." >&2
     exit 1
   fi
-  UPDATER_DISABLE_ON_EXIT=0
-  UPDATER_REENABLE_ON_EXIT=0
-  UPDATER_RESTART_ON_EXIT=0
+  # Keep restoration armed until run-fleet durably records the disabled
+  # fallback. If it fails earlier, EXIT restores the prior working updater.
+  UPDATER_FALLBACK_PENDING=1
   echo "ℹ️  One-click upgrades are unavailable; the in-product copy command remains usable."
   RUN_FLEET_ARGS+=(--disable-one-click-updates)
 fi
@@ -1914,6 +2005,22 @@ if ./run-fleet.sh "${RUN_FLEET_ARGS[@]}"; then
   RUN_FLEET_STATUS=0
 else
   RUN_FLEET_STATUS=$?
+fi
+
+if [ "$UPDATER_FALLBACK_PENDING" = "1" ]; then
+  if finalize_disabled_updater_fallback_if_persisted \
+      "$INSTALL_DIR/$DEPLOYMENT_DIR/.env"; then
+    :
+  elif [ "$RUN_FLEET_STATUS" -eq 0 ]; then
+    echo "❌ Deployment completed without durably disabling one-click updates." >&2
+    RUN_FLEET_STATUS=1
+  fi
+  if [ "$RUN_FLEET_STATUS" -ne 0 ]; then
+    # EXIT cleanup restores the previous updater only while the old persisted
+    # true value proves the fallback was not committed. A durable false value
+    # clears restoration above and leaves the updater safely disabled.
+    exit "$RUN_FLEET_STATUS"
+  fi
 fi
 
 UPDATER_RESTART_FAILED=0

--- a/deployment-files/install.sh
+++ b/deployment-files/install.sh
@@ -1082,6 +1082,16 @@ finalize_disabled_updater_fallback_if_persisted() {
   UPDATER_FALLBACK_PENDING=0
 }
 
+complete_disabled_updater_fallback_after_run() {
+  local env_file="$1"
+  local run_status="$2"
+
+  # run-fleet persists overlay intent before Compose validation. Only its
+  # successful exit proves that the replacement stack adopted the fallback.
+  [ "$run_status" -eq 0 ] || return "$run_status"
+  finalize_disabled_updater_fallback_if_persisted "$env_file"
+}
+
 install_updater_bootstrap_files_with() {
   local env_source="$1"
   shift
@@ -2008,18 +2018,18 @@ else
 fi
 
 if [ "$UPDATER_FALLBACK_PENDING" = "1" ]; then
-  if finalize_disabled_updater_fallback_if_persisted \
-      "$INSTALL_DIR/$DEPLOYMENT_DIR/.env"; then
-    :
-  elif [ "$RUN_FLEET_STATUS" -eq 0 ]; then
-    echo "❌ Deployment completed without durably disabling one-click updates." >&2
-    RUN_FLEET_STATUS=1
-  fi
-  if [ "$RUN_FLEET_STATUS" -ne 0 ]; then
-    # EXIT cleanup restores the previous updater only while the old persisted
-    # true value proves the fallback was not committed. A durable false value
-    # clears restoration above and leaves the updater safely disabled.
-    exit "$RUN_FLEET_STATUS"
+  UPDATER_FALLBACK_STATUS=0
+  complete_disabled_updater_fallback_after_run \
+    "$INSTALL_DIR/$DEPLOYMENT_DIR/.env" "$RUN_FLEET_STATUS" \
+    || UPDATER_FALLBACK_STATUS=$?
+  if [ "$UPDATER_FALLBACK_STATUS" -ne 0 ]; then
+    if [ "$RUN_FLEET_STATUS" -eq 0 ]; then
+      echo "❌ Deployment completed without durably disabling one-click updates." >&2
+    fi
+    # run-fleet restores the prior deployment setting on failure; the
+    # installer's EXIT cleanup then restores the prior updater artifacts and
+    # service state. Never discard those rollback assets on a failed run.
+    exit "$UPDATER_FALLBACK_STATUS"
   fi
 fi
 

--- a/deployment-files/install.sh
+++ b/deployment-files/install.sh
@@ -12,8 +12,13 @@ UPDATER_REENABLE_ON_EXIT=0
 UPDATER_RESTART_ON_EXIT=0
 UPDATER_ENV_PATH="/etc/proto-fleet/updater.env"
 UPDATER_ENV_RESTORE_FILE=""
-UPDATER_SOCKET_PATH="/run/proto-fleet-updater/updater.sock"
-UPDATER_VALIDATION_SOCKET_PATH="/run/proto-fleet-updater/installer-validation.sock"
+UPDATER_BINARY_PATH="/usr/local/libexec/proto-fleet/proto-fleet-updater"
+UPDATER_UNIT_PATH="/etc/systemd/system/proto-fleet-updater.service"
+UPDATER_RUNTIME_DIR="/run/proto-fleet-updater"
+UPDATER_SOCKET_PATH="$UPDATER_RUNTIME_DIR/updater.sock"
+UPDATER_VALIDATION_RUNTIME_DIR="/run/proto-fleet-updater-validation"
+UPDATER_VALIDATION_SOCKET_PATH="$UPDATER_VALIDATION_RUNTIME_DIR/updater.sock"
+UPDATER_VALIDATION_RUNTIME_ON_EXIT=0
 UPDATER_DOCKER_HOST="unix:///var/run/docker.sock"
 
 # Probe docker for an existing fleet-api container and return the install
@@ -914,6 +919,56 @@ restore_updater_environment_with() {
     "$UPDATER_ENV_RESTORE_FILE" "$UPDATER_ENV_PATH"
 }
 
+install_updater_bootstrap_files_with() {
+  local env_source="$1"
+  shift
+  local privilege=("$@")
+
+  if ! ${privilege[@]+"${privilege[@]}"} install -d -m 0755 \
+      "$(dirname "$UPDATER_ENV_PATH")"; then
+    UPDATER_CLEANUP_FAILED=1
+    return 1
+  fi
+  # Persist the selected installation root before any other global artifact.
+  # A later partial failure therefore remains attributable and removable by
+  # the supported uninstaller instead of becoming ownerless host state.
+  if ! ${privilege[@]+"${privilege[@]}"} install -m 0600 \
+      "$env_source" "$UPDATER_ENV_PATH"; then
+    UPDATER_CLEANUP_FAILED=1
+    return 1
+  fi
+  if ! ${privilege[@]+"${privilege[@]}"} install -d -m 0755 \
+      "$(dirname "$UPDATER_BINARY_PATH")" \
+    || ! ${privilege[@]+"${privilege[@]}"} install -m 0755 \
+      "$UPDATER_BOOTSTRAP_DIR/proto-fleet-updater" "$UPDATER_BINARY_PATH" \
+    || ! ${privilege[@]+"${privilege[@]}"} install -m 0644 \
+      "$UPDATER_BOOTSTRAP_DIR/proto-fleet-updater.service" "$UPDATER_UNIT_PATH"; then
+    UPDATER_CLEANUP_FAILED=1
+    return 1
+  fi
+}
+
+cleanup_updater_validation_runtime_with() {
+  local privilege=("$@")
+  if ! ${privilege[@]+"${privilege[@]}"} test -e \
+      "$UPDATER_VALIDATION_RUNTIME_DIR" \
+    && ! ${privilege[@]+"${privilege[@]}"} test -L \
+      "$UPDATER_VALIDATION_RUNTIME_DIR"; then
+    return 0
+  fi
+  if ${privilege[@]+"${privilege[@]}"} test -L \
+      "$UPDATER_VALIDATION_RUNTIME_DIR" \
+    || ! ${privilege[@]+"${privilege[@]}"} test -d \
+      "$UPDATER_VALIDATION_RUNTIME_DIR"; then
+    echo "❌ Refusing invalid updater validation runtime path: $UPDATER_VALIDATION_RUNTIME_DIR" >&2
+    return 1
+  fi
+  ${privilege[@]+"${privilege[@]}"} rm -f -- \
+    "$UPDATER_VALIDATION_SOCKET_PATH" || return 1
+  ${privilege[@]+"${privilege[@]}"} rmdir \
+    "$UPDATER_VALIDATION_RUNTIME_DIR"
+}
+
 # Stop the existing updater before the release tree can be replaced. systemd's
 # inactive state proves the supervised process has exited, which also releases
 # the updater's lifetime flock. A missing unit needs no privilege or prompt.
@@ -990,7 +1045,7 @@ write_updater_environment_file() {
     printf 'PROTO_FLEET_DOWNLOAD_BASE_URL="%s/download"\n' "$escaped_download"
     printf 'PROTO_FLEET_UPDATER_STATE_DIR="/var/lib/proto-fleet-updater"\n'
     printf 'PROTO_FLEET_UPDATER_SOCKET_PATH="%s"\n' "$escaped_socket"
-    printf 'PROTO_FLEET_UPDATER_BINARY_PATH="/usr/local/libexec/proto-fleet/proto-fleet-updater"\n'
+    printf 'PROTO_FLEET_UPDATER_BINARY_PATH="%s"\n' "$UPDATER_BINARY_PATH"
   } > "$target"
 }
 
@@ -1058,6 +1113,12 @@ installer_exit_cleanup() {
       ${UPDATER_PRIVILEGE[@]+"${UPDATER_PRIVILEGE[@]}"}; then
       status=1
     fi
+  fi
+  if [ "${UPDATER_VALIDATION_RUNTIME_ON_EXIT:-0}" = "1" ] \
+    && ! cleanup_updater_validation_runtime_with \
+      ${UPDATER_PRIVILEGE[@]+"${UPDATER_PRIVILEGE[@]}"}; then
+    echo "❌ Could not remove the private updater validation runtime." >&2
+    status=1
   fi
   if [ -n "${UPDATER_ENV_RESTORE_FILE:-}" ]; then
     echo "🔄 Restoring the prior host updater configuration..." >&2
@@ -1634,9 +1695,9 @@ install_updater_service() {
     disable_updater_service_with ${privilege[@]+"${privilege[@]}"} || true
     return 1
   fi
-  # Validate against a socket name the old fleet-api does not know. Its
-  # preserved directory bind mount therefore cannot reach /v1/upgrade while
-  # the replacement updater is briefly running for its health check.
+  # Validate in a root-only runtime directory that is never bind-mounted into
+  # fleet-api. A different filename inside the production directory would not
+  # be isolation: read-only bind mounts still permit Unix-socket connections.
   if ! write_updater_environment_file "$env_temp" "$INSTALL_DIR" \
     "$GITHUB_RELEASES_URL" "$UPDATER_VALIDATION_SOCKET_PATH"; then
     echo "⚠️  Could not write the host updater environment file." >&2
@@ -1645,40 +1706,54 @@ install_updater_service() {
     return 1
   fi
 
-  if ! ${privilege[@]+"${privilege[@]}"} install -d -m 0755 /usr/local/libexec/proto-fleet /etc/proto-fleet; then
+  UPDATER_VALIDATION_RUNTIME_ON_EXIT=1
+  if ! cleanup_updater_validation_runtime_with \
+      ${privilege[@]+"${privilege[@]}"} \
+    || ! ${privilege[@]+"${privilege[@]}"} install -d -m 0700 \
+      "$UPDATER_VALIDATION_RUNTIME_DIR"; then
+    echo "⚠️  Could not establish the private updater validation runtime." >&2
+    UPDATER_CLEANUP_FAILED=1
     rm -f "$env_temp"
     disable_updater_service_with ${privilege[@]+"${privilege[@]}"} || true
     return 1
   fi
-  if ! ${privilege[@]+"${privilege[@]}"} install -m 0755 "$UPDATER_BOOTSTRAP_DIR/proto-fleet-updater" /usr/local/libexec/proto-fleet/proto-fleet-updater \
-    || ! ${privilege[@]+"${privilege[@]}"} install -m 0644 "$UPDATER_BOOTSTRAP_DIR/proto-fleet-updater.service" /etc/systemd/system/proto-fleet-updater.service \
-    || ! ${privilege[@]+"${privilege[@]}"} install -m 0600 "$env_temp" "$UPDATER_ENV_PATH"; then
+  if ! install_updater_bootstrap_files_with "$env_temp" \
+      ${privilege[@]+"${privilege[@]}"}; then
     rm -f "$env_temp"
     disable_updater_service_with ${privilege[@]+"${privilege[@]}"} || true
     return 1
   fi
   if ! ${privilege[@]+"${privilege[@]}"} systemctl daemon-reload \
     || ! ${privilege[@]+"${privilege[@]}"} systemctl enable proto-fleet-updater.service; then
+    UPDATER_CLEANUP_FAILED=1
     rm -f "$env_temp"
     disable_updater_service_with ${privilege[@]+"${privilege[@]}"} || true
     return 1
   fi
-  # The replacement unit now owns its boot enablement. EXIT cleanup only
-  # needs to stop a failed validation or restart the validated service.
-  UPDATER_REENABLE_ON_EXIT=0
   UPDATER_DISABLE_ON_EXIT=1
   if ! restart_updater_service_with "$UPDATER_VALIDATION_SOCKET_PATH" \
     ${privilege[@]+"${privilege[@]}"}; then
+    UPDATER_CLEANUP_FAILED=1
     rm -f "$env_temp"
     disable_updater_service_with ${privilege[@]+"${privilege[@]}"} || true
     return 1
   fi
   if ! quiesce_updater_service_for_manual_run_with \
     ${privilege[@]+"${privilege[@]}"}; then
+    UPDATER_CLEANUP_FAILED=1
     rm -f "$env_temp"
     disable_updater_service_with ${privilege[@]+"${privilege[@]}"} || true
     return 1
   fi
+  if ! cleanup_updater_validation_runtime_with \
+      ${privilege[@]+"${privilege[@]}"}; then
+    echo "⚠️  Could not remove the private updater validation runtime." >&2
+    UPDATER_CLEANUP_FAILED=1
+    rm -f "$env_temp"
+    disable_updater_service_with ${privilege[@]+"${privilege[@]}"} || true
+    return 1
+  fi
+  UPDATER_VALIDATION_RUNTIME_ON_EXIT=0
   # The validated service is now stopped. Persist its production socket only
   # after the temporary listener is gone, and do not start it until run-fleet
   # has finished replacing the deployment.
@@ -1686,6 +1761,7 @@ install_updater_service() {
       "$GITHUB_RELEASES_URL" "$UPDATER_SOCKET_PATH" \
     || ! ${privilege[@]+"${privilege[@]}"} install -m 0600 \
       "$env_temp" "$UPDATER_ENV_PATH"; then
+    UPDATER_CLEANUP_FAILED=1
     rm -f "$env_temp"
     disable_updater_service_with ${privilege[@]+"${privilege[@]}"} || true
     return 1
@@ -1695,6 +1771,7 @@ install_updater_service() {
   # installation root. Interrupted cleanup can safely restart it without
   # restoring the pre-validation file.
   UPDATER_ENV_RESTORE_FILE=""
+  UPDATER_REENABLE_ON_EXIT=0
   # From this point until the explicit post-run restart, every unexpected exit
   # must restore the validated service for the existing deployment.
   UPDATER_DISABLE_ON_EXIT=0

--- a/deployment-files/install.sh
+++ b/deployment-files/install.sh
@@ -10,6 +10,9 @@ UPDATER_PRIVILEGE_AVAILABLE=1
 UPDATER_DISABLE_ON_EXIT=0
 UPDATER_REENABLE_ON_EXIT=0
 UPDATER_RESTART_ON_EXIT=0
+UPDATER_START_AFTER_RUN=0
+UPDATER_REENABLE_AFTER_FAILED_RUN=0
+UPDATER_RESTART_AFTER_FAILED_RUN=0
 UPDATER_FALLBACK_PENDING=0
 UPDATER_ENV_PATH="/etc/proto-fleet/updater.env"
 UPDATER_ENV_RESTORE_FILE=""
@@ -340,8 +343,9 @@ capture_previous_run_options() {
   PREVIOUS_BETA_ALERTS=0
   PREVIOUS_SYSTEM_MONITORING=0
   PREVIOUS_TRACING=0
+  PREVIOUS_ONE_CLICK_UPDATES=false
 
-  local beta_state system_state tracing_state
+  local beta_state system_state tracing_state one_click_state
   beta_state=$(deployment_boolean_state "$env_file" ENABLE_BETA_ALERTS) || {
     echo "❌ Existing ENABLE_BETA_ALERTS in $env_file must be true or false." >&2
     return 1
@@ -354,6 +358,13 @@ capture_previous_run_options() {
     echo "❌ Existing ENABLE_TRACING in $env_file must be true or false." >&2
     return 1
   }
+  one_click_state=$(deployment_boolean_state "$env_file" ENABLE_ONE_CLICK_UPDATES) || {
+    echo "❌ Existing ENABLE_ONE_CLICK_UPDATES in $env_file must be true or false." >&2
+    return 1
+  }
+  if [ "$one_click_state" = "true" ]; then
+    PREVIOUS_ONE_CLICK_UPDATES=true
+  fi
 
   if [ "$beta_state" != "missing" ] \
     && [ "$system_state" != "missing" ] \
@@ -1092,6 +1103,62 @@ complete_disabled_updater_fallback_after_run() {
   finalize_disabled_updater_fallback_if_persisted "$env_file"
 }
 
+reconcile_updater_after_failed_deployment() {
+  local env_file="$1"
+  local expected_state="$2"
+  local reenable_after_failure="$3"
+  local restart_after_failure="$4"
+  shift 4
+  local privilege=("$@")
+  local restored_state
+
+  # The replacement service must stay fail-closed until the old deployment
+  # setting and service lifecycle have both been restored. Clear the generic
+  # EXIT restoration flags so a reconciliation error cannot accidentally
+  # start the replacement service.
+  UPDATER_REENABLE_ON_EXIT=0
+  UPDATER_RESTART_ON_EXIT=0
+  UPDATER_START_AFTER_RUN=0
+  UPDATER_DISABLE_ON_EXIT=1
+
+  if ! restored_state=$(deployment_boolean_state \
+      "$env_file" ENABLE_ONE_CLICK_UPDATES); then
+    echo "❌ Could not verify the restored one-click update setting after deployment failure." >&2
+    disable_updater_service_with \
+      ${privilege[@]+"${privilege[@]}"} || true
+    return 1
+  fi
+  [ "$restored_state" != "missing" ] || restored_state=false
+  if [ "$restored_state" != "$expected_state" ]; then
+    echo "❌ The failed deployment did not restore the prior one-click update setting." >&2
+    disable_updater_service_with \
+      ${privilege[@]+"${privilege[@]}"} || true
+    return 1
+  fi
+
+  if ! disable_updater_service_with \
+      ${privilege[@]+"${privilege[@]}"}; then
+    return 1
+  fi
+  if [ "$expected_state" = "true" ]; then
+    if [ "$reenable_after_failure" = "1" ] \
+      && ! ${privilege[@]+"${privilege[@]}"} systemctl enable \
+        proto-fleet-updater.service >/dev/null 2>&1; then
+      echo "❌ Could not restore host updater boot enablement after deployment failure." >&2
+      return 1
+    fi
+    if [ "$restart_after_failure" = "1" ] \
+      && ! restart_updater_service_with "$UPDATER_SOCKET_PATH" \
+        ${privilege[@]+"${privilege[@]}"}; then
+      echo "❌ Could not restore the prior host updater after deployment failure." >&2
+      return 1
+    fi
+  fi
+
+  UPDATER_DISABLE_ON_EXIT=0
+  return 0
+}
+
 install_updater_bootstrap_files_with() {
   local env_source="$1"
   shift
@@ -1792,6 +1859,10 @@ if ! prepare_existing_updater_service "$INSTALL_DIR"; then
   echo "❌ Existing host updater could not be stopped safely; no files were replaced." >&2
   exit 1
 fi
+if [ "$PREVIOUS_ONE_CLICK_UPDATES" = "true" ]; then
+  UPDATER_REENABLE_AFTER_FAILED_RUN="$UPDATER_REENABLE_ON_EXIT"
+  UPDATER_RESTART_AFTER_FAILED_RUN="$UPDATER_RESTART_ON_EXIT"
+fi
 
 extract_and_cd "$TAR_PATH" "$INSTALL_DIR"
 # The system service starts with / as its working directory, so persist the
@@ -1965,11 +2036,13 @@ install_updater_service() {
   UPDATER_BINARY_RESTORE_FILE=""
   UPDATER_UNIT_RESTORE_FILE=""
   UPDATER_ARTIFACT_RESTORE_PENDING=0
-  UPDATER_REENABLE_ON_EXIT=0
-  # From this point until the explicit post-run restart, every unexpected exit
-  # must restore the validated service for the existing deployment.
-  UPDATER_DISABLE_ON_EXIT=0
-  UPDATER_RESTART_ON_EXIT=1
+  # Until run-fleet succeeds, an interrupted or failed installation must
+  # disable the replacement service and restore only the prior service state.
+  # Starting the newly validated service is a separate post-success action.
+  UPDATER_DISABLE_ON_EXIT=1
+  UPDATER_REENABLE_ON_EXIT="$UPDATER_REENABLE_AFTER_FAILED_RUN"
+  UPDATER_RESTART_ON_EXIT="$UPDATER_RESTART_AFTER_FAILED_RUN"
+  UPDATER_START_AFTER_RUN=1
   return 0
 }
 
@@ -2033,13 +2106,29 @@ if [ "$UPDATER_FALLBACK_PENDING" = "1" ]; then
   fi
 fi
 
+if [ "$RUN_FLEET_STATUS" -ne 0 ]; then
+  if [ "$UPDATER_START_AFTER_RUN" = "1" ] \
+    && ! reconcile_updater_after_failed_deployment \
+      "$INSTALL_DIR/$DEPLOYMENT_DIR/.env" \
+      "$PREVIOUS_ONE_CLICK_UPDATES" \
+      "$UPDATER_REENABLE_AFTER_FAILED_RUN" \
+      "$UPDATER_RESTART_AFTER_FAILED_RUN" \
+      ${UPDATER_PRIVILEGE[@]+"${UPDATER_PRIVILEGE[@]}"}; then
+    echo "❌ Could not reconcile the host updater after deployment failure." >&2
+    exit 1
+  fi
+  exit "$RUN_FLEET_STATUS"
+fi
+
 UPDATER_RESTART_FAILED=0
-if [ "$UPDATER_RESTART_ON_EXIT" = "1" ]; then
-  echo "🔄 Restoring the host updater after the manual deployment run..."
+if [ "$UPDATER_START_AFTER_RUN" = "1" ]; then
+  echo "🔄 Starting the host updater after the manual deployment run..."
   # run-fleet is finished, so the old API can no longer race this deployment.
   # systemd owns the service lifecycle once the restart is issued.
+  UPDATER_DISABLE_ON_EXIT=0
   UPDATER_RESTART_ON_EXIT=0
   UPDATER_REENABLE_ON_EXIT=0
+  UPDATER_START_AFTER_RUN=0
   if restart_updater_service_with "$UPDATER_SOCKET_PATH" \
     ${UPDATER_PRIVILEGE[@]+"${UPDATER_PRIVILEGE[@]}"}; then
     :
@@ -2051,9 +2140,6 @@ if [ "$UPDATER_RESTART_ON_EXIT" = "1" ]; then
   fi
 fi
 
-if [ "$RUN_FLEET_STATUS" -ne 0 ]; then
-  exit "$RUN_FLEET_STATUS"
-fi
 if [ "$UPDATER_RESTART_FAILED" -ne 0 ]; then
   exit 1
 fi

--- a/deployment-files/install.sh
+++ b/deployment-files/install.sh
@@ -487,10 +487,12 @@ disable_updater_service_with() {
   local load_state active_state unit_file_state
   command -v systemctl >/dev/null 2>&1 || return 0
 
-  # A missing unit is already safe. For a known unit, query final state with
-  # checked commands so a sudo/systemctl failure cannot masquerade as
-  # inactive merely because `is-active` returned nonzero.
-  if ! load_state=$(${privilege[@]+"${privilege[@]}"} systemctl show \
+  # A missing unit is already safe and LoadState is readable without
+  # privilege. Check it directly before invoking sudo so a non-interactive
+  # fallback does not turn a previously proven missing unit into a fatal
+  # cleanup failure merely because sudo would require a password. For a known
+  # unit, all mutation and final-state checks still use the resolved privilege.
+  if ! load_state=$(systemctl show \
       --property=LoadState --value proto-fleet-updater.service 2>/dev/null); then
     echo "❌ Could not inspect the host updater while disabling it." >&2
     UPDATER_CLEANUP_FAILED=1

--- a/deployment-files/install.sh
+++ b/deployment-files/install.sh
@@ -2,10 +2,15 @@
 set -euo pipefail
 
 DEPLOYMENT_DIR="deployment"
+DOWNLOAD_DIR=""
 UPDATER_BOOTSTRAP_DIR=""
 UPDATER_CLEANUP_FAILED=0
 UPDATER_PRIVILEGE=()
 UPDATER_PRIVILEGE_AVAILABLE=1
+UPDATER_DISABLE_ON_EXIT=0
+UPDATER_RESTART_ON_EXIT=0
+UPDATER_SOCKET_PATH="/run/proto-fleet-updater/updater.sock"
+UPDATER_VALIDATION_SOCKET_PATH="/run/proto-fleet-updater/installer-validation.sock"
 
 # Probe docker for an existing fleet-api container and return the install
 # directory inferred from its bind mount. Echoes the path on success; returns
@@ -576,6 +581,109 @@ prepare_existing_updater_service() {
   disable_updater_service_with ${UPDATER_PRIVILEGE[@]+"${UPDATER_PRIVILEGE[@]}"}
 }
 
+write_updater_environment_file() {
+  local target="$1"
+  local install_root="$2"
+  local download_base="$3"
+  local socket_path="$4"
+  local escaped_install escaped_download escaped_socket
+
+  escaped_install=${install_root//\\/\\\\}
+  escaped_install=${escaped_install//\"/\\\"}
+  escaped_download=${download_base//\\/\\\\}
+  escaped_download=${escaped_download//\"/\\\"}
+  escaped_socket=${socket_path//\\/\\\\}
+  escaped_socket=${escaped_socket//\"/\\\"}
+  {
+    printf 'PROTO_FLEET_INSTALL_ROOT="%s"\n' "$escaped_install"
+    printf 'PROTO_FLEET_DOWNLOAD_BASE_URL="%s/download"\n' "$escaped_download"
+    printf 'PROTO_FLEET_UPDATER_STATE_DIR="/var/lib/proto-fleet-updater"\n'
+    printf 'PROTO_FLEET_UPDATER_SOCKET_PATH="%s"\n' "$escaped_socket"
+    printf 'PROTO_FLEET_UPDATER_BINARY_PATH="/usr/local/libexec/proto-fleet/proto-fleet-updater"\n'
+  } > "$target"
+}
+
+restart_updater_service_with() {
+  local socket_path="$1"
+  shift
+  local privilege=("$@")
+  if ! ${privilege[@]+"${privilege[@]}"} systemctl restart \
+    proto-fleet-updater.service; then
+    return 1
+  fi
+
+  # Type=simple reports the restart as soon as the process is spawned. Wait
+  # for the updater to validate its privileged configuration and bind the
+  # secured API socket before considering it available to fleet-api.
+  local ready_deadline=$((SECONDS + 60))
+  while [ "$SECONDS" -lt "$ready_deadline" ]; do
+    if ${privilege[@]+"${privilege[@]}"} curl -fsS --max-time 1 \
+      --unix-socket "$socket_path" \
+      http://localhost/v1/status >/dev/null 2>&1 \
+      && ${privilege[@]+"${privilege[@]}"} systemctl is-active --quiet \
+        proto-fleet-updater.service; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "⚠️  Host updater did not become ready." >&2
+  return 1
+}
+
+# A manual install replaces the same deployment tree as the host updater.
+# Keep the enabled, validated service stopped while run-fleet operates so an
+# old fleet-api container cannot submit a concurrent upgrade through its
+# preserved socket mount. systemctl stop waits for the process and its
+# daemon-lifetime lock to exit; the checked state prevents a live listener
+# from being mistaken for a successful quiesce.
+quiesce_updater_service_for_manual_run_with() {
+  local privilege=("$@")
+  local active_state
+  if ! ${privilege[@]+"${privilege[@]}"} systemctl stop \
+    proto-fleet-updater.service; then
+    echo "⚠️  Could not stop the host updater before the manual deployment run." >&2
+    return 1
+  fi
+  if ! active_state=$(${privilege[@]+"${privilege[@]}"} systemctl show \
+      --property=ActiveState --value proto-fleet-updater.service 2>/dev/null); then
+    echo "⚠️  Could not verify the stopped host updater before the manual deployment run." >&2
+    return 1
+  fi
+  case "$active_state" in
+    inactive|failed) return 0 ;;
+    *)
+      echo "⚠️  Host updater remained active before the manual deployment run." >&2
+      return 1
+      ;;
+  esac
+}
+
+installer_exit_cleanup() {
+  local status=$?
+  trap - EXIT
+  if [ "${UPDATER_DISABLE_ON_EXIT:-0}" = "1" ]; then
+    echo "🔒 Disabling the host updater after interrupted validation..." >&2
+    if ! disable_updater_service_with \
+      ${UPDATER_PRIVILEGE[@]+"${UPDATER_PRIVILEGE[@]}"}; then
+      status=1
+    fi
+  fi
+  if [ "${UPDATER_RESTART_ON_EXIT:-0}" = "1" ]; then
+    echo "🔄 Restoring the host updater after the interrupted manual deployment..." >&2
+    if ! restart_updater_service_with "$UPDATER_SOCKET_PATH" \
+      ${UPDATER_PRIVILEGE[@]+"${UPDATER_PRIVILEGE[@]}"}; then
+      echo "❌ Could not restore the host updater after the manual deployment stopped." >&2
+      disable_updater_service_with \
+        ${UPDATER_PRIVILEGE[@]+"${UPDATER_PRIVILEGE[@]}"} || true
+      status=1
+    fi
+  fi
+  if [ -n "${DOWNLOAD_DIR:-}" ]; then
+    rm -rf -- "$DOWNLOAD_DIR"
+  fi
+  exit "$status"
+}
+
 # Match the Docker CLI environment the system service is guaranteed to use.
 # The unit also unsets these variables, so neither an invoking root shell nor
 # the systemd manager can redirect upgrades to a different daemon.
@@ -803,7 +911,7 @@ DOWNLOAD_DIR=$(mktemp -d /tmp/proto-fleet-install.XXXXXX) || {
   echo "❌ Could not create a private release-download directory." >&2
   exit 1
 }
-trap 'rm -rf -- "$DOWNLOAD_DIR"' EXIT
+trap installer_exit_cleanup EXIT
 chmod 700 "$DOWNLOAD_DIR" || {
   echo "❌ Could not secure the release-download directory." >&2
   exit 1
@@ -1089,23 +1197,17 @@ install_updater_service() {
     return 1
   fi
 
-  local env_temp escaped_install escaped_download
+  local env_temp
   if ! env_temp=$(mktemp); then
     echo "⚠️  Could not create the host updater environment file." >&2
     disable_updater_service_with ${privilege[@]+"${privilege[@]}"} || true
     return 1
   fi
-  escaped_install=${INSTALL_DIR//\\/\\\\}
-  escaped_install=${escaped_install//\"/\\\"}
-  escaped_download=${GITHUB_RELEASES_URL//\\/\\\\}
-  escaped_download=${escaped_download//\"/\\\"}
-  if ! {
-    printf 'PROTO_FLEET_INSTALL_ROOT="%s"\n' "$escaped_install"
-    printf 'PROTO_FLEET_DOWNLOAD_BASE_URL="%s/download"\n' "$escaped_download"
-    printf 'PROTO_FLEET_UPDATER_STATE_DIR="/var/lib/proto-fleet-updater"\n'
-    printf 'PROTO_FLEET_UPDATER_SOCKET_PATH="/run/proto-fleet-updater/updater.sock"\n'
-    printf 'PROTO_FLEET_UPDATER_BINARY_PATH="/usr/local/libexec/proto-fleet/proto-fleet-updater"\n'
-  } > "$env_temp"; then
+  # Validate against a socket name the old fleet-api does not know. Its
+  # preserved directory bind mount therefore cannot reach /v1/upgrade while
+  # the replacement updater is briefly running for its health check.
+  if ! write_updater_environment_file "$env_temp" "$INSTALL_DIR" \
+    "$GITHUB_RELEASES_URL" "$UPDATER_VALIDATION_SOCKET_PATH"; then
     echo "⚠️  Could not write the host updater environment file." >&2
     rm -f "$env_temp"
     disable_updater_service_with ${privilege[@]+"${privilege[@]}"} || true
@@ -1124,35 +1226,42 @@ install_updater_service() {
     disable_updater_service_with ${privilege[@]+"${privilege[@]}"} || true
     return 1
   fi
-  rm -f "$env_temp"
   if ! ${privilege[@]+"${privilege[@]}"} systemctl daemon-reload \
     || ! ${privilege[@]+"${privilege[@]}"} systemctl enable proto-fleet-updater.service; then
+    rm -f "$env_temp"
     disable_updater_service_with ${privilege[@]+"${privilege[@]}"} || true
     return 1
   fi
-  # The old updater was drained before extraction. Start the newly installed
-  # binary only after its unit and environment have been replaced atomically.
-  if ! ${privilege[@]+"${privilege[@]}"} systemctl restart proto-fleet-updater.service; then
+  UPDATER_DISABLE_ON_EXIT=1
+  if ! restart_updater_service_with "$UPDATER_VALIDATION_SOCKET_PATH" \
+    ${privilege[@]+"${privilege[@]}"}; then
+    rm -f "$env_temp"
     disable_updater_service_with ${privilege[@]+"${privilege[@]}"} || true
     return 1
   fi
-
-  # Type=simple reports the restart as soon as the process is spawned. Wait
-  # for the updater to finish validating its privileged configuration and
-  # bind the secured API socket before exposing that socket to fleet-api.
-  local ready_deadline=$((SECONDS + 60))
-  while [ "$SECONDS" -lt "$ready_deadline" ]; do
-    if ${privilege[@]+"${privilege[@]}"} curl -fsS --max-time 1 \
-      --unix-socket /run/proto-fleet-updater/updater.sock \
-      http://localhost/v1/status >/dev/null 2>&1 \
-      && ${privilege[@]+"${privilege[@]}"} systemctl is-active --quiet proto-fleet-updater.service; then
-      return 0
-    fi
-    sleep 1
-  done
-  echo "⚠️  Host updater did not become ready; keeping copy-command upgrades." >&2
-  disable_updater_service_with ${privilege[@]+"${privilege[@]}"} || true
-  return 1
+  if ! quiesce_updater_service_for_manual_run_with \
+    ${privilege[@]+"${privilege[@]}"}; then
+    rm -f "$env_temp"
+    disable_updater_service_with ${privilege[@]+"${privilege[@]}"} || true
+    return 1
+  fi
+  # The validated service is now stopped. Persist its production socket only
+  # after the temporary listener is gone, and do not start it until run-fleet
+  # has finished replacing the deployment.
+  if ! write_updater_environment_file "$env_temp" "$INSTALL_DIR" \
+      "$GITHUB_RELEASES_URL" "$UPDATER_SOCKET_PATH" \
+    || ! ${privilege[@]+"${privilege[@]}"} install -m 0600 \
+      "$env_temp" /etc/proto-fleet/updater.env; then
+    rm -f "$env_temp"
+    disable_updater_service_with ${privilege[@]+"${privilege[@]}"} || true
+    return 1
+  fi
+  rm -f "$env_temp"
+  # From this point until the explicit post-run restart, every unexpected exit
+  # must restore the validated service for the existing deployment.
+  UPDATER_DISABLE_ON_EXIT=0
+  UPDATER_RESTART_ON_EXIT=1
+  return 0
 }
 
 RUN_FLEET_ARGS=()
@@ -1166,7 +1275,7 @@ if [ "$PREVIOUS_TRACING" = "1" ]; then
   RUN_FLEET_ARGS+=(--enable-tracing)
 fi
 if install_updater_service; then
-  echo "✅ Host updater installed; one-click upgrades are enabled."
+  echo "✅ Host updater installed and validated; one-click upgrades will be enabled after deployment."
   RUN_FLEET_ARGS+=(--enable-one-click-updates)
 else
   # Keep every fallback fail-closed, including returns that happen before the
@@ -1181,6 +1290,7 @@ else
     echo "❌ Installation stopped because the host updater could not be left in a safe state." >&2
     exit 1
   fi
+  UPDATER_DISABLE_ON_EXIT=0
   echo "ℹ️  One-click upgrades are unavailable; the in-product copy command remains usable."
   RUN_FLEET_ARGS+=(--disable-one-click-updates)
 fi
@@ -1189,10 +1299,33 @@ echo "🔧 Running deployment script..."
 if [ "$NON_INTERACTIVE" = "1" ]; then
   RUN_FLEET_ARGS+=(--non-interactive)
 fi
-# run-fleet persists the selected overlay before later build/start work. If a
-# later deployment step fails, keep the already-verified updater service ready
-# so that persisted true state never points fleet-api at a dead socket. A fresh
-# installation cannot expose the socket until run-fleet successfully starts
-# the overlay; an existing socket-enabled deployment already owned this
-# service before the manual retry.
-./run-fleet.sh "${RUN_FLEET_ARGS[@]}"
+RUN_FLEET_STATUS=0
+if ./run-fleet.sh "${RUN_FLEET_ARGS[@]}"; then
+  RUN_FLEET_STATUS=0
+else
+  RUN_FLEET_STATUS=$?
+fi
+
+UPDATER_RESTART_FAILED=0
+if [ "$UPDATER_RESTART_ON_EXIT" = "1" ]; then
+  echo "🔄 Restoring the host updater after the manual deployment run..."
+  # run-fleet is finished, so the old API can no longer race this deployment.
+  # systemd owns the service lifecycle once the restart is issued.
+  UPDATER_RESTART_ON_EXIT=0
+  if restart_updater_service_with "$UPDATER_SOCKET_PATH" \
+    ${UPDATER_PRIVILEGE[@]+"${UPDATER_PRIVILEGE[@]}"}; then
+    :
+  else
+    echo "❌ Could not restore the host updater after the manual deployment run." >&2
+    disable_updater_service_with \
+      ${UPDATER_PRIVILEGE[@]+"${UPDATER_PRIVILEGE[@]}"} || true
+    UPDATER_RESTART_FAILED=1
+  fi
+fi
+
+if [ "$RUN_FLEET_STATUS" -ne 0 ]; then
+  exit "$RUN_FLEET_STATUS"
+fi
+if [ "$UPDATER_RESTART_FAILED" -ne 0 ]; then
+  exit 1
+fi

--- a/deployment-files/install.sh
+++ b/deployment-files/install.sh
@@ -1103,6 +1103,34 @@ complete_disabled_updater_fallback_after_run() {
   finalize_disabled_updater_fallback_if_persisted "$env_file"
 }
 
+run_disabled_updater_fallback() {
+  local runner="$1"
+  local env_file="$2"
+  shift 2
+  local argument
+  local fallback_args=()
+  local run_status=0
+
+  # Replace any earlier updater choice instead of relying on argument order.
+  # The remaining installer options still describe the deployment that just
+  # succeeded, so the fallback only changes the socket overlay.
+  for argument in "$@"; do
+    case "$argument" in
+      --enable-one-click-updates|--disable-one-click-updates) continue ;;
+      *) fallback_args+=("$argument") ;;
+    esac
+  done
+  fallback_args+=(--disable-one-click-updates)
+
+  if PROTO_FLEET_INSTALLER_MANAGED_RUN=1 \
+    "$runner" "${fallback_args[@]}"; then
+    run_status=0
+  else
+    run_status=$?
+  fi
+  complete_disabled_updater_fallback_after_run "$env_file" "$run_status"
+}
+
 reconcile_updater_after_failed_deployment() {
   local env_file="$1"
   local previous_state="$2"
@@ -2133,26 +2161,32 @@ if [ "$RUN_FLEET_STATUS" -ne 0 ]; then
   exit "$RUN_FLEET_STATUS"
 fi
 
-UPDATER_RESTART_FAILED=0
 if [ "$UPDATER_START_AFTER_RUN" = "1" ]; then
   echo "🔄 Starting the host updater after the manual deployment run..."
   # run-fleet is finished, so the old API can no longer race this deployment.
   # systemd owns the service lifecycle once the restart is issued.
-  UPDATER_DISABLE_ON_EXIT=0
-  UPDATER_RESTART_ON_EXIT=0
-  UPDATER_REENABLE_ON_EXIT=0
-  UPDATER_START_AFTER_RUN=0
   if restart_updater_service_with "$UPDATER_SOCKET_PATH" \
     ${UPDATER_PRIVILEGE[@]+"${UPDATER_PRIVILEGE[@]}"}; then
-    :
+    UPDATER_DISABLE_ON_EXIT=0
+    UPDATER_RESTART_ON_EXIT=0
+    UPDATER_REENABLE_ON_EXIT=0
+    UPDATER_START_AFTER_RUN=0
   else
-    echo "❌ Could not restore the host updater after the manual deployment run." >&2
+    echo "⚠️  The host updater did not become ready; redeploying without its socket overlay." >&2
     disable_updater_service_with \
       ${UPDATER_PRIVILEGE[@]+"${UPDATER_PRIVILEGE[@]}"} || true
-    UPDATER_RESTART_FAILED=1
+    # Never let EXIT retry a service that failed readiness. Keep disablement
+    # armed until run-fleet proves the copy-command fallback is active.
+    UPDATER_RESTART_ON_EXIT=0
+    UPDATER_REENABLE_ON_EXIT=0
+    UPDATER_START_AFTER_RUN=0
+    UPDATER_DISABLE_ON_EXIT=1
+    if ! run_disabled_updater_fallback \
+      ./run-fleet.sh "$INSTALL_DIR/$DEPLOYMENT_DIR/.env" \
+      "${RUN_FLEET_ARGS[@]}"; then
+      echo "❌ Could not deploy the copy-command fallback after the host updater failed readiness." >&2
+      exit 1
+    fi
+    echo "ℹ️  One-click upgrades are unavailable; the in-product copy command remains usable."
   fi
-fi
-
-if [ "$UPDATER_RESTART_FAILED" -ne 0 ]; then
-  exit 1
 fi

--- a/deployment-files/install.sh
+++ b/deployment-files/install.sh
@@ -12,6 +12,9 @@ UPDATER_REENABLE_ON_EXIT=0
 UPDATER_RESTART_ON_EXIT=0
 UPDATER_ENV_PATH="/etc/proto-fleet/updater.env"
 UPDATER_ENV_RESTORE_FILE=""
+UPDATER_BINARY_RESTORE_FILE=""
+UPDATER_UNIT_RESTORE_FILE=""
+UPDATER_ARTIFACT_RESTORE_PENDING=0
 UPDATER_BINARY_PATH="/usr/local/libexec/proto-fleet/proto-fleet-updater"
 UPDATER_UNIT_PATH="/etc/systemd/system/proto-fleet-updater.service"
 UPDATER_RUNTIME_DIR="/run/proto-fleet-updater"
@@ -679,6 +682,20 @@ canonical_existing_install_path() {
   printf '%s\n' "$canonical"
 }
 
+promote_selected_install_if_existing() {
+  local selected="$1"
+  local marker="${selected%/}/${DEPLOYMENT_DIR}/docker-compose.yaml"
+
+  [ -z "${PREVIOUS_INSTALL_DIR:-}" ] || return 0
+  if [ ! -e "$marker" ] && [ ! -L "$marker" ]; then
+    return 0
+  fi
+  if ! PREVIOUS_INSTALL_DIR=$(canonical_existing_install_path "$selected"); then
+    return 1
+  fi
+  echo "📁 No running fleet containers, but found selected install on disk at: ${PREVIOUS_INSTALL_DIR}"
+}
+
 resolve_selected_install_path() {
   local selected="$1"
   local discovered="${2:-}"
@@ -911,12 +928,81 @@ verify_existing_updater_ownership_with() {
   fi
 }
 
-restore_updater_environment_with() {
+backup_existing_updater_artifacts_with() {
   local privilege=("$@")
-  [ -n "${UPDATER_ENV_RESTORE_FILE:-}" ] || return 0
-  [ -f "$UPDATER_ENV_RESTORE_FILE" ] || return 1
-  ${privilege[@]+"${privilege[@]}"} install -m 0600 \
-    "$UPDATER_ENV_RESTORE_FILE" "$UPDATER_ENV_PATH"
+  local env_restore binary_restore unit_restore
+
+  [ -n "${DOWNLOAD_DIR:-}" ] || return 1
+  if [ -L "$UPDATER_ENV_PATH" ] || [ ! -f "$UPDATER_ENV_PATH" ] \
+    || [ -L "$UPDATER_BINARY_PATH" ] || [ ! -f "$UPDATER_BINARY_PATH" ] \
+    || [ -L "$UPDATER_UNIT_PATH" ] || [ ! -f "$UPDATER_UNIT_PATH" ]; then
+    echo "❌ Existing host updater artifacts must be regular, non-symlink files." >&2
+    return 1
+  fi
+  env_restore="${DOWNLOAD_DIR%/}/updater.env.previous"
+  binary_restore="${DOWNLOAD_DIR%/}/proto-fleet-updater.previous"
+  unit_restore="${DOWNLOAD_DIR%/}/proto-fleet-updater.service.previous"
+  if ! ${privilege[@]+"${privilege[@]}"} install -m 0600 \
+      "$UPDATER_ENV_PATH" "$env_restore" \
+    || ! ${privilege[@]+"${privilege[@]}"} install -m 0600 \
+      "$UPDATER_BINARY_PATH" "$binary_restore" \
+    || ! ${privilege[@]+"${privilege[@]}"} install -m 0600 \
+      "$UPDATER_UNIT_PATH" "$unit_restore"; then
+    echo "❌ Could not preserve the existing host updater artifacts." >&2
+    return 1
+  fi
+  UPDATER_ENV_RESTORE_FILE="$env_restore"
+  UPDATER_BINARY_RESTORE_FILE="$binary_restore"
+  UPDATER_UNIT_RESTORE_FILE="$unit_restore"
+  UPDATER_ARTIFACT_RESTORE_PENDING=1
+}
+
+atomic_restore_file_with() {
+  local source="$1"
+  local destination="$2"
+  local mode="$3"
+  shift 3
+  local privilege=("$@")
+  local temp
+
+  if ! temp=$(${privilege[@]+"${privilege[@]}"} \
+      mktemp "${destination}.restore.XXXXXX"); then
+    return 1
+  fi
+  if ! ${privilege[@]+"${privilege[@]}"} install -m "$mode" \
+      "$source" "$temp" \
+    || ! ${privilege[@]+"${privilege[@]}"} mv -f -- \
+      "$temp" "$destination"; then
+    ${privilege[@]+"${privilege[@]}"} rm -f -- "$temp" || true
+    return 1
+  fi
+}
+
+restore_updater_artifacts_with() {
+  local privilege=("$@")
+
+  [ "${UPDATER_ARTIFACT_RESTORE_PENDING:-0}" = "1" ] || return 0
+  if [ -L "$UPDATER_ENV_RESTORE_FILE" ] || [ ! -f "$UPDATER_ENV_RESTORE_FILE" ] \
+    || [ -L "$UPDATER_BINARY_RESTORE_FILE" ] || [ ! -f "$UPDATER_BINARY_RESTORE_FILE" ] \
+    || [ -L "$UPDATER_UNIT_RESTORE_FILE" ] || [ ! -f "$UPDATER_UNIT_RESTORE_FILE" ]; then
+    return 1
+  fi
+  # The service is stopped before this runs. Replace each file atomically, then
+  # make systemd load the restored unit before any old enablement or active
+  # state is reinstated.
+  if ! atomic_restore_file_with \
+      "$UPDATER_ENV_RESTORE_FILE" "$UPDATER_ENV_PATH" 0600 \
+      ${privilege[@]+"${privilege[@]}"} \
+    || ! atomic_restore_file_with \
+      "$UPDATER_BINARY_RESTORE_FILE" "$UPDATER_BINARY_PATH" 0755 \
+      ${privilege[@]+"${privilege[@]}"} \
+    || ! atomic_restore_file_with \
+      "$UPDATER_UNIT_RESTORE_FILE" "$UPDATER_UNIT_PATH" 0644 \
+      ${privilege[@]+"${privilege[@]}"} \
+    || ! ${privilege[@]+"${privilege[@]}"} systemctl daemon-reload; then
+    return 1
+  fi
+  UPDATER_ARTIFACT_RESTORE_PENDING=0
 }
 
 install_updater_bootstrap_files_with() {
@@ -1000,14 +1086,6 @@ prepare_existing_updater_service() {
     UPDATER_CLEANUP_FAILED=1
     return 1
   fi
-  local restore_file="${DOWNLOAD_DIR%/}/updater.env.previous"
-  if ! ${UPDATER_PRIVILEGE[@]+"${UPDATER_PRIVILEGE[@]}"} install -m 0600 \
-      "$UPDATER_ENV_PATH" "$restore_file"; then
-    echo "❌ Could not preserve the existing host updater configuration." >&2
-    UPDATER_CLEANUP_FAILED=1
-    return 1
-  fi
-  UPDATER_ENV_RESTORE_FILE="$restore_file"
   if ! active_state=$(systemctl show --property=ActiveState --value \
       proto-fleet-updater.service 2>/dev/null) \
     || ! unit_file_state=$(systemctl show --property=UnitFileState --value \
@@ -1022,6 +1100,13 @@ prepare_existing_updater_service() {
   arm_existing_updater_restoration "$active_state" "$unit_file_state"
   if ! disable_updater_service_with \
       ${UPDATER_PRIVILEGE[@]+"${UPDATER_PRIVILEGE[@]}"}; then
+    return 1
+  fi
+  # Snapshot a coherent stopped service. If the copy fails, the original host
+  # files are still untouched and EXIT cleanup can restart them directly.
+  if ! backup_existing_updater_artifacts_with \
+      ${UPDATER_PRIVILEGE[@]+"${UPDATER_PRIVILEGE[@]}"}; then
+    UPDATER_CLEANUP_FAILED=1
     return 1
   fi
   return 0
@@ -1120,11 +1205,11 @@ installer_exit_cleanup() {
     echo "❌ Could not remove the private updater validation runtime." >&2
     status=1
   fi
-  if [ -n "${UPDATER_ENV_RESTORE_FILE:-}" ]; then
-    echo "🔄 Restoring the prior host updater configuration..." >&2
-    if ! restore_updater_environment_with \
+  if [ "${UPDATER_ARTIFACT_RESTORE_PENDING:-0}" = "1" ]; then
+    echo "🔄 Restoring the prior host updater artifacts..." >&2
+    if ! restore_updater_artifacts_with \
         ${UPDATER_PRIVILEGE[@]+"${UPDATER_PRIVILEGE[@]}"}; then
-      echo "❌ Could not restore the prior host updater configuration." >&2
+      echo "❌ Could not restore the prior host updater artifacts." >&2
       UPDATER_REENABLE_ON_EXIT=0
       UPDATER_RESTART_ON_EXIT=0
       status=1
@@ -1148,7 +1233,9 @@ installer_exit_cleanup() {
       status=1
     fi
   fi
-  if [ -n "${DOWNLOAD_DIR:-}" ]; then
+  if [ "${UPDATER_ARTIFACT_RESTORE_PENDING:-0}" = "1" ]; then
+    echo "⚠️  Preserving updater rollback artifacts after failed restoration: $DOWNLOAD_DIR" >&2
+  elif [ -n "${DOWNLOAD_DIR:-}" ]; then
     rm -rf -- "$DOWNLOAD_DIR"
   fi
   exit "$status"
@@ -1562,6 +1649,9 @@ case "$INSTALL_DIR" in
     ;;
 esac
 
+if ! promote_selected_install_if_existing "$INSTALL_DIR"; then
+  exit 1
+fi
 if ! INSTALL_DIR=$(resolve_selected_install_path "$INSTALL_DIR" "${PREVIOUS_INSTALL_DIR:-}"); then
   exit 1
 fi
@@ -1771,6 +1861,9 @@ install_updater_service() {
   # installation root. Interrupted cleanup can safely restart it without
   # restoring the pre-validation file.
   UPDATER_ENV_RESTORE_FILE=""
+  UPDATER_BINARY_RESTORE_FILE=""
+  UPDATER_UNIT_RESTORE_FILE=""
+  UPDATER_ARTIFACT_RESTORE_PENDING=0
   UPDATER_REENABLE_ON_EXIT=0
   # From this point until the explicit post-run restart, every unexpected exit
   # must restore the validated service for the existing deployment.

--- a/deployment-files/install.sh
+++ b/deployment-files/install.sh
@@ -10,6 +10,8 @@ UPDATER_PRIVILEGE_AVAILABLE=1
 UPDATER_DISABLE_ON_EXIT=0
 UPDATER_REENABLE_ON_EXIT=0
 UPDATER_RESTART_ON_EXIT=0
+UPDATER_ENV_PATH="/etc/proto-fleet/updater.env"
+UPDATER_ENV_RESTORE_FILE=""
 UPDATER_SOCKET_PATH="/run/proto-fleet-updater/updater.sock"
 UPDATER_VALIDATION_SOCKET_PATH="/run/proto-fleet-updater/installer-validation.sock"
 UPDATER_DOCKER_HOST="unix:///var/run/docker.sock"
@@ -685,10 +687,11 @@ resolve_selected_install_path() {
     prepare_fresh_install_path "$selected"
     return $?
   fi
-  canonical_discovered=$(cd "$discovered" 2>/dev/null && pwd -P) || {
-    echo "❌ Discovered installation path cannot be accessed: $discovered" >&2
-    return 1
-  }
+  # Docker proves which deployment tree is active, but not who owns that
+  # tree. Apply the same administrator-bound ownership, permission, and
+  # non-symlink checks used for stopped on-disk installations before a root
+  # updater is allowed to trust it.
+  canonical_discovered=$(canonical_existing_install_path "$discovered") || return 1
   canonical_selected=$(cd "$selected" 2>/dev/null && pwd -P) || {
     echo "❌ An existing Proto Fleet installation was discovered at ${canonical_discovered}." >&2
     echo "   The selected path ${selected} does not resolve to that installation." >&2
@@ -833,10 +836,89 @@ arm_existing_updater_restoration() {
   esac
 }
 
+parse_updater_install_root() {
+  local contents="$1"
+  local key_re='^[[:space:]]*PROTO_FLEET_INSTALL_ROOT[[:space:]]*='
+  local assignment_re='^PROTO_FLEET_INSTALL_ROOT="(([^"\\]|\\["\\])*)"$'
+  local line encoded decoded char
+  local found=0
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    [[ "$line" =~ $key_re ]] || continue
+    [ "$found" -eq 0 ] || return 1
+    [[ "$line" =~ $assignment_re ]] || return 1
+    encoded="${BASH_REMATCH[1]}"
+    decoded=""
+    while [ -n "$encoded" ]; do
+      char="${encoded:0:1}"
+      encoded="${encoded:1}"
+      if [ "$char" = '\' ]; then
+        [ -n "$encoded" ] || return 1
+        char="${encoded:0:1}"
+        encoded="${encoded:1}"
+        [ "$char" = '\' ] || [ "$char" = '"' ] || return 1
+      fi
+      decoded="${decoded}${char}"
+    done
+    [ -n "$decoded" ] || return 1
+    found=1
+  done <<< "$contents"
+
+  [ "$found" -eq 1 ] || return 1
+  printf '%s\n' "$decoded"
+}
+
+read_updater_install_root_with() {
+  local privilege=("$@")
+  local contents
+  if ! contents=$(${privilege[@]+"${privilege[@]}"} \
+      cat -- "$UPDATER_ENV_PATH" 2>/dev/null); then
+    return 1
+  fi
+  parse_updater_install_root "$contents"
+}
+
+verify_existing_updater_ownership_with() {
+  local selected_root="$1"
+  shift
+  local privilege=("$@")
+  local configured_root configured_resolved selected_resolved
+  if ! configured_root=$(read_updater_install_root_with \
+      ${privilege[@]+"${privilege[@]}"}); then
+    echo "❌ Could not read a valid install root from the existing host updater configuration." >&2
+    echo "   Refusing to replace the global updater; repair or uninstall it first." >&2
+    return 1
+  fi
+  configured_resolved=$(cd "$configured_root" 2>/dev/null && pwd -P) || {
+    echo "❌ Existing host updater install root cannot be resolved: $configured_root" >&2
+    return 1
+  }
+  selected_resolved=$(cd "$selected_root" 2>/dev/null && pwd -P) || {
+    echo "❌ Selected installation root cannot be resolved: $selected_root" >&2
+    return 1
+  }
+  if [ "${configured_resolved%/}" != "${selected_resolved%/}" ]; then
+    echo "❌ The global host updater belongs to a different Proto Fleet installation." >&2
+    echo "   Updater install root: $configured_resolved" >&2
+    echo "   Selected install root: $selected_resolved" >&2
+    echo "   Relocation is not supported; uninstall the existing deployment before installing elsewhere." >&2
+    return 1
+  fi
+}
+
+restore_updater_environment_with() {
+  local privilege=("$@")
+  [ -n "${UPDATER_ENV_RESTORE_FILE:-}" ] || return 0
+  [ -f "$UPDATER_ENV_RESTORE_FILE" ] || return 1
+  ${privilege[@]+"${privilege[@]}"} install -m 0600 \
+    "$UPDATER_ENV_RESTORE_FILE" "$UPDATER_ENV_PATH"
+}
+
 # Stop the existing updater before the release tree can be replaced. systemd's
 # inactive state proves the supervised process has exited, which also releases
 # the updater's lifetime flock. A missing unit needs no privilege or prompt.
 prepare_existing_updater_service() {
+  local selected_root="$1"
   if [ "$(uname -s)" != "Linux" ] \
     || ! command -v systemctl >/dev/null 2>&1 \
     || [ ! -d /run/systemd/system ]; then
@@ -858,6 +940,19 @@ prepare_existing_updater_service() {
     UPDATER_CLEANUP_FAILED=1
     return 1
   fi
+  if ! verify_existing_updater_ownership_with "$selected_root" \
+      ${UPDATER_PRIVILEGE[@]+"${UPDATER_PRIVILEGE[@]}"}; then
+    UPDATER_CLEANUP_FAILED=1
+    return 1
+  fi
+  local restore_file="${DOWNLOAD_DIR%/}/updater.env.previous"
+  if ! ${UPDATER_PRIVILEGE[@]+"${UPDATER_PRIVILEGE[@]}"} install -m 0600 \
+      "$UPDATER_ENV_PATH" "$restore_file"; then
+    echo "❌ Could not preserve the existing host updater configuration." >&2
+    UPDATER_CLEANUP_FAILED=1
+    return 1
+  fi
+  UPDATER_ENV_RESTORE_FILE="$restore_file"
   if ! active_state=$(systemctl show --property=ActiveState --value \
       proto-fleet-updater.service 2>/dev/null) \
     || ! unit_file_state=$(systemctl show --property=UnitFileState --value \
@@ -961,6 +1056,16 @@ installer_exit_cleanup() {
     echo "🔒 Disabling the host updater after interrupted validation..." >&2
     if ! disable_updater_service_with \
       ${UPDATER_PRIVILEGE[@]+"${UPDATER_PRIVILEGE[@]}"}; then
+      status=1
+    fi
+  fi
+  if [ -n "${UPDATER_ENV_RESTORE_FILE:-}" ]; then
+    echo "🔄 Restoring the prior host updater configuration..." >&2
+    if ! restore_updater_environment_with \
+        ${UPDATER_PRIVILEGE[@]+"${UPDATER_PRIVILEGE[@]}"}; then
+      echo "❌ Could not restore the prior host updater configuration." >&2
+      UPDATER_REENABLE_ON_EXIT=0
+      UPDATER_RESTART_ON_EXIT=0
       status=1
     fi
   fi
@@ -1431,7 +1536,7 @@ fi
 # Drain and disable the service before extraction so those writers can never
 # overlap. Any failure here leaves the existing Fleet containers untouched.
 resolve_updater_privilege
-if ! prepare_existing_updater_service; then
+if ! prepare_existing_updater_service "$INSTALL_DIR"; then
   echo "❌ Existing host updater could not be stopped safely; no files were replaced." >&2
   exit 1
 fi
@@ -1547,7 +1652,7 @@ install_updater_service() {
   fi
   if ! ${privilege[@]+"${privilege[@]}"} install -m 0755 "$UPDATER_BOOTSTRAP_DIR/proto-fleet-updater" /usr/local/libexec/proto-fleet/proto-fleet-updater \
     || ! ${privilege[@]+"${privilege[@]}"} install -m 0644 "$UPDATER_BOOTSTRAP_DIR/proto-fleet-updater.service" /etc/systemd/system/proto-fleet-updater.service \
-    || ! ${privilege[@]+"${privilege[@]}"} install -m 0600 "$env_temp" /etc/proto-fleet/updater.env; then
+    || ! ${privilege[@]+"${privilege[@]}"} install -m 0600 "$env_temp" "$UPDATER_ENV_PATH"; then
     rm -f "$env_temp"
     disable_updater_service_with ${privilege[@]+"${privilege[@]}"} || true
     return 1
@@ -1580,12 +1685,16 @@ install_updater_service() {
   if ! write_updater_environment_file "$env_temp" "$INSTALL_DIR" \
       "$GITHUB_RELEASES_URL" "$UPDATER_SOCKET_PATH" \
     || ! ${privilege[@]+"${privilege[@]}"} install -m 0600 \
-      "$env_temp" /etc/proto-fleet/updater.env; then
+      "$env_temp" "$UPDATER_ENV_PATH"; then
     rm -f "$env_temp"
     disable_updater_service_with ${privilege[@]+"${privilege[@]}"} || true
     return 1
   fi
   rm -f "$env_temp"
+  # The replacement now has a production configuration for the same validated
+  # installation root. Interrupted cleanup can safely restart it without
+  # restoring the pre-validation file.
+  UPDATER_ENV_RESTORE_FILE=""
   # From this point until the explicit post-run restart, every unexpected exit
   # must restore the validated service for the existing deployment.
   UPDATER_DISABLE_ON_EXIT=0

--- a/deployment-files/install.sh
+++ b/deployment-files/install.sh
@@ -2,6 +2,10 @@
 set -euo pipefail
 
 DEPLOYMENT_DIR="deployment"
+UPDATER_BOOTSTRAP_DIR=""
+UPDATER_CLEANUP_FAILED=0
+UPDATER_PRIVILEGE=()
+UPDATER_PRIVILEGE_AVAILABLE=1
 
 # Probe docker for an existing fleet-api container and return the install
 # directory inferred from its bind mount. Echoes the path on success; returns
@@ -390,7 +394,169 @@ capture_previous_run_options() {
   [ "$tracing_state" != "missing" ] || [ "$inferred_tracing" != "true" ] || PREVIOUS_TRACING=1
 }
 
-# END INSTALL DISCOVERY AND LEGACY MIGRATION HELPERS
+resolve_selected_install_path() {
+  local selected="$1"
+  local discovered="${2:-}"
+  local canonical_selected canonical_discovered
+
+  [ -n "$selected" ] || {
+    echo "❌ Installation path cannot be empty." >&2
+    return 1
+  }
+  # A fresh path has nothing to compare yet and is made absolute after
+  # extraction. When Docker or the on-disk fallback found an installation,
+  # both paths already exist and can be canonicalized without filesystem
+  # mutation or non-portable realpath flags.
+  if [ -z "$discovered" ]; then
+    printf '%s' "$selected"
+    return 0
+  fi
+  canonical_discovered=$(cd "$discovered" 2>/dev/null && pwd -P) || {
+    echo "❌ Discovered installation path cannot be accessed: $discovered" >&2
+    return 1
+  }
+  canonical_selected=$(cd "$selected" 2>/dev/null && pwd -P) || {
+    echo "❌ An existing Proto Fleet installation was discovered at ${canonical_discovered}." >&2
+    echo "   The selected path ${selected} does not resolve to that installation." >&2
+    echo "   Relocation is not supported; use the discovered installation path or uninstall it first." >&2
+    return 1
+  }
+  if [ "$canonical_selected" != "$canonical_discovered" ]; then
+    echo "❌ An existing Proto Fleet installation was discovered at ${canonical_discovered}." >&2
+    echo "   Installing to ${canonical_selected} would target the same default Compose project from a different directory." >&2
+    echo "   Relocation is not supported; use the discovered installation path or uninstall it first." >&2
+    return 1
+  fi
+  printf '%s' "$canonical_selected"
+}
+
+# Keep the privileged bootstrap payload inside the private, checksum-verified
+# download directory. The deployment tree is operator-controlled after
+# extraction, so it must never be the source for files copied into /etc or
+# /usr/local and then executed by systemd as root.
+extract_updater_bootstrap() {
+  local tar_path="$1"
+  local target_dir="$2"
+  local binary="$target_dir/proto-fleet-updater"
+  local unit="$target_dir/proto-fleet-updater.service"
+
+  mkdir -m 0700 "$target_dir" || return 1
+  if ! tar --no-same-owner --strip-components=2 -xzf "$tar_path" -C "$target_dir" \
+    deployment/updater/proto-fleet-updater \
+    deployment/updater/proto-fleet-updater.service; then
+    return 1
+  fi
+  if [ -L "$binary" ] || [ ! -f "$binary" ] || [ ! -x "$binary" ] \
+    || [ -L "$unit" ] || [ ! -f "$unit" ]; then
+    echo "⚠️  The release host-updater bootstrap payload is invalid." >&2
+    return 1
+  fi
+}
+
+disable_updater_service_with() {
+  local privilege=("$@")
+  local load_state active_state unit_file_state
+  command -v systemctl >/dev/null 2>&1 || return 0
+
+  # A missing unit is already safe. For a known unit, query final state with
+  # checked commands so a sudo/systemctl failure cannot masquerade as
+  # inactive merely because `is-active` returned nonzero.
+  if ! load_state=$(${privilege[@]+"${privilege[@]}"} systemctl show \
+      --property=LoadState --value proto-fleet-updater.service 2>/dev/null); then
+    echo "❌ Could not inspect the host updater while disabling it." >&2
+    UPDATER_CLEANUP_FAILED=1
+    return 1
+  fi
+  if [ "$load_state" = "not-found" ]; then
+    return 0
+  fi
+
+  ${privilege[@]+"${privilege[@]}"} systemctl disable --now \
+    proto-fleet-updater.service >/dev/null 2>&1 || true
+  if ! active_state=$(${privilege[@]+"${privilege[@]}"} systemctl show \
+      --property=ActiveState --value proto-fleet-updater.service 2>/dev/null) \
+    || ! unit_file_state=$(${privilege[@]+"${privilege[@]}"} systemctl show \
+      --property=UnitFileState --value proto-fleet-updater.service 2>/dev/null); then
+    echo "❌ Could not stop and disable the host updater safely." >&2
+    UPDATER_CLEANUP_FAILED=1
+    return 1
+  fi
+  case "$active_state" in
+    inactive|failed) ;;
+    *)
+      echo "❌ Could not stop and disable the host updater safely." >&2
+      UPDATER_CLEANUP_FAILED=1
+      return 1
+      ;;
+  esac
+  case "$unit_file_state" in
+    disabled|masked|masked-runtime|static) ;;
+    *)
+      echo "❌ Could not stop and disable the host updater safely." >&2
+      UPDATER_CLEANUP_FAILED=1
+      return 1
+      ;;
+  esac
+  return 0
+}
+
+resolve_updater_privilege() {
+  UPDATER_PRIVILEGE=()
+  UPDATER_PRIVILEGE_AVAILABLE=1
+  if [ "$(id -u)" -eq 0 ]; then
+    return 0
+  fi
+  if ! command -v sudo >/dev/null 2>&1; then
+    UPDATER_PRIVILEGE_AVAILABLE=0
+    return 0
+  fi
+  if [ "$NON_INTERACTIVE" = "1" ]; then
+    UPDATER_PRIVILEGE=(sudo -n)
+  else
+    UPDATER_PRIVILEGE=(sudo)
+  fi
+}
+
+# Stop the existing updater before the release tree can be replaced. systemd's
+# inactive state proves the supervised process has exited, which also releases
+# the updater's lifetime flock. A missing unit needs no privilege or prompt.
+prepare_existing_updater_service() {
+  if [ "$(uname -s)" != "Linux" ] \
+    || ! command -v systemctl >/dev/null 2>&1 \
+    || [ ! -d /run/systemd/system ]; then
+    return 0
+  fi
+
+  local load_state
+  if ! load_state=$(systemctl show --property=LoadState --value \
+      proto-fleet-updater.service 2>/dev/null); then
+    echo "❌ Could not inspect the existing host updater before installation." >&2
+    UPDATER_CLEANUP_FAILED=1
+    return 1
+  fi
+  if [ "$load_state" = "not-found" ]; then
+    return 0
+  fi
+  if [ "$UPDATER_PRIVILEGE_AVAILABLE" != "1" ]; then
+    echo "❌ The existing host updater must be stopped, but sudo is unavailable." >&2
+    UPDATER_CLEANUP_FAILED=1
+    return 1
+  fi
+  disable_updater_service_with ${UPDATER_PRIVILEGE[@]+"${UPDATER_PRIVILEGE[@]}"}
+}
+
+# Match the Docker CLI environment the system service is guaranteed to use.
+# The unit also unsets these variables, so neither an invoking root shell nor
+# the systemd manager can redirect upgrades to a different daemon.
+service_docker_id_with() {
+  local privilege=("$@")
+  (
+    unset DOCKER_HOST DOCKER_CONTEXT DOCKER_CONFIG DOCKER_TLS DOCKER_TLS_VERIFY DOCKER_CERT_PATH
+    ${privilege[@]+"${privilege[@]}"} docker info --format '{{.ID}}' 2>/dev/null || true
+  )
+}
+
+# END INSTALLER TESTABLE HELPERS
 
 # Function to extract files to the installation directory and cd to it
 extract_and_cd() {
@@ -404,11 +570,14 @@ extract_and_cd() {
   mkdir -p "$target_dir"
   
   # Check if we need to preserve existing .env file
+  # Never preserve the release builder's numeric UID/GID. Files should belong
+  # to the invoking install administrator (or root for a root-run install),
+  # matching the updater's root-plus-one-admin ownership trust model.
   if [ -f "$env_file" ]; then
     echo "📦 Preserving existing $env_file file"
-    tar -xzvf "$tar_path" -C "$target_dir" --exclude="${DEPLOYMENT_DIR}/server/influx_config/.env"
+    tar --no-same-owner -xzvf "$tar_path" -C "$target_dir" --exclude="${DEPLOYMENT_DIR}/server/influx_config/.env"
   else
-    tar -xzvf "$tar_path" -C "$target_dir"
+    tar --no-same-owner -xzvf "$tar_path" -C "$target_dir"
   fi
   
   # Clean up the tarball
@@ -642,6 +811,12 @@ else
 fi
 rm -f "${CHECKSUM_PATH}"
 
+UPDATER_BOOTSTRAP_DIR="${DOWNLOAD_DIR}/updater-bootstrap"
+if ! extract_updater_bootstrap "$TAR_PATH" "$UPDATER_BOOTSTRAP_DIR"; then
+  echo "ℹ️  This release has no valid host-updater bootstrap payload; one-click upgrades will remain disabled."
+  UPDATER_BOOTSTRAP_DIR=""
+fi
+
 # Function to determine default installation directory based on OS.
 # When invoked under sudo on Linux, prefer the invoking user's home over
 # /root — fleet is normally installed under the user account, and falling
@@ -761,16 +936,20 @@ else
   fi
 fi
 
-if [ "$NON_INTERACTIVE" = "1" ] && [ ! -f "${INSTALL_DIR}/${DEPLOYMENT_DIR}/.env" ]; then
-  echo "❌ Non-interactive mode requires an existing configured deployment at ${INSTALL_DIR}/${DEPLOYMENT_DIR}." >&2
-  exit 1
-fi
 case "$INSTALL_DIR" in
   *$'\n'*|*$'\r'*)
     echo "❌ Installation paths cannot contain newline characters." >&2
     exit 1
     ;;
 esac
+
+if ! INSTALL_DIR=$(resolve_selected_install_path "$INSTALL_DIR" "${PREVIOUS_INSTALL_DIR:-}"); then
+  exit 1
+fi
+if [ "$NON_INTERACTIVE" = "1" ] && [ ! -f "${INSTALL_DIR}/${DEPLOYMENT_DIR}/.env" ]; then
+  echo "❌ Non-interactive mode requires an existing configured deployment at ${INSTALL_DIR}/${DEPLOYMENT_DIR}." >&2
+  exit 1
+fi
 
 echo "📌 Will install to: ${INSTALL_DIR}"
 
@@ -788,6 +967,15 @@ fi
 if ! capture_previous_run_options "$INSTALL_DIR" "$EXISTING_DEPLOYMENT" \
   ${CAPTURE_PRIVILEGE[@]+"${CAPTURE_PRIVILEGE[@]}"}; then
   echo "❌ Existing deployment options could not be migrated safely; no files were replaced." >&2
+  exit 1
+fi
+
+# A manual install and the privileged updater both replace the deployment tree.
+# Drain and disable the service before extraction so those writers can never
+# overlap. Any failure here leaves the existing Fleet containers untouched.
+resolve_updater_privilege
+if ! prepare_existing_updater_service; then
+  echo "❌ Existing host updater could not be stopped safely; no files were replaced." >&2
   exit 1
 fi
 
@@ -822,55 +1010,6 @@ for plugin in "${REQUIRED_PLUGINS[@]}"; do
 done
 echo "✅ Plugin binaries validated"
 
-UPDATER_CLEANUP_FAILED=0
-
-disable_updater_service_with() {
-  local privilege=("$@")
-  local load_state active_state unit_file_state
-  command -v systemctl >/dev/null 2>&1 || return 0
-
-  # A missing unit is already safe. For a known unit, query final state with
-  # checked commands so a sudo/systemctl failure cannot masquerade as
-  # inactive merely because `is-active` returned nonzero.
-  if ! load_state=$(${privilege[@]+"${privilege[@]}"} systemctl show \
-      --property=LoadState --value proto-fleet-updater.service 2>/dev/null); then
-    echo "❌ Could not inspect the host updater while disabling it." >&2
-    UPDATER_CLEANUP_FAILED=1
-    return 1
-  fi
-  if [ "$load_state" = "not-found" ]; then
-    return 0
-  fi
-
-  ${privilege[@]+"${privilege[@]}"} systemctl disable --now \
-    proto-fleet-updater.service >/dev/null 2>&1 || true
-  if ! active_state=$(${privilege[@]+"${privilege[@]}"} systemctl show \
-      --property=ActiveState --value proto-fleet-updater.service 2>/dev/null) \
-    || ! unit_file_state=$(${privilege[@]+"${privilege[@]}"} systemctl show \
-      --property=UnitFileState --value proto-fleet-updater.service 2>/dev/null); then
-    echo "❌ Could not stop and disable the host updater safely." >&2
-    UPDATER_CLEANUP_FAILED=1
-    return 1
-  fi
-  case "$active_state" in
-    inactive|failed) ;;
-    *)
-      echo "❌ Could not stop and disable the host updater safely." >&2
-      UPDATER_CLEANUP_FAILED=1
-      return 1
-      ;;
-  esac
-  case "$unit_file_state" in
-    disabled|masked|masked-runtime|static) ;;
-    *)
-      echo "❌ Could not stop and disable the host updater safely." >&2
-      UPDATER_CLEANUP_FAILED=1
-      return 1
-      ;;
-  esac
-  return 0
-}
-
 install_updater_service() {
   if [ "$(uname -s)" != "Linux" ]; then
     return 1
@@ -885,28 +1024,28 @@ install_updater_service() {
       return 1
       ;;
   esac
-  if [ ! -x "updater/proto-fleet-updater" ] || [ ! -f "updater/proto-fleet-updater.service" ]; then
+  if [ -z "$UPDATER_BOOTSTRAP_DIR" ] \
+    || [ -L "$UPDATER_BOOTSTRAP_DIR/proto-fleet-updater" ] \
+    || [ ! -x "$UPDATER_BOOTSTRAP_DIR/proto-fleet-updater" ] \
+    || [ -L "$UPDATER_BOOTSTRAP_DIR/proto-fleet-updater.service" ] \
+    || [ ! -f "$UPDATER_BOOTSTRAP_DIR/proto-fleet-updater.service" ]; then
     echo "⚠️  This release does not contain the host updater payload."
     return 1
   fi
 
   local privilege=()
-  if [ "$(id -u)" -ne 0 ]; then
-    command -v sudo >/dev/null 2>&1 || {
-      echo "⚠️  sudo is unavailable; one-click upgrades cannot be enabled."
-      return 1
-    }
-    if [ "$NON_INTERACTIVE" = "1" ]; then
-      privilege=(sudo -n)
-    else
-      privilege=(sudo)
-    fi
+  if [ "$UPDATER_PRIVILEGE_AVAILABLE" != "1" ]; then
+    echo "⚠️  sudo is unavailable; one-click upgrades cannot be enabled."
+    return 1
+  fi
+  if (( ${#UPDATER_PRIVILEGE[@]} )); then
+    privilege=("${UPDATER_PRIVILEGE[@]}")
   fi
 
-  # The service runs as root. Only enable it when root sees the same Docker
-  # daemon as the current installation; rootless Docker needs a future
-  # user-service adapter and must keep the manual fallback.
-  local current_docker_id root_docker_id attempt
+  # The service runs with Docker selector variables removed. Only enable it
+  # when that exact environment sees the same daemon as the current install;
+  # rootless/custom-daemon support needs a future service adapter.
+  local current_docker_id service_docker_id attempt
   current_docker_id=$(docker info --format '{{.ID}}' 2>/dev/null || true)
   if [ -z "$current_docker_id" ] && command -v docker >/dev/null 2>&1; then
     # Docker is an installer prerequisite, but tolerate an installed rootful
@@ -920,9 +1059,9 @@ install_updater_service() {
       sleep 0.25
     done
   fi
-  root_docker_id=$(${privilege[@]+"${privilege[@]}"} docker info --format '{{.ID}}' 2>/dev/null || true)
-  if [ -z "$current_docker_id" ] || [ "$current_docker_id" != "$root_docker_id" ]; then
-    echo "ℹ️  Root does not manage this installation's Docker daemon; keeping copy-command upgrades."
+  service_docker_id=$(service_docker_id_with ${privilege[@]+"${privilege[@]}"})
+  if [ -z "$current_docker_id" ] || [ "$current_docker_id" != "$service_docker_id" ]; then
+    echo "ℹ️  The host updater service does not manage this installation's Docker daemon; keeping copy-command upgrades."
     disable_updater_service_with ${privilege[@]+"${privilege[@]}"} || true
     return 1
   fi
@@ -955,8 +1094,8 @@ install_updater_service() {
     disable_updater_service_with ${privilege[@]+"${privilege[@]}"} || true
     return 1
   fi
-  if ! ${privilege[@]+"${privilege[@]}"} install -m 0755 updater/proto-fleet-updater /usr/local/libexec/proto-fleet/proto-fleet-updater \
-    || ! ${privilege[@]+"${privilege[@]}"} install -m 0644 updater/proto-fleet-updater.service /etc/systemd/system/proto-fleet-updater.service \
+  if ! ${privilege[@]+"${privilege[@]}"} install -m 0755 "$UPDATER_BOOTSTRAP_DIR/proto-fleet-updater" /usr/local/libexec/proto-fleet/proto-fleet-updater \
+    || ! ${privilege[@]+"${privilege[@]}"} install -m 0644 "$UPDATER_BOOTSTRAP_DIR/proto-fleet-updater.service" /etc/systemd/system/proto-fleet-updater.service \
     || ! ${privilege[@]+"${privilege[@]}"} install -m 0600 "$env_temp" /etc/proto-fleet/updater.env; then
     rm -f "$env_temp"
     disable_updater_service_with ${privilege[@]+"${privilege[@]}"} || true
@@ -968,9 +1107,8 @@ install_updater_service() {
     disable_updater_service_with ${privilege[@]+"${privilege[@]}"} || true
     return 1
   fi
-  # A manual install can safely restart an already-running updater; the
-  # updater-driven path never invokes install.sh and refreshes its on-disk
-  # binary for the next service start instead.
+  # The old updater was drained before extraction. Start the newly installed
+  # binary only after its unit and environment have been replaced atomically.
   if ! ${privilege[@]+"${privilege[@]}"} systemctl restart proto-fleet-updater.service; then
     disable_updater_service_with ${privilege[@]+"${privilege[@]}"} || true
     return 1
@@ -1008,6 +1146,14 @@ if install_updater_service; then
   echo "✅ Host updater installed; one-click upgrades are enabled."
   RUN_FLEET_ARGS+=(--enable-one-click-updates)
 else
+  # Keep every fallback fail-closed, including returns that happen before the
+  # service payload is copied. Unsupported non-systemd hosts have no system
+  # updater to reconcile.
+  if [ "$(uname -s)" = "Linux" ] \
+    && command -v systemctl >/dev/null 2>&1 \
+    && [ -d /run/systemd/system ]; then
+    disable_updater_service_with ${UPDATER_PRIVILEGE[@]+"${UPDATER_PRIVILEGE[@]}"} || true
+  fi
   if [ "$UPDATER_CLEANUP_FAILED" = "1" ]; then
     echo "❌ Installation stopped because the host updater could not be left in a safe state." >&2
     exit 1

--- a/deployment-files/install.sh
+++ b/deployment-files/install.sh
@@ -675,13 +675,10 @@ get_default_install_dir() {
 }
 
 echo "🔍 Checking for previous ProtoFleet installations via Docker..."
-if [ -z "$REQUESTED_INSTALL_DIR" ]; then
-  detect_previous_install || true
-else
-  PREVIOUS_INSTALL_DIR=""
-  PREVIOUS_INSTALL_NEEDS_SUDO=0
-  PREVIOUS_INSTALL_SUDO_BLOCKED=0
-fi
+# An explicit target controls the destination, not the Docker ownership
+# boundary. Always probe both daemon contexts before replacing files so
+# --install-dir cannot bypass the root-daemon mismatch guard.
+detect_previous_install || true
 DEFAULT_INSTALL_DIR=$(get_default_install_dir)
 
 # If the existing containers were only visible via `sudo docker`, this script

--- a/deployment-files/install.sh
+++ b/deployment-files/install.sh
@@ -177,10 +177,16 @@ extract_and_cd() {
 
 usage() {
   cat <<EOF
-Usage: install.sh [VERSION]
+Usage: install.sh [options] [VERSION]
 
 If you omit VERSION or pass "latest", installs the latest GitHub release.
 Pass "nightly" to install the latest successful nightly prerelease.
+Options:
+  --install-dir PATH       Use PATH without prompting.
+  --non-interactive        Fail instead of prompting; for an existing install
+                           with a complete deployment .env.
+  --skip-updater-service   Do not install/reconfigure the host updater.
+                           Reserved for updater-driven internal workflows.
 You can override by doing, e.g.:
   install.sh v0.1.0-beta-5
   install.sh nightly
@@ -255,6 +261,10 @@ check_page_size() {
     echo "4. Reboot: sudo reboot"
     echo "5. Verify with: getconf PAGESIZE (should show 4096)"
     echo "6. Run this installation script again"
+    if [ "$NON_INTERACTIVE" = "1" ]; then
+      echo "Installation aborted because non-interactive mode cannot accept this unsafe host prerequisite."
+      exit 1
+    fi
     read -p "Do you want to continue anyway? (y/N): " continue_anyway < /dev/tty
       
     if [[ ! "$continue_anyway" =~ ^[Yy]$ ]]; then
@@ -266,8 +276,50 @@ check_page_size() {
   fi
 }
 
-# show help for -h/--help
-if [[ "${1:-}" =~ ^(-h|--help)$ ]]; then
+NON_INTERACTIVE=0
+SKIP_UPDATER_SERVICE=0
+REQUESTED_INSTALL_DIR=""
+REQUESTED_VERSION=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --install-dir)
+      [ "$#" -ge 2 ] || { echo "Error: --install-dir requires a path." >&2; usage; }
+      REQUESTED_INSTALL_DIR="$2"
+      shift 2
+      ;;
+    --non-interactive)
+      NON_INTERACTIVE=1
+      shift
+      ;;
+    --skip-updater-service)
+      SKIP_UPDATER_SERVICE=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      echo "Error: unknown option $1" >&2
+      usage
+      ;;
+    *)
+      if [ -n "$REQUESTED_VERSION" ]; then
+        echo "Error: only one VERSION may be supplied." >&2
+        usage
+      fi
+      REQUESTED_VERSION="$1"
+      shift
+      ;;
+  esac
+done
+
+if [ "$#" -gt 0 ]; then
+  echo "Error: unexpected arguments: $*" >&2
   usage
 fi
 
@@ -276,7 +328,7 @@ check_page_size
 GITHUB_RELEASES_URL="https://github.com/block/proto-fleet/releases"
 
 # determine version and tarball name
-case "${1:-latest}" in
+case "${REQUESTED_VERSION:-latest}" in
   latest)
     VERSION=$(resolve_latest_version)
     echo "🔖 Latest version is ${VERSION}"
@@ -286,7 +338,7 @@ case "${1:-latest}" in
     echo "🔖 Latest nightly version is ${VERSION}"
     ;;
   *)
-    VERSION="$1"
+    VERSION="$REQUESTED_VERSION"
     ;;
 esac
 
@@ -311,6 +363,31 @@ if ! curl -fsSL "${URL}" -o "/tmp/${TAR_NAME}"; then
   echo "❌ Failed to download ${TAR_NAME} from GitHub Releases — does that release asset exist?"
   usage
 fi
+
+CHECKSUM_PATH="/tmp/${TAR_NAME}.sha256"
+trap 'rm -f "/tmp/${TAR_NAME}" "${CHECKSUM_PATH}"' EXIT
+echo "🔐 Fetching and verifying ${TAR_NAME}.sha256"
+if ! curl -fsSL "${URL}.sha256" -o "${CHECKSUM_PATH}"; then
+  echo "❌ This release does not provide the required SHA-256 integrity file."
+  exit 1
+fi
+checksum_fields=$(wc -w < "${CHECKSUM_PATH}" | tr -d '[:space:]')
+checksum_name=$(awk '{print $2}' "${CHECKSUM_PATH}" | sed 's/^\*//')
+if [ "$checksum_fields" != "2" ] || [ "$checksum_name" != "$TAR_NAME" ]; then
+  echo "❌ Invalid checksum file for ${TAR_NAME}."
+  exit 1
+fi
+if command -v sha256sum >/dev/null 2>&1; then
+  (cd /tmp && sha256sum -c "${TAR_NAME}.sha256")
+elif command -v shasum >/dev/null 2>&1; then
+  expected_checksum=$(awk '{print $1}' "${CHECKSUM_PATH}")
+  actual_checksum=$(shasum -a 256 "/tmp/${TAR_NAME}" | awk '{print $1}')
+  [ "$expected_checksum" = "$actual_checksum" ] || { echo "❌ Release checksum verification failed."; exit 1; }
+else
+  echo "❌ Neither sha256sum nor shasum is available to verify the release."
+  exit 1
+fi
+rm -f "${CHECKSUM_PATH}"
 
 # Function to determine default installation directory based on OS.
 # When invoked under sudo on Linux, prefer the invoking user's home over
@@ -345,7 +422,13 @@ get_default_install_dir() {
 }
 
 echo "🔍 Checking for previous ProtoFleet installations via Docker..."
-detect_previous_install || true
+if [ -z "$REQUESTED_INSTALL_DIR" ]; then
+  detect_previous_install || true
+else
+  PREVIOUS_INSTALL_DIR=""
+  PREVIOUS_INSTALL_NEEDS_SUDO=0
+  PREVIOUS_INSTALL_SUDO_BLOCKED=0
+fi
 DEFAULT_INSTALL_DIR=$(get_default_install_dir)
 
 # If the existing containers were only visible via `sudo docker`, this script
@@ -385,7 +468,10 @@ if [ -z "${PREVIOUS_INSTALL_DIR:-}" ] \
   echo "📁 No running fleet containers, but found existing install on disk at: ${PREVIOUS_INSTALL_DIR}"
 fi
 
-if [ -n "${PREVIOUS_INSTALL_DIR:-}" ]; then
+if [ -n "$REQUESTED_INSTALL_DIR" ]; then
+  SUGGESTED_DIR="$REQUESTED_INSTALL_DIR"
+  echo "📌 Using requested installation location: ${SUGGESTED_DIR}"
+elif [ -n "${PREVIOUS_INSTALL_DIR:-}" ]; then
   SUGGESTED_DIR="$PREVIOUS_INSTALL_DIR"
   echo "📌 Found previous installation at: ${SUGGESTED_DIR}"
 else
@@ -406,21 +492,64 @@ if [ "${PREVIOUS_INSTALL_SUDO_BLOCKED:-0}" = "1" ]; then
   echo "      curl -fsSL https://fleet.proto.xyz/install.sh | sudo bash -s -- ${QUOTED_VERSION})"
 fi
 
-# Read from /dev/tty so the prompts work under `curl ... | sudo bash -s --`.
-# Without this, stdin is the curl pipe (already consumed) and the reads
-# silently hit EOF, leaving the responses empty — defaulting users into the
-# happy path with no chance to redirect.
-read -p "   Use this location? (Y/n): " use_suggested < /dev/tty
-if [[ "$use_suggested" =~ ^[Nn]$ ]]; then
-  read -p "   Enter installation directory [${DEFAULT_INSTALL_DIR}]: " custom_dir < /dev/tty
-  INSTALL_DIR="${custom_dir:-$DEFAULT_INSTALL_DIR}"
-else
+if [ -n "$REQUESTED_INSTALL_DIR" ]; then
+  INSTALL_DIR="$REQUESTED_INSTALL_DIR"
+elif [ "$NON_INTERACTIVE" = "1" ]; then
+  if [ -z "${PREVIOUS_INSTALL_DIR:-}" ]; then
+    echo "❌ A fresh non-interactive install requires --install-dir." >&2
+    exit 1
+  fi
   INSTALL_DIR="$SUGGESTED_DIR"
+else
+  # Read from /dev/tty so prompts work under `curl ... | sudo bash -s --`.
+  read -p "   Use this location? (Y/n): " use_suggested < /dev/tty
+  if [[ "$use_suggested" =~ ^[Nn]$ ]]; then
+    read -p "   Enter installation directory [${DEFAULT_INSTALL_DIR}]: " custom_dir < /dev/tty
+    INSTALL_DIR="${custom_dir:-$DEFAULT_INSTALL_DIR}"
+  else
+    INSTALL_DIR="$SUGGESTED_DIR"
+  fi
 fi
+
+if [ "$NON_INTERACTIVE" = "1" ] && [ ! -f "${INSTALL_DIR}/${DEPLOYMENT_DIR}/.env" ]; then
+  echo "❌ Non-interactive mode requires an existing configured deployment at ${INSTALL_DIR}/${DEPLOYMENT_DIR}." >&2
+  exit 1
+fi
+case "$INSTALL_DIR" in
+  *$'\n'*|*$'\r'*)
+    echo "❌ Installation paths cannot contain newline characters." >&2
+    exit 1
+    ;;
+esac
 
 echo "📌 Will install to: ${INSTALL_DIR}"
 
+# Releases before one-click support treated optional Compose overlays as
+# process-only flags. Capture the effective fleet-api environment while the
+# old stack is still running so the bootstrap upgrade can persist those
+# choices into the new deployment's .env.
+PREVIOUS_BETA_ALERTS=0
+PREVIOUS_SYSTEM_MONITORING=0
+PREVIOUS_TRACING=0
+capture_previous_run_options() {
+  local container_id container_env
+  container_id=$(docker ps -a \
+    --filter "name=${DEPLOYMENT_DIR}-fleet-api" \
+    --filter "name=${DEPLOYMENT_DIR}_fleet-api" \
+    --format "{{.ID}}" 2>/dev/null | head -n 1 || true)
+  [ -n "$container_id" ] || return 0
+  container_env=$(docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' "$container_id" 2>/dev/null || true)
+  printf '%s\n' "$container_env" | grep -Eqi '^FLEET_ALERTS_ENABLED=true$' && PREVIOUS_BETA_ALERTS=1
+  printf '%s\n' "$container_env" | grep -Eqi '^FLEET_SYSTEM_MONITORING_ENABLED=true$' && PREVIOUS_SYSTEM_MONITORING=1
+  printf '%s\n' "$container_env" | grep -Eqi '^FLEET_TELEMETRY_ENABLED=true$' && PREVIOUS_TRACING=1
+}
+capture_previous_run_options
+
 extract_and_cd "/tmp/${TAR_NAME}" "$INSTALL_DIR"
+# The system service starts with / as its working directory, so persist the
+# canonical absolute install root even when the interactive installer was
+# given a relative path.
+INSTALL_DIR=$(cd .. && pwd -P)
 
 # Validate plugin binaries exist
 echo "🔌 Validating plugin binaries..."
@@ -447,5 +576,101 @@ for plugin in "${REQUIRED_PLUGINS[@]}"; do
 done
 echo "✅ Plugin binaries validated"
 
+install_updater_service() {
+  if [ "$SKIP_UPDATER_SERVICE" = "1" ] || [ "$(uname -s)" != "Linux" ]; then
+    return 1
+  fi
+  if ! command -v systemctl >/dev/null 2>&1 || [ ! -d /run/systemd/system ]; then
+    echo "ℹ️  systemd is unavailable; keeping copy-command upgrades on this host."
+    return 1
+  fi
+  case "$INSTALL_DIR" in
+    /usr|/usr/*|/boot|/boot/*|/efi|/efi/*|/etc|/etc/*)
+      echo "ℹ️  The hardened updater cannot write to ${INSTALL_DIR}; keeping copy-command upgrades."
+      return 1
+      ;;
+  esac
+  if [ ! -x "updater/proto-fleet-updater" ] || [ ! -f "updater/proto-fleet-updater.service" ]; then
+    echo "⚠️  This release does not contain the host updater payload."
+    return 1
+  fi
+
+  local privilege=()
+  if [ "$(id -u)" -ne 0 ]; then
+    command -v sudo >/dev/null 2>&1 || {
+      echo "⚠️  sudo is unavailable; one-click upgrades cannot be enabled."
+      return 1
+    }
+    if [ "$NON_INTERACTIVE" = "1" ]; then
+      privilege=(sudo -n)
+    else
+      privilege=(sudo)
+    fi
+  fi
+
+  # The service runs as root. Only enable it when root sees the same Docker
+  # daemon as the current installation; rootless Docker needs a future
+  # user-service adapter and must keep the manual fallback.
+  local current_docker_id root_docker_id
+  current_docker_id=$(docker info --format '{{.ID}}' 2>/dev/null || true)
+  root_docker_id=$(${privilege[@]+"${privilege[@]}"} docker info --format '{{.ID}}' 2>/dev/null || true)
+  if [ -z "$current_docker_id" ] || [ "$current_docker_id" != "$root_docker_id" ]; then
+    echo "ℹ️  Root does not manage this installation's Docker daemon; keeping copy-command upgrades."
+    return 1
+  fi
+
+  local env_temp escaped_install escaped_download
+  env_temp=$(mktemp)
+  escaped_install=${INSTALL_DIR//\\/\\\\}
+  escaped_install=${escaped_install//\"/\\\"}
+  escaped_download=${GITHUB_RELEASES_URL//\\/\\\\}
+  escaped_download=${escaped_download//\"/\\\"}
+  {
+    printf 'PROTO_FLEET_INSTALL_ROOT="%s"\n' "$escaped_install"
+    printf 'PROTO_FLEET_DOWNLOAD_BASE_URL="%s/download"\n' "$escaped_download"
+    printf 'PROTO_FLEET_UPDATER_STATE_DIR="/var/lib/proto-fleet-updater"\n'
+    printf 'PROTO_FLEET_UPDATER_SOCKET_PATH="/run/proto-fleet-updater/updater.sock"\n'
+    printf 'PROTO_FLEET_UPDATER_BINARY_PATH="/usr/local/libexec/proto-fleet/proto-fleet-updater"\n'
+  } > "$env_temp"
+
+  if ! ${privilege[@]+"${privilege[@]}"} install -d -m 0755 /usr/local/libexec/proto-fleet /etc/proto-fleet; then
+    rm -f "$env_temp"
+    return 1
+  fi
+  if ! ${privilege[@]+"${privilege[@]}"} install -m 0755 updater/proto-fleet-updater /usr/local/libexec/proto-fleet/proto-fleet-updater \
+    || ! ${privilege[@]+"${privilege[@]}"} install -m 0644 updater/proto-fleet-updater.service /etc/systemd/system/proto-fleet-updater.service \
+    || ! ${privilege[@]+"${privilege[@]}"} install -m 0600 "$env_temp" /etc/proto-fleet/updater.env; then
+    rm -f "$env_temp"
+    return 1
+  fi
+  rm -f "$env_temp"
+  ${privilege[@]+"${privilege[@]}"} systemctl daemon-reload
+  ${privilege[@]+"${privilege[@]}"} systemctl enable proto-fleet-updater.service
+  # A manual install can safely restart an already-running updater; the
+  # updater-driven path never invokes install.sh and refreshes its on-disk
+  # binary for the next service start instead.
+  ${privilege[@]+"${privilege[@]}"} systemctl restart proto-fleet-updater.service
+}
+
+RUN_FLEET_ARGS=()
+if [ "$PREVIOUS_BETA_ALERTS" = "1" ] || [ "$PREVIOUS_SYSTEM_MONITORING" = "1" ]; then
+  RUN_FLEET_ARGS+=(--enable-beta-alerts)
+fi
+if [ "$PREVIOUS_SYSTEM_MONITORING" = "1" ]; then
+  RUN_FLEET_ARGS+=(--enable-system-monitoring)
+fi
+if [ "$PREVIOUS_TRACING" = "1" ]; then
+  RUN_FLEET_ARGS+=(--enable-tracing)
+fi
+if install_updater_service; then
+  echo "✅ Host updater installed; one-click upgrades are enabled."
+  RUN_FLEET_ARGS+=(--enable-one-click-updates)
+else
+  echo "ℹ️  One-click upgrades are unavailable; the in-product copy command remains usable."
+fi
+
 echo "🔧 Running deployment script..."
-./run-fleet.sh
+if [ "$NON_INTERACTIVE" = "1" ]; then
+  RUN_FLEET_ARGS+=(--non-interactive)
+fi
+./run-fleet.sh "${RUN_FLEET_ARGS[@]}"

--- a/deployment-files/install.sh
+++ b/deployment-files/install.sh
@@ -11,6 +11,7 @@ UPDATER_DISABLE_ON_EXIT=0
 UPDATER_RESTART_ON_EXIT=0
 UPDATER_SOCKET_PATH="/run/proto-fleet-updater/updater.sock"
 UPDATER_VALIDATION_SOCKET_PATH="/run/proto-fleet-updater/installer-validation.sock"
+UPDATER_DOCKER_HOST="unix:///var/run/docker.sock"
 
 # Probe docker for an existing fleet-api container and return the install
 # directory inferred from its bind mount. Echoes the path on success; returns
@@ -399,6 +400,231 @@ capture_previous_run_options() {
   [ "$tracing_state" != "missing" ] || [ "$inferred_tracing" != "true" ] || PREVIOUS_TRACING=1
 }
 
+lexical_absolute_path() {
+  local selected="$1"
+  local input remainder component result="/"
+  case "$selected" in
+    /*) input="$selected" ;;
+    *) input="$(pwd -P)/$selected" ;;
+  esac
+
+  remainder="${input#/}"
+  while [ -n "$remainder" ]; do
+    component="${remainder%%/*}"
+    if [ "$component" = "$remainder" ]; then
+      remainder=""
+    else
+      remainder="${remainder#*/}"
+    fi
+    case "$component" in
+      ""|.) continue ;;
+      ..)
+        [ "$result" = "/" ] || result="${result%/*}"
+        [ -n "$result" ] || result="/"
+        ;;
+      *)
+        if [ "$result" = "/" ]; then
+          result="/$component"
+        else
+          result="$result/$component"
+        fi
+        ;;
+    esac
+  done
+  printf '%s\n' "$result"
+}
+
+reject_dangerous_install_root() {
+  local install_root="${1%/}"
+  [ -n "$install_root" ] || install_root="/"
+  case "$install_root" in
+    /|/home|/Users|/root|/opt|/usr|/var|/tmp|/srv|/mnt|/media|/private/var|/private/tmp)
+      echo "❌ Refusing dangerous installation root: $install_root" >&2
+      return 1
+      ;;
+    /etc|/etc/*|/private/etc|/private/etc/*|/bin|/bin/*|/sbin|/sbin/*|/lib|/lib/*|/lib64|/lib64/*|/sys|/sys/*|/dev|/dev/*|/proc|/proc/*|/boot|/boot/*|/run|/run/*|/usr/*|/efi|/efi/*)
+      echo "❌ Refusing installation inside a protected system path: $install_root" >&2
+      return 1
+      ;;
+  esac
+
+  local home_path="" sudo_home=""
+  if [ -n "${HOME:-}" ] && [ -d "$HOME" ]; then
+    home_path=$(cd "$HOME" 2>/dev/null && pwd -P) || home_path=""
+  fi
+  if [ -n "$home_path" ] && [ "$install_root" = "${home_path%/}" ]; then
+    echo "❌ Refusing to use the home directory itself as the installation root." >&2
+    return 1
+  fi
+  if [ "$(id -u)" -eq 0 ] \
+    && [ -n "${SUDO_USER:-}" ] \
+    && [ "$SUDO_USER" != "root" ] \
+    && command -v getent >/dev/null 2>&1; then
+    sudo_home=$(getent passwd "$SUDO_USER" 2>/dev/null | cut -d: -f6 || true)
+    if [ -n "$sudo_home" ] && [ -d "$sudo_home" ]; then
+      sudo_home=$(cd "$sudo_home" 2>/dev/null && pwd -P) || sudo_home=""
+    fi
+    if [ -n "$sudo_home" ] && [ "$install_root" = "${sudo_home%/}" ]; then
+      echo "❌ Refusing to use the invoking administrator's home directory itself as the installation root." >&2
+      return 1
+    fi
+  fi
+}
+
+install_admin_uid() {
+  local current_uid
+  current_uid=$(id -u) || return 1
+  if [ "$current_uid" -ne 0 ]; then
+    printf '%s\n' "$current_uid"
+    return 0
+  fi
+  case "${SUDO_UID:-}" in
+    ""|*[!0-9]*|0) printf '0\n' ;;
+    *) printf '%s\n' "$SUDO_UID" ;;
+  esac
+}
+
+install_path_metadata() {
+  local path="$1"
+  local metadata
+  if metadata=$(stat -c '%u %a' -- "$path" 2>/dev/null); then
+    :
+  elif metadata=$(stat -f '%u %Lp' "$path" 2>/dev/null); then
+    :
+  else
+    return 1
+  fi
+  printf '%s\n' "$metadata"
+}
+
+validate_install_path_metadata() {
+  local path="$1"
+  local owner_uid="$2"
+  local mode="$3"
+  local trusted_uid="$4"
+  local is_install_root="$5"
+  case "$owner_uid" in ""|*[!0-9]*) return 1 ;; esac
+  case "$trusted_uid" in ""|*[!0-9]*) return 1 ;; esac
+  case "$mode" in ""|*[!0-7]*) return 1 ;; esac
+  if [ "$owner_uid" -ne 0 ] && [ "$owner_uid" -ne "$trusted_uid" ]; then
+    echo "❌ Installation path component is owned by unrelated UID $owner_uid: $path" >&2
+    return 1
+  fi
+
+  local numeric_mode=$((8#$mode))
+  if (( (numeric_mode & 0022) != 0 )); then
+    # Root-owned sticky directories such as /tmp are safe ancestors: another
+    # user cannot replace the trusted-owned child created beneath them. The
+    # install root itself is never allowed to be group- or world-writable.
+    if [ "$is_install_root" != "1" ] \
+      && [ "$owner_uid" -eq 0 ] \
+      && (( (numeric_mode & 01000) != 0 )); then
+      return 0
+    fi
+    echo "❌ Installation path component is group- or world-writable: $path" >&2
+    return 1
+  fi
+}
+
+validate_install_directory_chain() {
+  local path="$1"
+  local trusted_uid="$2"
+  local final_is_install_root="$3"
+  local current="/" remainder component metadata owner_uid mode is_final
+
+  remainder="${path#/}"
+  while :; do
+    is_final=0
+    [ "$current" != "$path" ] || is_final="$final_is_install_root"
+    [ -d "$current" ] || {
+      echo "❌ Installation path component is not a directory: $current" >&2
+      return 1
+    }
+    metadata=$(install_path_metadata "$current") || {
+      echo "❌ Could not inspect installation path component: $current" >&2
+      return 1
+    }
+    owner_uid="${metadata%% *}"
+    mode="${metadata#* }"
+    validate_install_path_metadata "$current" "$owner_uid" "$mode" \
+      "$trusted_uid" "$is_final" || return 1
+
+    [ -n "$remainder" ] || break
+    component="${remainder%%/*}"
+    if [ "$component" = "$remainder" ]; then
+      remainder=""
+    else
+      remainder="${remainder#*/}"
+    fi
+    [ -n "$component" ] || continue
+    if [ "$current" = "/" ]; then
+      current="/$component"
+    else
+      current="$current/$component"
+    fi
+  done
+}
+
+prepare_fresh_install_path() {
+  local selected="$1"
+  local normalized nearest_existing canonical canonical_target missing_suffix trusted_uid
+  normalized=$(lexical_absolute_path "$selected") || return 1
+  reject_dangerous_install_root "$normalized" || return 1
+  if [ -L "$normalized" ]; then
+    echo "❌ Installation root must not be a symlink: $normalized" >&2
+    return 1
+  fi
+
+  trusted_uid=$(install_admin_uid) || {
+    echo "❌ Could not determine the invoking installation administrator." >&2
+    return 1
+  }
+  if [ -e "$normalized" ]; then
+    [ -d "$normalized" ] || {
+      echo "❌ Installation root exists but is not a directory: $normalized" >&2
+      return 1
+    }
+    canonical=$(cd "$normalized" 2>/dev/null && pwd -P) || return 1
+    reject_dangerous_install_root "$canonical" || return 1
+    validate_install_directory_chain "$canonical" "$trusted_uid" 1 || return 1
+  else
+    nearest_existing="$normalized"
+    while [ ! -e "$nearest_existing" ] && [ ! -L "$nearest_existing" ]; do
+      nearest_existing="${nearest_existing%/*}"
+      [ -n "$nearest_existing" ] || nearest_existing="/"
+    done
+    [ ! -L "$nearest_existing" ] || {
+      echo "❌ Installation path ancestor must not be a symlink: $nearest_existing" >&2
+      return 1
+    }
+    canonical=$(cd "$nearest_existing" 2>/dev/null && pwd -P) || return 1
+    validate_install_directory_chain "$canonical" "$trusted_uid" 0 || return 1
+    missing_suffix="${normalized#"$nearest_existing"}"
+    canonical_target=$(lexical_absolute_path "${canonical%/}$missing_suffix") || return 1
+    reject_dangerous_install_root "$canonical_target" || return 1
+    if ! (umask 077; mkdir -p "$normalized"); then
+      echo "❌ Could not create installation root: $normalized" >&2
+      return 1
+    fi
+    [ ! -L "$normalized" ] || {
+      echo "❌ Installation root became a symlink while it was created: $normalized" >&2
+      return 1
+    }
+    canonical=$(cd "$normalized" 2>/dev/null && pwd -P) || return 1
+    reject_dangerous_install_root "$canonical" || return 1
+    validate_install_directory_chain "$canonical" "$trusted_uid" 1 || return 1
+  fi
+
+  for name in deployment deployment.previous; do
+    if [ -e "$canonical/$name" ] || [ -L "$canonical/$name" ]; then
+      echo "❌ A purported fresh install already contains $canonical/$name." >&2
+      echo "   Remove or explicitly recover that deployment before installing." >&2
+      return 1
+    fi
+  done
+  printf '%s\n' "$canonical"
+}
+
 resolve_selected_install_path() {
   local selected="$1"
   local discovered="${2:-}"
@@ -408,13 +634,9 @@ resolve_selected_install_path() {
     echo "❌ Installation path cannot be empty." >&2
     return 1
   }
-  # A fresh path has nothing to compare yet and is made absolute after
-  # extraction. When Docker or the on-disk fallback found an installation,
-  # both paths already exist and can be canonicalized without filesystem
-  # mutation or non-portable realpath flags.
   if [ -z "$discovered" ]; then
-    printf '%s' "$selected"
-    return 0
+    prepare_fresh_install_path "$selected"
+    return $?
   fi
   canonical_discovered=$(cd "$discovered" 2>/dev/null && pwd -P) || {
     echo "❌ Discovered installation path cannot be accessed: $discovered" >&2
@@ -685,14 +907,26 @@ installer_exit_cleanup() {
 }
 
 # Match the Docker CLI environment the system service is guaranteed to use.
-# The unit also unsets these variables, so neither an invoking root shell nor
-# the systemd manager can redirect upgrades to a different daemon.
+# Set the endpoint after sudo so neither sudo environment filtering nor a
+# persisted currentContext in root's Docker config can redirect the probe.
 service_docker_id_with() {
   local privilege=("$@")
-  (
-    unset DOCKER_HOST DOCKER_CONTEXT DOCKER_CONFIG DOCKER_TLS DOCKER_TLS_VERIFY DOCKER_CERT_PATH
-    ${privilege[@]+"${privilege[@]}"} docker info --format '{{.ID}}' 2>/dev/null || true
-  )
+  if (( ${#privilege[@]} )); then
+    ${privilege[@]+"${privilege[@]}"} env \
+      -u DOCKER_CONTEXT \
+      -u DOCKER_CONFIG \
+      -u DOCKER_TLS \
+      -u DOCKER_TLS_VERIFY \
+      -u DOCKER_CERT_PATH \
+      DOCKER_HOST="$UPDATER_DOCKER_HOST" \
+      docker info --format '{{.ID}}' 2>/dev/null || true
+  else
+    (
+      unset DOCKER_CONTEXT DOCKER_CONFIG DOCKER_TLS DOCKER_TLS_VERIFY DOCKER_CERT_PATH
+      export DOCKER_HOST="$UPDATER_DOCKER_HOST"
+      docker info --format '{{.ID}}' 2>/dev/null || true
+    )
+  fi
 }
 
 # END INSTALLER TESTABLE HELPERS

--- a/deployment-files/install.sh
+++ b/deployment-files/install.sh
@@ -11,6 +11,7 @@ UPDATER_DISABLE_ON_EXIT=0
 UPDATER_REENABLE_ON_EXIT=0
 UPDATER_RESTART_ON_EXIT=0
 UPDATER_START_AFTER_RUN=0
+UPDATER_DEPLOYMENT_COMMITTED=0
 UPDATER_REENABLE_AFTER_FAILED_RUN=0
 UPDATER_RESTART_AFTER_FAILED_RUN=0
 UPDATER_FALLBACK_PENDING=0
@@ -1131,6 +1132,59 @@ run_disabled_updater_fallback() {
   complete_disabled_updater_fallback_after_run "$env_file" "$run_status"
 }
 
+reconcile_committed_updater_enablement() {
+  local runner="$1"
+  local env_file="$2"
+  shift 2
+  local run_args=("$@")
+  local committed_state
+
+  # The setting is written before Compose validation and startup, so only the
+  # caller's successful run-fleet completion may arm this recovery path.
+  if [ "${UPDATER_DEPLOYMENT_COMMITTED:-0}" != "1" ] \
+    || [ "${UPDATER_START_AFTER_RUN:-0}" != "1" ]; then
+    return 0
+  fi
+  if ! committed_state=$(deployment_boolean_state \
+      "$env_file" ENABLE_ONE_CLICK_UPDATES) \
+    || [ "$committed_state" != "true" ]; then
+    echo "❌ The committed deployment does not have a valid enabled one-click update setting." >&2
+    disable_updater_service_with \
+      ${UPDATER_PRIVILEGE[@]+"${UPDATER_PRIVILEGE[@]}"} || true
+    return 1
+  fi
+
+  echo "🔄 Starting the host updater after the committed deployment..."
+  if ${UPDATER_PRIVILEGE[@]+"${UPDATER_PRIVILEGE[@]}"} systemctl enable \
+      proto-fleet-updater.service >/dev/null 2>&1 \
+    && restart_updater_service_with "$UPDATER_SOCKET_PATH" \
+      ${UPDATER_PRIVILEGE[@]+"${UPDATER_PRIVILEGE[@]}"}; then
+    UPDATER_DISABLE_ON_EXIT=0
+    UPDATER_RESTART_ON_EXIT=0
+    UPDATER_REENABLE_ON_EXIT=0
+    UPDATER_START_AFTER_RUN=0
+    UPDATER_DEPLOYMENT_COMMITTED=0
+    return 0
+  fi
+
+  echo "⚠️  The host updater did not become ready; redeploying without its socket overlay." >&2
+  disable_updater_service_with \
+    ${UPDATER_PRIVILEGE[@]+"${UPDATER_PRIVILEGE[@]}"} || true
+  # Never let EXIT retry a service that failed readiness. Keep disablement
+  # armed until run-fleet proves the copy-command fallback is active.
+  UPDATER_RESTART_ON_EXIT=0
+  UPDATER_REENABLE_ON_EXIT=0
+  UPDATER_START_AFTER_RUN=0
+  UPDATER_DISABLE_ON_EXIT=1
+  if ! run_disabled_updater_fallback "$runner" "$env_file" \
+      "${run_args[@]}"; then
+    echo "❌ Could not deploy the copy-command fallback after the host updater failed readiness." >&2
+    return 1
+  fi
+  UPDATER_DEPLOYMENT_COMMITTED=0
+  echo "ℹ️  One-click upgrades are unavailable; the in-product copy command remains usable."
+}
+
 reconcile_updater_after_failed_deployment() {
   local env_file="$1"
   local previous_state="$2"
@@ -1399,6 +1453,15 @@ quiesce_updater_service_for_manual_run_with() {
 installer_exit_cleanup() {
   local status=$?
   trap - EXIT
+  if [ "${UPDATER_DEPLOYMENT_COMMITTED:-0}" = "1" ] \
+    && [ "${UPDATER_START_AFTER_RUN:-0}" = "1" ]; then
+    echo "🔄 Reconciling the committed updater deployment after interruption..." >&2
+    if ! reconcile_committed_updater_enablement \
+      ./run-fleet.sh "$INSTALL_DIR/$DEPLOYMENT_DIR/.env" \
+      ${RUN_FLEET_ARGS[@]+"${RUN_FLEET_ARGS[@]}"}; then
+      status=1
+    fi
+  fi
   if [ "${UPDATER_DISABLE_ON_EXIT:-0}" = "1" ]; then
     echo "🔒 Disabling the host updater after interrupted validation..." >&2
     if ! disable_updater_service_with \
@@ -2126,6 +2189,11 @@ RUN_FLEET_STATUS=0
 if PROTO_FLEET_INSTALLER_MANAGED_RUN=1 \
   ./run-fleet.sh "${RUN_FLEET_ARGS[@]}"; then
   RUN_FLEET_STATUS=0
+  if [ "$UPDATER_START_AFTER_RUN" = "1" ]; then
+    # A zero exit is the commit boundary. The .env flag is persisted earlier
+    # and cannot by itself prove that the socket-enabled topology is active.
+    UPDATER_DEPLOYMENT_COMMITTED=1
+  fi
 else
   RUN_FLEET_STATUS=$?
 fi
@@ -2161,32 +2229,9 @@ if [ "$RUN_FLEET_STATUS" -ne 0 ]; then
   exit "$RUN_FLEET_STATUS"
 fi
 
-if [ "$UPDATER_START_AFTER_RUN" = "1" ]; then
-  echo "🔄 Starting the host updater after the manual deployment run..."
-  # run-fleet is finished, so the old API can no longer race this deployment.
-  # systemd owns the service lifecycle once the restart is issued.
-  if restart_updater_service_with "$UPDATER_SOCKET_PATH" \
-    ${UPDATER_PRIVILEGE[@]+"${UPDATER_PRIVILEGE[@]}"}; then
-    UPDATER_DISABLE_ON_EXIT=0
-    UPDATER_RESTART_ON_EXIT=0
-    UPDATER_REENABLE_ON_EXIT=0
-    UPDATER_START_AFTER_RUN=0
-  else
-    echo "⚠️  The host updater did not become ready; redeploying without its socket overlay." >&2
-    disable_updater_service_with \
-      ${UPDATER_PRIVILEGE[@]+"${UPDATER_PRIVILEGE[@]}"} || true
-    # Never let EXIT retry a service that failed readiness. Keep disablement
-    # armed until run-fleet proves the copy-command fallback is active.
-    UPDATER_RESTART_ON_EXIT=0
-    UPDATER_REENABLE_ON_EXIT=0
-    UPDATER_START_AFTER_RUN=0
-    UPDATER_DISABLE_ON_EXIT=1
-    if ! run_disabled_updater_fallback \
-      ./run-fleet.sh "$INSTALL_DIR/$DEPLOYMENT_DIR/.env" \
-      "${RUN_FLEET_ARGS[@]}"; then
-      echo "❌ Could not deploy the copy-command fallback after the host updater failed readiness." >&2
-      exit 1
-    fi
-    echo "ℹ️  One-click upgrades are unavailable; the in-product copy command remains usable."
-  fi
+if [ "$UPDATER_START_AFTER_RUN" = "1" ] \
+  && ! reconcile_committed_updater_enablement \
+    ./run-fleet.sh "$INSTALL_DIR/$DEPLOYMENT_DIR/.env" \
+    "${RUN_FLEET_ARGS[@]}"; then
+  exit 1
 fi

--- a/deployment-files/install.sh
+++ b/deployment-files/install.sh
@@ -376,7 +376,6 @@ capture_previous_run_options() {
     fi
     return 0
   fi
-  # Fresh installs have no legacy state to migrate and retain false defaults.
   [ "$existing_deployment" = "1" ] || return 0
 
   local container_id find_status
@@ -1098,8 +1097,7 @@ complete_disabled_updater_fallback_after_run() {
   local env_file="$1"
   local run_status="$2"
 
-  # run-fleet persists overlay intent before Compose validation. Only its
-  # successful exit proves that the replacement stack adopted the fallback.
+  # Only a successful run proves the replacement stack adopted the fallback.
   [ "$run_status" -eq 0 ] || return "$run_status"
   finalize_disabled_updater_fallback_if_persisted "$env_file"
 }
@@ -1112,9 +1110,7 @@ run_disabled_updater_fallback() {
   local fallback_args=()
   local run_status=0
 
-  # Replace any earlier updater choice instead of relying on argument order.
-  # The remaining installer options still describe the deployment that just
-  # succeeded, so the fallback only changes the socket overlay.
+  # Preserve other installer options while replacing the updater choice.
   for argument in "$@"; do
     case "$argument" in
       --enable-one-click-updates|--disable-one-click-updates) continue ;;
@@ -1139,8 +1135,7 @@ reconcile_committed_updater_enablement() {
   local run_args=("$@")
   local committed_state
 
-  # The setting is written before Compose validation and startup, so only the
-  # caller's successful run-fleet completion may arm this recovery path.
+  # Persisted intent is not a commit until run-fleet succeeds.
   if [ "${UPDATER_DEPLOYMENT_COMMITTED:-0}" != "1" ] \
     || [ "${UPDATER_START_AFTER_RUN:-0}" != "1" ]; then
     return 0
@@ -1170,8 +1165,7 @@ reconcile_committed_updater_enablement() {
   echo "⚠️  The host updater did not become ready; redeploying without its socket overlay." >&2
   disable_updater_service_with \
     ${UPDATER_PRIVILEGE[@]+"${UPDATER_PRIVILEGE[@]}"} || true
-  # Never let EXIT retry a service that failed readiness. Keep disablement
-  # armed until run-fleet proves the copy-command fallback is active.
+  # Keep disablement armed until the copy-command fallback is active.
   UPDATER_RESTART_ON_EXIT=0
   UPDATER_REENABLE_ON_EXIT=0
   UPDATER_START_AFTER_RUN=0
@@ -1195,10 +1189,7 @@ reconcile_updater_after_failed_deployment() {
   local privilege=("$@")
   local restored_state
 
-  # The replacement service must stay fail-closed until the old deployment
-  # setting and service lifecycle have both been restored. Clear the generic
-  # EXIT restoration flags so a reconciliation error cannot accidentally
-  # start the replacement service.
+  # Keep the replacement fail-closed while restoring prior state.
   UPDATER_REENABLE_ON_EXIT=0
   UPDATER_RESTART_ON_EXIT=0
   UPDATER_START_AFTER_RUN=0
@@ -1363,8 +1354,7 @@ prepare_existing_updater_service() {
       ${UPDATER_PRIVILEGE[@]+"${UPDATER_PRIVILEGE[@]}"}; then
     return 1
   fi
-  # Snapshot a coherent stopped service. If the copy fails, the original host
-  # files are still untouched and EXIT cleanup can restart them directly.
+  # Snapshot only after the service is coherently stopped.
   if ! backup_existing_updater_artifacts_with \
       ${UPDATER_PRIVILEGE[@]+"${UPDATER_PRIVILEGE[@]}"}; then
     UPDATER_CLEANUP_FAILED=1
@@ -2118,9 +2108,7 @@ install_updater_service() {
     return 1
   fi
   UPDATER_VALIDATION_RUNTIME_ON_EXIT=0
-  # The validated service is now stopped. Persist its production socket only
-  # after the temporary listener is gone, and do not start it until run-fleet
-  # has finished replacing the deployment.
+  # Switch from the private validation socket only after its listener stops.
   if ! write_updater_environment_file "$env_temp" "$INSTALL_DIR" \
       "$GITHUB_RELEASES_URL" "$UPDATER_SOCKET_PATH" \
     || ! ${privilege[@]+"${privilege[@]}"} install -m 0600 \
@@ -2131,16 +2119,12 @@ install_updater_service() {
     return 1
   fi
   rm -f "$env_temp"
-  # The replacement now has a production configuration for the same validated
-  # installation root. Interrupted cleanup can safely restart it without
-  # restoring the pre-validation file.
+  # Production configuration now refers to the validated installation root.
   UPDATER_ENV_RESTORE_FILE=""
   UPDATER_BINARY_RESTORE_FILE=""
   UPDATER_UNIT_RESTORE_FILE=""
   UPDATER_ARTIFACT_RESTORE_PENDING=0
-  # Until run-fleet succeeds, an interrupted or failed installation must
-  # disable the replacement service and restore only the prior service state.
-  # Starting the newly validated service is a separate post-success action.
+  # Start the validated service only after run-fleet succeeds.
   UPDATER_DISABLE_ON_EXIT=1
   UPDATER_REENABLE_ON_EXIT="$UPDATER_REENABLE_AFTER_FAILED_RUN"
   UPDATER_RESTART_ON_EXIT="$UPDATER_RESTART_AFTER_FAILED_RUN"
@@ -2162,9 +2146,7 @@ if install_updater_service; then
   echo "✅ Host updater installed and validated; one-click upgrades will be enabled after deployment."
   RUN_FLEET_ARGS+=(--enable-one-click-updates)
 else
-  # Keep every fallback fail-closed, including returns that happen before the
-  # service payload is copied. Unsupported non-systemd hosts have no system
-  # updater to reconcile.
+  # Unsupported non-systemd hosts have no updater lifecycle to reconcile.
   if [ "$(uname -s)" = "Linux" ] \
     && command -v systemctl >/dev/null 2>&1 \
     && [ -d "$UPDATER_SYSTEMD_RUNTIME_DIR" ]; then
@@ -2174,8 +2156,7 @@ else
     echo "❌ Installation stopped because the host updater could not be left in a safe state." >&2
     exit 1
   fi
-  # Keep restoration armed until run-fleet durably records the disabled
-  # fallback. If it fails earlier, EXIT restores the prior working updater.
+  # Keep restoration armed until the disabled fallback commits.
   UPDATER_FALLBACK_PENDING=1
   echo "ℹ️  One-click upgrades are unavailable; the in-product copy command remains usable."
   RUN_FLEET_ARGS+=(--disable-one-click-updates)
@@ -2190,8 +2171,7 @@ if PROTO_FLEET_INSTALLER_MANAGED_RUN=1 \
   ./run-fleet.sh "${RUN_FLEET_ARGS[@]}"; then
   RUN_FLEET_STATUS=0
   if [ "$UPDATER_START_AFTER_RUN" = "1" ]; then
-    # A zero exit is the commit boundary. The .env flag is persisted earlier
-    # and cannot by itself prove that the socket-enabled topology is active.
+    # A zero exit, not the earlier .env write, commits the topology.
     UPDATER_DEPLOYMENT_COMMITTED=1
   fi
 else
@@ -2207,9 +2187,7 @@ if [ "$UPDATER_FALLBACK_PENDING" = "1" ]; then
     if [ "$RUN_FLEET_STATUS" -eq 0 ]; then
       echo "❌ Deployment completed without durably disabling one-click updates." >&2
     fi
-    # run-fleet restores the prior deployment setting on failure; the
-    # installer's EXIT cleanup then restores the prior updater artifacts and
-    # service state. Never discard those rollback assets on a failed run.
+    # Preserve rollback artifacts until run-fleet succeeds.
     exit "$UPDATER_FALLBACK_STATUS"
   fi
 fi

--- a/deployment-files/install.sh
+++ b/deployment-files/install.sh
@@ -148,6 +148,250 @@ detect_previous_install() {
   return 1
 }
 
+parse_compose_env_value() {
+  local value="$1"
+  local double_quoted='^"(.*)"[[:space:]]*(#.*)?$'
+  local single_quoted="^'(.*)'[[:space:]]*(#.*)?$"
+
+  value=$(printf '%s' "$value" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
+  case "$value" in
+    \"*)
+      [[ "$value" =~ $double_quoted ]] || return 2
+      value="${BASH_REMATCH[1]}"
+      ;;
+    \'*)
+      [[ "$value" =~ $single_quoted ]] || return 2
+      value="${BASH_REMATCH[1]}"
+      ;;
+    *)
+      # Compose treats # as an inline comment only when whitespace separates
+      # it from an unquoted value.
+      value=$(printf '%s' "$value" | sed -E 's/[[:space:]]+#.*$//; s/[[:space:]]+$//')
+      ;;
+  esac
+  printf '%s' "$value"
+}
+
+# Read the last assignment using Compose's documented dotenv delimiters and
+# comment rules. Returns 1 when absent and 2 when the file or assignment is
+# malformed, so callers never silently infer over an explicit value.
+compose_env_last_value() {
+  local env_file="$1"
+  local key="$2"
+  local line normalized parsed found=false
+  local assignment_re="^${key}[[:space:]]*([=:])(.*)$"
+  local malformed_re="^${key}([[:space:]]|$)"
+
+  [ -e "$env_file" ] || return 1
+  [ -f "$env_file" ] && [ -r "$env_file" ] || return 2
+  while IFS= read -r line || [ -n "$line" ]; do
+    normalized=$(printf '%s' "$line" | sed -E 's/^[[:space:]]+//')
+    case "$normalized" in
+      export[[:space:]]*)
+        normalized="${normalized#export}"
+        normalized=$(printf '%s' "$normalized" | sed -E 's/^[[:space:]]+//')
+        ;;
+    esac
+    if [[ "$normalized" =~ $assignment_re ]]; then
+      parsed=$(parse_compose_env_value "${BASH_REMATCH[2]}") || return 2
+      found=true
+    elif [[ "$normalized" =~ $malformed_re ]]; then
+      return 2
+    fi
+  done < "$env_file"
+
+  [ "$found" = true ] || return 1
+  printf '%s' "$parsed"
+}
+
+# Report an explicit deployment boolean as true/false, or "missing" when the
+# key is absent. Invalid explicit values are rejected instead of being
+# silently replaced by an inferred container state.
+deployment_boolean_state() {
+  local env_file="$1"
+  local key="$2"
+  local value read_status
+
+  if value=$(compose_env_last_value "$env_file" "$key"); then
+    :
+  else
+    read_status=$?
+    if [ "$read_status" -eq 1 ]; then
+      echo "missing"
+      return 0
+    fi
+    return 2
+  fi
+
+  value=$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')
+  case "$value" in
+    true|false) echo "$value" ;;
+    '') echo "false" ;;
+    *) return 2 ;;
+  esac
+}
+
+compose_config_files_has() {
+  local config_files="$1"
+  local expected_file="$2"
+  case "$expected_file" in
+    *,*) return 2 ;;
+  esac
+
+  local expected_dir expected_name canonical_expected
+  expected_dir=$(cd "$(dirname "$expected_file")" 2>/dev/null && pwd -P) || return 2
+  expected_name=$(basename "$expected_file")
+  canonical_expected="${expected_dir%/}/${expected_name}"
+
+  local config_file config_dir config_name canonical_config
+  while IFS= read -r config_file; do
+    config_file=$(printf '%s' "$config_file" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+    case "$config_file" in
+      /*) ;;
+      *) continue ;;
+    esac
+    config_dir=$(cd "$(dirname "$config_file")" 2>/dev/null && pwd -P) || continue
+    config_name=$(basename "$config_file")
+    canonical_config="${config_dir%/}/${config_name}"
+    [ "$canonical_config" = "$canonical_expected" ] && return 0
+  done <<< "$(printf '%s' "$config_files" | tr ',' '\n')"
+  return 1
+}
+
+# Return the one Compose-managed fleet-api container whose recorded base
+# Compose file belongs to the selected installation. Exact service labels and
+# canonical paths avoid guessing from container-name substrings.
+find_install_container_with() {
+  local install_dir="$1"
+  shift
+  local privilege=("$@")
+  local base_file="${install_dir%/}/${DEPLOYMENT_DIR}/docker-compose.yaml"
+  local container_ids
+  if ! container_ids=$(${privilege[@]+"${privilege[@]}"} docker ps -a \
+    --filter "label=com.docker.compose.service=fleet-api" \
+    --format "{{.ID}}" 2>/dev/null); then
+    return 3
+  fi
+
+  local container_id config_files selected_container="" match_count=0 inspect_failed=0
+  while IFS= read -r container_id; do
+    [ -n "$container_id" ] || continue
+    if ! config_files=$(${privilege[@]+"${privilege[@]}"} docker inspect \
+      --format '{{with index .Config.Labels "com.docker.compose.project.config_files"}}{{.}}{{end}}' \
+      "$container_id" 2>/dev/null); then
+      inspect_failed=1
+      continue
+    fi
+    if compose_config_files_has "$config_files" "$base_file"; then
+      selected_container="$container_id"
+      match_count=$((match_count + 1))
+    fi
+  done <<< "$container_ids"
+
+  [ "$inspect_failed" -eq 0 ] || return 3
+  [ "$match_count" -le 1 ] || return 2
+  [ "$match_count" -eq 1 ] || return 1
+  echo "$selected_container"
+}
+
+# Migrate only overlay settings absent from the existing deployment .env.
+# The Compose config-files label records the old model without trusting
+# mutable service environment values. PREVIOUS_* is set only for a missing
+# setting whose legacy overlay was active.
+capture_previous_run_options() {
+  local install_dir="$1"
+  local existing_deployment="$2"
+  shift 2
+  local privilege=("$@")
+  local env_file="${install_dir%/}/${DEPLOYMENT_DIR}/.env"
+
+  PREVIOUS_BETA_ALERTS=0
+  PREVIOUS_SYSTEM_MONITORING=0
+  PREVIOUS_TRACING=0
+
+  local beta_state system_state tracing_state
+  beta_state=$(deployment_boolean_state "$env_file" ENABLE_BETA_ALERTS) || {
+    echo "❌ Existing ENABLE_BETA_ALERTS in $env_file must be true or false." >&2
+    return 1
+  }
+  system_state=$(deployment_boolean_state "$env_file" ENABLE_SYSTEM_MONITORING) || {
+    echo "❌ Existing ENABLE_SYSTEM_MONITORING in $env_file must be true or false." >&2
+    return 1
+  }
+  tracing_state=$(deployment_boolean_state "$env_file" ENABLE_TRACING) || {
+    echo "❌ Existing ENABLE_TRACING in $env_file must be true or false." >&2
+    return 1
+  }
+
+  if [ "$beta_state" != "missing" ] \
+    && [ "$system_state" != "missing" ] \
+    && [ "$tracing_state" != "missing" ]; then
+    if [ "$system_state" = "true" ] && [ "$beta_state" != "true" ]; then
+      echo "❌ Existing overlay state enables system monitoring without beta alerts; correct the ENABLE_* values in ${env_file} before upgrading." >&2
+      return 1
+    fi
+    return 0
+  fi
+  # Fresh installs have no legacy state to migrate and retain false defaults.
+  [ "$existing_deployment" = "1" ] || return 0
+
+  local container_id find_status
+  if container_id=$(find_install_container_with "$install_dir" \
+    ${privilege[@]+"${privilege[@]}"}); then
+    :
+  else
+    find_status=$?
+    case "$find_status" in
+      2) echo "❌ Multiple fleet-api containers match ${install_dir}; remove the stale container before upgrading." >&2 ;;
+      3) echo "❌ Could not inspect Docker to migrate missing deployment overlay settings." >&2 ;;
+      *) echo "❌ No existing fleet-api container matches ${install_dir}; add explicit ENABLE_BETA_ALERTS, ENABLE_SYSTEM_MONITORING, and ENABLE_TRACING values to ${env_file} before upgrading." >&2 ;;
+    esac
+    return 1
+  fi
+
+  local config_files
+  if ! config_files=$(${privilege[@]+"${privilege[@]}"} docker inspect \
+    --format '{{with index .Config.Labels "com.docker.compose.project.config_files"}}{{.}}{{end}}' \
+    "$container_id" 2>/dev/null); then
+    echo "❌ Could not inspect the old fleet-api Compose config-files label." >&2
+    return 1
+  fi
+  [ -n "$config_files" ] || {
+    echo "❌ The old fleet-api container has no Compose config-files label; set all ENABLE_* overlay values explicitly in ${env_file} before upgrading." >&2
+    return 1
+  }
+
+  local deployment_path
+  deployment_path=$(cd "${install_dir%/}/${DEPLOYMENT_DIR}" 2>/dev/null && pwd -P) || return 1
+  local base_file="${deployment_path}/docker-compose.yaml"
+  local alerts_file="${deployment_path}/docker-compose.alerts.yaml"
+  local system_file="${deployment_path}/docker-compose.system-monitoring.yaml"
+  local tracing_file="${deployment_path}/docker-compose.tracing.yaml"
+  if ! compose_config_files_has "$config_files" "$base_file"; then
+    echo "❌ The old fleet-api Compose config-files label does not belong to ${deployment_path}." >&2
+    return 1
+  fi
+
+  local inferred_beta=false inferred_system=false inferred_tracing=false
+  if compose_config_files_has "$config_files" "$alerts_file"; then inferred_beta=true; fi
+  if compose_config_files_has "$config_files" "$system_file"; then inferred_system=true; fi
+  if compose_config_files_has "$config_files" "$tracing_file"; then inferred_tracing=true; fi
+
+  local effective_beta="$beta_state" effective_system="$system_state"
+  [ "$effective_beta" != "missing" ] || effective_beta="$inferred_beta"
+  [ "$effective_system" != "missing" ] || effective_system="$inferred_system"
+  if [ "$effective_system" = "true" ] && [ "$effective_beta" != "true" ]; then
+    echo "❌ Existing overlay state enables system monitoring without beta alerts; correct the ENABLE_* values in ${env_file} before upgrading." >&2
+    return 1
+  fi
+
+  [ "$beta_state" != "missing" ] || [ "$inferred_beta" != "true" ] || PREVIOUS_BETA_ALERTS=1
+  [ "$system_state" != "missing" ] || [ "$inferred_system" != "true" ] || PREVIOUS_SYSTEM_MONITORING=1
+  [ "$tracing_state" != "missing" ] || [ "$inferred_tracing" != "true" ] || PREVIOUS_TRACING=1
+}
+
+# END INSTALL DISCOVERY AND LEGACY MIGRATION HELPERS
+
 # Function to extract files to the installation directory and cd to it
 extract_and_cd() {
   local tar_path="$1"
@@ -525,25 +769,21 @@ esac
 echo "📌 Will install to: ${INSTALL_DIR}"
 
 # Releases before one-click support treated optional Compose overlays as
-# process-only flags. Capture the effective fleet-api environment while the
-# old stack is still running so the bootstrap upgrade can persist those
-# choices into the new deployment's .env.
-PREVIOUS_BETA_ALERTS=0
-PREVIOUS_SYSTEM_MONITORING=0
-PREVIOUS_TRACING=0
-capture_previous_run_options() {
-  local container_id container_env
-  container_id=$(docker ps -a \
-    --filter "name=${DEPLOYMENT_DIR}-fleet-api" \
-    --filter "name=${DEPLOYMENT_DIR}_fleet-api" \
-    --format "{{.ID}}" 2>/dev/null | head -n 1 || true)
-  [ -n "$container_id" ] || return 0
-  container_env=$(docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' "$container_id" 2>/dev/null || true)
-  printf '%s\n' "$container_env" | grep -Eqi '^FLEET_ALERTS_ENABLED=true$' && PREVIOUS_BETA_ALERTS=1
-  printf '%s\n' "$container_env" | grep -Eqi '^FLEET_SYSTEM_MONITORING_ENABLED=true$' && PREVIOUS_SYSTEM_MONITORING=1
-  printf '%s\n' "$container_env" | grep -Eqi '^FLEET_TELEMETRY_ENABLED=true$' && PREVIOUS_TRACING=1
-}
-capture_previous_run_options
+# process-only flags. Capture only missing values while the validated old
+# stack still exists, and abort before extraction if its state is ambiguous.
+EXISTING_DEPLOYMENT=0
+if [ -f "${INSTALL_DIR%/}/${DEPLOYMENT_DIR}/docker-compose.yaml" ]; then
+  EXISTING_DEPLOYMENT=1
+fi
+CAPTURE_PRIVILEGE=()
+if [ "${PREVIOUS_INSTALL_NEEDS_SUDO:-0}" = "1" ]; then
+  CAPTURE_PRIVILEGE=(sudo -n)
+fi
+if ! capture_previous_run_options "$INSTALL_DIR" "$EXISTING_DEPLOYMENT" \
+  ${CAPTURE_PRIVILEGE[@]+"${CAPTURE_PRIVILEGE[@]}"}; then
+  echo "❌ Existing deployment options could not be migrated safely; no files were replaced." >&2
+  exit 1
+fi
 
 extract_and_cd "/tmp/${TAR_NAME}" "$INSTALL_DIR"
 # The system service starts with / as its working directory, so persist the

--- a/deployment-files/install.sh
+++ b/deployment-files/install.sh
@@ -430,6 +430,35 @@ resolve_selected_install_path() {
   printf '%s' "$canonical_selected"
 }
 
+# If sudo refused a non-interactive Docker probe, an unprivileged caller
+# cannot prove that an on-disk deployment belongs to the daemon it can
+# manage. Never replace an existing deployment in that state: complete
+# persisted overlay values can otherwise bypass every later Docker lookup.
+# Fresh installs remain allowed, with a warning that a root-managed install
+# could not be ruled out.
+guard_selected_install_when_sudo_blocked() {
+  local install_dir="$1"
+  local sudo_blocked="${2:-0}"
+  local quoted_version="$3"
+
+  [ "$sudo_blocked" = "1" ] || return 0
+  [ "$(id -u)" -ne 0 ] || return 0
+
+  if [ -f "${install_dir%/}/${DEPLOYMENT_DIR}/docker-compose.yaml" ]; then
+    echo "❌ Cannot safely replace the existing Proto Fleet deployment at ${install_dir}." >&2
+    echo "   The root Docker daemon could not be inspected because sudo requires authorization." >&2
+    echo "   Re-run the installer as root before any deployment files are replaced:" >&2
+    echo "" >&2
+    echo "     curl -fsSL https://fleet.proto.xyz/install.sh | sudo bash -s -- ${quoted_version}" >&2
+    return 1
+  fi
+
+  echo "" >&2
+  echo "   (Note: sudo required authorization, so we couldn't check whether a" >&2
+  echo "    root-managed fleet install also exists. If one might, re-run as root:" >&2
+  echo "      curl -fsSL https://fleet.proto.xyz/install.sh | sudo bash -s -- ${quoted_version})" >&2
+}
+
 # Keep the privileged bootstrap payload inside the private, checksum-verified
 # download directory. The deployment tree is operator-controlled after
 # extraction, so it must never be the source for files copied into /etc or
@@ -905,18 +934,6 @@ else
   echo "   Suggested installation location: ${SUGGESTED_DIR}"
 fi
 
-# When sudo would have prompted for a password, we couldn't probe the root
-# daemon at all — a parallel root-managed install would otherwise stay
-# invisible. Print this whenever the sudo probe was blocked, even if the
-# on-disk fallback found an unprivileged install (the two installs could
-# coexist on the same host).
-if [ "${PREVIOUS_INSTALL_SUDO_BLOCKED:-0}" = "1" ]; then
-  echo ""
-  echo "   (Note: sudo required a password, so we couldn't check whether a"
-  echo "    root-managed fleet install also exists. If one might, re-run as root:"
-  echo "      curl -fsSL https://fleet.proto.xyz/install.sh | sudo bash -s -- ${QUOTED_VERSION})"
-fi
-
 if [ -n "$REQUESTED_INSTALL_DIR" ]; then
   INSTALL_DIR="$REQUESTED_INSTALL_DIR"
 elif [ "$NON_INTERACTIVE" = "1" ]; then
@@ -944,6 +961,10 @@ case "$INSTALL_DIR" in
 esac
 
 if ! INSTALL_DIR=$(resolve_selected_install_path "$INSTALL_DIR" "${PREVIOUS_INSTALL_DIR:-}"); then
+  exit 1
+fi
+if ! guard_selected_install_when_sudo_blocked \
+  "$INSTALL_DIR" "${PREVIOUS_INSTALL_SUDO_BLOCKED:-0}" "$QUOTED_VERSION"; then
   exit 1
 fi
 if [ "$NON_INTERACTIVE" = "1" ] && [ ! -f "${INSTALL_DIR}/${DEPLOYMENT_DIR}/.env" ]; then

--- a/deployment-files/run-fleet.sh
+++ b/deployment-files/run-fleet.sh
@@ -52,7 +52,6 @@ FLEET_API_IMAGE=""
 FLEET_CLIENT_IMAGE=""
 TIMESCALEDB_IMAGE=""
 TIMESCALEDB_HA_IMAGE=""
-# Every repository whose tags release retention may protect or remove.
 PROTO_FLEET_IMAGE_REPOSITORIES=(
     proto-fleet-api
     proto-fleet-client
@@ -125,10 +124,8 @@ verify_direct_updater_ownership() {
 deployment_directory_identity() {
     local identity
 
-    # GNU and BSD stat spell the device/inode format differently. Directory
-    # identity, rather than a content hash, detects an updater activation that
-    # exchanged the complete deployment tree while this shell waited for the
-    # daemon to stop.
+    # Directory identity detects an activation that swaps the tree while this
+    # shell waits; support both GNU and BSD stat.
     identity=$(stat -Lc '%d:%i' -- "$PROJECT_ROOT" 2>/dev/null) \
       || identity=$(stat -f '%d:%i' "$PROJECT_ROOT" 2>/dev/null) \
       || return 1
@@ -190,9 +187,8 @@ restart_direct_run_updater() {
 
 disable_direct_run_updater() {
     DIRECT_UPDATER_WAS_ACTIVE=false
-    # An unavailable systemd manager cannot have a supervised updater to
-    # disable. This preserves the supported WSL fallback to copy-command
-    # upgrades when systemd has been turned off.
+    # No systemd manager means no supervised updater to disable (for example,
+    # WSL after systemd is turned off).
     if ! systemctl show --property=Version --value >/dev/null 2>&1; then
         return 0
     fi
@@ -223,21 +219,28 @@ disable_direct_run_updater() {
 }
 
 deploy_direct_run_updater_fallback() {
+    local fallback_status=0
+
     echo "Warning: the host updater did not become ready; redeploying without its socket overlay." >&2
-    # A failed readiness check can leave a partially started updater behind.
-    # Stop and disable it before the fallback runner mutates the deployment so
-    # it cannot race the second Compose transition.
+    # Quiesce a partially started updater before the second Compose transition.
     if ! disable_direct_run_updater; then
         echo "Error: could not stop the unavailable host updater before deploying the copy-command fallback." >&2
         return 1
     fi
-    # The successful deployment already persisted every other overlay choice.
-    # Use only the non-interactive updater override here: preflight proof has
-    # been consumed, and carrying --skip-build would reject this recovery run.
-    if ! /bin/bash "$PROJECT_ROOT/run-fleet.sh" \
-        --non-interactive --disable-one-click-updates; then
+    # Other overlays are persisted; consumed preflight state makes carrying
+    # the original --skip-build unsafe.
+    PROTO_FLEET_INSTALLER_MANAGED_RUN=1 \
+        /bin/bash "$PROJECT_ROOT/run-fleet.sh" \
+        --non-interactive --disable-one-click-updates \
+        || fallback_status=$?
+    if [ "$fallback_status" -ne 0 ]; then
         echo "Error: could not deploy the copy-command fallback after the host updater failed readiness." >&2
-        return 1
+        # The parent retains lifecycle ownership if the nested run rolls back.
+        if ! disable_direct_run_updater; then
+            echo "Error: could not keep the unavailable host updater disabled after fallback failure." >&2
+            return 1
+        fi
+        return "$fallback_status"
     fi
     ENABLE_ONE_CLICK_UPDATES=false
     DIRECT_UPDATER_ENV_ROLLBACK_PENDING=false
@@ -250,9 +253,8 @@ reconcile_direct_run_updater() {
     [ "${PROTO_FLEET_UPDATER_MANAGED_RUN:-0}" != "1" ] || return 0
     [ "${PROTO_FLEET_INSTALLER_MANAGED_RUN:-0}" != "1" ] || return 0
 
-    # Before Compose mutation, failure leaves the old topology running and
-    # therefore restores its updater state. Once teardown begins, topology is
-    # uncertain and the persisted desired state is the only safe authority.
+    # Before teardown, restore the old topology's state. After teardown starts,
+    # persisted intent is the only safe authority.
     if [ "$run_status" -ne 0 ] \
       && [ "$DEPLOYMENT_MUTATION_STARTED" != "true" ]; then
         committed_state="$ONE_CLICK_UPDATES_WAS_CONFIGURED"
@@ -264,13 +266,8 @@ reconcile_direct_run_updater() {
             return 1
         fi
         resolve_direct_updater_privilege || return 1
-        # Enforce the persisted contract even when systemd drifted before this
-        # run: enabled configuration always ends with a boot-enabled, ready
-        # service rather than relying on its state at admission time.
         if ! restart_direct_run_updater true; then
-            # Once teardown has started, Fleet may already be running with the
-            # updater socket overlay. Commit the supported copy-command mode
-            # rather than returning with a broken privileged endpoint.
+            # A committed socket overlay must degrade to copy-command mode.
             if [ "$DEPLOYMENT_MUTATION_STARTED" = "true" ]; then
                 deploy_direct_run_updater_fallback || return 1
                 return 0
@@ -281,8 +278,6 @@ reconcile_direct_run_updater() {
     fi
     if [ "$DIRECT_UPDATER_SERVICE_PRESENT" = "true" ]; then
         resolve_direct_updater_privilege || return 1
-        # Likewise, disabled configuration always removes boot enablement and
-        # stops a stale process, even when both desired flags were already false.
         disable_direct_run_updater || return 1
     fi
     return 0
@@ -322,19 +317,15 @@ run_fleet_exit_cleanup() {
     exit "$status"
 }
 
-# The updater daemon owns serialization for its staged preflight and activation
-# children. A human running this script against the active deployment must
-# instead stop the daemon before any environment or Compose mutation so the
-# deployment directory cannot be renamed out from under the shell.
+# Updater-owned children are serialized by the daemon; manual runs must stop it
+# before mutation so deployment/ cannot be renamed out from under this shell.
 quiesce_updater_for_direct_run() {
     local one_click_was_configured="$1"
     local load_state active_state identity_before_stop identity_after_stop
 
     [ "${PROTO_FLEET_UPDATER_MANAGED_RUN:-0}" != "1" ] || return 0
     [ "$(uname -s)" = "Linux" ] || return 0
-    # A source checkout has no relationship to the packaged installation's
-    # global updater. Inspect it only for a packaged deployment, or when this
-    # runner explicitly carries updater state that must be serialized.
+    # Source checkouts do not control the packaged installation's updater.
     if [ ! -f "$VERSION_FILE" ] \
       && [ "$one_click_was_configured" != "true" ] \
       && [ "$ENABLE_ONE_CLICK_UPDATES" != "true" ]; then
@@ -348,11 +339,8 @@ quiesce_updater_for_direct_run() {
         echo "Error: one-click updates are configured, but systemctl is unavailable to serialize this manual run." >&2
         return 1
     fi
-    # A host that previously supported the updater may later lose its systemd
-    # manager (notably WSL after an init configuration change). The installer
-    # must still be able to persist its explicit fallback to copy-command
-    # upgrades. Keep enabled runs fail-closed, and distinguish manager absence
-    # from a later failure to inspect the updater unit itself.
+    # Preserve installer fallback when a host loses systemd, but keep enabled
+    # runs fail-closed.
     if ! systemctl show --property=Version --value >/dev/null 2>&1; then
         if [ "$ENABLE_ONE_CLICK_UPDATES" != "true" ]; then
             return 0
@@ -371,9 +359,7 @@ quiesce_updater_for_direct_run() {
         return 1
     fi
     [ "$load_state" = "not-found" ] || DIRECT_UPDATER_SERVICE_PRESENT=true
-    # A loaded updater is a global privileged resource even while inactive or
-    # failed. Verify its durable ownership before any branch can return and
-    # before this deployment can mount its socket directory into Fleet API.
+    # Verify ownership before even an inactive global updater can be mounted.
     if [ "$DIRECT_UPDATER_SERVICE_PRESENT" = "true" ]; then
         resolve_direct_updater_privilege || return 1
     fi
@@ -404,9 +390,7 @@ quiesce_updater_for_direct_run() {
         echo "Error: could not stop proto-fleet-updater.service before mutating the deployment." >&2
         return 1
     fi
-    # Arm restoration as soon as systemd reports a successful stop. If the
-    # checked inactive-state query fails, EXIT cleanup still repairs service
-    # availability rather than leaving the updater accidentally stopped.
+    # Arm restoration before the checked inactive-state query can fail.
     DIRECT_UPDATER_WAS_ACTIVE=true
     if ! identity_after_stop=$(deployment_directory_identity); then
         echo "Error: could not identify the current deployment after stopping the host updater." >&2
@@ -579,7 +563,6 @@ env_has_nonempty_value() {
     [ -n "$value" ]
 }
 
-# .env-scoped counterpart: whether a key still needs persisting, ignoring any process-level override.
 dotenv_has_nonempty_value() {
     local value
     value=$(compose_env_last_value "$1") || return 1
@@ -705,7 +688,6 @@ append_env_line() {
     echo "$1" >> "$ENV_FILE"
 }
 
-# Satisfies the tracing overlay's ${DD_HOSTNAME:?}; env_has_nonempty_value already reads the effective Compose value, so only default when that is empty.
 ensure_dd_hostname() {
     if env_has_nonempty_value DD_HOSTNAME; then
         return 0
@@ -902,8 +884,7 @@ if [ "$ENABLE_ONE_CLICK_UPDATES" = "true" ] && [ ! -f "$COMPOSE_UPDATER_FILE" ];
     exit 1
 fi
 
-# Install cleanup before quiescing the updater so every later validation,
-# configuration, build, and Compose failure restores the service.
+# Install cleanup before quiescing so every later failure restores the service.
 trap run_fleet_exit_cleanup EXIT
 trap 'exit 129' HUP
 trap 'exit 130' INT
@@ -1433,7 +1414,6 @@ verify_preflight_marker() {
     fi
 }
 
-# Poll psql until the query returns true; caller owns the warning.
 wait_for_psql_true() {
     local query="$1" attempt result
     for attempt in $(seq 1 "$FLEET_API_READY_ATTEMPTS"); do

--- a/deployment-files/run-fleet.sh
+++ b/deployment-files/run-fleet.sh
@@ -131,7 +131,13 @@ quiesce_updater_for_direct_run() {
         echo "Error: could not inspect proto-fleet-updater.service before the manual deployment run." >&2
         return 1
     fi
-    [ "$load_state" != "not-found" ] || return 0
+    if [ "$load_state" = "not-found" ]; then
+        if [ "$ENABLE_ONE_CLICK_UPDATES" = "true" ]; then
+            echo "Error: one-click updates are enabled, but proto-fleet-updater.service is not installed." >&2
+            return 1
+        fi
+        return 0
+    fi
     if ! active_state=$(systemctl show --property=ActiveState --value \
         proto-fleet-updater.service 2>/dev/null); then
         echo "Error: could not inspect proto-fleet-updater.service state before the manual deployment run." >&2

--- a/deployment-files/run-fleet.sh
+++ b/deployment-files/run-fleet.sh
@@ -114,6 +114,18 @@ quiesce_updater_for_direct_run() {
         echo "Error: one-click updates are configured, but systemctl is unavailable to serialize this manual run." >&2
         return 1
     }
+    # A host that previously supported the updater may later lose its systemd
+    # manager (notably WSL after an init configuration change). The installer
+    # must still be able to persist its explicit fallback to copy-command
+    # upgrades. Keep enabled runs fail-closed, and distinguish manager absence
+    # from a later failure to inspect the updater unit itself.
+    if ! systemctl show --property=Version --value >/dev/null 2>&1; then
+        if [ "$ENABLE_ONE_CLICK_UPDATES" != "true" ]; then
+            return 0
+        fi
+        echo "Error: one-click updates are enabled, but the systemd manager is unavailable to serialize this manual run." >&2
+        return 1
+    fi
     if ! load_state=$(systemctl show --property=LoadState --value \
         proto-fleet-updater.service 2>/dev/null); then
         echo "Error: could not inspect proto-fleet-updater.service before the manual deployment run." >&2

--- a/deployment-files/run-fleet.sh
+++ b/deployment-files/run-fleet.sh
@@ -10,6 +10,7 @@ COMPOSE_FILE="$PROJECT_ROOT/docker-compose.yaml"
 COMPOSE_ALERTS_FILE="$PROJECT_ROOT/docker-compose.alerts.yaml"
 COMPOSE_SYSTEM_MONITORING_FILE="$PROJECT_ROOT/docker-compose.system-monitoring.yaml"
 COMPOSE_TRACING_FILE="$PROJECT_ROOT/docker-compose.tracing.yaml"
+COMPOSE_UPDATER_FILE="$PROJECT_ROOT/docker-compose.updater.yaml"
 ENV_FILE="$PROJECT_ROOT/.env"
 VERSION_FILE="$PROJECT_ROOT/version.txt"
 RELEASE_MANIFEST_FILE="$PROJECT_ROOT/deployment-manifest.sha256"
@@ -21,7 +22,7 @@ NGINX_CONFIG_TEMP=""
 # runtime flags with the same names. Plain shell assignment keeps an inherited
 # variable's export bit, so inspecting those names later would otherwise see
 # the script default instead of the invoking environment.
-OVERLAY_FLAG_KEYS=(ENABLE_BETA_ALERTS ENABLE_SYSTEM_MONITORING ENABLE_TRACING)
+OVERLAY_FLAG_KEYS=(ENABLE_BETA_ALERTS ENABLE_SYSTEM_MONITORING ENABLE_TRACING ENABLE_ONE_CLICK_UPDATES)
 for overlay_key in "${OVERLAY_FLAG_KEYS[@]}"; do
     printf -v "INVOKING_${overlay_key}_SET" '%s' "${!overlay_key+x}"
     printf -v "INVOKING_${overlay_key}_VALUE" '%s' "${!overlay_key-}"
@@ -31,6 +32,8 @@ unset overlay_key
 ENABLE_BETA_ALERTS=false
 ENABLE_SYSTEM_MONITORING=false
 ENABLE_TRACING=false
+ENABLE_ONE_CLICK_UPDATES=false
+ONE_CLICK_UPDATES_OVERRIDE=""
 NON_INTERACTIVE=false
 PREFLIGHT_ONLY=false
 SKIP_BUILD=false
@@ -67,7 +70,7 @@ env_last_value() {
     # overlay flags read their pre-initialization snapshot because the script
     # reuses their names for its runtime defaults.
     case "$key" in
-        ENABLE_BETA_ALERTS|ENABLE_SYSTEM_MONITORING|ENABLE_TRACING)
+        ENABLE_BETA_ALERTS|ENABLE_SYSTEM_MONITORING|ENABLE_TRACING|ENABLE_ONE_CLICK_UPDATES)
             snapshot_set="INVOKING_${key}_SET"
             snapshot_value="INVOKING_${key}_VALUE"
             if [ "${!snapshot_set}" = "x" ]; then
@@ -173,6 +176,7 @@ validate_runner_env_values() {
         ENABLE_BETA_ALERTS
         ENABLE_SYSTEM_MONITORING
         ENABLE_TRACING
+        ENABLE_ONE_CLICK_UPDATES
         FLEET_PROFILE
         DB_USERNAME
         DB_PASSWORD
@@ -337,6 +341,12 @@ Options:
                                 the .env file. Off by default. Can also be
                                 enabled by setting ENABLE_TRACING=true in
                                 the .env file.
+  --enable-one-click-updates    Connect fleet-api to the host updater Unix
+                                socket. The installer sets this only after
+                                the systemd updater starts successfully.
+  --disable-one-click-updates   Disconnect fleet-api from the host updater.
+                                The installer uses this when host bootstrap
+                                is unavailable or fails.
   --non-interactive              Reuse complete persisted configuration and
                                 fail instead of prompting. Intended for the
                                 host updater, not first-time setup.
@@ -361,6 +371,14 @@ while [ $# -gt 0 ]; do
             ;;
         --enable-tracing)
             ENABLE_TRACING=true
+            shift
+            ;;
+        --enable-one-click-updates)
+            ONE_CLICK_UPDATES_OVERRIDE=true
+            shift
+            ;;
+        --disable-one-click-updates)
+            ONE_CLICK_UPDATES_OVERRIDE=false
             shift
             ;;
         --non-interactive)
@@ -424,6 +442,12 @@ fi
 if env_boolean_is_true ENABLE_TRACING; then
     ENABLE_TRACING=true
 fi
+if env_boolean_is_true ENABLE_ONE_CLICK_UPDATES; then
+    ENABLE_ONE_CLICK_UPDATES=true
+fi
+if [ -n "$ONE_CLICK_UPDATES_OVERRIDE" ]; then
+    ENABLE_ONE_CLICK_UPDATES="$ONE_CLICK_UPDATES_OVERRIDE"
+fi
 # System monitoring rides the alerts stack (the in-process metrics writer,
 # Grafana rule evaluation, and webhook delivery are all alerts-gated), so it
 # cannot run alone.
@@ -462,6 +486,11 @@ if [ "$ENABLE_TRACING" = "true" ]; then
     ensure_dd_hostname
 fi
 
+if [ "$ENABLE_ONE_CLICK_UPDATES" = "true" ] && [ ! -f "$COMPOSE_UPDATER_FILE" ]; then
+    echo "Error: one-click updates are enabled but $COMPOSE_UPDATER_FILE is missing." >&2
+    exit 1
+fi
+
 if [ "$PREFLIGHT_ONLY" = "true" ]; then
     # A failed retry must not leave an older success marker reusable.
     if ! rm -f "$PREFLIGHT_MARKER"; then
@@ -482,6 +511,9 @@ refresh_compose_files() {
     fi
     if [ "$ENABLE_TRACING" = "true" ] && [ -f "$COMPOSE_TRACING_FILE" ]; then
         COMPOSE_FILES+=(-f "$COMPOSE_TRACING_FILE")
+    fi
+    if [ "$ENABLE_ONE_CLICK_UPDATES" = "true" ]; then
+        COMPOSE_FILES+=(-f "$COMPOSE_UPDATER_FILE")
     fi
 }
 refresh_compose_files
@@ -1836,7 +1868,8 @@ fi
 if ! atomic_set_env_values \
     ENABLE_BETA_ALERTS "$ENABLE_BETA_ALERTS" \
     ENABLE_SYSTEM_MONITORING "$ENABLE_SYSTEM_MONITORING" \
-    ENABLE_TRACING "$ENABLE_TRACING"; then
+    ENABLE_TRACING "$ENABLE_TRACING" \
+    ENABLE_ONE_CLICK_UPDATES "$ENABLE_ONE_CLICK_UPDATES"; then
     echo "Error: could not persist deployment overlay settings; aborting before Compose validation or service changes." >&2
     exit 1
 fi

--- a/deployment-files/run-fleet.sh
+++ b/deployment-files/run-fleet.sh
@@ -20,7 +20,9 @@ NGINX_CONFIG_TEMP=""
 UPDATER_SOCKET_PATH="/run/proto-fleet-updater/updater.sock"
 DIRECT_UPDATER_PRIVILEGE=()
 DIRECT_UPDATER_WAS_ACTIVE=false
+DIRECT_UPDATER_SERVICE_PRESENT=false
 DIRECT_UPDATER_ENV_ROLLBACK_PENDING=false
+DEPLOYMENT_MUTATION_STARTED=false
 
 # Preserve process-level Compose overrides before the script initializes its
 # runtime flags with the same names. Plain shell assignment keeps an inherited
@@ -58,18 +60,31 @@ PREVIOUS_RELEASE_IMAGE_TAGS=()
 RELEASE_IMAGE_CLEANUP_SAFE=true
 DD_HOSTNAME_DEFAULTED=false
 
-restore_direct_run_updater() {
-    local run_status="$1"
-    [ "$DIRECT_UPDATER_WAS_ACTIVE" = "true" ] || return 0
-    # A successful disable intentionally leaves the daemon stopped. On a
-    # failed run, restore only the service state that matched the previously
-    # persisted deployment configuration.
-    if [ "$run_status" -eq 0 ]; then
-        [ "$ENABLE_ONE_CLICK_UPDATES" = "true" ] || return 0
-    else
-        [ "$ONE_CLICK_UPDATES_WAS_CONFIGURED" = "true" ] || return 0
+resolve_direct_updater_privilege() {
+    DIRECT_UPDATER_PRIVILEGE=()
+    if [ "$(id -u)" -eq 0 ]; then
+        return 0
     fi
+    command -v sudo >/dev/null 2>&1 || {
+        echo "Error: sudo is required to manage the host updater during this manual deployment run." >&2
+        return 1
+    }
+    if [ "$NON_INTERACTIVE" = "true" ]; then
+        DIRECT_UPDATER_PRIVILEGE=(sudo -n)
+    else
+        DIRECT_UPDATER_PRIVILEGE=(sudo)
+    fi
+}
+
+restart_direct_run_updater() {
+    local enable_at_boot="$1"
     DIRECT_UPDATER_WAS_ACTIVE=false
+    if [ "$enable_at_boot" = "true" ] \
+      && ! ${DIRECT_UPDATER_PRIVILEGE[@]+"${DIRECT_UPDATER_PRIVILEGE[@]}"} \
+        systemctl enable proto-fleet-updater.service; then
+        echo "Error: could not enable proto-fleet-updater.service after the manual deployment run." >&2
+        return 1
+    fi
     echo "Restoring the host updater after the manual deployment run..."
     if ! ${DIRECT_UPDATER_PRIVILEGE[@]+"${DIRECT_UPDATER_PRIVILEGE[@]}"} \
         systemctl restart proto-fleet-updater.service; then
@@ -91,6 +106,54 @@ restore_direct_run_updater() {
     return 1
 }
 
+disable_direct_run_updater() {
+    DIRECT_UPDATER_WAS_ACTIVE=false
+    # An unavailable systemd manager cannot have a supervised updater to
+    # disable. This preserves the supported WSL fallback to copy-command
+    # upgrades when systemd has been turned off.
+    if ! systemctl show --property=Version --value >/dev/null 2>&1; then
+        return 0
+    fi
+    echo "Disabling the host updater after the manual deployment run..."
+    if ! ${DIRECT_UPDATER_PRIVILEGE[@]+"${DIRECT_UPDATER_PRIVILEGE[@]}"} \
+        systemctl disable --now proto-fleet-updater.service; then
+        echo "Error: could not disable proto-fleet-updater.service after the manual deployment run." >&2
+        return 1
+    fi
+    return 0
+}
+
+reconcile_direct_run_updater() {
+    local run_status="$1"
+    local committed_state="$ENABLE_ONE_CLICK_UPDATES"
+    [ "${PROTO_FLEET_UPDATER_MANAGED_RUN:-0}" != "1" ] || return 0
+    [ "${PROTO_FLEET_INSTALLER_MANAGED_RUN:-0}" != "1" ] || return 0
+
+    # Before Compose mutation, failure leaves the old topology running and
+    # therefore restores its updater state. Once teardown begins, topology is
+    # uncertain and the persisted desired state is the only safe authority.
+    if [ "$run_status" -ne 0 ] \
+      && [ "$DEPLOYMENT_MUTATION_STARTED" != "true" ]; then
+        committed_state="$ONE_CLICK_UPDATES_WAS_CONFIGURED"
+    fi
+
+    if [ "$committed_state" = "true" ]; then
+        if [ "$DIRECT_UPDATER_WAS_ACTIVE" = "true" ]; then
+            restart_direct_run_updater false || return 1
+        elif [ "$DIRECT_UPDATER_SERVICE_PRESENT" = "true" ] \
+          && [ "$ONE_CLICK_UPDATES_WAS_CONFIGURED" != "true" ]; then
+            restart_direct_run_updater true || return 1
+        fi
+        return 0
+    fi
+    if [ "$DIRECT_UPDATER_SERVICE_PRESENT" = "true" ] \
+      && { [ "$DIRECT_UPDATER_WAS_ACTIVE" = "true" ] \
+        || [ "$ONE_CLICK_UPDATES_WAS_CONFIGURED" = "true" ]; }; then
+        disable_direct_run_updater || return 1
+    fi
+    return 0
+}
+
 run_fleet_exit_cleanup() {
     local run_status=$?
     local status="$run_status"
@@ -103,6 +166,7 @@ run_fleet_exit_cleanup() {
         cleanup_env_rewrite || status=1
     fi
     if [ "$run_status" -ne 0 ] \
+      && [ "$DEPLOYMENT_MUTATION_STARTED" != "true" ] \
       && [ "$DIRECT_UPDATER_ENV_ROLLBACK_PENDING" = "true" ]; then
         echo "Restoring the previous one-click update setting after the failed deployment run..." >&2
         if atomic_set_env_values \
@@ -113,11 +177,12 @@ run_fleet_exit_cleanup() {
             env_rollback_failed=true
             status=1
         fi
-    elif [ "$run_status" -eq 0 ]; then
+    elif [ "$run_status" -eq 0 ] \
+      || [ "$DEPLOYMENT_MUTATION_STARTED" = "true" ]; then
         DIRECT_UPDATER_ENV_ROLLBACK_PENDING=false
     fi
     if [ "$env_rollback_failed" != "true" ] \
-      && ! restore_direct_run_updater "$run_status"; then
+      && ! reconcile_direct_run_updater "$run_status"; then
         status=1
     fi
     exit "$status"
@@ -167,16 +232,21 @@ quiesce_updater_for_direct_run() {
         return 1
     fi
     if ! active_state=$(systemctl show --property=ActiveState --value \
-        proto-fleet-updater.service 2>/dev/null); then
+      proto-fleet-updater.service 2>/dev/null); then
         echo "Error: could not inspect proto-fleet-updater.service state before the manual deployment run." >&2
         return 1
     fi
+    [ "$load_state" = "not-found" ] || DIRECT_UPDATER_SERVICE_PRESENT=true
     case "$active_state" in
         inactive|failed)
             if [ "$load_state" = "not-found" ] \
               && [ "$ENABLE_ONE_CLICK_UPDATES" = "true" ]; then
                 echo "Error: one-click updates are enabled, but proto-fleet-updater.service is not installed." >&2
                 return 1
+            fi
+            if [ "$DIRECT_UPDATER_SERVICE_PRESENT" = "true" ] \
+              && [ "$one_click_was_configured" != "$ENABLE_ONE_CLICK_UPDATES" ]; then
+                resolve_direct_updater_privilege || return 1
             fi
             return 0
             ;;
@@ -187,18 +257,7 @@ quiesce_updater_for_direct_run() {
             ;;
     esac
 
-    DIRECT_UPDATER_PRIVILEGE=()
-    if [ "$(id -u)" -ne 0 ]; then
-        command -v sudo >/dev/null 2>&1 || {
-            echo "Error: sudo is required to stop the host updater before this manual deployment run." >&2
-            return 1
-        }
-        if [ "$NON_INTERACTIVE" = "true" ]; then
-            DIRECT_UPDATER_PRIVILEGE=(sudo -n)
-        else
-            DIRECT_UPDATER_PRIVILEGE=(sudo)
-        fi
-    fi
+    resolve_direct_updater_privilege || return 1
     echo "Stopping the host updater for this manual deployment run..."
     if ! ${DIRECT_UPDATER_PRIVILEGE[@]+"${DIRECT_UPDATER_PRIVILEGE[@]}"} \
         systemctl stop proto-fleet-updater.service; then
@@ -643,6 +702,12 @@ if env_boolean_is_true ENABLE_ONE_CLICK_UPDATES; then
 fi
 if [ -n "$ONE_CLICK_UPDATES_OVERRIDE" ]; then
     ENABLE_ONE_CLICK_UPDATES="$ONE_CLICK_UPDATES_OVERRIDE"
+fi
+if [ "$PREFLIGHT_ONLY" = "true" ] \
+  && [ "${PROTO_FLEET_UPDATER_MANAGED_RUN:-0}" != "1" ] \
+  && [ "$ONE_CLICK_UPDATES_WAS_CONFIGURED" != "$ENABLE_ONE_CLICK_UPDATES" ]; then
+    echo "Error: --preflight-only cannot change one-click update state for the active deployment; run the complete deployment with the same enable/disable option." >&2
+    exit 1
 fi
 # System monitoring rides the alerts stack (the in-process metrics writer,
 # Grafana rule evaluation, and webhook delivery are all alerts-gated), so it
@@ -2380,7 +2445,11 @@ fi
 
 echo "Stopping any running services..."
 capture_previous_release_image_tags
-compose down --remove-orphans
+DEPLOYMENT_MUTATION_STARTED=true
+if ! compose down --remove-orphans; then
+    echo "Error: could not stop the existing services cleanly." >&2
+    exit 1
+fi
 
 echo "Starting services..."
 # --wait blocks until every service is running (or healthy, when a healthcheck is defined).

--- a/deployment-files/run-fleet.sh
+++ b/deployment-files/run-fleet.sh
@@ -222,6 +222,28 @@ disable_direct_run_updater() {
     return 0
 }
 
+deploy_direct_run_updater_fallback() {
+    echo "Warning: the host updater did not become ready; redeploying without its socket overlay." >&2
+    # A failed readiness check can leave a partially started updater behind.
+    # Stop and disable it before the fallback runner mutates the deployment so
+    # it cannot race the second Compose transition.
+    if ! disable_direct_run_updater; then
+        echo "Error: could not stop the unavailable host updater before deploying the copy-command fallback." >&2
+        return 1
+    fi
+    # The successful deployment already persisted every other overlay choice.
+    # Use only the non-interactive updater override here: preflight proof has
+    # been consumed, and carrying --skip-build would reject this recovery run.
+    if ! /bin/bash "$PROJECT_ROOT/run-fleet.sh" \
+        --non-interactive --disable-one-click-updates; then
+        echo "Error: could not deploy the copy-command fallback after the host updater failed readiness." >&2
+        return 1
+    fi
+    ENABLE_ONE_CLICK_UPDATES=false
+    DIRECT_UPDATER_ENV_ROLLBACK_PENDING=false
+    echo "One-click upgrades are unavailable; the in-product copy command remains usable."
+}
+
 reconcile_direct_run_updater() {
     local run_status="$1"
     local committed_state="$ENABLE_ONE_CLICK_UPDATES"
@@ -245,7 +267,16 @@ reconcile_direct_run_updater() {
         # Enforce the persisted contract even when systemd drifted before this
         # run: enabled configuration always ends with a boot-enabled, ready
         # service rather than relying on its state at admission time.
-        restart_direct_run_updater true || return 1
+        if ! restart_direct_run_updater true; then
+            # Once teardown has started, Fleet may already be running with the
+            # updater socket overlay. Commit the supported copy-command mode
+            # rather than returning with a broken privileged endpoint.
+            if [ "$DEPLOYMENT_MUTATION_STARTED" = "true" ]; then
+                deploy_direct_run_updater_fallback || return 1
+                return 0
+            fi
+            return 1
+        fi
         return 0
     fi
     if [ "$DIRECT_UPDATER_SERVICE_PRESENT" = "true" ]; then

--- a/deployment-files/run-fleet.sh
+++ b/deployment-files/run-fleet.sh
@@ -124,8 +124,10 @@ verify_direct_updater_ownership() {
 resolve_direct_updater_privilege() {
     DIRECT_UPDATER_PRIVILEGE=()
     if [ "$(id -u)" -eq 0 ]; then
-        verify_direct_updater_ownership
-        return
+        if ! verify_direct_updater_ownership; then
+            return 1
+        fi
+        return 0
     fi
     command -v sudo >/dev/null 2>&1 || {
         echo "Error: sudo is required to manage the host updater during this manual deployment run." >&2

--- a/deployment-files/run-fleet.sh
+++ b/deployment-files/run-fleet.sh
@@ -18,9 +18,11 @@ TSDB_IMAGE="$PROJECT_ROOT/images/timescaledb.tar.gz"
 PREFLIGHT_MARKER="$PROJECT_ROOT/.update-preflight-complete"
 NGINX_CONFIG_TEMP=""
 UPDATER_SOCKET_PATH="/run/proto-fleet-updater/updater.sock"
+HOST_UPDATER_ENV_PATH="/etc/proto-fleet/updater.env"
 DIRECT_UPDATER_PRIVILEGE=()
 DIRECT_UPDATER_WAS_ACTIVE=false
 DIRECT_UPDATER_SERVICE_PRESENT=false
+DIRECT_UPDATER_OWNERSHIP_VERIFIED=false
 DIRECT_UPDATER_ENV_ROLLBACK_PENDING=false
 DEPLOYMENT_MUTATION_STARTED=false
 
@@ -60,10 +62,70 @@ PREVIOUS_RELEASE_IMAGE_TAGS=()
 RELEASE_IMAGE_CLEANUP_SAFE=true
 DD_HOSTNAME_DEFAULTED=false
 
+parse_direct_updater_install_root() {
+    local contents="$1"
+    local key_re='^[[:space:]]*PROTO_FLEET_INSTALL_ROOT[[:space:]]*='
+    local assignment_re='^PROTO_FLEET_INSTALL_ROOT="(([^"\\]|\\["\\])*)"$'
+    local line encoded decoded char
+    local found=0
+
+    while IFS= read -r line || [ -n "$line" ]; do
+        [[ "$line" =~ $key_re ]] || continue
+        [ "$found" -eq 0 ] || return 1
+        [[ "$line" =~ $assignment_re ]] || return 1
+        encoded="${BASH_REMATCH[1]}"
+        decoded=""
+        while [ -n "$encoded" ]; do
+            char="${encoded:0:1}"
+            encoded="${encoded:1}"
+            if [ "$char" = '\' ]; then
+                [ -n "$encoded" ] || return 1
+                char="${encoded:0:1}"
+                encoded="${encoded:1}"
+                [ "$char" = '\' ] || [ "$char" = '"' ] || return 1
+            fi
+            decoded="${decoded}${char}"
+        done
+        [ -n "$decoded" ] || return 1
+        found=1
+    done <<< "$contents"
+
+    [ "$found" -eq 1 ] || return 1
+    printf '%s\n' "$decoded"
+}
+
+verify_direct_updater_ownership() {
+    local contents configured_root configured_resolved expected_resolved
+
+    [ "$DIRECT_UPDATER_OWNERSHIP_VERIFIED" != "true" ] || return 0
+    if ! contents="$(${DIRECT_UPDATER_PRIVILEGE[@]+"${DIRECT_UPDATER_PRIVILEGE[@]}"} \
+        cat -- "$HOST_UPDATER_ENV_PATH" 2>/dev/null)" \
+      || ! configured_root="$(parse_direct_updater_install_root "$contents")"; then
+        echo "Error: could not read a valid updater install root from $HOST_UPDATER_ENV_PATH; refusing to control the global updater service." >&2
+        return 1
+    fi
+    if ! configured_resolved="$(cd "$configured_root" 2>/dev/null && pwd -P)"; then
+        echo "Error: the configured updater install root cannot be resolved: $configured_root" >&2
+        return 1
+    fi
+    if ! expected_resolved="$(cd "$PROJECT_ROOT/.." 2>/dev/null && pwd -P)"; then
+        echo "Error: the current Proto Fleet install root cannot be resolved from $PROJECT_ROOT." >&2
+        return 1
+    fi
+    if [ "${configured_resolved%/}" != "${expected_resolved%/}" ]; then
+        echo "Error: proto-fleet-updater.service belongs to a different Proto Fleet installation; refusing to change it." >&2
+        echo "  Updater install root: $configured_resolved" >&2
+        echo "  Current install root: $expected_resolved" >&2
+        return 1
+    fi
+    DIRECT_UPDATER_OWNERSHIP_VERIFIED=true
+}
+
 resolve_direct_updater_privilege() {
     DIRECT_UPDATER_PRIVILEGE=()
     if [ "$(id -u)" -eq 0 ]; then
-        return 0
+        verify_direct_updater_ownership
+        return
     fi
     command -v sudo >/dev/null 2>&1 || {
         echo "Error: sudo is required to manage the host updater during this manual deployment run." >&2
@@ -74,6 +136,7 @@ resolve_direct_updater_privilege() {
     else
         DIRECT_UPDATER_PRIVILEGE=(sudo)
     fi
+    verify_direct_updater_ownership
 }
 
 restart_direct_run_updater() {

--- a/deployment-files/run-fleet.sh
+++ b/deployment-files/run-fleet.sh
@@ -17,6 +17,9 @@ RELEASE_MANIFEST_FILE="$PROJECT_ROOT/deployment-manifest.sha256"
 TSDB_IMAGE="$PROJECT_ROOT/images/timescaledb.tar.gz"
 PREFLIGHT_MARKER="$PROJECT_ROOT/.update-preflight-complete"
 NGINX_CONFIG_TEMP=""
+UPDATER_SOCKET_PATH="/run/proto-fleet-updater/updater.sock"
+DIRECT_UPDATER_PRIVILEGE=()
+DIRECT_UPDATER_RESTART_ON_EXIT=false
 
 # Preserve process-level Compose overrides before the script initializes its
 # runtime flags with the same names. Plain shell assignment keeps an inherited
@@ -53,6 +56,120 @@ PROTO_FLEET_IMAGE_REPOSITORIES=(
 PREVIOUS_RELEASE_IMAGE_TAGS=()
 RELEASE_IMAGE_CLEANUP_SAFE=true
 DD_HOSTNAME_DEFAULTED=false
+
+restore_direct_run_updater() {
+    [ "$DIRECT_UPDATER_RESTART_ON_EXIT" = "true" ] || return 0
+    DIRECT_UPDATER_RESTART_ON_EXIT=false
+    echo "Restoring the host updater after the manual deployment run..."
+    if ! ${DIRECT_UPDATER_PRIVILEGE[@]+"${DIRECT_UPDATER_PRIVILEGE[@]}"} \
+        systemctl restart proto-fleet-updater.service; then
+        echo "Error: could not restart proto-fleet-updater.service after the manual deployment run." >&2
+        return 1
+    fi
+    local ready_deadline=$((SECONDS + 60))
+    while [ "$SECONDS" -lt "$ready_deadline" ]; do
+        if ${DIRECT_UPDATER_PRIVILEGE[@]+"${DIRECT_UPDATER_PRIVILEGE[@]}"} \
+            curl -fsS --max-time 1 --unix-socket "$UPDATER_SOCKET_PATH" \
+            http://localhost/v1/status >/dev/null 2>&1 \
+          && ${DIRECT_UPDATER_PRIVILEGE[@]+"${DIRECT_UPDATER_PRIVILEGE[@]}"} \
+            systemctl is-active --quiet proto-fleet-updater.service; then
+            return 0
+        fi
+        sleep 1
+    done
+    echo "Error: proto-fleet-updater.service did not become ready after the manual deployment run." >&2
+    return 1
+}
+
+run_fleet_exit_cleanup() {
+    local status=$?
+    trap - EXIT
+    if declare -F cleanup_nginx_config_temp >/dev/null 2>&1; then
+        cleanup_nginx_config_temp || status=1
+    fi
+    if declare -F cleanup_env_rewrite >/dev/null 2>&1; then
+        cleanup_env_rewrite || status=1
+    fi
+    if ! restore_direct_run_updater; then
+        status=1
+    fi
+    exit "$status"
+}
+
+# The updater daemon owns serialization for its staged preflight and activation
+# children. A human running this script against the active deployment must
+# instead stop the daemon before any environment or Compose mutation so the
+# deployment directory cannot be renamed out from under the shell.
+quiesce_updater_for_direct_run() {
+    local one_click_was_configured="$1"
+    local load_state active_state
+
+    [ "${PROTO_FLEET_UPDATER_MANAGED_RUN:-0}" != "1" ] || return 0
+    if [ "$one_click_was_configured" != "true" ] \
+        && [ "$ENABLE_ONE_CLICK_UPDATES" != "true" ]; then
+        return 0
+    fi
+    [ "$(uname -s)" = "Linux" ] || return 0
+    command -v systemctl >/dev/null 2>&1 || {
+        echo "Error: one-click updates are configured, but systemctl is unavailable to serialize this manual run." >&2
+        return 1
+    }
+    if ! load_state=$(systemctl show --property=LoadState --value \
+        proto-fleet-updater.service 2>/dev/null); then
+        echo "Error: could not inspect proto-fleet-updater.service before the manual deployment run." >&2
+        return 1
+    fi
+    [ "$load_state" != "not-found" ] || return 0
+    if ! active_state=$(systemctl show --property=ActiveState --value \
+        proto-fleet-updater.service 2>/dev/null); then
+        echo "Error: could not inspect proto-fleet-updater.service state before the manual deployment run." >&2
+        return 1
+    fi
+    case "$active_state" in
+        inactive|failed) return 0 ;;
+        active|activating|reloading) ;;
+        *)
+            echo "Error: proto-fleet-updater.service has unexpected state '$active_state'." >&2
+            return 1
+            ;;
+    esac
+
+    DIRECT_UPDATER_PRIVILEGE=()
+    if [ "$(id -u)" -ne 0 ]; then
+        command -v sudo >/dev/null 2>&1 || {
+            echo "Error: sudo is required to stop the host updater before this manual deployment run." >&2
+            return 1
+        }
+        if [ "$NON_INTERACTIVE" = "true" ]; then
+            DIRECT_UPDATER_PRIVILEGE=(sudo -n)
+        else
+            DIRECT_UPDATER_PRIVILEGE=(sudo)
+        fi
+    fi
+    echo "Stopping the host updater for this manual deployment run..."
+    if ! ${DIRECT_UPDATER_PRIVILEGE[@]+"${DIRECT_UPDATER_PRIVILEGE[@]}"} \
+        systemctl stop proto-fleet-updater.service; then
+        echo "Error: could not stop proto-fleet-updater.service before mutating the deployment." >&2
+        return 1
+    fi
+    # Arm restoration as soon as systemd reports a successful stop. If the
+    # checked inactive-state query fails, EXIT cleanup still repairs service
+    # availability rather than leaving the updater accidentally stopped.
+    DIRECT_UPDATER_RESTART_ON_EXIT=true
+    if ! active_state=$(${DIRECT_UPDATER_PRIVILEGE[@]+"${DIRECT_UPDATER_PRIVILEGE[@]}"} \
+        systemctl show --property=ActiveState --value \
+        proto-fleet-updater.service 2>/dev/null); then
+        echo "Error: could not verify that proto-fleet-updater.service stopped." >&2
+        return 1
+    fi
+    case "$active_state" in
+        inactive|failed) return 0 ;;
+        *)
+            echo "Error: proto-fleet-updater.service remained active; refusing to mutate the deployment." >&2
+            return 1
+            ;;
+    esac
+}
 
 # How long the post-start steps wait for fleet-api to finish its migrations.
 # 300 x 2s = 10 minutes: a first boot on SD-card-class hardware (Raspberry Pi)
@@ -442,7 +559,9 @@ fi
 if env_boolean_is_true ENABLE_TRACING; then
     ENABLE_TRACING=true
 fi
+ONE_CLICK_UPDATES_WAS_CONFIGURED=false
 if env_boolean_is_true ENABLE_ONE_CLICK_UPDATES; then
+    ONE_CLICK_UPDATES_WAS_CONFIGURED=true
     ENABLE_ONE_CLICK_UPDATES=true
 fi
 if [ -n "$ONE_CLICK_UPDATES_OVERRIDE" ]; then
@@ -488,6 +607,16 @@ fi
 
 if [ "$ENABLE_ONE_CLICK_UPDATES" = "true" ] && [ ! -f "$COMPOSE_UPDATER_FILE" ]; then
     echo "Error: one-click updates are enabled but $COMPOSE_UPDATER_FILE is missing." >&2
+    exit 1
+fi
+
+# Install cleanup before quiescing the updater so every later validation,
+# configuration, build, and Compose failure restores the service.
+trap run_fleet_exit_cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+if ! quiesce_updater_for_direct_run "$ONE_CLICK_UPDATES_WAS_CONFIGURED"; then
     exit 1
 fi
 
@@ -1551,13 +1680,6 @@ abort_env_rewrite() {
     cleanup_env_rewrite || true
     return 1
 }
-
-# Keep cleanup in the main shell so a supervisor signalling only the runner
-# cannot leave a partial generated config or environment rewrite behind.
-trap 'cleanup_nginx_config_temp || true; cleanup_env_rewrite || true' EXIT
-trap 'exit 129' HUP
-trap 'exit 130' INT
-trap 'exit 143' TERM
 
 atomic_set_env_values() {
     local key value key_csv original_owner temp_owner last_byte assignment

--- a/deployment-files/run-fleet.sh
+++ b/deployment-files/run-fleet.sh
@@ -160,7 +160,9 @@ restart_direct_run_updater() {
             curl -fsS --max-time 1 --unix-socket "$UPDATER_SOCKET_PATH" \
             http://localhost/v1/status >/dev/null 2>&1 \
           && ${DIRECT_UPDATER_PRIVILEGE[@]+"${DIRECT_UPDATER_PRIVILEGE[@]}"} \
-            systemctl is-active --quiet proto-fleet-updater.service; then
+            systemctl is-active --quiet proto-fleet-updater.service \
+          && ${DIRECT_UPDATER_PRIVILEGE[@]+"${DIRECT_UPDATER_PRIVILEGE[@]}"} \
+            systemctl is-enabled --quiet proto-fleet-updater.service; then
             return 0
         fi
         sleep 1
@@ -183,6 +185,23 @@ disable_direct_run_updater() {
         echo "Error: could not disable proto-fleet-updater.service after the manual deployment run." >&2
         return 1
     fi
+    local active_state unit_file_state
+    if ! active_state="$(${DIRECT_UPDATER_PRIVILEGE[@]+"${DIRECT_UPDATER_PRIVILEGE[@]}"} \
+        systemctl show --property=ActiveState --value \
+        proto-fleet-updater.service 2>/dev/null)" \
+      || ! unit_file_state="$(${DIRECT_UPDATER_PRIVILEGE[@]+"${DIRECT_UPDATER_PRIVILEGE[@]}"} \
+        systemctl show --property=UnitFileState --value \
+        proto-fleet-updater.service 2>/dev/null)"; then
+        echo "Error: could not verify that proto-fleet-updater.service is stopped and disabled." >&2
+        return 1
+    fi
+    case "$active_state:$unit_file_state" in
+        inactive:disabled|failed:disabled) ;;
+        *)
+            echo "Error: proto-fleet-updater.service did not reach the stopped and disabled state." >&2
+            return 1
+            ;;
+    esac
     return 0
 }
 
@@ -201,17 +220,21 @@ reconcile_direct_run_updater() {
     fi
 
     if [ "$committed_state" = "true" ]; then
-        if [ "$DIRECT_UPDATER_WAS_ACTIVE" = "true" ]; then
-            restart_direct_run_updater false || return 1
-        elif [ "$DIRECT_UPDATER_SERVICE_PRESENT" = "true" ] \
-          && [ "$ONE_CLICK_UPDATES_WAS_CONFIGURED" != "true" ]; then
-            restart_direct_run_updater true || return 1
+        if [ "$DIRECT_UPDATER_SERVICE_PRESENT" != "true" ]; then
+            echo "Error: one-click updates are enabled, but proto-fleet-updater.service cannot be reconciled." >&2
+            return 1
         fi
+        resolve_direct_updater_privilege || return 1
+        # Enforce the persisted contract even when systemd drifted before this
+        # run: enabled configuration always ends with a boot-enabled, ready
+        # service rather than relying on its state at admission time.
+        restart_direct_run_updater true || return 1
         return 0
     fi
-    if [ "$DIRECT_UPDATER_SERVICE_PRESENT" = "true" ] \
-      && { [ "$DIRECT_UPDATER_WAS_ACTIVE" = "true" ] \
-        || [ "$ONE_CLICK_UPDATES_WAS_CONFIGURED" = "true" ]; }; then
+    if [ "$DIRECT_UPDATER_SERVICE_PRESENT" = "true" ]; then
+        resolve_direct_updater_privilege || return 1
+        # Likewise, disabled configuration always removes boot enablement and
+        # stops a stale process, even when both desired flags were already false.
         disable_direct_run_updater || return 1
     fi
     return 0

--- a/deployment-files/run-fleet.sh
+++ b/deployment-files/run-fleet.sh
@@ -19,7 +19,8 @@ PREFLIGHT_MARKER="$PROJECT_ROOT/.update-preflight-complete"
 NGINX_CONFIG_TEMP=""
 UPDATER_SOCKET_PATH="/run/proto-fleet-updater/updater.sock"
 DIRECT_UPDATER_PRIVILEGE=()
-DIRECT_UPDATER_RESTART_ON_EXIT=false
+DIRECT_UPDATER_WAS_ACTIVE=false
+DIRECT_UPDATER_ENV_ROLLBACK_PENDING=false
 
 # Preserve process-level Compose overrides before the script initializes its
 # runtime flags with the same names. Plain shell assignment keeps an inherited
@@ -58,8 +59,17 @@ RELEASE_IMAGE_CLEANUP_SAFE=true
 DD_HOSTNAME_DEFAULTED=false
 
 restore_direct_run_updater() {
-    [ "$DIRECT_UPDATER_RESTART_ON_EXIT" = "true" ] || return 0
-    DIRECT_UPDATER_RESTART_ON_EXIT=false
+    local run_status="$1"
+    [ "$DIRECT_UPDATER_WAS_ACTIVE" = "true" ] || return 0
+    # A successful disable intentionally leaves the daemon stopped. On a
+    # failed run, restore only the service state that matched the previously
+    # persisted deployment configuration.
+    if [ "$run_status" -eq 0 ]; then
+        [ "$ENABLE_ONE_CLICK_UPDATES" = "true" ] || return 0
+    else
+        [ "$ONE_CLICK_UPDATES_WAS_CONFIGURED" = "true" ] || return 0
+    fi
+    DIRECT_UPDATER_WAS_ACTIVE=false
     echo "Restoring the host updater after the manual deployment run..."
     if ! ${DIRECT_UPDATER_PRIVILEGE[@]+"${DIRECT_UPDATER_PRIVILEGE[@]}"} \
         systemctl restart proto-fleet-updater.service; then
@@ -82,7 +92,9 @@ restore_direct_run_updater() {
 }
 
 run_fleet_exit_cleanup() {
-    local status=$?
+    local run_status=$?
+    local status="$run_status"
+    local env_rollback_failed=false
     trap - EXIT
     if declare -F cleanup_nginx_config_temp >/dev/null 2>&1; then
         cleanup_nginx_config_temp || status=1
@@ -90,7 +102,22 @@ run_fleet_exit_cleanup() {
     if declare -F cleanup_env_rewrite >/dev/null 2>&1; then
         cleanup_env_rewrite || status=1
     fi
-    if ! restore_direct_run_updater; then
+    if [ "$run_status" -ne 0 ] \
+      && [ "$DIRECT_UPDATER_ENV_ROLLBACK_PENDING" = "true" ]; then
+        echo "Restoring the previous one-click update setting after the failed deployment run..." >&2
+        if atomic_set_env_values \
+            ENABLE_ONE_CLICK_UPDATES "$ONE_CLICK_UPDATES_WAS_CONFIGURED"; then
+            DIRECT_UPDATER_ENV_ROLLBACK_PENDING=false
+        else
+            echo "Error: could not restore the previous one-click update setting; leaving the updater stopped." >&2
+            env_rollback_failed=true
+            status=1
+        fi
+    elif [ "$run_status" -eq 0 ]; then
+        DIRECT_UPDATER_ENV_ROLLBACK_PENDING=false
+    fi
+    if [ "$env_rollback_failed" != "true" ] \
+      && ! restore_direct_run_updater "$run_status"; then
         status=1
     fi
     exit "$status"
@@ -105,15 +132,23 @@ quiesce_updater_for_direct_run() {
     local load_state active_state
 
     [ "${PROTO_FLEET_UPDATER_MANAGED_RUN:-0}" != "1" ] || return 0
-    if [ "$one_click_was_configured" != "true" ] \
-        && [ "$ENABLE_ONE_CLICK_UPDATES" != "true" ]; then
+    [ "$(uname -s)" = "Linux" ] || return 0
+    # A source checkout has no relationship to the packaged installation's
+    # global updater. Inspect it only for a packaged deployment, or when this
+    # runner explicitly carries updater state that must be serialized.
+    if [ ! -f "$VERSION_FILE" ] \
+      && [ "$one_click_was_configured" != "true" ] \
+      && [ "$ENABLE_ONE_CLICK_UPDATES" != "true" ]; then
         return 0
     fi
-    [ "$(uname -s)" = "Linux" ] || return 0
-    command -v systemctl >/dev/null 2>&1 || {
+    if ! command -v systemctl >/dev/null 2>&1; then
+        if [ "$one_click_was_configured" != "true" ] \
+          && [ "$ENABLE_ONE_CLICK_UPDATES" != "true" ]; then
+            return 0
+        fi
         echo "Error: one-click updates are configured, but systemctl is unavailable to serialize this manual run." >&2
         return 1
-    }
+    fi
     # A host that previously supported the updater may later lose its systemd
     # manager (notably WSL after an init configuration change). The installer
     # must still be able to persist its explicit fallback to copy-command
@@ -131,21 +166,21 @@ quiesce_updater_for_direct_run() {
         echo "Error: could not inspect proto-fleet-updater.service before the manual deployment run." >&2
         return 1
     fi
-    if [ "$load_state" = "not-found" ]; then
-        if [ "$ENABLE_ONE_CLICK_UPDATES" = "true" ]; then
-            echo "Error: one-click updates are enabled, but proto-fleet-updater.service is not installed." >&2
-            return 1
-        fi
-        return 0
-    fi
     if ! active_state=$(systemctl show --property=ActiveState --value \
         proto-fleet-updater.service 2>/dev/null); then
         echo "Error: could not inspect proto-fleet-updater.service state before the manual deployment run." >&2
         return 1
     fi
     case "$active_state" in
-        inactive|failed) return 0 ;;
-        active|activating|reloading) ;;
+        inactive|failed)
+            if [ "$load_state" = "not-found" ] \
+              && [ "$ENABLE_ONE_CLICK_UPDATES" = "true" ]; then
+                echo "Error: one-click updates are enabled, but proto-fleet-updater.service is not installed." >&2
+                return 1
+            fi
+            return 0
+            ;;
+        active|activating|reloading|deactivating) ;;
         *)
             echo "Error: proto-fleet-updater.service has unexpected state '$active_state'." >&2
             return 1
@@ -173,7 +208,7 @@ quiesce_updater_for_direct_run() {
     # Arm restoration as soon as systemd reports a successful stop. If the
     # checked inactive-state query fails, EXIT cleanup still repairs service
     # availability rather than leaving the updater accidentally stopped.
-    DIRECT_UPDATER_RESTART_ON_EXIT=true
+    DIRECT_UPDATER_WAS_ACTIVE=true
     if ! active_state=$(${DIRECT_UPDATER_PRIVILEGE[@]+"${DIRECT_UPDATER_PRIVILEGE[@]}"} \
         systemctl show --property=ActiveState --value \
         proto-fleet-updater.service 2>/dev/null); then
@@ -2036,6 +2071,9 @@ if ! atomic_set_env_values \
     ENABLE_ONE_CLICK_UPDATES "$ENABLE_ONE_CLICK_UPDATES"; then
     echo "Error: could not persist deployment overlay settings; aborting before Compose validation or service changes." >&2
     exit 1
+fi
+if [ "$ONE_CLICK_UPDATES_WAS_CONFIGURED" != "$ENABLE_ONE_CLICK_UPDATES" ]; then
+    DIRECT_UPDATER_ENV_ROLLBACK_PENDING=true
 fi
 
 # ----------------------------------------------------------------------------

--- a/deployment-files/run-fleet.sh
+++ b/deployment-files/run-fleet.sh
@@ -358,6 +358,28 @@ env_boolean_is_true() {
     esac
 }
 
+dotenv_boolean_is_true() {
+    local key="$1" value read_status
+    value=$(compose_env_last_value "$key")
+    read_status=$?
+    if [ "$read_status" -ne 0 ]; then
+        if [ "$read_status" -eq 1 ]; then
+            return 1
+        fi
+        echo "Error: $key in $ENV_FILE uses unsupported or malformed Compose dotenv syntax." >&2
+        exit 1
+    fi
+    value=$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]')
+    case "$value" in
+        true) return 0 ;;
+        false|'') return 1 ;;
+        *)
+            echo "Error: persisted $key in $ENV_FILE must be true or false." >&2
+            exit 1
+            ;;
+    esac
+}
+
 resolve_compose_project_name() {
     local project_name persisted_status
 
@@ -572,8 +594,10 @@ if env_boolean_is_true ENABLE_TRACING; then
     ENABLE_TRACING=true
 fi
 ONE_CLICK_UPDATES_WAS_CONFIGURED=false
-if env_boolean_is_true ENABLE_ONE_CLICK_UPDATES; then
+if dotenv_boolean_is_true ENABLE_ONE_CLICK_UPDATES; then
     ONE_CLICK_UPDATES_WAS_CONFIGURED=true
+fi
+if env_boolean_is_true ENABLE_ONE_CLICK_UPDATES; then
     ENABLE_ONE_CLICK_UPDATES=true
 fi
 if [ -n "$ONE_CLICK_UPDATES_OVERRIDE" ]; then

--- a/deployment-files/run-fleet.sh
+++ b/deployment-files/run-fleet.sh
@@ -5,6 +5,7 @@
 # ============================================================================
 
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RUN_FLEET_ORIGINAL_ARGS=("$@")
 FLEET_COMPOSE_PROJECT_NAME=""
 COMPOSE_FILE="$PROJECT_ROOT/docker-compose.yaml"
 COMPOSE_ALERTS_FILE="$PROJECT_ROOT/docker-compose.alerts.yaml"
@@ -119,6 +120,20 @@ verify_direct_updater_ownership() {
         return 1
     fi
     DIRECT_UPDATER_OWNERSHIP_VERIFIED=true
+}
+
+deployment_directory_identity() {
+    local identity
+
+    # GNU and BSD stat spell the device/inode format differently. Directory
+    # identity, rather than a content hash, detects an updater activation that
+    # exchanged the complete deployment tree while this shell waited for the
+    # daemon to stop.
+    identity=$(stat -Lc '%d:%i' -- "$PROJECT_ROOT" 2>/dev/null) \
+      || identity=$(stat -f '%d:%i' "$PROJECT_ROOT" 2>/dev/null) \
+      || return 1
+    [ -n "$identity" ] || return 1
+    printf '%s\n' "$identity"
 }
 
 resolve_direct_updater_privilege() {
@@ -282,7 +297,7 @@ run_fleet_exit_cleanup() {
 # deployment directory cannot be renamed out from under the shell.
 quiesce_updater_for_direct_run() {
     local one_click_was_configured="$1"
-    local load_state active_state
+    local load_state active_state identity_before_stop identity_after_stop
 
     [ "${PROTO_FLEET_UPDATER_MANAGED_RUN:-0}" != "1" ] || return 0
     [ "$(uname -s)" = "Linux" ] || return 0
@@ -325,16 +340,18 @@ quiesce_updater_for_direct_run() {
         return 1
     fi
     [ "$load_state" = "not-found" ] || DIRECT_UPDATER_SERVICE_PRESENT=true
+    # A loaded updater is a global privileged resource even while inactive or
+    # failed. Verify its durable ownership before any branch can return and
+    # before this deployment can mount its socket directory into Fleet API.
+    if [ "$DIRECT_UPDATER_SERVICE_PRESENT" = "true" ]; then
+        resolve_direct_updater_privilege || return 1
+    fi
     case "$active_state" in
         inactive|failed)
             if [ "$load_state" = "not-found" ] \
               && [ "$ENABLE_ONE_CLICK_UPDATES" = "true" ]; then
                 echo "Error: one-click updates are enabled, but proto-fleet-updater.service is not installed." >&2
                 return 1
-            fi
-            if [ "$DIRECT_UPDATER_SERVICE_PRESENT" = "true" ] \
-              && [ "$one_click_was_configured" != "$ENABLE_ONE_CLICK_UPDATES" ]; then
-                resolve_direct_updater_privilege || return 1
             fi
             return 0
             ;;
@@ -346,6 +363,10 @@ quiesce_updater_for_direct_run() {
     esac
 
     resolve_direct_updater_privilege || return 1
+    if ! identity_before_stop=$(deployment_directory_identity); then
+        echo "Error: could not identify the current deployment before stopping the host updater." >&2
+        return 1
+    fi
     echo "Stopping the host updater for this manual deployment run..."
     if ! ${DIRECT_UPDATER_PRIVILEGE[@]+"${DIRECT_UPDATER_PRIVILEGE[@]}"} \
         systemctl stop proto-fleet-updater.service; then
@@ -356,6 +377,16 @@ quiesce_updater_for_direct_run() {
     # checked inactive-state query fails, EXIT cleanup still repairs service
     # availability rather than leaving the updater accidentally stopped.
     DIRECT_UPDATER_WAS_ACTIVE=true
+    if ! identity_after_stop=$(deployment_directory_identity); then
+        echo "Error: could not identify the current deployment after stopping the host updater." >&2
+        return 1
+    fi
+    if [ "$identity_before_stop" != "$identity_after_stop" ]; then
+        echo "The host updater activated a new deployment while stopping; restarting with the current release runner..."
+        exec /bin/bash "$PROJECT_ROOT/run-fleet.sh" "${RUN_FLEET_ORIGINAL_ARGS[@]}"
+        echo "Error: could not restart with the current release runner after the deployment changed." >&2
+        return 1
+    fi
     if ! active_state=$(${DIRECT_UPDATER_PRIVILEGE[@]+"${DIRECT_UPDATER_PRIVILEGE[@]}"} \
         systemctl show --property=ActiveState --value \
         proto-fleet-updater.service 2>/dev/null); then

--- a/deployment-files/tests/test-install-overlay-migration.sh
+++ b/deployment-files/tests/test-install-overlay-migration.sh
@@ -823,21 +823,90 @@ validation_cleanup_line=$(awk '
   }
 ' "$INSTALL_SCRIPT")
 production_socket_line=$(awk '/^      "\$GITHUB_RELEASES_URL" "\$UPDATER_SOCKET_PATH"/ { print NR; exit }' "$INSTALL_SCRIPT")
-restart_arm_line=$(awk '/^  UPDATER_RESTART_ON_EXIT=1$/ { print NR; exit }' "$INSTALL_SCRIPT")
+start_after_run_arm_line=$(awk '/^  UPDATER_START_AFTER_RUN=1$/ { print NR; exit }' "$INSTALL_SCRIPT")
 run_fleet_line=$(awk '/^if \.\/run-fleet\.sh / { print NR; exit }' "$INSTALL_SCRIPT")
+run_status_check_line=$(awk -v start="$run_fleet_line" 'NR > start && /^if \[ "\$RUN_FLEET_STATUS" -ne 0 \]; then$/ { print NR; exit }' "$INSTALL_SCRIPT")
 post_run_restart_line=$(awk -v start="$run_fleet_line" 'NR > start && /^  if restart_updater_service_with/ { print NR; exit }' "$INSTALL_SCRIPT")
 if [ -n "$validation_restart_line" ] \
   && [ "$validation_restart_line" -lt "$quiesce_line" ] \
   && [ "$quiesce_line" -lt "$validation_cleanup_line" ] \
   && [ "$validation_cleanup_line" -lt "$production_socket_line" ] \
   && [ "$quiesce_line" -lt "$production_socket_line" ] \
-  && [ "$production_socket_line" -lt "$restart_arm_line" ] \
-  && [ "$quiesce_line" -lt "$restart_arm_line" ] \
-  && [ "$restart_arm_line" -lt "$run_fleet_line" ] \
+  && [ "$production_socket_line" -lt "$start_after_run_arm_line" ] \
+  && [ "$quiesce_line" -lt "$start_after_run_arm_line" ] \
+  && [ "$start_after_run_arm_line" -lt "$run_fleet_line" ] \
+  && [ "$run_fleet_line" -lt "$run_status_check_line" ] \
+  && [ "$run_status_check_line" -lt "$post_run_restart_line" ] \
   && [ "$run_fleet_line" -lt "$post_run_restart_line" ]; then
   pass "host updater stays quiesced for the complete manual deployment run"
 else
   fail "host updater lifecycle does not serialize the manual deployment run"
+fi
+
+if (
+  failed_env="$TEST_TMP/updater-failed-enable.env"
+  lifecycle_log="$TEST_TMP/updater-failed-enable-calls"
+  printf 'ENABLE_ONE_CLICK_UPDATES=false\n' > "$failed_env"
+  : > "$lifecycle_log"
+  UPDATER_DISABLE_ON_EXIT=1
+  UPDATER_REENABLE_ON_EXIT=0
+  UPDATER_RESTART_ON_EXIT=0
+  UPDATER_START_AFTER_RUN=1
+  disable_updater_service_with() {
+    printf 'disable\n' >> "$lifecycle_log"
+    return 0
+  }
+  restart_updater_service_with() {
+    printf 'restart\n' >> "$lifecycle_log"
+    return 0
+  }
+  systemctl() {
+    printf 'systemctl %s\n' "$*" >> "$lifecycle_log"
+    return 0
+  }
+  reconcile_updater_after_failed_deployment \
+    "$failed_env" false 0 0 \
+    && [ "$(cat "$lifecycle_log")" = disable ] \
+    && [ "$UPDATER_DISABLE_ON_EXIT" = 0 ] \
+    && [ "$UPDATER_START_AFTER_RUN" = 0 ]
+); then
+  pass "failed first-time enablement leaves the replacement updater disabled"
+else
+  fail "failed first-time enablement can reactivate the replacement updater"
+fi
+
+if (
+  failed_env="$TEST_TMP/updater-failed-reenable.env"
+  lifecycle_log="$TEST_TMP/updater-failed-reenable-calls"
+  printf 'ENABLE_ONE_CLICK_UPDATES=true\n' > "$failed_env"
+  : > "$lifecycle_log"
+  UPDATER_DISABLE_ON_EXIT=1
+  UPDATER_REENABLE_ON_EXIT=1
+  UPDATER_RESTART_ON_EXIT=1
+  UPDATER_START_AFTER_RUN=1
+  disable_updater_service_with() {
+    printf 'disable\n' >> "$lifecycle_log"
+    return 0
+  }
+  restart_updater_service_with() {
+    printf 'restart %s\n' "$1" >> "$lifecycle_log"
+    return 0
+  }
+  systemctl() {
+    printf 'systemctl %s\n' "$*" >> "$lifecycle_log"
+    return 0
+  }
+  reconcile_updater_after_failed_deployment \
+    "$failed_env" true 1 1 \
+    && grep -q '^disable$' "$lifecycle_log" \
+    && grep -q '^systemctl enable proto-fleet-updater.service$' "$lifecycle_log" \
+    && grep -q '^restart /run/proto-fleet-updater/updater.sock$' "$lifecycle_log" \
+    && [ "$UPDATER_DISABLE_ON_EXIT" = 0 ] \
+    && [ "$UPDATER_START_AFTER_RUN" = 0 ]
+); then
+  pass "failed replacement restores a previously active configured updater"
+else
+  fail "failed replacement does not restore the prior updater lifecycle"
 fi
 
 if (

--- a/deployment-files/tests/test-install-overlay-migration.sh
+++ b/deployment-files/tests/test-install-overlay-migration.sh
@@ -398,8 +398,9 @@ fi
 # before any extraction can target the shared default Compose project.
 if (
   root="$TEST_TMP/path-alias"
-  mkdir -p "$root/existing"
+  make_install "$root/existing"
   ln -s "$root/existing" "$root/alias"
+  FAKE_UID=$(command id -u)
   resolved=$(resolve_selected_install_path "$root/alias/" "$root/existing") \
     && [ "$resolved" = "$(cd "$root/existing" && pwd -P)" ]
 ); then
@@ -410,7 +411,9 @@ fi
 
 if (
   root="$TEST_TMP/path-mismatch"
-  mkdir -p "$root/existing" "$root/other"
+  make_install "$root/existing"
+  mkdir -p "$root/other"
+  FAKE_UID=$(command id -u)
   ! resolve_selected_install_path "$root/other" "$root/existing" \
     > /dev/null 2> "$TEST_TMP/path-mismatch.err" \
     && grep -q 'Relocation is not supported' "$TEST_TMP/path-mismatch.err" \
@@ -421,6 +424,21 @@ if (
   pass "relocation and path typos are rejected when an install was discovered"
 else
   fail "mismatched install path should fail closed"
+fi
+
+if (
+  root="$TEST_TMP/docker-discovered-foreign-owner"
+  make_install "$root"
+  FAKE_UID=0
+  unset SUDO_UID
+  ! resolve_selected_install_path "$root" "$root" \
+    > /dev/null 2> "$TEST_TMP/docker-discovered-foreign-owner.err" \
+    && grep -q 'owned by unrelated UID' \
+      "$TEST_TMP/docker-discovered-foreign-owner.err"
+); then
+  pass "Docker-discovered installs enforce the invoking administrator ownership boundary"
+else
+  fail "Docker discovery bypassed trusted install-root ownership validation"
 fi
 
 if (
@@ -701,7 +719,7 @@ else
   fail "installer still trusts archive ownership or mutable deployment bootstrap files"
 fi
 
-prepare_line=$(awk '/^if ! prepare_existing_updater_service; then$/ { print NR; exit }' "$INSTALL_SCRIPT")
+prepare_line=$(awk '/^if ! prepare_existing_updater_service "\$INSTALL_DIR"; then$/ { print NR; exit }' "$INSTALL_SCRIPT")
 extract_line=$(awk '/^extract_and_cd "\$TAR_PATH" "\$INSTALL_DIR"$/ { print NR; exit }' "$INSTALL_SCRIPT")
 if [ -n "$prepare_line" ] && [ -n "$extract_line" ] && [ "$prepare_line" -lt "$extract_line" ]; then
   pass "existing updater is drained before deployment extraction"
@@ -791,6 +809,31 @@ else
 fi
 
 if (
+  configured_root="$TEST_TMP/configured-updater-root"
+  selected_root="$TEST_TMP/selected-updater-root"
+  updater_env="$TEST_TMP/existing-updater.env"
+  mkdir -p "$configured_root" "$selected_root"
+  UPDATER_ENV_PATH="$updater_env"
+  escaped_configured_root=${configured_root//\\/\\\\}
+  escaped_configured_root=${escaped_configured_root//\"/\\\"}
+  printf 'PROTO_FLEET_INSTALL_ROOT="%s"\n' "$escaped_configured_root" > "$updater_env"
+  verify_existing_updater_ownership_with "$configured_root" \
+    && ! verify_existing_updater_ownership_with "$selected_root" \
+      > /dev/null 2> "$TEST_TMP/updater-owner-mismatch.err" \
+    && grep -q 'belongs to a different Proto Fleet installation' \
+      "$TEST_TMP/updater-owner-mismatch.err" \
+    && printf 'PROTO_FLEET_INSTALL_ROOT=/tmp/unquoted\n' > "$updater_env" \
+    && ! verify_existing_updater_ownership_with "$configured_root" \
+      > /dev/null 2> "$TEST_TMP/updater-owner-malformed.err" \
+    && grep -q 'Could not read a valid install root' \
+      "$TEST_TMP/updater-owner-malformed.err"
+); then
+  pass "existing global updater can only be replaced by its configured installation"
+else
+  fail "installer can silently rebind an unrelated or malformed global updater"
+fi
+
+if (
   restore_log="$TEST_TMP/updater-exit-restore"
   DOWNLOAD_DIR="$TEST_TMP/updater-exit-download"
   mkdir -p "$DOWNLOAD_DIR"
@@ -815,6 +858,39 @@ if (
   pass "interrupted installation restores updater enablement and production socket"
 else
   fail "installer exit cleanup did not restore the updater after interruption"
+fi
+
+if (
+  restore_log="$TEST_TMP/updater-validation-restore"
+  DOWNLOAD_DIR="$TEST_TMP/updater-validation-download"
+  mkdir -p "$DOWNLOAD_DIR"
+  UPDATER_ENV_PATH="$TEST_TMP/updater-validation-current.env"
+  UPDATER_ENV_RESTORE_FILE="$DOWNLOAD_DIR/updater.env.previous"
+  printf 'production socket\n' > "$UPDATER_ENV_RESTORE_FILE"
+  printf 'validation socket\n' > "$UPDATER_ENV_PATH"
+  UPDATER_PRIVILEGE=()
+  UPDATER_DISABLE_ON_EXIT=1
+  UPDATER_REENABLE_ON_EXIT=0
+  UPDATER_RESTART_ON_EXIT=1
+  disable_updater_service_with() {
+    printf 'disable\n' >> "$restore_log"
+    return 0
+  }
+  restart_updater_service_with() {
+    printf 'restart-socket %s\n' "$1" >> "$restore_log"
+    [ "$(cat "$UPDATER_ENV_PATH")" = 'production socket' ]
+  }
+  (trap installer_exit_cleanup EXIT; exit 7)
+  cleanup_status=$?
+  [ "$cleanup_status" -eq 7 ] \
+    && [ "$(cat "$UPDATER_ENV_PATH")" = 'production socket' ] \
+    && [ "$(sed -n '1p' "$restore_log")" = disable ] \
+    && grep -q '^restart-socket /run/proto-fleet-updater/updater.sock$' "$restore_log" \
+    && [ ! -e "$DOWNLOAD_DIR" ]
+); then
+  pass "interrupted validation restores production configuration before restart"
+else
+  fail "validation interruption can restart the updater with its private socket configuration"
 fi
 
 if (

--- a/deployment-files/tests/test-install-overlay-migration.sh
+++ b/deployment-files/tests/test-install-overlay-migration.sh
@@ -537,6 +537,21 @@ fi
 
 if (
   UPDATER_CLEANUP_FAILED=0
+  FAKE_SYSTEMCTL_MODE=missing
+  # Model a non-root, non-interactive install where sudo -n would require a
+  # password. The authoritative unprivileged LoadState result must make sudo
+  # unnecessary when the unit is absent.
+  sudo() { return 1; }
+  disable_updater_service_with sudo -n \
+    && [ "$UPDATER_CLEANUP_FAILED" = 0 ]
+); then
+  pass "missing updater unit bypasses unavailable non-interactive sudo"
+else
+  fail "missing updater unit should not be rechecked through sudo -n"
+fi
+
+if (
+  UPDATER_CLEANUP_FAILED=0
   FAKE_SYSTEMCTL_MODE=safe
   disable_updater_service_with \
     && [ "$UPDATER_CLEANUP_FAILED" = 0 ]
@@ -544,6 +559,20 @@ if (
   pass "updater fallback verifies inactive and disabled service state"
 else
   fail "verified inactive and disabled updater should be a safe fallback"
+fi
+
+if (
+  UPDATER_CLEANUP_FAILED=0
+  FAKE_SYSTEMCTL_MODE=safe
+  sudo() { return 1; }
+  ! disable_updater_service_with sudo -n \
+    2> "$TEST_TMP/systemctl-sudo-required.err" \
+    && [ "$UPDATER_CLEANUP_FAILED" = 1 ] \
+    && grep -q 'Could not stop and disable' "$TEST_TMP/systemctl-sudo-required.err"
+); then
+  pass "known updater unit still fails closed when privilege is unavailable"
+else
+  fail "known updater cleanup must not trust an unavailable privilege wrapper"
 fi
 
 if (

--- a/deployment-files/tests/test-install-overlay-migration.sh
+++ b/deployment-files/tests/test-install-overlay-migration.sh
@@ -431,6 +431,14 @@ if (
   make_install "$root"
   FAKE_UID=0
   unset SUDO_UID
+  stat() {
+    local path="${!#}"
+    if [ "$path" = "$root" ]; then
+      printf '1234 755\n'
+      return 0
+    fi
+    command stat "$@"
+  }
   ! resolve_selected_install_path "$root" "$root" \
     > /dev/null 2> "$TEST_TMP/docker-discovered-foreign-owner.err" \
     && grep -q 'owned by unrelated UID' \
@@ -507,6 +515,14 @@ if (
   mkdir -p "$root"
   FAKE_UID=0
   unset SUDO_UID
+  stat() {
+    local path="${!#}"
+    if [ "$path" = "$root" ]; then
+      printf '1234 755\n'
+      return 0
+    fi
+    command stat "$@"
+  }
   ! resolve_selected_install_path "$root" "" \
     > /dev/null 2> "$TEST_TMP/path-owner.err" \
     && grep -q 'owned by unrelated UID' "$TEST_TMP/path-owner.err"

--- a/deployment-files/tests/test-install-overlay-migration.sh
+++ b/deployment-files/tests/test-install-overlay-migration.sh
@@ -115,10 +115,11 @@ docker() {
       esac
       ;;
     info)
-      if [ -n "${DOCKER_HOST+x}${DOCKER_CONTEXT+x}${DOCKER_CONFIG+x}${DOCKER_TLS+x}${DOCKER_TLS_VERIFY+x}${DOCKER_CERT_PATH+x}" ]; then
-        printf '%s\n' "$FAKE_SELECTED_DOCKER_ID"
-      else
+      if [ "${DOCKER_HOST:-}" = "$UPDATER_DOCKER_HOST" ] \
+        && [ -z "${DOCKER_CONTEXT+x}${DOCKER_CONFIG+x}${DOCKER_TLS+x}${DOCKER_TLS_VERIFY+x}${DOCKER_CERT_PATH+x}" ]; then
         printf '%s\n' "$FAKE_SERVICE_DOCKER_ID"
+      else
+        printf '%s\n' "$FAKE_SELECTED_DOCKER_ID"
       fi
       ;;
     version) return 0 ;;
@@ -425,13 +426,112 @@ fi
 if (
   root="$TEST_TMP/fresh-path"
   mkdir -p "$root"
+  FAKE_UID=$(command id -u)
   resolved=$(resolve_selected_install_path "$root/not-created/child" "") \
-    && [ "$resolved" = "$root/not-created/child" ] \
-    && [ ! -e "$root/not-created" ]
+    && [ "$resolved" = "$(cd "$root/not-created/child" && pwd -P)" ] \
+    && [ -d "$root/not-created/child" ] \
+    && [ ! -e "$root/not-created/child/deployment" ]
 ); then
-  pass "fresh install paths remain unchanged without filesystem mutation"
+  pass "fresh install paths are created privately and canonicalized"
 else
-  fail "fresh path resolution should not create directories"
+  fail "fresh path resolution did not establish a trusted destination"
+fi
+
+if (
+  FAKE_UID=$(command id -u)
+  ! resolve_selected_install_path / "" > /dev/null 2> "$TEST_TMP/path-root.err" \
+    && grep -q 'dangerous installation root' "$TEST_TMP/path-root.err" \
+    && ! resolve_selected_install_path /etc/proto-fleet-review-test "" \
+      > /dev/null 2> "$TEST_TMP/path-etc.err" \
+    && grep -q 'protected system path' "$TEST_TMP/path-etc.err"
+); then
+  pass "fresh installs reject dangerous roots and protected system paths"
+else
+  fail "fresh install path validation accepted a dangerous system target"
+fi
+
+if (
+  root="$TEST_TMP/fresh-symlink"
+  target="$TEST_TMP/fresh-symlink-target"
+  mkdir -p "$target"
+  printf 'unchanged\n' > "$target/sentinel"
+  ln -s "$target" "$root"
+  FAKE_UID=$(command id -u)
+  ! resolve_selected_install_path "$root" "" \
+    > /dev/null 2> "$TEST_TMP/path-symlink.err" \
+    && grep -q 'must not be a symlink' "$TEST_TMP/path-symlink.err" \
+    && [ "$(cat "$target/sentinel")" = unchanged ] \
+    && [ ! -e "$target/deployment" ]
+); then
+  pass "fresh installs reject a symlinked destination without touching its target"
+else
+  fail "fresh install path validation followed a symlinked destination"
+fi
+
+if (
+  link="$TEST_TMP/protected-ancestor-link"
+  protected_target="/etc/ssl/proto-fleet-review-$$"
+  [ -d /etc/ssl ]
+  ln -s /etc "$link"
+  FAKE_UID=$(command id -u)
+  ! resolve_selected_install_path "$link/ssl/proto-fleet-review-$$" "" \
+    > /dev/null 2> "$TEST_TMP/path-protected-alias.err" \
+    && grep -q 'protected system path' "$TEST_TMP/path-protected-alias.err" \
+    && [ ! -e "$protected_target" ]
+); then
+  pass "fresh installs reject protected paths reached through an ancestor symlink"
+else
+  fail "fresh install path validation wrote through a protected ancestor alias"
+fi
+
+if (
+  root="$TEST_TMP/root-direct-foreign-owner"
+  mkdir -p "$root"
+  FAKE_UID=0
+  unset SUDO_UID
+  ! resolve_selected_install_path "$root" "" \
+    > /dev/null 2> "$TEST_TMP/path-owner.err" \
+    && grep -q 'owned by unrelated UID' "$TEST_TMP/path-owner.err"
+); then
+  pass "direct root installs reject paths owned by another user"
+else
+  fail "direct root install trusted an unrelated path owner"
+fi
+
+if (
+  root="$TEST_TMP/sudo-admin-owner/new-install"
+  FAKE_UID=0
+  SUDO_UID=$(command id -u)
+  resolved=$(resolve_selected_install_path "$root" "") \
+    && [ "$resolved" = "$(cd "$root" && pwd -P)" ]
+); then
+  pass "sudo installs trust only the invoking administrator UID"
+else
+  fail "sudo install rejected the invoking administrator's path"
+fi
+
+if (
+  root="$TEST_TMP/unrecognized-deployment"
+  mkdir -p "$root/deployment"
+  FAKE_UID=$(command id -u)
+  ! resolve_selected_install_path "$root" "" \
+    > /dev/null 2> "$TEST_TMP/path-existing-deployment.err" \
+    && grep -q 'purported fresh install already contains' \
+      "$TEST_TMP/path-existing-deployment.err"
+); then
+  pass "fresh installs reject an unrecognized existing deployment tree"
+else
+  fail "fresh install path validation accepted an existing deployment tree"
+fi
+
+if ! validate_install_path_metadata /srv/foreign 2000 755 1000 1 \
+    > /dev/null 2>&1 \
+  && validate_install_path_metadata /tmp 0 1777 1000 0 \
+  && ! validate_install_path_metadata /tmp 0 1777 1000 1 \
+    > /dev/null 2>&1; then
+  pass "path metadata permits only the trusted owner and sticky shared ancestors"
+else
+  fail "path metadata trust rules accepted an unrelated or writable install root"
 fi
 
 # If the root-daemon probe was blocked, an explicit on-disk deployment must
@@ -479,8 +579,9 @@ else
 fi
 
 # A root caller may carry Docker selectors that point at a custom or rootless
-# daemon. The system-service probe must discard every endpoint/TLS selector so
-# equality cannot be proven against an environment the unit will not receive.
+# daemon. The system-service probe must discard them and explicitly select the
+# local rootful socket so neither inherited variables nor a persisted current
+# context can redirect updater operations.
 if (
   FAKE_UID=0
   export DOCKER_HOST='unix:///run/user/1000/docker.sock'
@@ -495,17 +596,21 @@ if (
     && [ "$service_id" = "$FAKE_SERVICE_DOCKER_ID" ] \
     && [ "$current_id" != "$service_id" ]
 ); then
-  pass "system-service Docker probe drops inherited daemon selectors"
+  pass "system-service Docker probe pins the local rootful socket"
 else
-  fail "system-service Docker probe inherited a caller selector"
+  fail "system-service Docker probe was not pinned to the local rootful socket"
 fi
 
-if grep -Fq \
-  'UnsetEnvironment=DOCKER_HOST DOCKER_CONTEXT DOCKER_CONFIG DOCKER_TLS DOCKER_TLS_VERIFY DOCKER_CERT_PATH' \
-  "$REPO_ROOT/deployment-files/updater/proto-fleet-updater.service"; then
-  pass "systemd unit enforces the same selector-free Docker environment"
+if grep -Fq 'Environment=DOCKER_HOST=unix:///var/run/docker.sock' \
+    "$REPO_ROOT/deployment-files/updater/proto-fleet-updater.service" \
+  && grep -Fq \
+    'UnsetEnvironment=DOCKER_CONTEXT DOCKER_CONFIG DOCKER_TLS DOCKER_TLS_VERIFY DOCKER_CERT_PATH' \
+    "$REPO_ROOT/deployment-files/updater/proto-fleet-updater.service" \
+  && ! grep -Eq '^UnsetEnvironment=.*DOCKER_HOST' \
+    "$REPO_ROOT/deployment-files/updater/proto-fleet-updater.service"; then
+  pass "systemd unit pins the same local rootful Docker socket"
 else
-  fail "systemd unit does not clear every Docker selector"
+  fail "systemd unit does not pin the local rootful Docker socket"
 fi
 
 # The two files copied into privileged host locations are extracted directly

--- a/deployment-files/tests/test-install-overlay-migration.sh
+++ b/deployment-files/tests/test-install-overlay-migration.sh
@@ -46,24 +46,34 @@ make_install() {
 # Defaults consumed by the docker test double. Individual cases override only
 # the state they need.
 FAKE_IDS="fleet-container"
+FAKE_DIRECT_IDS=""
+FAKE_SUDO_IDS=""
+FAKE_MOUNT_PATH=""
 FAKE_CONFIG_FILES=""
 FAKE_INSPECT_FAILURE=0
 DOCKER_CALL_LOG="$TEST_TMP/docker-calls"
 
 docker() {
+  local ids="$FAKE_IDS"
+  case "${FAKE_DOCKER_CONTEXT:-direct}" in
+    direct) [ -z "$FAKE_DIRECT_IDS" ] || ids="$FAKE_DIRECT_IDS" ;;
+    sudo) [ -z "$FAKE_SUDO_IDS" ] || ids="$FAKE_SUDO_IDS" ;;
+  esac
   printf '%s docker %s\n' "${FAKE_DOCKER_CONTEXT:-direct}" "$*" >> "$DOCKER_CALL_LOG"
   case "${1:-}" in
     ps)
-      printf '%s\n' "$FAKE_IDS"
+      printf '%s\n' "$ids"
       ;;
     inspect)
       [ "$FAKE_INSPECT_FAILURE" != 1 ] || return 1
       case "${3:-}" in
         *com.docker.compose.service*) printf 'fleet-api\n' ;;
         *com.docker.compose.project.config_files*) printf '%s\n' "$FAKE_CONFIG_FILES" ;;
+        *'.Destination "/var/lib/fleet/start"'*) printf '%s\n' "$FAKE_MOUNT_PATH" ;;
         *) return 1 ;;
       esac
       ;;
+    version) return 0 ;;
     *) return 1 ;;
   esac
 }
@@ -72,6 +82,14 @@ sudo() {
   printf 'sudo %s\n' "$*" >> "$DOCKER_CALL_LOG"
   [ "${1:-}" != "-n" ] || shift
   FAKE_DOCKER_CONTEXT=sudo "$@"
+}
+
+id() {
+  if [ "${1:-}" = "-u" ]; then
+    printf '1000\n'
+    return 0
+  fi
+  command id "$@"
 }
 
 # Explicit settings are authoritative, including false, and avoid Docker
@@ -303,6 +321,27 @@ if (
   pass "overlay migration reuses the detected Docker privilege"
 else
   fail "overlay migration did not use the selected Docker privilege"
+fi
+
+# --install-dir chooses a destination but must not suppress root-daemon
+# discovery. The caller needs this state before extraction so it can reject a
+# mixed-privilege upgrade even when every legacy overlay value is explicit.
+if (
+  root="$TEST_TMP/explicit-root-daemon"
+  make_install "$root"
+  : > "$DOCKER_CALL_LOG"
+  FAKE_IDS=""
+  FAKE_DIRECT_IDS=""
+  FAKE_SUDO_IDS="root-fleet"
+  FAKE_MOUNT_PATH="$root/deployment/server/start"
+  detect_previous_install \
+    && [ "$PREVIOUS_INSTALL_DIR" = "$root" ] \
+    && [ "$PREVIOUS_INSTALL_NEEDS_SUDO" = 1 ] \
+    && grep -q '^sudo docker ps -a ' "$DOCKER_CALL_LOG"
+); then
+  pass "explicit install paths retain root-daemon ownership discovery"
+else
+  fail "explicit install path discovery missed the root-managed deployment"
 fi
 
 # A systemctl/query failure must never be interpreted as proof that the

--- a/deployment-files/tests/test-install-overlay-migration.sh
+++ b/deployment-files/tests/test-install-overlay-migration.sh
@@ -1022,7 +1022,9 @@ fi
 
 if (
   fallback_env="$TEST_TMP/updater-fallback.env"
-  printf 'ENABLE_ONE_CLICK_UPDATES=true\n' > "$fallback_env"
+  # run-fleet writes false before later deployment work can fail. The false
+  # value alone must not commit fallback or discard installer restoration.
+  printf 'ENABLE_ONE_CLICK_UPDATES=false\n' > "$fallback_env"
   UPDATER_DISABLE_ON_EXIT=1
   UPDATER_REENABLE_ON_EXIT=1
   UPDATER_RESTART_ON_EXIT=1
@@ -1031,13 +1033,12 @@ if (
   UPDATER_UNIT_RESTORE_FILE=unit-backup
   UPDATER_ARTIFACT_RESTORE_PENDING=1
   UPDATER_FALLBACK_PENDING=1
-  ! finalize_disabled_updater_fallback_if_persisted "$fallback_env" \
+  ! complete_disabled_updater_fallback_after_run "$fallback_env" 1 \
     && [ "$UPDATER_REENABLE_ON_EXIT" = 1 ] \
     && [ "$UPDATER_RESTART_ON_EXIT" = 1 ] \
     && [ "$UPDATER_ARTIFACT_RESTORE_PENDING" = 1 ] \
     && [ "$UPDATER_FALLBACK_PENDING" = 1 ] \
-    && printf 'ENABLE_ONE_CLICK_UPDATES=false\n' > "$fallback_env" \
-    && finalize_disabled_updater_fallback_if_persisted "$fallback_env" \
+    && complete_disabled_updater_fallback_after_run "$fallback_env" 0 \
     && [ "$UPDATER_DISABLE_ON_EXIT" = 0 ] \
     && [ "$UPDATER_REENABLE_ON_EXIT" = 0 ] \
     && [ "$UPDATER_RESTART_ON_EXIT" = 0 ] \

--- a/deployment-files/tests/test-install-overlay-migration.sh
+++ b/deployment-files/tests/test-install-overlay-migration.sh
@@ -796,15 +796,15 @@ else
 fi
 
 if (
-  UPDATER_REENABLE_ON_EXIT=0
+  UPDATER_REENABLE_ON_EXIT=disabled
   UPDATER_RESTART_ON_EXIT=0
-  arm_existing_updater_restoration active enabled \
-    && [ "$UPDATER_REENABLE_ON_EXIT" = 1 ] \
+  arm_existing_updater_restoration active enabled-runtime \
+    && [ "$UPDATER_REENABLE_ON_EXIT" = enabled-runtime ] \
     && [ "$UPDATER_RESTART_ON_EXIT" = 1 ] \
     && grep -q 'arm_existing_updater_restoration "\$active_state" "\$unit_file_state"' \
       "$INSTALL_SCRIPT"
 ); then
-  pass "quiescing an active enabled updater immediately arms exact restoration"
+  pass "quiescing an active runtime-enabled updater arms exact restoration"
 else
   fail "pre-bootstrap failures can leave the prior updater disabled"
 fi
@@ -852,7 +852,7 @@ if (
   printf 'ENABLE_ONE_CLICK_UPDATES=false\n' > "$failed_env"
   : > "$lifecycle_log"
   UPDATER_DISABLE_ON_EXIT=1
-  UPDATER_REENABLE_ON_EXIT=0
+  UPDATER_REENABLE_ON_EXIT=disabled
   UPDATER_RESTART_ON_EXIT=0
   UPDATER_START_AFTER_RUN=1
   disable_updater_service_with() {
@@ -868,7 +868,7 @@ if (
     return 0
   }
   reconcile_updater_after_failed_deployment \
-    "$failed_env" false true 0 0 \
+    "$failed_env" false true disabled 0 \
     && [ "$(cat "$lifecycle_log")" = disable ] \
     && [ "$UPDATER_DISABLE_ON_EXIT" = 0 ] \
     && [ "$UPDATER_START_AFTER_RUN" = 0 ]
@@ -884,7 +884,7 @@ if (
   printf 'ENABLE_ONE_CLICK_UPDATES=true\n' > "$failed_env"
   : > "$lifecycle_log"
   UPDATER_DISABLE_ON_EXIT=1
-  UPDATER_REENABLE_ON_EXIT=1
+  UPDATER_REENABLE_ON_EXIT=enabled-runtime
   UPDATER_RESTART_ON_EXIT=1
   UPDATER_START_AFTER_RUN=1
   disable_updater_service_with() {
@@ -900,14 +900,14 @@ if (
     return 0
   }
   reconcile_updater_after_failed_deployment \
-    "$failed_env" true true 1 1 \
+    "$failed_env" true true enabled-runtime 1 \
     && grep -q '^disable$' "$lifecycle_log" \
-    && grep -q '^systemctl enable proto-fleet-updater.service$' "$lifecycle_log" \
+    && grep -q '^systemctl enable --runtime proto-fleet-updater.service$' "$lifecycle_log" \
     && grep -q '^restart /run/proto-fleet-updater/updater.sock$' "$lifecycle_log" \
     && [ "$UPDATER_DISABLE_ON_EXIT" = 0 ] \
     && [ "$UPDATER_START_AFTER_RUN" = 0 ]
 ); then
-  pass "failed replacement restores a previously active configured updater"
+  pass "failed replacement restores runtime-only updater enablement"
 else
   fail "failed replacement does not restore the prior updater lifecycle"
 fi
@@ -918,7 +918,7 @@ if (
   printf 'ENABLE_ONE_CLICK_UPDATES=true\n' > "$failed_env"
   : > "$lifecycle_log"
   UPDATER_DISABLE_ON_EXIT=1
-  UPDATER_REENABLE_ON_EXIT=0
+  UPDATER_REENABLE_ON_EXIT=disabled
   UPDATER_RESTART_ON_EXIT=0
   UPDATER_START_AFTER_RUN=1
   disable_updater_service_with() {
@@ -934,7 +934,7 @@ if (
     return 0
   }
   reconcile_updater_after_failed_deployment \
-    "$failed_env" false true 0 0 \
+    "$failed_env" false true disabled 0 \
     && grep -q '^disable$' "$lifecycle_log" \
     && grep -q '^systemctl enable proto-fleet-updater.service$' "$lifecycle_log" \
     && grep -q '^restart /run/proto-fleet-updater/updater.sock$' "$lifecycle_log" \
@@ -1104,7 +1104,7 @@ if (
   DOWNLOAD_DIR="$TEST_TMP/updater-exit-download"
   mkdir -p "$DOWNLOAD_DIR"
   UPDATER_DISABLE_ON_EXIT=0
-  UPDATER_REENABLE_ON_EXIT=1
+  UPDATER_REENABLE_ON_EXIT=enabled
   UPDATER_RESTART_ON_EXIT=1
   systemctl() {
     printf '%s\n' "$*" >> "$restore_log"
@@ -1126,6 +1126,33 @@ else
   fail "installer exit cleanup did not restore the updater after interruption"
 fi
 
+if (
+  restore_log="$TEST_TMP/updater-runtime-enable-restore"
+  DOWNLOAD_DIR="$TEST_TMP/updater-runtime-enable-download"
+  mkdir -p "$DOWNLOAD_DIR"
+  UPDATER_DISABLE_ON_EXIT=0
+  UPDATER_REENABLE_ON_EXIT=enabled-runtime
+  UPDATER_RESTART_ON_EXIT=0
+  UPDATER_START_AFTER_RUN=0
+  UPDATER_DEPLOYMENT_COMMITTED=0
+  UPDATER_VALIDATION_RUNTIME_ON_EXIT=0
+  UPDATER_ARTIFACT_RESTORE_PENDING=0
+  systemctl() {
+    printf '%s\n' "$*" >> "$restore_log"
+    return 0
+  }
+  (trap installer_exit_cleanup EXIT; exit 7)
+  cleanup_status=$?
+  [ "$cleanup_status" -eq 7 ] \
+    && [ "$(cat "$restore_log")" = \
+      'enable --runtime proto-fleet-updater.service' ] \
+    && [ ! -e "$DOWNLOAD_DIR" ]
+); then
+  pass "interrupted installation preserves runtime-only updater enablement"
+else
+  fail "installer exit cleanup made runtime-only enablement persistent"
+fi
+
 # A successful run-fleet return commits the socket-enabled topology. Signals
 # after that boundary must finish enabling the updater instead of applying the
 # pre-deployment fail-closed cleanup policy.
@@ -1141,7 +1168,7 @@ if (
   RUN_FLEET_ARGS=(--enable-one-click-updates --non-interactive)
   UPDATER_PRIVILEGE=()
   UPDATER_DISABLE_ON_EXIT=1
-  UPDATER_REENABLE_ON_EXIT=0
+  UPDATER_REENABLE_ON_EXIT=disabled
   UPDATER_RESTART_ON_EXIT=0
   UPDATER_START_AFTER_RUN=1
   UPDATER_DEPLOYMENT_COMMITTED=1
@@ -1189,7 +1216,7 @@ if (
   RUN_FLEET_ARGS=(--enable-one-click-updates --non-interactive)
   UPDATER_PRIVILEGE=()
   UPDATER_DISABLE_ON_EXIT=1
-  UPDATER_REENABLE_ON_EXIT=0
+  UPDATER_REENABLE_ON_EXIT=disabled
   UPDATER_RESTART_ON_EXIT=0
   UPDATER_START_AFTER_RUN=1
   UPDATER_DEPLOYMENT_COMMITTED=1
@@ -1230,7 +1257,7 @@ if (
   # value alone must not commit fallback or discard installer restoration.
   printf 'ENABLE_ONE_CLICK_UPDATES=false\n' > "$fallback_env"
   UPDATER_DISABLE_ON_EXIT=1
-  UPDATER_REENABLE_ON_EXIT=1
+  UPDATER_REENABLE_ON_EXIT=enabled
   UPDATER_RESTART_ON_EXIT=1
   UPDATER_ENV_RESTORE_FILE=env-backup
   UPDATER_BINARY_RESTORE_FILE=binary-backup
@@ -1238,13 +1265,13 @@ if (
   UPDATER_ARTIFACT_RESTORE_PENDING=1
   UPDATER_FALLBACK_PENDING=1
   ! complete_disabled_updater_fallback_after_run "$fallback_env" 1 \
-    && [ "$UPDATER_REENABLE_ON_EXIT" = 1 ] \
+    && [ "$UPDATER_REENABLE_ON_EXIT" = enabled ] \
     && [ "$UPDATER_RESTART_ON_EXIT" = 1 ] \
     && [ "$UPDATER_ARTIFACT_RESTORE_PENDING" = 1 ] \
     && [ "$UPDATER_FALLBACK_PENDING" = 1 ] \
     && complete_disabled_updater_fallback_after_run "$fallback_env" 0 \
     && [ "$UPDATER_DISABLE_ON_EXIT" = 0 ] \
-    && [ "$UPDATER_REENABLE_ON_EXIT" = 0 ] \
+    && [ "$UPDATER_REENABLE_ON_EXIT" = disabled ] \
     && [ "$UPDATER_RESTART_ON_EXIT" = 0 ] \
     && [ "$UPDATER_ARTIFACT_RESTORE_PENDING" = 0 ] \
     && [ "$UPDATER_FALLBACK_PENDING" = 0 ]
@@ -1260,7 +1287,7 @@ if (
   printf 'ENABLE_ONE_CLICK_UPDATES=true\n' > "$fallback_env"
   : > "$fallback_log"
   UPDATER_DISABLE_ON_EXIT=1
-  UPDATER_REENABLE_ON_EXIT=0
+  UPDATER_REENABLE_ON_EXIT=disabled
   UPDATER_RESTART_ON_EXIT=0
   UPDATER_START_AFTER_RUN=0
   updater_fallback_runner() {
@@ -1283,7 +1310,7 @@ if (
   fallback_env="$TEST_TMP/updater-restart-fallback-failure.env"
   printf 'ENABLE_ONE_CLICK_UPDATES=true\n' > "$fallback_env"
   UPDATER_DISABLE_ON_EXIT=1
-  UPDATER_REENABLE_ON_EXIT=0
+  UPDATER_REENABLE_ON_EXIT=disabled
   UPDATER_RESTART_ON_EXIT=0
   UPDATER_START_AFTER_RUN=0
   updater_fallback_failure() { return 7; }
@@ -1317,7 +1344,7 @@ if (
   printf 'new unit\n' > "$UPDATER_UNIT_PATH"
   UPDATER_PRIVILEGE=()
   UPDATER_DISABLE_ON_EXIT=1
-  UPDATER_REENABLE_ON_EXIT=1
+  UPDATER_REENABLE_ON_EXIT=enabled
   UPDATER_RESTART_ON_EXIT=1
   UPDATER_ARTIFACT_RESTORE_PENDING=1
   systemctl() {

--- a/deployment-files/tests/test-install-overlay-migration.sh
+++ b/deployment-files/tests/test-install-overlay-migration.sh
@@ -12,14 +12,10 @@ TEST_TMP=$(cd "$TEST_TMP" && pwd -P)
 trap 'rm -rf "$TEST_TMP"' EXIT
 
 # install.sh is intentionally standalone because it is executed directly from
-# curl before a release bundle exists. Extract just its discovery/migration
-# definitions instead of adding a production-only source-mode escape hatch.
-sed '/^# END INSTALL DISCOVERY AND LEGACY MIGRATION HELPERS$/q' \
+# curl before a release bundle exists. Extract its testable helper definitions
+# instead of adding a production-only source-mode escape hatch.
+sed '/^# END INSTALLER TESTABLE HELPERS$/q' \
   "$INSTALL_SCRIPT" > "$TEST_TMP/install-functions.sh"
-# The privileged service fallback lives after the installer's main download
-# path. Extract just that function as a second focused unit under test.
-sed -n '/^disable_updater_service_with()/,/^}/p' \
-  "$INSTALL_SCRIPT" >> "$TEST_TMP/install-functions.sh"
 # shellcheck source=/dev/null
 source "$TEST_TMP/install-functions.sh"
 
@@ -51,6 +47,9 @@ FAKE_SUDO_IDS=""
 FAKE_MOUNT_PATH=""
 FAKE_CONFIG_FILES=""
 FAKE_INSPECT_FAILURE=0
+FAKE_UID=1000
+FAKE_SELECTED_DOCKER_ID="selected-daemon"
+FAKE_SERVICE_DOCKER_ID="service-daemon"
 DOCKER_CALL_LOG="$TEST_TMP/docker-calls"
 
 docker() {
@@ -73,6 +72,13 @@ docker() {
         *) return 1 ;;
       esac
       ;;
+    info)
+      if [ -n "${DOCKER_HOST+x}${DOCKER_CONTEXT+x}${DOCKER_CONFIG+x}${DOCKER_TLS+x}${DOCKER_TLS_VERIFY+x}${DOCKER_CERT_PATH+x}" ]; then
+        printf '%s\n' "$FAKE_SELECTED_DOCKER_ID"
+      else
+        printf '%s\n' "$FAKE_SERVICE_DOCKER_ID"
+      fi
+      ;;
     version) return 0 ;;
     *) return 1 ;;
   esac
@@ -86,7 +92,7 @@ sudo() {
 
 id() {
   if [ "${1:-}" = "-u" ]; then
-    printf '1000\n'
+    printf '%s\n' "$FAKE_UID"
     return 0
   fi
   command id "$@"
@@ -342,6 +348,117 @@ if (
   pass "explicit install paths retain root-daemon ownership discovery"
 else
   fail "explicit install path discovery missed the root-managed deployment"
+fi
+
+# The final selected path must remain tied to the Docker-discovered install.
+# Canonical aliases are accepted, but a typo or attempted relocation fails
+# before any extraction can target the shared default Compose project.
+if (
+  root="$TEST_TMP/path-alias"
+  mkdir -p "$root/existing"
+  ln -s "$root/existing" "$root/alias"
+  resolved=$(resolve_selected_install_path "$root/alias/" "$root/existing") \
+    && [ "$resolved" = "$(cd "$root/existing" && pwd -P)" ]
+); then
+  pass "canonical aliases of the discovered install are accepted"
+else
+  fail "canonical install path comparison rejected an equivalent alias"
+fi
+
+if (
+  root="$TEST_TMP/path-mismatch"
+  mkdir -p "$root/existing" "$root/other"
+  ! resolve_selected_install_path "$root/other" "$root/existing" \
+    > /dev/null 2> "$TEST_TMP/path-mismatch.err" \
+    && grep -q 'Relocation is not supported' "$TEST_TMP/path-mismatch.err" \
+    && ! resolve_selected_install_path "$root/typo" "$root/existing" \
+      > /dev/null 2> "$TEST_TMP/path-typo.err" \
+    && grep -q 'does not resolve to that installation' "$TEST_TMP/path-typo.err"
+); then
+  pass "relocation and path typos are rejected when an install was discovered"
+else
+  fail "mismatched install path should fail closed"
+fi
+
+if (
+  root="$TEST_TMP/fresh-path"
+  mkdir -p "$root"
+  resolved=$(resolve_selected_install_path "$root/not-created/child" "") \
+    && [ "$resolved" = "$root/not-created/child" ] \
+    && [ ! -e "$root/not-created" ]
+); then
+  pass "fresh install paths remain unchanged without filesystem mutation"
+else
+  fail "fresh path resolution should not create directories"
+fi
+
+# A root caller may carry Docker selectors that point at a custom or rootless
+# daemon. The system-service probe must discard every endpoint/TLS selector so
+# equality cannot be proven against an environment the unit will not receive.
+if (
+  FAKE_UID=0
+  export DOCKER_HOST='unix:///run/user/1000/docker.sock'
+  export DOCKER_CONTEXT='rootless'
+  export DOCKER_CONFIG="$TEST_TMP/docker-config"
+  export DOCKER_TLS=1
+  export DOCKER_TLS_VERIFY=1
+  export DOCKER_CERT_PATH="$TEST_TMP/certs"
+  current_id=$(docker info --format '{{.ID}}')
+  service_id=$(service_docker_id_with)
+  [ "$current_id" = "$FAKE_SELECTED_DOCKER_ID" ] \
+    && [ "$service_id" = "$FAKE_SERVICE_DOCKER_ID" ] \
+    && [ "$current_id" != "$service_id" ]
+); then
+  pass "system-service Docker probe drops inherited daemon selectors"
+else
+  fail "system-service Docker probe inherited a caller selector"
+fi
+
+if grep -Fq \
+  'UnsetEnvironment=DOCKER_HOST DOCKER_CONTEXT DOCKER_CONFIG DOCKER_TLS DOCKER_TLS_VERIFY DOCKER_CERT_PATH' \
+  "$REPO_ROOT/deployment-files/updater/proto-fleet-updater.service"; then
+  pass "systemd unit enforces the same selector-free Docker environment"
+else
+  fail "systemd unit does not clear every Docker selector"
+fi
+
+# The two files copied into privileged host locations are extracted directly
+# from the verified archive into its private download tree. A mutable copy in
+# the final deployment is never used as the bootstrap source.
+if (
+  payload="$TEST_TMP/bootstrap-payload"
+  archive="$TEST_TMP/bootstrap.tar.gz"
+  destination="$TEST_TMP/private-bootstrap"
+  mkdir -p "$payload/deployment/updater"
+  printf 'verified updater\n' > "$payload/deployment/updater/proto-fleet-updater"
+  chmod +x "$payload/deployment/updater/proto-fleet-updater"
+  printf 'verified unit\n' > "$payload/deployment/updater/proto-fleet-updater.service"
+  tar -czf "$archive" -C "$payload" deployment
+  extract_updater_bootstrap "$archive" "$destination" \
+    && [ "$(cat "$destination/proto-fleet-updater")" = 'verified updater' ] \
+    && [ "$(cat "$destination/proto-fleet-updater.service")" = 'verified unit' ] \
+    && [ ! -L "$destination/proto-fleet-updater" ] \
+    && [ ! -L "$destination/proto-fleet-updater.service" ]
+); then
+  pass "privileged updater inputs are staged from the verified archive"
+else
+  fail "verified updater bootstrap extraction failed"
+fi
+
+if [ "$(grep -c 'tar --no-same-owner -xzvf' "$INSTALL_SCRIPT")" -eq 2 ] \
+  && grep -Fq 'install -m 0755 "$UPDATER_BOOTSTRAP_DIR/proto-fleet-updater"' "$INSTALL_SCRIPT" \
+  && grep -Fq 'install -m 0644 "$UPDATER_BOOTSTRAP_DIR/proto-fleet-updater.service"' "$INSTALL_SCRIPT"; then
+  pass "deployment extraction normalizes archive ownership and privileged copies use private sources"
+else
+  fail "installer still trusts archive ownership or mutable deployment bootstrap files"
+fi
+
+prepare_line=$(awk '/^if ! prepare_existing_updater_service; then$/ { print NR; exit }' "$INSTALL_SCRIPT")
+extract_line=$(awk '/^extract_and_cd "\$TAR_PATH" "\$INSTALL_DIR"$/ { print NR; exit }' "$INSTALL_SCRIPT")
+if [ -n "$prepare_line" ] && [ -n "$extract_line" ] && [ "$prepare_line" -lt "$extract_line" ]; then
+  pass "existing updater is drained before deployment extraction"
+else
+  fail "deployment extraction can run before updater shutdown"
 fi
 
 # A systemctl/query failure must never be interpreted as proof that the

--- a/deployment-files/tests/test-install-overlay-migration.sh
+++ b/deployment-files/tests/test-install-overlay-migration.sh
@@ -824,7 +824,7 @@ validation_cleanup_line=$(awk '
 ' "$INSTALL_SCRIPT")
 production_socket_line=$(awk '/^      "\$GITHUB_RELEASES_URL" "\$UPDATER_SOCKET_PATH"/ { print NR; exit }' "$INSTALL_SCRIPT")
 start_after_run_arm_line=$(awk '/^  UPDATER_START_AFTER_RUN=1$/ { print NR; exit }' "$INSTALL_SCRIPT")
-run_fleet_line=$(awk '/^if \.\/run-fleet\.sh / { print NR; exit }' "$INSTALL_SCRIPT")
+run_fleet_line=$(awk '/^  \.\/run-fleet\.sh / { print NR; exit }' "$INSTALL_SCRIPT")
 run_status_check_line=$(awk -v start="$run_fleet_line" 'NR > start && /^if \[ "\$RUN_FLEET_STATUS" -ne 0 \]; then$/ { print NR; exit }' "$INSTALL_SCRIPT")
 post_run_restart_line=$(awk -v start="$run_fleet_line" 'NR > start && /^  if restart_updater_service_with/ { print NR; exit }' "$INSTALL_SCRIPT")
 if [ -n "$validation_restart_line" ] \
@@ -865,7 +865,7 @@ if (
     return 0
   }
   reconcile_updater_after_failed_deployment \
-    "$failed_env" false 0 0 \
+    "$failed_env" false true 0 0 \
     && [ "$(cat "$lifecycle_log")" = disable ] \
     && [ "$UPDATER_DISABLE_ON_EXIT" = 0 ] \
     && [ "$UPDATER_START_AFTER_RUN" = 0 ]
@@ -897,7 +897,7 @@ if (
     return 0
   }
   reconcile_updater_after_failed_deployment \
-    "$failed_env" true 1 1 \
+    "$failed_env" true true 1 1 \
     && grep -q '^disable$' "$lifecycle_log" \
     && grep -q '^systemctl enable proto-fleet-updater.service$' "$lifecycle_log" \
     && grep -q '^restart /run/proto-fleet-updater/updater.sock$' "$lifecycle_log" \
@@ -907,6 +907,40 @@ if (
   pass "failed replacement restores a previously active configured updater"
 else
   fail "failed replacement does not restore the prior updater lifecycle"
+fi
+
+if (
+  failed_env="$TEST_TMP/updater-post-mutation-enable.env"
+  lifecycle_log="$TEST_TMP/updater-post-mutation-enable-calls"
+  printf 'ENABLE_ONE_CLICK_UPDATES=true\n' > "$failed_env"
+  : > "$lifecycle_log"
+  UPDATER_DISABLE_ON_EXIT=1
+  UPDATER_REENABLE_ON_EXIT=0
+  UPDATER_RESTART_ON_EXIT=0
+  UPDATER_START_AFTER_RUN=1
+  disable_updater_service_with() {
+    printf 'disable\n' >> "$lifecycle_log"
+    return 0
+  }
+  restart_updater_service_with() {
+    printf 'restart %s\n' "$1" >> "$lifecycle_log"
+    return 0
+  }
+  systemctl() {
+    printf 'systemctl %s\n' "$*" >> "$lifecycle_log"
+    return 0
+  }
+  reconcile_updater_after_failed_deployment \
+    "$failed_env" false true 0 0 \
+    && grep -q '^disable$' "$lifecycle_log" \
+    && grep -q '^systemctl enable proto-fleet-updater.service$' "$lifecycle_log" \
+    && grep -q '^restart /run/proto-fleet-updater/updater.sock$' "$lifecycle_log" \
+    && [ "$UPDATER_DISABLE_ON_EXIT" = 0 ] \
+    && [ "$UPDATER_START_AFTER_RUN" = 0 ]
+); then
+  pass "post-mutation failure retains the updater required by the new topology"
+else
+  fail "post-mutation failure can disable the updater required by the new topology"
 fi
 
 if (

--- a/deployment-files/tests/test-install-overlay-migration.sh
+++ b/deployment-files/tests/test-install-overlay-migration.sh
@@ -728,11 +728,42 @@ else
 fi
 
 if [ "$(grep -c 'tar --no-same-owner -xzvf' "$INSTALL_SCRIPT")" -eq 2 ] \
-  && grep -Fq 'install -m 0755 "$UPDATER_BOOTSTRAP_DIR/proto-fleet-updater"' "$INSTALL_SCRIPT" \
-  && grep -Fq 'install -m 0644 "$UPDATER_BOOTSTRAP_DIR/proto-fleet-updater.service"' "$INSTALL_SCRIPT"; then
+  && grep -Fq '"$UPDATER_BOOTSTRAP_DIR/proto-fleet-updater" "$UPDATER_BINARY_PATH"' "$INSTALL_SCRIPT" \
+  && grep -Fq '"$UPDATER_BOOTSTRAP_DIR/proto-fleet-updater.service" "$UPDATER_UNIT_PATH"' "$INSTALL_SCRIPT"; then
   pass "deployment extraction normalizes archive ownership and privileged copies use private sources"
 else
   fail "installer still trusts archive ownership or mutable deployment bootstrap files"
+fi
+
+# Persist updater ownership before copying the binary or unit. If a later copy
+# fails, the installer aborts but the supported uninstaller can still identify
+# which deployment owns the partial host bootstrap.
+if (
+  bootstrap_root="$TEST_TMP/partial-bootstrap"
+  UPDATER_BOOTSTRAP_DIR="$bootstrap_root/payload"
+  UPDATER_ENV_PATH="$bootstrap_root/etc/updater.env"
+  UPDATER_BINARY_PATH="$bootstrap_root/libexec/proto-fleet-updater"
+  UPDATER_UNIT_PATH="$bootstrap_root/systemd/proto-fleet-updater.service"
+  env_source="$bootstrap_root/updater.env.pending"
+  mkdir -p "$UPDATER_BOOTSTRAP_DIR"
+  printf 'PROTO_FLEET_INSTALL_ROOT="/srv/proto-fleet"\n' > "$env_source"
+  printf 'verified updater\n' > "$UPDATER_BOOTSTRAP_DIR/proto-fleet-updater"
+  printf 'verified unit\n' > "$UPDATER_BOOTSTRAP_DIR/proto-fleet-updater.service"
+  UPDATER_CLEANUP_FAILED=0
+  install() {
+    local destination="${!#}"
+    [ "$destination" != "$UPDATER_BINARY_PATH" ] || return 1
+    command install "$@"
+  }
+  ! install_updater_bootstrap_files_with "$env_source" \
+    && [ "$UPDATER_CLEANUP_FAILED" = 1 ] \
+    && cmp -s "$env_source" "$UPDATER_ENV_PATH" \
+    && [ ! -e "$UPDATER_BINARY_PATH" ] \
+    && [ ! -e "$UPDATER_UNIT_PATH" ]
+); then
+  pass "partial updater bootstrap retains ownership proof and fails closed"
+else
+  fail "partial updater bootstrap can leave ownerless global artifacts"
 fi
 
 prepare_line=$(awk '/^if ! prepare_existing_updater_service "\$INSTALL_DIR"; then$/ { print NR; exit }' "$INSTALL_SCRIPT")
@@ -763,12 +794,21 @@ fi
 # and other failures during run-fleet as well as its ordinary nonzero result.
 validation_restart_line=$(awk '/^  if ! restart_updater_service_with/ { print NR; exit }' "$INSTALL_SCRIPT")
 quiesce_line=$(awk '/^  if ! quiesce_updater_service_for_manual_run_with/ { print NR; exit }' "$INSTALL_SCRIPT")
+validation_cleanup_line=$(awk '
+  /^install_updater_service\(\)/ { in_install = 1 }
+  in_install && /^  if ! cleanup_updater_validation_runtime_with/ {
+    count++
+    if (count == 2) { print NR; exit }
+  }
+' "$INSTALL_SCRIPT")
 production_socket_line=$(awk '/^      "\$GITHUB_RELEASES_URL" "\$UPDATER_SOCKET_PATH"/ { print NR; exit }' "$INSTALL_SCRIPT")
 restart_arm_line=$(awk '/^  UPDATER_RESTART_ON_EXIT=1$/ { print NR; exit }' "$INSTALL_SCRIPT")
 run_fleet_line=$(awk '/^if \.\/run-fleet\.sh / { print NR; exit }' "$INSTALL_SCRIPT")
 post_run_restart_line=$(awk -v start="$run_fleet_line" 'NR > start && /^  if restart_updater_service_with/ { print NR; exit }' "$INSTALL_SCRIPT")
 if [ -n "$validation_restart_line" ] \
   && [ "$validation_restart_line" -lt "$quiesce_line" ] \
+  && [ "$quiesce_line" -lt "$validation_cleanup_line" ] \
+  && [ "$validation_cleanup_line" -lt "$production_socket_line" ] \
   && [ "$quiesce_line" -lt "$production_socket_line" ] \
   && [ "$production_socket_line" -lt "$restart_arm_line" ] \
   && [ "$quiesce_line" -lt "$restart_arm_line" ] \
@@ -794,10 +834,10 @@ if (
     printf 'curl %s\n' "$*" >> "$lifecycle_log"
     return 0
   }
-  restart_updater_service_with /run/proto-fleet-updater/test-validation.sock \
+  restart_updater_service_with /run/proto-fleet-updater-validation/test.sock \
     && quiesce_updater_service_for_manual_run_with \
     && [ "$(sed -n '1p' "$lifecycle_log")" = 'restart proto-fleet-updater.service' ] \
-    && grep -q -- '--unix-socket /run/proto-fleet-updater/test-validation.sock' "$lifecycle_log" \
+    && grep -q -- '--unix-socket /run/proto-fleet-updater-validation/test.sock' "$lifecycle_log" \
     && grep -q '^stop proto-fleet-updater.service$' "$lifecycle_log" \
     && grep -q '^show --property=ActiveState --value proto-fleet-updater.service$' "$lifecycle_log"
 ); then
@@ -810,18 +850,35 @@ if (
   updater_env="$TEST_TMP/updater.env"
   write_updater_environment_file "$updater_env" '/srv/proto fleet' \
     'https://github.com/block/proto-fleet/releases' \
-    /run/proto-fleet-updater/installer-validation.sock \
+    "$UPDATER_VALIDATION_SOCKET_PATH" \
     && grep -q 'PROTO_FLEET_INSTALL_ROOT="/srv/proto fleet"' "$updater_env" \
-    && grep -q 'PROTO_FLEET_UPDATER_SOCKET_PATH="/run/proto-fleet-updater/installer-validation.sock"' "$updater_env" \
+    && grep -Fq "PROTO_FLEET_UPDATER_SOCKET_PATH=\"$UPDATER_VALIDATION_SOCKET_PATH\"" "$updater_env" \
+    && [ "$(dirname "$UPDATER_VALIDATION_SOCKET_PATH")" = "$UPDATER_VALIDATION_RUNTIME_DIR" ] \
+    && [ "$UPDATER_VALIDATION_RUNTIME_DIR" != "$UPDATER_RUNTIME_DIR" ] \
+    && ! grep -Fq "$UPDATER_VALIDATION_RUNTIME_DIR" \
+      "$REPO_ROOT/deployment-files/docker-compose.updater.yaml" \
     && write_updater_environment_file "$updater_env" '/srv/proto fleet' \
       'https://github.com/block/proto-fleet/releases' \
-      /run/proto-fleet-updater/updater.sock \
-    && grep -q 'PROTO_FLEET_UPDATER_SOCKET_PATH="/run/proto-fleet-updater/updater.sock"' "$updater_env" \
-    && ! grep -q 'installer-validation.sock' "$updater_env"
+      "$UPDATER_SOCKET_PATH" \
+    && grep -Fq "PROTO_FLEET_UPDATER_SOCKET_PATH=\"$UPDATER_SOCKET_PATH\"" "$updater_env" \
+    && ! grep -Fq "$UPDATER_VALIDATION_RUNTIME_DIR" "$updater_env"
 ); then
-  pass "updater validation uses a private socket name before production activation"
+  pass "updater validation uses a separate unmounted runtime before production activation"
 else
-  fail "updater validation socket can leak into the production environment"
+  fail "updater validation socket is exposed to fleet-api or leaks into production"
+fi
+
+if (
+  UPDATER_VALIDATION_RUNTIME_DIR="$TEST_TMP/validation-runtime"
+  UPDATER_VALIDATION_SOCKET_PATH="$UPDATER_VALIDATION_RUNTIME_DIR/updater.sock"
+  mkdir -m 0700 "$UPDATER_VALIDATION_RUNTIME_DIR"
+  : > "$UPDATER_VALIDATION_SOCKET_PATH"
+  cleanup_updater_validation_runtime_with \
+    && [ ! -e "$UPDATER_VALIDATION_RUNTIME_DIR" ]
+); then
+  pass "private updater validation runtime is removed after validation"
+else
+  fail "private updater validation runtime cleanup is incomplete"
 fi
 
 if (

--- a/deployment-files/tests/test-install-overlay-migration.sh
+++ b/deployment-files/tests/test-install-overlay-migration.sh
@@ -524,6 +524,63 @@ else
   fail "fresh install path validation accepted an existing deployment tree"
 fi
 
+if (
+  root="$TEST_TMP/stopped-custom-install"
+  make_install "$root"
+  FAKE_UID=$(command id -u)
+  recognized=$(canonical_existing_install_path "$root") \
+    && resolved=$(resolve_selected_install_path "$root" "$recognized") \
+    && [ "$recognized" = "$(cd "$root" && pwd -P)" ] \
+    && [ "$resolved" = "$recognized" ]
+); then
+  pass "trusted stopped custom-path deployments are recognized on disk"
+else
+  fail "explicit stopped custom-path deployment was treated as a fresh install"
+fi
+
+if (
+  root="$TEST_TMP/stopped-custom-symlink-marker"
+  marker_target="$TEST_TMP/stopped-custom-marker-target"
+  make_install "$root"
+  : > "$marker_target"
+  rm "$root/deployment/docker-compose.yaml"
+  ln -s "$marker_target" "$root/deployment/docker-compose.yaml"
+  FAKE_UID=$(command id -u)
+  ! canonical_existing_install_path "$root" \
+    > /dev/null 2> "$TEST_TMP/stopped-custom-symlink-marker.err" \
+    && grep -q 'regular, non-symlink file' \
+      "$TEST_TMP/stopped-custom-symlink-marker.err"
+); then
+  pass "on-disk deployment recognition rejects a symlink marker"
+else
+  fail "on-disk deployment recognition trusted a symlink marker"
+fi
+
+if (
+  root="$TEST_TMP/stopped-custom-writable-marker"
+  make_install "$root"
+  chmod 666 "$root/deployment/docker-compose.yaml"
+  FAKE_UID=$(command id -u)
+  ! canonical_existing_install_path "$root" \
+    > /dev/null 2> "$TEST_TMP/stopped-custom-writable-marker.err" \
+    && grep -q 'group- or world-writable' \
+      "$TEST_TMP/stopped-custom-writable-marker.err"
+); then
+  pass "on-disk deployment recognition rejects a writable marker"
+else
+  fail "on-disk deployment recognition trusted a writable marker"
+fi
+
+requested_disk_line=$(grep -n '&& \[ -n "\$REQUESTED_INSTALL_DIR" \]' "$INSTALL_SCRIPT" | cut -d: -f1)
+resolve_selected_line=$(grep -n '^if ! INSTALL_DIR=$(resolve_selected_install_path' "$INSTALL_SCRIPT" | cut -d: -f1)
+if [ -n "$requested_disk_line" ] \
+  && [ -n "$resolve_selected_line" ] \
+  && [ "$requested_disk_line" -lt "$resolve_selected_line" ]; then
+  pass "explicit on-disk deployment recognition precedes fresh-path resolution"
+else
+  fail "explicit custom-path installs are not promoted before fresh validation"
+fi
+
 if ! validate_install_path_metadata /srv/foreign 2000 755 1000 1 \
     > /dev/null 2>&1 \
   && validate_install_path_metadata /tmp 0 1777 1000 0 \
@@ -652,6 +709,20 @@ else
   fail "deployment extraction can run before updater shutdown"
 fi
 
+if (
+  UPDATER_REENABLE_ON_EXIT=0
+  UPDATER_RESTART_ON_EXIT=0
+  arm_existing_updater_restoration active enabled \
+    && [ "$UPDATER_REENABLE_ON_EXIT" = 1 ] \
+    && [ "$UPDATER_RESTART_ON_EXIT" = 1 ] \
+    && grep -q 'arm_existing_updater_restoration "\$active_state" "\$unit_file_state"' \
+      "$INSTALL_SCRIPT"
+); then
+  pass "quiescing an active enabled updater immediately arms exact restoration"
+else
+  fail "pre-bootstrap failures can leave the prior updater disabled"
+fi
+
 # The replacement updater is validated first, then stopped while run-fleet
 # owns the deployment tree, and restored only after that manual run returns.
 # Arming the EXIT cleanup before the installer function returns covers signals
@@ -724,18 +795,24 @@ if (
   DOWNLOAD_DIR="$TEST_TMP/updater-exit-download"
   mkdir -p "$DOWNLOAD_DIR"
   UPDATER_DISABLE_ON_EXIT=0
+  UPDATER_REENABLE_ON_EXIT=1
   UPDATER_RESTART_ON_EXIT=1
+  systemctl() {
+    printf '%s\n' "$*" >> "$restore_log"
+    return 0
+  }
   restart_updater_service_with() {
-    printf '%s\n' "$1" > "$restore_log"
+    printf 'restart-socket %s\n' "$1" >> "$restore_log"
     return 0
   }
   (trap installer_exit_cleanup EXIT; exit 7)
   cleanup_status=$?
   [ "$cleanup_status" -eq 7 ] \
-    && [ "$(cat "$restore_log")" = '/run/proto-fleet-updater/updater.sock' ] \
+    && grep -q '^enable proto-fleet-updater.service$' "$restore_log" \
+    && grep -q '^restart-socket /run/proto-fleet-updater/updater.sock$' "$restore_log" \
     && [ ! -e "$DOWNLOAD_DIR" ]
 ); then
-  pass "interrupted manual deployment restores the production updater socket"
+  pass "interrupted installation restores updater enablement and production socket"
 else
   fail "installer exit cleanup did not restore the updater after interruption"
 fi

--- a/deployment-files/tests/test-install-overlay-migration.sh
+++ b/deployment-files/tests/test-install-overlay-migration.sh
@@ -1,0 +1,305 @@
+#!/usr/bin/env bash
+# Focused tests for the installer's legacy optional-overlay migration. Docker
+# is stubbed so these cases exercise discovery, target validation, and label
+# parsing without touching the host daemon.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+INSTALL_SCRIPT="$REPO_ROOT/deployment-files/install.sh"
+TEST_TMP=$(mktemp -d)
+TEST_TMP=$(cd "$TEST_TMP" && pwd -P)
+trap 'rm -rf "$TEST_TMP"' EXIT
+
+# install.sh is intentionally standalone because it is executed directly from
+# curl before a release bundle exists. Extract just its discovery/migration
+# definitions instead of adding a production-only source-mode escape hatch.
+sed '/^# END INSTALL DISCOVERY AND LEGACY MIGRATION HELPERS$/q' \
+  "$INSTALL_SCRIPT" > "$TEST_TMP/install-functions.sh"
+# shellcheck source=/dev/null
+source "$TEST_TMP/install-functions.sh"
+
+FAILURES=0
+
+fail() {
+  echo "FAIL: $*" >&2
+  FAILURES=$((FAILURES + 1))
+}
+
+pass() {
+  echo "ok: $*"
+}
+
+make_install() {
+  local root="$1"
+  mkdir -p "$root/deployment/server/start"
+  : > "$root/deployment/docker-compose.yaml"
+  : > "$root/deployment/docker-compose.alerts.yaml"
+  : > "$root/deployment/docker-compose.system-monitoring.yaml"
+  : > "$root/deployment/docker-compose.tracing.yaml"
+}
+
+# Defaults consumed by the docker test double. Individual cases override only
+# the state they need.
+FAKE_IDS="fleet-container"
+FAKE_CONFIG_FILES=""
+FAKE_INSPECT_FAILURE=0
+DOCKER_CALL_LOG="$TEST_TMP/docker-calls"
+
+docker() {
+  printf '%s\n' "$*" >> "$DOCKER_CALL_LOG"
+  case "${1:-}" in
+    ps)
+      printf '%s\n' "$FAKE_IDS"
+      ;;
+    inspect)
+      [ "$FAKE_INSPECT_FAILURE" != 1 ] || return 1
+      case "${3:-}" in
+        *com.docker.compose.service*) printf 'fleet-api\n' ;;
+        *com.docker.compose.project.config_files*) printf '%s\n' "$FAKE_CONFIG_FILES" ;;
+        *) return 1 ;;
+      esac
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+sudo() {
+  printf 'sudo %s\n' "$*" >> "$DOCKER_CALL_LOG"
+  [ "${1:-}" != "-n" ] || shift
+  "$@"
+}
+
+# Explicit settings are authoritative, including false, and avoid Docker
+# inspection entirely.
+if (
+  root="$TEST_TMP/explicit"
+  make_install "$root"
+  printf '%s\n' \
+    'ENABLE_BETA_ALERTS=true' \
+    'export ENABLE_BETA_ALERTS: "false" # last value wins' \
+    'ENABLE_SYSTEM_MONITORING: false' \
+    $'ENABLE_TRACING: TRUE # explicit\r' > "$root/deployment/.env"
+  : > "$DOCKER_CALL_LOG"
+  capture_previous_run_options "$root" 1 || exit 1
+  [ "$PREVIOUS_BETA_ALERTS" = 0 ] \
+    && [ "$PREVIOUS_SYSTEM_MONITORING" = 0 ] \
+    && [ "$PREVIOUS_TRACING" = 0 ] \
+    && [ ! -s "$DOCKER_CALL_LOG" ]
+); then
+  pass "complete explicit ENABLE_* state bypasses inference"
+else
+  fail "complete explicit ENABLE_* state should remain authoritative"
+fi
+
+# Only absent keys are inferred. Active alerts/system overlays must not
+# override explicit false values while a missing tracing key is migrated.
+if (
+  root="$TEST_TMP/partial"
+  make_install "$root"
+  printf '%s\n' \
+    'ENABLE_BETA_ALERTS: false' \
+    'ENABLE_SYSTEM_MONITORING=false' > "$root/deployment/.env"
+  : > "$DOCKER_CALL_LOG"
+  FAKE_CONFIG_FILES="$root/deployment/docker-compose.yaml,$root/deployment/docker-compose.alerts.yaml,$root/deployment/docker-compose.system-monitoring.yaml,$root/deployment/docker-compose.tracing.yaml"
+  capture_previous_run_options "$root" 1 || exit 1
+  [ "$PREVIOUS_BETA_ALERTS" = 0 ] \
+    && [ "$PREVIOUS_SYSTEM_MONITORING" = 0 ] \
+    && [ "$PREVIOUS_TRACING" = 1 ]
+); then
+  pass "inference fills only missing overlay settings"
+else
+  fail "inference overrode explicit false or missed active tracing"
+fi
+
+# A preseeded .env alone is not evidence of a legacy deployment. Fresh
+# automation may write configuration before install, and must not require an
+# old container merely because optional overlay keys are absent.
+if (
+  root="$TEST_TMP/fresh-preseeded"
+  mkdir -p "$root/deployment"
+  printf 'DB_PASSWORD=preseeded\n' > "$root/deployment/.env"
+  : > "$DOCKER_CALL_LOG"
+  capture_previous_run_options "$root" 0 || exit 1
+  [ "$PREVIOUS_BETA_ALERTS" = 0 ] \
+    && [ "$PREVIOUS_SYSTEM_MONITORING" = 0 ] \
+    && [ "$PREVIOUS_TRACING" = 0 ] \
+    && [ ! -s "$DOCKER_CALL_LOG" ]
+); then
+  pass "fresh preseeded env does not trigger legacy inference"
+else
+  fail "fresh preseeded env should retain disabled overlay defaults"
+fi
+
+# A base-only config label is a complete, trustworthy signal that all missing
+# optional overlays were disabled.
+if (
+  root="$TEST_TMP/base-only"
+  make_install "$root"
+  : > "$root/deployment/.env"
+  : > "$DOCKER_CALL_LOG"
+  FAKE_CONFIG_FILES="$root/deployment/docker-compose.yaml"
+  capture_previous_run_options "$root" 1 || exit 1
+  [ "$PREVIOUS_BETA_ALERTS" = 0 ] \
+    && [ "$PREVIOUS_SYSTEM_MONITORING" = 0 ] \
+    && [ "$PREVIOUS_TRACING" = 0 ]
+); then
+  pass "base-only Compose label infers disabled overlays"
+else
+  fail "base-only Compose label should infer all overlays disabled"
+fi
+
+# The documented legacy CLI path can enable every overlay without persisting
+# any ENABLE_* keys. Recover all three selections from the old Compose model.
+if (
+  root="$TEST_TMP/all-overlays"
+  make_install "$root"
+  : > "$root/deployment/.env"
+  FAKE_CONFIG_FILES="$root/deployment/docker-compose.yaml,$root/deployment/docker-compose.alerts.yaml,$root/deployment/docker-compose.system-monitoring.yaml,$root/deployment/docker-compose.tracing.yaml"
+  capture_previous_run_options "$root" 1 || exit 1
+  [ "$PREVIOUS_BETA_ALERTS" = 1 ] \
+    && [ "$PREVIOUS_SYSTEM_MONITORING" = 1 ] \
+    && [ "$PREVIOUS_TRACING" = 1 ]
+); then
+  pass "all legacy overlays are recovered from the Compose model"
+else
+  fail "active legacy overlays should all be migrated"
+fi
+
+# Discovery is label-based and tied to the selected install's recorded base
+# Compose file rather than a substring container-name match.
+if (
+  root="$TEST_TMP/labeled"
+  make_install "$root"
+  : > "$root/deployment/.env"
+  : > "$DOCKER_CALL_LOG"
+  FAKE_CONFIG_FILES="$root/deployment/docker-compose.yaml,$root/deployment/docker-compose.alerts.yaml"
+  capture_previous_run_options "$root" 1 || exit 1
+  grep -q -- '--filter label=com.docker.compose.service=fleet-api' "$DOCKER_CALL_LOG"
+  ! grep -q -- '--filter name=' "$DOCKER_CALL_LOG"
+); then
+  pass "container discovery uses exact Compose service labels"
+else
+  fail "container discovery used a loose name match"
+fi
+
+# An existing deployment with missing settings must fail closed if the
+# container disappeared; the installer calls this before extracting files.
+if (
+  root="$TEST_TMP/no-container"
+  make_install "$root"
+  : > "$root/deployment/.env"
+  FAKE_IDS=""
+  FAKE_CONFIG_FILES="$root/deployment/docker-compose.yaml"
+  ! capture_previous_run_options "$root" 1 2> "$TEST_TMP/no-container.err"
+  grep -q 'No existing fleet-api container matches' "$TEST_TMP/no-container.err"
+); then
+  pass "missing legacy source fails closed"
+else
+  fail "missing legacy source should abort migration"
+fi
+
+# A transient Docker inspection error is not evidence that overlays were off.
+# Stop before extraction and let the operator retry instead of persisting false.
+if (
+  root="$TEST_TMP/inspect-failure"
+  make_install "$root"
+  : > "$root/deployment/.env"
+  FAKE_INSPECT_FAILURE=1
+  ! capture_previous_run_options "$root" 1 2> "$TEST_TMP/inspect-failure.err"
+  grep -q 'Could not inspect Docker' "$TEST_TMP/inspect-failure.err"
+); then
+  pass "Docker inspection failures fail closed"
+else
+  fail "Docker inspection failure should abort migration"
+fi
+
+# Multiple containers recording the same selected root are ambiguous; do not
+# let Docker result ordering choose one.
+if (
+  root="$TEST_TMP/ambiguous"
+  make_install "$root"
+  : > "$root/deployment/.env"
+  FAKE_IDS=$'first\nsecond'
+  FAKE_CONFIG_FILES="$root/deployment/docker-compose.yaml"
+  ! capture_previous_run_options "$root" 1 2> "$TEST_TMP/ambiguous.err"
+  grep -q 'Multiple fleet-api containers match' "$TEST_TMP/ambiguous.err"
+); then
+  pass "ambiguous matching containers fail closed"
+else
+  fail "ambiguous matching containers should abort migration"
+fi
+
+# The config-files label must include the selected deployment's base file;
+# otherwise a stale or unrelated container cannot authorize migration.
+if (
+  root="$TEST_TMP/wrong-label"
+  make_install "$root"
+  : > "$root/deployment/.env"
+  FAKE_IDS="fleet-container"
+  FAKE_CONFIG_FILES="/other/deployment/docker-compose.yaml,/other/deployment/docker-compose.alerts.yaml"
+  ! capture_previous_run_options "$root" 1 2> "$TEST_TMP/wrong-label.err"
+  grep -q 'No existing fleet-api container matches' "$TEST_TMP/wrong-label.err"
+); then
+  pass "foreign Compose config-files label is rejected"
+else
+  fail "foreign Compose config-files label should abort migration"
+fi
+
+# Invalid explicit settings are neither preserved as valid state nor silently
+# overwritten with an inferred value.
+if (
+  root="$TEST_TMP/invalid-env"
+  make_install "$root"
+  printf '%s\n' \
+    'ENABLE_BETA_ALERTS=maybe' \
+    'ENABLE_SYSTEM_MONITORING=false' \
+    'ENABLE_TRACING=false' > "$root/deployment/.env"
+  ! capture_previous_run_options "$root" 1 2> "$TEST_TMP/invalid-env.err"
+  grep -q 'must be true or false' "$TEST_TMP/invalid-env.err"
+); then
+  pass "invalid explicit overlay value is rejected"
+else
+  fail "invalid explicit overlay value should abort migration"
+fi
+
+# Preserve explicit false rather than silently enabling its dependency when
+# the old label and persisted state disagree.
+if (
+  root="$TEST_TMP/inconsistent"
+  make_install "$root"
+  printf '%s\n' \
+    'ENABLE_BETA_ALERTS=false' \
+    'ENABLE_TRACING=false' > "$root/deployment/.env"
+  FAKE_IDS="fleet-container"
+  FAKE_CONFIG_FILES="$root/deployment/docker-compose.yaml,$root/deployment/docker-compose.alerts.yaml,$root/deployment/docker-compose.system-monitoring.yaml"
+  ! capture_previous_run_options "$root" 1 2> "$TEST_TMP/inconsistent.err"
+  grep -q 'system monitoring without beta alerts' "$TEST_TMP/inconsistent.err"
+); then
+  pass "inconsistent explicit and inferred dependencies fail closed"
+else
+  fail "inconsistent explicit and inferred dependencies should abort migration"
+fi
+
+# The caller can reuse the privilege context that discovered the deployment;
+# every migration probe must stay on that same Docker daemon.
+if (
+  root="$TEST_TMP/privileged"
+  make_install "$root"
+  : > "$root/deployment/.env"
+  : > "$DOCKER_CALL_LOG"
+  FAKE_CONFIG_FILES="$root/deployment/docker-compose.yaml"
+  capture_previous_run_options "$root" 1 sudo -n || exit 1
+  grep -q '^sudo -n docker ps -a ' "$DOCKER_CALL_LOG"
+  grep -q '^sudo -n docker inspect ' "$DOCKER_CALL_LOG"
+); then
+  pass "overlay migration reuses the detected Docker privilege"
+else
+  fail "overlay migration did not use the selected Docker privilege"
+fi
+
+if [ "$FAILURES" -ne 0 ]; then
+  echo "$FAILURES failure(s)"
+  exit 1
+fi
+echo "all installer overlay migration checks passed"

--- a/deployment-files/tests/test-install-overlay-migration.sh
+++ b/deployment-files/tests/test-install-overlay-migration.sh
@@ -505,6 +505,111 @@ else
   fail "deployment extraction can run before updater shutdown"
 fi
 
+# The replacement updater is validated first, then stopped while run-fleet
+# owns the deployment tree, and restored only after that manual run returns.
+# Arming the EXIT cleanup before the installer function returns covers signals
+# and other failures during run-fleet as well as its ordinary nonzero result.
+validation_restart_line=$(awk '/^  if ! restart_updater_service_with/ { print NR; exit }' "$INSTALL_SCRIPT")
+quiesce_line=$(awk '/^  if ! quiesce_updater_service_for_manual_run_with/ { print NR; exit }' "$INSTALL_SCRIPT")
+production_socket_line=$(awk '/^      "\$GITHUB_RELEASES_URL" "\$UPDATER_SOCKET_PATH"/ { print NR; exit }' "$INSTALL_SCRIPT")
+restart_arm_line=$(awk '/^  UPDATER_RESTART_ON_EXIT=1$/ { print NR; exit }' "$INSTALL_SCRIPT")
+run_fleet_line=$(awk '/^if \.\/run-fleet\.sh / { print NR; exit }' "$INSTALL_SCRIPT")
+post_run_restart_line=$(awk -v start="$run_fleet_line" 'NR > start && /^  if restart_updater_service_with/ { print NR; exit }' "$INSTALL_SCRIPT")
+if [ -n "$validation_restart_line" ] \
+  && [ "$validation_restart_line" -lt "$quiesce_line" ] \
+  && [ "$quiesce_line" -lt "$production_socket_line" ] \
+  && [ "$production_socket_line" -lt "$restart_arm_line" ] \
+  && [ "$quiesce_line" -lt "$restart_arm_line" ] \
+  && [ "$restart_arm_line" -lt "$run_fleet_line" ] \
+  && [ "$run_fleet_line" -lt "$post_run_restart_line" ]; then
+  pass "host updater stays quiesced for the complete manual deployment run"
+else
+  fail "host updater lifecycle does not serialize the manual deployment run"
+fi
+
+if (
+  lifecycle_log="$TEST_TMP/updater-lifecycle-calls"
+  : > "$lifecycle_log"
+  systemctl() {
+    printf '%s\n' "$*" >> "$lifecycle_log"
+    case "${1:-}" in
+      restart|stop|is-active) return 0 ;;
+      show) printf 'inactive\n' ;;
+      *) return 1 ;;
+    esac
+  }
+  curl() {
+    printf 'curl %s\n' "$*" >> "$lifecycle_log"
+    return 0
+  }
+  restart_updater_service_with /run/proto-fleet-updater/test-validation.sock \
+    && quiesce_updater_service_for_manual_run_with \
+    && [ "$(sed -n '1p' "$lifecycle_log")" = 'restart proto-fleet-updater.service' ] \
+    && grep -q -- '--unix-socket /run/proto-fleet-updater/test-validation.sock' "$lifecycle_log" \
+    && grep -q '^stop proto-fleet-updater.service$' "$lifecycle_log" \
+    && grep -q '^show --property=ActiveState --value proto-fleet-updater.service$' "$lifecycle_log"
+); then
+  pass "validated updater is stopped and verified before manual deployment"
+else
+  fail "updater validation and quiesce helpers do not enforce the lifecycle boundary"
+fi
+
+if (
+  updater_env="$TEST_TMP/updater.env"
+  write_updater_environment_file "$updater_env" '/srv/proto fleet' \
+    'https://github.com/block/proto-fleet/releases' \
+    /run/proto-fleet-updater/installer-validation.sock \
+    && grep -q 'PROTO_FLEET_INSTALL_ROOT="/srv/proto fleet"' "$updater_env" \
+    && grep -q 'PROTO_FLEET_UPDATER_SOCKET_PATH="/run/proto-fleet-updater/installer-validation.sock"' "$updater_env" \
+    && write_updater_environment_file "$updater_env" '/srv/proto fleet' \
+      'https://github.com/block/proto-fleet/releases' \
+      /run/proto-fleet-updater/updater.sock \
+    && grep -q 'PROTO_FLEET_UPDATER_SOCKET_PATH="/run/proto-fleet-updater/updater.sock"' "$updater_env" \
+    && ! grep -q 'installer-validation.sock' "$updater_env"
+); then
+  pass "updater validation uses a private socket name before production activation"
+else
+  fail "updater validation socket can leak into the production environment"
+fi
+
+if (
+  restore_log="$TEST_TMP/updater-exit-restore"
+  DOWNLOAD_DIR="$TEST_TMP/updater-exit-download"
+  mkdir -p "$DOWNLOAD_DIR"
+  UPDATER_DISABLE_ON_EXIT=0
+  UPDATER_RESTART_ON_EXIT=1
+  restart_updater_service_with() {
+    printf '%s\n' "$1" > "$restore_log"
+    return 0
+  }
+  (trap installer_exit_cleanup EXIT; exit 7)
+  cleanup_status=$?
+  [ "$cleanup_status" -eq 7 ] \
+    && [ "$(cat "$restore_log")" = '/run/proto-fleet-updater/updater.sock' ] \
+    && [ ! -e "$DOWNLOAD_DIR" ]
+); then
+  pass "interrupted manual deployment restores the production updater socket"
+else
+  fail "installer exit cleanup did not restore the updater after interruption"
+fi
+
+if (
+  systemctl() {
+    case "${1:-}" in
+      stop) return 0 ;;
+      show) printf 'active\n' ;;
+      *) return 1 ;;
+    esac
+  }
+  ! quiesce_updater_service_for_manual_run_with \
+    2> "$TEST_TMP/updater-remained-active.err" \
+    && grep -q 'remained active' "$TEST_TMP/updater-remained-active.err"
+); then
+  pass "manual deployment rejects an updater that did not stop"
+else
+  fail "manual deployment must not proceed while the updater remains active"
+fi
+
 # A systemctl/query failure must never be interpreted as proof that the
 # privileged updater is inactive. Conversely, a genuinely absent unit and a
 # verified inactive+disabled unit are safe terminal states.

--- a/deployment-files/tests/test-install-overlay-migration.sh
+++ b/deployment-files/tests/test-install-overlay-migration.sh
@@ -392,6 +392,50 @@ else
   fail "fresh path resolution should not create directories"
 fi
 
+# If the root-daemon probe was blocked, an explicit on-disk deployment must
+# not become writable merely because all persisted overlay values are already
+# complete and no later migration lookup would touch Docker.
+if (
+  root="$TEST_TMP/sudo-blocked-existing"
+  make_install "$root"
+  printf '%s\n' \
+    'ENABLE_BETA_ALERTS=false' \
+    'ENABLE_SYSTEM_MONITORING=false' \
+    'ENABLE_TRACING=false' > "$root/deployment/.env"
+  FAKE_UID=1000
+  ! guard_selected_install_when_sudo_blocked "$root" 1 v1.2.3 \
+    > /dev/null 2> "$TEST_TMP/sudo-blocked-existing.err" \
+    && grep -q 'Re-run the installer as root' "$TEST_TMP/sudo-blocked-existing.err"
+); then
+  pass "blocked root-daemon discovery rejects an existing selected deployment"
+else
+  fail "blocked root-daemon discovery must fail before replacing an existing deployment"
+fi
+
+if (
+  root="$TEST_TMP/sudo-blocked-fresh"
+  mkdir -p "$root"
+  FAKE_UID=1000
+  guard_selected_install_when_sudo_blocked "$root" 1 v1.2.3 \
+    > /dev/null 2> "$TEST_TMP/sudo-blocked-fresh.err" \
+    && grep -q "couldn't check whether a" "$TEST_TMP/sudo-blocked-fresh.err"
+); then
+  pass "blocked root-daemon discovery still permits a fresh selected path with warning"
+else
+  fail "fresh installs should remain available when the root daemon cannot be probed"
+fi
+
+# Keep the fail-closed check ahead of every operation that can inspect,
+# disable, or replace the existing deployment.
+guard_line=$(grep -n '^if ! guard_selected_install_when_sudo_blocked' "$INSTALL_SCRIPT" | cut -d: -f1)
+capture_line=$(grep -n '^if ! capture_previous_run_options' "$INSTALL_SCRIPT" | cut -d: -f1)
+extract_line=$(grep -n '^extract_and_cd ' "$INSTALL_SCRIPT" | cut -d: -f1)
+if [ -n "$guard_line" ] && [ "$guard_line" -lt "$capture_line" ] && [ "$guard_line" -lt "$extract_line" ]; then
+  pass "blocked root-daemon guard runs before migration and extraction"
+else
+  fail "blocked root-daemon guard must precede deployment mutation"
+fi
+
 # A root caller may carry Docker selectors that point at a custom or rootless
 # daemon. The system-service probe must discard every endpoint/TLS selector so
 # equality cannot be proven against an environment the unit will not receive.

--- a/deployment-files/tests/test-install-overlay-migration.sh
+++ b/deployment-files/tests/test-install-overlay-migration.sh
@@ -7,9 +7,51 @@ set -u
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 INSTALL_SCRIPT="$REPO_ROOT/deployment-files/install.sh"
-TEST_TMP=$(mktemp -d)
-TEST_TMP=$(cd "$TEST_TMP" && pwd -P)
-trap 'rm -rf "$TEST_TMP"' EXIT
+TEST_TMP=""
+TEST_TMP_RESOLVED=""
+TEST_TMP_PARENT=""
+TEST_TMP_PREFIX=""
+
+cleanup_test_tmp() {
+  case "${TEST_TMP:-}" in
+    "$TEST_TMP_PREFIX".*)
+      [[ -d "$TEST_TMP" && ! -L "$TEST_TMP" ]] \
+        && rm -rf -- "${TEST_TMP:?}"
+      ;;
+  esac
+}
+
+if ! TEST_TMP_PARENT=$(cd "${TMPDIR:-/tmp}" 2>/dev/null && pwd -P); then
+  echo "FAIL: could not resolve the temporary-directory parent" >&2
+  exit 1
+fi
+TEST_TMP_PREFIX="${TEST_TMP_PARENT%/}/proto-fleet-install-overlay"
+if ! TEST_TMP=$(mktemp -d "$TEST_TMP_PREFIX.XXXXXX"); then
+  echo "FAIL: could not create the test temporary directory" >&2
+  exit 1
+fi
+case "$TEST_TMP" in
+  "$TEST_TMP_PREFIX".*) ;;
+  *)
+    echo "FAIL: mktemp returned an unexpected path: $TEST_TMP" >&2
+    exit 1
+    ;;
+esac
+if ! TEST_TMP_RESOLVED=$(cd "$TEST_TMP" 2>/dev/null && pwd -P); then
+  echo "FAIL: could not resolve the test temporary directory" >&2
+  rm -rf -- "${TEST_TMP:?}"
+  TEST_TMP=""
+  exit 1
+fi
+TEST_TMP="$TEST_TMP_RESOLVED"
+case "$TEST_TMP" in
+  "$TEST_TMP_PREFIX".*) ;;
+  *)
+    echo "FAIL: temporary directory escaped its expected parent: $TEST_TMP" >&2
+    exit 1
+    ;;
+esac
+trap cleanup_test_tmp EXIT
 
 # install.sh is intentionally standalone because it is executed directly from
 # curl before a release bundle exists. Extract its testable helper definitions

--- a/deployment-files/tests/test-install-overlay-migration.sh
+++ b/deployment-files/tests/test-install-overlay-migration.sh
@@ -825,8 +825,9 @@ validation_cleanup_line=$(awk '
 production_socket_line=$(awk '/^      "\$GITHUB_RELEASES_URL" "\$UPDATER_SOCKET_PATH"/ { print NR; exit }' "$INSTALL_SCRIPT")
 start_after_run_arm_line=$(awk '/^  UPDATER_START_AFTER_RUN=1$/ { print NR; exit }' "$INSTALL_SCRIPT")
 run_fleet_line=$(awk '/^  \.\/run-fleet\.sh / { print NR; exit }' "$INSTALL_SCRIPT")
+deployment_commit_line=$(awk -v start="$run_fleet_line" 'NR > start && /^    UPDATER_DEPLOYMENT_COMMITTED=1$/ { print NR; exit }' "$INSTALL_SCRIPT")
 run_status_check_line=$(awk -v start="$run_fleet_line" 'NR > start && /^if \[ "\$RUN_FLEET_STATUS" -ne 0 \]; then$/ { print NR; exit }' "$INSTALL_SCRIPT")
-post_run_restart_line=$(awk -v start="$run_fleet_line" 'NR > start && /^  if restart_updater_service_with/ { print NR; exit }' "$INSTALL_SCRIPT")
+post_run_reconcile_line=$(awk -v start="$run_status_check_line" 'NR > start && /^  && ! reconcile_committed_updater_enablement/ { print NR; exit }' "$INSTALL_SCRIPT")
 if [ -n "$validation_restart_line" ] \
   && [ "$validation_restart_line" -lt "$quiesce_line" ] \
   && [ "$quiesce_line" -lt "$validation_cleanup_line" ] \
@@ -835,9 +836,11 @@ if [ -n "$validation_restart_line" ] \
   && [ "$production_socket_line" -lt "$start_after_run_arm_line" ] \
   && [ "$quiesce_line" -lt "$start_after_run_arm_line" ] \
   && [ "$start_after_run_arm_line" -lt "$run_fleet_line" ] \
+  && [ "$run_fleet_line" -lt "$deployment_commit_line" ] \
+  && [ "$deployment_commit_line" -lt "$run_status_check_line" ] \
   && [ "$run_fleet_line" -lt "$run_status_check_line" ] \
-  && [ "$run_status_check_line" -lt "$post_run_restart_line" ] \
-  && [ "$run_fleet_line" -lt "$post_run_restart_line" ]; then
+  && [ "$run_status_check_line" -lt "$post_run_reconcile_line" ] \
+  && [ "$run_fleet_line" -lt "$post_run_reconcile_line" ]; then
   pass "host updater stays quiesced for the complete manual deployment run"
 else
   fail "host updater lifecycle does not serialize the manual deployment run"
@@ -1121,6 +1124,104 @@ if (
   pass "interrupted installation restores updater enablement and production socket"
 else
   fail "installer exit cleanup did not restore the updater after interruption"
+fi
+
+# A successful run-fleet return commits the socket-enabled topology. Signals
+# after that boundary must finish enabling the updater instead of applying the
+# pre-deployment fail-closed cleanup policy.
+if (
+  committed_root="$TEST_TMP/updater-committed-signal"
+  committed_env="$committed_root/deployment/.env"
+  lifecycle_log="$TEST_TMP/updater-committed-signal-calls"
+  mkdir -p "$(dirname "$committed_env")"
+  printf 'ENABLE_ONE_CLICK_UPDATES=true\n' > "$committed_env"
+  : > "$lifecycle_log"
+  INSTALL_DIR="$committed_root"
+  DEPLOYMENT_DIR=deployment
+  RUN_FLEET_ARGS=(--enable-one-click-updates --non-interactive)
+  UPDATER_PRIVILEGE=()
+  UPDATER_DISABLE_ON_EXIT=1
+  UPDATER_REENABLE_ON_EXIT=0
+  UPDATER_RESTART_ON_EXIT=0
+  UPDATER_START_AFTER_RUN=1
+  UPDATER_DEPLOYMENT_COMMITTED=1
+  systemctl() {
+    printf 'systemctl %s\n' "$*" >> "$lifecycle_log"
+    return 0
+  }
+  restart_updater_service_with() {
+    printf 'restart %s\n' "$1" >> "$lifecycle_log"
+    return 0
+  }
+  disable_updater_service_with() {
+    printf 'disable\n' >> "$lifecycle_log"
+    return 0
+  }
+  run_disabled_updater_fallback() {
+    printf 'fallback\n' >> "$lifecycle_log"
+    return 1
+  }
+  (trap installer_exit_cleanup EXIT; exit 143)
+  cleanup_status=$?
+  [ "$cleanup_status" -eq 143 ] \
+    && grep -q '^systemctl enable proto-fleet-updater.service$' "$lifecycle_log" \
+    && grep -q '^restart /run/proto-fleet-updater/updater.sock$' "$lifecycle_log" \
+    && ! grep -q '^disable$' "$lifecycle_log" \
+    && ! grep -q '^fallback$' "$lifecycle_log"
+); then
+  pass "signal after committed deployment starts the updater"
+else
+  fail "committed updater enablement can be disabled by interrupted cleanup"
+fi
+
+# If the signal arrives during the final readiness phase and the retry cannot
+# establish a ready updater, cleanup must replace the committed socket overlay
+# with the copy-command fallback before it exits.
+if (
+  committed_root="$TEST_TMP/updater-readiness-signal"
+  committed_env="$committed_root/deployment/.env"
+  lifecycle_log="$TEST_TMP/updater-readiness-signal-calls"
+  mkdir -p "$(dirname "$committed_env")"
+  printf 'ENABLE_ONE_CLICK_UPDATES=true\n' > "$committed_env"
+  : > "$lifecycle_log"
+  INSTALL_DIR="$committed_root"
+  DEPLOYMENT_DIR=deployment
+  RUN_FLEET_ARGS=(--enable-one-click-updates --non-interactive)
+  UPDATER_PRIVILEGE=()
+  UPDATER_DISABLE_ON_EXIT=1
+  UPDATER_REENABLE_ON_EXIT=0
+  UPDATER_RESTART_ON_EXIT=0
+  UPDATER_START_AFTER_RUN=1
+  UPDATER_DEPLOYMENT_COMMITTED=1
+  systemctl() {
+    printf 'systemctl %s\n' "$*" >> "$lifecycle_log"
+    return 0
+  }
+  restart_updater_service_with() {
+    printf 'restart %s\n' "$1" >> "$lifecycle_log"
+    return 1
+  }
+  disable_updater_service_with() {
+    printf 'disable\n' >> "$lifecycle_log"
+    return 0
+  }
+  run_disabled_updater_fallback() {
+    printf 'fallback %s\n' "$*" >> "$lifecycle_log"
+    printf 'ENABLE_ONE_CLICK_UPDATES=false\n' > "$committed_env"
+    UPDATER_DISABLE_ON_EXIT=0
+    return 0
+  }
+  (trap installer_exit_cleanup EXIT; exit 130)
+  cleanup_status=$?
+  [ "$cleanup_status" -eq 130 ] \
+    && grep -q '^restart /run/proto-fleet-updater/updater.sock$' "$lifecycle_log" \
+    && grep -q '^disable$' "$lifecycle_log" \
+    && grep -q '^fallback ./run-fleet.sh .*--enable-one-click-updates --non-interactive$' "$lifecycle_log" \
+    && grep -q '^ENABLE_ONE_CLICK_UPDATES=false$' "$committed_env"
+); then
+  pass "signal during final updater readiness deploys the disabled fallback"
+else
+  fail "interrupted updater readiness can leave the socket overlay committed"
 fi
 
 if (

--- a/deployment-files/tests/test-install-overlay-migration.sh
+++ b/deployment-files/tests/test-install-overlay-migration.sh
@@ -1154,6 +1154,51 @@ else
 fi
 
 if (
+  fallback_env="$TEST_TMP/updater-restart-fallback.env"
+  fallback_log="$TEST_TMP/updater-restart-fallback-calls"
+  printf 'ENABLE_ONE_CLICK_UPDATES=true\n' > "$fallback_env"
+  : > "$fallback_log"
+  UPDATER_DISABLE_ON_EXIT=1
+  UPDATER_REENABLE_ON_EXIT=0
+  UPDATER_RESTART_ON_EXIT=0
+  UPDATER_START_AFTER_RUN=0
+  updater_fallback_runner() {
+    printf '%s\n' "$*" > "$fallback_log"
+    [ "${PROTO_FLEET_INSTALLER_MANAGED_RUN:-0}" = 1 ] || return 1
+    printf 'ENABLE_ONE_CLICK_UPDATES=false\n' > "$fallback_env"
+    return 0
+  }
+  run_disabled_updater_fallback updater_fallback_runner "$fallback_env" \
+    --enable-one-click-updates --non-interactive \
+    && grep -q '^--non-interactive --disable-one-click-updates$' "$fallback_log" \
+    && [ "$UPDATER_DISABLE_ON_EXIT" = 0 ]
+); then
+  pass "failed production restart deploys and commits the disabled fallback"
+else
+  fail "failed production restart can leave the socket overlay active"
+fi
+
+if (
+  fallback_env="$TEST_TMP/updater-restart-fallback-failure.env"
+  printf 'ENABLE_ONE_CLICK_UPDATES=true\n' > "$fallback_env"
+  UPDATER_DISABLE_ON_EXIT=1
+  UPDATER_REENABLE_ON_EXIT=0
+  UPDATER_RESTART_ON_EXIT=0
+  UPDATER_START_AFTER_RUN=0
+  updater_fallback_failure() { return 7; }
+  fallback_status=0
+  run_disabled_updater_fallback updater_fallback_failure "$fallback_env" \
+    --enable-one-click-updates || fallback_status=$?
+  [ "$fallback_status" -eq 7 ] \
+    && grep -q '^ENABLE_ONE_CLICK_UPDATES=true$' "$fallback_env" \
+    && [ "$UPDATER_DISABLE_ON_EXIT" = 1 ]
+); then
+  pass "failed copy-command fallback keeps updater disablement armed"
+else
+  fail "failed copy-command fallback can reactivate the unready updater"
+fi
+
+if (
   restore_log="$TEST_TMP/updater-validation-restore"
   DOWNLOAD_DIR="$TEST_TMP/updater-validation-download"
   mkdir -p "$DOWNLOAD_DIR"

--- a/deployment-files/tests/test-install-overlay-migration.sh
+++ b/deployment-files/tests/test-install-overlay-migration.sh
@@ -573,6 +573,21 @@ else
 fi
 
 if (
+  root="$TEST_TMP/interactive-stopped-custom-install"
+  make_install "$root"
+  FAKE_UID=$(command id -u)
+  PREVIOUS_INSTALL_DIR=""
+  promote_selected_install_if_existing "$root" \
+    && resolved=$(resolve_selected_install_path "$root" "$PREVIOUS_INSTALL_DIR") \
+    && [ "$PREVIOUS_INSTALL_DIR" = "$(cd "$root" && pwd -P)" ] \
+    && [ "$resolved" = "$PREVIOUS_INSTALL_DIR" ]
+); then
+  pass "interactively selected stopped deployment is promoted before fresh validation"
+else
+  fail "interactive custom-path deployment was treated as a fresh install"
+fi
+
+if (
   root="$TEST_TMP/stopped-custom-symlink-marker"
   marker_target="$TEST_TMP/stopped-custom-marker-target"
   make_install "$root"
@@ -606,13 +621,19 @@ else
 fi
 
 requested_disk_line=$(grep -n '&& \[ -n "\$REQUESTED_INSTALL_DIR" \]' "$INSTALL_SCRIPT" | cut -d: -f1)
+interactive_selection_line=$(grep -n 'INSTALL_DIR="\${custom_dir:-\$DEFAULT_INSTALL_DIR}"' "$INSTALL_SCRIPT" | cut -d: -f1)
+selected_promotion_line=$(grep -n '^if ! promote_selected_install_if_existing "\$INSTALL_DIR"; then$' "$INSTALL_SCRIPT" | cut -d: -f1)
 resolve_selected_line=$(grep -n '^if ! INSTALL_DIR=$(resolve_selected_install_path' "$INSTALL_SCRIPT" | cut -d: -f1)
 if [ -n "$requested_disk_line" ] \
+  && [ -n "$interactive_selection_line" ] \
+  && [ -n "$selected_promotion_line" ] \
   && [ -n "$resolve_selected_line" ] \
-  && [ "$requested_disk_line" -lt "$resolve_selected_line" ]; then
-  pass "explicit on-disk deployment recognition precedes fresh-path resolution"
+  && [ "$requested_disk_line" -lt "$resolve_selected_line" ] \
+  && [ "$interactive_selection_line" -lt "$selected_promotion_line" ] \
+  && [ "$selected_promotion_line" -lt "$resolve_selected_line" ]; then
+  pass "explicit and interactive on-disk recognition precede fresh-path resolution"
 else
-  fail "explicit custom-path installs are not promoted before fresh validation"
+  fail "custom-path installs are not promoted after selection and before fresh validation"
 fi
 
 if ! validate_install_path_metadata /srv/foreign 2000 755 1000 1 \
@@ -907,6 +928,30 @@ else
 fi
 
 if (
+  DOWNLOAD_DIR="$TEST_TMP/updater-artifact-backup"
+  UPDATER_ENV_PATH="$TEST_TMP/updater-artifact-current.env"
+  UPDATER_BINARY_PATH="$TEST_TMP/updater-artifact-current.bin"
+  UPDATER_UNIT_PATH="$TEST_TMP/updater-artifact-current.service"
+  mkdir -p "$DOWNLOAD_DIR"
+  printf 'old environment\n' > "$UPDATER_ENV_PATH"
+  printf 'old binary\n' > "$UPDATER_BINARY_PATH"
+  printf 'old unit\n' > "$UPDATER_UNIT_PATH"
+  UPDATER_ENV_RESTORE_FILE=""
+  UPDATER_BINARY_RESTORE_FILE=""
+  UPDATER_UNIT_RESTORE_FILE=""
+  UPDATER_ARTIFACT_RESTORE_PENDING=0
+  backup_existing_updater_artifacts_with \
+    && [ "$UPDATER_ARTIFACT_RESTORE_PENDING" = 1 ] \
+    && [ "$(cat "$UPDATER_ENV_RESTORE_FILE")" = 'old environment' ] \
+    && [ "$(cat "$UPDATER_BINARY_RESTORE_FILE")" = 'old binary' ] \
+    && [ "$(cat "$UPDATER_UNIT_RESTORE_FILE")" = 'old unit' ]
+); then
+  pass "existing updater backup preserves environment, binary, and unit"
+else
+  fail "existing updater backup omits a rollback artifact"
+fi
+
+if (
   restore_log="$TEST_TMP/updater-exit-restore"
   DOWNLOAD_DIR="$TEST_TMP/updater-exit-download"
   mkdir -p "$DOWNLOAD_DIR"
@@ -938,32 +983,54 @@ if (
   DOWNLOAD_DIR="$TEST_TMP/updater-validation-download"
   mkdir -p "$DOWNLOAD_DIR"
   UPDATER_ENV_PATH="$TEST_TMP/updater-validation-current.env"
+  UPDATER_BINARY_PATH="$TEST_TMP/updater-validation-current.bin"
+  UPDATER_UNIT_PATH="$TEST_TMP/updater-validation-current.service"
   UPDATER_ENV_RESTORE_FILE="$DOWNLOAD_DIR/updater.env.previous"
-  printf 'production socket\n' > "$UPDATER_ENV_RESTORE_FILE"
-  printf 'validation socket\n' > "$UPDATER_ENV_PATH"
+  UPDATER_BINARY_RESTORE_FILE="$DOWNLOAD_DIR/proto-fleet-updater.previous"
+  UPDATER_UNIT_RESTORE_FILE="$DOWNLOAD_DIR/proto-fleet-updater.service.previous"
+  printf 'old environment\n' > "$UPDATER_ENV_RESTORE_FILE"
+  printf 'old binary\n' > "$UPDATER_BINARY_RESTORE_FILE"
+  printf 'old unit\n' > "$UPDATER_UNIT_RESTORE_FILE"
+  printf 'new environment\n' > "$UPDATER_ENV_PATH"
+  printf 'new binary\n' > "$UPDATER_BINARY_PATH"
+  printf 'new unit\n' > "$UPDATER_UNIT_PATH"
   UPDATER_PRIVILEGE=()
   UPDATER_DISABLE_ON_EXIT=1
-  UPDATER_REENABLE_ON_EXIT=0
+  UPDATER_REENABLE_ON_EXIT=1
   UPDATER_RESTART_ON_EXIT=1
+  UPDATER_ARTIFACT_RESTORE_PENDING=1
+  systemctl() {
+    printf '%s\n' "$*" >> "$restore_log"
+    return 0
+  }
   disable_updater_service_with() {
     printf 'disable\n' >> "$restore_log"
     return 0
   }
   restart_updater_service_with() {
     printf 'restart-socket %s\n' "$1" >> "$restore_log"
-    [ "$(cat "$UPDATER_ENV_PATH")" = 'production socket' ]
+    [ "$(cat "$UPDATER_ENV_PATH")" = 'old environment' ] \
+      && [ "$(cat "$UPDATER_BINARY_PATH")" = 'old binary' ] \
+      && [ "$(cat "$UPDATER_UNIT_PATH")" = 'old unit' ]
   }
   (trap installer_exit_cleanup EXIT; exit 7)
   cleanup_status=$?
+  reload_line=$(grep -n '^daemon-reload$' "$restore_log" | cut -d: -f1)
+  enable_line=$(grep -n '^enable proto-fleet-updater.service$' "$restore_log" | cut -d: -f1)
+  restart_line=$(grep -n '^restart-socket /run/proto-fleet-updater/updater.sock$' "$restore_log" | cut -d: -f1)
   [ "$cleanup_status" -eq 7 ] \
-    && [ "$(cat "$UPDATER_ENV_PATH")" = 'production socket' ] \
+    && [ "$(cat "$UPDATER_ENV_PATH")" = 'old environment' ] \
+    && [ "$(cat "$UPDATER_BINARY_PATH")" = 'old binary' ] \
+    && [ "$(cat "$UPDATER_UNIT_PATH")" = 'old unit' ] \
     && [ "$(sed -n '1p' "$restore_log")" = disable ] \
-    && grep -q '^restart-socket /run/proto-fleet-updater/updater.sock$' "$restore_log" \
+    && [ -n "$reload_line" ] \
+    && [ "$reload_line" -lt "$enable_line" ] \
+    && [ "$enable_line" -lt "$restart_line" ] \
     && [ ! -e "$DOWNLOAD_DIR" ]
 ); then
-  pass "interrupted validation restores production configuration before restart"
+  pass "interrupted validation atomically restores all updater artifacts before restart"
 else
-  fail "validation interruption can restart the updater with its private socket configuration"
+  fail "validation interruption can restart a partially replaced updater"
 fi
 
 if (

--- a/deployment-files/tests/test-install-overlay-migration.sh
+++ b/deployment-files/tests/test-install-overlay-migration.sh
@@ -16,6 +16,10 @@ trap 'rm -rf "$TEST_TMP"' EXIT
 # definitions instead of adding a production-only source-mode escape hatch.
 sed '/^# END INSTALL DISCOVERY AND LEGACY MIGRATION HELPERS$/q' \
   "$INSTALL_SCRIPT" > "$TEST_TMP/install-functions.sh"
+# The privileged service fallback lives after the installer's main download
+# path. Extract just that function as a second focused unit under test.
+sed -n '/^disable_updater_service_with()/,/^}/p' \
+  "$INSTALL_SCRIPT" >> "$TEST_TMP/install-functions.sh"
 # shellcheck source=/dev/null
 source "$TEST_TMP/install-functions.sh"
 
@@ -47,7 +51,7 @@ FAKE_INSPECT_FAILURE=0
 DOCKER_CALL_LOG="$TEST_TMP/docker-calls"
 
 docker() {
-  printf '%s\n' "$*" >> "$DOCKER_CALL_LOG"
+  printf '%s docker %s\n' "${FAKE_DOCKER_CONTEXT:-direct}" "$*" >> "$DOCKER_CALL_LOG"
   case "${1:-}" in
     ps)
       printf '%s\n' "$FAKE_IDS"
@@ -67,7 +71,7 @@ docker() {
 sudo() {
   printf 'sudo %s\n' "$*" >> "$DOCKER_CALL_LOG"
   [ "${1:-}" != "-n" ] || shift
-  "$@"
+  FAKE_DOCKER_CONTEXT=sudo "$@"
 }
 
 # Explicit settings are authoritative, including false, and avoid Docker
@@ -77,7 +81,7 @@ if (
   make_install "$root"
   printf '%s\n' \
     'ENABLE_BETA_ALERTS=true' \
-    'export ENABLE_BETA_ALERTS: "false" # last value wins' \
+    'export ENABLE_BETA_ALERTS: "false" # says "disabled"; last value wins' \
     'ENABLE_SYSTEM_MONITORING: false' \
     $'ENABLE_TRACING: TRUE # explicit\r' > "$root/deployment/.env"
   : > "$DOCKER_CALL_LOG"
@@ -175,8 +179,8 @@ if (
   : > "$DOCKER_CALL_LOG"
   FAKE_CONFIG_FILES="$root/deployment/docker-compose.yaml,$root/deployment/docker-compose.alerts.yaml"
   capture_previous_run_options "$root" 1 || exit 1
-  grep -q -- '--filter label=com.docker.compose.service=fleet-api' "$DOCKER_CALL_LOG"
-  ! grep -q -- '--filter name=' "$DOCKER_CALL_LOG"
+  grep -q -- '--filter label=com.docker.compose.service=fleet-api' "$DOCKER_CALL_LOG" \
+    && ! grep -q -- '--filter name=' "$DOCKER_CALL_LOG"
 ); then
   pass "container discovery uses exact Compose service labels"
 else
@@ -191,8 +195,8 @@ if (
   : > "$root/deployment/.env"
   FAKE_IDS=""
   FAKE_CONFIG_FILES="$root/deployment/docker-compose.yaml"
-  ! capture_previous_run_options "$root" 1 2> "$TEST_TMP/no-container.err"
-  grep -q 'No existing fleet-api container matches' "$TEST_TMP/no-container.err"
+  ! capture_previous_run_options "$root" 1 2> "$TEST_TMP/no-container.err" \
+    && grep -q 'No existing fleet-api container matches' "$TEST_TMP/no-container.err"
 ); then
   pass "missing legacy source fails closed"
 else
@@ -206,8 +210,8 @@ if (
   make_install "$root"
   : > "$root/deployment/.env"
   FAKE_INSPECT_FAILURE=1
-  ! capture_previous_run_options "$root" 1 2> "$TEST_TMP/inspect-failure.err"
-  grep -q 'Could not inspect Docker' "$TEST_TMP/inspect-failure.err"
+  ! capture_previous_run_options "$root" 1 2> "$TEST_TMP/inspect-failure.err" \
+    && grep -q 'Could not inspect Docker' "$TEST_TMP/inspect-failure.err"
 ); then
   pass "Docker inspection failures fail closed"
 else
@@ -222,8 +226,8 @@ if (
   : > "$root/deployment/.env"
   FAKE_IDS=$'first\nsecond'
   FAKE_CONFIG_FILES="$root/deployment/docker-compose.yaml"
-  ! capture_previous_run_options "$root" 1 2> "$TEST_TMP/ambiguous.err"
-  grep -q 'Multiple fleet-api containers match' "$TEST_TMP/ambiguous.err"
+  ! capture_previous_run_options "$root" 1 2> "$TEST_TMP/ambiguous.err" \
+    && grep -q 'Multiple fleet-api containers match' "$TEST_TMP/ambiguous.err"
 ); then
   pass "ambiguous matching containers fail closed"
 else
@@ -238,8 +242,8 @@ if (
   : > "$root/deployment/.env"
   FAKE_IDS="fleet-container"
   FAKE_CONFIG_FILES="/other/deployment/docker-compose.yaml,/other/deployment/docker-compose.alerts.yaml"
-  ! capture_previous_run_options "$root" 1 2> "$TEST_TMP/wrong-label.err"
-  grep -q 'No existing fleet-api container matches' "$TEST_TMP/wrong-label.err"
+  ! capture_previous_run_options "$root" 1 2> "$TEST_TMP/wrong-label.err" \
+    && grep -q 'No existing fleet-api container matches' "$TEST_TMP/wrong-label.err"
 ); then
   pass "foreign Compose config-files label is rejected"
 else
@@ -255,8 +259,8 @@ if (
     'ENABLE_BETA_ALERTS=maybe' \
     'ENABLE_SYSTEM_MONITORING=false' \
     'ENABLE_TRACING=false' > "$root/deployment/.env"
-  ! capture_previous_run_options "$root" 1 2> "$TEST_TMP/invalid-env.err"
-  grep -q 'must be true or false' "$TEST_TMP/invalid-env.err"
+  ! capture_previous_run_options "$root" 1 2> "$TEST_TMP/invalid-env.err" \
+    && grep -q 'must be true or false' "$TEST_TMP/invalid-env.err"
 ); then
   pass "invalid explicit overlay value is rejected"
 else
@@ -273,8 +277,8 @@ if (
     'ENABLE_TRACING=false' > "$root/deployment/.env"
   FAKE_IDS="fleet-container"
   FAKE_CONFIG_FILES="$root/deployment/docker-compose.yaml,$root/deployment/docker-compose.alerts.yaml,$root/deployment/docker-compose.system-monitoring.yaml"
-  ! capture_previous_run_options "$root" 1 2> "$TEST_TMP/inconsistent.err"
-  grep -q 'system monitoring without beta alerts' "$TEST_TMP/inconsistent.err"
+  ! capture_previous_run_options "$root" 1 2> "$TEST_TMP/inconsistent.err" \
+    && grep -q 'system monitoring without beta alerts' "$TEST_TMP/inconsistent.err"
 ); then
   pass "inconsistent explicit and inferred dependencies fail closed"
 else
@@ -290,12 +294,80 @@ if (
   : > "$DOCKER_CALL_LOG"
   FAKE_CONFIG_FILES="$root/deployment/docker-compose.yaml"
   capture_previous_run_options "$root" 1 sudo -n || exit 1
-  grep -q '^sudo -n docker ps -a ' "$DOCKER_CALL_LOG"
-  grep -q '^sudo -n docker inspect ' "$DOCKER_CALL_LOG"
+  grep -q '^sudo -n docker ps -a ' "$DOCKER_CALL_LOG" \
+    && grep -q '^sudo -n docker inspect ' "$DOCKER_CALL_LOG" \
+    && grep -q '^sudo docker ps -a ' "$DOCKER_CALL_LOG" \
+    && grep -q '^sudo docker inspect ' "$DOCKER_CALL_LOG" \
+    && ! grep -q '^direct docker ' "$DOCKER_CALL_LOG"
 ); then
   pass "overlay migration reuses the detected Docker privilege"
 else
   fail "overlay migration did not use the selected Docker privilege"
+fi
+
+# A systemctl/query failure must never be interpreted as proof that the
+# privileged updater is inactive. Conversely, a genuinely absent unit and a
+# verified inactive+disabled unit are safe terminal states.
+systemctl() {
+  case "$FAKE_SYSTEMCTL_MODE:$*" in
+    missing:*--property=LoadState*) printf 'not-found\n' ;;
+    safe:*--property=LoadState*) printf 'loaded\n' ;;
+    safe:*'disable --now'*) return 0 ;;
+    safe:*--property=ActiveState*) printf 'inactive\n' ;;
+    safe:*--property=UnitFileState*) printf 'disabled\n' ;;
+    unsafe:*--property=LoadState*) printf 'loaded\n' ;;
+    unsafe:*'disable --now'*) return 1 ;;
+    unsafe:*--property=ActiveState*) printf 'active\n' ;;
+    unsafe:*--property=UnitFileState*) printf 'enabled\n' ;;
+    query-failure:*) return 1 ;;
+    *) return 1 ;;
+  esac
+}
+
+if (
+  UPDATER_CLEANUP_FAILED=0
+  FAKE_SYSTEMCTL_MODE=missing
+  disable_updater_service_with \
+    && [ "$UPDATER_CLEANUP_FAILED" = 0 ]
+); then
+  pass "missing updater unit is already a safe fallback state"
+else
+  fail "missing updater unit should not make installer fallback fatal"
+fi
+
+if (
+  UPDATER_CLEANUP_FAILED=0
+  FAKE_SYSTEMCTL_MODE=safe
+  disable_updater_service_with \
+    && [ "$UPDATER_CLEANUP_FAILED" = 0 ]
+); then
+  pass "updater fallback verifies inactive and disabled service state"
+else
+  fail "verified inactive and disabled updater should be a safe fallback"
+fi
+
+if (
+  UPDATER_CLEANUP_FAILED=0
+  FAKE_SYSTEMCTL_MODE=query-failure
+  ! disable_updater_service_with 2> "$TEST_TMP/systemctl-query.err" \
+    && [ "$UPDATER_CLEANUP_FAILED" = 1 ] \
+    && grep -q 'Could not inspect the host updater' "$TEST_TMP/systemctl-query.err"
+); then
+  pass "updater fallback fails closed when systemctl inspection fails"
+else
+  fail "systemctl inspection failure should make updater fallback fatal"
+fi
+
+if (
+  UPDATER_CLEANUP_FAILED=0
+  FAKE_SYSTEMCTL_MODE=unsafe
+  ! disable_updater_service_with 2> "$TEST_TMP/systemctl-unsafe.err" \
+    && [ "$UPDATER_CLEANUP_FAILED" = 1 ] \
+    && grep -q 'Could not stop and disable' "$TEST_TMP/systemctl-unsafe.err"
+); then
+  pass "updater fallback rejects an active or enabled final state"
+else
+  fail "active or enabled updater state should make fallback fatal"
 fi
 
 if [ "$FAILURES" -ne 0 ]; then

--- a/deployment-files/tests/test-install-overlay-migration.sh
+++ b/deployment-files/tests/test-install-overlay-migration.sh
@@ -928,6 +928,48 @@ else
 fi
 
 if (
+  configured_root="$TEST_TMP/missing-unit-configured-root"
+  selected_root="$TEST_TMP/missing-unit-selected-root"
+  mkdir -p "$configured_root" "$selected_root"
+  UPDATER_ENV_PATH="$TEST_TMP/missing-unit-updater.env"
+  UPDATER_BINARY_PATH="$TEST_TMP/missing-unit-updater.bin"
+  UPDATER_UNIT_PATH="$TEST_TMP/missing-unit-updater.service"
+  UPDATER_STATE_DIR="$TEST_TMP/missing-unit-state"
+  UPDATER_RUNTIME_DIR="$TEST_TMP/missing-unit-runtime"
+  UPDATER_SYSTEMD_RUNTIME_DIR="$TEST_TMP/missing-unit-systemd"
+  mkdir -p "$UPDATER_SYSTEMD_RUNTIME_DIR"
+  escaped_configured_root=${configured_root//\\/\\\\}
+  escaped_configured_root=${escaped_configured_root//\"/\\\"}
+  printf 'PROTO_FLEET_INSTALL_ROOT="%s"\n' "$escaped_configured_root" \
+    > "$UPDATER_ENV_PATH"
+  UPDATER_PRIVILEGE=()
+  UPDATER_PRIVILEGE_AVAILABLE=1
+  UPDATER_CLEANUP_FAILED=0
+  service_log="$TEST_TMP/missing-unit-service.log"
+  uname() {
+    printf 'Linux\n'
+  }
+  systemctl() {
+    printf '%s\n' "$*" >> "$service_log"
+    case "$*" in
+      *'--property=LoadState --value'*) printf 'not-found\n' ;;
+      *'--property=ActiveState --value'*) printf 'inactive\n' ;;
+      *) return 1 ;;
+    esac
+  }
+  ! prepare_existing_updater_service "$selected_root" \
+    > /dev/null 2> "$TEST_TMP/missing-unit-owner.err" \
+    && [ "$UPDATER_CLEANUP_FAILED" = 1 ] \
+    && grep -q 'belongs to a different Proto Fleet installation' \
+      "$TEST_TMP/missing-unit-owner.err" \
+    && ! grep -q '^stop proto-fleet-updater.service$' "$service_log"
+); then
+  pass "durable updater artifacts enforce ownership even when the unit is missing"
+else
+  fail "missing updater unit bypassed durable artifact ownership"
+fi
+
+if (
   DOWNLOAD_DIR="$TEST_TMP/updater-artifact-backup"
   UPDATER_ENV_PATH="$TEST_TMP/updater-artifact-current.env"
   UPDATER_BINARY_PATH="$TEST_TMP/updater-artifact-current.bin"
@@ -976,6 +1018,35 @@ if (
   pass "interrupted installation restores updater enablement and production socket"
 else
   fail "installer exit cleanup did not restore the updater after interruption"
+fi
+
+if (
+  fallback_env="$TEST_TMP/updater-fallback.env"
+  printf 'ENABLE_ONE_CLICK_UPDATES=true\n' > "$fallback_env"
+  UPDATER_DISABLE_ON_EXIT=1
+  UPDATER_REENABLE_ON_EXIT=1
+  UPDATER_RESTART_ON_EXIT=1
+  UPDATER_ENV_RESTORE_FILE=env-backup
+  UPDATER_BINARY_RESTORE_FILE=binary-backup
+  UPDATER_UNIT_RESTORE_FILE=unit-backup
+  UPDATER_ARTIFACT_RESTORE_PENDING=1
+  UPDATER_FALLBACK_PENDING=1
+  ! finalize_disabled_updater_fallback_if_persisted "$fallback_env" \
+    && [ "$UPDATER_REENABLE_ON_EXIT" = 1 ] \
+    && [ "$UPDATER_RESTART_ON_EXIT" = 1 ] \
+    && [ "$UPDATER_ARTIFACT_RESTORE_PENDING" = 1 ] \
+    && [ "$UPDATER_FALLBACK_PENDING" = 1 ] \
+    && printf 'ENABLE_ONE_CLICK_UPDATES=false\n' > "$fallback_env" \
+    && finalize_disabled_updater_fallback_if_persisted "$fallback_env" \
+    && [ "$UPDATER_DISABLE_ON_EXIT" = 0 ] \
+    && [ "$UPDATER_REENABLE_ON_EXIT" = 0 ] \
+    && [ "$UPDATER_RESTART_ON_EXIT" = 0 ] \
+    && [ "$UPDATER_ARTIFACT_RESTORE_PENDING" = 0 ] \
+    && [ "$UPDATER_FALLBACK_PENDING" = 0 ]
+); then
+  pass "updater restoration remains armed until disabled fallback is durable"
+else
+  fail "updater fallback discards restoration before persistence"
 fi
 
 if (
@@ -1056,6 +1127,7 @@ fi
 systemctl() {
   case "$FAKE_SYSTEMCTL_MODE:$*" in
     missing:*--property=LoadState*) printf 'not-found\n' ;;
+    missing:*--property=ActiveState*) printf 'inactive\n' ;;
     safe:*--property=LoadState*) printf 'loaded\n' ;;
     safe:*'disable --now'*) return 0 ;;
     safe:*--property=ActiveState*) printf 'inactive\n' ;;

--- a/deployment-files/tests/test-profiles.sh
+++ b/deployment-files/tests/test-profiles.sh
@@ -216,6 +216,7 @@ STAGE=$(mktemp -d)
 trap 'rm -rf "$STRICT_TMP" "$STAGE"' EXIT
 mkdir -p "$STAGE/server" "$STAGE/client" "$STAGE/ha"
 cp "$PROD_COMPOSE" "$STAGE/"
+cp "$REPO_ROOT/deployment-files/docker-compose.updater.yaml" "$STAGE/"
 cp "$REPO_ROOT/deployment-files/ha/compose.yaml" "$STAGE/ha/"
 cp "$BASE_COMPOSE" "$STAGE/server/"
 cp -r "$PROFILES_DIR" "$STAGE/profiles"
@@ -302,6 +303,29 @@ assert_rendered "max render" "$out" \
 out=$(render --env-file profiles/standard.env --env-file override.env)
 assert_rendered "operator .env overrides the profile" "$out" \
     "shared_buffers=999MB" "max_worker_processes=13"
+
+out=$(cd "$STAGE" && docker compose --env-file base-secrets.env \
+    -f docker-compose.yaml -f docker-compose.updater.yaml config 2>"$STAGE/render.err")
+assert_rendered "host updater overlay exposes only its Unix socket" "$out" \
+    'UPDATES_UPDATER_SOCKET_PATH: /run/proto-fleet-updater/updater.sock' \
+    'source: /run/proto-fleet-updater' \
+    'target: /run/proto-fleet-updater'
+if printf '%s\n' "$out" | awk '
+    $1 == "source:" && $2 == "/run/proto-fleet-updater" { in_socket = 1; target = 0; next }
+    in_socket && $1 == "target:" && $2 == "/run/proto-fleet-updater" { target = 1; next }
+    in_socket && target && $1 == "read_only:" && $2 == "true" { read_only = 1; exit }
+    in_socket && $1 == "source:" { in_socket = 0 }
+    END { exit !(read_only == 1) }
+'; then
+    pass "host updater socket mount is read-only"
+else
+    fail "host updater socket mount is not read-only"
+fi
+if printf '%s\n' "$out" | grep -qF '/var/run/docker.sock'; then
+    fail "host updater overlay exposes the Docker socket"
+else
+    pass "host updater overlay does not expose the Docker socket"
+fi
 
 # ----------------------------------------------------------------------------
 

--- a/deployment-files/tests/test-run-fleet-upgrade.sh
+++ b/deployment-files/tests/test-run-fleet-upgrade.sh
@@ -325,6 +325,8 @@ case " $* " in
                 ;;
             'stop proto-fleet-updater.service') printf 'inactive\n' > "$UPDATER_STATE_FILE" ;;
             'restart proto-fleet-updater.service') printf 'active\n' > "$UPDATER_STATE_FILE" ;;
+            'enable proto-fleet-updater.service') ;;
+            'disable --now proto-fleet-updater.service') printf 'inactive\n' > "$UPDATER_STATE_FILE" ;;
             'is-active --quiet proto-fleet-updater.service') [ "$updater_state" = "active" ] ;;
             *) exit 1 ;;
         esac
@@ -567,14 +569,15 @@ done
 assert_contains "enabled one-click updates layer the socket overlay" "$HARNESS_CALL_LOG" "-f $STAGE/docker-compose.updater.yaml"
 
 # Exercise the exact installer contract: a successful service bootstrap must
-# override a persisted false value, layer the socket overlay, and survive the
-# preflight-to-activation handoff.
+# override a persisted false value and layer the socket overlay in the same
+# deployment run. Unmanaged preflight cannot commit this transition.
 make_stage enable-updater-overlay
 # The installer validates and then stops the loaded service while run-fleet
 # changes the deployment; it restarts the updater only after this handoff.
 printf 'inactive\n' > "$HARNESS_UPDATER_STATE_FILE"
-if run_stage "$STAGE" --enable-one-click-updates --non-interactive --preflight-only; then
-    pass "installer updater enablement preflights"
+if PROTO_FLEET_INSTALLER_MANAGED_RUN=1 \
+    run_stage "$STAGE" --enable-one-click-updates --non-interactive; then
+    pass "installer updater enablement deploys"
 else
     fail "installer updater enablement should override persisted false state"
 fi
@@ -585,13 +588,8 @@ if [ "$(grep -c '^ENABLE_ONE_CLICK_UPDATES=' "$STAGE/.env")" -eq 1 ] \
 else
     fail "installer updater enablement did not normalize persisted state to true"
 fi
-: > "$HARNESS_CALL_LOG"
-if run_stage "$STAGE" --non-interactive --skip-build; then
-    pass "enabled updater activation succeeds"
-else
-    fail "enabled updater state should survive activation"
-fi
-assert_contains "enabled updater activation retains the socket overlay" "$HARNESS_CALL_LOG" "-f $STAGE/docker-compose.updater.yaml"
+assert_not_contains "installer retains updater lifecycle ownership after deployment" \
+    "$HARNESS_CALL_LOG" "systemctl restart proto-fleet-updater.service"
 
 # A manual runner operating on a deployment whose fleet-api can still reach
 # the updater must stop that writer before Compose teardown and restore it on
@@ -635,29 +633,27 @@ else
     fail "failed direct run left the updater stopped"
 fi
 
-# Process-level Compose overrides select the new effective state, but cannot
-# erase evidence that the running deployment was wired to the updater. The
-# active daemon must be quiesced before a persisted true value is changed.
+# Preflight prepares images but leaves the active topology untouched. Reject
+# an unmanaged updater-state transition before persisting or quiescing it.
 make_stage process-disable-active-updater
 printf 'ENABLE_ONE_CLICK_UPDATES=true\n' >> "$STAGE/.env"
 printf 'active\n' > "$HARNESS_UPDATER_STATE_FILE"
 if ENABLE_ONE_CLICK_UPDATES=false \
     run_stage "$STAGE" --non-interactive --preflight-only; then
-    pass "process override can disable a persisted updater safely"
+    fail "preflight should reject an updater-state transition"
 else
-    fail "process override failed while disabling a persisted updater"
+    pass "preflight rejects an updater-state transition"
 fi
-assert_contains "persisted updater state survives process override for serialization" \
+assert_not_contains "rejected preflight does not stop the active updater" \
     "$HARNESS_CALL_LOG" "systemctl stop proto-fleet-updater.service"
-if [ "$(grep -c '^ENABLE_ONE_CLICK_UPDATES=' "$STAGE/.env")" -eq 1 ] \
-    && grep -q '^ENABLE_ONE_CLICK_UPDATES=false$' "$STAGE/.env" \
-    && [ "$(cat "$HARNESS_UPDATER_STATE_FILE")" = inactive ]; then
-    pass "process disable persists false after updater serialization"
+if [ "$(grep '^ENABLE_ONE_CLICK_UPDATES=' "$STAGE/.env" | tail -n 1)" = 'ENABLE_ONE_CLICK_UPDATES=true' ] \
+    && [ "$(cat "$HARNESS_UPDATER_STATE_FILE")" = active ]; then
+    pass "rejected preflight preserves active updater state"
 else
-    fail "process disable did not persist state or leave the updater stopped"
+    fail "rejected preflight changed updater configuration or runtime state"
 fi
-assert_not_contains "successful process disable does not restart the updater" \
-    "$HARNESS_CALL_LOG" "systemctl restart proto-fleet-updater.service"
+assert_contains "rejected preflight explains the lifecycle boundary" \
+    "$HARNESS_OUTPUT_LOG" "--preflight-only cannot change one-click update state"
 
 # Persisting the desired flag is not deployment success. A later failure must
 # restore both the prior flag and the updater that served the still-running
@@ -666,7 +662,7 @@ make_stage failed-process-disable-active-updater
 printf 'ENABLE_ONE_CLICK_UPDATES=true\n' >> "$STAGE/.env"
 printf 'active\n' > "$HARNESS_UPDATER_STATE_FILE"
 if ENABLE_ONE_CLICK_UPDATES=false FAKE_COMPOSE_CONFIG_FAILURE=true \
-    run_stage "$STAGE" --non-interactive --preflight-only; then
+    run_stage "$STAGE" --non-interactive; then
     fail "failed process disable should propagate its Compose failure"
 else
     pass "failed process disable exercises updater configuration rollback"
@@ -683,6 +679,52 @@ else
     fail "failed process disable left updater configuration and runtime state inconsistent"
 fi
 
+# Once Compose teardown begins, the old topology can no longer be assumed.
+# Failures after the replacement starts retain the desired setting and align
+# the service with whichever new containers were created.
+make_stage post-compose-disable-failure
+printf 'ENABLE_ONE_CLICK_UPDATES=true\n' >> "$STAGE/.env"
+printf 'active\n' > "$HARNESS_UPDATER_STATE_FILE"
+if FLEET_API_READY_ATTEMPTS=1 FAKE_API_READINESS_FAILURE=true \
+    run_stage "$STAGE" --disable-one-click-updates --non-interactive; then
+    fail "post-Compose disable fixture should fail readiness"
+else
+    pass "post-Compose disable failure preserves the new lifecycle boundary"
+fi
+assert_contains "post-Compose disable reaches replacement startup" \
+    "$HARNESS_CALL_LOG" " up --remove-orphans"
+assert_contains "post-Compose disable disables the updater unit" \
+    "$HARNESS_CALL_LOG" "systemctl disable --now proto-fleet-updater.service"
+assert_not_contains "post-Compose disable does not restore the old updater" \
+    "$HARNESS_CALL_LOG" "systemctl restart proto-fleet-updater.service"
+if [ "$(grep '^ENABLE_ONE_CLICK_UPDATES=' "$STAGE/.env" | tail -n 1)" = 'ENABLE_ONE_CLICK_UPDATES=false' ] \
+    && [ "$(cat "$HARNESS_UPDATER_STATE_FILE")" = inactive ]; then
+    pass "post-Compose disable keeps configuration and service disabled"
+else
+    fail "post-Compose disable restored state for a topology that was already replaced"
+fi
+
+make_stage post-compose-enable-failure
+printf 'inactive\n' > "$HARNESS_UPDATER_STATE_FILE"
+if FLEET_API_READY_ATTEMPTS=1 FAKE_API_READINESS_FAILURE=true \
+    run_stage "$STAGE" --enable-one-click-updates --non-interactive; then
+    fail "post-Compose enable fixture should fail readiness"
+else
+    pass "post-Compose enable failure preserves the new lifecycle boundary"
+fi
+assert_contains "post-Compose enable reaches replacement startup" \
+    "$HARNESS_CALL_LOG" " up --remove-orphans"
+assert_contains "post-Compose enable enables the updater unit" \
+    "$HARNESS_CALL_LOG" "systemctl enable proto-fleet-updater.service"
+assert_contains "post-Compose enable starts the updater" \
+    "$HARNESS_CALL_LOG" "systemctl restart proto-fleet-updater.service"
+if [ "$(grep '^ENABLE_ONE_CLICK_UPDATES=' "$STAGE/.env" | tail -n 1)" = 'ENABLE_ONE_CLICK_UPDATES=true' ] \
+    && [ "$(cat "$HARNESS_UPDATER_STATE_FILE")" = active ]; then
+    pass "post-Compose enable keeps configuration and service enabled"
+else
+    fail "post-Compose enable restored state for a topology that was already replaced"
+fi
+
 # Desired flags cannot prove that the daemon is stopped. An unmanaged retry
 # must drain a stale active updater even when the persisted and effective
 # settings are already false.
@@ -697,6 +739,8 @@ assert_contains "disabled retry stops a stale active updater" \
     "$HARNESS_CALL_LOG" "systemctl stop proto-fleet-updater.service"
 assert_not_contains "disabled retry does not restart a stale updater" \
     "$HARNESS_CALL_LOG" "systemctl restart proto-fleet-updater.service"
+assert_contains "disabled retry disables a stale updater unit" \
+    "$HARNESS_CALL_LOG" "systemctl disable --now proto-fleet-updater.service"
 if [ "$(cat "$HARNESS_UPDATER_STATE_FILE")" = inactive ]; then
     pass "disabled retry leaves the stale updater stopped"
 else
@@ -725,10 +769,10 @@ assert_not_contains "managed activation leaves lifecycle ownership with the daem
 # state so fleet-api does not advertise or mount a dead host updater.
 make_stage disable-updater-overlay
 printf 'ENABLE_ONE_CLICK_UPDATES=true\n' >> "$STAGE/.env"
-if run_stage "$STAGE" --disable-one-click-updates --non-interactive --preflight-only; then
-    pass "explicit updater fallback preflights"
+if run_stage "$STAGE" --disable-one-click-updates --non-interactive; then
+    pass "explicit updater fallback deploys"
 else
-    fail "explicit updater fallback should override persisted true state"
+    fail "explicit updater fallback should deploy with persisted false state"
 fi
 assert_not_contains "explicit updater fallback omits the socket overlay" "$HARNESS_CALL_LOG" "docker-compose.updater.yaml"
 if [ "$(grep -c '^ENABLE_ONE_CLICK_UPDATES=' "$STAGE/.env")" -eq 1 ] \
@@ -745,7 +789,7 @@ fi
 make_stage disable-updater-without-systemd
 printf 'ENABLE_ONE_CLICK_UPDATES=true\n' >> "$STAGE/.env"
 if FAKE_WSL=true FAKE_SYSTEMD_UNAVAILABLE=true \
-    run_stage "$STAGE" --disable-one-click-updates --non-interactive --preflight-only; then
+    run_stage "$STAGE" --disable-one-click-updates --non-interactive; then
     pass "explicit updater fallback survives an unavailable systemd manager"
 else
     fail "unavailable systemd manager blocked the explicit updater fallback"

--- a/deployment-files/tests/test-run-fleet-upgrade.sh
+++ b/deployment-files/tests/test-run-fleet-upgrade.sh
@@ -658,6 +658,38 @@ else
     fail "explicit updater fallback did not normalize persisted state to false"
 fi
 
+# Once one-click updates ship, a host may lose its systemd manager before a
+# later installer run. An explicit disable remains safe because no systemd
+# updater can be active, while leaving the feature enabled must still fail
+# before any deployment mutation.
+make_stage disable-updater-without-systemd
+printf 'ENABLE_ONE_CLICK_UPDATES=true\n' >> "$STAGE/.env"
+if FAKE_WSL=true FAKE_SYSTEMD_UNAVAILABLE=true \
+    run_stage "$STAGE" --disable-one-click-updates --non-interactive --preflight-only; then
+    pass "explicit updater fallback survives an unavailable systemd manager"
+else
+    fail "unavailable systemd manager blocked the explicit updater fallback"
+fi
+if [ "$(grep -c '^ENABLE_ONE_CLICK_UPDATES=' "$STAGE/.env")" -eq 1 ] \
+    && grep -q '^ENABLE_ONE_CLICK_UPDATES=false$' "$STAGE/.env"; then
+    pass "non-systemd fallback persists disabled updater state"
+else
+    fail "non-systemd fallback did not normalize persisted updater state"
+fi
+
+make_stage enabled-updater-without-systemd
+printf 'ENABLE_ONE_CLICK_UPDATES=true\n' >> "$STAGE/.env"
+if FAKE_WSL=true FAKE_SYSTEMD_UNAVAILABLE=true \
+    run_stage "$STAGE" --non-interactive --preflight-only; then
+    fail "enabled updater should not proceed without a systemd manager"
+else
+    pass "enabled updater fails closed without a systemd manager"
+fi
+assert_contains "missing updater manager is diagnosed" "$HARNESS_OUTPUT_LOG" \
+    "systemd manager is unavailable"
+assert_not_contains "missing updater manager prevents Docker activity" \
+    "$HARNESS_CALL_LOG" "docker "
+
 # Persisted one-click state must fail before Docker activity when its release
 # bundle is incomplete; silently omitting the socket would expose a false
 # upgrade capability state to Fleet API.

--- a/deployment-files/tests/test-run-fleet-upgrade.sh
+++ b/deployment-files/tests/test-run-fleet-upgrade.sh
@@ -135,9 +135,11 @@ make_stage() {
     HARNESS_BIN_DIR="$runtime/bin"
     HARNESS_CALL_LOG="$runtime/calls.log"
     HARNESS_OUTPUT_LOG="$runtime/output.log"
+    HARNESS_UPDATER_STATE_FILE="$runtime/updater-state"
     mkdir -p "$STAGE/client" "$STAGE/ha" "$STAGE/profiles" "$STAGE/server/monitoring/grafana/provisioning/datasources" "$HARNESS_BIN_DIR"
     : > "$HARNESS_CALL_LOG"
     : > "$HARNESS_OUTPUT_LOG"
+    printf 'not-found\n' > "$HARNESS_UPDATER_STATE_FILE"
     cp "$DEPLOY_DIR/run-fleet.sh" "$STAGE/"
     cp "$DEPLOY_DIR/docker-compose.yaml" "$STAGE/"
     cp "$DEPLOY_DIR/docker-compose.alerts.yaml" "$STAGE/"
@@ -302,7 +304,27 @@ EOF
     cat > "$HARNESS_BIN_DIR/systemctl" <<'EOF'
 #!/bin/bash
 printf 'systemctl %s\n' "$*" >> "$CALL_LOG"
-[ "${FAKE_SYSTEMD_UNAVAILABLE:-false}" != "true" ]
+[ "${FAKE_SYSTEMD_UNAVAILABLE:-false}" != "true" ] || exit 1
+case " $* " in
+    *" proto-fleet-updater.service "*)
+        updater_state=$(cat "$UPDATER_STATE_FILE")
+        case "$*" in
+            *'--property=LoadState --value'*)
+                if [ "$updater_state" = "not-found" ]; then
+                    printf 'not-found\n'
+                else
+                    printf 'loaded\n'
+                fi
+                ;;
+            *'--property=ActiveState --value'*) printf '%s\n' "$updater_state" ;;
+            'stop proto-fleet-updater.service') printf 'inactive\n' > "$UPDATER_STATE_FILE" ;;
+            'restart proto-fleet-updater.service') printf 'active\n' > "$UPDATER_STATE_FILE" ;;
+            'is-active --quiet proto-fleet-updater.service') [ "$updater_state" = "active" ] ;;
+            *) exit 1 ;;
+        esac
+        ;;
+esac
+exit 0
 EOF
 
     cat > "$HARNESS_BIN_DIR/id" <<'EOF'
@@ -453,6 +475,7 @@ run_stage() {
     REAL_MKTEMP="$REAL_MKTEMP" \
     REAL_MV="$REAL_MV" \
     REAL_STAT="$REAL_STAT" \
+    UPDATER_STATE_FILE="$HARNESS_UPDATER_STATE_FILE" \
     PATH="$HARNESS_BIN_DIR:$PATH" \
     /bin/bash "$stage/run-fleet.sh" "$@" > "$HARNESS_OUTPUT_LOG" 2>&1
 }
@@ -557,6 +580,66 @@ else
     fail "enabled updater state should survive activation"
 fi
 assert_contains "enabled updater activation retains the socket overlay" "$HARNESS_CALL_LOG" "-f $STAGE/docker-compose.updater.yaml"
+
+# A manual runner operating on a deployment whose fleet-api can still reach
+# the updater must stop that writer before Compose teardown and restore it on
+# every exit. Updater-owned children identify themselves explicitly and the
+# staged preflight remains non-mutating with respect to the active tree.
+make_stage direct-updater-serialization
+printf 'ENABLE_ONE_CLICK_UPDATES=true\n' >> "$STAGE/.env"
+printf 'active\n' > "$HARNESS_UPDATER_STATE_FILE"
+if run_stage "$STAGE" --non-interactive; then
+    pass "direct deployment run serializes with the active host updater"
+else
+    fail "direct deployment run should stop and restore the host updater"
+fi
+direct_stop_line=$(grep -n '^systemctl stop proto-fleet-updater.service$' "$HARNESS_CALL_LOG" | cut -d: -f1)
+direct_down_line=$(grep -n ' compose .* down --remove-orphans$' "$HARNESS_CALL_LOG" | cut -d: -f1)
+direct_restart_line=$(grep -n '^systemctl restart proto-fleet-updater.service$' "$HARNESS_CALL_LOG" | cut -d: -f1)
+if [ -n "$direct_stop_line" ] \
+    && [ -n "$direct_down_line" ] \
+    && [ -n "$direct_restart_line" ] \
+    && [ "$direct_stop_line" -lt "$direct_down_line" ] \
+    && [ "$direct_down_line" -lt "$direct_restart_line" ] \
+    && [ "$(cat "$HARNESS_UPDATER_STATE_FILE")" = active ]; then
+    pass "direct runner holds the updater quiesced across deployment mutation"
+else
+    fail "direct runner did not serialize its complete mutation window"
+fi
+
+make_stage direct-updater-failure
+printf 'ENABLE_ONE_CLICK_UPDATES=true\n' >> "$STAGE/.env"
+printf 'active\n' > "$HARNESS_UPDATER_STATE_FILE"
+if FAKE_COMPOSE_CONFIG_FAILURE=true run_stage "$STAGE" --non-interactive; then
+    fail "direct runner fixture should fail after updater quiescing"
+else
+    pass "direct runner failure exercises updater EXIT restoration"
+fi
+assert_contains "failed direct run stops the updater first" "$HARNESS_CALL_LOG" "systemctl stop proto-fleet-updater.service"
+assert_contains "failed direct run restores the updater" "$HARNESS_CALL_LOG" "systemctl restart proto-fleet-updater.service"
+if [ "$(cat "$HARNESS_UPDATER_STATE_FILE")" = active ]; then
+    pass "failed direct run leaves the updater active"
+else
+    fail "failed direct run left the updater stopped"
+fi
+
+make_stage updater-managed-runner
+printf 'ENABLE_ONE_CLICK_UPDATES=true\n' >> "$STAGE/.env"
+printf 'active\n' > "$HARNESS_UPDATER_STATE_FILE"
+if PROTO_FLEET_UPDATER_MANAGED_RUN=1 run_stage "$STAGE" --non-interactive --preflight-only; then
+    pass "updater preflight remains available while the daemon is active"
+else
+    fail "preflight should not attempt to stop its owning updater"
+fi
+assert_not_contains "preflight does not stop its updater" "$HARNESS_CALL_LOG" "systemctl stop proto-fleet-updater.service"
+: > "$HARNESS_CALL_LOG"
+if PROTO_FLEET_UPDATER_MANAGED_RUN=1 run_stage "$STAGE" --non-interactive --skip-build; then
+    pass "updater-managed activation bypasses direct-run quiescing"
+else
+    fail "updater-managed activation should not stop its parent daemon"
+fi
+assert_not_contains "managed activation does not stop its updater" "$HARNESS_CALL_LOG" "systemctl stop proto-fleet-updater.service"
+assert_not_contains "managed activation leaves lifecycle ownership with the daemon" "$HARNESS_CALL_LOG" "systemctl restart proto-fleet-updater.service"
 
 # An installer bootstrap failure must explicitly override previously persisted
 # state so fleet-api does not advertise or mount a dead host updater.

--- a/deployment-files/tests/test-run-fleet-upgrade.sh
+++ b/deployment-files/tests/test-run-fleet-upgrade.sh
@@ -353,7 +353,10 @@ case " $* " in
                 fi
                 printf 'inactive\n' > "$UPDATER_STATE_FILE"
                 ;;
-            'restart proto-fleet-updater.service') printf 'active\n' > "$UPDATER_STATE_FILE" ;;
+            'restart proto-fleet-updater.service')
+                [ "${FAKE_UPDATER_RESTART_FAILURE:-false}" != "true" ] || exit 1
+                printf 'active\n' > "$UPDATER_STATE_FILE"
+                ;;
             'enable proto-fleet-updater.service') printf 'true\n' > "$UPDATER_ENABLED_FILE" ;;
             'disable --now proto-fleet-updater.service')
                 printf 'inactive\n' > "$UPDATER_STATE_FILE"
@@ -653,6 +656,36 @@ else
 fi
 assert_contains "direct runner repairs missing boot enablement" \
     "$HARNESS_CALL_LOG" "systemctl enable proto-fleet-updater.service"
+
+# A committed socket-enabled deployment must not remain active when the host
+# updater cannot restart. Degrade to the supported copy-command mode and prove
+# the second Compose transition omits the privileged socket overlay.
+make_stage direct-updater-restart-fallback
+printf 'ENABLE_ONE_CLICK_UPDATES=true\n' >> "$STAGE/.env"
+printf 'active\n' > "$HARNESS_UPDATER_STATE_FILE"
+if FAKE_UPDATER_RESTART_FAILURE=true run_stage "$STAGE" --non-interactive; then
+    pass "failed updater restart deploys the copy-command fallback"
+else
+    fail "failed updater restart should degrade to copy-command updates"
+fi
+assert_contains "failed updater restart is diagnosed" "$HARNESS_OUTPUT_LOG" \
+    "redeploying without its socket overlay"
+assert_contains "failed updater restart disables the service" \
+    "$HARNESS_CALL_LOG" "systemctl disable --now proto-fleet-updater.service"
+fallback_up_line=$(grep ' compose .* up --remove-orphans' "$HARNESS_CALL_LOG" | tail -1)
+if [ "$(grep -c ' compose .* up --remove-orphans' "$HARNESS_CALL_LOG")" -eq 2 ] \
+  && [[ "$fallback_up_line" != *"docker-compose.updater.yaml"* ]]; then
+    pass "copy-command fallback replaces the socket-enabled topology"
+else
+    fail "copy-command fallback did not remove the updater overlay"
+fi
+if grep -q '^ENABLE_ONE_CLICK_UPDATES=false$' "$STAGE/.env" \
+  && [ "$(cat "$HARNESS_UPDATER_STATE_FILE")" = inactive ] \
+  && [ "$(cat "$HARNESS_UPDATER_ENABLED_FILE")" = false ]; then
+    pass "copy-command fallback commits disabled updater state"
+else
+    fail "copy-command fallback left updater configuration or service enabled"
+fi
 
 # systemctl stop drains an activation that has already crossed its commit
 # boundary. If that activation swaps deployment/ while the old runner waits,

--- a/deployment-files/tests/test-run-fleet-upgrade.sh
+++ b/deployment-files/tests/test-run-fleet-upgrade.sh
@@ -623,6 +623,28 @@ else
     fail "failed direct run left the updater stopped"
 fi
 
+# Process-level Compose overrides select the new effective state, but cannot
+# erase evidence that the running deployment was wired to the updater. The
+# active daemon must be quiesced before a persisted true value is changed.
+make_stage process-disable-active-updater
+printf 'ENABLE_ONE_CLICK_UPDATES=true\n' >> "$STAGE/.env"
+printf 'active\n' > "$HARNESS_UPDATER_STATE_FILE"
+if ENABLE_ONE_CLICK_UPDATES=false \
+    run_stage "$STAGE" --non-interactive --preflight-only; then
+    pass "process override can disable a persisted updater safely"
+else
+    fail "process override failed while disabling a persisted updater"
+fi
+assert_contains "persisted updater state survives process override for serialization" \
+    "$HARNESS_CALL_LOG" "systemctl stop proto-fleet-updater.service"
+if [ "$(grep -c '^ENABLE_ONE_CLICK_UPDATES=' "$STAGE/.env")" -eq 1 ] \
+    && grep -q '^ENABLE_ONE_CLICK_UPDATES=false$' "$STAGE/.env" \
+    && [ "$(cat "$HARNESS_UPDATER_STATE_FILE")" = active ]; then
+    pass "process disable persists false after updater serialization"
+else
+    fail "process disable did not persist or restore updater state correctly"
+fi
+
 make_stage updater-managed-runner
 printf 'ENABLE_ONE_CLICK_UPDATES=true\n' >> "$STAGE/.env"
 printf 'active\n' > "$HARNESS_UPDATER_STATE_FILE"

--- a/deployment-files/tests/test-run-fleet-upgrade.sh
+++ b/deployment-files/tests/test-run-fleet-upgrade.sh
@@ -345,7 +345,14 @@ case " $* " in
                     printf 'disabled\n'
                 fi
                 ;;
-            'stop proto-fleet-updater.service') printf 'inactive\n' > "$UPDATER_STATE_FILE" ;;
+            'stop proto-fleet-updater.service')
+                if [ "${FAKE_SWAP_DEPLOYMENT_ON_STOP:-false}" = "true" ] \
+                  && [ -d "$STAGE_ROOT.replacement" ]; then
+                    /bin/mv "$STAGE_ROOT" "$STAGE_ROOT.previous"
+                    /bin/mv "$STAGE_ROOT.replacement" "$STAGE_ROOT"
+                fi
+                printf 'inactive\n' > "$UPDATER_STATE_FILE"
+                ;;
             'restart proto-fleet-updater.service') printf 'active\n' > "$UPDATER_STATE_FILE" ;;
             'enable proto-fleet-updater.service') printf 'true\n' > "$UPDATER_ENABLED_FILE" ;;
             'disable --now proto-fleet-updater.service')
@@ -647,6 +654,29 @@ fi
 assert_contains "direct runner repairs missing boot enablement" \
     "$HARNESS_CALL_LOG" "systemctl enable proto-fleet-updater.service"
 
+# systemctl stop drains an activation that has already crossed its commit
+# boundary. If that activation swaps deployment/ while the old runner waits,
+# the old shell must re-exec the newly active release before touching Compose.
+make_stage direct-updater-deployment-swap
+printf 'ENABLE_ONE_CLICK_UPDATES=true\n' >> "$STAGE/.env"
+printf 'active\n' > "$HARNESS_UPDATER_STATE_FILE"
+cp -R "$STAGE" "$STAGE.replacement"
+printf 'COMPOSE_PROJECT_NAME=reexecuted-release\n' >> "$STAGE.replacement/.env"
+if FAKE_SWAP_DEPLOYMENT_ON_STOP=true run_stage "$STAGE" --non-interactive; then
+    pass "direct runner re-executes after an updater deployment swap"
+else
+    fail "direct runner should continue through the newly activated release"
+fi
+assert_contains "deployment swap is detected after updater drain" \
+    "$HARNESS_OUTPUT_LOG" "restarting with the current release runner"
+assert_contains "replacement runner recomputes deployment configuration" \
+    "$HARNESS_CALL_LOG" "--project-name reexecuted-release"
+if [ "$(grep -c '^systemctl stop proto-fleet-updater.service$' "$HARNESS_CALL_LOG")" -eq 1 ]; then
+    pass "replacement runner does not repeat updater shutdown"
+else
+    fail "replacement runner repeated or skipped updater shutdown"
+fi
+
 # Persisted configuration is authoritative even when the service was already
 # inactive before the direct run, so successful deployment repairs runtime and
 # boot state instead of preserving a broken socket overlay.
@@ -689,28 +719,30 @@ fi
 
 # A stale or alternate deployment tree must not control the fixed global
 # updater service owned by another installation.
-make_stage foreign-updater-owner
-foreign_install_root="$TMP_DIR/foreign-install"
-mkdir -p "$foreign_install_root"
-printf 'PROTO_FLEET_INSTALL_ROOT="%s"\n' "$foreign_install_root" \
-    > "$HARNESS_UPDATER_ENV_FILE"
-printf 'ENABLE_ONE_CLICK_UPDATES=true\n' >> "$STAGE/.env"
-printf 'active\n' > "$HARNESS_UPDATER_STATE_FILE"
-if run_stage "$STAGE" --non-interactive; then
-    fail "runner should reject an updater owned by another installation"
-else
-    pass "runner rejects an updater owned by another installation"
-fi
-assert_contains "ownership mismatch is diagnosed" "$HARNESS_OUTPUT_LOG" \
-    "belongs to a different Proto Fleet installation"
-assert_not_contains "ownership mismatch prevents updater stop" \
-    "$HARNESS_CALL_LOG" "systemctl stop proto-fleet-updater.service"
-assert_not_contains "ownership mismatch prevents updater restart" \
-    "$HARNESS_CALL_LOG" "systemctl restart proto-fleet-updater.service"
-assert_not_contains "ownership mismatch prevents updater disable" \
-    "$HARNESS_CALL_LOG" "systemctl disable --now proto-fleet-updater.service"
-assert_not_contains "ownership mismatch prevents deployment mutation" \
-    "$HARNESS_CALL_LOG" "docker "
+for foreign_updater_state in active inactive failed; do
+    make_stage "foreign-updater-owner-$foreign_updater_state"
+    foreign_install_root="$TMP_DIR/foreign-install-$foreign_updater_state"
+    mkdir -p "$foreign_install_root"
+    printf 'PROTO_FLEET_INSTALL_ROOT="%s"\n' "$foreign_install_root" \
+        > "$HARNESS_UPDATER_ENV_FILE"
+    printf 'ENABLE_ONE_CLICK_UPDATES=true\n' >> "$STAGE/.env"
+    printf '%s\n' "$foreign_updater_state" > "$HARNESS_UPDATER_STATE_FILE"
+    if run_stage "$STAGE" --non-interactive; then
+        fail "runner should reject a $foreign_updater_state updater owned by another installation"
+    else
+        pass "runner rejects a $foreign_updater_state updater owned by another installation"
+    fi
+    assert_contains "$foreign_updater_state ownership mismatch is diagnosed" \
+        "$HARNESS_OUTPUT_LOG" "belongs to a different Proto Fleet installation"
+    assert_not_contains "$foreign_updater_state ownership mismatch prevents updater stop" \
+        "$HARNESS_CALL_LOG" "systemctl stop proto-fleet-updater.service"
+    assert_not_contains "$foreign_updater_state ownership mismatch prevents updater restart" \
+        "$HARNESS_CALL_LOG" "systemctl restart proto-fleet-updater.service"
+    assert_not_contains "$foreign_updater_state ownership mismatch prevents updater disable" \
+        "$HARNESS_CALL_LOG" "systemctl disable --now proto-fleet-updater.service"
+    assert_not_contains "$foreign_updater_state ownership mismatch prevents deployment mutation" \
+        "$HARNESS_CALL_LOG" "docker "
+done
 
 make_stage direct-updater-failure
 printf 'ENABLE_ONE_CLICK_UPDATES=true\n' >> "$STAGE/.env"

--- a/deployment-files/tests/test-run-fleet-upgrade.sh
+++ b/deployment-files/tests/test-run-fleet-upgrade.sh
@@ -77,8 +77,10 @@ write_valid_env() {
         'ENABLE_BETA_ALERTS=true' \
         'ENABLE_BETA_ALERTS="false"' \
         'ENABLE_SYSTEM_MONITORING=false' \
-        'ENABLE_TRACING=true' > "$env_file"
+        'ENABLE_TRACING=true' \
+        'ENABLE_ONE_CLICK_UPDATES=true' > "$env_file"
     printf 'ENABLE_TRACING="FALSE" \r\n' >> "$env_file"
+    printf 'ENABLE_ONE_CLICK_UPDATES="FALSE" \r\n' >> "$env_file"
 }
 
 # Build a minimal docker-save-shaped archive whose manifest carries the given
@@ -141,6 +143,7 @@ make_stage() {
     cp "$DEPLOY_DIR/docker-compose.alerts.yaml" "$STAGE/"
     cp "$DEPLOY_DIR/docker-compose.system-monitoring.yaml" "$STAGE/"
     cp "$DEPLOY_DIR/docker-compose.tracing.yaml" "$STAGE/"
+    cp "$DEPLOY_DIR/docker-compose.updater.yaml" "$STAGE/"
     cp "$DEPLOY_DIR/ha/compose.yaml" "$STAGE/ha/"
     cp "$DEPLOY_DIR/profiles/mini.env" "$STAGE/profiles/"
     cp "$DEPLOY_DIR/client/nginx.http.conf" "$STAGE/client/"
@@ -454,11 +457,12 @@ run_stage() {
     /bin/bash "$stage/run-fleet.sh" "$@" > "$HARNESS_OUTPUT_LOG" 2>&1
 }
 
-# The updater-specific option is intentionally deferred until its Compose
-# overlay is shipped and packaged later in the stack.
+# The packaged updater overlay is activated only after the installer has
+# successfully started the host service.
 make_stage help
 if run_stage "$STAGE" --help; then
-    assert_not_contains "help omits the unavailable updater overlay" "$HARNESS_OUTPUT_LOG" "enable-one-click-updates"
+    assert_contains "help documents the updater overlay" "$HARNESS_OUTPUT_LOG" "enable-one-click-updates"
+    assert_contains "help documents the updater fallback" "$HARNESS_OUTPUT_LOG" "disable-one-click-updates"
 else
     fail "--help should succeed"
 fi
@@ -513,13 +517,14 @@ printf 'DD_API_KEY=test-datadog-key\n' >> "$STAGE/.env"
 printf '%s\n' \
     'export ENABLE_BETA_ALERTS: true # preserve alerts' \
     'ENABLE_SYSTEM_MONITORING: "true"' \
-    'ENABLE_TRACING: TRUE' >> "$STAGE/.env"
+    'ENABLE_TRACING: TRUE' \
+    'ENABLE_ONE_CLICK_UPDATES: "true"' >> "$STAGE/.env"
 if run_stage "$STAGE" --non-interactive --preflight-only; then
     pass "Compose colon-form overlay settings preflight"
 else
     fail "Compose colon-form overlay settings should be preserved"
 fi
-for persisted_boolean in ENABLE_BETA_ALERTS ENABLE_SYSTEM_MONITORING ENABLE_TRACING; do
+for persisted_boolean in ENABLE_BETA_ALERTS ENABLE_SYSTEM_MONITORING ENABLE_TRACING ENABLE_ONE_CLICK_UPDATES; do
     if [ "$(grep -Ec "^[[:space:]]*(export[[:space:]]+)?${persisted_boolean}[[:space:]]*[:=]" "$STAGE/.env")" -eq 1 ] \
         && grep -q "^${persisted_boolean}=true$" "$STAGE/.env"; then
         pass "$persisted_boolean normalizes Compose colon syntax without changing its value"
@@ -527,6 +532,62 @@ for persisted_boolean in ENABLE_BETA_ALERTS ENABLE_SYSTEM_MONITORING ENABLE_TRAC
         fail "$persisted_boolean did not preserve its Compose colon-form true value"
     fi
 done
+assert_contains "enabled one-click updates layer the socket overlay" "$HARNESS_CALL_LOG" "-f $STAGE/docker-compose.updater.yaml"
+
+# Exercise the exact installer contract: a successful service bootstrap must
+# override a persisted false value, layer the socket overlay, and survive the
+# preflight-to-activation handoff.
+make_stage enable-updater-overlay
+if run_stage "$STAGE" --enable-one-click-updates --non-interactive --preflight-only; then
+    pass "installer updater enablement preflights"
+else
+    fail "installer updater enablement should override persisted false state"
+fi
+assert_contains "installer updater enablement layers the socket overlay" "$HARNESS_CALL_LOG" "-f $STAGE/docker-compose.updater.yaml"
+if [ "$(grep -c '^ENABLE_ONE_CLICK_UPDATES=' "$STAGE/.env")" -eq 1 ] \
+    && grep -q '^ENABLE_ONE_CLICK_UPDATES=true$' "$STAGE/.env"; then
+    pass "installer updater enablement persists enabled state"
+else
+    fail "installer updater enablement did not normalize persisted state to true"
+fi
+: > "$HARNESS_CALL_LOG"
+if run_stage "$STAGE" --non-interactive --skip-build; then
+    pass "enabled updater activation succeeds"
+else
+    fail "enabled updater state should survive activation"
+fi
+assert_contains "enabled updater activation retains the socket overlay" "$HARNESS_CALL_LOG" "-f $STAGE/docker-compose.updater.yaml"
+
+# An installer bootstrap failure must explicitly override previously persisted
+# state so fleet-api does not advertise or mount a dead host updater.
+make_stage disable-updater-overlay
+printf 'ENABLE_ONE_CLICK_UPDATES=true\n' >> "$STAGE/.env"
+if run_stage "$STAGE" --disable-one-click-updates --non-interactive --preflight-only; then
+    pass "explicit updater fallback preflights"
+else
+    fail "explicit updater fallback should override persisted true state"
+fi
+assert_not_contains "explicit updater fallback omits the socket overlay" "$HARNESS_CALL_LOG" "docker-compose.updater.yaml"
+if [ "$(grep -c '^ENABLE_ONE_CLICK_UPDATES=' "$STAGE/.env")" -eq 1 ] \
+    && grep -q '^ENABLE_ONE_CLICK_UPDATES=false$' "$STAGE/.env"; then
+    pass "explicit updater fallback persists disabled state"
+else
+    fail "explicit updater fallback did not normalize persisted state to false"
+fi
+
+# Persisted one-click state must fail before Docker activity when its release
+# bundle is incomplete; silently omitting the socket would expose a false
+# upgrade capability state to Fleet API.
+make_stage missing-updater-overlay
+printf 'ENABLE_ONE_CLICK_UPDATES=true\n' >> "$STAGE/.env"
+rm -f "$STAGE/docker-compose.updater.yaml"
+if run_stage "$STAGE" --non-interactive --preflight-only; then
+    fail "missing updater overlay should fail preflight"
+else
+    pass "missing updater overlay fails closed"
+fi
+assert_contains "missing updater overlay is diagnosed" "$HARNESS_OUTPUT_LOG" "one-click updates are enabled but $STAGE/docker-compose.updater.yaml is missing"
+assert_not_contains "missing updater overlay prevents Docker activity" "$HARNESS_CALL_LOG" "docker "
 
 # Required credentials use the same literal dotenv forms accepted for project
 # identity and booleans. Mixed duplicate delimiters, export prefixes, quoting,
@@ -582,6 +643,7 @@ else
 fi
 assert_not_contains "disabled tracing omits its Compose overlay" "$HARNESS_CALL_LOG" "docker-compose.tracing.yaml"
 assert_not_contains "disabled alerts omit their Compose overlay" "$HARNESS_CALL_LOG" "docker-compose.alerts.yaml"
+assert_not_contains "disabled one-click updates omit the socket overlay" "$HARNESS_CALL_LOG" "docker-compose.updater.yaml"
 assert_contains "dormant tracing value is preserved" "$STAGE/.env" 'DD_API_KEY=${DATADOG_API_KEY}'
 assert_contains "dormant alert value is preserved" "$STAGE/.env" 'GRAFANA_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD_FROM_VAULT}'
 
@@ -789,7 +851,7 @@ if [ "$marker_mode" = "600" ]; then
 else
     fail "preflight marker mode should be 600, got $marker_mode"
 fi
-for persisted_boolean in ENABLE_BETA_ALERTS ENABLE_SYSTEM_MONITORING ENABLE_TRACING SESSION_COOKIE_SECURE; do
+for persisted_boolean in ENABLE_BETA_ALERTS ENABLE_SYSTEM_MONITORING ENABLE_TRACING ENABLE_ONE_CLICK_UPDATES SESSION_COOKIE_SECURE; do
     if [ "$(grep -c "^${persisted_boolean}=" "$STAGE/.env")" -eq 1 ] && \
         grep -q "^${persisted_boolean}=false$" "$STAGE/.env"; then
         pass "$persisted_boolean uses one normalized last-value assignment"

--- a/deployment-files/tests/test-run-fleet-upgrade.sh
+++ b/deployment-files/tests/test-run-fleet-upgrade.sh
@@ -136,11 +136,13 @@ make_stage() {
     HARNESS_CALL_LOG="$runtime/calls.log"
     HARNESS_OUTPUT_LOG="$runtime/output.log"
     HARNESS_UPDATER_STATE_FILE="$runtime/updater-state"
+    HARNESS_UPDATER_ENABLED_FILE="$runtime/updater-enabled"
     HARNESS_UPDATER_ENV_FILE="$runtime/updater.env"
     mkdir -p "$STAGE/client" "$STAGE/ha" "$STAGE/profiles" "$STAGE/server/monitoring/grafana/provisioning/datasources" "$HARNESS_BIN_DIR"
     : > "$HARNESS_CALL_LOG"
     : > "$HARNESS_OUTPUT_LOG"
     printf 'not-found\n' > "$HARNESS_UPDATER_STATE_FILE"
+    printf 'false\n' > "$HARNESS_UPDATER_ENABLED_FILE"
     cp "$DEPLOY_DIR/run-fleet.sh" "$STAGE/"
     "$REAL_AWK" -v env_path="$HARNESS_UPDATER_ENV_FILE" '
         /^HOST_UPDATER_ENV_PATH=/ {
@@ -318,6 +320,7 @@ printf 'systemctl %s\n' "$*" >> "$CALL_LOG"
 case " $* " in
     *" proto-fleet-updater.service "*)
         updater_state=$(cat "$UPDATER_STATE_FILE")
+        updater_enabled=$(cat "$UPDATER_ENABLED_FILE")
         case "$*" in
             *'--property=LoadState --value'*)
                 if [ "$updater_state" = "not-found" ]; then
@@ -333,11 +336,24 @@ case " $* " in
                     printf '%s\n' "$updater_state"
                 fi
                 ;;
+            *'--property=UnitFileState --value'*)
+                if [ "$updater_state" = "not-found" ]; then
+                    printf 'not-found\n'
+                elif [ "$updater_enabled" = "true" ]; then
+                    printf 'enabled\n'
+                else
+                    printf 'disabled\n'
+                fi
+                ;;
             'stop proto-fleet-updater.service') printf 'inactive\n' > "$UPDATER_STATE_FILE" ;;
             'restart proto-fleet-updater.service') printf 'active\n' > "$UPDATER_STATE_FILE" ;;
-            'enable proto-fleet-updater.service') ;;
-            'disable --now proto-fleet-updater.service') printf 'inactive\n' > "$UPDATER_STATE_FILE" ;;
+            'enable proto-fleet-updater.service') printf 'true\n' > "$UPDATER_ENABLED_FILE" ;;
+            'disable --now proto-fleet-updater.service')
+                printf 'inactive\n' > "$UPDATER_STATE_FILE"
+                printf 'false\n' > "$UPDATER_ENABLED_FILE"
+                ;;
             'is-active --quiet proto-fleet-updater.service') [ "$updater_state" = "active" ] ;;
+            'is-enabled --quiet proto-fleet-updater.service') [ "$updater_enabled" = "true" ] ;;
             *) exit 1 ;;
         esac
         ;;
@@ -494,6 +510,7 @@ run_stage() {
     REAL_MV="$REAL_MV" \
     REAL_STAT="$REAL_STAT" \
     UPDATER_STATE_FILE="$HARNESS_UPDATER_STATE_FILE" \
+    UPDATER_ENABLED_FILE="$HARNESS_UPDATER_ENABLED_FILE" \
     PATH="$HARNESS_BIN_DIR:$PATH" \
     /bin/bash "$stage/run-fleet.sh" "$@" > "$HARNESS_OUTPUT_LOG" 2>&1
 }
@@ -621,10 +638,53 @@ if [ -n "$direct_stop_line" ] \
     && [ -n "$direct_restart_line" ] \
     && [ "$direct_stop_line" -lt "$direct_down_line" ] \
     && [ "$direct_down_line" -lt "$direct_restart_line" ] \
-    && [ "$(cat "$HARNESS_UPDATER_STATE_FILE")" = active ]; then
+    && [ "$(cat "$HARNESS_UPDATER_STATE_FILE")" = active ] \
+    && [ "$(cat "$HARNESS_UPDATER_ENABLED_FILE")" = true ]; then
     pass "direct runner holds the updater quiesced across deployment mutation"
 else
     fail "direct runner did not serialize its complete mutation window"
+fi
+assert_contains "direct runner repairs missing boot enablement" \
+    "$HARNESS_CALL_LOG" "systemctl enable proto-fleet-updater.service"
+
+# Persisted configuration is authoritative even when the service was already
+# inactive before the direct run, so successful deployment repairs runtime and
+# boot state instead of preserving a broken socket overlay.
+make_stage configured-updater-inactive
+printf 'ENABLE_ONE_CLICK_UPDATES=true\n' >> "$STAGE/.env"
+printf 'inactive\n' > "$HARNESS_UPDATER_STATE_FILE"
+printf 'false\n' > "$HARNESS_UPDATER_ENABLED_FILE"
+if run_stage "$STAGE" --non-interactive; then
+    pass "configured updater drift is reconciled"
+else
+    fail "configured updater drift should be repaired after deployment"
+fi
+assert_contains "inactive configured updater is enabled" \
+    "$HARNESS_CALL_LOG" "systemctl enable proto-fleet-updater.service"
+assert_contains "inactive configured updater is started" \
+    "$HARNESS_CALL_LOG" "systemctl restart proto-fleet-updater.service"
+if [ "$(cat "$HARNESS_UPDATER_STATE_FILE")" = active ] \
+    && [ "$(cat "$HARNESS_UPDATER_ENABLED_FILE")" = true ]; then
+    pass "configured updater finishes active and boot-enabled"
+else
+    fail "configured updater retained its inactive or boot-disabled drift"
+fi
+
+make_stage disabled-updater-still-enabled
+printf 'inactive\n' > "$HARNESS_UPDATER_STATE_FILE"
+printf 'true\n' > "$HARNESS_UPDATER_ENABLED_FILE"
+if run_stage "$STAGE" --non-interactive; then
+    pass "disabled updater boot drift is reconciled"
+else
+    fail "disabled updater boot drift should be repaired after deployment"
+fi
+assert_contains "disabled configuration removes stale boot enablement" \
+    "$HARNESS_CALL_LOG" "systemctl disable --now proto-fleet-updater.service"
+if [ "$(cat "$HARNESS_UPDATER_STATE_FILE")" = inactive ] \
+    && [ "$(cat "$HARNESS_UPDATER_ENABLED_FILE")" = false ]; then
+    pass "disabled updater finishes inactive and boot-disabled"
+else
+    fail "disabled updater retained active or boot-enabled drift"
 fi
 
 # A stale or alternate deployment tree must not control the fixed global

--- a/deployment-files/tests/test-run-fleet-upgrade.sh
+++ b/deployment-files/tests/test-run-fleet-upgrade.sh
@@ -316,7 +316,13 @@ case " $* " in
                     printf 'loaded\n'
                 fi
                 ;;
-            *'--property=ActiveState --value'*) printf '%s\n' "$updater_state" ;;
+            *'--property=ActiveState --value'*)
+                if [ "$updater_state" = "not-found" ]; then
+                    printf 'inactive\n'
+                else
+                    printf '%s\n' "$updater_state"
+                fi
+                ;;
             'stop proto-fleet-updater.service') printf 'inactive\n' > "$UPDATER_STATE_FILE" ;;
             'restart proto-fleet-updater.service') printf 'active\n' > "$UPDATER_STATE_FILE" ;;
             'is-active --quiet proto-fleet-updater.service') [ "$updater_state" = "active" ] ;;
@@ -505,6 +511,8 @@ fi
 assert_contains "source-tree run targets its directory project" "$HARNESS_CALL_LOG" "compose --project-name source-layout"
 assert_not_contains "source-tree run cannot target an installed deployment project" "$HARNESS_CALL_LOG" "compose --project-name deployment "
 assert_contains "source-tree run reaches teardown in its isolated project" "$HARNESS_CALL_LOG" " down --remove-orphans"
+assert_not_contains "source-tree run does not inspect the packaged updater" \
+    "$HARNESS_CALL_LOG" "proto-fleet-updater.service"
 
 # Existing process-level overrides remain authoritative and are reused by
 # volume detection. Do not persist a new multi-install identity here: the
@@ -643,10 +651,56 @@ assert_contains "persisted updater state survives process override for serializa
     "$HARNESS_CALL_LOG" "systemctl stop proto-fleet-updater.service"
 if [ "$(grep -c '^ENABLE_ONE_CLICK_UPDATES=' "$STAGE/.env")" -eq 1 ] \
     && grep -q '^ENABLE_ONE_CLICK_UPDATES=false$' "$STAGE/.env" \
-    && [ "$(cat "$HARNESS_UPDATER_STATE_FILE")" = active ]; then
+    && [ "$(cat "$HARNESS_UPDATER_STATE_FILE")" = inactive ]; then
     pass "process disable persists false after updater serialization"
 else
-    fail "process disable did not persist or restore updater state correctly"
+    fail "process disable did not persist state or leave the updater stopped"
+fi
+assert_not_contains "successful process disable does not restart the updater" \
+    "$HARNESS_CALL_LOG" "systemctl restart proto-fleet-updater.service"
+
+# Persisting the desired flag is not deployment success. A later failure must
+# restore both the prior flag and the updater that served the still-running
+# socket-enabled Fleet container.
+make_stage failed-process-disable-active-updater
+printf 'ENABLE_ONE_CLICK_UPDATES=true\n' >> "$STAGE/.env"
+printf 'active\n' > "$HARNESS_UPDATER_STATE_FILE"
+if ENABLE_ONE_CLICK_UPDATES=false FAKE_COMPOSE_CONFIG_FAILURE=true \
+    run_stage "$STAGE" --non-interactive --preflight-only; then
+    fail "failed process disable should propagate its Compose failure"
+else
+    pass "failed process disable exercises updater configuration rollback"
+fi
+assert_contains "failed process disable stops the updater" \
+    "$HARNESS_CALL_LOG" "systemctl stop proto-fleet-updater.service"
+assert_contains "failed process disable restores the updater" \
+    "$HARNESS_CALL_LOG" "systemctl restart proto-fleet-updater.service"
+if [ "$(grep -c '^ENABLE_ONE_CLICK_UPDATES=' "$STAGE/.env")" -eq 1 ] \
+    && grep -q '^ENABLE_ONE_CLICK_UPDATES=true$' "$STAGE/.env" \
+    && [ "$(cat "$HARNESS_UPDATER_STATE_FILE")" = active ]; then
+    pass "failed process disable restores prior updater configuration and runtime state"
+else
+    fail "failed process disable left updater configuration and runtime state inconsistent"
+fi
+
+# Desired flags cannot prove that the daemon is stopped. An unmanaged retry
+# must drain a stale active updater even when the persisted and effective
+# settings are already false.
+make_stage stale-active-disabled-updater
+printf 'active\n' > "$HARNESS_UPDATER_STATE_FILE"
+if run_stage "$STAGE" --non-interactive --preflight-only; then
+    pass "disabled retry inspects the actual updater service state"
+else
+    fail "disabled retry should quiesce a stale active updater"
+fi
+assert_contains "disabled retry stops a stale active updater" \
+    "$HARNESS_CALL_LOG" "systemctl stop proto-fleet-updater.service"
+assert_not_contains "disabled retry does not restart a stale updater" \
+    "$HARNESS_CALL_LOG" "systemctl restart proto-fleet-updater.service"
+if [ "$(cat "$HARNESS_UPDATER_STATE_FILE")" = inactive ]; then
+    pass "disabled retry leaves the stale updater stopped"
+else
+    fail "disabled retry left the stale updater active"
 fi
 
 make_stage updater-managed-runner

--- a/deployment-files/tests/test-run-fleet-upgrade.sh
+++ b/deployment-files/tests/test-run-fleet-upgrade.sh
@@ -235,6 +235,10 @@ case " $* " in
         echo 'Options: --wait --wait-timeout --no-build --pull string'
         ;;
     *" compose "*" config --quiet "*)
+        if [ "${FAKE_DISABLED_FALLBACK_CONFIG_FAILURE:-false}" = "true" ] \
+          && grep -q '^ENABLE_ONE_CLICK_UPDATES=false$' "$STAGE_ROOT/.env"; then
+            exit 1
+        fi
         [ "${FAKE_COMPOSE_CONFIG_FAILURE:-false}" != "true" ]
         ;;
     *" compose "*" config --images "*)
@@ -525,8 +529,7 @@ run_stage() {
     /bin/bash "$stage/run-fleet.sh" "$@" > "$HARNESS_OUTPUT_LOG" 2>&1
 }
 
-# The packaged updater overlay is activated only after the installer has
-# successfully started the host service.
+# The installer activates the overlay only after updater bootstrap.
 make_stage help
 if run_stage "$STAGE" --help; then
     assert_contains "help documents the updater overlay" "$HARNESS_OUTPUT_LOG" "enable-one-click-updates"
@@ -605,12 +608,8 @@ for persisted_boolean in ENABLE_BETA_ALERTS ENABLE_SYSTEM_MONITORING ENABLE_TRAC
 done
 assert_contains "enabled one-click updates layer the socket overlay" "$HARNESS_CALL_LOG" "-f $STAGE/docker-compose.updater.yaml"
 
-# Exercise the exact installer contract: a successful service bootstrap must
-# override a persisted false value and layer the socket overlay in the same
-# deployment run. Unmanaged preflight cannot commit this transition.
+# Installer bootstrap overrides persisted false and layers the socket overlay.
 make_stage enable-updater-overlay
-# The installer validates and then stops the loaded service while run-fleet
-# changes the deployment; it restarts the updater only after this handoff.
 printf 'inactive\n' > "$HARNESS_UPDATER_STATE_FILE"
 if PROTO_FLEET_INSTALLER_MANAGED_RUN=1 \
     run_stage "$STAGE" --enable-one-click-updates --non-interactive; then
@@ -628,10 +627,7 @@ fi
 assert_not_contains "installer retains updater lifecycle ownership after deployment" \
     "$HARNESS_CALL_LOG" "systemctl restart proto-fleet-updater.service"
 
-# A manual runner operating on a deployment whose fleet-api can still reach
-# the updater must stop that writer before Compose teardown and restore it on
-# every exit. Updater-owned children identify themselves explicitly and the
-# staged preflight remains non-mutating with respect to the active tree.
+# A manual runner must quiesce the updater across its complete mutation window.
 make_stage direct-updater-serialization
 printf 'ENABLE_ONE_CLICK_UPDATES=true\n' >> "$STAGE/.env"
 printf 'active\n' > "$HARNESS_UPDATER_STATE_FILE"
@@ -657,9 +653,7 @@ fi
 assert_contains "direct runner repairs missing boot enablement" \
     "$HARNESS_CALL_LOG" "systemctl enable proto-fleet-updater.service"
 
-# A committed socket-enabled deployment must not remain active when the host
-# updater cannot restart. Degrade to the supported copy-command mode and prove
-# the second Compose transition omits the privileged socket overlay.
+# Failed updater restart must replace the socket overlay with copy-command mode.
 make_stage direct-updater-restart-fallback
 printf 'ENABLE_ONE_CLICK_UPDATES=true\n' >> "$STAGE/.env"
 printf 'active\n' > "$HARNESS_UPDATER_STATE_FILE"
@@ -687,9 +681,33 @@ else
     fail "copy-command fallback left updater configuration or service enabled"
 fi
 
-# systemctl stop drains an activation that has already crossed its commit
-# boundary. If that activation swaps deployment/ while the old runner waits,
-# the old shell must re-exec the newly active release before touching Compose.
+make_stage direct-updater-fallback-failure
+printf 'ENABLE_ONE_CLICK_UPDATES=true\n' >> "$STAGE/.env"
+printf 'active\n' > "$HARNESS_UPDATER_STATE_FILE"
+if FAKE_UPDATER_RESTART_FAILURE=true \
+  FAKE_DISABLED_FALLBACK_CONFIG_FAILURE=true \
+  run_stage "$STAGE" --non-interactive; then
+    fail "failed copy-command fallback should propagate its error"
+else
+    pass "failed copy-command fallback propagates its error"
+fi
+assert_contains "failed fallback reaches pre-Compose validation" \
+    "$HARNESS_OUTPUT_LOG" "could not deploy the copy-command fallback"
+if [ "$(grep -c ' compose .* up --remove-orphans' "$HARNESS_CALL_LOG")" -eq 1 ]; then
+    pass "failed fallback leaves the original topology running"
+else
+    fail "failed fallback unexpectedly replaced the original topology"
+fi
+if grep -q '^ENABLE_ONE_CLICK_UPDATES=true$' "$STAGE/.env" \
+  && [ "$(cat "$HARNESS_UPDATER_STATE_FILE")" = inactive ] \
+  && [ "$(cat "$HARNESS_UPDATER_ENABLED_FILE")" = false ] \
+  && [ "$(grep -c '^systemctl restart proto-fleet-updater.service$' "$HARNESS_CALL_LOG")" -eq 1 ]; then
+    pass "failed fallback keeps the unhealthy updater disabled"
+else
+    fail "failed fallback re-enabled the unhealthy updater"
+fi
+
+# Re-exec the active release if systemctl stop drains a deployment swap.
 make_stage direct-updater-deployment-swap
 printf 'ENABLE_ONE_CLICK_UPDATES=true\n' >> "$STAGE/.env"
 printf 'active\n' > "$HARNESS_UPDATER_STATE_FILE"
@@ -710,9 +728,7 @@ else
     fail "replacement runner repeated or skipped updater shutdown"
 fi
 
-# Persisted configuration is authoritative even when the service was already
-# inactive before the direct run, so successful deployment repairs runtime and
-# boot state instead of preserving a broken socket overlay.
+# Successful deployment repairs updater runtime and boot-state drift.
 make_stage configured-updater-inactive
 printf 'ENABLE_ONE_CLICK_UPDATES=true\n' >> "$STAGE/.env"
 printf 'inactive\n' > "$HARNESS_UPDATER_STATE_FILE"
@@ -750,8 +766,7 @@ else
     fail "disabled updater retained active or boot-enabled drift"
 fi
 
-# A stale or alternate deployment tree must not control the fixed global
-# updater service owned by another installation.
+# Foreign deployment trees cannot control the global updater.
 for foreign_updater_state in active inactive failed; do
     make_stage "foreign-updater-owner-$foreign_updater_state"
     foreign_install_root="$TMP_DIR/foreign-install-$foreign_updater_state"
@@ -793,8 +808,7 @@ else
     fail "failed direct run left the updater stopped"
 fi
 
-# Preflight prepares images but leaves the active topology untouched. Reject
-# an unmanaged updater-state transition before persisting or quiescing it.
+# Unmanaged preflight cannot change active updater state.
 make_stage process-disable-active-updater
 printf 'ENABLE_ONE_CLICK_UPDATES=true\n' >> "$STAGE/.env"
 printf 'active\n' > "$HARNESS_UPDATER_STATE_FILE"
@@ -815,9 +829,7 @@ fi
 assert_contains "rejected preflight explains the lifecycle boundary" \
     "$HARNESS_OUTPUT_LOG" "--preflight-only cannot change one-click update state"
 
-# Persisting the desired flag is not deployment success. A later failure must
-# restore both the prior flag and the updater that served the still-running
-# socket-enabled Fleet container.
+# Pre-mutation failure restores the prior setting and updater.
 make_stage failed-process-disable-active-updater
 printf 'ENABLE_ONE_CLICK_UPDATES=true\n' >> "$STAGE/.env"
 printf 'active\n' > "$HARNESS_UPDATER_STATE_FILE"
@@ -839,9 +851,7 @@ else
     fail "failed process disable left updater configuration and runtime state inconsistent"
 fi
 
-# Once Compose teardown begins, the old topology can no longer be assumed.
-# Failures after the replacement starts retain the desired setting and align
-# the service with whichever new containers were created.
+# Post-teardown failure reconciles the service to persisted intent.
 make_stage post-compose-disable-failure
 printf 'ENABLE_ONE_CLICK_UPDATES=true\n' >> "$STAGE/.env"
 printf 'active\n' > "$HARNESS_UPDATER_STATE_FILE"
@@ -885,9 +895,7 @@ else
     fail "post-Compose enable restored state for a topology that was already replaced"
 fi
 
-# Desired flags cannot prove that the daemon is stopped. An unmanaged retry
-# must drain a stale active updater even when the persisted and effective
-# settings are already false.
+# Disabled retries still drain a stale active updater.
 make_stage stale-active-disabled-updater
 printf 'active\n' > "$HARNESS_UPDATER_STATE_FILE"
 if run_stage "$STAGE" --non-interactive --preflight-only; then
@@ -925,8 +933,7 @@ fi
 assert_not_contains "managed activation does not stop its updater" "$HARNESS_CALL_LOG" "systemctl stop proto-fleet-updater.service"
 assert_not_contains "managed activation leaves lifecycle ownership with the daemon" "$HARNESS_CALL_LOG" "systemctl restart proto-fleet-updater.service"
 
-# An installer bootstrap failure must explicitly override previously persisted
-# state so fleet-api does not advertise or mount a dead host updater.
+# Installer fallback overrides stale enabled state.
 make_stage disable-updater-overlay
 printf 'ENABLE_ONE_CLICK_UPDATES=true\n' >> "$STAGE/.env"
 if run_stage "$STAGE" --disable-one-click-updates --non-interactive; then
@@ -942,10 +949,7 @@ else
     fail "explicit updater fallback did not normalize persisted state to false"
 fi
 
-# Once one-click updates ship, a host may lose its systemd manager before a
-# later installer run. An explicit disable remains safe because no systemd
-# updater can be active, while leaving the feature enabled must still fail
-# before any deployment mutation.
+# A host that loses systemd may disable, but cannot keep, one-click updates.
 make_stage disable-updater-without-systemd
 printf 'ENABLE_ONE_CLICK_UPDATES=true\n' >> "$STAGE/.env"
 if FAKE_WSL=true FAKE_SYSTEMD_UNAVAILABLE=true \
@@ -986,9 +990,7 @@ assert_contains "missing updater service is diagnosed" "$HARNESS_OUTPUT_LOG" \
 assert_not_contains "missing updater service prevents environment and Docker mutation" \
     "$HARNESS_CALL_LOG" "docker "
 
-# Persisted one-click state must fail before Docker activity when its release
-# bundle is incomplete; silently omitting the socket would expose a false
-# upgrade capability state to Fleet API.
+# Missing updater overlay fails before Docker activity.
 make_stage missing-updater-overlay
 printf 'ENABLE_ONE_CLICK_UPDATES=true\n' >> "$STAGE/.env"
 rm -f "$STAGE/docker-compose.updater.yaml"

--- a/deployment-files/tests/test-run-fleet-upgrade.sh
+++ b/deployment-files/tests/test-run-fleet-upgrade.sh
@@ -136,11 +136,20 @@ make_stage() {
     HARNESS_CALL_LOG="$runtime/calls.log"
     HARNESS_OUTPUT_LOG="$runtime/output.log"
     HARNESS_UPDATER_STATE_FILE="$runtime/updater-state"
+    HARNESS_UPDATER_ENV_FILE="$runtime/updater.env"
     mkdir -p "$STAGE/client" "$STAGE/ha" "$STAGE/profiles" "$STAGE/server/monitoring/grafana/provisioning/datasources" "$HARNESS_BIN_DIR"
     : > "$HARNESS_CALL_LOG"
     : > "$HARNESS_OUTPUT_LOG"
     printf 'not-found\n' > "$HARNESS_UPDATER_STATE_FILE"
     cp "$DEPLOY_DIR/run-fleet.sh" "$STAGE/"
+    "$REAL_AWK" -v env_path="$HARNESS_UPDATER_ENV_FILE" '
+        /^HOST_UPDATER_ENV_PATH=/ {
+            printf "HOST_UPDATER_ENV_PATH=\"%s\"\n", env_path
+            next
+        }
+        { print }
+    ' "$STAGE/run-fleet.sh" > "$runtime/run-fleet.sh"
+    /bin/mv "$runtime/run-fleet.sh" "$STAGE/run-fleet.sh"
     cp "$DEPLOY_DIR/docker-compose.yaml" "$STAGE/"
     cp "$DEPLOY_DIR/docker-compose.alerts.yaml" "$STAGE/"
     cp "$DEPLOY_DIR/docker-compose.system-monitoring.yaml" "$STAGE/"
@@ -153,6 +162,7 @@ make_stage() {
     cp "$DEPLOY_DIR/server/otel-collector-config.datadog.yaml" "$STAGE/server/"
     printf 'apiVersion: 1\n' > "$STAGE/server/monitoring/grafana/provisioning/datasources/base.yaml"
     printf '%s\n' "version: $RELEASE_TAG" 'commit: test-release' > "$STAGE/version.txt"
+    printf 'PROTO_FLEET_INSTALL_ROOT="%s"\n' "$TMP_DIR" > "$HARNESS_UPDATER_ENV_FILE"
     "$DEPLOY_DIR/scripts/pin-release-images.sh" "$STAGE" "$RELEASE_TAG"
     write_tsdb_archive "$STAGE" "\"$TIMESCALEDB_IMAGE\",\"$TIMESCALEDB_HA_IMAGE\""
     write_valid_env "$STAGE/.env"
@@ -616,6 +626,31 @@ if [ -n "$direct_stop_line" ] \
 else
     fail "direct runner did not serialize its complete mutation window"
 fi
+
+# A stale or alternate deployment tree must not control the fixed global
+# updater service owned by another installation.
+make_stage foreign-updater-owner
+foreign_install_root="$TMP_DIR/foreign-install"
+mkdir -p "$foreign_install_root"
+printf 'PROTO_FLEET_INSTALL_ROOT="%s"\n' "$foreign_install_root" \
+    > "$HARNESS_UPDATER_ENV_FILE"
+printf 'ENABLE_ONE_CLICK_UPDATES=true\n' >> "$STAGE/.env"
+printf 'active\n' > "$HARNESS_UPDATER_STATE_FILE"
+if run_stage "$STAGE" --non-interactive; then
+    fail "runner should reject an updater owned by another installation"
+else
+    pass "runner rejects an updater owned by another installation"
+fi
+assert_contains "ownership mismatch is diagnosed" "$HARNESS_OUTPUT_LOG" \
+    "belongs to a different Proto Fleet installation"
+assert_not_contains "ownership mismatch prevents updater stop" \
+    "$HARNESS_CALL_LOG" "systemctl stop proto-fleet-updater.service"
+assert_not_contains "ownership mismatch prevents updater restart" \
+    "$HARNESS_CALL_LOG" "systemctl restart proto-fleet-updater.service"
+assert_not_contains "ownership mismatch prevents updater disable" \
+    "$HARNESS_CALL_LOG" "systemctl disable --now proto-fleet-updater.service"
+assert_not_contains "ownership mismatch prevents deployment mutation" \
+    "$HARNESS_CALL_LOG" "docker "
 
 make_stage direct-updater-failure
 printf 'ENABLE_ONE_CLICK_UPDATES=true\n' >> "$STAGE/.env"

--- a/deployment-files/tests/test-run-fleet-upgrade.sh
+++ b/deployment-files/tests/test-run-fleet-upgrade.sh
@@ -535,6 +535,7 @@ assert_not_contains "earlier persisted project name is ignored" "$HARNESS_CALL_L
 # Compose also accepts `KEY: value`. Read true overlay settings through that
 # syntax and atomically normalize every prior form to one final assignment.
 make_stage compose-env-booleans
+printf 'active\n' > "$HARNESS_UPDATER_STATE_FILE"
 enable_valid_alerts "$STAGE/.env"
 printf 'DD_API_KEY=test-datadog-key\n' >> "$STAGE/.env"
 printf '%s\n' \
@@ -561,6 +562,9 @@ assert_contains "enabled one-click updates layer the socket overlay" "$HARNESS_C
 # override a persisted false value, layer the socket overlay, and survive the
 # preflight-to-activation handoff.
 make_stage enable-updater-overlay
+# The installer validates and then stops the loaded service while run-fleet
+# changes the deployment; it restarts the updater only after this handoff.
+printf 'inactive\n' > "$HARNESS_UPDATER_STATE_FILE"
 if run_stage "$STAGE" --enable-one-click-updates --non-interactive --preflight-only; then
     pass "installer updater enablement preflights"
 else
@@ -710,6 +714,18 @@ fi
 assert_contains "missing updater manager is diagnosed" "$HARNESS_OUTPUT_LOG" \
     "systemd manager is unavailable"
 assert_not_contains "missing updater manager prevents Docker activity" \
+    "$HARNESS_CALL_LOG" "docker "
+
+make_stage enabled-updater-without-service
+printf 'ENABLE_ONE_CLICK_UPDATES=true\n' >> "$STAGE/.env"
+if run_stage "$STAGE" --non-interactive --preflight-only; then
+    fail "enabled updater should not proceed without its systemd unit"
+else
+    pass "enabled updater fails closed when its systemd unit is missing"
+fi
+assert_contains "missing updater service is diagnosed" "$HARNESS_OUTPUT_LOG" \
+    "proto-fleet-updater.service is not installed"
+assert_not_contains "missing updater service prevents environment and Docker mutation" \
     "$HARNESS_CALL_LOG" "docker "
 
 # Persisted one-click state must fail before Docker activity when its release

--- a/deployment-files/tests/test-uninstall-updater-cleanup.sh
+++ b/deployment-files/tests/test-uninstall-updater-cleanup.sh
@@ -64,6 +64,9 @@ sed -n \
   -e '/^HOST_UPDATER_REMOVAL_STARTED=/p' \
   -e '/^HOST_UPDATER_ORIGINAL_ACTIVE=/p' \
   -e '/^HOST_UPDATER_ORIGINAL_UNIT_FILE_STATE=/p' \
+  -e '/^USER_SYSTEMD_UID=/p' \
+  -e '/^USER_SYSTEMD_NAME=/p' \
+  -e '/^USER_SYSTEMD_HOME=/p' \
   -e '/^HOST_UPDATER_BINARY_PATHS=(/,/^)/p' \
   -e '/^HOST_UPDATER_SELF_UPDATE_SUFFIXES=(/,/^)/p' \
   -e '/^canonicalize_existing_dir()/,/^}/p' \
@@ -79,6 +82,9 @@ sed -n \
   -e '/^verify_host_updater_process_lock_free_with()/,/^}/p' \
   -e '/^restore_host_updater_service_if_needed()/,/^}/p' \
   -e '/^prepare_host_updater_removal()/,/^}/p' \
+  -e '/^resolve_user_systemd_context()/,/^}/p' \
+  -e '/^user_systemctl()/,/^}/p' \
+  -e '/^remove_systemd_units()/,/^}/p' \
   "$UNINSTALL_SCRIPT" > "$TEST_TMP/uninstall-updater-functions.sh"
 # shellcheck source=/dev/null
 source "$TEST_TMP/uninstall-updater-functions.sh"
@@ -193,6 +199,66 @@ if (
   pass "non-root uninstall aborts before mutating a root-managed updater"
 else
   fail "non-root uninstall can remove the updater before deployment cleanup"
+fi
+
+if (
+  invoking_name=operator
+  invoking_uid=1000
+  invoking_home="$TEST_TMP/invoking-home"
+  systemd_log="$TEST_TMP/invoking-user-systemd.log"
+  mkdir -p "$invoking_home/.config/systemd/user"
+  : > "$systemd_log"
+  SUDO_USER="$invoking_name"
+  SUDO_UID="$invoking_uid"
+  HOME=/root
+  USER_SYSTEMD_UID=""
+  USER_SYSTEMD_NAME=""
+  USER_SYSTEMD_HOME=""
+  id() {
+    if [[ "${1:-}" == -u && $# -eq 1 ]]; then
+      printf '0\n'
+    elif [[ "${1:-}" == -u && "${2:-}" == "$invoking_name" ]]; then
+      printf '%s\n' "$invoking_uid"
+    elif [[ "${1:-}" == -un ]]; then
+      printf 'root\n'
+    else
+      return 1
+    fi
+  }
+  getent() {
+    [[ "${1:-}" == passwd && "${2:-}" == "$invoking_uid" ]] || return 1
+    printf '%s:x:%s:20::%s:/bin/bash\n' \
+      "$invoking_name" "$invoking_uid" "$invoking_home"
+  }
+  sudo() {
+    printf 'sudo %s\n' "$*" >> "$systemd_log"
+    if [[ "$*" == *'list-unit-files'* ]]; then
+      printf 'protofleet.service enabled\n'
+    fi
+    return 0
+  }
+  systemctl() {
+    printf 'root-systemctl %s\n' "$*" >> "$systemd_log"
+    return 1
+  }
+  rm() {
+    printf 'rm %s\n' "$*" >> "$systemd_log"
+    return 0
+  }
+  print_success() { :; }
+  print_warn() { printf 'warn %s\n' "$*" >> "$systemd_log"; }
+  LAST_ERROR=""
+  resolve_user_systemd_context \
+    && remove_systemd_units \
+    && grep -q "sudo -n -u $invoking_name env HOME=$invoking_home XDG_RUNTIME_DIR=/run/user/$invoking_uid systemctl --user list-unit-files" \
+      "$systemd_log" \
+    && grep -q "rm -f $invoking_home/.config/systemd/user/protofleet" \
+      "$systemd_log" \
+    && ! grep -q 'root-systemctl\|/root' "$systemd_log"
+); then
+  pass "root rerun cleans the invoking user's systemd units"
+else
+  fail "root rerun targets root instead of the invoking user's systemd units"
 fi
 
 service_mutation_log="$TEST_TMP/service-mutations"

--- a/deployment-files/tests/test-uninstall-updater-cleanup.sh
+++ b/deployment-files/tests/test-uninstall-updater-cleanup.sh
@@ -209,6 +209,32 @@ else
   fail "updater cleanup removed the wrong paths or left an exact artifact"
 fi
 
+state_remove_line=$(awk '
+  /^remove_host_updater\(\)/ { in_remove=1 }
+  in_remove && /\/var\/lib\/proto-fleet-updater \/run\/proto-fleet-updater/ { print NR; exit }
+' "$UNINSTALL_SCRIPT")
+staging_verify_line=$(awk '
+  /^remove_host_updater\(\)/ { in_remove=1 }
+  in_remove && /if host_updater_staging_artifacts_present; then/ { print NR; exit }
+' "$UNINSTALL_SCRIPT")
+daemon_reload_line=$(awk '
+  /^remove_host_updater\(\)/ { in_remove=1 }
+  in_remove && /systemctl daemon-reload/ { print NR; exit }
+' "$UNINSTALL_SCRIPT")
+env_remove_line=$(awk '
+  /^remove_host_updater\(\)/ { in_remove=1 }
+  in_remove && /rm -f -- "\$HOST_UPDATER_ENV_PATH"/ { print NR; exit }
+' "$UNINSTALL_SCRIPT")
+if [[ -n "$state_remove_line" && -n "$staging_verify_line" \
+    && -n "$daemon_reload_line" && -n "$env_remove_line" ]] \
+  && [[ "$state_remove_line" -lt "$staging_verify_line" ]] \
+  && [[ "$staging_verify_line" -lt "$daemon_reload_line" ]] \
+  && [[ "$daemon_reload_line" -lt "$env_remove_line" ]]; then
+  pass "updater ownership proof is retained until state and service cleanup succeed"
+else
+  fail "updater cleanup can erase its ownership proof before a retry is safe"
+fi
+
 if [[ "$FAILURES" -ne 0 ]]; then
   echo "$FAILURES failure(s)"
   exit 1

--- a/deployment-files/tests/test-uninstall-updater-cleanup.sh
+++ b/deployment-files/tests/test-uninstall-updater-cleanup.sh
@@ -60,6 +60,10 @@ sed -n \
   -e '/^HOST_UPDATER_RUNTIME_DIR=/p' \
   -e '/^HOST_UPDATER_LOCK_PATH=/p' \
   -e '/^HOST_UPDATER_SYSTEMD_RUNTIME_DIR=/p' \
+  -e '/^HOST_UPDATER_RESTORE_PENDING=/p' \
+  -e '/^HOST_UPDATER_REMOVAL_STARTED=/p' \
+  -e '/^HOST_UPDATER_ORIGINAL_ACTIVE=/p' \
+  -e '/^HOST_UPDATER_ORIGINAL_UNIT_FILE_STATE=/p' \
   -e '/^HOST_UPDATER_BINARY_PATHS=(/,/^)/p' \
   -e '/^HOST_UPDATER_SELF_UPDATE_SUFFIXES=(/,/^)/p' \
   -e '/^canonicalize_existing_dir()/,/^}/p' \
@@ -71,7 +75,9 @@ sed -n \
   -e '/^verify_host_updater_ownership_with()/,/^}/p' \
   -e '/^host_updater_staging_artifacts_present()/,/^}/p' \
   -e '/^host_updater_artifacts_present()/,/^}/p' \
+  -e '/^validate_host_updater_process_lock_prerequisites_with()/,/^}/p' \
   -e '/^verify_host_updater_process_lock_free_with()/,/^}/p' \
+  -e '/^restore_host_updater_service_if_needed()/,/^}/p' \
   -e '/^prepare_host_updater_removal()/,/^}/p' \
   "$UNINSTALL_SCRIPT" > "$TEST_TMP/uninstall-updater-functions.sh"
 # shellcheck source=/dev/null
@@ -180,6 +186,31 @@ if (
   INSTALL_ROOT="$owned_root"
   HOST_UPDATER_PRESENT=false
   HOST_UPDATER_PRIVILEGE=()
+  HOST_UPDATER_STATE_DIR="$TEST_TMP/missing-flock-state"
+  HOST_UPDATER_RUNTIME_DIR="$TEST_TMP/missing-flock-runtime"
+  HOST_UPDATER_LOCK_PATH="$HOST_UPDATER_STATE_DIR/updater.lock"
+  HOST_UPDATER_SYSTEMD_RUNTIME_DIR="$TEST_TMP/missing-flock-systemd"
+  missing_flock_log="$TEST_TMP/missing-flock-service.log"
+  mkdir -p "$HOST_UPDATER_STATE_DIR" "$HOST_UPDATER_SYSTEMD_RUNTIME_DIR" "$TEST_TMP/no-tools"
+  : > "$HOST_UPDATER_LOCK_PATH"
+  id() { printf '0\n'; }
+  cat() { /bin/cat "$@"; }
+  systemctl() { printf '%s\n' "$*" >> "$missing_flock_log"; }
+  PATH="$TEST_TMP/no-tools"
+  LAST_ERROR=""
+  ! prepare_host_updater_removal \
+    && [[ "$LAST_ERROR" == *"flock is unavailable"* ]] \
+    && [[ ! -e "$missing_flock_log" ]]
+); then
+  pass "missing flock aborts before updater service mutation"
+else
+  fail "missing flock left the updater service changed"
+fi
+
+if (
+  INSTALL_ROOT="$owned_root"
+  HOST_UPDATER_PRESENT=false
+  HOST_UPDATER_PRIVILEGE=()
   HOST_UPDATER_STATE_DIR="$TEST_TMP/not-found-active-state"
   HOST_UPDATER_RUNTIME_DIR="$TEST_TMP/not-found-active-runtime"
   HOST_UPDATER_LOCK_PATH="$HOST_UPDATER_STATE_DIR/updater.lock"
@@ -239,6 +270,49 @@ if (
   pass "uninstaller fails closed while any updater process holds the lifetime lock"
 else
   fail "uninstaller can remove state while the updater lifetime lock is held"
+fi
+
+if (
+  INSTALL_ROOT="$owned_root"
+  HOST_UPDATER_PRESENT=false
+  HOST_UPDATER_PRIVILEGE=()
+  HOST_UPDATER_RESTORE_PENDING=false
+  HOST_UPDATER_REMOVAL_STARTED=false
+  HOST_UPDATER_STATE_DIR="$TEST_TMP/restore-state"
+  HOST_UPDATER_RUNTIME_DIR="$TEST_TMP/restore-runtime"
+  HOST_UPDATER_LOCK_PATH="$HOST_UPDATER_STATE_DIR/updater.lock"
+  HOST_UPDATER_SYSTEMD_RUNTIME_DIR="$TEST_TMP/restore-systemd"
+  mkdir -p "$HOST_UPDATER_STATE_DIR" "$HOST_UPDATER_SYSTEMD_RUNTIME_DIR"
+  : > "$HOST_UPDATER_LOCK_PATH"
+  service_state=active
+  mock_unit_file_state=enabled
+  lifecycle_log="$TEST_TMP/restore-service.log"
+  id() { printf '0\n'; }
+  systemctl() {
+    printf 'systemctl %s\n' "$*" >> "$lifecycle_log"
+    case "$*" in
+      *'--property=LoadState --value'*) printf 'loaded\n' ;;
+      *'--property=ActiveState --value'*) printf '%s\n' "$service_state" ;;
+      *'--property=UnitFileState --value'*) printf '%s\n' "$mock_unit_file_state" ;;
+      'stop proto-fleet-updater.service') service_state=inactive ;;
+      'disable proto-fleet-updater.service') mock_unit_file_state=disabled ;;
+      'enable proto-fleet-updater.service') mock_unit_file_state=enabled ;;
+      'start proto-fleet-updater.service') service_state=active ;;
+      *) return 1 ;;
+    esac
+  }
+  flock() { return 1; }
+  ! prepare_host_updater_removal \
+    && [[ "$HOST_UPDATER_RESTORE_PENDING" == true ]] \
+    && restore_host_updater_service_if_needed \
+    && [[ "$service_state" == active ]] \
+    && [[ "$mock_unit_file_state" == enabled ]] \
+    && grep -q '^systemctl enable proto-fleet-updater.service$' "$lifecycle_log" \
+    && grep -q '^systemctl start proto-fleet-updater.service$' "$lifecycle_log"
+); then
+  pass "failed lock verification restores the updater's active and enabled state"
+else
+  fail "failed lock verification stranded the updater disabled"
 fi
 
 canonical="$TEST_TMP/canonical/proto-fleet-updater"

--- a/deployment-files/tests/test-uninstall-updater-cleanup.sh
+++ b/deployment-files/tests/test-uninstall-updater-cleanup.sh
@@ -165,6 +165,36 @@ done
 printf 'PROTO_FLEET_INSTALL_ROOT="%s"\n' "$escaped_owned_root" \
   > "$HOST_UPDATER_ENV_PATH"
 
+# An explicit deployment path can be readable even when the installation is
+# root-managed. Do not elevate only updater removal and then continue Docker
+# and filesystem cleanup as the invoking user; the entire uninstall must be
+# rerun through one root privilege boundary.
+if (
+  INSTALL_ROOT="$owned_root"
+  HOST_UPDATER_ENV_PATH="$TEST_TMP/non-root-updater.env"
+  HOST_UPDATER_STATE_DIR="$TEST_TMP/non-root-state"
+  HOST_UPDATER_RUNTIME_DIR="$TEST_TMP/non-root-runtime"
+  HOST_UPDATER_PRESENT=false
+  HOST_UPDATER_PRIVILEGE=()
+  mutation_log="$TEST_TMP/non-root-mutations.log"
+  printf 'PROTO_FLEET_INSTALL_ROOT="%s"\n' "$escaped_owned_root" \
+    > "$HOST_UPDATER_ENV_PATH"
+  id() { printf '1000\n'; }
+  quoted_rerun_argv() { printf ' --deployment-path %q' "$INSTALL_ROOT"; }
+  sudo() { printf 'sudo %s\n' "$*" >> "$mutation_log"; }
+  systemctl() { printf 'systemctl %s\n' "$*" >> "$mutation_log"; }
+  LAST_ERROR=""
+  ! prepare_host_updater_removal \
+    && [[ "$LAST_ERROR" == *"re-run the complete uninstaller as root"* ]] \
+    && [[ "$HOST_UPDATER_PRESENT" == true ]] \
+    && (( ${#HOST_UPDATER_PRIVILEGE[@]} == 0 )) \
+    && [[ ! -e "$mutation_log" ]]
+); then
+  pass "non-root uninstall aborts before mutating a root-managed updater"
+else
+  fail "non-root uninstall can remove the updater before deployment cleanup"
+fi
+
 service_mutation_log="$TEST_TMP/service-mutations"
 if (
   INSTALL_ROOT="$other_root"

--- a/deployment-files/tests/test-uninstall-updater-cleanup.sh
+++ b/deployment-files/tests/test-uninstall-updater-cleanup.sh
@@ -56,6 +56,10 @@ trap cleanup_test_tmp EXIT
 # helpers under test instead of sourcing its interactive main path.
 sed -n \
   -e '/^HOST_UPDATER_ENV_PATH=/p' \
+  -e '/^HOST_UPDATER_STATE_DIR=/p' \
+  -e '/^HOST_UPDATER_RUNTIME_DIR=/p' \
+  -e '/^HOST_UPDATER_LOCK_PATH=/p' \
+  -e '/^HOST_UPDATER_SYSTEMD_RUNTIME_DIR=/p' \
   -e '/^HOST_UPDATER_BINARY_PATHS=(/,/^)/p' \
   -e '/^HOST_UPDATER_SELF_UPDATE_SUFFIXES=(/,/^)/p' \
   -e '/^canonicalize_existing_dir()/,/^}/p' \
@@ -67,6 +71,7 @@ sed -n \
   -e '/^verify_host_updater_ownership_with()/,/^}/p' \
   -e '/^host_updater_staging_artifacts_present()/,/^}/p' \
   -e '/^host_updater_artifacts_present()/,/^}/p' \
+  -e '/^verify_host_updater_process_lock_free_with()/,/^}/p' \
   -e '/^prepare_host_updater_removal()/,/^}/p' \
   "$UNINSTALL_SCRIPT" > "$TEST_TMP/uninstall-updater-functions.sh"
 # shellcheck source=/dev/null
@@ -171,6 +176,71 @@ else
   fail "ownership mismatch reached updater service mutation"
 fi
 
+if (
+  INSTALL_ROOT="$owned_root"
+  HOST_UPDATER_PRESENT=false
+  HOST_UPDATER_PRIVILEGE=()
+  HOST_UPDATER_STATE_DIR="$TEST_TMP/not-found-active-state"
+  HOST_UPDATER_RUNTIME_DIR="$TEST_TMP/not-found-active-runtime"
+  HOST_UPDATER_LOCK_PATH="$HOST_UPDATER_STATE_DIR/updater.lock"
+  HOST_UPDATER_SYSTEMD_RUNTIME_DIR="$TEST_TMP/systemd-runtime"
+  mkdir -p "$HOST_UPDATER_STATE_DIR" "$HOST_UPDATER_SYSTEMD_RUNTIME_DIR"
+  : > "$HOST_UPDATER_LOCK_PATH"
+  service_state=active
+  lifecycle_log="$TEST_TMP/not-found-active.log"
+  id() { printf '0\n'; }
+  systemctl() {
+    printf 'systemctl %s\n' "$*" >> "$lifecycle_log"
+    case "$*" in
+      *'--property=LoadState --value'*) printf 'not-found\n' ;;
+      *'--property=ActiveState --value'*) printf '%s\n' "$service_state" ;;
+      'stop proto-fleet-updater.service') service_state=inactive ;;
+      *) return 1 ;;
+    esac
+  }
+  flock() {
+    printf 'flock %s\n' "$*" >> "$lifecycle_log"
+    return 0
+  }
+  prepare_host_updater_removal \
+    && grep -q '^systemctl stop proto-fleet-updater.service$' "$lifecycle_log" \
+    && ! grep -q '^systemctl disable ' "$lifecycle_log" \
+    && grep -q "^flock -n $HOST_UPDATER_LOCK_PATH true$" "$lifecycle_log" \
+    && [ "$service_state" = inactive ]
+); then
+  pass "not-found updater unit still stops its active process and verifies the lifetime lock"
+else
+  fail "not-found updater unit was treated as proof that its process stopped"
+fi
+
+if (
+  INSTALL_ROOT="$owned_root"
+  HOST_UPDATER_PRESENT=false
+  HOST_UPDATER_PRIVILEGE=()
+  HOST_UPDATER_STATE_DIR="$TEST_TMP/held-lock-state"
+  HOST_UPDATER_RUNTIME_DIR="$TEST_TMP/held-lock-runtime"
+  HOST_UPDATER_LOCK_PATH="$HOST_UPDATER_STATE_DIR/updater.lock"
+  HOST_UPDATER_SYSTEMD_RUNTIME_DIR="$TEST_TMP/held-lock-systemd"
+  mkdir -p "$HOST_UPDATER_STATE_DIR" "$HOST_UPDATER_SYSTEMD_RUNTIME_DIR"
+  : > "$HOST_UPDATER_LOCK_PATH"
+  id() { printf '0\n'; }
+  systemctl() {
+    case "$*" in
+      *'--property=LoadState --value'*) printf 'not-found\n' ;;
+      *'--property=ActiveState --value'*) printf 'inactive\n' ;;
+      *) return 1 ;;
+    esac
+  }
+  flock() { return 1; }
+  LAST_ERROR=""
+  ! prepare_host_updater_removal \
+    && [[ "$LAST_ERROR" == *"still holds its lifetime lock"* ]]
+); then
+  pass "uninstaller fails closed while any updater process holds the lifetime lock"
+else
+  fail "uninstaller can remove state while the updater lifetime lock is held"
+fi
+
 canonical="$TEST_TMP/canonical/proto-fleet-updater"
 legacy="$TEST_TMP/legacy/proto-fleet-updater"
 mkdir -p "$(dirname "$canonical")" "$(dirname "$legacy")"
@@ -211,7 +281,7 @@ fi
 
 state_remove_line=$(awk '
   /^remove_host_updater\(\)/ { in_remove=1 }
-  in_remove && /\/var\/lib\/proto-fleet-updater \/run\/proto-fleet-updater/ { print NR; exit }
+  in_remove && /"\$HOST_UPDATER_STATE_DIR"/ { print NR; exit }
 ' "$UNINSTALL_SCRIPT")
 staging_verify_line=$(awk '
   /^remove_host_updater\(\)/ { in_remove=1 }

--- a/deployment-files/tests/test-uninstall-updater-cleanup.sh
+++ b/deployment-files/tests/test-uninstall-updater-cleanup.sh
@@ -6,18 +6,68 @@ set -u
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 UNINSTALL_SCRIPT="$REPO_ROOT/deployment-files/uninstall.sh"
-TEST_TMP=$(mktemp -d)
-TEST_TMP=$(cd "$TEST_TMP" && pwd -P)
-trap 'rm -rf "$TEST_TMP"' EXIT
+TEST_TMP=""
+TEST_TMP_RESOLVED=""
+TEST_TMP_PARENT=""
+TEST_TMP_PREFIX=""
+
+cleanup_test_tmp() {
+  case "${TEST_TMP:-}" in
+    "$TEST_TMP_PREFIX".*)
+      [[ -d "$TEST_TMP" && ! -L "$TEST_TMP" ]] \
+        && rm -rf -- "${TEST_TMP:?}"
+      ;;
+  esac
+}
+
+if ! TEST_TMP_PARENT=$(cd "${TMPDIR:-/tmp}" 2>/dev/null && pwd -P); then
+  echo "FAIL: could not resolve the temporary-directory parent" >&2
+  exit 1
+fi
+TEST_TMP_PREFIX="${TEST_TMP_PARENT%/}/proto-fleet-uninstall-updater"
+if ! TEST_TMP=$(mktemp -d "$TEST_TMP_PREFIX.XXXXXX"); then
+  echo "FAIL: could not create the test temporary directory" >&2
+  exit 1
+fi
+case "$TEST_TMP" in
+  "$TEST_TMP_PREFIX".*) ;;
+  *)
+    echo "FAIL: mktemp returned an unexpected path: $TEST_TMP" >&2
+    exit 1
+    ;;
+esac
+if ! TEST_TMP_RESOLVED=$(cd "$TEST_TMP" 2>/dev/null && pwd -P); then
+  echo "FAIL: could not resolve the test temporary directory" >&2
+  rm -rf -- "${TEST_TMP:?}"
+  TEST_TMP=""
+  exit 1
+fi
+TEST_TMP="$TEST_TMP_RESOLVED"
+case "$TEST_TMP" in
+  "$TEST_TMP_PREFIX".*) ;;
+  *)
+    echo "FAIL: temporary directory escaped its expected parent: $TEST_TMP" >&2
+    exit 1
+    ;;
+esac
+trap cleanup_test_tmp EXIT
 
 # uninstall.sh is a standalone executable, so extract only the constants and
 # helpers under test instead of sourcing its interactive main path.
 sed -n \
+  -e '/^HOST_UPDATER_ENV_PATH=/p' \
   -e '/^HOST_UPDATER_BINARY_PATHS=(/,/^)/p' \
   -e '/^HOST_UPDATER_SELF_UPDATE_SUFFIXES=(/,/^)/p' \
+  -e '/^canonicalize_existing_dir()/,/^}/p' \
   -e '/^host_updater_binary_artifact_paths()/,/^}/p' \
   -e '/^host_updater_binary_artifacts_present()/,/^}/p' \
   -e '/^remove_host_updater_binary_artifacts_with()/,/^}/p' \
+  -e '/^parse_host_updater_install_root()/,/^}/p' \
+  -e '/^read_host_updater_install_root_with()/,/^}/p' \
+  -e '/^verify_host_updater_ownership_with()/,/^}/p' \
+  -e '/^host_updater_staging_artifacts_present()/,/^}/p' \
+  -e '/^host_updater_artifacts_present()/,/^}/p' \
+  -e '/^prepare_host_updater_removal()/,/^}/p' \
   "$UNINSTALL_SCRIPT" > "$TEST_TMP/uninstall-updater-functions.sh"
 # shellcheck source=/dev/null
 source "$TEST_TMP/uninstall-updater-functions.sh"
@@ -33,6 +83,11 @@ pass() {
   echo "ok: $*"
 }
 
+LAST_ERROR=""
+print_error() {
+  LAST_ERROR="${LAST_ERROR}${LAST_ERROR:+$'\n'}$*"
+}
+
 if [[ "${#HOST_UPDATER_BINARY_PATHS[@]}" -eq 2 ]] \
   && [[ "${HOST_UPDATER_BINARY_PATHS[0]}" == /usr/local/libexec/proto-fleet/proto-fleet-updater ]] \
   && [[ "${HOST_UPDATER_BINARY_PATHS[1]}" == /usr/local/libexec/proto-fleet-updater ]]; then
@@ -45,6 +100,75 @@ if [[ "${HOST_UPDATER_SELF_UPDATE_SUFFIXES[*]}" == ".previous .candidate .handof
   pass "all self-update sibling suffixes are covered"
 else
   fail "self-update sibling suffix contract is incomplete"
+fi
+
+owned_root="$TEST_TMP/owned root with a \"quote\" and \\slash"
+other_root="$TEST_TMP/other-root"
+mkdir -p "$owned_root" "$other_root"
+HOST_UPDATER_ENV_PATH="$TEST_TMP/updater.env"
+INSTALL_ROOT="$owned_root"
+escaped_owned_root=${owned_root//\\/\\\\}
+escaped_owned_root=${escaped_owned_root//\"/\\\"}
+cat > "$HOST_UPDATER_ENV_PATH" <<EOF
+PROTO_FLEET_INSTALL_ROOT="$escaped_owned_root"
+PROTO_FLEET_DOWNLOAD_BASE_URL="https://github.com/block/proto-fleet/releases/download"
+PROTO_FLEET_UPDATER_SOCKET_PATH="/run/proto-fleet-updater/updater.sock"
+EOF
+
+if [[ "$(read_host_updater_install_root_with)" == "$owned_root" ]] \
+  && verify_host_updater_ownership_with; then
+  pass "updater ownership accepts the selected canonical install root"
+else
+  fail "updater ownership rejected its selected install root"
+fi
+
+INSTALL_ROOT="$other_root"
+LAST_ERROR=""
+if verify_host_updater_ownership_with; then
+  fail "updater ownership accepted a different selected install root"
+elif [[ "$LAST_ERROR" == *"belongs to a different Proto Fleet installation"* ]]; then
+  pass "updater ownership rejects a different selected install root"
+else
+  fail "updater ownership mismatch did not produce an actionable error"
+fi
+
+INSTALL_ROOT="$owned_root"
+for malformed_environment in \
+  'PROTO_FLEET_INSTALL_ROOT=/tmp/unquoted' \
+  'PROTO_FLEET_INSTALL_ROOT="/tmp/bad\qescape"' \
+  $'PROTO_FLEET_INSTALL_ROOT="/tmp/first"\nPROTO_FLEET_INSTALL_ROOT="/tmp/second"' \
+  'PROTO_FLEET_DOWNLOAD_BASE_URL="https://example.invalid"'; do
+  printf '%s\n' "$malformed_environment" > "$HOST_UPDATER_ENV_PATH"
+  LAST_ERROR=""
+  if verify_host_updater_ownership_with; then
+    fail "updater ownership accepted malformed or ownerless configuration"
+  elif [[ "$LAST_ERROR" == *"Could not read a valid updater install root"* ]]; then
+    pass "updater ownership fails closed on malformed or ownerless configuration"
+  else
+    fail "malformed updater ownership did not produce an actionable error"
+  fi
+done
+
+# Restore a valid ownership file before exercising the unrelated binary
+# cleanup helpers below.
+printf 'PROTO_FLEET_INSTALL_ROOT="%s"\n' "$escaped_owned_root" \
+  > "$HOST_UPDATER_ENV_PATH"
+
+service_mutation_log="$TEST_TMP/service-mutations"
+if (
+  INSTALL_ROOT="$other_root"
+  HOST_UPDATER_PRESENT=false
+  HOST_UPDATER_PRIVILEGE=()
+  id() { printf '0\n'; }
+  systemctl() { printf '%s\n' "$*" >> "$service_mutation_log"; }
+  if prepare_host_updater_removal; then
+    exit 1
+  fi
+  [[ ! -e "$service_mutation_log" ]]
+); then
+  pass "ownership mismatch aborts before updater service mutation"
+else
+  fail "ownership mismatch reached updater service mutation"
 fi
 
 canonical="$TEST_TMP/canonical/proto-fleet-updater"

--- a/deployment-files/tests/test-uninstall-updater-cleanup.sh
+++ b/deployment-files/tests/test-uninstall-updater-cleanup.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Focused regression checks for exact host-updater binary cleanup. Production
+# paths are redirected into a temporary directory; no host files are touched.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+UNINSTALL_SCRIPT="$REPO_ROOT/deployment-files/uninstall.sh"
+TEST_TMP=$(mktemp -d)
+TEST_TMP=$(cd "$TEST_TMP" && pwd -P)
+trap 'rm -rf "$TEST_TMP"' EXIT
+
+# uninstall.sh is a standalone executable, so extract only the constants and
+# helpers under test instead of sourcing its interactive main path.
+sed -n \
+  -e '/^HOST_UPDATER_BINARY_PATHS=(/,/^)/p' \
+  -e '/^HOST_UPDATER_SELF_UPDATE_SUFFIXES=(/,/^)/p' \
+  -e '/^host_updater_binary_artifact_paths()/,/^}/p' \
+  -e '/^host_updater_binary_artifacts_present()/,/^}/p' \
+  -e '/^remove_host_updater_binary_artifacts_with()/,/^}/p' \
+  "$UNINSTALL_SCRIPT" > "$TEST_TMP/uninstall-updater-functions.sh"
+# shellcheck source=/dev/null
+source "$TEST_TMP/uninstall-updater-functions.sh"
+
+FAILURES=0
+
+fail() {
+  echo "FAIL: $*" >&2
+  FAILURES=$((FAILURES + 1))
+}
+
+pass() {
+  echo "ok: $*"
+}
+
+if [[ "${#HOST_UPDATER_BINARY_PATHS[@]}" -eq 2 ]] \
+  && [[ "${HOST_UPDATER_BINARY_PATHS[0]}" == /usr/local/libexec/proto-fleet/proto-fleet-updater ]] \
+  && [[ "${HOST_UPDATER_BINARY_PATHS[1]}" == /usr/local/libexec/proto-fleet-updater ]]; then
+  pass "canonical and legacy updater binary paths are covered"
+else
+  fail "updater binary path contract is incomplete"
+fi
+
+if [[ "${HOST_UPDATER_SELF_UPDATE_SUFFIXES[*]}" == ".previous .candidate .handoff .handoff.tmp .restore" ]]; then
+  pass "all self-update sibling suffixes are covered"
+else
+  fail "self-update sibling suffix contract is incomplete"
+fi
+
+canonical="$TEST_TMP/canonical/proto-fleet-updater"
+legacy="$TEST_TMP/legacy/proto-fleet-updater"
+mkdir -p "$(dirname "$canonical")" "$(dirname "$legacy")"
+HOST_UPDATER_BINARY_PATHS=("$canonical" "$legacy")
+
+# A sibling by itself must make the updater discoverable so uninstall does not
+# skip privileged cleanup merely because the active binary is already gone.
+: > "${legacy}.restore"
+if host_updater_binary_artifacts_present; then
+  pass "orphaned self-update sibling is detected"
+else
+  fail "orphaned self-update sibling was not detected"
+fi
+rm -f "${legacy}.restore"
+
+# Populate every exact artifact, including a dangling symlink, and nearby
+# lookalikes that are outside the updater's closed naming contract.
+while IFS= read -r path; do
+  if [[ "$path" == *.handoff.tmp ]]; then
+    ln -s "$TEST_TMP/missing-target" "$path"
+  else
+    : > "$path"
+  fi
+done < <(host_updater_binary_artifact_paths)
+canonical_lookalike="${canonical}.previous.keep"
+legacy_lookalike="${legacy}.candidate-extra"
+: > "$canonical_lookalike"
+: > "$legacy_lookalike"
+
+if remove_host_updater_binary_artifacts_with \
+  && ! host_updater_binary_artifacts_present \
+  && [[ -f "$canonical_lookalike" ]] \
+  && [[ -f "$legacy_lookalike" ]]; then
+  pass "exact updater artifacts are removed and lookalikes are preserved"
+else
+  fail "updater cleanup removed the wrong paths or left an exact artifact"
+fi
+
+if [[ "$FAILURES" -ne 0 ]]; then
+  echo "$FAILURES failure(s)"
+  exit 1
+fi
+echo "all uninstall updater cleanup checks passed"

--- a/deployment-files/uninstall.sh
+++ b/deployment-files/uninstall.sh
@@ -15,6 +15,7 @@ DRY_RUN=false
 HOST_UPDATER_PRESENT=false
 HOST_UPDATER_PRIVILEGE=()
 HOST_UPDATER_STAGING_NAME_RE='^\.proto-fleet-upgrade-[a-f0-9]{64}$'
+HOST_UPDATER_ENV_PATH=/etc/proto-fleet/updater.env
 HOST_UPDATER_BINARY_PATHS=(
   /usr/local/libexec/proto-fleet/proto-fleet-updater
   /usr/local/libexec/proto-fleet-updater
@@ -500,6 +501,76 @@ remove_host_updater_binary_artifacts_with() {
   ${privilege[@]+"${privilege[@]}"} rm -f -- "${artifacts[@]}"
 }
 
+parse_host_updater_install_root() {
+  local contents="$1"
+  local key_re='^[[:space:]]*PROTO_FLEET_INSTALL_ROOT[[:space:]]*='
+  local assignment_re='^PROTO_FLEET_INSTALL_ROOT="(([^"\\]|\\["\\])*)"$'
+  local line encoded decoded char
+  local found=0
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    [[ "$line" =~ $key_re ]] || continue
+    [[ "$found" -eq 0 ]] || return 1
+    [[ "$line" =~ $assignment_re ]] || return 1
+    encoded="${BASH_REMATCH[1]}"
+    decoded=""
+    while [[ -n "$encoded" ]]; do
+      char="${encoded:0:1}"
+      encoded="${encoded:1}"
+      if [[ "$char" == '\' ]]; then
+        [[ -n "$encoded" ]] || return 1
+        char="${encoded:0:1}"
+        encoded="${encoded:1}"
+        [[ "$char" == '\' || "$char" == '"' ]] || return 1
+      fi
+      decoded="${decoded}${char}"
+    done
+    [[ -n "$decoded" ]] || return 1
+    found=1
+  done <<< "$contents"
+
+  [[ "$found" -eq 1 ]] || return 1
+  printf '%s\n' "$decoded"
+}
+
+read_host_updater_install_root_with() {
+  local privilege=("$@")
+  local contents
+  if ! contents="$(${privilege[@]+"${privilege[@]}"} \
+      cat -- "$HOST_UPDATER_ENV_PATH" 2>/dev/null)"; then
+    return 1
+  fi
+  parse_host_updater_install_root "$contents"
+}
+
+verify_host_updater_ownership_with() {
+  local privilege=("$@")
+  local configured_root configured_resolved selected_resolved
+  if ! configured_root="$(read_host_updater_install_root_with \
+      ${privilege[@]+"${privilege[@]}"})"; then
+    print_error "Could not read a valid updater install root from $HOST_UPDATER_ENV_PATH."
+    print_error "No updater, Docker, or deployment files were removed."
+    return 1
+  fi
+  if ! configured_resolved="$(canonicalize_existing_dir "$configured_root")"; then
+    print_error "The updater install root cannot be resolved: $configured_root"
+    print_error "No updater, Docker, or deployment files were removed."
+    return 1
+  fi
+  if ! selected_resolved="$(canonicalize_existing_dir "$INSTALL_ROOT")"; then
+    print_error "The selected install root cannot be resolved: $INSTALL_ROOT"
+    print_error "No updater, Docker, or deployment files were removed."
+    return 1
+  fi
+  if [[ "${configured_resolved%/}" != "${selected_resolved%/}" ]]; then
+    print_error "The host updater belongs to a different Proto Fleet installation."
+    print_error "  Updater install root: $configured_resolved"
+    print_error "  Selected install root: $selected_resolved"
+    print_error "No updater, Docker, or deployment files were removed."
+    return 1
+  fi
+}
+
 host_updater_staging_artifacts_present() {
   local path name
   [[ -n "$INSTALL_ROOT" ]] || return 1
@@ -516,7 +587,7 @@ host_updater_artifacts_present() {
   host_updater_binary_artifacts_present && return 0
   for path in \
     /etc/systemd/system/proto-fleet-updater.service \
-    /etc/proto-fleet/updater.env \
+    "$HOST_UPDATER_ENV_PATH" \
     /var/lib/proto-fleet-updater \
     /run/proto-fleet-updater; do
     [[ -e "$path" || -L "$path" ]] && return 0
@@ -561,6 +632,11 @@ prepare_host_updater_removal() {
       return 1
     fi
     HOST_UPDATER_PRIVILEGE=(sudo -n)
+  fi
+
+  if ! verify_host_updater_ownership_with \
+      ${HOST_UPDATER_PRIVILEGE[@]+"${HOST_UPDATER_PRIVILEGE[@]}"}; then
+    return 1
   fi
 
   if command -v systemctl &>/dev/null && [[ -d /run/systemd/system ]]; then
@@ -612,7 +688,7 @@ remove_host_updater() {
   fi
   if ! ${privilege[@]+"${privilege[@]}"} rm -f -- \
     /etc/systemd/system/proto-fleet-updater.service \
-    /etc/proto-fleet/updater.env; then
+    "$HOST_UPDATER_ENV_PATH"; then
     print_error "Could not remove host updater files; deployment removal was aborted."
     return 1
   fi
@@ -659,7 +735,7 @@ remove_host_updater() {
   done < <(host_updater_binary_artifact_paths)
   for path in \
     /etc/systemd/system/proto-fleet-updater.service \
-    /etc/proto-fleet/updater.env \
+    "$HOST_UPDATER_ENV_PATH" \
     /var/lib/proto-fleet-updater \
     /run/proto-fleet-updater; do
     if ${privilege[@]+"${privilege[@]}"} test -e "$path" \

--- a/deployment-files/uninstall.sh
+++ b/deployment-files/uninstall.sh
@@ -707,15 +707,15 @@ prepare_host_updater_removal() {
   HOST_UPDATER_PRESENT=true
 
   if [[ "$(id -u)" -ne 0 ]]; then
-    if ! command -v sudo &>/dev/null; then
-      print_error "The host updater is installed, but sudo is unavailable. Re-run this uninstaller as root."
-      return 1
-    fi
-    if ! sudo -v; then
-      print_error "Administrator access is required to stop and remove the host updater."
-      return 1
-    fi
-    HOST_UPDATER_PRIVILEGE=(sudo -n)
+    # Removing the updater with sudo but continuing Docker and deployment
+    # cleanup as the invoking user can strand a root-managed installation
+    # without its updater. Require one privilege boundary for the complete
+    # destructive workflow instead of elevating only its first step.
+    print_error "The host updater is installed; re-run the complete uninstaller as root (flags preserved):"
+    echo ""
+    echo "    curl -fsSL https://fleet.proto.xyz/uninstall.sh | sudo bash -s --$(quoted_rerun_argv)"
+    echo ""
+    return 1
   fi
 
   if ! verify_host_updater_ownership_with \

--- a/deployment-files/uninstall.sh
+++ b/deployment-files/uninstall.sh
@@ -12,6 +12,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DEPLOYMENT_PATH=""
 INSTALL_ROOT=""
 DRY_RUN=false
+HOST_UPDATER_PRESENT=false
+HOST_UPDATER_PRIVILEGE=()
+HOST_UPDATER_STAGING_NAME_RE='^\.proto-fleet-upgrade-[a-f0-9]{64}$'
 
 # =====================================================================
 # Output Helpers
@@ -457,29 +460,168 @@ remove_systemd_units() {
   print_success "Systemd user units cleaned up."
 }
 
-remove_host_updater() {
-  local privilege=()
-  if [[ "$(id -u)" -ne 0 ]]; then
-    if ! command -v sudo &>/dev/null; then
-      print_warn "sudo is unavailable; remove proto-fleet-updater.service manually."
-      return
-    fi
-    privilege=(sudo)
-  fi
-  if command -v systemctl &>/dev/null; then
-    ${privilege[@]+"${privilege[@]}"} systemctl disable --now proto-fleet-updater.service 2>/dev/null || true
-  fi
-  ${privilege[@]+"${privilege[@]}"} rm -f /etc/systemd/system/proto-fleet-updater.service \
+host_updater_staging_artifacts_present() {
+  local path name
+  [[ -n "$INSTALL_ROOT" ]] || return 1
+  for path in "${INSTALL_ROOT%/}"/.proto-fleet-upgrade-*; do
+    [[ -e "$path" || -L "$path" ]] || continue
+    name="${path##*/}"
+    [[ "$name" =~ $HOST_UPDATER_STAGING_NAME_RE ]] && return 0
+  done
+  return 1
+}
+
+host_updater_artifacts_present() {
+  local path load_state
+  for path in \
+    /etc/systemd/system/proto-fleet-updater.service \
     /usr/local/libexec/proto-fleet/proto-fleet-updater \
     /usr/local/libexec/proto-fleet-updater \
-    /etc/proto-fleet/updater.env 2>/dev/null || true
-  ${privilege[@]+"${privilege[@]}"} rm -rf /var/lib/proto-fleet-updater /run/proto-fleet-updater 2>/dev/null || true
+    /etc/proto-fleet/updater.env \
+    /var/lib/proto-fleet-updater \
+    /run/proto-fleet-updater; do
+    [[ -e "$path" || -L "$path" ]] && return 0
+  done
+  host_updater_staging_artifacts_present && return 0
+  if command -v systemctl &>/dev/null && [[ -d /run/systemd/system ]]; then
+    if ! load_state="$(systemctl show --property=LoadState --value \
+      proto-fleet-updater.service 2>/dev/null)"; then
+      return 2
+    fi
+    [[ "$load_state" != "not-found" ]] && return 0
+  fi
+  return 1
+}
+
+# Acquire all privilege and stop the updater before Docker or deployment
+# teardown begins. A failed stop can mean an activation is still replacing
+# this deployment, so continuing would race the privileged updater.
+prepare_host_updater_removal() {
+  HOST_UPDATER_PRESENT=false
+  HOST_UPDATER_PRIVILEGE=()
+  local artifact_status
+  if host_updater_artifacts_present; then
+    :
+  else
+    artifact_status=$?
+    if [[ "$artifact_status" -eq 2 ]]; then
+      print_error "Could not inspect the host updater service; no Docker or deployment files were removed."
+      return 1
+    fi
+    return 0
+  fi
+  HOST_UPDATER_PRESENT=true
+
+  if [[ "$(id -u)" -ne 0 ]]; then
+    if ! command -v sudo &>/dev/null; then
+      print_error "The host updater is installed, but sudo is unavailable. Re-run this uninstaller as root."
+      return 1
+    fi
+    if ! sudo -v; then
+      print_error "Administrator access is required to stop and remove the host updater."
+      return 1
+    fi
+    HOST_UPDATER_PRIVILEGE=(sudo -n)
+  fi
+
+  if command -v systemctl &>/dev/null && [[ -d /run/systemd/system ]]; then
+    local load_state active_state
+    if ! load_state="$(${HOST_UPDATER_PRIVILEGE[@]+"${HOST_UPDATER_PRIVILEGE[@]}"} \
+      systemctl show --property=LoadState --value proto-fleet-updater.service 2>/dev/null)"; then
+      print_error "Could not inspect the host updater service; no Docker or deployment files were removed."
+      return 1
+    fi
+    if [[ -z "$load_state" ]]; then
+      print_error "Host updater service inspection returned no state; no Docker or deployment files were removed."
+      return 1
+    fi
+    if [[ "$load_state" != "not-found" ]]; then
+      if ! ${HOST_UPDATER_PRIVILEGE[@]+"${HOST_UPDATER_PRIVILEGE[@]}"} \
+        systemctl disable --now proto-fleet-updater.service; then
+        print_error "Could not stop the host updater; no Docker or deployment files were removed."
+        return 1
+      fi
+      if ! active_state="$(${HOST_UPDATER_PRIVILEGE[@]+"${HOST_UPDATER_PRIVILEGE[@]}"} \
+        systemctl show --property=ActiveState --value proto-fleet-updater.service 2>/dev/null)"; then
+        print_error "Could not verify that the host updater stopped; no Docker or deployment files were removed."
+        return 1
+      fi
+      case "$active_state" in
+        inactive|failed) ;;
+        *)
+          print_error "The host updater is still active; no Docker or deployment files were removed."
+          return 1
+          ;;
+      esac
+    fi
+  fi
+}
+
+remove_host_updater() {
+  if [[ "$HOST_UPDATER_PRESENT" != true ]]; then
+    print_success "Host updater is not installed; privileged cleanup skipped."
+    return 0
+  fi
+
+  local privilege=()
+  if (( ${#HOST_UPDATER_PRIVILEGE[@]} )); then
+    privilege=("${HOST_UPDATER_PRIVILEGE[@]}")
+  fi
+  if ! ${privilege[@]+"${privilege[@]}"} rm -f \
+    /etc/systemd/system/proto-fleet-updater.service \
+    /usr/local/libexec/proto-fleet/proto-fleet-updater \
+    /usr/local/libexec/proto-fleet-updater \
+    /etc/proto-fleet/updater.env; then
+    print_error "Could not remove host updater files; deployment removal was aborted."
+    return 1
+  fi
+  if ! ${privilege[@]+"${privilege[@]}"} rm -rf \
+    /var/lib/proto-fleet-updater /run/proto-fleet-updater; then
+    print_error "Could not remove host updater state; deployment removal was aborted."
+    return 1
+  fi
+
+  # The privileged updater stages extracted releases as exact, hash-suffixed
+  # siblings of deployment/. Remove only that closed naming contract; leave
+  # operator-created files and lookalikes untouched.
+  local staging_path staging_name
+  for staging_path in "${INSTALL_ROOT%/}"/.proto-fleet-upgrade-*; do
+    [[ -e "$staging_path" || -L "$staging_path" ]] || continue
+    staging_name="${staging_path##*/}"
+    [[ "$staging_name" =~ $HOST_UPDATER_STAGING_NAME_RE ]] || continue
+    if ! ${privilege[@]+"${privilege[@]}"} rm -rf -- "$staging_path"; then
+      print_error "Could not remove host updater staging directory: $staging_path"
+      return 1
+    fi
+  done
+  if host_updater_staging_artifacts_present; then
+    print_error "Host updater staging directories remain after cleanup."
+    return 1
+  fi
+
   ${privilege[@]+"${privilege[@]}"} rmdir /usr/local/libexec/proto-fleet 2>/dev/null || true
   ${privilege[@]+"${privilege[@]}"} rmdir /etc/proto-fleet 2>/dev/null || true
-  if command -v systemctl &>/dev/null; then
-    ${privilege[@]+"${privilege[@]}"} systemctl daemon-reload 2>/dev/null || true
-    ${privilege[@]+"${privilege[@]}"} systemctl reset-failed 2>/dev/null || true
+  if command -v systemctl &>/dev/null && [[ -d /run/systemd/system ]]; then
+    if ! ${privilege[@]+"${privilege[@]}"} systemctl daemon-reload; then
+      print_error "Could not finalize host updater removal; deployment removal was aborted."
+      return 1
+    fi
   fi
+
+  local path
+  for path in \
+    /etc/systemd/system/proto-fleet-updater.service \
+    /usr/local/libexec/proto-fleet/proto-fleet-updater \
+    /usr/local/libexec/proto-fleet-updater \
+    /etc/proto-fleet/updater.env \
+    /var/lib/proto-fleet-updater \
+    /run/proto-fleet-updater; do
+    if ${privilege[@]+"${privilege[@]}"} test -e "$path" \
+      || ${privilege[@]+"${privilege[@]}"} test -L "$path"; then
+      print_error "Host updater artifact remains after cleanup: $path"
+      return 1
+    fi
+  done
   print_success "Host updater service and state removed."
 }
 
@@ -549,11 +691,12 @@ if ! $DRY_RUN; then
     echo "Uninstall canceled."
     exit 0
   fi
+  prepare_host_updater_removal || exit 1
 fi
 
+run_action "Removing Proto Fleet host updater..." remove_host_updater
 run_action "Tearing down Proto Fleet Docker stack (containers/images/volumes)..." teardown_docker_stack
 run_action "Removing Proto Fleet systemd units..." remove_systemd_units
-run_action "Removing Proto Fleet host updater..." remove_host_updater
 run_action "Removing Proto Fleet deployment files..." remove_deployment_files
 
 echo ""

--- a/deployment-files/uninstall.sh
+++ b/deployment-files/uninstall.sh
@@ -16,6 +16,10 @@ HOST_UPDATER_PRESENT=false
 HOST_UPDATER_PRIVILEGE=()
 HOST_UPDATER_STAGING_NAME_RE='^\.proto-fleet-upgrade-[a-f0-9]{64}$'
 HOST_UPDATER_ENV_PATH=/etc/proto-fleet/updater.env
+HOST_UPDATER_STATE_DIR=/var/lib/proto-fleet-updater
+HOST_UPDATER_RUNTIME_DIR=/run/proto-fleet-updater
+HOST_UPDATER_LOCK_PATH="$HOST_UPDATER_STATE_DIR/updater.lock"
+HOST_UPDATER_SYSTEMD_RUNTIME_DIR=/run/systemd/system
 HOST_UPDATER_BINARY_PATHS=(
   /usr/local/libexec/proto-fleet/proto-fleet-updater
   /usr/local/libexec/proto-fleet-updater
@@ -588,12 +592,12 @@ host_updater_artifacts_present() {
   for path in \
     /etc/systemd/system/proto-fleet-updater.service \
     "$HOST_UPDATER_ENV_PATH" \
-    /var/lib/proto-fleet-updater \
-    /run/proto-fleet-updater; do
+    "$HOST_UPDATER_STATE_DIR" \
+    "$HOST_UPDATER_RUNTIME_DIR"; do
     [[ -e "$path" || -L "$path" ]] && return 0
   done
   host_updater_staging_artifacts_present && return 0
-  if command -v systemctl &>/dev/null && [[ -d /run/systemd/system ]]; then
+  if command -v systemctl &>/dev/null && [[ -d "$HOST_UPDATER_SYSTEMD_RUNTIME_DIR" ]]; then
     if ! load_state="$(systemctl show --property=LoadState --value \
       proto-fleet-updater.service 2>/dev/null)"; then
       return 2
@@ -601,6 +605,29 @@ host_updater_artifacts_present() {
     [[ "$load_state" != "not-found" ]] && return 0
   fi
   return 1
+}
+
+verify_host_updater_process_lock_free_with() {
+  local privilege=("$@")
+
+  if ! ${privilege[@]+"${privilege[@]}"} test -e "$HOST_UPDATER_LOCK_PATH" \
+    && ! ${privilege[@]+"${privilege[@]}"} test -L "$HOST_UPDATER_LOCK_PATH"; then
+    return 0
+  fi
+  if ${privilege[@]+"${privilege[@]}"} test -L "$HOST_UPDATER_LOCK_PATH" \
+    || ! ${privilege[@]+"${privilege[@]}"} test -f "$HOST_UPDATER_LOCK_PATH"; then
+    print_error "The updater lifetime lock is not a regular, non-symlink file; no files were removed."
+    return 1
+  fi
+  if ! command -v flock &>/dev/null; then
+    print_error "Cannot verify the updater lifetime lock because flock is unavailable; no files were removed."
+    return 1
+  fi
+  if ! ${privilege[@]+"${privilege[@]}"} flock -n \
+      "$HOST_UPDATER_LOCK_PATH" true; then
+    print_error "The host updater still holds its lifetime lock; no files were removed."
+    return 1
+  fi
 }
 
 # Acquire all privilege and stop the updater before Docker or deployment
@@ -639,7 +666,7 @@ prepare_host_updater_removal() {
     return 1
   fi
 
-  if command -v systemctl &>/dev/null && [[ -d /run/systemd/system ]]; then
+  if command -v systemctl &>/dev/null && [[ -d "$HOST_UPDATER_SYSTEMD_RUNTIME_DIR" ]]; then
     local load_state active_state
     if ! load_state="$(${HOST_UPDATER_PRIVILEGE[@]+"${HOST_UPDATER_PRIVILEGE[@]}"} \
       systemctl show --property=LoadState --value proto-fleet-updater.service 2>/dev/null)"; then
@@ -650,25 +677,47 @@ prepare_host_updater_removal() {
       print_error "Host updater service inspection returned no state; no Docker or deployment files were removed."
       return 1
     fi
-    if [[ "$load_state" != "not-found" ]]; then
-      if ! ${HOST_UPDATER_PRIVILEGE[@]+"${HOST_UPDATER_PRIVILEGE[@]}"} \
-        systemctl disable --now proto-fleet-updater.service; then
-        print_error "Could not stop the host updater; no Docker or deployment files were removed."
-        return 1
-      fi
-      if ! active_state="$(${HOST_UPDATER_PRIVILEGE[@]+"${HOST_UPDATER_PRIVILEGE[@]}"} \
-        systemctl show --property=ActiveState --value proto-fleet-updater.service 2>/dev/null)"; then
-        print_error "Could not verify that the host updater stopped; no Docker or deployment files were removed."
-        return 1
-      fi
-      case "$active_state" in
-        inactive|failed) ;;
-        *)
-          print_error "The host updater is still active; no Docker or deployment files were removed."
-          return 1
-          ;;
-      esac
+    if ! active_state="$(${HOST_UPDATER_PRIVILEGE[@]+"${HOST_UPDATER_PRIVILEGE[@]}"} \
+      systemctl show --property=ActiveState --value proto-fleet-updater.service 2>/dev/null)"; then
+      print_error "Could not inspect the host updater process; no Docker or deployment files were removed."
+      return 1
     fi
+    case "$active_state" in
+      inactive|failed) ;;
+      active|activating|reloading|deactivating)
+        if ! ${HOST_UPDATER_PRIVILEGE[@]+"${HOST_UPDATER_PRIVILEGE[@]}"} \
+          systemctl stop proto-fleet-updater.service; then
+          print_error "Could not stop the host updater; no Docker or deployment files were removed."
+          return 1
+        fi
+        ;;
+      *)
+        print_error "The host updater has an unexpected active state; no Docker or deployment files were removed."
+        return 1
+        ;;
+    esac
+    if [[ "$load_state" != "not-found" ]] \
+      && ! ${HOST_UPDATER_PRIVILEGE[@]+"${HOST_UPDATER_PRIVILEGE[@]}"} \
+        systemctl disable proto-fleet-updater.service; then
+      print_error "Could not disable the host updater; no Docker or deployment files were removed."
+      return 1
+    fi
+    if ! active_state="$(${HOST_UPDATER_PRIVILEGE[@]+"${HOST_UPDATER_PRIVILEGE[@]}"} \
+      systemctl show --property=ActiveState --value proto-fleet-updater.service 2>/dev/null)"; then
+      print_error "Could not verify that the host updater stopped; no Docker or deployment files were removed."
+      return 1
+    fi
+    case "$active_state" in
+      inactive|failed) ;;
+      *)
+        print_error "The host updater is still active; no Docker or deployment files were removed."
+        return 1
+        ;;
+    esac
+  fi
+  if ! verify_host_updater_process_lock_free_with \
+      ${HOST_UPDATER_PRIVILEGE[@]+"${HOST_UPDATER_PRIVILEGE[@]}"}; then
+    return 1
   fi
 }
 
@@ -692,7 +741,7 @@ remove_host_updater() {
     return 1
   fi
   if ! ${privilege[@]+"${privilege[@]}"} rm -rf \
-    /var/lib/proto-fleet-updater /run/proto-fleet-updater; then
+    "$HOST_UPDATER_STATE_DIR" "$HOST_UPDATER_RUNTIME_DIR"; then
     print_error "Could not remove host updater state; deployment removal was aborted."
     return 1
   fi
@@ -716,7 +765,7 @@ remove_host_updater() {
   fi
 
   ${privilege[@]+"${privilege[@]}"} rmdir /usr/local/libexec/proto-fleet 2>/dev/null || true
-  if command -v systemctl &>/dev/null && [[ -d /run/systemd/system ]]; then
+  if command -v systemctl &>/dev/null && [[ -d "$HOST_UPDATER_SYSTEMD_RUNTIME_DIR" ]]; then
     if ! ${privilege[@]+"${privilege[@]}"} systemctl daemon-reload; then
       print_error "Could not finalize host updater removal; deployment removal was aborted."
       return 1
@@ -733,8 +782,8 @@ remove_host_updater() {
   done < <(host_updater_binary_artifact_paths)
   for path in \
     /etc/systemd/system/proto-fleet-updater.service \
-    /var/lib/proto-fleet-updater \
-    /run/proto-fleet-updater; do
+    "$HOST_UPDATER_STATE_DIR" \
+    "$HOST_UPDATER_RUNTIME_DIR"; do
     if ${privilege[@]+"${privilege[@]}"} test -e "$path" \
       || ${privilege[@]+"${privilege[@]}"} test -L "$path"; then
       print_error "Host updater artifact remains after cleanup: $path"

--- a/deployment-files/uninstall.sh
+++ b/deployment-files/uninstall.sh
@@ -457,6 +457,32 @@ remove_systemd_units() {
   print_success "Systemd user units cleaned up."
 }
 
+remove_host_updater() {
+  local privilege=()
+  if [[ "$(id -u)" -ne 0 ]]; then
+    if ! command -v sudo &>/dev/null; then
+      print_warn "sudo is unavailable; remove proto-fleet-updater.service manually."
+      return
+    fi
+    privilege=(sudo)
+  fi
+  if command -v systemctl &>/dev/null; then
+    ${privilege[@]+"${privilege[@]}"} systemctl disable --now proto-fleet-updater.service 2>/dev/null || true
+  fi
+  ${privilege[@]+"${privilege[@]}"} rm -f /etc/systemd/system/proto-fleet-updater.service \
+    /usr/local/libexec/proto-fleet/proto-fleet-updater \
+    /usr/local/libexec/proto-fleet-updater \
+    /etc/proto-fleet/updater.env 2>/dev/null || true
+  ${privilege[@]+"${privilege[@]}"} rm -rf /var/lib/proto-fleet-updater /run/proto-fleet-updater 2>/dev/null || true
+  ${privilege[@]+"${privilege[@]}"} rmdir /usr/local/libexec/proto-fleet 2>/dev/null || true
+  ${privilege[@]+"${privilege[@]}"} rmdir /etc/proto-fleet 2>/dev/null || true
+  if command -v systemctl &>/dev/null; then
+    ${privilege[@]+"${privilege[@]}"} systemctl daemon-reload 2>/dev/null || true
+    ${privilege[@]+"${privilege[@]}"} systemctl reset-failed 2>/dev/null || true
+  fi
+  print_success "Host updater service and state removed."
+}
+
 remove_deployment_files() {
   assert_safe_removal_path "$DEPLOYMENT_PATH"
 
@@ -465,6 +491,15 @@ remove_deployment_files() {
     print_success "Deployment directory removed: $DEPLOYMENT_PATH"
   else
     print_warn "Deployment directory not found: $DEPLOYMENT_PATH"
+  fi
+
+  # A successful one-click upgrade keeps one exact previous deployment next
+  # to the active one for operator recovery. It has the same trusted install
+  # root as DEPLOYMENT_PATH and is never expanded from a glob.
+  local previous_deployment="${INSTALL_ROOT%/}/deployment.previous"
+  if [[ -d "$previous_deployment" ]]; then
+    rm -rf "$previous_deployment"
+    print_success "Previous deployment backup removed: $previous_deployment"
   fi
 
   # Remove install root if it's now empty
@@ -501,6 +536,7 @@ echo "  - Docker containers (Proto Fleet services)"
 echo "  - Docker images used by Proto Fleet"
 echo "  - Docker volumes (ALL Proto Fleet data)"
 echo "  - systemd user unit files matching protofleet/proto-fleet/fleet*.service"
+echo "  - Proto Fleet host updater service, logs, and state"
 echo "  - Deployment directory: $DEPLOYMENT_PATH"
 echo ""
 
@@ -517,6 +553,7 @@ fi
 
 run_action "Tearing down Proto Fleet Docker stack (containers/images/volumes)..." teardown_docker_stack
 run_action "Removing Proto Fleet systemd units..." remove_systemd_units
+run_action "Removing Proto Fleet host updater..." remove_host_updater
 run_action "Removing Proto Fleet deployment files..." remove_deployment_files
 
 echo ""

--- a/deployment-files/uninstall.sh
+++ b/deployment-files/uninstall.sh
@@ -15,6 +15,17 @@ DRY_RUN=false
 HOST_UPDATER_PRESENT=false
 HOST_UPDATER_PRIVILEGE=()
 HOST_UPDATER_STAGING_NAME_RE='^\.proto-fleet-upgrade-[a-f0-9]{64}$'
+HOST_UPDATER_BINARY_PATHS=(
+  /usr/local/libexec/proto-fleet/proto-fleet-updater
+  /usr/local/libexec/proto-fleet-updater
+)
+HOST_UPDATER_SELF_UPDATE_SUFFIXES=(
+  .previous
+  .candidate
+  .handoff
+  .handoff.tmp
+  .restore
+)
 
 # =====================================================================
 # Output Helpers
@@ -460,6 +471,35 @@ remove_systemd_units() {
   print_success "Systemd user units cleaned up."
 }
 
+host_updater_binary_artifact_paths() {
+  local binary_path suffix
+  for binary_path in "${HOST_UPDATER_BINARY_PATHS[@]}"; do
+    printf '%s\n' "$binary_path"
+    for suffix in "${HOST_UPDATER_SELF_UPDATE_SUFFIXES[@]}"; do
+      printf '%s%s\n' "$binary_path" "$suffix"
+    done
+  done
+}
+
+host_updater_binary_artifacts_present() {
+  local path
+  while IFS= read -r path; do
+    [[ -e "$path" || -L "$path" ]] && return 0
+  done < <(host_updater_binary_artifact_paths)
+  return 1
+}
+
+remove_host_updater_binary_artifacts_with() {
+  local privilege=("$@")
+  local path
+  local artifacts=()
+  while IFS= read -r path; do
+    artifacts+=("$path")
+  done < <(host_updater_binary_artifact_paths)
+
+  ${privilege[@]+"${privilege[@]}"} rm -f -- "${artifacts[@]}"
+}
+
 host_updater_staging_artifacts_present() {
   local path name
   [[ -n "$INSTALL_ROOT" ]] || return 1
@@ -473,10 +513,9 @@ host_updater_staging_artifacts_present() {
 
 host_updater_artifacts_present() {
   local path load_state
+  host_updater_binary_artifacts_present && return 0
   for path in \
     /etc/systemd/system/proto-fleet-updater.service \
-    /usr/local/libexec/proto-fleet/proto-fleet-updater \
-    /usr/local/libexec/proto-fleet-updater \
     /etc/proto-fleet/updater.env \
     /var/lib/proto-fleet-updater \
     /run/proto-fleet-updater; do
@@ -567,10 +606,12 @@ remove_host_updater() {
   if (( ${#HOST_UPDATER_PRIVILEGE[@]} )); then
     privilege=("${HOST_UPDATER_PRIVILEGE[@]}")
   fi
-  if ! ${privilege[@]+"${privilege[@]}"} rm -f \
+  if ! remove_host_updater_binary_artifacts_with ${privilege[@]+"${privilege[@]}"}; then
+    print_error "Could not remove host updater binaries; deployment removal was aborted."
+    return 1
+  fi
+  if ! ${privilege[@]+"${privilege[@]}"} rm -f -- \
     /etc/systemd/system/proto-fleet-updater.service \
-    /usr/local/libexec/proto-fleet/proto-fleet-updater \
-    /usr/local/libexec/proto-fleet-updater \
     /etc/proto-fleet/updater.env; then
     print_error "Could not remove host updater files; deployment removal was aborted."
     return 1
@@ -609,10 +650,15 @@ remove_host_updater() {
   fi
 
   local path
+  while IFS= read -r path; do
+    if ${privilege[@]+"${privilege[@]}"} test -e "$path" \
+      || ${privilege[@]+"${privilege[@]}"} test -L "$path"; then
+      print_error "Host updater artifact remains after cleanup: $path"
+      return 1
+    fi
+  done < <(host_updater_binary_artifact_paths)
   for path in \
     /etc/systemd/system/proto-fleet-updater.service \
-    /usr/local/libexec/proto-fleet/proto-fleet-updater \
-    /usr/local/libexec/proto-fleet-updater \
     /etc/proto-fleet/updater.env \
     /var/lib/proto-fleet-updater \
     /run/proto-fleet-updater; do

--- a/deployment-files/uninstall.sh
+++ b/deployment-files/uninstall.sh
@@ -14,6 +14,10 @@ INSTALL_ROOT=""
 DRY_RUN=false
 HOST_UPDATER_PRESENT=false
 HOST_UPDATER_PRIVILEGE=()
+HOST_UPDATER_RESTORE_PENDING=false
+HOST_UPDATER_REMOVAL_STARTED=false
+HOST_UPDATER_ORIGINAL_ACTIVE=false
+HOST_UPDATER_ORIGINAL_UNIT_FILE_STATE=disabled
 HOST_UPDATER_STAGING_NAME_RE='^\.proto-fleet-upgrade-[a-f0-9]{64}$'
 HOST_UPDATER_ENV_PATH=/etc/proto-fleet/updater.env
 HOST_UPDATER_STATE_DIR=/var/lib/proto-fleet-updater
@@ -610,6 +614,24 @@ host_updater_artifacts_present() {
 verify_host_updater_process_lock_free_with() {
   local privilege=("$@")
 
+  if ! validate_host_updater_process_lock_prerequisites_with \
+      ${privilege[@]+"${privilege[@]}"}; then
+    return 1
+  fi
+  if ! ${privilege[@]+"${privilege[@]}"} test -e "$HOST_UPDATER_LOCK_PATH" \
+    && ! ${privilege[@]+"${privilege[@]}"} test -L "$HOST_UPDATER_LOCK_PATH"; then
+    return 0
+  fi
+  if ! ${privilege[@]+"${privilege[@]}"} flock -n \
+      "$HOST_UPDATER_LOCK_PATH" true; then
+    print_error "The host updater still holds its lifetime lock; no files were removed."
+    return 1
+  fi
+}
+
+validate_host_updater_process_lock_prerequisites_with() {
+  local privilege=("$@")
+
   if ! ${privilege[@]+"${privilege[@]}"} test -e "$HOST_UPDATER_LOCK_PATH" \
     && ! ${privilege[@]+"${privilege[@]}"} test -L "$HOST_UPDATER_LOCK_PATH"; then
     return 0
@@ -623,11 +645,42 @@ verify_host_updater_process_lock_free_with() {
     print_error "Cannot verify the updater lifetime lock because flock is unavailable; no files were removed."
     return 1
   fi
-  if ! ${privilege[@]+"${privilege[@]}"} flock -n \
-      "$HOST_UPDATER_LOCK_PATH" true; then
-    print_error "The host updater still holds its lifetime lock; no files were removed."
+}
+
+restore_host_updater_service_if_needed() {
+  [[ "$HOST_UPDATER_RESTORE_PENDING" == true ]] || return 0
+  [[ "$HOST_UPDATER_REMOVAL_STARTED" != true ]] || return 0
+
+  local status=0
+  case "$HOST_UPDATER_ORIGINAL_UNIT_FILE_STATE" in
+    enabled)
+      ${HOST_UPDATER_PRIVILEGE[@]+"${HOST_UPDATER_PRIVILEGE[@]}"} \
+        systemctl enable proto-fleet-updater.service || status=1
+      ;;
+    enabled-runtime)
+      ${HOST_UPDATER_PRIVILEGE[@]+"${HOST_UPDATER_PRIVILEGE[@]}"} \
+        systemctl enable --runtime proto-fleet-updater.service || status=1
+      ;;
+  esac
+  if [[ "$HOST_UPDATER_ORIGINAL_ACTIVE" == true ]]; then
+    ${HOST_UPDATER_PRIVILEGE[@]+"${HOST_UPDATER_PRIVILEGE[@]}"} \
+      systemctl start proto-fleet-updater.service || status=1
+  fi
+  if [[ "$status" -ne 0 ]]; then
+    print_error "Could not restore the host updater after uninstall aborted; manual systemd recovery may be required."
     return 1
   fi
+  HOST_UPDATER_RESTORE_PENDING=false
+}
+
+uninstall_exit_cleanup() {
+  local run_status=$?
+  local status="$run_status"
+  trap - EXIT HUP INT TERM
+  if ! restore_host_updater_service_if_needed; then
+    status=1
+  fi
+  exit "$status"
 }
 
 # Acquire all privilege and stop the updater before Docker or deployment
@@ -636,6 +689,10 @@ verify_host_updater_process_lock_free_with() {
 prepare_host_updater_removal() {
   HOST_UPDATER_PRESENT=false
   HOST_UPDATER_PRIVILEGE=()
+  HOST_UPDATER_RESTORE_PENDING=false
+  HOST_UPDATER_REMOVAL_STARTED=false
+  HOST_UPDATER_ORIGINAL_ACTIVE=false
+  HOST_UPDATER_ORIGINAL_UNIT_FILE_STATE=disabled
   local artifact_status
   if host_updater_artifacts_present; then
     :
@@ -665,9 +722,15 @@ prepare_host_updater_removal() {
       ${HOST_UPDATER_PRIVILEGE[@]+"${HOST_UPDATER_PRIVILEGE[@]}"}; then
     return 1
   fi
+  # Validate the lock path and flock availability before changing systemd.
+  # The lock cannot be required to be free until the updater has stopped.
+  if ! validate_host_updater_process_lock_prerequisites_with \
+      ${HOST_UPDATER_PRIVILEGE[@]+"${HOST_UPDATER_PRIVILEGE[@]}"}; then
+    return 1
+  fi
 
   if command -v systemctl &>/dev/null && [[ -d "$HOST_UPDATER_SYSTEMD_RUNTIME_DIR" ]]; then
-    local load_state active_state
+    local load_state active_state unit_file_state=disabled
     if ! load_state="$(${HOST_UPDATER_PRIVILEGE[@]+"${HOST_UPDATER_PRIVILEGE[@]}"} \
       systemctl show --property=LoadState --value proto-fleet-updater.service 2>/dev/null)"; then
       print_error "Could not inspect the host updater service; no Docker or deployment files were removed."
@@ -682,9 +745,26 @@ prepare_host_updater_removal() {
       print_error "Could not inspect the host updater process; no Docker or deployment files were removed."
       return 1
     fi
+    if [[ "$load_state" != "not-found" ]]; then
+      if ! unit_file_state="$(${HOST_UPDATER_PRIVILEGE[@]+"${HOST_UPDATER_PRIVILEGE[@]}"} \
+        systemctl show --property=UnitFileState --value proto-fleet-updater.service 2>/dev/null)"; then
+        print_error "Could not inspect whether the host updater is enabled; no Docker or deployment files were removed."
+        return 1
+      fi
+      case "$unit_file_state" in
+        enabled|enabled-runtime|disabled) ;;
+        *)
+          print_error "The host updater has an unsupported unit-file state '$unit_file_state'; no Docker or deployment files were removed."
+          return 1
+          ;;
+      esac
+    fi
+    HOST_UPDATER_ORIGINAL_UNIT_FILE_STATE="$unit_file_state"
     case "$active_state" in
       inactive|failed) ;;
       active|activating|reloading|deactivating)
+        HOST_UPDATER_ORIGINAL_ACTIVE=true
+        HOST_UPDATER_RESTORE_PENDING=true
         if ! ${HOST_UPDATER_PRIVILEGE[@]+"${HOST_UPDATER_PRIVILEGE[@]}"} \
           systemctl stop proto-fleet-updater.service; then
           print_error "Could not stop the host updater; no Docker or deployment files were removed."
@@ -696,6 +776,9 @@ prepare_host_updater_removal() {
         return 1
         ;;
     esac
+    if [[ "$unit_file_state" == "enabled" || "$unit_file_state" == "enabled-runtime" ]]; then
+      HOST_UPDATER_RESTORE_PENDING=true
+    fi
     if [[ "$load_state" != "not-found" ]] \
       && ! ${HOST_UPDATER_PRIVILEGE[@]+"${HOST_UPDATER_PRIVILEGE[@]}"} \
         systemctl disable proto-fleet-updater.service; then
@@ -731,6 +814,10 @@ remove_host_updater() {
   if (( ${#HOST_UPDATER_PRIVILEGE[@]} )); then
     privilege=("${HOST_UPDATER_PRIVILEGE[@]}")
   fi
+  # Past this point privileged artifacts may be partially removed, so
+  # restarting the old service is no longer safe or reliably possible.
+  HOST_UPDATER_REMOVAL_STARTED=true
+  HOST_UPDATER_RESTORE_PENDING=false
   if ! remove_host_updater_binary_artifacts_with ${privilege[@]+"${privilege[@]}"}; then
     print_error "Could not remove host updater binaries; deployment removal was aborted."
     return 1
@@ -874,6 +961,10 @@ if ! $DRY_RUN; then
     echo "Uninstall canceled."
     exit 0
   fi
+  trap uninstall_exit_cleanup EXIT
+  trap 'exit 129' HUP
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
   prepare_host_updater_removal || exit 1
 fi
 

--- a/deployment-files/uninstall.sh
+++ b/deployment-files/uninstall.sh
@@ -18,6 +18,9 @@ HOST_UPDATER_RESTORE_PENDING=false
 HOST_UPDATER_REMOVAL_STARTED=false
 HOST_UPDATER_ORIGINAL_ACTIVE=false
 HOST_UPDATER_ORIGINAL_UNIT_FILE_STATE=disabled
+USER_SYSTEMD_UID=""
+USER_SYSTEMD_NAME=""
+USER_SYSTEMD_HOME=""
 HOST_UPDATER_STAGING_NAME_RE='^\.proto-fleet-upgrade-[a-f0-9]{64}$'
 HOST_UPDATER_ENV_PATH=/etc/proto-fleet/updater.env
 HOST_UPDATER_STATE_DIR=/var/lib/proto-fleet-updater
@@ -452,32 +455,113 @@ teardown_docker_stack() {
   print_success "Containers, images, and volumes removed."
 }
 
+resolve_user_systemd_context() {
+  local current_uid target_uid target_name passwd_entry passwd_name passwd_uid target_home
+
+  current_uid=$(id -u) || return 1
+  target_uid="$current_uid"
+  target_name=$(id -un) || return 1
+  if [[ "$current_uid" -eq 0 && -n "${SUDO_USER:-}" && "$SUDO_USER" != root ]]; then
+    case "${SUDO_UID:-}" in
+      ""|*[!0-9]*|0)
+        print_error "Could not determine the invoking user's UID for systemd cleanup."
+        return 1
+        ;;
+    esac
+    target_uid="$SUDO_UID"
+    target_name="$SUDO_USER"
+    if [[ "$(id -u "$target_name" 2>/dev/null || true)" != "$target_uid" ]]; then
+      print_error "The invoking user's name and UID do not identify the same account."
+      return 1
+    fi
+  fi
+
+  if command -v getent &>/dev/null; then
+    passwd_entry=$(getent passwd "$target_uid" 2>/dev/null || true)
+  else
+    passwd_entry=""
+  fi
+  if [[ -n "$passwd_entry" ]]; then
+    IFS=: read -r passwd_name _ passwd_uid _ _ target_home _ <<< "$passwd_entry"
+    if [[ "$passwd_name" != "$target_name" || "$passwd_uid" != "$target_uid" ]]; then
+      print_error "Could not validate the invoking user's account for systemd cleanup."
+      return 1
+    fi
+  elif [[ "$target_uid" == "$current_uid" && -n "${HOME:-}" ]]; then
+    target_home="$HOME"
+  else
+    print_error "Could not resolve the invoking user's home for systemd cleanup."
+    return 1
+  fi
+  if [[ -z "$target_home" || "$target_home" == / || ! -d "$target_home" ]]; then
+    print_error "The invoking user's home is unavailable for systemd cleanup: $target_home"
+    return 1
+  fi
+  if [[ "$target_uid" != "$current_uid" ]] && ! command -v sudo &>/dev/null; then
+    print_error "sudo is required to clean up the invoking user's systemd units."
+    return 1
+  fi
+
+  USER_SYSTEMD_UID="$target_uid"
+  USER_SYSTEMD_NAME="$target_name"
+  USER_SYSTEMD_HOME="$target_home"
+}
+
+user_systemctl() {
+  if [[ "$USER_SYSTEMD_UID" == "$(id -u)" ]]; then
+    HOME="$USER_SYSTEMD_HOME" \
+      XDG_RUNTIME_DIR="/run/user/$USER_SYSTEMD_UID" \
+      systemctl --user "$@"
+    return
+  fi
+  sudo -n -u "$USER_SYSTEMD_NAME" env \
+    "HOME=$USER_SYSTEMD_HOME" \
+    "XDG_RUNTIME_DIR=/run/user/$USER_SYSTEMD_UID" \
+    systemctl --user "$@"
+}
+
 remove_systemd_units() {
   if ! command -v systemctl &>/dev/null; then
     print_success "systemctl not found, skipping systemd cleanup."
     return
   fi
+  if [[ -z "$USER_SYSTEMD_UID" ]] && ! resolve_user_systemd_context; then
+    return 1
+  fi
 
-  local units
-  units="$(systemctl --user list-unit-files --type=service --no-legend 2>/dev/null \
-    | awk '{print $1}' \
-    | grep -E '^(protofleet|proto-fleet|fleet).*\.service$' || true)"
+  local unit_files="" units="" systemd_cleanup_complete=true
+  if unit_files="$(user_systemctl list-unit-files \
+      --type=service --no-legend 2>/dev/null)"; then
+    units="$(printf '%s\n' "$unit_files" \
+      | awk '{print $1}' \
+      | grep -E '^(protofleet|proto-fleet|fleet).*\.service$' || true)"
+  else
+    systemd_cleanup_complete=false
+  fi
 
   if [[ -n "$units" ]]; then
     while IFS= read -r unit; do
       [[ -z "$unit" ]] && continue
-      systemctl --user disable --now "$unit" 2>/dev/null || true
+      user_systemctl disable --now "$unit" 2>/dev/null \
+        || systemd_cleanup_complete=false
     done <<< "$units"
   fi
 
-  systemctl --user daemon-reload 2>/dev/null || true
-  systemctl --user reset-failed 2>/dev/null || true
+  if ! rm -f \
+      "$USER_SYSTEMD_HOME/.config/systemd/user"/protofleet*.service \
+      "$USER_SYSTEMD_HOME/.config/systemd/user"/proto-fleet*.service \
+      "$USER_SYSTEMD_HOME/.config/systemd/user"/fleet*.service 2>/dev/null; then
+    print_error "Could not remove systemd units from $USER_SYSTEMD_HOME."
+    return 1
+  fi
+  user_systemctl daemon-reload 2>/dev/null || systemd_cleanup_complete=false
+  user_systemctl reset-failed 2>/dev/null || systemd_cleanup_complete=false
 
-  rm -f ~/.config/systemd/user/protofleet*.service \
-        ~/.config/systemd/user/proto-fleet*.service \
-        ~/.config/systemd/user/fleet*.service 2>/dev/null || true
-
-  print_success "Systemd user units cleaned up."
+  if $systemd_cleanup_complete; then
+    print_success "Systemd user units cleaned up for $USER_SYSTEMD_NAME."
+  else
+    print_warn "Unit files were removed, but $USER_SYSTEMD_NAME's systemd manager could not be fully reconciled."
+  fi
 }
 
 host_updater_binary_artifact_paths() {
@@ -957,6 +1041,9 @@ if ! $DRY_RUN; then
   trap 'exit 129' HUP
   trap 'exit 130' INT
   trap 'exit 143' TERM
+  if command -v systemctl &>/dev/null; then
+    resolve_user_systemd_context || exit 1
+  fi
   prepare_host_updater_removal || exit 1
 fi
 

--- a/deployment-files/uninstall.sh
+++ b/deployment-files/uninstall.sh
@@ -707,10 +707,7 @@ prepare_host_updater_removal() {
   HOST_UPDATER_PRESENT=true
 
   if [[ "$(id -u)" -ne 0 ]]; then
-    # Removing the updater with sudo but continuing Docker and deployment
-    # cleanup as the invoking user can strand a root-managed installation
-    # without its updater. Require one privilege boundary for the complete
-    # destructive workflow instead of elevating only its first step.
+    # Use one privilege boundary for the complete destructive workflow.
     print_error "The host updater is installed; re-run the complete uninstaller as root (flags preserved):"
     echo ""
     echo "    curl -fsSL https://fleet.proto.xyz/uninstall.sh | sudo bash -s --$(quoted_rerun_argv)"
@@ -878,10 +875,7 @@ remove_host_updater() {
     fi
   done
 
-  # Keep the configured install root as durable ownership proof until every
-  # other privileged artifact has been removed and verified. If an earlier
-  # cleanup step fails, a retry can still prove that this updater belongs to
-  # the selected deployment rather than becoming stranded on missing metadata.
+  # Keep ownership proof until all other privileged cleanup succeeds.
   if ! ${privilege[@]+"${privilege[@]}"} rm -f -- "$HOST_UPDATER_ENV_PATH"; then
     print_error "Could not remove the host updater ownership configuration; deployment removal was aborted."
     return 1
@@ -905,9 +899,7 @@ remove_deployment_files() {
     print_warn "Deployment directory not found: $DEPLOYMENT_PATH"
   fi
 
-  # A successful one-click upgrade keeps one exact previous deployment next
-  # to the active one for operator recovery. It has the same trusted install
-  # root as DEPLOYMENT_PATH and is never expanded from a glob.
+  # Remove the updater's one exact recovery deployment without a glob.
   local previous_deployment="${INSTALL_ROOT%/}/deployment.previous"
   if [[ -d "$previous_deployment" ]]; then
     rm -rf "$previous_deployment"

--- a/deployment-files/uninstall.sh
+++ b/deployment-files/uninstall.sh
@@ -687,9 +687,8 @@ remove_host_updater() {
     return 1
   fi
   if ! ${privilege[@]+"${privilege[@]}"} rm -f -- \
-    /etc/systemd/system/proto-fleet-updater.service \
-    "$HOST_UPDATER_ENV_PATH"; then
-    print_error "Could not remove host updater files; deployment removal was aborted."
+    /etc/systemd/system/proto-fleet-updater.service; then
+    print_error "Could not remove the host updater unit; deployment removal was aborted."
     return 1
   fi
   if ! ${privilege[@]+"${privilege[@]}"} rm -rf \
@@ -717,7 +716,6 @@ remove_host_updater() {
   fi
 
   ${privilege[@]+"${privilege[@]}"} rmdir /usr/local/libexec/proto-fleet 2>/dev/null || true
-  ${privilege[@]+"${privilege[@]}"} rmdir /etc/proto-fleet 2>/dev/null || true
   if command -v systemctl &>/dev/null && [[ -d /run/systemd/system ]]; then
     if ! ${privilege[@]+"${privilege[@]}"} systemctl daemon-reload; then
       print_error "Could not finalize host updater removal; deployment removal was aborted."
@@ -735,7 +733,6 @@ remove_host_updater() {
   done < <(host_updater_binary_artifact_paths)
   for path in \
     /etc/systemd/system/proto-fleet-updater.service \
-    "$HOST_UPDATER_ENV_PATH" \
     /var/lib/proto-fleet-updater \
     /run/proto-fleet-updater; do
     if ${privilege[@]+"${privilege[@]}"} test -e "$path" \
@@ -744,6 +741,21 @@ remove_host_updater() {
       return 1
     fi
   done
+
+  # Keep the configured install root as durable ownership proof until every
+  # other privileged artifact has been removed and verified. If an earlier
+  # cleanup step fails, a retry can still prove that this updater belongs to
+  # the selected deployment rather than becoming stranded on missing metadata.
+  if ! ${privilege[@]+"${privilege[@]}"} rm -f -- "$HOST_UPDATER_ENV_PATH"; then
+    print_error "Could not remove the host updater ownership configuration; deployment removal was aborted."
+    return 1
+  fi
+  if ${privilege[@]+"${privilege[@]}"} test -e "$HOST_UPDATER_ENV_PATH" \
+    || ${privilege[@]+"${privilege[@]}"} test -L "$HOST_UPDATER_ENV_PATH"; then
+    print_error "Host updater ownership configuration remains after cleanup: $HOST_UPDATER_ENV_PATH"
+    return 1
+  fi
+  ${privilege[@]+"${privilege[@]}"} rmdir /etc/proto-fleet 2>/dev/null || true
   print_success "Host updater service and state removed."
 }
 

--- a/deployment-files/updater/proto-fleet-updater.service
+++ b/deployment-files/updater/proto-fleet-updater.service
@@ -9,10 +9,8 @@ Wants=docker.service network-online.target
 [Service]
 Type=simple
 EnvironmentFile=/etc/proto-fleet/updater.env
-# One-click upgrades support only the rootful local Docker socket. Pin it
-# explicitly so root's persisted Docker currentContext cannot redirect a later
-# upgrade, while retaining normal root Docker config for registry credentials
-# and proxy settings.
+# Pin the supported rootful local daemon without discarding root's registry and
+# proxy configuration.
 Environment=DOCKER_HOST=unix:///var/run/docker.sock
 UnsetEnvironment=DOCKER_CONTEXT DOCKER_CONFIG DOCKER_TLS DOCKER_TLS_VERIFY DOCKER_CERT_PATH
 ExecStart=/usr/local/libexec/proto-fleet/proto-fleet-updater

--- a/deployment-files/updater/proto-fleet-updater.service
+++ b/deployment-files/updater/proto-fleet-updater.service
@@ -9,10 +9,12 @@ Wants=docker.service network-online.target
 [Service]
 Type=simple
 EnvironmentFile=/etc/proto-fleet/updater.env
-# One-click upgrades support the root service's default Docker daemon only.
-# Ignore selector variables inherited through the system manager so runtime
-# behavior always matches the installer's sanitized daemon-identity probe.
-UnsetEnvironment=DOCKER_HOST DOCKER_CONTEXT DOCKER_CONFIG DOCKER_TLS DOCKER_TLS_VERIFY DOCKER_CERT_PATH
+# One-click upgrades support only the rootful local Docker socket. Pin it
+# explicitly so root's persisted Docker currentContext cannot redirect a later
+# upgrade, while retaining normal root Docker config for registry credentials
+# and proxy settings.
+Environment=DOCKER_HOST=unix:///var/run/docker.sock
+UnsetEnvironment=DOCKER_CONTEXT DOCKER_CONFIG DOCKER_TLS DOCKER_TLS_VERIFY DOCKER_CERT_PATH
 ExecStart=/usr/local/libexec/proto-fleet/proto-fleet-updater
 Restart=on-failure
 RestartSec=5s

--- a/deployment-files/updater/proto-fleet-updater.service
+++ b/deployment-files/updater/proto-fleet-updater.service
@@ -9,6 +9,10 @@ Wants=docker.service network-online.target
 [Service]
 Type=simple
 EnvironmentFile=/etc/proto-fleet/updater.env
+# One-click upgrades support the root service's default Docker daemon only.
+# Ignore selector variables inherited through the system manager so runtime
+# behavior always matches the installer's sanitized daemon-identity probe.
+UnsetEnvironment=DOCKER_HOST DOCKER_CONTEXT DOCKER_CONFIG DOCKER_TLS DOCKER_TLS_VERIFY DOCKER_CERT_PATH
 ExecStart=/usr/local/libexec/proto-fleet/proto-fleet-updater
 Restart=on-failure
 RestartSec=5s

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -115,9 +115,7 @@ func (execRunner) Run(ctx context.Context, dir string, output io.Writer, name st
 		os.Environ(),
 		"CI=1",
 		"TERM=dumb",
-		// run-fleet uses this marker to distinguish updater-owned preflight and
-		// activation children from a human invoking the mutable deployment
-		// runner directly. It is a coordination signal, not an auth boundary.
+		// Coordination marker for updater-owned run-fleet children; not auth.
 		"PROTO_FLEET_UPDATER_MANAGED_RUN=1",
 	)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -111,7 +111,15 @@ func (execRunner) Run(ctx context.Context, dir string, output io.Writer, name st
 	cmd.Dir = dir
 	cmd.Stdout = output
 	cmd.Stderr = output
-	cmd.Env = append(os.Environ(), "CI=1", "TERM=dumb")
+	cmd.Env = append(
+		os.Environ(),
+		"CI=1",
+		"TERM=dumb",
+		// run-fleet uses this marker to distinguish updater-owned preflight and
+		// activation children from a human invoking the mutable deployment
+		// runner directly. It is a coordination signal, not an auth boundary.
+		"PROTO_FLEET_UPDATER_MANAGED_RUN=1",
+	)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.Cancel = func() error {
 		if cmd.Process == nil {

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -2595,6 +2595,22 @@ func TestExecRunnerCancellationKillsBackgroundDescendants(t *testing.T) {
 	assert.NoFileExists(t, delayedMarker, "background descendant survived command cancellation")
 }
 
+func TestExecRunnerMarksCommandsAsUpdaterManaged(t *testing.T) {
+	t.Parallel()
+
+	var output bytes.Buffer
+	err := (execRunner{}).Run(
+		context.Background(),
+		t.TempDir(),
+		&output,
+		"/bin/sh",
+		"-c",
+		`printf '%s' "$PROTO_FLEET_UPDATER_MANAGED_RUN"`,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "1", output.String())
+}
+
 func newTestManager(t *testing.T, installRoot string, server *httptest.Server, runner CommandRunner) *Manager {
 	t.Helper()
 	return newTestManagerWithConfig(t, installRoot, server, runner, nil)


### PR DESCRIPTION
Reviewable diff: +907/-32 across 6 files (excludes generated, test, and story files).

## Summary

Bootstraps the packaged host updater on supported Linux/systemd installations with rootful Docker, then exposes only its secured Unix socket to Fleet. Unsupported hosts and any bootstrap path that cannot reach a verified safe state explicitly retain the existing copy-command experience.

*Stack:* [#841](https://github.com/block/proto-fleet/pull/841) → [#842](https://github.com/block/proto-fleet/pull/842) → [#843](https://github.com/block/proto-fleet/pull/843) → [#844](https://github.com/block/proto-fleet/pull/844) → [#845](https://github.com/block/proto-fleet/pull/845) → [#835](https://github.com/block/proto-fleet/pull/835) → [#836](https://github.com/block/proto-fleet/pull/836) → [#837](https://github.com/block/proto-fleet/pull/837) → [#838](https://github.com/block/proto-fleet/pull/838) → **#839** → [#840](https://github.com/block/proto-fleet/pull/840). This is **5/6** of the one-click phase. All ancestors are merged, so this diff is directly against `main`; those PRs provide release discovery, capability reporting, the privileged updater, and the server trigger path. This PR installs and connects that updater, while #840 adds the operator-facing one-click action. Manual upgrades remain available throughout.

## How it works

The installer validates the requested release name, downloads the bundle and matching SHA-256 sidecar into a private temporary directory, checks the exact filename and digest, and captures any legacy optional-overlay choices before replacing the deployment. On a compatible host it installs the updater binary, root-only environment, and systemd unit; verifies root and the installer use the same Docker daemon; and waits up to 60 seconds for an authenticated request over the Unix socket to succeed. Only then does `run-fleet.sh` persist `ENABLE_ONE_CLICK_UPDATES=true` and layer the socket-only Compose overlay. Every unsupported or safely recoverable failure persists `false`; cleanup uncertainty aborts the install. Uninstall stops and verifies the service before touching Docker, then removes exact updater files, state, runtime sockets, and hash-named staging directories.

```mermaid
flowchart LR
  I["Installer"] --> D["Private bundle download"]
  D --> V["Validate version, sidecar name, and SHA-256"]
  V --> H{"Compatible systemd and rootful Docker host?"}
  H -->|"yes"| S["Install service and verify Unix-socket readiness"]
  S --> O["Persist enabled state and layer updater socket"]
  H -->|"no or safe fallback"| M["Persist disabled state and keep copy command"]
  O --> F["Start Fleet"]
  M --> F
```

```mermaid
sequenceDiagram
  participant I as Installer
  participant G as GitHub Releases
  participant U as Host updater service
  participant R as run-fleet
  participant F as fleet-api
  I->>G: Download bundle and checksum sidecar
  I->>I: Verify exact asset digest and migrate legacy flags
  I->>U: Install, enable, restart
  I->>U: Poll status over secured Unix socket
  alt updater is ready
    I->>R: Enable one-click overlay
    R->>F: Start with read-only socket mount
  else unsupported or safely disabled
    I->>R: Disable one-click overlay
    R->>F: Start with manual fallback only
  end
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
|---|---|---|
| `deployment-files/install.sh` | Release validation, private checksum download, legacy option capture, daemon compatibility, service bootstrap/readiness, and fail-closed fallback | Highest-risk host mutation and capability boundary |
| `deployment-files/run-fleet.sh` | Persists the one-click setting and conditionally layers the updater socket overlay | Prevents the UI capability from diverging from the active Compose model |
| `deployment-files/uninstall.sh` | Serializes service shutdown ahead of teardown and removes exact updater/staging artifacts | Review destructive scope, privilege use, and failure ordering |
| `deployment-files/README.md`, `README.md` | Supported-host contract, exact-version install flow, trust boundary, logs, and recovery | Defines operator expectations and fallback behavior |
| `.github/workflows/deployment-config-checks.yml` | Adds individual shell syntax validation | Catches installer/uninstaller syntax outside sourced test helpers |
| Focused deployment tests | Covers migration ambiguity, CLI enable/disable persistence, overlay rendering, activation handoff, and cleanup verification | Tests — review alongside the lifecycle paths |

## Key technical decisions & trade-offs

- One-click is enabled only when root and the installer see the same Docker daemon, avoiding an unsafe rootless-Docker privilege bridge.
- Service readiness requires both a successful socket status request and an active unit before Fleet receives the socket mount.
- Failures before readiness must produce a verified inactive/disabled service; once readiness succeeds, the service stays available if later deployment work fails so persisted enabled state never points at a dead socket.
- The SHA-256 sidecar detects corruption and binds the installer to the named release asset; it is not independent publisher authentication. GitHub Releases remains the publisher trust anchor, and detached signing is outside this PR.
- Uninstall removes only fixed paths and the updater's exact lowercase 64-hex staging-name contract; alternate/multi-instance ownership remains outside the supported single-install model.

## Testing & validation

- Individual `bash -n` validation for installer, runner, uninstaller, and deployment test scripts.
- `./deployment-files/tests/test-install-overlay-migration.sh`
- `./deployment-files/tests/test-profiles.sh`
- `./deployment-files/ha/tests/test-profile.sh`
- `./deployment-files/tests/test-run-fleet-upgrade.sh`
- `git diff --check origin/main..HEAD`
- Pre-commit and pre-push hooks passed.
- A real systemd/rootful-Docker clean-install and upgrade matrix was not run locally; that remains explicit release-host validation.
