### PR TITLE
feat(updates): add one-click upgrade experience

### DIFF
--- a/client/src/protoFleet/features/settings/components/Updates.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Updates.test.tsx
@@ -393,15 +393,12 @@ describe("Updates", () => {
   });
 
   it("refreshes the eligible release after reconciliation finds no operation", async () => {
+    const refreshedStatus = createDeferred<GetUpdateStatusResponse>();
     upgradeHookMock.current.reconciling = true;
     upgradeHookMock.current.triggerError = "Fleet did not confirm the request";
-    mockGetUpdateStatus.mockResolvedValueOnce(buildStatus({ oneClickAvailable: true })).mockResolvedValueOnce(
-      buildStatus({
-        installCommand: "install v1.4.0",
-        latestEligible: buildReleaseInfo({ version: "v1.4.0" }),
-        oneClickAvailable: true,
-      }),
-    );
+    mockGetUpdateStatus
+      .mockResolvedValueOnce(buildStatus({ oneClickAvailable: true }))
+      .mockReturnValueOnce(refreshedStatus.promise);
 
     const page = render(<Updates />);
     expect(await page.findByText("v1.3.0")).toBeInTheDocument();
@@ -410,7 +407,45 @@ describe("Updates", () => {
     page.rerender(<Updates />);
 
     await waitFor(() => expect(mockGetUpdateStatus).toHaveBeenCalledTimes(2));
+    expect(page.queryByRole("button", { name: "Confirm upgrade to v1.3.0" })).not.toBeInTheDocument();
+
+    await act(async () => {
+      refreshedStatus.resolve(
+        buildStatus({
+          installCommand: "install v1.4.0",
+          latestEligible: buildReleaseInfo({ version: "v1.4.0" }),
+          oneClickAvailable: true,
+        }),
+      );
+      await refreshedStatus.promise;
+    });
+
     expect(await page.findByText("v1.4.0")).toBeInTheDocument();
+    expect(page.getByRole("button", { name: "Confirm upgrade to v1.4.0" })).toBeEnabled();
+  });
+
+  it("keeps a stale modal target disabled after its authoritative refresh fails", async () => {
+    const failedRefresh = createDeferred<GetUpdateStatusResponse>();
+    upgradeHookMock.current.reconciling = true;
+    upgradeHookMock.current.triggerError = "Fleet did not confirm the request";
+    mockGetUpdateStatus
+      .mockResolvedValueOnce(buildStatus({ oneClickAvailable: true }))
+      .mockReturnValueOnce(failedRefresh.promise);
+
+    const page = render(<Updates />);
+    expect(await page.findByText("v1.3.0")).toBeInTheDocument();
+
+    upgradeHookMock.current = { ...upgradeHookMock.current, reconciling: false };
+    page.rerender(<Updates />);
+    await waitFor(() => expect(mockGetUpdateStatus).toHaveBeenCalledTimes(2));
+
+    await act(async () => {
+      failedRefresh.reject(new Error("release status unavailable"));
+      await failedRefresh.promise.catch(() => undefined);
+    });
+
+    expect(page.getByRole("alert")).toHaveTextContent("Fleet did not confirm the request");
+    expect(page.queryByRole("button", { name: /Confirm upgrade/ })).not.toBeInTheDocument();
   });
 
   it("omits the release notes link when the server provides no URL", async () => {

--- a/client/src/protoFleet/features/settings/components/Updates.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Updates.test.tsx
@@ -39,6 +39,7 @@ interface UpgradeHookMockState {
   connectionLost: boolean;
   manualFallbackReady: boolean;
   operation?: UpgradeOperation;
+  operationStatusPending: boolean;
   reconciling: boolean;
   reloadFleet: ReturnType<typeof vi.fn>;
   triggerError: string | null;
@@ -172,6 +173,7 @@ beforeEach(() => {
     connectionLost: false,
     manualFallbackReady: false,
     operation: undefined,
+    operationStatusPending: false,
     reconciling: false,
     reloadFleet: vi.fn(),
     triggerError: null,
@@ -302,6 +304,17 @@ describe("Updates", () => {
     expect(detailsButton).toBeEnabled();
     fireEvent.click(detailsButton);
     expect(page.getByTestId("upgrade-operation-modal")).toBeInTheDocument();
+  });
+
+  it("locks competing controls until the initial operation status resolves", async () => {
+    upgradeHookMock.current.operationStatusPending = true;
+    mockGetUpdateStatus.mockResolvedValue(buildStatus({ oneClickAvailable: true }));
+
+    const page = render(<Updates />);
+
+    expect(await page.findByRole("button", { name: "Upgrade to v1.3.0" })).toBeDisabled();
+    expect(page.getByRole("button", { name: "Copy install command" })).toBeDisabled();
+    expect(page.getByRole("checkbox", { name: RC_CHECKBOX_NAME })).toBeDisabled();
   });
 
   it("locks competing controls whenever a persisted operation remains unresolved", async () => {

--- a/client/src/protoFleet/features/settings/components/Updates.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Updates.test.tsx
@@ -296,6 +296,12 @@ describe("Updates", () => {
     expect(await page.findByText(/checking upgrade status/i)).toBeInTheDocument();
     expect(page.getByRole("button", { name: "Copy install command" })).toBeDisabled();
     expect(page.getByRole("checkbox", { name: RC_CHECKBOX_NAME })).toBeDisabled();
+
+    fireEvent.click(page.getByRole("button", { name: "Close dialog" }));
+    const detailsButton = page.getByRole("button", { name: "View upgrade details" });
+    expect(detailsButton).toBeEnabled();
+    fireEvent.click(detailsButton);
+    expect(page.getByTestId("upgrade-operation-modal")).toBeInTheDocument();
   });
 
   it("locks competing controls whenever a persisted operation remains unresolved", async () => {
@@ -431,6 +437,11 @@ describe("Updates", () => {
 
     expect(await findByText("Unable to load update status")).toBeInTheDocument();
     expect(getByText("release registry unreachable")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(mockUseUpgradeOperation).toHaveBeenLastCalledWith(
+        expect.objectContaining({ currentVersionUnavailable: true }),
+      ),
+    );
   });
 
   it("saves a channel change and toasts success", async () => {

--- a/client/src/protoFleet/features/settings/components/Updates.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Updates.test.tsx
@@ -28,6 +28,7 @@ const permissionsMock = vi.hoisted(() => ({
   current: ["instance:update", "fleet:read"],
   isAuthenticated: true,
   sessionExpiry: new Date(1_000),
+  sessionGeneration: 1,
   setPermissions: vi.fn<(permissions: string[]) => void>(),
   username: "operator-a",
 }));
@@ -66,6 +67,7 @@ vi.mock("@/protoFleet/store", () => {
     useHasPermission: vi.fn((permission: string) => permissionsMock.current.includes(permission)),
     usePermissions: () => permissionsMock.current,
     useSessionExpiry: () => permissionsMock.sessionExpiry,
+    useSessionGeneration: () => permissionsMock.sessionGeneration,
     useSetPermissions: () => permissionsMock.setPermissions,
     useUsername: () => permissionsMock.username,
     useAuthErrors: () => authErrorsMock,
@@ -185,6 +187,7 @@ beforeEach(() => {
   permissionsMock.current = ["instance:update", "fleet:read"];
   permissionsMock.isAuthenticated = true;
   permissionsMock.sessionExpiry = new Date(1_000);
+  permissionsMock.sessionGeneration = 1;
   permissionsMock.username = "operator-a";
   permissionsMock.setPermissions.mockImplementation((permissions) => {
     permissionsMock.current = permissions;

--- a/client/src/protoFleet/features/settings/components/Updates.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Updates.test.tsx
@@ -77,6 +77,8 @@ vi.mock("@/protoFleet/store", () => {
           isAuthenticated: permissionsMock.isAuthenticated,
           permissions: permissionsMock.current,
           sessionExpiry: permissionsMock.sessionExpiry,
+          sessionGeneration: permissionsMock.sessionGeneration,
+          username: permissionsMock.username,
         },
       }),
     },
@@ -702,6 +704,36 @@ describe("Updates", () => {
     expect(authErrorsMock.handleAuthErrors).not.toHaveBeenCalled();
     expect(permissionsMock.setPermissions).not.toHaveBeenCalled();
     expect(mockPushToast).not.toHaveBeenCalled();
+  });
+
+  it("restarts a pending status refresh when the authenticated session changes in place", async () => {
+    const previousRequest = createDeferred<GetUpdateStatusResponse>();
+    const replacementRequest = createDeferred<GetUpdateStatusResponse>();
+    mockGetUpdateStatus.mockReturnValueOnce(previousRequest.promise).mockReturnValueOnce(replacementRequest.promise);
+
+    const page = render(<Updates />);
+    await waitFor(() => expect(mockGetUpdateStatus).toHaveBeenCalledTimes(1));
+
+    permissionsMock.sessionExpiry = new Date(2_000);
+    permissionsMock.sessionGeneration = 2;
+    page.rerender(<Updates />);
+
+    await waitFor(() => expect(mockGetUpdateStatus).toHaveBeenCalledTimes(2));
+
+    await act(async () => {
+      replacementRequest.resolve(buildStatus());
+      await replacementRequest.promise;
+    });
+
+    expect(await page.findByText("v1.3.0")).toBeInTheDocument();
+    expect(page.getByRole("button", { name: "Copy install command" })).toBeEnabled();
+
+    await act(async () => {
+      previousRequest.reject(new ConnectError("old session expired", Code.Unauthenticated));
+      await previousRequest.promise.catch(() => undefined);
+    });
+
+    expect(authErrorsMock.handleAuthErrors).not.toHaveBeenCalled();
   });
 
   it("disables channel and copy controls throughout the save and refetch", async () => {

--- a/client/src/protoFleet/features/settings/components/Updates.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Updates.test.tsx
@@ -29,6 +29,7 @@ const permissionsMock = vi.hoisted(() => ({
   isAuthenticated: true,
   sessionExpiry: new Date(1_000),
   setPermissions: vi.fn<(permissions: string[]) => void>(),
+  username: "operator-a",
 }));
 const authErrorsMock = vi.hoisted(() => ({
   handleAuthErrors: vi.fn(),
@@ -63,7 +64,9 @@ vi.mock("@/protoFleet/store", () => {
   return {
     useHasPermission: vi.fn((permission: string) => permissionsMock.current.includes(permission)),
     usePermissions: () => permissionsMock.current,
+    useSessionExpiry: () => permissionsMock.sessionExpiry,
     useSetPermissions: () => permissionsMock.setPermissions,
+    useUsername: () => permissionsMock.username,
     useAuthErrors: () => authErrorsMock,
     useFleetStore: {
       getState: () => ({
@@ -84,11 +87,13 @@ vi.mock("@/protoFleet/api/clients", () => ({
   },
 }));
 
-vi.mock("@/protoFleet/features/updates/api/useUpgradeOperation", () => ({
-  isUpgradeActive: (operation?: { phase: number }) =>
-    Boolean(operation && operation.phase !== 0 && operation.phase !== 7 && operation.phase !== 8),
-  useUpgradeOperation: vi.fn(() => upgradeHookMock.current),
-}));
+vi.mock("@/protoFleet/features/updates/api/useUpgradeOperation", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/protoFleet/features/updates/api/useUpgradeOperation")>();
+  return {
+    ...actual,
+    useUpgradeOperation: vi.fn(() => upgradeHookMock.current),
+  };
+});
 
 vi.mock("@/shared/utils/utility", () => ({
   copyToClipboard: vi.fn(),
@@ -178,6 +183,7 @@ beforeEach(() => {
   permissionsMock.current = ["instance:update", "fleet:read"];
   permissionsMock.isAuthenticated = true;
   permissionsMock.sessionExpiry = new Date(1_000);
+  permissionsMock.username = "operator-a";
   permissionsMock.setPermissions.mockImplementation((permissions) => {
     permissionsMock.current = permissions;
   });
@@ -287,7 +293,18 @@ describe("Updates", () => {
 
     const page = render(<Updates />);
 
-    expect(await page.findByText(/checking whether the upgrade started/i)).toBeInTheDocument();
+    expect(await page.findByText(/checking upgrade status/i)).toBeInTheDocument();
+    expect(page.getByRole("button", { name: "Copy install command" })).toBeDisabled();
+    expect(page.getByRole("checkbox", { name: RC_CHECKBOX_NAME })).toBeDisabled();
+  });
+
+  it("locks competing controls whenever a persisted operation remains unresolved", async () => {
+    upgradeHookMock.current.trackedTargetVersion = "v1.3.0";
+    mockGetUpdateStatus.mockResolvedValue(buildStatus({ oneClickAvailable: true }));
+
+    const page = render(<Updates />);
+
+    expect(await page.findByRole("button", { name: "Upgrade to v1.3.0" })).toBeDisabled();
     expect(page.getByRole("button", { name: "Copy install command" })).toBeDisabled();
     expect(page.getByRole("checkbox", { name: RC_CHECKBOX_NAME })).toBeDisabled();
   });

--- a/client/src/protoFleet/features/settings/components/Updates.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Updates.test.tsx
@@ -309,6 +309,47 @@ describe("Updates", () => {
     expect(page.getByTestId("upgrade-operation-modal")).toBeInTheDocument();
   });
 
+  it("keeps install controls locked while fallback refreshes the authoritative offer", async () => {
+    const refreshedStatus = createDeferred<GetUpdateStatusResponse>();
+    upgradeHookMock.current.reconciling = true;
+    upgradeHookMock.current.manualFallbackReady = true;
+    upgradeHookMock.current.triggerError = "Fleet did not confirm the request";
+    mockGetUpdateStatus.mockResolvedValueOnce(buildStatus({ oneClickAvailable: true }));
+    mockGetUpdateStatus.mockReturnValueOnce(refreshedStatus.promise);
+
+    const page = render(<Updates />);
+    expect(await page.findByText("v1.3.0")).toBeInTheDocument();
+    fireEvent.click(page.getByRole("button", { name: "I confirmed — unlock manual install" }));
+    expect(upgradeHookMock.current.useManualFallback).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(mockGetUpdateStatus).toHaveBeenCalledTimes(2));
+
+    upgradeHookMock.current = {
+      ...upgradeHookMock.current,
+      manualFallbackReady: false,
+      reconciling: false,
+      triggerError: null,
+    };
+    page.rerender(<Updates />);
+
+    expect(page.getByRole("button", { name: "Copy install command" })).toBeDisabled();
+    expect(page.getByRole("checkbox", { name: RC_CHECKBOX_NAME })).toBeDisabled();
+
+    await act(async () => {
+      refreshedStatus.resolve(
+        buildStatus({
+          installCommand: "install v1.4.0",
+          latestEligible: buildReleaseInfo({ version: "v1.4.0" }),
+          oneClickAvailable: true,
+        }),
+      );
+      await refreshedStatus.promise;
+    });
+
+    expect(await page.findByText("v1.4.0")).toBeInTheDocument();
+    expect(page.getByRole("button", { name: "Copy install command" })).toBeEnabled();
+    expect(page.getByRole("checkbox", { name: RC_CHECKBOX_NAME })).toBeEnabled();
+  });
+
   it("locks competing controls until the initial operation status resolves", async () => {
     upgradeHookMock.current.operationStatusPending = true;
     mockGetUpdateStatus.mockResolvedValue(buildStatus({ oneClickAvailable: true }));

--- a/client/src/protoFleet/features/settings/components/Updates.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Updates.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { create } from "@bufbuild/protobuf";
 import { Code, ConnectError } from "@connectrpc/connect";
@@ -9,13 +9,17 @@ import type {
   GetUpdateStatusResponse,
   ReleaseInfo,
   SetReleaseChannelResponse,
+  UpgradeOperation,
 } from "@/protoFleet/api/generated/instance/v1/updates_pb";
 import {
   GetUpdateStatusResponseSchema,
   ReleaseChannel,
   ReleaseInfoSchema,
   SetReleaseChannelResponseSchema,
+  UpgradeOperationSchema,
+  UpgradePhase,
 } from "@/protoFleet/api/generated/instance/v1/updates_pb";
+import { useUpgradeOperation } from "@/protoFleet/features/updates/api/useUpgradeOperation";
 import { useHasPermission } from "@/protoFleet/store";
 import { pushToast } from "@/shared/features/toaster";
 import { copyToClipboard } from "@/shared/utils/utility";
@@ -28,6 +32,22 @@ const permissionsMock = vi.hoisted(() => ({
 }));
 const authErrorsMock = vi.hoisted(() => ({
   handleAuthErrors: vi.fn(),
+}));
+interface UpgradeHookMockState {
+  acknowledgeOperation: ReturnType<typeof vi.fn>;
+  connectionLost: boolean;
+  manualFallbackReady: boolean;
+  operation?: UpgradeOperation;
+  reconciling: boolean;
+  reloadFleet: ReturnType<typeof vi.fn>;
+  triggerError: string | null;
+  triggering: boolean;
+  trackedTargetVersion?: string;
+  triggerUpgrade: ReturnType<typeof vi.fn>;
+  useManualFallback: ReturnType<typeof vi.fn>;
+}
+const upgradeHookMock = vi.hoisted(() => ({
+  current: {} as UpgradeHookMockState,
 }));
 
 vi.mock("react-router-dom", () => ({
@@ -62,6 +82,12 @@ vi.mock("@/protoFleet/api/clients", () => ({
     getUpdateStatus: vi.fn(),
     setReleaseChannel: vi.fn(),
   },
+}));
+
+vi.mock("@/protoFleet/features/updates/api/useUpgradeOperation", () => ({
+  isUpgradeActive: (operation?: { phase: number }) =>
+    Boolean(operation && operation.phase !== 0 && operation.phase !== 7 && operation.phase !== 8),
+  useUpgradeOperation: vi.fn(() => upgradeHookMock.current),
 }));
 
 vi.mock("@/shared/utils/utility", () => ({
@@ -102,7 +128,17 @@ const buildStatus = (overrides?: MessageOverrides<GetUpdateStatusResponse>): Get
     ...overrides,
   });
 
+const buildOperation = (phase: UpgradePhase, overrides?: MessageOverrides<UpgradeOperation>): UpgradeOperation =>
+  create(UpgradeOperationSchema, {
+    id: "operation-1",
+    targetVersion: "v1.3.0",
+    phase,
+    message: "Preparing upgrade",
+    ...overrides,
+  });
+
 const mockUseHasPermission = vi.mocked(useHasPermission);
+const mockUseUpgradeOperation = vi.mocked(useUpgradeOperation);
 const mockGetUpdateStatus = vi.mocked(instanceUpdateClient.getUpdateStatus);
 const mockSetReleaseChannel = vi.mocked(instanceUpdateClient.setReleaseChannel);
 const mockCopyToClipboard = vi.mocked(copyToClipboard);
@@ -125,6 +161,20 @@ const createDeferred = <T,>() => {
 beforeEach(() => {
   vi.clearAllMocks();
   localStorage.clear();
+  sessionStorage.clear();
+  upgradeHookMock.current = {
+    acknowledgeOperation: vi.fn(),
+    connectionLost: false,
+    manualFallbackReady: false,
+    operation: undefined,
+    reconciling: false,
+    reloadFleet: vi.fn(),
+    triggerError: null,
+    triggering: false,
+    trackedTargetVersion: undefined,
+    triggerUpgrade: vi.fn().mockResolvedValue(undefined),
+    useManualFallback: vi.fn(),
+  };
   permissionsMock.current = ["instance:update", "fleet:read"];
   permissionsMock.isAuthenticated = true;
   permissionsMock.sessionExpiry = new Date(1_000);
@@ -150,6 +200,135 @@ describe("Updates", () => {
     expect(link).toHaveAttribute("rel", "noopener noreferrer");
     expect(getByText(INSTALL_COMMAND)).toBeInTheDocument();
     expect(getByRole("button", { name: "Copy install command" })).toBeInTheDocument();
+    expect(getByRole("button", { name: "Copy install command" })).toBeEnabled();
+    expect(screen.queryByRole("button", { name: "Upgrade to v1.3.0" })).not.toBeInTheDocument();
+  });
+
+  it("confirms the exact offered version before starting a one-click upgrade", async () => {
+    mockGetUpdateStatus.mockResolvedValue(buildStatus({ oneClickAvailable: true }));
+
+    const page = render(<Updates />);
+    fireEvent.click(await page.findByRole("button", { name: "Upgrade to v1.3.0" }));
+
+    expect(page.getByTestId("upgrade-operation-modal")).toHaveTextContent(
+      "Fleet will validate and build this exact release",
+    );
+    expect(upgradeHookMock.current.triggerUpgrade).not.toHaveBeenCalled();
+
+    fireEvent.click(page.getByRole("button", { name: "Confirm upgrade to v1.3.0" }));
+    await waitFor(() => expect(upgradeHookMock.current.triggerUpgrade).toHaveBeenCalledWith("v1.3.0"));
+  });
+
+  it("keeps an active operation ahead of a newer release offer", async () => {
+    upgradeHookMock.current.operation = buildOperation(UpgradePhase.PREFLIGHT, {
+      targetVersion: "v1.3.0",
+      message: "Validating v1.3.0",
+    });
+    mockGetUpdateStatus.mockResolvedValue(
+      buildStatus({
+        oneClickAvailable: true,
+        installCommand: "install v1.4.0",
+        latestEligible: buildReleaseInfo({ version: "v1.4.0" }),
+      }),
+    );
+
+    const page = render(<Updates />);
+
+    expect((await page.findAllByText("Validating v1.3.0")).length).toBeGreaterThan(0);
+    expect(page.queryByRole("button", { name: "Upgrade to v1.4.0" })).not.toBeInTheDocument();
+    expect(page.getByRole("button", { name: "Copy install command" })).toBeDisabled();
+    expect(page.getByRole("checkbox", { name: RC_CHECKBOX_NAME })).toBeDisabled();
+
+    fireEvent.click(page.getByRole("button", { name: "Close dialog" }));
+    fireEvent.click(page.getByRole("button", { name: "View upgrade details" }));
+    expect(page.getAllByText("Validating v1.3.0").length).toBeGreaterThan(0);
+  });
+
+  it("keeps manual recovery usable after a failed operation and can acknowledge its durable record", async () => {
+    upgradeHookMock.current.operation = buildOperation(UpgradePhase.FAILED, {
+      error: "new stack failed to start",
+      hostLogPath: "/var/lib/proto-fleet-updater/logs/operation-1.log",
+      recoveryCommand: "cd /opt/proto-fleet/deployment && ./run-fleet.sh --skip-build",
+    });
+    mockGetUpdateStatus.mockResolvedValue(buildStatus({ oneClickAvailable: true }));
+
+    const page = render(<Updates />);
+
+    expect(await page.findByText("new stack failed to start")).toBeInTheDocument();
+    expect(page.getByRole("button", { name: "Copy install command" })).toBeEnabled();
+    fireEvent.click(page.getByRole("button", { name: "Dismiss failure" }));
+    expect(upgradeHookMock.current.acknowledgeOperation).toHaveBeenCalledTimes(1);
+  });
+
+  it("offers a reload after the watched operation succeeds", async () => {
+    upgradeHookMock.current.operation = buildOperation(UpgradePhase.SUCCEEDED, {
+      message: "Upgrade complete",
+    });
+    mockGetUpdateStatus.mockResolvedValue(
+      buildStatus({
+        currentVersion: "v1.3.0",
+        updateAvailable: false,
+        installCommand: "",
+        latestEligible: undefined,
+        oneClickAvailable: true,
+      }),
+    );
+
+    const page = render(<Updates />);
+    fireEvent.click(await page.findByRole("button", { name: "Reload Fleet" }));
+
+    expect(upgradeHookMock.current.reloadFleet).toHaveBeenCalledTimes(1);
+  });
+
+  it("locks competing controls while reconciling an ambiguous trigger", async () => {
+    upgradeHookMock.current.reconciling = true;
+    upgradeHookMock.current.triggerError = "Fleet did not confirm the request";
+    mockGetUpdateStatus.mockResolvedValue(buildStatus({ oneClickAvailable: true }));
+
+    const page = render(<Updates />);
+
+    expect(await page.findByText(/checking whether the upgrade started/i)).toBeInTheDocument();
+    expect(page.getByRole("button", { name: "Copy install command" })).toBeDisabled();
+    expect(page.getByRole("checkbox", { name: RC_CHECKBOX_NAME })).toBeDisabled();
+  });
+
+  it("keeps an ambiguous request's target when a newer release is now eligible", async () => {
+    upgradeHookMock.current.reconciling = true;
+    upgradeHookMock.current.trackedTargetVersion = "v1.3.0";
+    upgradeHookMock.current.triggerError = "Fleet did not confirm the v1.3.0 request";
+    mockGetUpdateStatus.mockResolvedValue(
+      buildStatus({
+        installCommand: "install v1.4.0",
+        latestEligible: buildReleaseInfo({ version: "v1.4.0" }),
+        oneClickAvailable: true,
+      }),
+    );
+
+    const page = render(<Updates />);
+
+    expect(await page.findByText("v1.4.0")).toBeInTheDocument();
+    expect(page.getByTestId("upgrade-operation-modal")).toHaveTextContent("Upgrade Fleet to v1.3.0");
+  });
+
+  it("refreshes the eligible release after reconciliation finds no operation", async () => {
+    upgradeHookMock.current.reconciling = true;
+    upgradeHookMock.current.triggerError = "Fleet did not confirm the request";
+    mockGetUpdateStatus.mockResolvedValueOnce(buildStatus({ oneClickAvailable: true })).mockResolvedValueOnce(
+      buildStatus({
+        installCommand: "install v1.4.0",
+        latestEligible: buildReleaseInfo({ version: "v1.4.0" }),
+        oneClickAvailable: true,
+      }),
+    );
+
+    const page = render(<Updates />);
+    expect(await page.findByText("v1.3.0")).toBeInTheDocument();
+
+    upgradeHookMock.current = { ...upgradeHookMock.current, reconciling: false };
+    page.rerender(<Updates />);
+
+    await waitFor(() => expect(mockGetUpdateStatus).toHaveBeenCalledTimes(2));
+    expect(await page.findByText("v1.4.0")).toBeInTheDocument();
   });
 
   it("omits the release notes link when the server provides no URL", async () => {
@@ -687,6 +866,28 @@ describe("Updates", () => {
     );
     expect(permissionsMock.setPermissions).toHaveBeenCalledWith(["fleet:read"]);
     expect(page.queryByText("Unable to load update status")).not.toBeInTheDocument();
+
+    page.rerender(<Updates />);
+    expect(page.getByTestId("navigate")).toHaveAttribute("data-to", "/settings/network");
+  });
+
+  it("invalidates stale client permission when upgrade polling is denied", async () => {
+    mockGetUpdateStatus.mockResolvedValue(buildStatus());
+
+    const page = render(<Updates />);
+    await page.findByText("v1.2.0");
+    const lastHookCall = mockUseUpgradeOperation.mock.calls[mockUseUpgradeOperation.mock.calls.length - 1];
+    const onPollError = lastHookCall?.[0].onPollError;
+
+    act(() => {
+      onPollError?.(new ConnectError("permission revoked", Code.PermissionDenied));
+    });
+
+    expect(mockPushToast).toHaveBeenCalledWith({
+      message: PERMISSION_REVOKED_MESSAGE,
+      status: "error",
+    });
+    expect(permissionsMock.setPermissions).toHaveBeenCalledWith(["fleet:read"]);
 
     page.rerender(<Updates />);
     expect(page.getByTestId("navigate")).toHaveAttribute("data-to", "/settings/network");

--- a/client/src/protoFleet/features/settings/components/Updates.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Updates.test.tsx
@@ -155,6 +155,7 @@ const mockCopyToClipboard = vi.mocked(copyToClipboard);
 const mockPushToast = vi.mocked(pushToast);
 
 const RC_CHECKBOX_NAME = "Include release candidates";
+const UPDATE_STATUS_REQUEST_TIMEOUT_MS = 10_000;
 const RELEASE_CHANNEL_SAVE_TIMEOUT_MS = 30_000;
 const PERMISSION_REVOKED_MESSAGE = "You no longer have permission to update this instance";
 
@@ -215,6 +216,7 @@ describe("Updates", () => {
     expect(getByRole("button", { name: "Copy install command" })).toBeInTheDocument();
     expect(getByRole("button", { name: "Copy install command" })).toBeEnabled();
     expect(screen.queryByRole("button", { name: "Upgrade to v1.3.0" })).not.toBeInTheDocument();
+    expect(mockGetUpdateStatus).toHaveBeenCalledWith({}, { timeoutMs: UPDATE_STATUS_REQUEST_TIMEOUT_MS });
   });
 
   it("confirms the exact offered version before starting a one-click upgrade", async () => {
@@ -349,6 +351,41 @@ describe("Updates", () => {
 
     expect(await page.findByText("v1.4.0")).toBeInTheDocument();
     expect(page.getByRole("button", { name: "Copy install command" })).toBeEnabled();
+    expect(page.getByRole("checkbox", { name: RC_CHECKBOX_NAME })).toBeEnabled();
+  });
+
+  it("keeps controls locked while an untracked success refreshes the installed version", async () => {
+    const refreshedStatus = createDeferred<GetUpdateStatusResponse>();
+    mockGetUpdateStatus.mockResolvedValueOnce(buildStatus({ oneClickAvailable: true }));
+    mockGetUpdateStatus.mockReturnValueOnce(refreshedStatus.promise);
+
+    const page = render(<Updates />);
+    expect(await page.findByText("v1.3.0")).toBeInTheDocument();
+    const hookCalls = mockUseUpgradeOperation.mock.calls;
+    const hookOptions = hookCalls[hookCalls.length - 1]?.[0];
+    expect(hookOptions?.onUntrackedSuccess).toEqual(expect.any(Function));
+
+    act(() => hookOptions?.onUntrackedSuccess?.(buildOperation(UpgradePhase.SUCCEEDED)));
+    await waitFor(() => expect(mockGetUpdateStatus).toHaveBeenCalledTimes(2));
+
+    expect(page.getByRole("button", { name: "Copy install command" })).toBeDisabled();
+    expect(page.getByRole("checkbox", { name: RC_CHECKBOX_NAME })).toBeDisabled();
+
+    await act(async () => {
+      refreshedStatus.resolve(
+        buildStatus({
+          currentVersion: "v1.3.0",
+          updateAvailable: false,
+          installCommand: "",
+          latestEligible: undefined,
+          oneClickAvailable: true,
+        }),
+      );
+      await refreshedStatus.promise;
+    });
+
+    expect(await page.findByText("You're on the latest version")).toBeInTheDocument();
+    expect(page.queryByRole("button", { name: "Copy install command" })).not.toBeInTheDocument();
     expect(page.getByRole("checkbox", { name: RC_CHECKBOX_NAME })).toBeEnabled();
   });
 

--- a/client/src/protoFleet/features/settings/components/Updates.tsx
+++ b/client/src/protoFleet/features/settings/components/Updates.tsx
@@ -11,7 +11,15 @@ import SettingsPageHeader from "@/protoFleet/features/settings/components/Settin
 import UpgradeOperationModal from "@/protoFleet/features/settings/components/UpgradeOperationModal";
 import { isUpgradeActive, useUpgradeOperation } from "@/protoFleet/features/updates/api/useUpgradeOperation";
 import { copyInstallCommand } from "@/protoFleet/features/updates/copyInstallCommand";
-import { useAuthErrors, useFleetStore, useHasPermission, usePermissions, useSetPermissions } from "@/protoFleet/store";
+import {
+  useAuthErrors,
+  useFleetStore,
+  useHasPermission,
+  usePermissions,
+  useSessionExpiry,
+  useSetPermissions,
+  useUsername,
+} from "@/protoFleet/store";
 import { Copy } from "@/shared/assets/icons";
 import Button, { variants } from "@/shared/components/Button";
 import Checkbox from "@/shared/components/Checkbox";
@@ -87,7 +95,9 @@ const waitForReleaseChannelSave = async () => {
 const Updates = () => {
   const canUpdateInstance = useHasPermission(INSTANCE_UPDATE_PERMISSION);
   const permissions = usePermissions();
+  const sessionExpiry = useSessionExpiry();
   const setPermissions = useSetPermissions();
+  const username = useUsername();
   const { handleAuthErrors } = useAuthErrors();
   const [status, setStatus] = useState<GetUpdateStatusResponse | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -133,6 +143,7 @@ const Updates = () => {
   );
 
   const upgrade = useUpgradeOperation({
+    authSessionIdentity: `${username}:${sessionExpiry?.getTime() ?? "signed-out"}`,
     enabled: canUpdateInstance,
     currentVersion: status?.currentVersion,
     onPollError: handleUpgradePollError,
@@ -140,9 +151,15 @@ const Updates = () => {
   const activeUpgrade = isUpgradeActive(upgrade.operation);
   const succeededUpgrade = upgrade.operation?.phase === UpgradePhase.SUCCEEDED;
   const upgradeRequestPending = upgrade.triggering || upgrade.reconciling;
-  const upgradeLocksConfiguration = upgradeRequestPending || Boolean(upgrade.operation);
+  const unresolvedTrackedUpgrade = Boolean(upgrade.trackedTargetVersion && !upgrade.operation);
+  const upgradeLocksConfiguration = upgradeRequestPending || unresolvedTrackedUpgrade || Boolean(upgrade.operation);
+  const upgradeActionDisabled = isChannelChangePending || upgradeRequestPending || unresolvedTrackedUpgrade;
   const manualCommandDisabled =
-    isChannelChangePending || activeUpgrade || upgradeRequestPending || Boolean(succeededUpgrade);
+    isChannelChangePending ||
+    activeUpgrade ||
+    upgradeRequestPending ||
+    unresolvedTrackedUpgrade ||
+    Boolean(succeededUpgrade);
 
   const fetchStatus = useCallback(async () => {
     const requestId = ++latestStatusRequest.current;
@@ -310,7 +327,7 @@ const Updates = () => {
   const operationStatusLabel = upgrade.reconciling
     ? upgrade.manualFallbackReady
       ? "Upgrade outcome is unknown — host confirmation required"
-      : "Confirming whether the upgrade started"
+      : "Confirming upgrade status"
     : upgrade.operation?.phase === UpgradePhase.FAILED
       ? "Upgrade failed"
       : upgrade.operation?.phase === UpgradePhase.SUCCEEDED
@@ -405,7 +422,7 @@ const Updates = () => {
                       <Button
                         variant={hasUpgradeDetails ? variants.secondary : variants.primary}
                         text={hasUpgradeDetails ? "View upgrade details" : `Upgrade to ${release.version}`}
-                        disabled={isChannelChangePending || upgradeRequestPending}
+                        disabled={upgradeActionDisabled}
                         onClick={() => setUpgradeModalOpen(true)}
                       />
                     </Row>

--- a/client/src/protoFleet/features/settings/components/Updates.tsx
+++ b/client/src/protoFleet/features/settings/components/Updates.tsx
@@ -1,16 +1,19 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Navigate } from "react-router-dom";
 import { instanceUpdateClient } from "@/protoFleet/api/clients";
-import { ReleaseChannel } from "@/protoFleet/api/generated/instance/v1/updates_pb";
+import { ReleaseChannel, UpgradePhase } from "@/protoFleet/api/generated/instance/v1/updates_pb";
 import type { GetUpdateStatusResponse } from "@/protoFleet/api/generated/instance/v1/updates_pb";
 import { getErrorMessage } from "@/protoFleet/api/getErrorMessage";
 import { isAuthOrPermissionError, isPermissionDeniedError } from "@/protoFleet/api/requestErrors";
 import { getSettingsLandingPath } from "@/protoFleet/config/navItems";
 import SettingsEmptyState from "@/protoFleet/features/settings/components/SettingsEmptyState";
 import SettingsPageHeader from "@/protoFleet/features/settings/components/SettingsPageHeader";
+import UpgradeOperationModal from "@/protoFleet/features/settings/components/UpgradeOperationModal";
+import { isUpgradeActive, useUpgradeOperation } from "@/protoFleet/features/updates/api/useUpgradeOperation";
 import { copyInstallCommand } from "@/protoFleet/features/updates/copyInstallCommand";
 import { useAuthErrors, useFleetStore, useHasPermission, usePermissions, useSetPermissions } from "@/protoFleet/store";
 import { Copy } from "@/shared/assets/icons";
+import Button, { variants } from "@/shared/components/Button";
 import Checkbox from "@/shared/components/Checkbox";
 import Header from "@/shared/components/Header";
 import Row from "@/shared/components/Row";
@@ -21,7 +24,8 @@ const SkeletonLoader = <SkeletonBar className="h-[22px] w-24" />;
 const INSTANCE_UPDATE_PERMISSION = "instance:update";
 const RELEASE_CHANNEL_SAVE_TIMEOUT_MS = 30_000;
 const PERMISSION_REVOKED_MESSAGE = "You no longer have permission to update this instance";
-const UPDATES_PAGE_DESCRIPTION = "View the server version and choose which releases this instance installs.";
+const UPDATES_PAGE_DESCRIPTION =
+  "View the server version, choose which releases this instance installs, and apply eligible updates.";
 
 interface AuthSessionSnapshot {
   isAuthenticated: boolean;
@@ -88,8 +92,12 @@ const Updates = () => {
   const [status, setStatus] = useState<GetUpdateStatusResponse | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [isChannelChangePending, setIsChannelChangePending] = useState(false);
+  const [upgradeModalOpen, setUpgradeModalOpen] = useState(false);
   const latestStatusRequest = useRef(0);
   const isMounted = useRef(false);
+  const lastAutoOpenedOperation = useRef<string | null>(null);
+  const previousReconciling = useRef(false);
+  const previousTriggerError = useRef<string | null>(null);
   // The channel the server has persisted; the checkbox is controlled by it,
   // so a failed save never moves the control.
   const [channel, setChannel] = useState<ReleaseChannel>(ReleaseChannel.UNSPECIFIED);
@@ -109,6 +117,32 @@ const Updates = () => {
     },
     [setPermissions],
   );
+
+  const handleUpgradePollError = useCallback(
+    (error: unknown) => {
+      handleAuthErrors({
+        error,
+        onError: () => {
+          if (isPermissionDeniedError(error)) {
+            handlePermissionRevoked(isMounted.current);
+          }
+        },
+      });
+    },
+    [handleAuthErrors, handlePermissionRevoked],
+  );
+
+  const upgrade = useUpgradeOperation({
+    enabled: canUpdateInstance,
+    currentVersion: status?.currentVersion,
+    onPollError: handleUpgradePollError,
+  });
+  const activeUpgrade = isUpgradeActive(upgrade.operation);
+  const succeededUpgrade = upgrade.operation?.phase === UpgradePhase.SUCCEEDED;
+  const upgradeRequestPending = upgrade.triggering || upgrade.reconciling;
+  const upgradeLocksConfiguration = upgradeRequestPending || Boolean(upgrade.operation);
+  const manualCommandDisabled =
+    isChannelChangePending || activeUpgrade || upgradeRequestPending || Boolean(succeededUpgrade);
 
   const fetchStatus = useCallback(async () => {
     const requestId = ++latestStatusRequest.current;
@@ -154,6 +188,45 @@ const Updates = () => {
   }, []);
 
   useEffect(() => {
+    const operation = upgrade.operation;
+    if (!operation) {
+      return;
+    }
+    const terminal = operation.phase === UpgradePhase.SUCCEEDED || operation.phase === UpgradePhase.FAILED;
+    const autoOpenKey = `${operation.id}:${terminal ? "terminal" : "active"}`;
+    if (lastAutoOpenedOperation.current === autoOpenKey) {
+      return;
+    }
+    // Open once when an operation is first recovered, and once more when it
+    // becomes terminal. Intermediate phase updates must not keep stealing
+    // focus after an operator dismisses the progress modal.
+    lastAutoOpenedOperation.current = autoOpenKey;
+    setUpgradeModalOpen(true);
+  }, [upgrade.operation]);
+
+  useEffect(() => {
+    const wasReconciling = previousReconciling.current;
+    if (upgrade.reconciling && !previousReconciling.current) {
+      setUpgradeModalOpen(true);
+    }
+    if (wasReconciling && !upgrade.reconciling && !upgrade.operation && upgrade.triggerError) {
+      // A reachable executor authoritatively found no matching operation.
+      // Refresh the offer before allowing a retry because the release/channel
+      // may have changed while the trigger outcome was being reconciled.
+      void fetchStatus();
+    }
+    previousReconciling.current = upgrade.reconciling;
+  }, [fetchStatus, upgrade.operation, upgrade.reconciling, upgrade.triggerError]);
+
+  useEffect(() => {
+    if (upgrade.triggerError && upgrade.triggerError !== previousTriggerError.current && !upgrade.reconciling) {
+      setUpgradeModalOpen(true);
+      void fetchStatus();
+    }
+    previousTriggerError.current = upgrade.triggerError;
+  }, [fetchStatus, upgrade.reconciling, upgrade.triggerError]);
+
+  useEffect(() => {
     // The RPC is server-gated on instance:update; non-holders are redirected
     // below and must not fire it.
     if (!canUpdateInstance) {
@@ -169,7 +242,7 @@ const Updates = () => {
 
   const handleIncludeRCChange = async (includeRC: boolean) => {
     const nextChannel = includeRC ? ReleaseChannel.STABLE_AND_RC : ReleaseChannel.STABLE;
-    if (nextChannel === channel || isChannelChangePending) {
+    if (nextChannel === channel || isChannelChangePending || upgradeLocksConfiguration) {
       return;
     }
     const authSession = captureAuthSession();
@@ -233,10 +306,59 @@ const Updates = () => {
   }
 
   const release = status?.statusAvailable && status.updateAvailable ? status.latestEligible : undefined;
+  const modalRelease = upgrade.operation && upgrade.operation.targetVersion !== release?.version ? undefined : release;
+  const operationStatusLabel = upgrade.reconciling
+    ? upgrade.manualFallbackReady
+      ? "Upgrade outcome is unknown — host confirmation required"
+      : "Confirming whether the upgrade started"
+    : upgrade.operation?.phase === UpgradePhase.FAILED
+      ? "Upgrade failed"
+      : upgrade.operation?.phase === UpgradePhase.SUCCEEDED
+        ? "Upgrade complete — reload Fleet"
+        : upgrade.operation
+          ? upgrade.operation.message || `Upgrading Fleet to ${upgrade.operation.targetVersion}`
+          : upgrade.triggerError
+            ? "Upgrade request needs attention"
+            : null;
+  const hasUpgradeDetails = Boolean(upgrade.operation || upgrade.reconciling || upgrade.triggerError);
 
   return (
     <div className="flex flex-col gap-6">
+      <UpgradeOperationModal
+        connectionLost={upgrade.connectionLost}
+        manualFallbackReady={upgrade.manualFallbackReady}
+        onAcknowledge={() => {
+          upgrade.acknowledgeOperation();
+          setUpgradeModalOpen(false);
+        }}
+        onDismiss={() => setUpgradeModalOpen(false)}
+        onReload={upgrade.reloadFleet}
+        onUpgrade={upgrade.triggerUpgrade}
+        onUseManualFallback={() => {
+          upgrade.useManualFallback();
+          setUpgradeModalOpen(false);
+          void fetchStatus();
+        }}
+        open={upgradeModalOpen}
+        operation={upgrade.operation}
+        reconciling={upgrade.reconciling}
+        release={modalRelease}
+        targetVersion={
+          upgrade.operation?.targetVersion ?? (upgrade.reconciling ? upgrade.trackedTargetVersion : release?.version)
+        }
+        triggerError={upgrade.triggerError}
+        triggering={upgrade.triggering}
+      />
       <SettingsPageHeader title="Updates" description={UPDATES_PAGE_DESCRIPTION} />
+      {loadError && hasUpgradeDetails ? (
+        <div className="flex items-center justify-between gap-3 rounded-xl border border-border-5 p-6">
+          <div className="min-w-0">
+            <div className="text-heading-100 text-text-primary">Upgrade status</div>
+            <div className="truncate text-200 text-text-primary-50">{operationStatusLabel}</div>
+          </div>
+          <Button variant={variants.secondary} text="View upgrade details" onClick={() => setUpgradeModalOpen(true)} />
+        </div>
+      ) : null}
       {loadError ? (
         <SettingsEmptyState size="section" title="Unable to load update status" description={loadError} />
       ) : (
@@ -268,13 +390,33 @@ const Updates = () => {
                       ) : null}
                     </div>
                   </Row>
+                  {status?.oneClickAvailable || hasUpgradeDetails ? (
+                    <Row className="flex items-center justify-between gap-3" divider>
+                      <div className="min-w-0">
+                        <div className="text-300">{hasUpgradeDetails ? "Upgrade status" : "One-click upgrade"}</div>
+                        {operationStatusLabel ? (
+                          <div className="truncate text-200 text-text-primary-50">{operationStatusLabel}</div>
+                        ) : (
+                          <div className="text-200 text-text-primary-50">
+                            Fleet validates the release before restarting the instance.
+                          </div>
+                        )}
+                      </div>
+                      <Button
+                        variant={hasUpgradeDetails ? variants.secondary : variants.primary}
+                        text={hasUpgradeDetails ? "View upgrade details" : `Upgrade to ${release.version}`}
+                        disabled={isChannelChangePending || upgradeRequestPending}
+                        onClick={() => setUpgradeModalOpen(true)}
+                      />
+                    </Row>
+                  ) : null}
                   <Row className="flex items-center justify-between gap-2" divider={false}>
                     <code className="min-w-0 truncate font-mono text-200 text-text-primary-70">
                       {status?.installCommand}
                     </code>
                     <button
                       type="button"
-                      disabled={isChannelChangePending}
+                      disabled={manualCommandDisabled}
                       onClick={() => copyInstallCommand(status?.installCommand ?? "")}
                       className="flex h-8 shrink-0 items-center gap-2 rounded-lg bg-core-primary-10 px-2 text-200 whitespace-nowrap text-text-primary hover:cursor-pointer hover:bg-core-primary-20 disabled:cursor-not-allowed disabled:opacity-50"
                     >
@@ -284,7 +426,7 @@ const Updates = () => {
                   </Row>
                 </>
               ) : (
-                <Row className="flex justify-between" divider={false}>
+                <Row className="flex justify-between" divider={hasUpgradeDetails}>
                   <div className="text-300">
                     {status
                       ? status.statusAvailable
@@ -294,6 +436,19 @@ const Updates = () => {
                   </div>
                 </Row>
               )}
+              {!release && hasUpgradeDetails ? (
+                <Row className="flex items-center justify-between gap-3" divider={false}>
+                  <div className="min-w-0">
+                    <div className="text-300">Upgrade status</div>
+                    <div className="truncate text-200 text-text-primary-50">{operationStatusLabel}</div>
+                  </div>
+                  <Button
+                    variant={variants.secondary}
+                    text="View upgrade details"
+                    onClick={() => setUpgradeModalOpen(true)}
+                  />
+                </Row>
+              ) : null}
             </div>
           </div>
           <div className="flex flex-col gap-4 rounded-xl border border-border-5 p-6">
@@ -303,7 +458,7 @@ const Updates = () => {
                 <Checkbox
                   className="shrink-0"
                   checked={channel === ReleaseChannel.STABLE_AND_RC}
-                  disabled={isChannelChangePending}
+                  disabled={isChannelChangePending || upgradeLocksConfiguration}
                   onChange={(e) => void handleIncludeRCChange(e.target.checked)}
                 />
                 <span className="text-300">Include release candidates</span>

--- a/client/src/protoFleet/features/settings/components/Updates.tsx
+++ b/client/src/protoFleet/features/settings/components/Updates.tsx
@@ -153,10 +153,13 @@ const Updates = () => {
   const succeededUpgrade = upgrade.operation?.phase === UpgradePhase.SUCCEEDED;
   const upgradeRequestPending = upgrade.triggering || upgrade.reconciling;
   const unresolvedTrackedUpgrade = Boolean(upgrade.trackedTargetVersion && !upgrade.operation);
-  const upgradeLocksConfiguration = upgradeRequestPending || unresolvedTrackedUpgrade || Boolean(upgrade.operation);
-  const upgradeActionDisabled = isChannelChangePending || upgradeRequestPending || unresolvedTrackedUpgrade;
+  const upgradeLocksConfiguration =
+    upgrade.operationStatusPending || upgradeRequestPending || unresolvedTrackedUpgrade || Boolean(upgrade.operation);
+  const upgradeActionDisabled =
+    isChannelChangePending || upgrade.operationStatusPending || upgradeRequestPending || unresolvedTrackedUpgrade;
   const manualCommandDisabled =
     isChannelChangePending ||
+    upgrade.operationStatusPending ||
     activeUpgrade ||
     upgradeRequestPending ||
     unresolvedTrackedUpgrade ||

--- a/client/src/protoFleet/features/settings/components/Updates.tsx
+++ b/client/src/protoFleet/features/settings/components/Updates.tsx
@@ -30,6 +30,7 @@ import { pushToast, STATUSES } from "@/shared/features/toaster";
 
 const SkeletonLoader = <SkeletonBar className="h-[22px] w-24" />;
 const INSTANCE_UPDATE_PERMISSION = "instance:update";
+const UPDATE_STATUS_REQUEST_TIMEOUT_MS = 10_000;
 const RELEASE_CHANNEL_SAVE_TIMEOUT_MS = 30_000;
 const PERMISSION_REVOKED_MESSAGE = "You no longer have permission to update this instance";
 const UPDATES_PAGE_DESCRIPTION =
@@ -147,38 +148,6 @@ const Updates = () => {
     [handleAuthErrors, handlePermissionRevoked],
   );
 
-  const upgrade = useUpgradeOperation({
-    authSessionIdentity,
-    enabled: canUpdateInstance,
-    currentVersion: status?.currentVersion,
-    currentVersionUnavailable: Boolean(loadError && !status),
-    onPollError: handleUpgradePollError,
-  });
-  const activeUpgrade = isUpgradeActive(upgrade.operation);
-  const succeededUpgrade = upgrade.operation?.phase === UpgradePhase.SUCCEEDED;
-  const upgradeRequestPending = upgrade.triggering || upgrade.reconciling;
-  const unresolvedTrackedUpgrade = Boolean(upgrade.trackedTargetVersion && !upgrade.operation);
-  const upgradeLocksConfiguration =
-    isStatusRefreshPending ||
-    upgrade.operationStatusPending ||
-    upgradeRequestPending ||
-    unresolvedTrackedUpgrade ||
-    Boolean(upgrade.operation);
-  const upgradeActionDisabled =
-    isChannelChangePending ||
-    isStatusRefreshPending ||
-    upgrade.operationStatusPending ||
-    upgradeRequestPending ||
-    unresolvedTrackedUpgrade;
-  const manualCommandDisabled =
-    isChannelChangePending ||
-    isStatusRefreshPending ||
-    upgrade.operationStatusPending ||
-    activeUpgrade ||
-    upgradeRequestPending ||
-    unresolvedTrackedUpgrade ||
-    Boolean(succeededUpgrade);
-
   const fetchStatus = useCallback(async () => {
     const requestId = ++latestStatusRequest.current;
     const authSession = captureAuthSession(authSessionIdentity);
@@ -188,7 +157,7 @@ const Updates = () => {
       if (requestId !== latestStatusRequest.current || !isSameAuthSession(authSession)) {
         return;
       }
-      const response = await instanceUpdateClient.getUpdateStatus({});
+      const response = await instanceUpdateClient.getUpdateStatus({}, { timeoutMs: UPDATE_STATUS_REQUEST_TIMEOUT_MS });
       if (requestId !== latestStatusRequest.current || !isSameAuthSession(authSession)) {
         return;
       }
@@ -219,6 +188,41 @@ const Updates = () => {
       }
     }
   }, [authSessionIdentity, handleAuthErrors, handlePermissionRevoked]);
+
+  const upgrade = useUpgradeOperation({
+    authSessionIdentity,
+    enabled: canUpdateInstance,
+    currentVersion: status?.currentVersion,
+    currentVersionUnavailable: Boolean(loadError && !status),
+    onUntrackedSuccess: () => {
+      void fetchStatus();
+    },
+    onPollError: handleUpgradePollError,
+  });
+  const activeUpgrade = isUpgradeActive(upgrade.operation);
+  const succeededUpgrade = upgrade.operation?.phase === UpgradePhase.SUCCEEDED;
+  const upgradeRequestPending = upgrade.triggering || upgrade.reconciling;
+  const unresolvedTrackedUpgrade = Boolean(upgrade.trackedTargetVersion && !upgrade.operation);
+  const upgradeLocksConfiguration =
+    isStatusRefreshPending ||
+    upgrade.operationStatusPending ||
+    upgradeRequestPending ||
+    unresolvedTrackedUpgrade ||
+    Boolean(upgrade.operation);
+  const upgradeActionDisabled =
+    isChannelChangePending ||
+    isStatusRefreshPending ||
+    upgrade.operationStatusPending ||
+    upgradeRequestPending ||
+    unresolvedTrackedUpgrade;
+  const manualCommandDisabled =
+    isChannelChangePending ||
+    isStatusRefreshPending ||
+    upgrade.operationStatusPending ||
+    activeUpgrade ||
+    upgradeRequestPending ||
+    unresolvedTrackedUpgrade ||
+    Boolean(succeededUpgrade);
 
   useEffect(() => {
     isMounted.current = true;

--- a/client/src/protoFleet/features/settings/components/Updates.tsx
+++ b/client/src/protoFleet/features/settings/components/Updates.tsx
@@ -36,20 +36,23 @@ const UPDATES_PAGE_DESCRIPTION =
   "View the server version, choose which releases this instance installs, and apply eligible updates.";
 
 interface AuthSessionSnapshot {
+  identity: string;
   isAuthenticated: boolean;
   sessionExpiry: Date | null;
 }
 
-const captureAuthSession = (): AuthSessionSnapshot => {
+const captureAuthSession = (identity: string): AuthSessionSnapshot => {
   const { isAuthenticated, sessionExpiry } = useFleetStore.getState().auth;
-  return { isAuthenticated, sessionExpiry };
+  return { identity, isAuthenticated, sessionExpiry };
 };
 
 const isSameAuthSession = (snapshot: AuthSessionSnapshot) => {
-  const { isAuthenticated, sessionExpiry } = useFleetStore.getState().auth;
-  // Login installs a new Date object and logout clears it. Compare identity so
-  // even a replacement session for the same user cannot inherit old failures.
-  return isAuthenticated === snapshot.isAuthenticated && sessionExpiry === snapshot.sessionExpiry;
+  const { isAuthenticated, sessionExpiry, sessionGeneration, username } = useFleetStore.getState().auth;
+  return (
+    `${username}:${sessionGeneration}` === snapshot.identity &&
+    isAuthenticated === snapshot.isAuthenticated &&
+    sessionExpiry === snapshot.sessionExpiry
+  );
 };
 
 // A route remount must not load status while the previous page instance is
@@ -98,6 +101,7 @@ const Updates = () => {
   const sessionGeneration = useSessionGeneration();
   const setPermissions = useSetPermissions();
   const username = useUsername();
+  const authSessionIdentity = `${username}:${sessionGeneration}`;
   const { handleAuthErrors } = useAuthErrors();
   const [status, setStatus] = useState<GetUpdateStatusResponse | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -144,7 +148,7 @@ const Updates = () => {
   );
 
   const upgrade = useUpgradeOperation({
-    authSessionIdentity: `${username}:${sessionGeneration}`,
+    authSessionIdentity,
     enabled: canUpdateInstance,
     currentVersion: status?.currentVersion,
     currentVersionUnavailable: Boolean(loadError && !status),
@@ -177,7 +181,7 @@ const Updates = () => {
 
   const fetchStatus = useCallback(async () => {
     const requestId = ++latestStatusRequest.current;
-    const authSession = captureAuthSession();
+    const authSession = captureAuthSession(authSessionIdentity);
     setIsStatusRefreshPending(true);
     try {
       await waitForReleaseChannelSave();
@@ -214,7 +218,7 @@ const Updates = () => {
         setIsStatusRefreshPending(false);
       }
     }
-  }, [handleAuthErrors, handlePermissionRevoked]);
+  }, [authSessionIdentity, handleAuthErrors, handlePermissionRevoked]);
 
   useEffect(() => {
     isMounted.current = true;
@@ -281,7 +285,7 @@ const Updates = () => {
     if (nextChannel === channel || isChannelChangePending || upgradeLocksConfiguration) {
       return;
     }
-    const authSession = captureAuthSession();
+    const authSession = captureAuthSession(authSessionIdentity);
     setIsChannelChangePending(true);
     try {
       let saveSucceeded = false;

--- a/client/src/protoFleet/features/settings/components/Updates.tsx
+++ b/client/src/protoFleet/features/settings/components/Updates.tsx
@@ -146,6 +146,7 @@ const Updates = () => {
     authSessionIdentity: `${username}:${sessionExpiry?.getTime() ?? "signed-out"}`,
     enabled: canUpdateInstance,
     currentVersion: status?.currentVersion,
+    currentVersionUnavailable: Boolean(loadError && !status),
     onPollError: handleUpgradePollError,
   });
   const activeUpgrade = isUpgradeActive(upgrade.operation);
@@ -422,7 +423,7 @@ const Updates = () => {
                       <Button
                         variant={hasUpgradeDetails ? variants.secondary : variants.primary}
                         text={hasUpgradeDetails ? "View upgrade details" : `Upgrade to ${release.version}`}
-                        disabled={upgradeActionDisabled}
+                        disabled={hasUpgradeDetails ? false : upgradeActionDisabled}
                         onClick={() => setUpgradeModalOpen(true)}
                       />
                     </Row>

--- a/client/src/protoFleet/features/settings/components/Updates.tsx
+++ b/client/src/protoFleet/features/settings/components/Updates.tsx
@@ -144,6 +144,7 @@ const Updates = () => {
 
   const upgrade = useUpgradeOperation({
     authSessionIdentity: `${username}:${sessionExpiry?.getTime() ?? "signed-out"}`,
+    authSessionToken: sessionExpiry,
     enabled: canUpdateInstance,
     currentVersion: status?.currentVersion,
     currentVersionUnavailable: Boolean(loadError && !status),

--- a/client/src/protoFleet/features/settings/components/Updates.tsx
+++ b/client/src/protoFleet/features/settings/components/Updates.tsx
@@ -102,6 +102,7 @@ const Updates = () => {
   const [status, setStatus] = useState<GetUpdateStatusResponse | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [isChannelChangePending, setIsChannelChangePending] = useState(false);
+  const [isStatusRefreshPending, setIsStatusRefreshPending] = useState(false);
   const [upgradeModalOpen, setUpgradeModalOpen] = useState(false);
   const latestStatusRequest = useRef(0);
   const isMounted = useRef(false);
@@ -154,11 +155,20 @@ const Updates = () => {
   const upgradeRequestPending = upgrade.triggering || upgrade.reconciling;
   const unresolvedTrackedUpgrade = Boolean(upgrade.trackedTargetVersion && !upgrade.operation);
   const upgradeLocksConfiguration =
-    upgrade.operationStatusPending || upgradeRequestPending || unresolvedTrackedUpgrade || Boolean(upgrade.operation);
+    isStatusRefreshPending ||
+    upgrade.operationStatusPending ||
+    upgradeRequestPending ||
+    unresolvedTrackedUpgrade ||
+    Boolean(upgrade.operation);
   const upgradeActionDisabled =
-    isChannelChangePending || upgrade.operationStatusPending || upgradeRequestPending || unresolvedTrackedUpgrade;
+    isChannelChangePending ||
+    isStatusRefreshPending ||
+    upgrade.operationStatusPending ||
+    upgradeRequestPending ||
+    unresolvedTrackedUpgrade;
   const manualCommandDisabled =
     isChannelChangePending ||
+    isStatusRefreshPending ||
     upgrade.operationStatusPending ||
     activeUpgrade ||
     upgradeRequestPending ||
@@ -168,11 +178,12 @@ const Updates = () => {
   const fetchStatus = useCallback(async () => {
     const requestId = ++latestStatusRequest.current;
     const authSession = captureAuthSession();
-    await waitForReleaseChannelSave();
-    if (requestId !== latestStatusRequest.current || !isSameAuthSession(authSession)) {
-      return;
-    }
+    setIsStatusRefreshPending(true);
     try {
+      await waitForReleaseChannelSave();
+      if (requestId !== latestStatusRequest.current || !isSameAuthSession(authSession)) {
+        return;
+      }
       const response = await instanceUpdateClient.getUpdateStatus({});
       if (requestId !== latestStatusRequest.current || !isSameAuthSession(authSession)) {
         return;
@@ -198,6 +209,10 @@ const Updates = () => {
           setLoadError(getErrorMessage(err, "Failed to load update status"));
         },
       });
+    } finally {
+      if (requestId === latestStatusRequest.current && isSameAuthSession(authSession) && isMounted.current) {
+        setIsStatusRefreshPending(false);
+      }
     }
   }, [handleAuthErrors, handlePermissionRevoked]);
 

--- a/client/src/protoFleet/features/settings/components/Updates.tsx
+++ b/client/src/protoFleet/features/settings/components/Updates.tsx
@@ -346,7 +346,10 @@ const Updates = () => {
   }
 
   const release = status?.statusAvailable && status.updateAvailable ? status.latestEligible : undefined;
-  const modalRelease = upgrade.operation && upgrade.operation.targetVersion !== release?.version ? undefined : release;
+  const modalRelease =
+    isStatusRefreshPending || loadError || (upgrade.operation && upgrade.operation.targetVersion !== release?.version)
+      ? undefined
+      : release;
   const operationStatusLabel = upgrade.reconciling
     ? upgrade.manualFallbackReady
       ? "Upgrade outcome is unknown — host confirmation required"

--- a/client/src/protoFleet/features/settings/components/Updates.tsx
+++ b/client/src/protoFleet/features/settings/components/Updates.tsx
@@ -16,7 +16,7 @@ import {
   useFleetStore,
   useHasPermission,
   usePermissions,
-  useSessionExpiry,
+  useSessionGeneration,
   useSetPermissions,
   useUsername,
 } from "@/protoFleet/store";
@@ -95,7 +95,7 @@ const waitForReleaseChannelSave = async () => {
 const Updates = () => {
   const canUpdateInstance = useHasPermission(INSTANCE_UPDATE_PERMISSION);
   const permissions = usePermissions();
-  const sessionExpiry = useSessionExpiry();
+  const sessionGeneration = useSessionGeneration();
   const setPermissions = useSetPermissions();
   const username = useUsername();
   const { handleAuthErrors } = useAuthErrors();
@@ -143,8 +143,7 @@ const Updates = () => {
   );
 
   const upgrade = useUpgradeOperation({
-    authSessionIdentity: `${username}:${sessionExpiry?.getTime() ?? "signed-out"}`,
-    authSessionToken: sessionExpiry,
+    authSessionIdentity: `${username}:${sessionGeneration}`,
     enabled: canUpdateInstance,
     currentVersion: status?.currentVersion,
     currentVersionUnavailable: Boolean(loadError && !status),

--- a/client/src/protoFleet/features/settings/components/UpgradeOperationModal.stories.tsx
+++ b/client/src/protoFleet/features/settings/components/UpgradeOperationModal.stories.tsx
@@ -1,0 +1,117 @@
+import { create } from "@bufbuild/protobuf";
+import type { Meta, StoryObj } from "@storybook/react";
+import { action } from "storybook/actions";
+
+import {
+  ReleaseInfoSchema,
+  UpgradeOperationSchema,
+  UpgradePhase,
+} from "@/protoFleet/api/generated/instance/v1/updates_pb";
+import UpgradeOperationModal from "@/protoFleet/features/settings/components/UpgradeOperationModal";
+
+const release = (version = "v1.3.0", prerelease = false) =>
+  create(ReleaseInfoSchema, {
+    version,
+    prerelease,
+  });
+
+const operation = (phase: UpgradePhase, message: string) =>
+  create(UpgradeOperationSchema, {
+    id: "operation-1",
+    targetVersion: "v1.3.0",
+    phase,
+    message,
+  });
+
+const meta = {
+  title: "Proto Fleet/Settings/UpgradeOperationModal",
+  component: UpgradeOperationModal,
+  parameters: {
+    layout: "fullscreen",
+  },
+  args: {
+    connectionLost: false,
+    manualFallbackReady: false,
+    onAcknowledge: action("acknowledge failure"),
+    onDismiss: action("dismiss modal"),
+    onReload: action("reload Fleet"),
+    onUpgrade: (targetVersion: string) => {
+      action("start upgrade")(targetVersion);
+      return Promise.resolve();
+    },
+    onUseManualFallback: action("unlock manual install"),
+    open: true,
+    reconciling: false,
+    release: release(),
+    triggerError: null,
+    triggering: false,
+  },
+} satisfies Meta<typeof UpgradeOperationModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const StableConfirmation: Story = {};
+
+export const ReleaseCandidateConfirmation: Story = {
+  args: {
+    release: release("v1.3.0-rc.2", true),
+  },
+};
+
+export const CheckingStatus: Story = {
+  args: {
+    reconciling: true,
+    targetVersion: "v1.3.0",
+    triggerError: "The upgrade request timed out before Fleet received a response.",
+  },
+};
+
+export const ManualFallbackConfirmation: Story = {
+  args: {
+    connectionLost: true,
+    manualFallbackReady: true,
+    reconciling: true,
+    targetVersion: "v1.3.0",
+    triggerError: "The host updater is not reporting the tracked upgrade.",
+  },
+};
+
+export const Preflight: Story = {
+  args: {
+    operation: operation(UpgradePhase.PREFLIGHT, "Validating the new stack"),
+  },
+};
+
+export const RestartingServices: Story = {
+  args: {
+    connectionLost: true,
+    operation: operation(UpgradePhase.ACTIVATING, "Restarting Fleet services"),
+  },
+};
+
+export const FailedWithRecovery: Story = {
+  args: {
+    operation: create(UpgradeOperationSchema, {
+      id: "operation-1",
+      targetVersion: "v1.3.0",
+      phase: UpgradePhase.FAILED,
+      message: "Upgrade failed",
+      error: "The replacement stack did not become ready.",
+      hostLogPath: "/var/lib/proto-fleet-updater/logs/operation-1.log",
+      recoveryCommand: "cd /opt/proto-fleet/deployment && ./run-fleet.sh --non-interactive --skip-build",
+    }),
+  },
+};
+
+export const Succeeded: Story = {
+  args: {
+    operation: operation(UpgradePhase.SUCCEEDED, "Fleet v1.3.0 is running"),
+  },
+};
+
+export const TriggerError: Story = {
+  args: {
+    triggerError: "The host updater rejected the request. Review the host logs and try again.",
+  },
+};

--- a/client/src/protoFleet/features/settings/components/UpgradeOperationModal.test.tsx
+++ b/client/src/protoFleet/features/settings/components/UpgradeOperationModal.test.tsx
@@ -118,7 +118,7 @@ describe("UpgradeOperationModal", () => {
   it("warns against manual installation while reconciling an ambiguous trigger", () => {
     renderModal({ reconciling: true, triggerError: "The request timed out" });
 
-    expect(screen.getByRole("status")).toHaveTextContent(/Checking whether the upgrade started/);
+    expect(screen.getByRole("status")).toHaveTextContent(/Checking upgrade status/);
     expect(screen.getByRole("status")).toHaveTextContent(/Do not run the manual install command yet/);
     expect(screen.queryByRole("button", { name: /Confirm upgrade/ })).not.toBeInTheDocument();
   });

--- a/client/src/protoFleet/features/settings/components/UpgradeOperationModal.test.tsx
+++ b/client/src/protoFleet/features/settings/components/UpgradeOperationModal.test.tsx
@@ -123,6 +123,17 @@ describe("UpgradeOperationModal", () => {
     expect(screen.queryByRole("button", { name: /Confirm upgrade/ })).not.toBeInTheDocument();
   });
 
+  it("keeps an unknown host-updater phase visibly locked", () => {
+    renderModal({
+      operation: operation(UpgradePhase.UNSPECIFIED),
+      reconciling: true,
+    });
+
+    expect(screen.getByRole("status")).toHaveTextContent(/reported an unknown upgrade state/i);
+    expect(screen.getByRole("status")).toHaveTextContent(/Manual installation remains locked/i);
+    expect(screen.queryByRole("button", { name: /unlock manual install/i })).not.toBeInTheDocument();
+  });
+
   it("requires explicit host confirmation before unlocking a manual fallback", () => {
     const onUseManualFallback = vi.fn();
     renderModal({

--- a/client/src/protoFleet/features/settings/components/UpgradeOperationModal.test.tsx
+++ b/client/src/protoFleet/features/settings/components/UpgradeOperationModal.test.tsx
@@ -1,0 +1,252 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { create } from "@bufbuild/protobuf";
+
+import {
+  ReleaseInfoSchema,
+  type UpgradeOperation,
+  UpgradeOperationSchema,
+  UpgradePhase,
+} from "@/protoFleet/api/generated/instance/v1/updates_pb";
+import UpgradeOperationModal, {
+  type UpgradeOperationModalProps,
+} from "@/protoFleet/features/settings/components/UpgradeOperationModal";
+import { pushToast, STATUSES } from "@/shared/features/toaster";
+import { copyToClipboard } from "@/shared/utils/utility";
+
+vi.mock("@/shared/features/toaster", () => ({
+  pushToast: vi.fn(),
+  STATUSES: {
+    error: "error",
+    success: "success",
+  },
+}));
+
+vi.mock("@/shared/utils/utility", () => ({
+  copyToClipboard: vi.fn(),
+}));
+
+const mockCopyToClipboard = vi.mocked(copyToClipboard);
+const mockPushToast = vi.mocked(pushToast);
+
+const release = (version = "v1.3.0", prerelease = false) =>
+  create(ReleaseInfoSchema, {
+    version,
+    prerelease,
+  });
+
+type OperationOverrides = Partial<
+  Pick<UpgradeOperation, "error" | "hostLogPath" | "message" | "recoveryCommand" | "targetVersion">
+>;
+
+const operation = (phase: UpgradePhase, overrides?: OperationOverrides) =>
+  create(UpgradeOperationSchema, {
+    id: "operation-1",
+    targetVersion: "v1.3.0",
+    phase,
+    message: "Preparing upgrade",
+    ...overrides,
+  });
+
+const renderModal = (overrides: Partial<UpgradeOperationModalProps> = {}) => {
+  const props: UpgradeOperationModalProps = {
+    connectionLost: false,
+    manualFallbackReady: false,
+    onAcknowledge: vi.fn(),
+    onDismiss: vi.fn(),
+    onReload: vi.fn(),
+    onUpgrade: vi.fn().mockResolvedValue(undefined),
+    onUseManualFallback: vi.fn(),
+    open: true,
+    reconciling: false,
+    release: release(),
+    triggerError: null,
+    triggering: false,
+    ...overrides,
+  };
+  return { ...render(<UpgradeOperationModal {...props} />), props };
+};
+
+describe("UpgradeOperationModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCopyToClipboard.mockResolvedValue(undefined);
+  });
+
+  it("confirms the exact stable target before starting the upgrade", async () => {
+    const onUpgrade = vi.fn().mockResolvedValue(undefined);
+    renderModal({ onUpgrade });
+
+    const confirmButton = screen.getByRole("button", { name: "Confirm upgrade to v1.3.0" });
+    expect(confirmButton).toBeInTheDocument();
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => expect(onUpgrade).toHaveBeenCalledWith("v1.3.0"));
+  });
+
+  it("gives release candidates a strong forward-only migration warning", () => {
+    renderModal({ release: release("v1.3.0-rc.2", true) });
+
+    expect(screen.getByText(/This is a release candidate/)).toBeInTheDocument();
+    expect(screen.getByText(/forward-only database migrations/)).toBeInTheDocument();
+    expect(screen.getByText(/cannot downgrade this instance afterward/)).toBeInTheDocument();
+  });
+
+  it("keeps a long-running upgrade dismissible", () => {
+    const onDismiss = vi.fn();
+    renderModal({
+      onDismiss,
+      operation: operation(UpgradePhase.PREFLIGHT, { message: "Validating the new stack" }),
+    });
+
+    expect(screen.getByRole("status")).toHaveTextContent("Phase: Preflight");
+    fireEvent.click(screen.getByRole("button", { name: "Close dialog" }));
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  it("announces the expected reconnect state", () => {
+    renderModal({
+      connectionLost: true,
+      operation: operation(UpgradePhase.ACTIVATING),
+    });
+
+    const status = screen.getByRole("status");
+    expect(status).toHaveAttribute("aria-live", "polite");
+    expect(status).toHaveTextContent(/disconnect is expected while services restart/);
+  });
+
+  it("warns against manual installation while reconciling an ambiguous trigger", () => {
+    renderModal({ reconciling: true, triggerError: "The request timed out" });
+
+    expect(screen.getByRole("status")).toHaveTextContent(/Checking whether the upgrade started/);
+    expect(screen.getByRole("status")).toHaveTextContent(/Do not run the manual install command yet/);
+    expect(screen.queryByRole("button", { name: /Confirm upgrade/ })).not.toBeInTheDocument();
+  });
+
+  it("requires explicit host confirmation before unlocking a manual fallback", () => {
+    const onUseManualFallback = vi.fn();
+    renderModal({
+      connectionLost: true,
+      manualFallbackReady: true,
+      onUseManualFallback,
+      reconciling: true,
+      triggerError: "Host updater did not confirm the upgrade",
+    });
+
+    expect(screen.getByRole("status")).toHaveTextContent(/checking the host and confirming no upgrade is running/i);
+    fireEvent.click(screen.getByRole("button", { name: "I confirmed — unlock manual install" }));
+    expect(onUseManualFallback).toHaveBeenCalledOnce();
+  });
+
+  it("labels reconciliation with its tracked target rather than a newer offer", () => {
+    renderModal({
+      reconciling: true,
+      release: release("v1.4.0"),
+      targetVersion: "v1.3.0",
+      triggerError: "The v1.3.0 request has an unknown outcome",
+    });
+
+    expect(screen.getByTestId("upgrade-operation-modal")).toHaveTextContent("Upgrade Fleet to v1.3.0");
+    expect(screen.getByTestId("upgrade-operation-modal")).not.toHaveTextContent("Upgrade Fleet to v1.4.0");
+  });
+
+  it("shows failed-operation details and copies the recovery command", async () => {
+    const recoveryCommand = "cd /opt/proto-fleet/deployment && ./run-fleet.sh --non-interactive --skip-build";
+    renderModal({
+      operation: operation(UpgradePhase.FAILED, {
+        message: "Upgrade failed",
+        error: "new stack failed to start",
+        hostLogPath: "/var/lib/proto-fleet-updater/logs/operation-1.log",
+        recoveryCommand,
+      }),
+    });
+
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent("new stack failed to start");
+    expect(alert).toHaveTextContent("operation-1.log");
+    fireEvent.click(screen.getByRole("button", { name: "Copy recovery command" }));
+
+    await waitFor(() => expect(mockCopyToClipboard).toHaveBeenCalledWith(recoveryCommand));
+    expect(mockPushToast).toHaveBeenCalledWith({
+      message: "Recovery command copied to clipboard",
+      status: STATUSES.success,
+    });
+  });
+
+  it("reports a recovery-command copy failure", async () => {
+    mockCopyToClipboard.mockRejectedValue(new Error("copy failed"));
+    renderModal({
+      operation: operation(UpgradePhase.FAILED, {
+        recoveryCommand: "./run-fleet.sh --non-interactive --skip-build",
+      }),
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy recovery command" }));
+
+    await waitFor(() =>
+      expect(mockPushToast).toHaveBeenCalledWith({
+        message: "Failed to copy recovery command",
+        status: STATUSES.error,
+      }),
+    );
+  });
+
+  it("does not render an empty recovery fallback", () => {
+    renderModal({
+      operation: operation(UpgradePhase.FAILED, {
+        error: "preflight failed",
+        recoveryCommand: "   ",
+      }),
+    });
+
+    expect(screen.queryByText("Recovery command")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Copy recovery command" })).not.toBeInTheDocument();
+  });
+
+  it("acknowledges a failure separately from hiding its details", () => {
+    const onAcknowledge = vi.fn();
+    const onDismiss = vi.fn();
+    renderModal({
+      onAcknowledge,
+      onDismiss,
+      operation: operation(UpgradePhase.FAILED),
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss failure" }));
+    expect(onAcknowledge).toHaveBeenCalledOnce();
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it("reloads Fleet after a successful upgrade", () => {
+    const onReload = vi.fn();
+    renderModal({
+      onReload,
+      operation: operation(UpgradePhase.SUCCEEDED, { message: "Fleet v1.3.0 is running" }),
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Reload Fleet" }));
+    expect(onReload).toHaveBeenCalledOnce();
+  });
+
+  it("announces a trigger error and allows retry after reconciliation", async () => {
+    const onUpgrade = vi.fn().mockResolvedValue(undefined);
+    renderModal({
+      onUpgrade,
+      triggerError: "Host updater did not answer",
+    });
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Host updater did not answer");
+    fireEvent.click(screen.getByRole("button", { name: "Confirm upgrade to v1.3.0" }));
+    await waitFor(() => expect(onUpgrade).toHaveBeenCalledWith("v1.3.0"));
+  });
+
+  it("keeps a trigger error visible when there is no longer an eligible release", () => {
+    renderModal({
+      release: undefined,
+      triggerError: "The eligible release changed before the request completed",
+    });
+
+    expect(screen.getByRole("alert")).toHaveTextContent("The eligible release changed before the request completed");
+    expect(screen.queryByRole("button", { name: /Confirm upgrade/ })).not.toBeInTheDocument();
+  });
+});

--- a/client/src/protoFleet/features/settings/components/UpgradeOperationModal.tsx
+++ b/client/src/protoFleet/features/settings/components/UpgradeOperationModal.tsx
@@ -1,3 +1,4 @@
+import type { ComponentProps, ReactNode } from "react";
 import {
   type ReleaseInfo,
   type UpgradeOperation,
@@ -36,6 +37,254 @@ const ACTIVE_PHASE_LABELS: Partial<Record<UpgradePhase, string>> = {
   [UpgradePhase.ACTIVATING]: "Activating",
 };
 
+type ModalButtons = NonNullable<ComponentProps<typeof Modal>["buttons"]>;
+
+interface ProgressPanelProps {
+  children: ReactNode;
+  heading: string;
+}
+
+const ProgressPanel = ({ children, heading }: ProgressPanelProps) => (
+  <div
+    role="status"
+    aria-live="polite"
+    aria-atomic="true"
+    className="flex flex-col gap-3 rounded-xl bg-core-primary-5 p-5"
+  >
+    <div className="flex items-center gap-3">
+      <span aria-hidden="true">
+        <ProgressCircular indeterminate size={20} />
+      </span>
+      <div className="text-heading-100 text-text-primary">{heading}</div>
+    </div>
+    {children}
+  </div>
+);
+
+const ReconciliationPanel = ({ manualFallbackReady }: Pick<UpgradeOperationModalProps, "manualFallbackReady">) => (
+  <ProgressPanel
+    heading={manualFallbackReady ? "Fleet could not confirm the upgrade outcome" : "Checking upgrade status"}
+  >
+    {manualFallbackReady ? (
+      <p className="text-300 font-medium text-text-critical">
+        The host updater is not reporting this upgrade. Only unlock the manual command after checking the host and
+        confirming no upgrade is running. Overlapping installs can leave the deployment unusable.
+      </p>
+    ) : (
+      <p className="text-300 text-text-primary-70">
+        Fleet is reconciling the tracked upgrade with the host updater. Do not run the manual install command yet; wait
+        until this check finishes.
+      </p>
+    )}
+  </ProgressPanel>
+);
+
+interface ActiveUpgradePanelProps {
+  connectionLost: boolean;
+  operation: UpgradeOperation;
+}
+
+const ActiveUpgradePanel = ({ connectionLost, operation }: ActiveUpgradePanelProps) => (
+  <ProgressPanel heading={operation.message || "Upgrade in progress"}>
+    <div className="text-200 text-text-primary-70">Phase: {ACTIVE_PHASE_LABELS[operation.phase] ?? "Starting"}</div>
+    {connectionLost ? (
+      <p className="text-300 text-text-primary-70">
+        Fleet is temporarily unreachable. A disconnect is expected while services restart; this page will keep checking
+        for progress.
+      </p>
+    ) : (
+      <p className="text-300 text-text-primary-70">
+        You can close this dialog while Fleet downloads, validates, and activates the release. Return to this Updates
+        page to check progress.
+      </p>
+    )}
+  </ProgressPanel>
+);
+
+const copyRecoveryCommand = (recoveryCommand: string) => {
+  void copyToClipboard(recoveryCommand)
+    .then(() => {
+      pushToast({
+        message: "Recovery command copied to clipboard",
+        status: STATUSES.success,
+      });
+    })
+    .catch(() => {
+      pushToast({
+        message: "Failed to copy recovery command",
+        status: STATUSES.error,
+      });
+    });
+};
+
+const FailedUpgradePanel = ({ operation }: { operation: UpgradeOperation }) => {
+  const error = operation.error.trim();
+  const hostLogPath = operation.hostLogPath.trim();
+  const recoveryCommand = operation.recoveryCommand.trim();
+
+  return (
+    <div role="alert" className="flex flex-col gap-3 rounded-xl bg-intent-critical-10 p-5">
+      <div className="text-heading-100 text-text-primary">{operation.message || "Upgrade failed"}</div>
+      {error ? <p className="text-300 text-text-critical">{error}</p> : null}
+      {hostLogPath ? (
+        <p className="text-200 text-text-primary-70">
+          Host log: <code className="font-mono break-all">{hostLogPath}</code>
+        </p>
+      ) : null}
+      {recoveryCommand ? (
+        <div className="flex flex-col gap-2">
+          <div className="text-200 text-text-primary-70">Recovery command</div>
+          <div className="flex items-center justify-between gap-2 rounded-xl bg-surface-default px-4 py-3">
+            <code className="min-w-0 flex-1 font-mono text-200 break-all text-text-primary">{recoveryCommand}</code>
+            <Button
+              ariaLabel="Copy recovery command"
+              variant={variants.ghost}
+              prefixIcon={<Copy width="w-4" />}
+              onClick={() => copyRecoveryCommand(recoveryCommand)}
+              className="shrink-0"
+            />
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+const SucceededUpgradePanel = ({ operation }: { operation: UpgradeOperation }) => (
+  <div
+    role="status"
+    aria-live="polite"
+    aria-atomic="true"
+    className="flex flex-col gap-3 rounded-xl bg-core-primary-5 p-5"
+  >
+    <div className="text-heading-100 text-text-primary">{operation.message || "Upgrade complete"}</div>
+    <p className="text-300 text-text-primary-70">
+      Reload Fleet to use the client bundled with {operation.targetVersion}.
+    </p>
+  </div>
+);
+
+const UpgradeConfirmationPanel = ({ release }: { release: ReleaseInfo }) => (
+  <div className="flex flex-col gap-3 rounded-xl bg-intent-warning-10 p-5">
+    <div className="text-heading-100 text-text-primary">Confirm upgrade to {release.version}</div>
+    <p className="text-300 text-text-primary-70">
+      Fleet will validate and build this exact release first, then take the instance offline for several minutes while
+      containers restart and database migrations run.
+    </p>
+    {release.prerelease ? (
+      <p className="text-300 font-medium text-text-critical">
+        This is a release candidate. The upgrade can run forward-only database migrations, and you cannot downgrade this
+        instance afterward. Continue only if you accept that recovery may require a newer compatible release.
+      </p>
+    ) : null}
+  </div>
+);
+
+interface UpgradeOperationContentProps {
+  connectionLost: boolean;
+  manualFallbackReady: boolean;
+  operation?: UpgradeOperation;
+  reconciling: boolean;
+  release?: ReleaseInfo;
+}
+
+const UpgradeOperationContent = ({
+  connectionLost,
+  manualFallbackReady,
+  operation,
+  reconciling,
+  release,
+}: UpgradeOperationContentProps) => {
+  if (reconciling) {
+    return <ReconciliationPanel manualFallbackReady={manualFallbackReady} />;
+  }
+  if (!operation) {
+    return release ? <UpgradeConfirmationPanel release={release} /> : null;
+  }
+  if (operation.phase === UpgradePhase.FAILED) {
+    return <FailedUpgradePanel operation={operation} />;
+  }
+  if (operation.phase === UpgradePhase.SUCCEEDED) {
+    return <SucceededUpgradePanel operation={operation} />;
+  }
+  return <ActiveUpgradePanel connectionLost={connectionLost} operation={operation} />;
+};
+
+interface GetModalButtonsOptions {
+  handleUpgrade: () => void;
+  manualFallbackReady: boolean;
+  onAcknowledge: () => void;
+  onDismiss: () => void;
+  onReload: () => void;
+  onUseManualFallback: () => void;
+  operation?: UpgradeOperation;
+  reconciling: boolean;
+  release?: ReleaseInfo;
+  triggering: boolean;
+}
+
+const getModalButtons = ({
+  handleUpgrade,
+  manualFallbackReady,
+  onAcknowledge,
+  onDismiss,
+  onReload,
+  onUseManualFallback,
+  operation,
+  reconciling,
+  release,
+  triggering,
+}: GetModalButtonsOptions): ModalButtons | undefined => {
+  if (manualFallbackReady) {
+    return [
+      {
+        text: "I confirmed — unlock manual install",
+        variant: variants.secondaryDanger,
+        onClick: onUseManualFallback,
+        dismissModalOnClick: false,
+      },
+    ];
+  }
+  if (operation?.phase === UpgradePhase.SUCCEEDED) {
+    return [
+      {
+        text: "Reload Fleet",
+        variant: variants.primary,
+        onClick: onReload,
+        dismissModalOnClick: false,
+      },
+    ];
+  }
+  if (operation?.phase === UpgradePhase.FAILED) {
+    return [
+      {
+        text: "Dismiss failure",
+        variant: variants.secondary,
+        onClick: onAcknowledge,
+        dismissModalOnClick: false,
+      },
+    ];
+  }
+  if (operation || reconciling || !release) {
+    return undefined;
+  }
+  return [
+    {
+      text: "Cancel",
+      variant: variants.secondary,
+      onClick: onDismiss,
+      dismissModalOnClick: false,
+    },
+    {
+      text: `Confirm upgrade to ${release.version}`,
+      variant: variants.primary,
+      onClick: handleUpgrade,
+      loading: triggering,
+      dismissModalOnClick: false,
+    },
+  ];
+};
+
 const UpgradeOperationModal = ({
   connectionLost,
   manualFallbackReady,
@@ -57,13 +306,6 @@ const UpgradeOperationModal = ({
   }
 
   const displayedTargetVersion = operation?.targetVersion || targetVersion || release?.version;
-  const failed = operation?.phase === UpgradePhase.FAILED;
-  const succeeded = operation?.phase === UpgradePhase.SUCCEEDED;
-  const active = Boolean(operation && !failed && !succeeded);
-  const activePhaseLabel = operation ? (ACTIVE_PHASE_LABELS[operation.phase] ?? "Starting") : undefined;
-  const error = operation?.error.trim() ?? "";
-  const hostLogPath = operation?.hostLogPath.trim() ?? "";
-  const recoveryCommand = operation?.recoveryCommand.trim() ?? "";
 
   const handleUpgrade = () => {
     if (!release || reconciling) return;
@@ -72,67 +314,18 @@ const UpgradeOperationModal = ({
     });
   };
 
-  const handleCopyRecoveryCommand = () => {
-    if (!recoveryCommand) return;
-    void copyToClipboard(recoveryCommand)
-      .then(() => {
-        pushToast({
-          message: "Recovery command copied to clipboard",
-          status: STATUSES.success,
-        });
-      })
-      .catch(() => {
-        pushToast({
-          message: "Failed to copy recovery command",
-          status: STATUSES.error,
-        });
-      });
-  };
-
-  const buttons = manualFallbackReady
-    ? [
-        {
-          text: "I confirmed — unlock manual install",
-          variant: variants.secondaryDanger,
-          onClick: onUseManualFallback,
-          dismissModalOnClick: false,
-        },
-      ]
-    : succeeded
-      ? [
-          {
-            text: "Reload Fleet",
-            variant: variants.primary,
-            onClick: onReload,
-            dismissModalOnClick: false,
-          },
-        ]
-      : failed
-        ? [
-            {
-              text: "Dismiss failure",
-              variant: variants.secondary,
-              onClick: onAcknowledge,
-              dismissModalOnClick: false,
-            },
-          ]
-        : !active && !reconciling && release
-          ? [
-              {
-                text: "Cancel",
-                variant: variants.secondary,
-                onClick: onDismiss,
-                dismissModalOnClick: false,
-              },
-              {
-                text: `Confirm upgrade to ${release.version}`,
-                variant: variants.primary,
-                onClick: handleUpgrade,
-                loading: triggering,
-                dismissModalOnClick: false,
-              },
-            ]
-          : undefined;
+  const buttons = getModalButtons({
+    handleUpgrade,
+    manualFallbackReady,
+    onAcknowledge,
+    onDismiss,
+    onReload,
+    onUseManualFallback,
+    operation,
+    reconciling,
+    release,
+    triggering,
+  });
 
   return (
     <Modal
@@ -144,114 +337,13 @@ const UpgradeOperationModal = ({
       buttons={buttons}
     >
       <div className="flex flex-col gap-5">
-        {reconciling ? (
-          <div
-            role="status"
-            aria-live="polite"
-            aria-atomic="true"
-            className="flex flex-col gap-3 rounded-xl bg-core-primary-5 p-5"
-          >
-            <div className="flex items-center gap-3">
-              <span aria-hidden="true">
-                <ProgressCircular indeterminate size={20} />
-              </span>
-              <div className="text-heading-100 text-text-primary">
-                {manualFallbackReady ? "Fleet could not confirm the upgrade outcome" : "Checking upgrade status"}
-              </div>
-            </div>
-            {manualFallbackReady ? (
-              <p className="text-300 font-medium text-text-critical">
-                The host updater is not reporting this upgrade. Only unlock the manual command after checking the host
-                and confirming no upgrade is running. Overlapping installs can leave the deployment unusable.
-              </p>
-            ) : (
-              <p className="text-300 text-text-primary-70">
-                Fleet is reconciling the tracked upgrade with the host updater. Do not run the manual install command
-                yet; wait until this check finishes.
-              </p>
-            )}
-          </div>
-        ) : active ? (
-          <div
-            role="status"
-            aria-live="polite"
-            aria-atomic="true"
-            className="flex flex-col gap-3 rounded-xl bg-core-primary-5 p-5"
-          >
-            <div className="flex items-center gap-3">
-              <span aria-hidden="true">
-                <ProgressCircular indeterminate size={20} />
-              </span>
-              <div className="text-heading-100 text-text-primary">{operation?.message || "Upgrade in progress"}</div>
-            </div>
-            <div className="text-200 text-text-primary-70">Phase: {activePhaseLabel}</div>
-            {connectionLost ? (
-              <p className="text-300 text-text-primary-70">
-                Fleet is temporarily unreachable. A disconnect is expected while services restart; this page will keep
-                checking for progress.
-              </p>
-            ) : (
-              <p className="text-300 text-text-primary-70">
-                You can close this dialog while Fleet downloads, validates, and activates the release. Return to this
-                Updates page to check progress.
-              </p>
-            )}
-          </div>
-        ) : failed ? (
-          <div role="alert" className="flex flex-col gap-3 rounded-xl bg-intent-critical-10 p-5">
-            <div className="text-heading-100 text-text-primary">{operation?.message || "Upgrade failed"}</div>
-            {error ? <p className="text-300 text-text-critical">{error}</p> : null}
-            {hostLogPath ? (
-              <p className="text-200 text-text-primary-70">
-                Host log: <code className="font-mono break-all">{hostLogPath}</code>
-              </p>
-            ) : null}
-            {recoveryCommand ? (
-              <div className="flex flex-col gap-2">
-                <div className="text-200 text-text-primary-70">Recovery command</div>
-                <div className="flex items-center justify-between gap-2 rounded-xl bg-surface-default px-4 py-3">
-                  <code className="min-w-0 flex-1 font-mono text-200 break-all text-text-primary">
-                    {recoveryCommand}
-                  </code>
-                  <Button
-                    ariaLabel="Copy recovery command"
-                    variant={variants.ghost}
-                    prefixIcon={<Copy width="w-4" />}
-                    onClick={handleCopyRecoveryCommand}
-                    className="shrink-0"
-                  />
-                </div>
-              </div>
-            ) : null}
-          </div>
-        ) : succeeded ? (
-          <div
-            role="status"
-            aria-live="polite"
-            aria-atomic="true"
-            className="flex flex-col gap-3 rounded-xl bg-core-primary-5 p-5"
-          >
-            <div className="text-heading-100 text-text-primary">{operation?.message || "Upgrade complete"}</div>
-            <p className="text-300 text-text-primary-70">
-              Reload Fleet to use the client bundled with {operation?.targetVersion}.
-            </p>
-          </div>
-        ) : release ? (
-          <div className="flex flex-col gap-3 rounded-xl bg-intent-warning-10 p-5">
-            <div className="text-heading-100 text-text-primary">Confirm upgrade to {release.version}</div>
-            <p className="text-300 text-text-primary-70">
-              Fleet will validate and build this exact release first, then take the instance offline for several minutes
-              while containers restart and database migrations run.
-            </p>
-            {release.prerelease ? (
-              <p className="text-300 font-medium text-text-critical">
-                This is a release candidate. The upgrade can run forward-only database migrations, and you cannot
-                downgrade this instance afterward. Continue only if you accept that recovery may require a newer
-                compatible release.
-              </p>
-            ) : null}
-          </div>
-        ) : null}
+        <UpgradeOperationContent
+          connectionLost={connectionLost}
+          manualFallbackReady={manualFallbackReady}
+          operation={operation}
+          reconciling={reconciling}
+          release={release}
+        />
 
         {triggerError ? (
           <p role="alert" className="text-300 text-text-critical">

--- a/client/src/protoFleet/features/settings/components/UpgradeOperationModal.tsx
+++ b/client/src/protoFleet/features/settings/components/UpgradeOperationModal.tsx
@@ -61,14 +61,33 @@ const ProgressPanel = ({ children, heading }: ProgressPanelProps) => (
   </div>
 );
 
-const ReconciliationPanel = ({ manualFallbackReady }: Pick<UpgradeOperationModalProps, "manualFallbackReady">) => (
+interface ReconciliationPanelProps {
+  manualFallbackReady: boolean;
+  unknownPhase: boolean;
+}
+
+const ReconciliationPanel = ({ manualFallbackReady, unknownPhase }: ReconciliationPanelProps) => (
   <ProgressPanel
-    heading={manualFallbackReady ? "Fleet could not confirm the upgrade outcome" : "Checking upgrade status"}
+    heading={
+      manualFallbackReady
+        ? "Fleet could not confirm the upgrade outcome"
+        : unknownPhase
+          ? "Host updater reported an unknown upgrade state"
+          : "Checking upgrade status"
+    }
   >
     {manualFallbackReady ? (
       <p className="text-300 font-medium text-text-critical">
-        The host updater is not reporting this upgrade. Only unlock the manual command after checking the host and
-        confirming no upgrade is running. Overlapping installs can leave the deployment unusable.
+        {unknownPhase
+          ? "Fleet cannot interpret the host updater's current state. "
+          : "The host updater is not reporting this upgrade. "}
+        Only unlock the manual command after checking the host and confirming no upgrade is running. Overlapping
+        installs can leave the deployment unusable.
+      </p>
+    ) : unknownPhase ? (
+      <p className="text-300 text-text-primary-70">
+        This version of Fleet does not recognize the state returned by the host updater. Manual installation remains
+        locked while Fleet continues checking.
       </p>
     ) : (
       <p className="text-300 text-text-primary-70">
@@ -196,7 +215,12 @@ const UpgradeOperationContent = ({
   release,
 }: UpgradeOperationContentProps) => {
   if (reconciling) {
-    return <ReconciliationPanel manualFallbackReady={manualFallbackReady} />;
+    return (
+      <ReconciliationPanel
+        manualFallbackReady={manualFallbackReady}
+        unknownPhase={operation?.phase === UpgradePhase.UNSPECIFIED}
+      />
+    );
   }
   if (!operation) {
     return release ? <UpgradeConfirmationPanel release={release} /> : null;

--- a/client/src/protoFleet/features/settings/components/UpgradeOperationModal.tsx
+++ b/client/src/protoFleet/features/settings/components/UpgradeOperationModal.tsx
@@ -156,9 +156,7 @@ const UpgradeOperationModal = ({
                 <ProgressCircular indeterminate size={20} />
               </span>
               <div className="text-heading-100 text-text-primary">
-                {manualFallbackReady
-                  ? "Fleet could not confirm the upgrade outcome"
-                  : "Checking whether the upgrade started"}
+                {manualFallbackReady ? "Fleet could not confirm the upgrade outcome" : "Checking upgrade status"}
               </div>
             </div>
             {manualFallbackReady ? (
@@ -168,8 +166,8 @@ const UpgradeOperationModal = ({
               </p>
             ) : (
               <p className="text-300 text-text-primary-70">
-                Fleet is reconciling the request with the host updater. Do not run the manual install command yet; wait
-                until this check finishes.
+                Fleet is reconciling the tracked upgrade with the host updater. Do not run the manual install command
+                yet; wait until this check finishes.
               </p>
             )}
           </div>

--- a/client/src/protoFleet/features/settings/components/UpgradeOperationModal.tsx
+++ b/client/src/protoFleet/features/settings/components/UpgradeOperationModal.tsx
@@ -161,8 +161,8 @@ const UpgradeOperationModal = ({
             </div>
             {manualFallbackReady ? (
               <p className="text-300 font-medium text-text-critical">
-                The host updater is still unreachable. Only unlock the manual command after checking the host and
-                confirming no upgrade is running; overlapping installs can leave the deployment unusable.
+                The host updater is not reporting this upgrade. Only unlock the manual command after checking the host
+                and confirming no upgrade is running. Overlapping installs can leave the deployment unusable.
               </p>
             ) : (
               <p className="text-300 text-text-primary-70">

--- a/client/src/protoFleet/features/settings/components/UpgradeOperationModal.tsx
+++ b/client/src/protoFleet/features/settings/components/UpgradeOperationModal.tsx
@@ -1,0 +1,268 @@
+import {
+  type ReleaseInfo,
+  type UpgradeOperation,
+  UpgradePhase,
+} from "@/protoFleet/api/generated/instance/v1/updates_pb";
+import { Copy } from "@/shared/assets/icons";
+import Button, { variants } from "@/shared/components/Button";
+import Modal from "@/shared/components/Modal";
+import ProgressCircular from "@/shared/components/ProgressCircular";
+import { pushToast, STATUSES } from "@/shared/features/toaster";
+import { copyToClipboard } from "@/shared/utils/utility";
+
+export interface UpgradeOperationModalProps {
+  connectionLost: boolean;
+  manualFallbackReady: boolean;
+  onAcknowledge: () => void;
+  onDismiss: () => void;
+  onReload: () => void;
+  onUpgrade: (targetVersion: string) => Promise<void>;
+  onUseManualFallback: () => void;
+  open: boolean;
+  operation?: UpgradeOperation;
+  reconciling: boolean;
+  release?: ReleaseInfo;
+  targetVersion?: string;
+  triggerError: string | null;
+  triggering: boolean;
+}
+
+const ACTIVE_PHASE_LABELS: Partial<Record<UpgradePhase, string>> = {
+  [UpgradePhase.QUEUED]: "Queued",
+  [UpgradePhase.DOWNLOADING]: "Downloading",
+  [UpgradePhase.VERIFYING]: "Verifying",
+  [UpgradePhase.STAGING]: "Staging",
+  [UpgradePhase.PREFLIGHT]: "Preflight",
+  [UpgradePhase.ACTIVATING]: "Activating",
+};
+
+const UpgradeOperationModal = ({
+  connectionLost,
+  manualFallbackReady,
+  onAcknowledge,
+  onDismiss,
+  onReload,
+  onUpgrade,
+  onUseManualFallback,
+  open,
+  operation,
+  reconciling,
+  release,
+  targetVersion,
+  triggerError,
+  triggering,
+}: UpgradeOperationModalProps) => {
+  if (!release && !operation && !reconciling && !triggerError) {
+    return null;
+  }
+
+  const displayedTargetVersion = operation?.targetVersion || targetVersion || release?.version;
+  const failed = operation?.phase === UpgradePhase.FAILED;
+  const succeeded = operation?.phase === UpgradePhase.SUCCEEDED;
+  const active = Boolean(operation && !failed && !succeeded);
+  const activePhaseLabel = operation ? (ACTIVE_PHASE_LABELS[operation.phase] ?? "Starting") : undefined;
+  const error = operation?.error.trim() ?? "";
+  const hostLogPath = operation?.hostLogPath.trim() ?? "";
+  const recoveryCommand = operation?.recoveryCommand.trim() ?? "";
+
+  const handleUpgrade = () => {
+    if (!release || reconciling) return;
+    void onUpgrade(release.version).catch(() => {
+      // The route owns reconciliation and exposes a terminal triggerError.
+    });
+  };
+
+  const handleCopyRecoveryCommand = () => {
+    if (!recoveryCommand) return;
+    void copyToClipboard(recoveryCommand)
+      .then(() => {
+        pushToast({
+          message: "Recovery command copied to clipboard",
+          status: STATUSES.success,
+        });
+      })
+      .catch(() => {
+        pushToast({
+          message: "Failed to copy recovery command",
+          status: STATUSES.error,
+        });
+      });
+  };
+
+  const buttons = manualFallbackReady
+    ? [
+        {
+          text: "I confirmed — unlock manual install",
+          variant: variants.secondaryDanger,
+          onClick: onUseManualFallback,
+          dismissModalOnClick: false,
+        },
+      ]
+    : succeeded
+      ? [
+          {
+            text: "Reload Fleet",
+            variant: variants.primary,
+            onClick: onReload,
+            dismissModalOnClick: false,
+          },
+        ]
+      : failed
+        ? [
+            {
+              text: "Dismiss failure",
+              variant: variants.secondary,
+              onClick: onAcknowledge,
+              dismissModalOnClick: false,
+            },
+          ]
+        : !active && !reconciling && release
+          ? [
+              {
+                text: "Cancel",
+                variant: variants.secondary,
+                onClick: onDismiss,
+                dismissModalOnClick: false,
+              },
+              {
+                text: `Confirm upgrade to ${release.version}`,
+                variant: variants.primary,
+                onClick: handleUpgrade,
+                loading: triggering,
+                dismissModalOnClick: false,
+              },
+            ]
+          : undefined;
+
+  return (
+    <Modal
+      open={open}
+      onDismiss={onDismiss}
+      title={displayedTargetVersion ? `Upgrade Fleet to ${displayedTargetVersion}` : "Upgrade Fleet"}
+      divider={false}
+      testId="upgrade-operation-modal"
+      buttons={buttons}
+    >
+      <div className="flex flex-col gap-5">
+        {reconciling ? (
+          <div
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+            className="flex flex-col gap-3 rounded-xl bg-core-primary-5 p-5"
+          >
+            <div className="flex items-center gap-3">
+              <span aria-hidden="true">
+                <ProgressCircular indeterminate size={20} />
+              </span>
+              <div className="text-heading-100 text-text-primary">
+                {manualFallbackReady
+                  ? "Fleet could not confirm the upgrade outcome"
+                  : "Checking whether the upgrade started"}
+              </div>
+            </div>
+            {manualFallbackReady ? (
+              <p className="text-300 font-medium text-text-critical">
+                The host updater is still unreachable. Only unlock the manual command after checking the host and
+                confirming no upgrade is running; overlapping installs can leave the deployment unusable.
+              </p>
+            ) : (
+              <p className="text-300 text-text-primary-70">
+                Fleet is reconciling the request with the host updater. Do not run the manual install command yet; wait
+                until this check finishes.
+              </p>
+            )}
+          </div>
+        ) : active ? (
+          <div
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+            className="flex flex-col gap-3 rounded-xl bg-core-primary-5 p-5"
+          >
+            <div className="flex items-center gap-3">
+              <span aria-hidden="true">
+                <ProgressCircular indeterminate size={20} />
+              </span>
+              <div className="text-heading-100 text-text-primary">{operation?.message || "Upgrade in progress"}</div>
+            </div>
+            <div className="text-200 text-text-primary-70">Phase: {activePhaseLabel}</div>
+            {connectionLost ? (
+              <p className="text-300 text-text-primary-70">
+                Fleet is temporarily unreachable. A disconnect is expected while services restart; this page will keep
+                checking for progress.
+              </p>
+            ) : (
+              <p className="text-300 text-text-primary-70">
+                You can close this dialog while Fleet downloads, validates, and activates the release. Return to this
+                Updates page to check progress.
+              </p>
+            )}
+          </div>
+        ) : failed ? (
+          <div role="alert" className="flex flex-col gap-3 rounded-xl bg-intent-critical-10 p-5">
+            <div className="text-heading-100 text-text-primary">{operation?.message || "Upgrade failed"}</div>
+            {error ? <p className="text-300 text-text-critical">{error}</p> : null}
+            {hostLogPath ? (
+              <p className="text-200 text-text-primary-70">
+                Host log: <code className="font-mono break-all">{hostLogPath}</code>
+              </p>
+            ) : null}
+            {recoveryCommand ? (
+              <div className="flex flex-col gap-2">
+                <div className="text-200 text-text-primary-70">Recovery command</div>
+                <div className="flex items-center justify-between gap-2 rounded-xl bg-surface-default px-4 py-3">
+                  <code className="min-w-0 flex-1 font-mono text-200 break-all text-text-primary">
+                    {recoveryCommand}
+                  </code>
+                  <Button
+                    ariaLabel="Copy recovery command"
+                    variant={variants.ghost}
+                    prefixIcon={<Copy width="w-4" />}
+                    onClick={handleCopyRecoveryCommand}
+                    className="shrink-0"
+                  />
+                </div>
+              </div>
+            ) : null}
+          </div>
+        ) : succeeded ? (
+          <div
+            role="status"
+            aria-live="polite"
+            aria-atomic="true"
+            className="flex flex-col gap-3 rounded-xl bg-core-primary-5 p-5"
+          >
+            <div className="text-heading-100 text-text-primary">{operation?.message || "Upgrade complete"}</div>
+            <p className="text-300 text-text-primary-70">
+              Reload Fleet to use the client bundled with {operation?.targetVersion}.
+            </p>
+          </div>
+        ) : release ? (
+          <div className="flex flex-col gap-3 rounded-xl bg-intent-warning-10 p-5">
+            <div className="text-heading-100 text-text-primary">Confirm upgrade to {release.version}</div>
+            <p className="text-300 text-text-primary-70">
+              Fleet will validate and build this exact release first, then take the instance offline for several minutes
+              while containers restart and database migrations run.
+            </p>
+            {release.prerelease ? (
+              <p className="text-300 font-medium text-text-critical">
+                This is a release candidate. The upgrade can run forward-only database migrations, and you cannot
+                downgrade this instance afterward. Continue only if you accept that recovery may require a newer
+                compatible release.
+              </p>
+            ) : null}
+          </div>
+        ) : null}
+
+        {triggerError ? (
+          <p role="alert" className="text-300 text-text-critical">
+            {triggerError}
+          </p>
+        ) : null}
+      </div>
+    </Modal>
+  );
+};
+
+export default UpgradeOperationModal;

--- a/client/src/protoFleet/features/updates/api/useUpgradeOperation.test.tsx
+++ b/client/src/protoFleet/features/updates/api/useUpgradeOperation.test.tsx
@@ -222,11 +222,43 @@ describe("useUpgradeOperation", () => {
     expect(result.current.reconciling).toBe(false);
     expect(result.current.operation).toBeUndefined();
     expect(window.sessionStorage.getItem(TRACKED_OPERATION_KEY)).toBeNull();
-    expect(JSON.parse(window.sessionStorage.getItem(ACKNOWLEDGED_OPERATION_KEY) ?? "{}").id).toBe("operation-1");
+    expect(JSON.parse(window.sessionStorage.getItem(ACKNOWLEDGED_OPERATION_KEY) ?? "{}")).toEqual({
+      authSessionIdentity: AUTH_SESSION_IDENTITY,
+      id: "operation-1",
+      phase: UpgradePhase.UNSPECIFIED,
+    });
 
     await act(async () => vi.advanceTimersByTimeAsync(2_000));
     expect(result.current.operation).toBeUndefined();
   });
+
+  it.each([UpgradePhase.FAILED, UpgradePhase.SUCCEEDED])(
+    "surfaces terminal phase %s after manually unlocking an unknown operation",
+    async (terminalPhase) => {
+      vi.useFakeTimers();
+      const unknownOperation = operation(UpgradePhase.UNSPECIFIED);
+      const terminalOperation = operation(terminalPhase);
+      mockGetUpgradeStatus.mockResolvedValueOnce(status()).mockResolvedValue(status(true, unknownOperation));
+      mockTriggerUpgrade.mockResolvedValue(
+        create(TriggerUpgradeResponseSchema, {
+          operation: unknownOperation,
+        }),
+      );
+      const { result } = renderHook(() => useTestUpgradeOperation({ enabled: true, currentVersion: "v1.2.0" }));
+      await act(async () => Promise.resolve());
+
+      await act(async () => result.current.triggerUpgrade("v1.3.0"));
+      await act(async () => vi.advanceTimersByTimeAsync(17_000));
+      act(() => result.current.useManualFallback());
+
+      mockGetUpgradeStatus.mockReset();
+      mockGetUpgradeStatus.mockResolvedValue(status(true, terminalOperation));
+      await act(async () => vi.advanceTimersByTimeAsync(2_000));
+
+      expect(result.current.operation?.phase).toBe(terminalPhase);
+      expect(window.sessionStorage.getItem(ACKNOWLEDGED_OPERATION_KEY)).toBeNull();
+    },
+  );
 
   it("accepts a terminal operation returned directly by the trigger RPC", async () => {
     const failedOperation = operation(UpgradePhase.FAILED, { message: "Preflight failed" });
@@ -550,6 +582,7 @@ describe("useUpgradeOperation", () => {
     expect(acknowledgedRecord).toEqual({
       authSessionIdentity: AUTH_SESSION_IDENTITY,
       id: "operation-1",
+      phase: UpgradePhase.FAILED,
     });
     firstSession.unmount();
 

--- a/client/src/protoFleet/features/updates/api/useUpgradeOperation.test.tsx
+++ b/client/src/protoFleet/features/updates/api/useUpgradeOperation.test.tsx
@@ -10,7 +10,7 @@ import {
   UpgradeOperationSchema,
   UpgradePhase,
 } from "@/protoFleet/api/generated/instance/v1/updates_pb";
-import { useUpgradeOperation } from "@/protoFleet/features/updates/api/useUpgradeOperation";
+import { isUpgradeActive, useUpgradeOperation } from "@/protoFleet/features/updates/api/useUpgradeOperation";
 
 vi.mock("@/protoFleet/api/clients", () => ({
   instanceUpdateClient: {
@@ -23,21 +23,17 @@ const mockGetUpgradeStatus = vi.mocked(instanceUpdateClient.getUpgradeStatus);
 const mockTriggerUpgrade = vi.mocked(instanceUpdateClient.triggerUpgrade);
 const TRACKED_OPERATION_KEY = "protoFleet:tracked-upgrade-operation";
 const ACKNOWLEDGED_OPERATION_KEY = "protoFleet:acknowledged-upgrade-operation";
-const AUTH_SESSION_IDENTITY = "operator-a:1000";
-const AUTH_SESSION_TOKEN = new Date(1_000);
+const AUTH_SESSION_IDENTITY = "operator-a:1";
 
 type TestUpgradeOperationOptions = Omit<
   Parameters<typeof useUpgradeOperation>[0],
-  "authSessionIdentity" | "authSessionToken" | "currentVersionUnavailable"
+  "authSessionIdentity" | "currentVersionUnavailable"
 > & {
   currentVersionUnavailable?: boolean;
 };
 
-const useTestUpgradeOperation = (
-  options: TestUpgradeOperationOptions,
-  authSessionIdentity = AUTH_SESSION_IDENTITY,
-  authSessionToken: object | null = AUTH_SESSION_TOKEN,
-) => useUpgradeOperation({ authSessionIdentity, authSessionToken, currentVersionUnavailable: false, ...options });
+const useTestUpgradeOperation = (options: TestUpgradeOperationOptions, authSessionIdentity = AUTH_SESSION_IDENTITY) =>
+  useUpgradeOperation({ authSessionIdentity, currentVersionUnavailable: false, ...options });
 
 type MessageOverrides<T> = Omit<Partial<T>, "$typeName" | "$unknown">;
 
@@ -139,27 +135,21 @@ describe("useUpgradeOperation", () => {
     expect(result.current.operationStatusPending).toBe(false);
   });
 
-  it("restarts polling when a replacement session has the same serialized identity", async () => {
+  it("restarts polling when the authenticated session generation changes", async () => {
     const previousRequest = deferred<ReturnType<typeof status>>();
     const onPollError = vi.fn();
     mockGetUpgradeStatus.mockReturnValueOnce(previousRequest.promise).mockResolvedValue(status());
-    const previousSessionToken = new Date(1_000);
-    const replacementSessionToken = new Date(1_000);
 
     const { rerender, result } = renderHook(
-      ({ authSessionToken }: { authSessionToken: object }) =>
-        useTestUpgradeOperation(
-          { enabled: true, currentVersion: "v1.2.0", onPollError },
-          AUTH_SESSION_IDENTITY,
-          authSessionToken,
-        ),
-      { initialProps: { authSessionToken: previousSessionToken } },
+      ({ authSessionIdentity }: { authSessionIdentity: string }) =>
+        useTestUpgradeOperation({ enabled: true, currentVersion: "v1.2.0", onPollError }, authSessionIdentity),
+      { initialProps: { authSessionIdentity: AUTH_SESSION_IDENTITY } },
     );
 
     await waitFor(() => expect(mockGetUpgradeStatus).toHaveBeenCalledTimes(1));
     const previousSignal = mockGetUpgradeStatus.mock.calls[0]?.[1]?.signal;
 
-    rerender({ authSessionToken: replacementSessionToken });
+    rerender({ authSessionIdentity: "operator-a:2" });
 
     await waitFor(() => expect(mockGetUpgradeStatus).toHaveBeenCalledTimes(2));
     expect(previousSignal?.aborted).toBe(true);
@@ -194,12 +184,13 @@ describe("useUpgradeOperation", () => {
     });
   });
 
-  it("bounds reconciliation when a trigger response has an unsupported phase", async () => {
+  it("keeps an unknown phase locked until explicit host confirmation", async () => {
     vi.useFakeTimers();
-    mockGetUpgradeStatus.mockResolvedValue(status());
+    const unknownOperation = operation(UpgradePhase.UNSPECIFIED);
+    mockGetUpgradeStatus.mockResolvedValueOnce(status()).mockResolvedValue(status(true, unknownOperation));
     mockTriggerUpgrade.mockResolvedValue(
       create(TriggerUpgradeResponseSchema, {
-        operation: operation(UpgradePhase.UNSPECIFIED),
+        operation: unknownOperation,
       }),
     );
     const { result } = renderHook(() => useTestUpgradeOperation({ enabled: true, currentVersion: "v1.2.0" }));
@@ -208,15 +199,29 @@ describe("useUpgradeOperation", () => {
     await act(async () => result.current.triggerUpgrade("v1.3.0"));
 
     expect(result.current.reconciling).toBe(true);
-    expect(result.current.triggerError).toContain("couldn't confirm the upgrade state");
+    expect(result.current.operation?.phase).toBe(UpgradePhase.UNSPECIFIED);
+    expect(isUpgradeActive(result.current.operation)).toBe(true);
+    expect(result.current.triggerError).toBeNull();
     expect(JSON.parse(window.sessionStorage.getItem(TRACKED_OPERATION_KEY) ?? "{}")).toEqual({
+      id: "operation-1",
       targetVersion: "v1.3.0",
     });
 
     await act(async () => vi.advanceTimersByTimeAsync(17_000));
 
+    expect(result.current.reconciling).toBe(true);
+    expect(result.current.manualFallbackReady).toBe(true);
+    expect(result.current.operation?.phase).toBe(UpgradePhase.UNSPECIFIED);
+
+    act(() => result.current.useManualFallback());
+
     expect(result.current.reconciling).toBe(false);
+    expect(result.current.operation).toBeUndefined();
     expect(window.sessionStorage.getItem(TRACKED_OPERATION_KEY)).toBeNull();
+    expect(JSON.parse(window.sessionStorage.getItem(ACKNOWLEDGED_OPERATION_KEY) ?? "{}").id).toBe("operation-1");
+
+    await act(async () => vi.advanceTimersByTimeAsync(2_000));
+    expect(result.current.operation).toBeUndefined();
   });
 
   it("accepts a terminal operation returned directly by the trigger RPC", async () => {
@@ -478,7 +483,8 @@ describe("useUpgradeOperation", () => {
     act(() => firstSession.result.current.acknowledgeOperation());
 
     expect(firstSession.result.current.operation).toBeUndefined();
-    expect(JSON.parse(window.sessionStorage.getItem(ACKNOWLEDGED_OPERATION_KEY) ?? "{}")).toEqual({
+    const acknowledgedRecord = JSON.parse(window.sessionStorage.getItem(ACKNOWLEDGED_OPERATION_KEY) ?? "{}");
+    expect(acknowledgedRecord).toEqual({
       authSessionIdentity: AUTH_SESSION_IDENTITY,
       id: "operation-1",
     });
@@ -490,13 +496,10 @@ describe("useUpgradeOperation", () => {
     sameSession.unmount();
 
     const nextSession = renderHook(() =>
-      useTestUpgradeOperation({ enabled: true, currentVersion: "v1.2.0" }, "operator-b:2000"),
+      useTestUpgradeOperation({ enabled: true, currentVersion: "v1.2.0" }, "operator-a:2"),
     );
     await waitFor(() => expect(nextSession.result.current.operation?.phase).toBe(UpgradePhase.FAILED));
-    expect(JSON.parse(window.sessionStorage.getItem(ACKNOWLEDGED_OPERATION_KEY) ?? "{}")).toEqual({
-      authSessionIdentity: AUTH_SESSION_IDENTITY,
-      id: "operation-1",
-    });
+    expect(JSON.parse(window.sessionStorage.getItem(ACKNOWLEDGED_OPERATION_KEY) ?? "{}")).toEqual(acknowledgedRecord);
   });
 
   it("forwards poll errors for page-level auth handling", async () => {

--- a/client/src/protoFleet/features/updates/api/useUpgradeOperation.test.tsx
+++ b/client/src/protoFleet/features/updates/api/useUpgradeOperation.test.tsx
@@ -139,6 +139,31 @@ describe("useUpgradeOperation", () => {
     });
   });
 
+  it("bounds reconciliation when a trigger response has an unsupported phase", async () => {
+    vi.useFakeTimers();
+    mockGetUpgradeStatus.mockResolvedValue(status());
+    mockTriggerUpgrade.mockResolvedValue(
+      create(TriggerUpgradeResponseSchema, {
+        operation: operation(UpgradePhase.UNSPECIFIED),
+      }),
+    );
+    const { result } = renderHook(() => useTestUpgradeOperation({ enabled: true, currentVersion: "v1.2.0" }));
+    await act(async () => Promise.resolve());
+
+    await act(async () => result.current.triggerUpgrade("v1.3.0"));
+
+    expect(result.current.reconciling).toBe(true);
+    expect(result.current.triggerError).toContain("couldn't confirm the upgrade state");
+    expect(JSON.parse(window.sessionStorage.getItem(TRACKED_OPERATION_KEY) ?? "{}")).toEqual({
+      targetVersion: "v1.3.0",
+    });
+
+    await act(async () => vi.advanceTimersByTimeAsync(17_000));
+
+    expect(result.current.reconciling).toBe(false);
+    expect(window.sessionStorage.getItem(TRACKED_OPERATION_KEY)).toBeNull();
+  });
+
   it("reconciles an ambiguous trigger rejection to the durable operation", async () => {
     const activeOperation = operation(UpgradePhase.PREFLIGHT);
     mockGetUpgradeStatus.mockResolvedValueOnce(status()).mockResolvedValue(status(true, activeOperation));

--- a/client/src/protoFleet/features/updates/api/useUpgradeOperation.test.tsx
+++ b/client/src/protoFleet/features/updates/api/useUpgradeOperation.test.tsx
@@ -1,0 +1,247 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { create } from "@bufbuild/protobuf";
+
+import { instanceUpdateClient } from "@/protoFleet/api/clients";
+import {
+  GetUpgradeStatusResponseSchema,
+  TriggerUpgradeResponseSchema,
+  type UpgradeOperation,
+  UpgradeOperationSchema,
+  UpgradePhase,
+} from "@/protoFleet/api/generated/instance/v1/updates_pb";
+import { useUpgradeOperation } from "@/protoFleet/features/updates/api/useUpgradeOperation";
+
+vi.mock("@/protoFleet/api/clients", () => ({
+  instanceUpdateClient: {
+    getUpgradeStatus: vi.fn(),
+    triggerUpgrade: vi.fn(),
+  },
+}));
+
+const mockGetUpgradeStatus = vi.mocked(instanceUpdateClient.getUpgradeStatus);
+const mockTriggerUpgrade = vi.mocked(instanceUpdateClient.triggerUpgrade);
+const TRACKED_OPERATION_KEY = "protoFleet:tracked-upgrade-operation";
+const ACKNOWLEDGED_OPERATION_KEY = "protoFleet:acknowledged-upgrade-operation";
+
+type MessageOverrides<T> = Omit<Partial<T>, "$typeName" | "$unknown">;
+
+const operation = (phase: UpgradePhase, overrides?: MessageOverrides<UpgradeOperation>) =>
+  create(UpgradeOperationSchema, {
+    id: "operation-1",
+    targetVersion: "v1.3.0",
+    phase,
+    message: "Preparing upgrade",
+    ...overrides,
+  });
+
+const status = (executorAvailable = true, currentOperation?: UpgradeOperation) =>
+  create(GetUpgradeStatusResponseSchema, {
+    executorAvailable,
+    operation: currentOperation,
+  });
+
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, reject, resolve };
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.sessionStorage.clear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useUpgradeOperation", () => {
+  it("recovers a durable active operation without a capability gate", async () => {
+    const activeOperation = operation(UpgradePhase.PREFLIGHT);
+    mockGetUpgradeStatus.mockResolvedValue(status(true, activeOperation));
+
+    const { result } = renderHook(() => useUpgradeOperation({ enabled: true, currentVersion: "v1.2.0" }));
+
+    await waitFor(() => expect(result.current.operation?.id).toBe("operation-1"));
+    expect(result.current.connectionLost).toBe(false);
+    expect(mockGetUpgradeStatus).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({ signal: expect.any(AbortSignal), timeoutMs: 10_000 }),
+    );
+  });
+
+  it("does not overlap a pending poll and aborts it on cleanup", async () => {
+    vi.useFakeTimers();
+    const request = deferred<ReturnType<typeof status>>();
+    mockGetUpgradeStatus.mockReturnValue(request.promise);
+
+    const hook = renderHook(() => useUpgradeOperation({ enabled: true, currentVersion: "v1.2.0" }));
+    await act(async () => Promise.resolve());
+    expect(mockGetUpgradeStatus).toHaveBeenCalledTimes(1);
+
+    await act(async () => vi.advanceTimersByTimeAsync(120_000));
+    expect(mockGetUpgradeStatus).toHaveBeenCalledTimes(1);
+    const signal = mockGetUpgradeStatus.mock.calls[0]?.[1]?.signal;
+
+    hook.unmount();
+    expect(signal?.aborted).toBe(true);
+  });
+
+  it("starts the exact target and tracks the returned operation", async () => {
+    const activeOperation = operation(UpgradePhase.PREFLIGHT);
+    mockGetUpgradeStatus.mockResolvedValue(status());
+    mockTriggerUpgrade.mockResolvedValue(
+      create(TriggerUpgradeResponseSchema, {
+        operation: activeOperation,
+      }),
+    );
+    const { result } = renderHook(() => useUpgradeOperation({ enabled: true, currentVersion: "v1.2.0" }));
+
+    await waitFor(() => expect(mockGetUpgradeStatus).toHaveBeenCalled());
+    await act(async () => result.current.triggerUpgrade("v1.3.0"));
+
+    expect(mockTriggerUpgrade).toHaveBeenCalledWith({ targetVersion: "v1.3.0" }, { timeoutMs: 30_000 });
+    expect(result.current.operation?.phase).toBe(UpgradePhase.PREFLIGHT);
+    expect(JSON.parse(window.sessionStorage.getItem(TRACKED_OPERATION_KEY) ?? "{}")).toEqual({
+      id: "operation-1",
+      targetVersion: "v1.3.0",
+    });
+  });
+
+  it("reconciles an ambiguous trigger rejection to the durable operation", async () => {
+    const activeOperation = operation(UpgradePhase.PREFLIGHT);
+    mockGetUpgradeStatus.mockResolvedValueOnce(status()).mockResolvedValue(status(true, activeOperation));
+    mockTriggerUpgrade.mockRejectedValue(new Error("response lost"));
+    const { result } = renderHook(() => useUpgradeOperation({ enabled: true, currentVersion: "v1.2.0" }));
+
+    await waitFor(() => expect(mockGetUpgradeStatus).toHaveBeenCalledTimes(1));
+    await act(async () => result.current.triggerUpgrade("v1.3.0"));
+    await waitFor(() => expect(result.current.operation?.id).toBe("operation-1"));
+
+    expect(result.current.reconciling).toBe(false);
+    expect(result.current.triggerError).toBeNull();
+  });
+
+  it("ends bounded reconciliation and preserves an actionable trigger error", async () => {
+    vi.useFakeTimers();
+    mockGetUpgradeStatus.mockResolvedValue(status());
+    mockTriggerUpgrade.mockRejectedValue(new Error("host did not confirm"));
+    const { result } = renderHook(() => useUpgradeOperation({ enabled: true, currentVersion: "v1.2.0" }));
+    await act(async () => Promise.resolve());
+
+    await act(async () => result.current.triggerUpgrade("v1.3.0"));
+    expect(result.current.reconciling).toBe(true);
+
+    await act(async () => vi.advanceTimersByTimeAsync(17_000));
+
+    expect(result.current.reconciling).toBe(false);
+    expect(result.current.triggerError).toContain("host did not confirm");
+    expect(window.sessionStorage.getItem(TRACKED_OPERATION_KEY)).toBeNull();
+  });
+
+  it("does not unlock an unknown trigger outcome while the executor is unreachable", async () => {
+    vi.useFakeTimers();
+    mockGetUpgradeStatus.mockResolvedValueOnce(status()).mockResolvedValue(status(false));
+    mockTriggerUpgrade.mockRejectedValue(new Error("host did not confirm"));
+    const { result } = renderHook(() => useUpgradeOperation({ enabled: true, currentVersion: "v1.2.0" }));
+    await act(async () => Promise.resolve());
+
+    await act(async () => result.current.triggerUpgrade("v1.3.0"));
+    await act(async () => vi.advanceTimersByTimeAsync(30_000));
+
+    expect(result.current.reconciling).toBe(true);
+    expect(result.current.connectionLost).toBe(true);
+    expect(result.current.manualFallbackReady).toBe(true);
+    expect(window.sessionStorage.getItem(TRACKED_OPERATION_KEY)).not.toBeNull();
+
+    act(() => result.current.useManualFallback());
+
+    expect(result.current.reconciling).toBe(false);
+    expect(result.current.triggerError).toBeNull();
+    expect(window.sessionStorage.getItem(TRACKED_OPERATION_KEY)).toBeNull();
+  });
+
+  it("keeps progress through disconnect and accepts the terminal success", async () => {
+    vi.useFakeTimers();
+    const activeOperation = operation(UpgradePhase.ACTIVATING);
+    const succeededOperation = operation(UpgradePhase.SUCCEEDED, { message: "Upgrade complete" });
+    mockGetUpgradeStatus
+      .mockResolvedValueOnce(status(true, activeOperation))
+      .mockRejectedValueOnce(new Error("Fleet restarting"))
+      .mockResolvedValue(status(true, succeededOperation));
+    const { result } = renderHook(() => useUpgradeOperation({ enabled: true, currentVersion: "v1.2.0" }));
+    await act(async () => Promise.resolve());
+    expect(result.current.operation?.phase).toBe(UpgradePhase.ACTIVATING);
+
+    await act(async () => vi.advanceTimersByTimeAsync(2_000));
+    expect(result.current.connectionLost).toBe(true);
+    expect(result.current.operation?.phase).toBe(UpgradePhase.ACTIVATING);
+
+    await act(async () => vi.advanceTimersByTimeAsync(2_000));
+    expect(result.current.operation?.phase).toBe(UpgradePhase.SUCCEEDED);
+    expect(result.current.connectionLost).toBe(false);
+  });
+
+  it("does not replay an untracked historical success", async () => {
+    mockGetUpgradeStatus.mockResolvedValue(status(true, operation(UpgradePhase.SUCCEEDED)));
+    const { result } = renderHook(() => useUpgradeOperation({ enabled: true, currentVersion: "v1.3.0" }));
+
+    await waitFor(() => expect(mockGetUpgradeStatus).toHaveBeenCalled());
+    expect(result.current.operation).toBeUndefined();
+  });
+
+  it("suppresses a stale failure after manual recovery installed its target", async () => {
+    window.sessionStorage.setItem(
+      TRACKED_OPERATION_KEY,
+      JSON.stringify({ id: "operation-1", targetVersion: "v1.3.0" }),
+    );
+    mockGetUpgradeStatus.mockResolvedValue(status(true, operation(UpgradePhase.FAILED)));
+    const { result } = renderHook(() => useUpgradeOperation({ enabled: true, currentVersion: "v1.3.0" }));
+
+    await waitFor(() => expect(mockGetUpgradeStatus).toHaveBeenCalled());
+    expect(result.current.operation).toBeUndefined();
+    expect(window.sessionStorage.getItem(TRACKED_OPERATION_KEY)).toBeNull();
+  });
+
+  it("rechecks an unresolved failure as soon as the current version loads", async () => {
+    mockGetUpgradeStatus.mockResolvedValue(status(true, operation(UpgradePhase.FAILED)));
+    const initialProps: { currentVersion?: string } = {};
+    const { rerender, result } = renderHook(
+      ({ currentVersion }: { currentVersion?: string }) => useUpgradeOperation({ enabled: true, currentVersion }),
+      { initialProps },
+    );
+
+    await waitFor(() => expect(mockGetUpgradeStatus).toHaveBeenCalledTimes(1));
+    expect(result.current.operation).toBeUndefined();
+
+    rerender({ currentVersion: "v1.2.0" });
+
+    await waitFor(() => expect(result.current.operation?.phase).toBe(UpgradePhase.FAILED));
+  });
+
+  it("acknowledges a terminal failure so it is not replayed", async () => {
+    mockGetUpgradeStatus.mockResolvedValue(status(true, operation(UpgradePhase.FAILED)));
+    const { result } = renderHook(() => useUpgradeOperation({ enabled: true, currentVersion: "v1.2.0" }));
+    await waitFor(() => expect(result.current.operation?.phase).toBe(UpgradePhase.FAILED));
+
+    act(() => result.current.acknowledgeOperation());
+
+    expect(result.current.operation).toBeUndefined();
+    expect(window.sessionStorage.getItem(ACKNOWLEDGED_OPERATION_KEY)).toBe("operation-1");
+  });
+
+  it("forwards poll errors for page-level auth handling", async () => {
+    const onPollError = vi.fn();
+    const pollError = new Error("permission revoked");
+    mockGetUpgradeStatus.mockRejectedValue(pollError);
+
+    renderHook(() => useUpgradeOperation({ enabled: true, currentVersion: "v1.2.0", onPollError }));
+
+    await waitFor(() => expect(onPollError).toHaveBeenCalledWith(pollError));
+  });
+});

--- a/client/src/protoFleet/features/updates/api/useUpgradeOperation.test.tsx
+++ b/client/src/protoFleet/features/updates/api/useUpgradeOperation.test.tsx
@@ -118,6 +118,51 @@ describe("useUpgradeOperation", () => {
     expect(signal?.aborted).toBe(true);
   });
 
+  it("keeps operation status pending until the first authoritative response", async () => {
+    const request = deferred<ReturnType<typeof status>>();
+    mockGetUpgradeStatus.mockReturnValue(request.promise);
+
+    const { result } = renderHook(() => useTestUpgradeOperation({ enabled: true, currentVersion: "v1.2.0" }));
+
+    expect(result.current.operationStatusPending).toBe(true);
+    await waitFor(() => expect(mockGetUpgradeStatus).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      request.resolve(status());
+      await request.promise;
+    });
+
+    expect(result.current.operationStatusPending).toBe(false);
+  });
+
+  it("restarts polling and ignores the previous authenticated session's request", async () => {
+    const previousRequest = deferred<ReturnType<typeof status>>();
+    const onPollError = vi.fn();
+    mockGetUpgradeStatus.mockReturnValueOnce(previousRequest.promise).mockResolvedValue(status());
+
+    const { rerender, result } = renderHook(
+      ({ authSessionIdentity }: { authSessionIdentity: string }) =>
+        useTestUpgradeOperation({ enabled: true, currentVersion: "v1.2.0", onPollError }, authSessionIdentity),
+      { initialProps: { authSessionIdentity: AUTH_SESSION_IDENTITY } },
+    );
+
+    await waitFor(() => expect(mockGetUpgradeStatus).toHaveBeenCalledTimes(1));
+    const previousSignal = mockGetUpgradeStatus.mock.calls[0]?.[1]?.signal;
+
+    rerender({ authSessionIdentity: "operator-b:2000" });
+
+    await waitFor(() => expect(mockGetUpgradeStatus).toHaveBeenCalledTimes(2));
+    expect(previousSignal?.aborted).toBe(true);
+    await waitFor(() => expect(result.current.operationStatusPending).toBe(false));
+
+    await act(async () => {
+      previousRequest.reject(new Error("previous session expired"));
+      await Promise.resolve();
+    });
+
+    expect(onPollError).not.toHaveBeenCalled();
+  });
+
   it("starts the exact target and tracks the returned operation", async () => {
     const activeOperation = operation(UpgradePhase.PREFLIGHT);
     mockGetUpgradeStatus.mockResolvedValue(status());
@@ -164,6 +209,24 @@ describe("useUpgradeOperation", () => {
     expect(window.sessionStorage.getItem(TRACKED_OPERATION_KEY)).toBeNull();
   });
 
+  it("accepts a terminal operation returned directly by the trigger RPC", async () => {
+    const failedOperation = operation(UpgradePhase.FAILED, { message: "Preflight failed" });
+    mockGetUpgradeStatus.mockResolvedValue(status());
+    mockTriggerUpgrade.mockResolvedValue(
+      create(TriggerUpgradeResponseSchema, {
+        operation: failedOperation,
+      }),
+    );
+    const { result } = renderHook(() => useTestUpgradeOperation({ enabled: true, currentVersion: "v1.2.0" }));
+    await waitFor(() => expect(mockGetUpgradeStatus).toHaveBeenCalled());
+
+    await act(async () => result.current.triggerUpgrade("v1.3.0"));
+
+    expect(result.current.operation?.id).toBe("operation-1");
+    expect(result.current.operation?.phase).toBe(UpgradePhase.FAILED);
+    expect(result.current.reconciling).toBe(false);
+  });
+
   it("reconciles an ambiguous trigger rejection to the durable operation", async () => {
     const activeOperation = operation(UpgradePhase.PREFLIGHT);
     mockGetUpgradeStatus.mockResolvedValueOnce(status()).mockResolvedValue(status(true, activeOperation));
@@ -181,7 +244,7 @@ describe("useUpgradeOperation", () => {
   it("does not let a stale terminal failure resolve an ambiguous trigger", async () => {
     const staleFailure = operation(UpgradePhase.FAILED, {
       id: "operation-old",
-      targetVersion: "v1.1.0",
+      targetVersion: "v1.3.0",
     });
     mockGetUpgradeStatus.mockResolvedValueOnce(status()).mockResolvedValue(status(true, staleFailure));
     mockTriggerUpgrade.mockRejectedValue(new Error("response lost"));

--- a/client/src/protoFleet/features/updates/api/useUpgradeOperation.test.tsx
+++ b/client/src/protoFleet/features/updates/api/useUpgradeOperation.test.tsx
@@ -424,7 +424,7 @@ describe("useUpgradeOperation", () => {
     expect(result.current.operation).toBeUndefined();
   });
 
-  it("suppresses a stale failure after manual recovery installed its target", async () => {
+  it("keeps a tracked activation failure visible when Fleet reports its target version", async () => {
     window.sessionStorage.setItem(
       TRACKED_OPERATION_KEY,
       JSON.stringify({ id: "operation-1", targetVersion: "v1.3.0" }),
@@ -432,9 +432,15 @@ describe("useUpgradeOperation", () => {
     mockGetUpgradeStatus.mockResolvedValue(status(true, operation(UpgradePhase.FAILED)));
     const { result } = renderHook(() => useTestUpgradeOperation({ enabled: true, currentVersion: "v1.3.0" }));
 
-    await waitFor(() => expect(mockGetUpgradeStatus).toHaveBeenCalled());
-    expect(result.current.operation).toBeUndefined();
-    expect(window.sessionStorage.getItem(TRACKED_OPERATION_KEY)).toBeNull();
+    await waitFor(() => expect(result.current.operation?.phase).toBe(UpgradePhase.FAILED));
+    expect(window.sessionStorage.getItem(TRACKED_OPERATION_KEY)).not.toBeNull();
+  });
+
+  it("keeps an untracked activation failure visible when Fleet reports its target version", async () => {
+    mockGetUpgradeStatus.mockResolvedValue(status(true, operation(UpgradePhase.FAILED)));
+    const { result } = renderHook(() => useTestUpgradeOperation({ enabled: true, currentVersion: "v1.3.0" }));
+
+    await waitFor(() => expect(result.current.operation?.phase).toBe(UpgradePhase.FAILED));
   });
 
   it("suppresses a stale failure after manual recovery installed a newer release", async () => {

--- a/client/src/protoFleet/features/updates/api/useUpgradeOperation.test.tsx
+++ b/client/src/protoFleet/features/updates/api/useUpgradeOperation.test.tsx
@@ -1,6 +1,7 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { create } from "@bufbuild/protobuf";
+import { Code, ConnectError } from "@connectrpc/connect";
 
 import { instanceUpdateClient } from "@/protoFleet/api/clients";
 import {
@@ -148,11 +149,13 @@ describe("useUpgradeOperation", () => {
 
     await waitFor(() => expect(mockGetUpgradeStatus).toHaveBeenCalledTimes(1));
     const previousSignal = mockGetUpgradeStatus.mock.calls[0]?.[1]?.signal;
+    const abortSpy = vi.spyOn(AbortController.prototype, "abort").mockImplementation(() => undefined);
 
     rerender({ authSessionIdentity: "operator-a:2" });
 
     await waitFor(() => expect(mockGetUpgradeStatus).toHaveBeenCalledTimes(2));
-    expect(previousSignal?.aborted).toBe(true);
+    expect(abortSpy).toHaveBeenCalled();
+    expect(previousSignal?.aborted).toBe(false);
     await waitFor(() => expect(result.current.operationStatusPending).toBe(false));
 
     await act(async () => {
@@ -161,6 +164,7 @@ describe("useUpgradeOperation", () => {
     });
 
     expect(onPollError).not.toHaveBeenCalled();
+    abortSpy.mockRestore();
   });
 
   it("starts the exact target and tracks the returned operation", async () => {
@@ -254,6 +258,34 @@ describe("useUpgradeOperation", () => {
 
     expect(result.current.reconciling).toBe(false);
     expect(result.current.triggerError).toBeNull();
+  });
+
+  it("unlocks immediately when the server definitively rejects a stale target", async () => {
+    mockGetUpgradeStatus.mockResolvedValue(status());
+    mockTriggerUpgrade.mockRejectedValue(
+      new ConnectError('target "v1.3.0" is no longer the eligible update', Code.FailedPrecondition),
+    );
+    const { result } = renderHook(() => useTestUpgradeOperation({ enabled: true, currentVersion: "v1.2.0" }));
+
+    await waitFor(() => expect(mockGetUpgradeStatus).toHaveBeenCalled());
+    await act(async () => result.current.triggerUpgrade("v1.3.0"));
+
+    expect(result.current.reconciling).toBe(false);
+    expect(result.current.trackedTargetVersion).toBeUndefined();
+    expect(result.current.triggerError).toContain("no longer the eligible update");
+    expect(window.sessionStorage.getItem(TRACKED_OPERATION_KEY)).toBeNull();
+  });
+
+  it("reconciles an already-existing operation instead of treating the rejection as safe to unlock", async () => {
+    mockGetUpgradeStatus.mockResolvedValue(status());
+    mockTriggerUpgrade.mockRejectedValue(new ConnectError("another upgrade is active", Code.AlreadyExists));
+    const { result } = renderHook(() => useTestUpgradeOperation({ enabled: true, currentVersion: "v1.2.0" }));
+
+    await waitFor(() => expect(mockGetUpgradeStatus).toHaveBeenCalled());
+    await act(async () => result.current.triggerUpgrade("v1.3.0"));
+
+    expect(result.current.reconciling).toBe(true);
+    expect(result.current.trackedTargetVersion).toBe("v1.3.0");
   });
 
   it("reconciles an ambiguous trigger rejection to a completed upgrade", async () => {

--- a/client/src/protoFleet/features/updates/api/useUpgradeOperation.test.tsx
+++ b/client/src/protoFleet/features/updates/api/useUpgradeOperation.test.tsx
@@ -437,6 +437,31 @@ describe("useUpgradeOperation", () => {
     expect(window.sessionStorage.getItem(TRACKED_OPERATION_KEY)).toBeNull();
   });
 
+  it("suppresses a stale failure after manual recovery installed a newer release", async () => {
+    mockGetUpgradeStatus.mockResolvedValue(status(true, operation(UpgradePhase.FAILED)));
+    const { result } = renderHook(() => useTestUpgradeOperation({ enabled: true, currentVersion: "v1.4.0" }));
+
+    await waitFor(() => expect(mockGetUpgradeStatus).toHaveBeenCalled());
+    expect(result.current.operation).toBeUndefined();
+  });
+
+  it("treats a stable release as newer than its failed release candidate", async () => {
+    mockGetUpgradeStatus.mockResolvedValue(
+      status(true, operation(UpgradePhase.FAILED, { targetVersion: "v1.3.0-rc.4" })),
+    );
+    const { result } = renderHook(() => useTestUpgradeOperation({ enabled: true, currentVersion: "v1.3.0" }));
+
+    await waitFor(() => expect(mockGetUpgradeStatus).toHaveBeenCalled());
+    expect(result.current.operation).toBeUndefined();
+  });
+
+  it("retains a failed operation when the current version is not canonical", async () => {
+    mockGetUpgradeStatus.mockResolvedValue(status(true, operation(UpgradePhase.FAILED)));
+    const { result } = renderHook(() => useTestUpgradeOperation({ enabled: true, currentVersion: "dev" }));
+
+    await waitFor(() => expect(result.current.operation?.phase).toBe(UpgradePhase.FAILED));
+  });
+
   it("rechecks an unresolved failure as soon as the current version loads", async () => {
     mockGetUpgradeStatus.mockResolvedValue(status(true, operation(UpgradePhase.FAILED)));
     const initialProps: { currentVersion?: string } = {};

--- a/client/src/protoFleet/features/updates/api/useUpgradeOperation.test.tsx
+++ b/client/src/protoFleet/features/updates/api/useUpgradeOperation.test.tsx
@@ -24,16 +24,20 @@ const mockTriggerUpgrade = vi.mocked(instanceUpdateClient.triggerUpgrade);
 const TRACKED_OPERATION_KEY = "protoFleet:tracked-upgrade-operation";
 const ACKNOWLEDGED_OPERATION_KEY = "protoFleet:acknowledged-upgrade-operation";
 const AUTH_SESSION_IDENTITY = "operator-a:1000";
+const AUTH_SESSION_TOKEN = new Date(1_000);
 
 type TestUpgradeOperationOptions = Omit<
   Parameters<typeof useUpgradeOperation>[0],
-  "authSessionIdentity" | "currentVersionUnavailable"
+  "authSessionIdentity" | "authSessionToken" | "currentVersionUnavailable"
 > & {
   currentVersionUnavailable?: boolean;
 };
 
-const useTestUpgradeOperation = (options: TestUpgradeOperationOptions, authSessionIdentity = AUTH_SESSION_IDENTITY) =>
-  useUpgradeOperation({ authSessionIdentity, currentVersionUnavailable: false, ...options });
+const useTestUpgradeOperation = (
+  options: TestUpgradeOperationOptions,
+  authSessionIdentity = AUTH_SESSION_IDENTITY,
+  authSessionToken: object | null = AUTH_SESSION_TOKEN,
+) => useUpgradeOperation({ authSessionIdentity, authSessionToken, currentVersionUnavailable: false, ...options });
 
 type MessageOverrides<T> = Omit<Partial<T>, "$typeName" | "$unknown">;
 
@@ -135,21 +139,27 @@ describe("useUpgradeOperation", () => {
     expect(result.current.operationStatusPending).toBe(false);
   });
 
-  it("restarts polling and ignores the previous authenticated session's request", async () => {
+  it("restarts polling when a replacement session has the same serialized identity", async () => {
     const previousRequest = deferred<ReturnType<typeof status>>();
     const onPollError = vi.fn();
     mockGetUpgradeStatus.mockReturnValueOnce(previousRequest.promise).mockResolvedValue(status());
+    const previousSessionToken = new Date(1_000);
+    const replacementSessionToken = new Date(1_000);
 
     const { rerender, result } = renderHook(
-      ({ authSessionIdentity }: { authSessionIdentity: string }) =>
-        useTestUpgradeOperation({ enabled: true, currentVersion: "v1.2.0", onPollError }, authSessionIdentity),
-      { initialProps: { authSessionIdentity: AUTH_SESSION_IDENTITY } },
+      ({ authSessionToken }: { authSessionToken: object }) =>
+        useTestUpgradeOperation(
+          { enabled: true, currentVersion: "v1.2.0", onPollError },
+          AUTH_SESSION_IDENTITY,
+          authSessionToken,
+        ),
+      { initialProps: { authSessionToken: previousSessionToken } },
     );
 
     await waitFor(() => expect(mockGetUpgradeStatus).toHaveBeenCalledTimes(1));
     const previousSignal = mockGetUpgradeStatus.mock.calls[0]?.[1]?.signal;
 
-    rerender({ authSessionIdentity: "operator-b:2000" });
+    rerender({ authSessionToken: replacementSessionToken });
 
     await waitFor(() => expect(mockGetUpgradeStatus).toHaveBeenCalledTimes(2));
     expect(previousSignal?.aborted).toBe(true);
@@ -237,6 +247,21 @@ describe("useUpgradeOperation", () => {
     await act(async () => result.current.triggerUpgrade("v1.3.0"));
     await waitFor(() => expect(result.current.operation?.id).toBe("operation-1"));
 
+    expect(result.current.reconciling).toBe(false);
+    expect(result.current.triggerError).toBeNull();
+  });
+
+  it("reconciles an ambiguous trigger rejection to a completed upgrade", async () => {
+    const succeededOperation = operation(UpgradePhase.SUCCEEDED, { message: "Upgrade complete" });
+    mockGetUpgradeStatus.mockResolvedValueOnce(status()).mockResolvedValue(status(true, succeededOperation));
+    mockTriggerUpgrade.mockRejectedValue(new Error("response lost"));
+    const { result } = renderHook(() => useTestUpgradeOperation({ enabled: true, currentVersion: "v1.2.0" }));
+
+    await waitFor(() => expect(mockGetUpgradeStatus).toHaveBeenCalledTimes(1));
+    await act(async () => result.current.triggerUpgrade("v1.3.0"));
+    await waitFor(() => expect(result.current.operation?.phase).toBe(UpgradePhase.SUCCEEDED));
+
+    expect(result.current.operation?.id).toBe("operation-1");
     expect(result.current.reconciling).toBe(false);
     expect(result.current.triggerError).toBeNull();
   });

--- a/client/src/protoFleet/features/updates/api/useUpgradeOperation.test.tsx
+++ b/client/src/protoFleet/features/updates/api/useUpgradeOperation.test.tsx
@@ -23,6 +23,12 @@ const mockGetUpgradeStatus = vi.mocked(instanceUpdateClient.getUpgradeStatus);
 const mockTriggerUpgrade = vi.mocked(instanceUpdateClient.triggerUpgrade);
 const TRACKED_OPERATION_KEY = "protoFleet:tracked-upgrade-operation";
 const ACKNOWLEDGED_OPERATION_KEY = "protoFleet:acknowledged-upgrade-operation";
+const AUTH_SESSION_IDENTITY = "operator-a:1000";
+
+const useTestUpgradeOperation = (
+  options: Omit<Parameters<typeof useUpgradeOperation>[0], "authSessionIdentity">,
+  authSessionIdentity = AUTH_SESSION_IDENTITY,
+) => useUpgradeOperation({ authSessionIdentity, ...options });
 
 type MessageOverrides<T> = Omit<Partial<T>, "$typeName" | "$unknown">;
 
@@ -63,11 +69,17 @@ afterEach(() => {
 describe("useUpgradeOperation", () => {
   it("recovers a durable active operation without a capability gate", async () => {
     const activeOperation = operation(UpgradePhase.PREFLIGHT);
+    window.sessionStorage.setItem(
+      TRACKED_OPERATION_KEY,
+      JSON.stringify({ id: activeOperation.id, targetVersion: activeOperation.targetVersion }),
+    );
     mockGetUpgradeStatus.mockResolvedValue(status(true, activeOperation));
 
-    const { result } = renderHook(() => useUpgradeOperation({ enabled: true, currentVersion: "v1.2.0" }));
+    const { result } = renderHook(() => useTestUpgradeOperation({ enabled: true, currentVersion: "v1.2.0" }));
 
+    expect(result.current.reconciling).toBe(true);
     await waitFor(() => expect(result.current.operation?.id).toBe("operation-1"));
+    expect(result.current.reconciling).toBe(false);
     expect(result.current.connectionLost).toBe(false);
     expect(mockGetUpgradeStatus).toHaveBeenCalledWith(
       {},
@@ -75,12 +87,21 @@ describe("useUpgradeOperation", () => {
     );
   });
 
+  it("removes a malformed tracked-operation record", () => {
+    window.sessionStorage.setItem(TRACKED_OPERATION_KEY, "{not-json");
+    mockGetUpgradeStatus.mockResolvedValue(status());
+
+    renderHook(() => useTestUpgradeOperation({ enabled: true, currentVersion: "v1.2.0" }));
+
+    expect(window.sessionStorage.getItem(TRACKED_OPERATION_KEY)).toBeNull();
+  });
+
   it("does not overlap a pending poll and aborts it on cleanup", async () => {
     vi.useFakeTimers();
     const request = deferred<ReturnType<typeof status>>();
     mockGetUpgradeStatus.mockReturnValue(request.promise);
 
-    const hook = renderHook(() => useUpgradeOperation({ enabled: true, currentVersion: "v1.2.0" }));
+    const hook = renderHook(() => useTestUpgradeOperation({ enabled: true, currentVersion: "v1.2.0" }));
     await act(async () => Promise.resolve());
     expect(mockGetUpgradeStatus).toHaveBeenCalledTimes(1);
 
@@ -100,7 +121,7 @@ describe("useUpgradeOperation", () => {
         operation: activeOperation,
       }),
     );
-    const { result } = renderHook(() => useUpgradeOperation({ enabled: true, currentVersion: "v1.2.0" }));
+    const { result } = renderHook(() => useTestUpgradeOperation({ enabled: true, currentVersion: "v1.2.0" }));
 
     await waitFor(() => expect(mockGetUpgradeStatus).toHaveBeenCalled());
     await act(async () => result.current.triggerUpgrade("v1.3.0"));
@@ -117,7 +138,7 @@ describe("useUpgradeOperation", () => {
     const activeOperation = operation(UpgradePhase.PREFLIGHT);
     mockGetUpgradeStatus.mockResolvedValueOnce(status()).mockResolvedValue(status(true, activeOperation));
     mockTriggerUpgrade.mockRejectedValue(new Error("response lost"));
-    const { result } = renderHook(() => useUpgradeOperation({ enabled: true, currentVersion: "v1.2.0" }));
+    const { result } = renderHook(() => useTestUpgradeOperation({ enabled: true, currentVersion: "v1.2.0" }));
 
     await waitFor(() => expect(mockGetUpgradeStatus).toHaveBeenCalledTimes(1));
     await act(async () => result.current.triggerUpgrade("v1.3.0"));
@@ -131,7 +152,7 @@ describe("useUpgradeOperation", () => {
     vi.useFakeTimers();
     mockGetUpgradeStatus.mockResolvedValue(status());
     mockTriggerUpgrade.mockRejectedValue(new Error("host did not confirm"));
-    const { result } = renderHook(() => useUpgradeOperation({ enabled: true, currentVersion: "v1.2.0" }));
+    const { result } = renderHook(() => useTestUpgradeOperation({ enabled: true, currentVersion: "v1.2.0" }));
     await act(async () => Promise.resolve());
 
     await act(async () => result.current.triggerUpgrade("v1.3.0"));
@@ -148,7 +169,7 @@ describe("useUpgradeOperation", () => {
     vi.useFakeTimers();
     mockGetUpgradeStatus.mockResolvedValueOnce(status()).mockResolvedValue(status(false));
     mockTriggerUpgrade.mockRejectedValue(new Error("host did not confirm"));
-    const { result } = renderHook(() => useUpgradeOperation({ enabled: true, currentVersion: "v1.2.0" }));
+    const { result } = renderHook(() => useTestUpgradeOperation({ enabled: true, currentVersion: "v1.2.0" }));
     await act(async () => Promise.resolve());
 
     await act(async () => result.current.triggerUpgrade("v1.3.0"));
@@ -166,6 +187,47 @@ describe("useUpgradeOperation", () => {
     expect(window.sessionStorage.getItem(TRACKED_OPERATION_KEY)).toBeNull();
   });
 
+  it("keeps a recovered operation ID locked until the unreachable host is explicitly confirmed", async () => {
+    vi.useFakeTimers();
+    window.sessionStorage.setItem(
+      TRACKED_OPERATION_KEY,
+      JSON.stringify({ id: "operation-1", targetVersion: "v1.3.0" }),
+    );
+    mockGetUpgradeStatus.mockResolvedValue(status(false));
+
+    const { result } = renderHook(() => useTestUpgradeOperation({ enabled: true, currentVersion: "v1.2.0" }));
+    expect(result.current.reconciling).toBe(true);
+
+    await act(async () => vi.advanceTimersByTimeAsync(17_000));
+
+    expect(result.current.reconciling).toBe(true);
+    expect(result.current.connectionLost).toBe(true);
+    expect(result.current.manualFallbackReady).toBe(true);
+    expect(window.sessionStorage.getItem(TRACKED_OPERATION_KEY)).not.toBeNull();
+
+    act(() => result.current.useManualFallback());
+
+    expect(result.current.reconciling).toBe(false);
+    expect(window.sessionStorage.getItem(TRACKED_OPERATION_KEY)).toBeNull();
+  });
+
+  it("unlocks a recovered operation ID after an authoritative reachable miss", async () => {
+    window.sessionStorage.setItem(
+      TRACKED_OPERATION_KEY,
+      JSON.stringify({ id: "operation-1", targetVersion: "v1.3.0" }),
+    );
+    mockGetUpgradeStatus.mockResolvedValue(status(true));
+
+    const { result } = renderHook(() => useTestUpgradeOperation({ enabled: true, currentVersion: "v1.2.0" }));
+    expect(result.current.reconciling).toBe(true);
+
+    await waitFor(() => expect(result.current.reconciling).toBe(false));
+
+    expect(result.current.connectionLost).toBe(false);
+    expect(result.current.manualFallbackReady).toBe(false);
+    expect(window.sessionStorage.getItem(TRACKED_OPERATION_KEY)).toBeNull();
+  });
+
   it("keeps progress through disconnect and accepts the terminal success", async () => {
     vi.useFakeTimers();
     const activeOperation = operation(UpgradePhase.ACTIVATING);
@@ -174,7 +236,7 @@ describe("useUpgradeOperation", () => {
       .mockResolvedValueOnce(status(true, activeOperation))
       .mockRejectedValueOnce(new Error("Fleet restarting"))
       .mockResolvedValue(status(true, succeededOperation));
-    const { result } = renderHook(() => useUpgradeOperation({ enabled: true, currentVersion: "v1.2.0" }));
+    const { result } = renderHook(() => useTestUpgradeOperation({ enabled: true, currentVersion: "v1.2.0" }));
     await act(async () => Promise.resolve());
     expect(result.current.operation?.phase).toBe(UpgradePhase.ACTIVATING);
 
@@ -189,7 +251,7 @@ describe("useUpgradeOperation", () => {
 
   it("does not replay an untracked historical success", async () => {
     mockGetUpgradeStatus.mockResolvedValue(status(true, operation(UpgradePhase.SUCCEEDED)));
-    const { result } = renderHook(() => useUpgradeOperation({ enabled: true, currentVersion: "v1.3.0" }));
+    const { result } = renderHook(() => useTestUpgradeOperation({ enabled: true, currentVersion: "v1.3.0" }));
 
     await waitFor(() => expect(mockGetUpgradeStatus).toHaveBeenCalled());
     expect(result.current.operation).toBeUndefined();
@@ -201,7 +263,7 @@ describe("useUpgradeOperation", () => {
       JSON.stringify({ id: "operation-1", targetVersion: "v1.3.0" }),
     );
     mockGetUpgradeStatus.mockResolvedValue(status(true, operation(UpgradePhase.FAILED)));
-    const { result } = renderHook(() => useUpgradeOperation({ enabled: true, currentVersion: "v1.3.0" }));
+    const { result } = renderHook(() => useTestUpgradeOperation({ enabled: true, currentVersion: "v1.3.0" }));
 
     await waitFor(() => expect(mockGetUpgradeStatus).toHaveBeenCalled());
     expect(result.current.operation).toBeUndefined();
@@ -212,7 +274,7 @@ describe("useUpgradeOperation", () => {
     mockGetUpgradeStatus.mockResolvedValue(status(true, operation(UpgradePhase.FAILED)));
     const initialProps: { currentVersion?: string } = {};
     const { rerender, result } = renderHook(
-      ({ currentVersion }: { currentVersion?: string }) => useUpgradeOperation({ enabled: true, currentVersion }),
+      ({ currentVersion }: { currentVersion?: string }) => useTestUpgradeOperation({ enabled: true, currentVersion }),
       { initialProps },
     );
 
@@ -224,15 +286,33 @@ describe("useUpgradeOperation", () => {
     await waitFor(() => expect(result.current.operation?.phase).toBe(UpgradePhase.FAILED));
   });
 
-  it("acknowledges a terminal failure so it is not replayed", async () => {
+  it("scopes an acknowledged terminal failure to the authenticated session", async () => {
     mockGetUpgradeStatus.mockResolvedValue(status(true, operation(UpgradePhase.FAILED)));
-    const { result } = renderHook(() => useUpgradeOperation({ enabled: true, currentVersion: "v1.2.0" }));
-    await waitFor(() => expect(result.current.operation?.phase).toBe(UpgradePhase.FAILED));
+    const firstSession = renderHook(() => useTestUpgradeOperation({ enabled: true, currentVersion: "v1.2.0" }));
+    await waitFor(() => expect(firstSession.result.current.operation?.phase).toBe(UpgradePhase.FAILED));
 
-    act(() => result.current.acknowledgeOperation());
+    act(() => firstSession.result.current.acknowledgeOperation());
 
-    expect(result.current.operation).toBeUndefined();
-    expect(window.sessionStorage.getItem(ACKNOWLEDGED_OPERATION_KEY)).toBe("operation-1");
+    expect(firstSession.result.current.operation).toBeUndefined();
+    expect(JSON.parse(window.sessionStorage.getItem(ACKNOWLEDGED_OPERATION_KEY) ?? "{}")).toEqual({
+      authSessionIdentity: AUTH_SESSION_IDENTITY,
+      id: "operation-1",
+    });
+    firstSession.unmount();
+
+    const sameSession = renderHook(() => useTestUpgradeOperation({ enabled: true, currentVersion: "v1.2.0" }));
+    await waitFor(() => expect(mockGetUpgradeStatus).toHaveBeenCalledTimes(2));
+    expect(sameSession.result.current.operation).toBeUndefined();
+    sameSession.unmount();
+
+    const nextSession = renderHook(() =>
+      useTestUpgradeOperation({ enabled: true, currentVersion: "v1.2.0" }, "operator-b:2000"),
+    );
+    await waitFor(() => expect(nextSession.result.current.operation?.phase).toBe(UpgradePhase.FAILED));
+    expect(JSON.parse(window.sessionStorage.getItem(ACKNOWLEDGED_OPERATION_KEY) ?? "{}")).toEqual({
+      authSessionIdentity: AUTH_SESSION_IDENTITY,
+      id: "operation-1",
+    });
   });
 
   it("forwards poll errors for page-level auth handling", async () => {
@@ -240,7 +320,13 @@ describe("useUpgradeOperation", () => {
     const pollError = new Error("permission revoked");
     mockGetUpgradeStatus.mockRejectedValue(pollError);
 
-    renderHook(() => useUpgradeOperation({ enabled: true, currentVersion: "v1.2.0", onPollError }));
+    renderHook(() =>
+      useTestUpgradeOperation({
+        enabled: true,
+        currentVersion: "v1.2.0",
+        onPollError,
+      }),
+    );
 
     await waitFor(() => expect(onPollError).toHaveBeenCalledWith(pollError));
   });

--- a/client/src/protoFleet/features/updates/api/useUpgradeOperation.test.tsx
+++ b/client/src/protoFleet/features/updates/api/useUpgradeOperation.test.tsx
@@ -1,6 +1,7 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { create } from "@bufbuild/protobuf";
+import { TimestampSchema } from "@bufbuild/protobuf/wkt";
 import { Code, ConnectError } from "@connectrpc/connect";
 
 import { instanceUpdateClient } from "@/protoFleet/api/clients";
@@ -38,12 +39,16 @@ const useTestUpgradeOperation = (options: TestUpgradeOperationOptions, authSessi
 
 type MessageOverrides<T> = Omit<Partial<T>, "$typeName" | "$unknown">;
 
+const timestamp = (seconds: number) => create(TimestampSchema, { seconds: BigInt(seconds) });
+
 const operation = (phase: UpgradePhase, overrides?: MessageOverrides<UpgradeOperation>) =>
   create(UpgradeOperationSchema, {
     id: "operation-1",
     targetVersion: "v1.3.0",
     phase,
     message: "Preparing upgrade",
+    startedAt: timestamp(100),
+    updatedAt: timestamp(100),
     ...overrides,
   });
 
@@ -226,6 +231,7 @@ describe("useUpgradeOperation", () => {
       authSessionIdentity: AUTH_SESSION_IDENTITY,
       id: "operation-1",
       phase: UpgradePhase.UNSPECIFIED,
+      revision: "100:0",
     });
 
     await act(async () => vi.advanceTimersByTimeAsync(2_000));
@@ -335,12 +341,52 @@ describe("useUpgradeOperation", () => {
     expect(result.current.triggerError).toBeNull();
   });
 
+  it("reconciles an ambiguous trigger rejection to a newer same-target failure", async () => {
+    const previousFailure = operation(UpgradePhase.FAILED, { id: "operation-old" });
+    const failedOperation = operation(UpgradePhase.FAILED, {
+      id: "operation-new",
+      updatedAt: timestamp(101),
+      recoveryCommand: "./run-fleet.sh --skip-build",
+    });
+    window.sessionStorage.setItem(
+      ACKNOWLEDGED_OPERATION_KEY,
+      JSON.stringify({
+        authSessionIdentity: AUTH_SESSION_IDENTITY,
+        id: previousFailure.id,
+        phase: previousFailure.phase,
+        revision: "100:0",
+      }),
+    );
+    mockGetUpgradeStatus
+      .mockResolvedValueOnce(status(true, previousFailure))
+      .mockResolvedValue(status(true, failedOperation));
+    mockTriggerUpgrade.mockRejectedValue(new Error("response lost"));
+    const { result } = renderHook(() => useTestUpgradeOperation({ enabled: true, currentVersion: "v1.2.0" }));
+
+    await waitFor(() => expect(mockGetUpgradeStatus).toHaveBeenCalledTimes(1));
+    await act(async () => result.current.triggerUpgrade("v1.3.0"));
+    await waitFor(() => expect(result.current.operation?.id).toBe("operation-new"));
+
+    expect(result.current.operation?.phase).toBe(UpgradePhase.FAILED);
+    expect(result.current.operation?.recoveryCommand).toBe("./run-fleet.sh --skip-build");
+    expect(result.current.reconciling).toBe(false);
+  });
+
   it("does not let a stale terminal failure resolve an ambiguous trigger", async () => {
     const staleFailure = operation(UpgradePhase.FAILED, {
       id: "operation-old",
       targetVersion: "v1.3.0",
     });
-    mockGetUpgradeStatus.mockResolvedValueOnce(status()).mockResolvedValue(status(true, staleFailure));
+    window.sessionStorage.setItem(
+      ACKNOWLEDGED_OPERATION_KEY,
+      JSON.stringify({
+        authSessionIdentity: AUTH_SESSION_IDENTITY,
+        id: staleFailure.id,
+        phase: staleFailure.phase,
+        revision: "100:0",
+      }),
+    );
+    mockGetUpgradeStatus.mockResolvedValue(status(true, staleFailure));
     mockTriggerUpgrade.mockRejectedValue(new Error("response lost"));
     const { result } = renderHook(() => useTestUpgradeOperation({ enabled: true, currentVersion: "v1.2.0" }));
 
@@ -488,6 +534,26 @@ describe("useUpgradeOperation", () => {
     expect(result.current.operation).toBeUndefined();
   });
 
+  it("requests one authoritative offer refresh for an untracked success revision", async () => {
+    vi.useFakeTimers();
+    const onUntrackedSuccess = vi.fn();
+    mockGetUpgradeStatus.mockResolvedValue(status(true, operation(UpgradePhase.SUCCEEDED)));
+    const { result } = renderHook(() =>
+      useTestUpgradeOperation({
+        enabled: true,
+        currentVersion: "v1.2.0",
+        onUntrackedSuccess,
+      }),
+    );
+
+    await act(async () => Promise.resolve());
+    expect(onUntrackedSuccess).toHaveBeenCalledTimes(1);
+    expect(result.current.operation).toBeUndefined();
+
+    await act(async () => vi.advanceTimersByTimeAsync(60_000));
+    expect(onUntrackedSuccess).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps a tracked activation failure visible when Fleet reports its target version", async () => {
     window.sessionStorage.setItem(
       TRACKED_OPERATION_KEY,
@@ -583,6 +649,7 @@ describe("useUpgradeOperation", () => {
       authSessionIdentity: AUTH_SESSION_IDENTITY,
       id: "operation-1",
       phase: UpgradePhase.FAILED,
+      revision: "100:0",
     });
     firstSession.unmount();
 
@@ -596,6 +663,31 @@ describe("useUpgradeOperation", () => {
     );
     await waitFor(() => expect(nextSession.result.current.operation?.phase).toBe(UpgradePhase.FAILED));
     expect(JSON.parse(window.sessionStorage.getItem(ACKNOWLEDGED_OPERATION_KEY) ?? "{}")).toEqual(acknowledgedRecord);
+  });
+
+  it("resurfaces acknowledged failure details when startup reconciliation advances the revision", async () => {
+    const originalFailure = operation(UpgradePhase.FAILED, { recoveryCommand: "old recovery" });
+    mockGetUpgradeStatus.mockResolvedValue(status(true, originalFailure));
+    const firstSession = renderHook(() => useTestUpgradeOperation({ enabled: true, currentVersion: "v1.2.0" }));
+    await waitFor(() => expect(firstSession.result.current.operation?.phase).toBe(UpgradePhase.FAILED));
+
+    act(() => firstSession.result.current.acknowledgeOperation());
+    firstSession.unmount();
+
+    mockGetUpgradeStatus.mockReset();
+    mockGetUpgradeStatus.mockResolvedValue(
+      status(
+        true,
+        operation(UpgradePhase.FAILED, {
+          updatedAt: timestamp(101),
+          recoveryCommand: "new recovery",
+        }),
+      ),
+    );
+    const reconciledSession = renderHook(() => useTestUpgradeOperation({ enabled: true, currentVersion: "v1.2.0" }));
+
+    await waitFor(() => expect(reconciledSession.result.current.operation?.recoveryCommand).toBe("new recovery"));
+    expect(window.sessionStorage.getItem(ACKNOWLEDGED_OPERATION_KEY)).toBeNull();
   });
 
   it("forwards poll errors for page-level auth handling", async () => {

--- a/client/src/protoFleet/features/updates/api/useUpgradeOperation.test.tsx
+++ b/client/src/protoFleet/features/updates/api/useUpgradeOperation.test.tsx
@@ -25,10 +25,15 @@ const TRACKED_OPERATION_KEY = "protoFleet:tracked-upgrade-operation";
 const ACKNOWLEDGED_OPERATION_KEY = "protoFleet:acknowledged-upgrade-operation";
 const AUTH_SESSION_IDENTITY = "operator-a:1000";
 
-const useTestUpgradeOperation = (
-  options: Omit<Parameters<typeof useUpgradeOperation>[0], "authSessionIdentity">,
-  authSessionIdentity = AUTH_SESSION_IDENTITY,
-) => useUpgradeOperation({ authSessionIdentity, ...options });
+type TestUpgradeOperationOptions = Omit<
+  Parameters<typeof useUpgradeOperation>[0],
+  "authSessionIdentity" | "currentVersionUnavailable"
+> & {
+  currentVersionUnavailable?: boolean;
+};
+
+const useTestUpgradeOperation = (options: TestUpgradeOperationOptions, authSessionIdentity = AUTH_SESSION_IDENTITY) =>
+  useUpgradeOperation({ authSessionIdentity, currentVersionUnavailable: false, ...options });
 
 type MessageOverrides<T> = Omit<Partial<T>, "$typeName" | "$unknown">;
 
@@ -148,6 +153,24 @@ describe("useUpgradeOperation", () => {
     expect(result.current.triggerError).toBeNull();
   });
 
+  it("does not let a stale terminal failure resolve an ambiguous trigger", async () => {
+    const staleFailure = operation(UpgradePhase.FAILED, {
+      id: "operation-old",
+      targetVersion: "v1.1.0",
+    });
+    mockGetUpgradeStatus.mockResolvedValueOnce(status()).mockResolvedValue(status(true, staleFailure));
+    mockTriggerUpgrade.mockRejectedValue(new Error("response lost"));
+    const { result } = renderHook(() => useTestUpgradeOperation({ enabled: true, currentVersion: "v1.2.0" }));
+
+    await waitFor(() => expect(mockGetUpgradeStatus).toHaveBeenCalledTimes(1));
+    await act(async () => result.current.triggerUpgrade("v1.3.0"));
+    await waitFor(() => expect(mockGetUpgradeStatus).toHaveBeenCalledTimes(2));
+
+    expect(result.current.operation).toBeUndefined();
+    expect(result.current.reconciling).toBe(true);
+    expect(result.current.trackedTargetVersion).toBe("v1.3.0");
+  });
+
   it("ends bounded reconciliation and preserves an actionable trigger error", async () => {
     vi.useFakeTimers();
     mockGetUpgradeStatus.mockResolvedValue(status());
@@ -249,6 +272,32 @@ describe("useUpgradeOperation", () => {
     expect(result.current.connectionLost).toBe(false);
   });
 
+  it.each([
+    ["an unreachable executor", status(false)],
+    ["a reachable executor with no operation", status(true)],
+  ])("offers explicit fallback when an active operation is lost by %s", async (_scenario, missingStatus) => {
+    vi.useFakeTimers();
+    const activeOperation = operation(UpgradePhase.ACTIVATING);
+    mockGetUpgradeStatus.mockResolvedValueOnce(status(true, activeOperation)).mockResolvedValue(missingStatus);
+    const { result } = renderHook(() => useTestUpgradeOperation({ enabled: true, currentVersion: "v1.2.0" }));
+    await act(async () => Promise.resolve());
+    expect(result.current.operation?.phase).toBe(UpgradePhase.ACTIVATING);
+
+    await act(async () => vi.advanceTimersByTimeAsync(2_000));
+    expect(result.current.reconciling).toBe(true);
+    expect(result.current.connectionLost).toBe(true);
+    expect(result.current.manualFallbackReady).toBe(false);
+
+    await act(async () => vi.advanceTimersByTimeAsync(16_000));
+    expect(result.current.manualFallbackReady).toBe(true);
+    expect(result.current.operation?.phase).toBe(UpgradePhase.ACTIVATING);
+
+    act(() => result.current.useManualFallback());
+    expect(result.current.reconciling).toBe(false);
+    expect(result.current.operation).toBeUndefined();
+    expect(window.sessionStorage.getItem(TRACKED_OPERATION_KEY)).toBeNull();
+  });
+
   it("does not replay an untracked historical success", async () => {
     mockGetUpgradeStatus.mockResolvedValue(status(true, operation(UpgradePhase.SUCCEEDED)));
     const { result } = renderHook(() => useTestUpgradeOperation({ enabled: true, currentVersion: "v1.3.0" }));
@@ -284,6 +333,28 @@ describe("useUpgradeOperation", () => {
     rerender({ currentVersion: "v1.2.0" });
 
     await waitFor(() => expect(result.current.operation?.phase).toBe(UpgradePhase.FAILED));
+  });
+
+  it("shows an untracked failure after current-version loading definitively fails", async () => {
+    const failedOperation = operation(UpgradePhase.FAILED, {
+      hostLogPath: "/var/lib/proto-fleet-updater/logs/operation-1.log",
+      recoveryCommand: "./run-fleet.sh --skip-build",
+    });
+    mockGetUpgradeStatus.mockResolvedValue(status(true, failedOperation));
+    const { rerender, result } = renderHook(
+      ({ currentVersionUnavailable }: { currentVersionUnavailable: boolean }) =>
+        useTestUpgradeOperation({ enabled: true, currentVersionUnavailable }),
+      { initialProps: { currentVersionUnavailable: false } },
+    );
+
+    await waitFor(() => expect(mockGetUpgradeStatus).toHaveBeenCalledTimes(1));
+    expect(result.current.operation).toBeUndefined();
+
+    rerender({ currentVersionUnavailable: true });
+
+    await waitFor(() => expect(result.current.operation?.phase).toBe(UpgradePhase.FAILED));
+    expect(result.current.operation?.recoveryCommand).toBe("./run-fleet.sh --skip-build");
+    expect(result.current.operation?.hostLogPath).toContain("operation-1.log");
   });
 
   it("scopes an acknowledged terminal failure to the authenticated session", async () => {

--- a/client/src/protoFleet/features/updates/api/useUpgradeOperation.ts
+++ b/client/src/protoFleet/features/updates/api/useUpgradeOperation.ts
@@ -62,7 +62,16 @@ interface TrackedOperation {
 interface AcknowledgedOperation {
   authSessionIdentity: string;
   id: string;
+  phase: UpgradePhase;
 }
+
+type AcknowledgedOperationInput = Pick<AcknowledgedOperation, "id" | "phase">;
+
+const ACKNOWLEDGEABLE_PHASES = new Set<UpgradePhase>([
+  UpgradePhase.UNSPECIFIED,
+  UpgradePhase.SUCCEEDED,
+  UpgradePhase.FAILED,
+]);
 
 interface UseUpgradeOperationOptions {
   authSessionIdentity: string;
@@ -116,13 +125,19 @@ const readTrackedOperation = (): TrackedOperation | undefined => {
   }
 };
 
-const readAcknowledgedOperation = (authSessionIdentity: string): string | null => {
+const readAcknowledgedOperation = (authSessionIdentity: string): AcknowledgedOperationInput | null => {
   try {
     const raw = window.sessionStorage.getItem(ACKNOWLEDGED_OPERATION_KEY);
     if (!raw) return null;
     const value = JSON.parse(raw) as Partial<AcknowledgedOperation>;
-    if (typeof value.id === "string" && value.id && value.authSessionIdentity === authSessionIdentity) {
-      return value.id;
+    if (
+      typeof value.id === "string" &&
+      value.id &&
+      value.authSessionIdentity === authSessionIdentity &&
+      typeof value.phase === "number" &&
+      ACKNOWLEDGEABLE_PHASES.has(value.phase)
+    ) {
+      return { id: value.id, phase: value.phase };
     }
     return null;
   } catch {
@@ -158,7 +173,7 @@ export function useUpgradeOperation({
 
   const operationRef = useRef(operation);
   const trackedOperationRef = useRef(trackedOperation);
-  const acknowledgedOperationRef = useRef<string | null>(null);
+  const acknowledgedOperationRef = useRef<AcknowledgedOperationInput | null>(null);
   const acknowledgedOperationSessionRef = useRef<string | null>(null);
   const reconcilingRef = useRef(reconciling);
   const currentVersionRef = useRef(currentVersion);
@@ -210,13 +225,13 @@ export function useUpgradeOperation({
     }
   }, []);
 
-  const updateAcknowledgedOperation = useCallback((next: string | null) => {
+  const updateAcknowledgedOperation = useCallback((next: AcknowledgedOperationInput | null) => {
     acknowledgedOperationRef.current = next;
     try {
       if (next) {
         window.sessionStorage.setItem(
           ACKNOWLEDGED_OPERATION_KEY,
-          JSON.stringify({ authSessionIdentity: authSessionIdentityRef.current, id: next }),
+          JSON.stringify({ authSessionIdentity: authSessionIdentityRef.current, ...next }),
         );
       } else {
         window.sessionStorage.removeItem(ACKNOWLEDGED_OPERATION_KEY);
@@ -279,7 +294,9 @@ export function useUpgradeOperation({
       if (!next.id) {
         return false;
       }
-      if (next.phase === UpgradePhase.UNSPECIFIED && acknowledgedOperationRef.current === next.id) {
+      const acknowledged = acknowledgedOperationRef.current;
+      const acknowledgedTransition = acknowledged?.id === next.id && acknowledged.phase !== next.phase;
+      if (acknowledged?.id === next.id && acknowledged.phase === next.phase) {
         return false;
       }
       const active = isUpgradeActive(next);
@@ -291,7 +308,9 @@ export function useUpgradeOperation({
         next.phase === UpgradePhase.SUCCEEDED;
       const trackedMatches = tracked?.id
         ? tracked.id === next.id
-        : (fromTriggerResponse && tracked?.targetVersion === next.targetVersion) || reconciledSuccess;
+        : (fromTriggerResponse && tracked?.targetVersion === next.targetVersion) ||
+          reconciledSuccess ||
+          acknowledgedTransition;
 
       if (active) {
         // A durable active operation is authoritative, including one started
@@ -322,10 +341,6 @@ export function useUpgradeOperation({
         return false;
       }
 
-      if (acknowledgedOperationRef.current === next.id) {
-        return false;
-      }
-
       if (tracked && !trackedMatches) {
         return false;
       }
@@ -334,6 +349,7 @@ export function useUpgradeOperation({
       // match does not: activation can expose the target version before a
       // later service failure records the operation as failed.
       if (next.phase === UpgradePhase.FAILED && isReleaseNewer(currentVersionRef.current, next.targetVersion)) {
+        if (acknowledgedTransition) updateAcknowledgedOperation(null);
         if (trackedMatches) updateTrackedOperation(undefined);
         if (operationRef.current?.id === next.id) updateOperation(undefined);
         reconciliationDeadlineRef.current = null;
@@ -350,6 +366,7 @@ export function useUpgradeOperation({
         return false;
       }
 
+      if (acknowledgedTransition) updateAcknowledgedOperation(null);
       updateTrackedOperation({ id: next.id, targetVersion: next.targetVersion });
       updateOperation(next);
       reconciliationDeadlineRef.current = null;
@@ -504,8 +521,9 @@ export function useUpgradeOperation({
   );
 
   const acknowledgeOperation = useCallback(() => {
-    if (operationRef.current && isUpgradeTerminal(operationRef.current.phase)) {
-      updateAcknowledgedOperation(operationRef.current.id);
+    const currentOperation = operationRef.current;
+    if (currentOperation && isUpgradeTerminal(currentOperation.phase)) {
+      updateAcknowledgedOperation({ id: currentOperation.id, phase: currentOperation.phase });
     }
     updateTrackedOperation(undefined);
     updateOperation(undefined);
@@ -519,7 +537,7 @@ export function useUpgradeOperation({
   const useManualFallback = useCallback(() => {
     if (!manualFallbackReady) return;
     if (operationRef.current?.phase === UpgradePhase.UNSPECIFIED) {
-      updateAcknowledgedOperation(operationRef.current.id);
+      updateAcknowledgedOperation({ id: operationRef.current.id, phase: operationRef.current.phase });
     }
     updateTrackedOperation(undefined);
     updateOperation(undefined);

--- a/client/src/protoFleet/features/updates/api/useUpgradeOperation.ts
+++ b/client/src/protoFleet/features/updates/api/useUpgradeOperation.ts
@@ -17,7 +17,13 @@ interface TrackedOperation {
   targetVersion: string;
 }
 
+interface AcknowledgedOperation {
+  authSessionIdentity: string;
+  id: string;
+}
+
 interface UseUpgradeOperationOptions {
+  authSessionIdentity: string;
   currentVersion?: string;
   enabled: boolean;
   onPollError?: (error: unknown) => void;
@@ -57,19 +63,36 @@ const readTrackedOperation = (): TrackedOperation | undefined => {
       ...(typeof value.id === "string" && value.id ? { id: value.id } : {}),
     };
   } catch {
+    try {
+      window.sessionStorage.removeItem(TRACKED_OPERATION_KEY);
+    } catch {
+      // Storage is best-effort; the host remains authoritative.
+    }
     return undefined;
   }
 };
 
-const readAcknowledgedOperation = (): string | null => {
+const readAcknowledgedOperation = (authSessionIdentity: string): string | null => {
   try {
-    return window.sessionStorage.getItem(ACKNOWLEDGED_OPERATION_KEY);
+    const raw = window.sessionStorage.getItem(ACKNOWLEDGED_OPERATION_KEY);
+    if (!raw) return null;
+    const value = JSON.parse(raw) as Partial<AcknowledgedOperation>;
+    if (typeof value.id === "string" && value.id && value.authSessionIdentity === authSessionIdentity) {
+      return value.id;
+    }
+    return null;
   } catch {
+    try {
+      window.sessionStorage.removeItem(ACKNOWLEDGED_OPERATION_KEY);
+    } catch {
+      // Storage is best-effort; the host remains authoritative.
+    }
     return null;
   }
 };
 
 export function useUpgradeOperation({
+  authSessionIdentity,
   currentVersion,
   enabled,
   onPollError,
@@ -77,15 +100,18 @@ export function useUpgradeOperation({
   const [operation, setOperation] = useState<UpgradeOperation>();
   const [triggering, setTriggering] = useState(false);
   const [trackedOperation, setTrackedOperation] = useState<TrackedOperation | undefined>(readTrackedOperation);
+  const recoveredTrackedOperation = Boolean(trackedOperation);
   const recoveredUnknownOutcome = Boolean(trackedOperation && !trackedOperation.id);
-  const [reconciling, setReconciling] = useState(recoveredUnknownOutcome);
+  const [reconciling, setReconciling] = useState(recoveredTrackedOperation);
   const [connectionLost, setConnectionLost] = useState(false);
   const [manualFallbackReady, setManualFallbackReady] = useState(false);
   const [triggerError, setTriggerError] = useState<string | null>(
     recoveredUnknownOutcome ? "Fleet did not confirm whether the previous upgrade request started" : null,
   );
   const [pollRevision, setPollRevision] = useState(0);
-  const [acknowledgedOperation, setAcknowledgedOperation] = useState<string | null>(readAcknowledgedOperation);
+  const [acknowledgedOperation, setAcknowledgedOperation] = useState<string | null>(() =>
+    readAcknowledgedOperation(authSessionIdentity),
+  );
 
   const operationRef = useRef(operation);
   const trackedOperationRef = useRef(trackedOperation);
@@ -94,15 +120,24 @@ export function useUpgradeOperation({
   const currentVersionRef = useRef(currentVersion);
   const onPollErrorRef = useRef(onPollError);
   const reconciliationDeadlineRef = useRef<number | null>(null);
+  const authSessionIdentityRef = useRef(authSessionIdentity);
 
   currentVersionRef.current = currentVersion;
   onPollErrorRef.current = onPollError;
 
   useEffect(() => {
-    if (trackedOperationRef.current && !trackedOperationRef.current.id) {
+    if (trackedOperationRef.current) {
       reconciliationDeadlineRef.current = Date.now() + TRIGGER_RECONCILIATION_TIMEOUT_MS;
     }
   }, []);
+
+  useEffect(() => {
+    if (authSessionIdentityRef.current === authSessionIdentity) return;
+    authSessionIdentityRef.current = authSessionIdentity;
+    const next = readAcknowledgedOperation(authSessionIdentity);
+    acknowledgedOperationRef.current = next;
+    setAcknowledgedOperation(next);
+  }, [authSessionIdentity]);
 
   const updateOperation = useCallback((next: UpgradeOperation | undefined) => {
     operationRef.current = next;
@@ -134,7 +169,10 @@ export function useUpgradeOperation({
     setAcknowledgedOperation(next);
     try {
       if (next) {
-        window.sessionStorage.setItem(ACKNOWLEDGED_OPERATION_KEY, next);
+        window.sessionStorage.setItem(
+          ACKNOWLEDGED_OPERATION_KEY,
+          JSON.stringify({ authSessionIdentity: authSessionIdentityRef.current, id: next }),
+        );
       } else {
         window.sessionStorage.removeItem(ACKNOWLEDGED_OPERATION_KEY);
       }
@@ -163,6 +201,19 @@ export function useUpgradeOperation({
       setManualFallbackReady(true);
     }
   }, []);
+
+  const resolveRecoveredOperationMiss = useCallback(() => {
+    if (!reconcilingRef.current || !trackedOperationRef.current?.id) {
+      return false;
+    }
+    reconciliationDeadlineRef.current = null;
+    setManualFallbackReady(false);
+    updateTrackedOperation(undefined);
+    updateReconciling(false);
+    setConnectionLost(false);
+    setTriggerError(null);
+    return true;
+  }, [updateReconciling, updateTrackedOperation]);
 
   const acceptServerOperation = useCallback(
     (next: UpgradeOperation) => {
@@ -253,6 +304,9 @@ export function useUpgradeOperation({
         } else {
           setConnectionLost(false);
         }
+        if (resolveRecoveredOperationMiss()) {
+          return;
+        }
         finishExpiredReconciliation();
       } catch (error) {
         if (signal.aborted) return;
@@ -263,7 +317,12 @@ export function useUpgradeOperation({
         allowManualFallbackAfterTimeout();
       }
     },
-    [acceptServerOperation, allowManualFallbackAfterTimeout, finishExpiredReconciliation],
+    [
+      acceptServerOperation,
+      allowManualFallbackAfterTimeout,
+      finishExpiredReconciliation,
+      resolveRecoveredOperationMiss,
+    ],
   );
 
   useEffect(() => {

--- a/client/src/protoFleet/features/updates/api/useUpgradeOperation.ts
+++ b/client/src/protoFleet/features/updates/api/useUpgradeOperation.ts
@@ -396,7 +396,11 @@ export function useUpgradeOperation({
         if (!response.operation) {
           throw new Error("Host updater did not return an operation");
         }
-        acceptServerOperation(response.operation);
+        if (!acceptServerOperation(response.operation)) {
+          throw new Error(
+            "Fleet couldn't confirm the upgrade state. Fleet will check the host before unlocking other install options.",
+          );
+        }
       } catch (error) {
         setTriggerError(getErrorMessage(error, "Failed to start upgrade"));
         reconciliationDeadlineRef.current = Date.now() + TRIGGER_RECONCILIATION_TIMEOUT_MS;

--- a/client/src/protoFleet/features/updates/api/useUpgradeOperation.ts
+++ b/client/src/protoFleet/features/updates/api/useUpgradeOperation.ts
@@ -11,6 +11,37 @@ const TRIGGER_REQUEST_TIMEOUT_MS = 30_000;
 const TRIGGER_RECONCILIATION_TIMEOUT_MS = 15_000;
 const TRACKED_OPERATION_KEY = "protoFleet:tracked-upgrade-operation";
 const ACKNOWLEDGED_OPERATION_KEY = "protoFleet:acknowledged-upgrade-operation";
+const CANONICAL_RELEASE_PATTERN = /^v(\d+)\.(\d+)\.(\d+)(?:-rc\.(\d+))?$/;
+
+interface CanonicalRelease {
+  core: [number, number, number];
+  rc?: number;
+}
+
+const parseCanonicalRelease = (version?: string): CanonicalRelease | undefined => {
+  const match = version?.match(CANONICAL_RELEASE_PATTERN);
+  if (!match) return undefined;
+  const parts = match.slice(1).map((part) => (part === undefined ? undefined : Number(part)));
+  if (parts.some((part) => part !== undefined && !Number.isSafeInteger(part))) return undefined;
+  return {
+    core: [parts[0]!, parts[1]!, parts[2]!],
+    ...(parts[3] === undefined ? {} : { rc: parts[3] }),
+  };
+};
+
+const isReleaseAtLeast = (currentVersion: string | undefined, targetVersion: string) => {
+  const current = parseCanonicalRelease(currentVersion);
+  const target = parseCanonicalRelease(targetVersion);
+  if (!current || !target) return false;
+  for (let index = 0; index < current.core.length; index += 1) {
+    if (current.core[index] !== target.core[index]) {
+      return current.core[index] > target.core[index];
+    }
+  }
+  if (current.rc === undefined) return true;
+  if (target.rc === undefined) return false;
+  return current.rc >= target.rc;
+};
 
 interface TrackedOperation {
   id?: string;
@@ -288,10 +319,10 @@ export function useUpgradeOperation({
         return false;
       }
 
-      // A manual recovery may have installed the failed target successfully.
-      // Do not replay the updater's stale failure once Fleet reports that exact
-      // version as current.
-      if (next.phase === UpgradePhase.FAILED && currentVersionRef.current === next.targetVersion) {
+      // A later manual recovery can install the failed target or a newer
+      // release. Do not replay recovery instructions once Fleet has advanced
+      // beyond the failed operation.
+      if (next.phase === UpgradePhase.FAILED && isReleaseAtLeast(currentVersionRef.current, next.targetVersion)) {
         if (trackedMatches) updateTrackedOperation(undefined);
         if (operationRef.current?.id === next.id) updateOperation(undefined);
         reconciliationDeadlineRef.current = null;

--- a/client/src/protoFleet/features/updates/api/useUpgradeOperation.ts
+++ b/client/src/protoFleet/features/updates/api/useUpgradeOperation.ts
@@ -25,6 +25,7 @@ interface AcknowledgedOperation {
 interface UseUpgradeOperationOptions {
   authSessionIdentity: string;
   currentVersion?: string;
+  currentVersionUnavailable: boolean;
   enabled: boolean;
   onPollError?: (error: unknown) => void;
 }
@@ -94,6 +95,7 @@ const readAcknowledgedOperation = (authSessionIdentity: string): string | null =
 export function useUpgradeOperation({
   authSessionIdentity,
   currentVersion,
+  currentVersionUnavailable,
   enabled,
   onPollError,
 }: UseUpgradeOperationOptions): UseUpgradeOperationResult {
@@ -118,11 +120,13 @@ export function useUpgradeOperation({
   const acknowledgedOperationRef = useRef(acknowledgedOperation);
   const reconcilingRef = useRef(reconciling);
   const currentVersionRef = useRef(currentVersion);
+  const currentVersionUnavailableRef = useRef(currentVersionUnavailable);
   const onPollErrorRef = useRef(onPollError);
   const reconciliationDeadlineRef = useRef<number | null>(null);
   const authSessionIdentityRef = useRef(authSessionIdentity);
 
   currentVersionRef.current = currentVersion;
+  currentVersionUnavailableRef.current = currentVersionUnavailable;
   onPollErrorRef.current = onPollError;
 
   useEffect(() => {
@@ -202,6 +206,20 @@ export function useUpgradeOperation({
     }
   }, []);
 
+  const reconcileMissingActiveOperation = useCallback(() => {
+    if (!isUpgradeActive(operationRef.current)) {
+      return false;
+    }
+    if (!reconcilingRef.current) {
+      reconciliationDeadlineRef.current = Date.now() + TRIGGER_RECONCILIATION_TIMEOUT_MS;
+      setManualFallbackReady(false);
+      updateReconciling(true);
+    }
+    setConnectionLost(true);
+    allowManualFallbackAfterTimeout();
+    return true;
+  }, [allowManualFallbackAfterTimeout, updateReconciling]);
+
   const resolveRecoveredOperationMiss = useCallback(() => {
     if (!reconcilingRef.current || !trackedOperationRef.current?.id) {
       return false;
@@ -243,6 +261,10 @@ export function useUpgradeOperation({
         return false;
       }
 
+      if (tracked && !trackedMatches) {
+        return false;
+      }
+
       // A manual recovery may have installed the failed target successfully.
       // Do not replay the updater's stale failure once Fleet reports that exact
       // version as current.
@@ -258,7 +280,8 @@ export function useUpgradeOperation({
 
       const unresolvedFailure =
         next.phase === UpgradePhase.FAILED &&
-        Boolean(currentVersionRef.current && currentVersionRef.current !== next.targetVersion);
+        (currentVersionUnavailableRef.current ||
+          Boolean(currentVersionRef.current && currentVersionRef.current !== next.targetVersion));
       if (!trackedMatches && !unresolvedFailure) {
         return false;
       }
@@ -289,6 +312,9 @@ export function useUpgradeOperation({
         }
 
         if (!response.executorAvailable) {
+          if (reconcileMissingActiveOperation()) {
+            return;
+          }
           if (isUpgradeActive(operationRef.current) || reconcilingRef.current || trackedOperationRef.current) {
             setConnectionLost(true);
           }
@@ -296,14 +322,10 @@ export function useUpgradeOperation({
           return;
         }
 
-        if (isUpgradeActive(operationRef.current)) {
-          // The executor is reachable but lost the operation that Fleet was
-          // following. Preserve the last durable phase rather than exposing a
-          // competing action while reconciliation continues.
-          setConnectionLost(true);
-        } else {
-          setConnectionLost(false);
+        if (reconcileMissingActiveOperation()) {
+          return;
         }
+        setConnectionLost(false);
         if (resolveRecoveredOperationMiss()) {
           return;
         }
@@ -311,6 +333,9 @@ export function useUpgradeOperation({
       } catch (error) {
         if (signal.aborted) return;
         onPollErrorRef.current?.(error);
+        if (reconcileMissingActiveOperation()) {
+          return;
+        }
         if (isUpgradeActive(operationRef.current) || reconcilingRef.current || trackedOperationRef.current) {
           setConnectionLost(true);
         }
@@ -321,6 +346,7 @@ export function useUpgradeOperation({
       acceptServerOperation,
       allowManualFallbackAfterTimeout,
       finishExpiredReconciliation,
+      reconcileMissingActiveOperation,
       resolveRecoveredOperationMiss,
     ],
   );
@@ -351,7 +377,7 @@ export function useUpgradeOperation({
       controller?.abort();
       if (timer !== undefined) window.clearTimeout(timer);
     };
-  }, [currentVersion, enabled, pollRevision, pollStatus]);
+  }, [currentVersion, currentVersionUnavailable, enabled, pollRevision, pollStatus]);
 
   const triggerUpgrade = useCallback(
     async (targetVersion: string) => {
@@ -402,12 +428,13 @@ export function useUpgradeOperation({
   const useManualFallback = useCallback(() => {
     if (!manualFallbackReady) return;
     updateTrackedOperation(undefined);
+    updateOperation(undefined);
     reconciliationDeadlineRef.current = null;
     setManualFallbackReady(false);
     updateReconciling(false);
     setConnectionLost(false);
     setTriggerError(null);
-  }, [manualFallbackReady, updateReconciling, updateTrackedOperation]);
+  }, [manualFallbackReady, updateOperation, updateReconciling, updateTrackedOperation]);
 
   const reloadFleet = useCallback(() => {
     updateTrackedOperation(undefined);

--- a/client/src/protoFleet/features/updates/api/useUpgradeOperation.ts
+++ b/client/src/protoFleet/features/updates/api/useUpgradeOperation.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { Code, ConnectError } from "@connectrpc/connect";
 
 import { instanceUpdateClient } from "@/protoFleet/api/clients";
 import { type UpgradeOperation, UpgradePhase } from "@/protoFleet/api/generated/instance/v1/updates_pb";
@@ -12,6 +13,16 @@ const TRIGGER_RECONCILIATION_TIMEOUT_MS = 15_000;
 const TRACKED_OPERATION_KEY = "protoFleet:tracked-upgrade-operation";
 const ACKNOWLEDGED_OPERATION_KEY = "protoFleet:acknowledged-upgrade-operation";
 const CANONICAL_RELEASE_PATTERN = /^v(\d+)\.(\d+)\.(\d+)(?:-rc\.(\d+))?$/;
+const DEFINITIVE_TRIGGER_REJECTION_CODES = new Set<Code>([
+  Code.InvalidArgument,
+  Code.FailedPrecondition,
+  Code.PermissionDenied,
+  Code.Unauthenticated,
+  Code.Unimplemented,
+]);
+
+const isDefinitiveTriggerRejection = (error: unknown) =>
+  error instanceof ConnectError && DEFINITIVE_TRIGGER_REJECTION_CODES.has(error.code);
 
 interface CanonicalRelease {
   core: [number, number, number];
@@ -395,7 +406,7 @@ export function useUpgradeOperation({
         }
         finishExpiredReconciliation();
       } catch (error) {
-        if (signal.aborted) return;
+        if (signal.aborted || authSessionIdentityRef.current !== pollingAuthSessionIdentity) return;
         onPollErrorRef.current?.(error);
         if (reconcileMissingActiveOperation()) {
           return;
@@ -471,8 +482,16 @@ export function useUpgradeOperation({
         }
       } catch (error) {
         setTriggerError(getErrorMessage(error, "Failed to start upgrade"));
-        reconciliationDeadlineRef.current = Date.now() + TRIGGER_RECONCILIATION_TIMEOUT_MS;
-        updateReconciling(true);
+        if (isDefinitiveTriggerRejection(error)) {
+          updateTrackedOperation(undefined);
+          reconciliationDeadlineRef.current = null;
+          setManualFallbackReady(false);
+          updateReconciling(false);
+          setConnectionLost(false);
+        } else {
+          reconciliationDeadlineRef.current = Date.now() + TRIGGER_RECONCILIATION_TIMEOUT_MS;
+          updateReconciling(true);
+        }
       } finally {
         setTriggering(false);
         // An idle status poll may already be scheduled far in the future.

--- a/client/src/protoFleet/features/updates/api/useUpgradeOperation.ts
+++ b/client/src/protoFleet/features/updates/api/useUpgradeOperation.ts
@@ -63,9 +63,10 @@ interface AcknowledgedOperation {
   authSessionIdentity: string;
   id: string;
   phase: UpgradePhase;
+  revision: string;
 }
 
-type AcknowledgedOperationInput = Pick<AcknowledgedOperation, "id" | "phase">;
+type AcknowledgedOperationInput = Pick<AcknowledgedOperation, "id" | "phase" | "revision">;
 
 const ACKNOWLEDGEABLE_PHASES = new Set<UpgradePhase>([
   UpgradePhase.UNSPECIFIED,
@@ -78,6 +79,7 @@ interface UseUpgradeOperationOptions {
   currentVersion?: string;
   currentVersionUnavailable: boolean;
   enabled: boolean;
+  onUntrackedSuccess?: (operation: UpgradeOperation) => void;
   onPollError?: (error: unknown) => void;
 }
 
@@ -101,6 +103,14 @@ export const isUpgradeTerminal = (phase: UpgradePhase) =>
 
 export const isUpgradeActive = (operation?: UpgradeOperation) =>
   Boolean(operation && !isUpgradeTerminal(operation.phase));
+
+const operationRevision = (operation: UpgradeOperation) => {
+  const updatedAt = operation.updatedAt;
+  if (updatedAt) {
+    return `${updatedAt.seconds}:${updatedAt.nanos}`;
+  }
+  return JSON.stringify([operation.message, operation.error, operation.recoveryCommand, operation.hostLogPath]);
+};
 
 const readTrackedOperation = (): TrackedOperation | undefined => {
   try {
@@ -135,9 +145,10 @@ const readAcknowledgedOperation = (authSessionIdentity: string): AcknowledgedOpe
       value.id &&
       value.authSessionIdentity === authSessionIdentity &&
       typeof value.phase === "number" &&
-      ACKNOWLEDGEABLE_PHASES.has(value.phase)
+      ACKNOWLEDGEABLE_PHASES.has(value.phase) &&
+      typeof value.revision === "string"
     ) {
-      return { id: value.id, phase: value.phase };
+      return { id: value.id, phase: value.phase, revision: value.revision };
     }
     return null;
   } catch {
@@ -155,6 +166,7 @@ export function useUpgradeOperation({
   currentVersion,
   currentVersionUnavailable,
   enabled,
+  onUntrackedSuccess,
   onPollError,
 }: UseUpgradeOperationOptions): UseUpgradeOperationResult {
   const [operation, setOperation] = useState<UpgradeOperation>();
@@ -179,13 +191,18 @@ export function useUpgradeOperation({
   const currentVersionRef = useRef(currentVersion);
   const currentVersionUnavailableRef = useRef(currentVersionUnavailable);
   const onPollErrorRef = useRef(onPollError);
+  const onUntrackedSuccessRef = useRef(onUntrackedSuccess);
   const reconciliationDeadlineRef = useRef<number | null>(null);
+  const lastObservedOperationIDRef = useRef<string | null | undefined>(undefined);
+  const triggerBaselineOperationIDRef = useRef<string | null | undefined>(undefined);
+  const refreshedUntrackedSuccessRef = useRef<string | null>(null);
   const authSessionIdentityRef = useRef(authSessionIdentity);
   const resolvedStatusSessionIdentityRef = useRef<string | null>(null);
 
   currentVersionRef.current = currentVersion;
   currentVersionUnavailableRef.current = currentVersionUnavailable;
   onPollErrorRef.current = onPollError;
+  onUntrackedSuccessRef.current = onUntrackedSuccess;
   authSessionIdentityRef.current = authSessionIdentity;
   if (acknowledgedOperationSessionRef.current !== authSessionIdentity) {
     acknowledgedOperationSessionRef.current = authSessionIdentity;
@@ -295,21 +312,26 @@ export function useUpgradeOperation({
         return false;
       }
       const acknowledged = acknowledgedOperationRef.current;
-      const acknowledgedTransition = acknowledged?.id === next.id && acknowledged.phase !== next.phase;
-      if (acknowledged?.id === next.id && acknowledged.phase === next.phase) {
+      const revision = operationRevision(next);
+      const acknowledgedExactRevision =
+        acknowledged?.id === next.id && acknowledged.phase === next.phase && acknowledged.revision === revision;
+      const acknowledgedTransition = acknowledged?.id === next.id && !acknowledgedExactRevision;
+      if (acknowledgedExactRevision) {
         return false;
       }
       const active = isUpgradeActive(next);
       const tracked = trackedOperationRef.current;
-      const reconciledSuccess =
+      const reconciledTerminal =
         reconcilingRef.current &&
         !tracked?.id &&
         tracked?.targetVersion === next.targetVersion &&
-        next.phase === UpgradePhase.SUCCEEDED;
+        isUpgradeTerminal(next.phase) &&
+        triggerBaselineOperationIDRef.current !== undefined &&
+        triggerBaselineOperationIDRef.current !== next.id;
       const trackedMatches = tracked?.id
         ? tracked.id === next.id
         : (fromTriggerResponse && tracked?.targetVersion === next.targetVersion) ||
-          reconciledSuccess ||
+          reconciledTerminal ||
           acknowledgedTransition;
 
       if (active) {
@@ -342,6 +364,15 @@ export function useUpgradeOperation({
       }
 
       if (tracked && !trackedMatches) {
+        return false;
+      }
+
+      if (next.phase === UpgradePhase.SUCCEEDED && !trackedMatches) {
+        const successRevision = `${next.id}:${revision}`;
+        if (refreshedUntrackedSuccessRef.current !== successRevision) {
+          refreshedUntrackedSuccessRef.current = successRevision;
+          onUntrackedSuccessRef.current?.(next);
+        }
         return false;
       }
 
@@ -398,6 +429,7 @@ export function useUpgradeOperation({
 
         resolvedStatusSessionIdentityRef.current = pollingAuthSessionIdentity;
         setResolvedStatusSessionIdentity(pollingAuthSessionIdentity);
+        lastObservedOperationIDRef.current = response.operation?.id || null;
 
         if (response.operation && acceptServerOperation(response.operation)) {
           return;
@@ -477,6 +509,7 @@ export function useUpgradeOperation({
 
   const triggerUpgrade = useCallback(
     async (targetVersion: string) => {
+      triggerBaselineOperationIDRef.current = lastObservedOperationIDRef.current;
       updateTrackedOperation({ targetVersion });
       reconciliationDeadlineRef.current = null;
       setManualFallbackReady(false);
@@ -523,7 +556,11 @@ export function useUpgradeOperation({
   const acknowledgeOperation = useCallback(() => {
     const currentOperation = operationRef.current;
     if (currentOperation && isUpgradeTerminal(currentOperation.phase)) {
-      updateAcknowledgedOperation({ id: currentOperation.id, phase: currentOperation.phase });
+      updateAcknowledgedOperation({
+        id: currentOperation.id,
+        phase: currentOperation.phase,
+        revision: operationRevision(currentOperation),
+      });
     }
     updateTrackedOperation(undefined);
     updateOperation(undefined);
@@ -537,7 +574,11 @@ export function useUpgradeOperation({
   const useManualFallback = useCallback(() => {
     if (!manualFallbackReady) return;
     if (operationRef.current?.phase === UpgradePhase.UNSPECIFIED) {
-      updateAcknowledgedOperation({ id: operationRef.current.id, phase: operationRef.current.phase });
+      updateAcknowledgedOperation({
+        id: operationRef.current.id,
+        phase: operationRef.current.phase,
+        revision: operationRevision(operationRef.current),
+      });
     }
     updateTrackedOperation(undefined);
     updateOperation(undefined);

--- a/client/src/protoFleet/features/updates/api/useUpgradeOperation.ts
+++ b/client/src/protoFleet/features/updates/api/useUpgradeOperation.ts
@@ -29,7 +29,7 @@ const parseCanonicalRelease = (version?: string): CanonicalRelease | undefined =
   };
 };
 
-const isReleaseAtLeast = (currentVersion: string | undefined, targetVersion: string) => {
+const isReleaseNewer = (currentVersion: string | undefined, targetVersion: string) => {
   const current = parseCanonicalRelease(currentVersion);
   const target = parseCanonicalRelease(targetVersion);
   if (!current || !target) return false;
@@ -38,9 +38,9 @@ const isReleaseAtLeast = (currentVersion: string | undefined, targetVersion: str
       return current.core[index] > target.core[index];
     }
   }
-  if (current.rc === undefined) return true;
+  if (current.rc === undefined) return target.rc !== undefined;
   if (target.rc === undefined) return false;
-  return current.rc >= target.rc;
+  return current.rc > target.rc;
 };
 
 interface TrackedOperation {
@@ -319,10 +319,10 @@ export function useUpgradeOperation({
         return false;
       }
 
-      // A later manual recovery can install the failed target or a newer
-      // release. Do not replay recovery instructions once Fleet has advanced
-      // beyond the failed operation.
-      if (next.phase === UpgradePhase.FAILED && isReleaseAtLeast(currentVersionRef.current, next.targetVersion)) {
+      // A strictly newer release proves a later recovery. An exact target
+      // match does not: activation can expose the target version before a
+      // later service failure records the operation as failed.
+      if (next.phase === UpgradePhase.FAILED && isReleaseNewer(currentVersionRef.current, next.targetVersion)) {
         if (trackedMatches) updateTrackedOperation(undefined);
         if (operationRef.current?.id === next.id) updateOperation(undefined);
         reconciliationDeadlineRef.current = null;
@@ -334,8 +334,7 @@ export function useUpgradeOperation({
 
       const unresolvedFailure =
         next.phase === UpgradePhase.FAILED &&
-        (currentVersionUnavailableRef.current ||
-          Boolean(currentVersionRef.current && currentVersionRef.current !== next.targetVersion));
+        (currentVersionUnavailableRef.current || Boolean(currentVersionRef.current));
       if (!trackedMatches && !unresolvedFailure) {
         return false;
       }

--- a/client/src/protoFleet/features/updates/api/useUpgradeOperation.ts
+++ b/client/src/protoFleet/features/updates/api/useUpgradeOperation.ts
@@ -1,0 +1,371 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { instanceUpdateClient } from "@/protoFleet/api/clients";
+import { type UpgradeOperation, UpgradePhase } from "@/protoFleet/api/generated/instance/v1/updates_pb";
+import { getErrorMessage } from "@/protoFleet/api/getErrorMessage";
+
+const ACTIVE_POLL_INTERVAL_MS = 2_000;
+const IDLE_POLL_INTERVAL_MS = 60_000;
+const STATUS_REQUEST_TIMEOUT_MS = 10_000;
+const TRIGGER_REQUEST_TIMEOUT_MS = 30_000;
+const TRIGGER_RECONCILIATION_TIMEOUT_MS = 15_000;
+const TRACKED_OPERATION_KEY = "protoFleet:tracked-upgrade-operation";
+const ACKNOWLEDGED_OPERATION_KEY = "protoFleet:acknowledged-upgrade-operation";
+
+interface TrackedOperation {
+  id?: string;
+  targetVersion: string;
+}
+
+interface UseUpgradeOperationOptions {
+  currentVersion?: string;
+  enabled: boolean;
+  onPollError?: (error: unknown) => void;
+}
+
+interface UseUpgradeOperationResult {
+  acknowledgeOperation: () => void;
+  connectionLost: boolean;
+  manualFallbackReady: boolean;
+  operation: UpgradeOperation | undefined;
+  reconciling: boolean;
+  reloadFleet: () => void;
+  triggerError: string | null;
+  triggering: boolean;
+  trackedTargetVersion: string | undefined;
+  triggerUpgrade: (targetVersion: string) => Promise<void>;
+  useManualFallback: () => void;
+}
+
+export const isUpgradeTerminal = (phase: UpgradePhase) =>
+  phase === UpgradePhase.SUCCEEDED || phase === UpgradePhase.FAILED;
+
+export const isUpgradeActive = (operation?: UpgradeOperation) =>
+  Boolean(operation && operation.phase !== UpgradePhase.UNSPECIFIED && !isUpgradeTerminal(operation.phase));
+
+const readTrackedOperation = (): TrackedOperation | undefined => {
+  try {
+    const raw = window.sessionStorage.getItem(TRACKED_OPERATION_KEY);
+    if (!raw) return undefined;
+    const value = JSON.parse(raw) as Partial<TrackedOperation>;
+    if (typeof value.targetVersion !== "string" || !value.targetVersion) {
+      window.sessionStorage.removeItem(TRACKED_OPERATION_KEY);
+      return undefined;
+    }
+    return {
+      targetVersion: value.targetVersion,
+      ...(typeof value.id === "string" && value.id ? { id: value.id } : {}),
+    };
+  } catch {
+    return undefined;
+  }
+};
+
+const readAcknowledgedOperation = (): string | null => {
+  try {
+    return window.sessionStorage.getItem(ACKNOWLEDGED_OPERATION_KEY);
+  } catch {
+    return null;
+  }
+};
+
+export function useUpgradeOperation({
+  currentVersion,
+  enabled,
+  onPollError,
+}: UseUpgradeOperationOptions): UseUpgradeOperationResult {
+  const [operation, setOperation] = useState<UpgradeOperation>();
+  const [triggering, setTriggering] = useState(false);
+  const [trackedOperation, setTrackedOperation] = useState<TrackedOperation | undefined>(readTrackedOperation);
+  const recoveredUnknownOutcome = Boolean(trackedOperation && !trackedOperation.id);
+  const [reconciling, setReconciling] = useState(recoveredUnknownOutcome);
+  const [connectionLost, setConnectionLost] = useState(false);
+  const [manualFallbackReady, setManualFallbackReady] = useState(false);
+  const [triggerError, setTriggerError] = useState<string | null>(
+    recoveredUnknownOutcome ? "Fleet did not confirm whether the previous upgrade request started" : null,
+  );
+  const [pollRevision, setPollRevision] = useState(0);
+  const [acknowledgedOperation, setAcknowledgedOperation] = useState<string | null>(readAcknowledgedOperation);
+
+  const operationRef = useRef(operation);
+  const trackedOperationRef = useRef(trackedOperation);
+  const acknowledgedOperationRef = useRef(acknowledgedOperation);
+  const reconcilingRef = useRef(reconciling);
+  const currentVersionRef = useRef(currentVersion);
+  const onPollErrorRef = useRef(onPollError);
+  const reconciliationDeadlineRef = useRef<number | null>(null);
+
+  currentVersionRef.current = currentVersion;
+  onPollErrorRef.current = onPollError;
+
+  useEffect(() => {
+    if (trackedOperationRef.current && !trackedOperationRef.current.id) {
+      reconciliationDeadlineRef.current = Date.now() + TRIGGER_RECONCILIATION_TIMEOUT_MS;
+    }
+  }, []);
+
+  const updateOperation = useCallback((next: UpgradeOperation | undefined) => {
+    operationRef.current = next;
+    setOperation(next);
+  }, []);
+
+  const updateReconciling = useCallback((next: boolean) => {
+    reconcilingRef.current = next;
+    setReconciling(next);
+  }, []);
+
+  const updateTrackedOperation = useCallback((next: TrackedOperation | undefined) => {
+    trackedOperationRef.current = next;
+    setTrackedOperation(next);
+    try {
+      if (next) {
+        window.sessionStorage.setItem(TRACKED_OPERATION_KEY, JSON.stringify(next));
+      } else {
+        window.sessionStorage.removeItem(TRACKED_OPERATION_KEY);
+      }
+    } catch {
+      // Browser storage is an optimization for route/reload recovery. The
+      // host operation remains durable when storage is unavailable.
+    }
+  }, []);
+
+  const updateAcknowledgedOperation = useCallback((next: string | null) => {
+    acknowledgedOperationRef.current = next;
+    setAcknowledgedOperation(next);
+    try {
+      if (next) {
+        window.sessionStorage.setItem(ACKNOWLEDGED_OPERATION_KEY, next);
+      } else {
+        window.sessionStorage.removeItem(ACKNOWLEDGED_OPERATION_KEY);
+      }
+    } catch {
+      // See updateTrackedOperation: storage failure cannot affect host state.
+    }
+  }, []);
+
+  const finishExpiredReconciliation = useCallback(() => {
+    const deadline = reconciliationDeadlineRef.current;
+    if (!reconcilingRef.current || deadline === null || Date.now() < deadline) {
+      return false;
+    }
+    reconciliationDeadlineRef.current = null;
+    setManualFallbackReady(false);
+    updateReconciling(false);
+    if (!trackedOperationRef.current?.id) {
+      updateTrackedOperation(undefined);
+    }
+    return true;
+  }, [updateReconciling, updateTrackedOperation]);
+
+  const allowManualFallbackAfterTimeout = useCallback(() => {
+    const deadline = reconciliationDeadlineRef.current;
+    if (reconcilingRef.current && deadline !== null && Date.now() >= deadline) {
+      setManualFallbackReady(true);
+    }
+  }, []);
+
+  const acceptServerOperation = useCallback(
+    (next: UpgradeOperation) => {
+      const active = isUpgradeActive(next);
+      const tracked = trackedOperationRef.current;
+      const trackedMatches = tracked?.id ? tracked.id === next.id : tracked?.targetVersion === next.targetVersion;
+
+      if (active) {
+        // A durable active operation is authoritative, including one started
+        // by another operator. It takes precedence over a newer release offer.
+        updateAcknowledgedOperation(null);
+        updateTrackedOperation({ id: next.id, targetVersion: next.targetVersion });
+        updateOperation(next);
+        reconciliationDeadlineRef.current = null;
+        setManualFallbackReady(false);
+        updateReconciling(false);
+        setConnectionLost(false);
+        setTriggerError(null);
+        return true;
+      }
+
+      if (!isUpgradeTerminal(next.phase)) {
+        return false;
+      }
+
+      if (acknowledgedOperationRef.current === next.id) {
+        return false;
+      }
+
+      // A manual recovery may have installed the failed target successfully.
+      // Do not replay the updater's stale failure once Fleet reports that exact
+      // version as current.
+      if (next.phase === UpgradePhase.FAILED && currentVersionRef.current === next.targetVersion) {
+        if (trackedMatches) updateTrackedOperation(undefined);
+        if (operationRef.current?.id === next.id) updateOperation(undefined);
+        reconciliationDeadlineRef.current = null;
+        setManualFallbackReady(false);
+        updateReconciling(false);
+        setConnectionLost(false);
+        return false;
+      }
+
+      const unresolvedFailure =
+        next.phase === UpgradePhase.FAILED &&
+        Boolean(currentVersionRef.current && currentVersionRef.current !== next.targetVersion);
+      if (!trackedMatches && !unresolvedFailure) {
+        return false;
+      }
+
+      updateTrackedOperation({ id: next.id, targetVersion: next.targetVersion });
+      updateOperation(next);
+      reconciliationDeadlineRef.current = null;
+      setManualFallbackReady(false);
+      updateReconciling(false);
+      setConnectionLost(false);
+      setTriggerError(null);
+      return true;
+    },
+    [updateAcknowledgedOperation, updateOperation, updateReconciling, updateTrackedOperation],
+  );
+
+  const pollStatus = useCallback(
+    async (signal: AbortSignal) => {
+      try {
+        const response = await instanceUpdateClient.getUpgradeStatus(
+          {},
+          { signal, timeoutMs: STATUS_REQUEST_TIMEOUT_MS },
+        );
+        if (signal.aborted) return;
+
+        if (response.operation && acceptServerOperation(response.operation)) {
+          return;
+        }
+
+        if (!response.executorAvailable) {
+          if (isUpgradeActive(operationRef.current) || reconcilingRef.current || trackedOperationRef.current) {
+            setConnectionLost(true);
+          }
+          allowManualFallbackAfterTimeout();
+          return;
+        }
+
+        if (isUpgradeActive(operationRef.current)) {
+          // The executor is reachable but lost the operation that Fleet was
+          // following. Preserve the last durable phase rather than exposing a
+          // competing action while reconciliation continues.
+          setConnectionLost(true);
+        } else {
+          setConnectionLost(false);
+        }
+        finishExpiredReconciliation();
+      } catch (error) {
+        if (signal.aborted) return;
+        onPollErrorRef.current?.(error);
+        if (isUpgradeActive(operationRef.current) || reconcilingRef.current || trackedOperationRef.current) {
+          setConnectionLost(true);
+        }
+        allowManualFallbackAfterTimeout();
+      }
+    },
+    [acceptServerOperation, allowManualFallbackAfterTimeout, finishExpiredReconciliation],
+  );
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    let alive = true;
+    let timer: number | undefined;
+    let controller: AbortController | undefined;
+
+    const run = async () => {
+      controller = new AbortController();
+      await pollStatus(controller.signal);
+      if (alive) {
+        const awaitingTrackedOperation = Boolean(trackedOperationRef.current && !operationRef.current);
+        const pollIntervalMs =
+          isUpgradeActive(operationRef.current) || reconcilingRef.current || awaitingTrackedOperation
+            ? ACTIVE_POLL_INTERVAL_MS
+            : IDLE_POLL_INTERVAL_MS;
+        timer = window.setTimeout(run, pollIntervalMs);
+      }
+    };
+
+    void run();
+    return () => {
+      alive = false;
+      controller?.abort();
+      if (timer !== undefined) window.clearTimeout(timer);
+    };
+  }, [currentVersion, enabled, pollRevision, pollStatus]);
+
+  const triggerUpgrade = useCallback(
+    async (targetVersion: string) => {
+      updateTrackedOperation({ targetVersion });
+      reconciliationDeadlineRef.current = null;
+      setManualFallbackReady(false);
+      updateReconciling(false);
+      setConnectionLost(false);
+      setTriggerError(null);
+      setTriggering(true);
+      try {
+        const response = await instanceUpdateClient.triggerUpgrade(
+          { targetVersion },
+          { timeoutMs: TRIGGER_REQUEST_TIMEOUT_MS },
+        );
+        if (!response.operation) {
+          throw new Error("Host updater did not return an operation");
+        }
+        acceptServerOperation(response.operation);
+      } catch (error) {
+        setTriggerError(getErrorMessage(error, "Failed to start upgrade"));
+        reconciliationDeadlineRef.current = Date.now() + TRIGGER_RECONCILIATION_TIMEOUT_MS;
+        updateReconciling(true);
+      } finally {
+        setTriggering(false);
+        // An idle status poll may already be scheduled far in the future.
+        // Wake it after trigger admission settles so success and ambiguous
+        // responses both transition immediately to the active cadence.
+        setPollRevision((revision) => revision + 1);
+      }
+    },
+    [acceptServerOperation, updateReconciling, updateTrackedOperation],
+  );
+
+  const acknowledgeOperation = useCallback(() => {
+    if (operationRef.current && isUpgradeTerminal(operationRef.current.phase)) {
+      updateAcknowledgedOperation(operationRef.current.id);
+    }
+    updateTrackedOperation(undefined);
+    updateOperation(undefined);
+    reconciliationDeadlineRef.current = null;
+    setManualFallbackReady(false);
+    updateReconciling(false);
+    setConnectionLost(false);
+    setTriggerError(null);
+  }, [updateAcknowledgedOperation, updateOperation, updateReconciling, updateTrackedOperation]);
+
+  const useManualFallback = useCallback(() => {
+    if (!manualFallbackReady) return;
+    updateTrackedOperation(undefined);
+    reconciliationDeadlineRef.current = null;
+    setManualFallbackReady(false);
+    updateReconciling(false);
+    setConnectionLost(false);
+    setTriggerError(null);
+  }, [manualFallbackReady, updateReconciling, updateTrackedOperation]);
+
+  const reloadFleet = useCallback(() => {
+    updateTrackedOperation(undefined);
+    window.location.reload();
+  }, [updateTrackedOperation]);
+
+  return {
+    acknowledgeOperation,
+    connectionLost,
+    manualFallbackReady,
+    operation,
+    reconciling,
+    reloadFleet,
+    triggerError,
+    triggering,
+    trackedTargetVersion: trackedOperation?.targetVersion,
+    triggerUpgrade,
+    useManualFallback,
+  };
+}

--- a/client/src/protoFleet/features/updates/api/useUpgradeOperation.ts
+++ b/client/src/protoFleet/features/updates/api/useUpgradeOperation.ts
@@ -24,6 +24,7 @@ interface AcknowledgedOperation {
 
 interface UseUpgradeOperationOptions {
   authSessionIdentity: string;
+  authSessionToken: object | null;
   currentVersion?: string;
   currentVersionUnavailable: boolean;
   enabled: boolean;
@@ -95,6 +96,7 @@ const readAcknowledgedOperation = (authSessionIdentity: string): string | null =
 
 export function useUpgradeOperation({
   authSessionIdentity,
+  authSessionToken,
   currentVersion,
   currentVersionUnavailable,
   enabled,
@@ -113,6 +115,7 @@ export function useUpgradeOperation({
   );
   const [pollRevision, setPollRevision] = useState(0);
   const [resolvedStatusSessionIdentity, setResolvedStatusSessionIdentity] = useState<string | null>(null);
+  const [resolvedStatusSessionToken, setResolvedStatusSessionToken] = useState<object | null>();
 
   const operationRef = useRef(operation);
   const trackedOperationRef = useRef(trackedOperation);
@@ -124,18 +127,23 @@ export function useUpgradeOperation({
   const onPollErrorRef = useRef(onPollError);
   const reconciliationDeadlineRef = useRef<number | null>(null);
   const authSessionIdentityRef = useRef(authSessionIdentity);
+  const authSessionTokenRef = useRef(authSessionToken);
   const resolvedStatusSessionIdentityRef = useRef<string | null>(null);
+  const resolvedStatusSessionTokenRef = useRef<object | null | undefined>(undefined);
 
   currentVersionRef.current = currentVersion;
   currentVersionUnavailableRef.current = currentVersionUnavailable;
   onPollErrorRef.current = onPollError;
   authSessionIdentityRef.current = authSessionIdentity;
+  authSessionTokenRef.current = authSessionToken;
   if (acknowledgedOperationSessionRef.current !== authSessionIdentity) {
     acknowledgedOperationSessionRef.current = authSessionIdentity;
     acknowledgedOperationRef.current = readAcknowledgedOperation(authSessionIdentity);
   }
 
-  const operationStatusPending = enabled && resolvedStatusSessionIdentity !== authSessionIdentity;
+  const operationStatusPending =
+    enabled &&
+    (resolvedStatusSessionIdentity !== authSessionIdentity || resolvedStatusSessionToken !== authSessionToken);
 
   useEffect(() => {
     if (trackedOperationRef.current) {
@@ -239,9 +247,14 @@ export function useUpgradeOperation({
       }
       const active = isUpgradeActive(next);
       const tracked = trackedOperationRef.current;
+      const reconciledSuccess =
+        reconcilingRef.current &&
+        !tracked?.id &&
+        tracked?.targetVersion === next.targetVersion &&
+        next.phase === UpgradePhase.SUCCEEDED;
       const trackedMatches = tracked?.id
         ? tracked.id === next.id
-        : fromTriggerResponse && tracked?.targetVersion === next.targetVersion;
+        : (fromTriggerResponse && tracked?.targetVersion === next.targetVersion) || reconciledSuccess;
 
       if (active) {
         // A durable active operation is authoritative, including one started
@@ -303,16 +316,24 @@ export function useUpgradeOperation({
   );
 
   const pollStatus = useCallback(
-    async (signal: AbortSignal, pollingAuthSessionIdentity: string) => {
+    async (signal: AbortSignal, pollingAuthSessionIdentity: string, pollingAuthSessionToken: object | null) => {
       try {
         const response = await instanceUpdateClient.getUpgradeStatus(
           {},
           { signal, timeoutMs: STATUS_REQUEST_TIMEOUT_MS },
         );
-        if (signal.aborted || authSessionIdentityRef.current !== pollingAuthSessionIdentity) return;
+        if (
+          signal.aborted ||
+          authSessionIdentityRef.current !== pollingAuthSessionIdentity ||
+          authSessionTokenRef.current !== pollingAuthSessionToken
+        ) {
+          return;
+        }
 
         resolvedStatusSessionIdentityRef.current = pollingAuthSessionIdentity;
+        resolvedStatusSessionTokenRef.current = pollingAuthSessionToken;
         setResolvedStatusSessionIdentity(pollingAuthSessionIdentity);
+        setResolvedStatusSessionToken(pollingAuthSessionToken);
 
         if (response.operation && acceptServerOperation(response.operation)) {
           return;
@@ -367,10 +388,12 @@ export function useUpgradeOperation({
 
     const run = async () => {
       controller = new AbortController();
-      await pollStatus(controller.signal, authSessionIdentity);
+      await pollStatus(controller.signal, authSessionIdentity, authSessionToken);
       if (alive) {
         const awaitingTrackedOperation = Boolean(trackedOperationRef.current && !operationRef.current);
-        const awaitingInitialStatus = resolvedStatusSessionIdentityRef.current !== authSessionIdentity;
+        const awaitingInitialStatus =
+          resolvedStatusSessionIdentityRef.current !== authSessionIdentity ||
+          resolvedStatusSessionTokenRef.current !== authSessionToken;
         const pollIntervalMs =
           isUpgradeActive(operationRef.current) ||
           reconcilingRef.current ||
@@ -388,7 +411,15 @@ export function useUpgradeOperation({
       controller?.abort();
       if (timer !== undefined) window.clearTimeout(timer);
     };
-  }, [authSessionIdentity, currentVersion, currentVersionUnavailable, enabled, pollRevision, pollStatus]);
+  }, [
+    authSessionIdentity,
+    authSessionToken,
+    currentVersion,
+    currentVersionUnavailable,
+    enabled,
+    pollRevision,
+    pollStatus,
+  ]);
 
   const triggerUpgrade = useCallback(
     async (targetVersion: string) => {

--- a/client/src/protoFleet/features/updates/api/useUpgradeOperation.ts
+++ b/client/src/protoFleet/features/updates/api/useUpgradeOperation.ts
@@ -24,7 +24,6 @@ interface AcknowledgedOperation {
 
 interface UseUpgradeOperationOptions {
   authSessionIdentity: string;
-  authSessionToken: object | null;
   currentVersion?: string;
   currentVersionUnavailable: boolean;
   enabled: boolean;
@@ -50,7 +49,7 @@ export const isUpgradeTerminal = (phase: UpgradePhase) =>
   phase === UpgradePhase.SUCCEEDED || phase === UpgradePhase.FAILED;
 
 export const isUpgradeActive = (operation?: UpgradeOperation) =>
-  Boolean(operation && operation.phase !== UpgradePhase.UNSPECIFIED && !isUpgradeTerminal(operation.phase));
+  Boolean(operation && !isUpgradeTerminal(operation.phase));
 
 const readTrackedOperation = (): TrackedOperation | undefined => {
   try {
@@ -96,7 +95,6 @@ const readAcknowledgedOperation = (authSessionIdentity: string): string | null =
 
 export function useUpgradeOperation({
   authSessionIdentity,
-  authSessionToken,
   currentVersion,
   currentVersionUnavailable,
   enabled,
@@ -115,7 +113,6 @@ export function useUpgradeOperation({
   );
   const [pollRevision, setPollRevision] = useState(0);
   const [resolvedStatusSessionIdentity, setResolvedStatusSessionIdentity] = useState<string | null>(null);
-  const [resolvedStatusSessionToken, setResolvedStatusSessionToken] = useState<object | null>();
 
   const operationRef = useRef(operation);
   const trackedOperationRef = useRef(trackedOperation);
@@ -127,23 +124,18 @@ export function useUpgradeOperation({
   const onPollErrorRef = useRef(onPollError);
   const reconciliationDeadlineRef = useRef<number | null>(null);
   const authSessionIdentityRef = useRef(authSessionIdentity);
-  const authSessionTokenRef = useRef(authSessionToken);
   const resolvedStatusSessionIdentityRef = useRef<string | null>(null);
-  const resolvedStatusSessionTokenRef = useRef<object | null | undefined>(undefined);
 
   currentVersionRef.current = currentVersion;
   currentVersionUnavailableRef.current = currentVersionUnavailable;
   onPollErrorRef.current = onPollError;
   authSessionIdentityRef.current = authSessionIdentity;
-  authSessionTokenRef.current = authSessionToken;
   if (acknowledgedOperationSessionRef.current !== authSessionIdentity) {
     acknowledgedOperationSessionRef.current = authSessionIdentity;
     acknowledgedOperationRef.current = readAcknowledgedOperation(authSessionIdentity);
   }
 
-  const operationStatusPending =
-    enabled &&
-    (resolvedStatusSessionIdentity !== authSessionIdentity || resolvedStatusSessionToken !== authSessionToken);
+  const operationStatusPending = enabled && resolvedStatusSessionIdentity !== authSessionIdentity;
 
   useEffect(() => {
     if (trackedOperationRef.current) {
@@ -245,6 +237,9 @@ export function useUpgradeOperation({
       if (!next.id) {
         return false;
       }
+      if (next.phase === UpgradePhase.UNSPECIFIED && acknowledgedOperationRef.current === next.id) {
+        return false;
+      }
       const active = isUpgradeActive(next);
       const tracked = trackedOperationRef.current;
       const reconciledSuccess =
@@ -262,6 +257,17 @@ export function useUpgradeOperation({
         updateAcknowledgedOperation(null);
         updateTrackedOperation({ id: next.id, targetVersion: next.targetVersion });
         updateOperation(next);
+        if (next.phase === UpgradePhase.UNSPECIFIED) {
+          if (!reconcilingRef.current) {
+            reconciliationDeadlineRef.current = Date.now() + TRIGGER_RECONCILIATION_TIMEOUT_MS;
+            setManualFallbackReady(false);
+            updateReconciling(true);
+          }
+          setConnectionLost(false);
+          setTriggerError(null);
+          allowManualFallbackAfterTimeout();
+          return true;
+        }
         reconciliationDeadlineRef.current = null;
         setManualFallbackReady(false);
         updateReconciling(false);
@@ -312,28 +318,28 @@ export function useUpgradeOperation({
       setTriggerError(null);
       return true;
     },
-    [updateAcknowledgedOperation, updateOperation, updateReconciling, updateTrackedOperation],
+    [
+      allowManualFallbackAfterTimeout,
+      updateAcknowledgedOperation,
+      updateOperation,
+      updateReconciling,
+      updateTrackedOperation,
+    ],
   );
 
   const pollStatus = useCallback(
-    async (signal: AbortSignal, pollingAuthSessionIdentity: string, pollingAuthSessionToken: object | null) => {
+    async (signal: AbortSignal, pollingAuthSessionIdentity: string) => {
       try {
         const response = await instanceUpdateClient.getUpgradeStatus(
           {},
           { signal, timeoutMs: STATUS_REQUEST_TIMEOUT_MS },
         );
-        if (
-          signal.aborted ||
-          authSessionIdentityRef.current !== pollingAuthSessionIdentity ||
-          authSessionTokenRef.current !== pollingAuthSessionToken
-        ) {
+        if (signal.aborted || authSessionIdentityRef.current !== pollingAuthSessionIdentity) {
           return;
         }
 
         resolvedStatusSessionIdentityRef.current = pollingAuthSessionIdentity;
-        resolvedStatusSessionTokenRef.current = pollingAuthSessionToken;
         setResolvedStatusSessionIdentity(pollingAuthSessionIdentity);
-        setResolvedStatusSessionToken(pollingAuthSessionToken);
 
         if (response.operation && acceptServerOperation(response.operation)) {
           return;
@@ -388,12 +394,10 @@ export function useUpgradeOperation({
 
     const run = async () => {
       controller = new AbortController();
-      await pollStatus(controller.signal, authSessionIdentity, authSessionToken);
+      await pollStatus(controller.signal, authSessionIdentity);
       if (alive) {
         const awaitingTrackedOperation = Boolean(trackedOperationRef.current && !operationRef.current);
-        const awaitingInitialStatus =
-          resolvedStatusSessionIdentityRef.current !== authSessionIdentity ||
-          resolvedStatusSessionTokenRef.current !== authSessionToken;
+        const awaitingInitialStatus = resolvedStatusSessionIdentityRef.current !== authSessionIdentity;
         const pollIntervalMs =
           isUpgradeActive(operationRef.current) ||
           reconcilingRef.current ||
@@ -411,15 +415,7 @@ export function useUpgradeOperation({
       controller?.abort();
       if (timer !== undefined) window.clearTimeout(timer);
     };
-  }, [
-    authSessionIdentity,
-    authSessionToken,
-    currentVersion,
-    currentVersionUnavailable,
-    enabled,
-    pollRevision,
-    pollStatus,
-  ]);
+  }, [authSessionIdentity, currentVersion, currentVersionUnavailable, enabled, pollRevision, pollStatus]);
 
   const triggerUpgrade = useCallback(
     async (targetVersion: string) => {
@@ -473,6 +469,9 @@ export function useUpgradeOperation({
 
   const useManualFallback = useCallback(() => {
     if (!manualFallbackReady) return;
+    if (operationRef.current?.phase === UpgradePhase.UNSPECIFIED) {
+      updateAcknowledgedOperation(operationRef.current.id);
+    }
     updateTrackedOperation(undefined);
     updateOperation(undefined);
     reconciliationDeadlineRef.current = null;
@@ -480,7 +479,7 @@ export function useUpgradeOperation({
     updateReconciling(false);
     setConnectionLost(false);
     setTriggerError(null);
-  }, [manualFallbackReady, updateOperation, updateReconciling, updateTrackedOperation]);
+  }, [manualFallbackReady, updateAcknowledgedOperation, updateOperation, updateReconciling, updateTrackedOperation]);
 
   const reloadFleet = useCallback(() => {
     updateTrackedOperation(undefined);

--- a/client/src/protoFleet/features/updates/api/useUpgradeOperation.ts
+++ b/client/src/protoFleet/features/updates/api/useUpgradeOperation.ts
@@ -35,6 +35,7 @@ interface UseUpgradeOperationResult {
   connectionLost: boolean;
   manualFallbackReady: boolean;
   operation: UpgradeOperation | undefined;
+  operationStatusPending: boolean;
   reconciling: boolean;
   reloadFleet: () => void;
   triggerError: string | null;
@@ -111,37 +112,36 @@ export function useUpgradeOperation({
     recoveredUnknownOutcome ? "Fleet did not confirm whether the previous upgrade request started" : null,
   );
   const [pollRevision, setPollRevision] = useState(0);
-  const [acknowledgedOperation, setAcknowledgedOperation] = useState<string | null>(() =>
-    readAcknowledgedOperation(authSessionIdentity),
-  );
+  const [resolvedStatusSessionIdentity, setResolvedStatusSessionIdentity] = useState<string | null>(null);
 
   const operationRef = useRef(operation);
   const trackedOperationRef = useRef(trackedOperation);
-  const acknowledgedOperationRef = useRef(acknowledgedOperation);
+  const acknowledgedOperationRef = useRef<string | null>(null);
+  const acknowledgedOperationSessionRef = useRef<string | null>(null);
   const reconcilingRef = useRef(reconciling);
   const currentVersionRef = useRef(currentVersion);
   const currentVersionUnavailableRef = useRef(currentVersionUnavailable);
   const onPollErrorRef = useRef(onPollError);
   const reconciliationDeadlineRef = useRef<number | null>(null);
   const authSessionIdentityRef = useRef(authSessionIdentity);
+  const resolvedStatusSessionIdentityRef = useRef<string | null>(null);
 
   currentVersionRef.current = currentVersion;
   currentVersionUnavailableRef.current = currentVersionUnavailable;
   onPollErrorRef.current = onPollError;
+  authSessionIdentityRef.current = authSessionIdentity;
+  if (acknowledgedOperationSessionRef.current !== authSessionIdentity) {
+    acknowledgedOperationSessionRef.current = authSessionIdentity;
+    acknowledgedOperationRef.current = readAcknowledgedOperation(authSessionIdentity);
+  }
+
+  const operationStatusPending = enabled && resolvedStatusSessionIdentity !== authSessionIdentity;
 
   useEffect(() => {
     if (trackedOperationRef.current) {
       reconciliationDeadlineRef.current = Date.now() + TRIGGER_RECONCILIATION_TIMEOUT_MS;
     }
   }, []);
-
-  useEffect(() => {
-    if (authSessionIdentityRef.current === authSessionIdentity) return;
-    authSessionIdentityRef.current = authSessionIdentity;
-    const next = readAcknowledgedOperation(authSessionIdentity);
-    acknowledgedOperationRef.current = next;
-    setAcknowledgedOperation(next);
-  }, [authSessionIdentity]);
 
   const updateOperation = useCallback((next: UpgradeOperation | undefined) => {
     operationRef.current = next;
@@ -170,7 +170,6 @@ export function useUpgradeOperation({
 
   const updateAcknowledgedOperation = useCallback((next: string | null) => {
     acknowledgedOperationRef.current = next;
-    setAcknowledgedOperation(next);
     try {
       if (next) {
         window.sessionStorage.setItem(
@@ -234,10 +233,15 @@ export function useUpgradeOperation({
   }, [updateReconciling, updateTrackedOperation]);
 
   const acceptServerOperation = useCallback(
-    (next: UpgradeOperation) => {
+    (next: UpgradeOperation, fromTriggerResponse = false) => {
+      if (!next.id) {
+        return false;
+      }
       const active = isUpgradeActive(next);
       const tracked = trackedOperationRef.current;
-      const trackedMatches = tracked?.id ? tracked.id === next.id : tracked?.targetVersion === next.targetVersion;
+      const trackedMatches = tracked?.id
+        ? tracked.id === next.id
+        : fromTriggerResponse && tracked?.targetVersion === next.targetVersion;
 
       if (active) {
         // A durable active operation is authoritative, including one started
@@ -299,13 +303,16 @@ export function useUpgradeOperation({
   );
 
   const pollStatus = useCallback(
-    async (signal: AbortSignal) => {
+    async (signal: AbortSignal, pollingAuthSessionIdentity: string) => {
       try {
         const response = await instanceUpdateClient.getUpgradeStatus(
           {},
           { signal, timeoutMs: STATUS_REQUEST_TIMEOUT_MS },
         );
-        if (signal.aborted) return;
+        if (signal.aborted || authSessionIdentityRef.current !== pollingAuthSessionIdentity) return;
+
+        resolvedStatusSessionIdentityRef.current = pollingAuthSessionIdentity;
+        setResolvedStatusSessionIdentity(pollingAuthSessionIdentity);
 
         if (response.operation && acceptServerOperation(response.operation)) {
           return;
@@ -360,11 +367,15 @@ export function useUpgradeOperation({
 
     const run = async () => {
       controller = new AbortController();
-      await pollStatus(controller.signal);
+      await pollStatus(controller.signal, authSessionIdentity);
       if (alive) {
         const awaitingTrackedOperation = Boolean(trackedOperationRef.current && !operationRef.current);
+        const awaitingInitialStatus = resolvedStatusSessionIdentityRef.current !== authSessionIdentity;
         const pollIntervalMs =
-          isUpgradeActive(operationRef.current) || reconcilingRef.current || awaitingTrackedOperation
+          isUpgradeActive(operationRef.current) ||
+          reconcilingRef.current ||
+          awaitingTrackedOperation ||
+          awaitingInitialStatus
             ? ACTIVE_POLL_INTERVAL_MS
             : IDLE_POLL_INTERVAL_MS;
         timer = window.setTimeout(run, pollIntervalMs);
@@ -377,7 +388,7 @@ export function useUpgradeOperation({
       controller?.abort();
       if (timer !== undefined) window.clearTimeout(timer);
     };
-  }, [currentVersion, currentVersionUnavailable, enabled, pollRevision, pollStatus]);
+  }, [authSessionIdentity, currentVersion, currentVersionUnavailable, enabled, pollRevision, pollStatus]);
 
   const triggerUpgrade = useCallback(
     async (targetVersion: string) => {
@@ -396,7 +407,7 @@ export function useUpgradeOperation({
         if (!response.operation) {
           throw new Error("Host updater did not return an operation");
         }
-        if (!acceptServerOperation(response.operation)) {
+        if (!acceptServerOperation(response.operation, true)) {
           throw new Error(
             "Fleet couldn't confirm the upgrade state. Fleet will check the host before unlocking other install options.",
           );
@@ -450,6 +461,7 @@ export function useUpgradeOperation({
     connectionLost,
     manualFallbackReady,
     operation,
+    operationStatusPending,
     reconciling,
     reloadFleet,
     triggerError,

--- a/client/src/protoFleet/features/updates/copyInstallCommand.ts
+++ b/client/src/protoFleet/features/updates/copyInstallCommand.ts
@@ -1,8 +1,8 @@
 import { pushToast, STATUSES } from "@/shared/features/toaster";
 import { copyToClipboard } from "@/shared/utils/utility";
 
-// Shared by the update notification modal and the settings Updates page so
-// both surfaces give identical feedback for the same action.
+// Keep the manual fallback's clipboard feedback consistent wherever the
+// Settings update flow renders it.
 export const copyInstallCommand = (installCommand: string) => {
   copyToClipboard(installCommand)
     .then(() => {

--- a/client/src/protoFleet/store/hooks/useAuth.ts
+++ b/client/src/protoFleet/store/hooks/useAuth.ts
@@ -8,6 +8,8 @@ import { useFleetStore } from "../useFleetStore";
 
 export const useSessionExpiry = () => useFleetStore((state) => state.auth.sessionExpiry);
 
+export const useSessionGeneration = () => useFleetStore((state) => state.auth.sessionGeneration);
+
 export const useIsAuthenticated = () => useFleetStore((state) => state.auth.isAuthenticated);
 
 export const useUsername = () => useFleetStore((state) => state.auth.username);

--- a/client/src/protoFleet/store/index.ts
+++ b/client/src/protoFleet/store/index.ts
@@ -11,6 +11,7 @@ export type { FleetStore } from "./useFleetStore";
 
 export {
   useSessionExpiry,
+  useSessionGeneration,
   useIsAuthenticated,
   useUsername,
   useRole,

--- a/client/src/protoFleet/store/slices/authSlice.ts
+++ b/client/src/protoFleet/store/slices/authSlice.ts
@@ -9,6 +9,7 @@ import { resetActiveCurtailmentData } from "@/protoFleet/api/activeCurtailmentDa
 
 export interface AuthSlice {
   sessionExpiry: Date | null;
+  sessionGeneration: number;
   isAuthenticated: boolean;
   username: string;
   role: string;
@@ -38,6 +39,7 @@ export interface AuthSlice {
 export const createAuthSlice: StateCreator<FleetStore, [["zustand/immer", never]], [], AuthSlice> = (set) => ({
   // Initial state
   sessionExpiry: null,
+  sessionGeneration: 0,
   isAuthenticated: false,
   username: "",
   role: "",
@@ -49,6 +51,9 @@ export const createAuthSlice: StateCreator<FleetStore, [["zustand/immer", never]
   setSessionExpiry: (expiry) =>
     set((state) => {
       state.auth.sessionExpiry = expiry;
+      if (expiry) {
+        state.auth.sessionGeneration += 1;
+      }
     }),
 
   setIsAuthenticated: (isAuthenticated) =>

--- a/client/src/protoFleet/store/useFleetStore.test.ts
+++ b/client/src/protoFleet/store/useFleetStore.test.ts
@@ -58,6 +58,7 @@ describe("useFleetStore persistence", () => {
   it("preserves persisted org-scoped permissions", async () => {
     seedPersistedAuth({
       sessionExpiry: new Date(Date.now() + 60_000),
+      sessionGeneration: 7,
       isAuthenticated: true,
       username: "alice@example.com",
       role: "ADMIN",
@@ -70,6 +71,18 @@ describe("useFleetStore persistence", () => {
 
     expect(useFleetStore.getState().auth.permissions).toEqual(["site:read"]);
     expect(useFleetStore.getState().auth.isAuthenticated).toBe(true);
+    expect(useFleetStore.getState().auth.sessionGeneration).toBe(7);
+  });
+
+  it("advances the session generation for replacement sessions with the same expiry", async () => {
+    const { useFleetStore } = await import("./useFleetStore");
+    const expiry = new Date(1_000);
+
+    useFleetStore.getState().auth.setSessionExpiry(expiry);
+    expect(useFleetStore.getState().auth.sessionGeneration).toBe(1);
+
+    useFleetStore.getState().auth.setSessionExpiry(new Date(expiry.getTime()));
+    expect(useFleetStore.getState().auth.sessionGeneration).toBe(2);
   });
 
   it("preserves org-scoped sessions with no permissions", async () => {

--- a/client/src/protoFleet/store/useFleetStore.ts
+++ b/client/src/protoFleet/store/useFleetStore.ts
@@ -29,7 +29,10 @@ export interface FleetStore {
 
 const ORG_PERMISSIONS_SCOPE = "org" as const;
 
-type PersistedAuthState = Pick<AuthSlice, "sessionExpiry" | "isAuthenticated" | "username" | "role" | "permissions"> & {
+type PersistedAuthState = Pick<
+  AuthSlice,
+  "sessionExpiry" | "sessionGeneration" | "isAuthenticated" | "username" | "role" | "permissions"
+> & {
   // Guards against rehydrating old sessions where permissions meant a flat
   // "has this anywhere" projection. Current permissions are org/default scope.
   permissionsScope?: typeof ORG_PERMISSIONS_SCOPE;
@@ -103,6 +106,7 @@ const createMultiKeyStorage = (): PersistStorage<PersistedFleetState> => {
             state: {
               auth: {
                 sessionExpiry: state.auth.sessionExpiry,
+                sessionGeneration: state.auth.sessionGeneration,
                 isAuthenticated: state.auth.isAuthenticated,
                 username: state.auth.username,
                 role: state.auth.role,
@@ -181,6 +185,7 @@ export const useFleetStore = create<FleetStore>()(
           partialize: (state) => ({
             auth: {
               sessionExpiry: state.auth.sessionExpiry,
+              sessionGeneration: state.auth.sessionGeneration,
               isAuthenticated: state.auth.isAuthenticated,
               username: state.auth.username,
               role: state.auth.role,
@@ -222,6 +227,9 @@ export const useFleetStore = create<FleetStore>()(
                 sessionExpiry: sessionIsStalePreOrgDefault
                   ? currentState.auth.sessionExpiry
                   : (persisted?.auth?.sessionExpiry ?? currentState.auth.sessionExpiry),
+                sessionGeneration: sessionIsStalePreOrgDefault
+                  ? currentState.auth.sessionGeneration
+                  : (persisted?.auth?.sessionGeneration ?? currentState.auth.sessionGeneration),
                 isAuthenticated: sessionIsStalePreOrgDefault
                   ? false
                   : (persisted?.auth?.isAuthenticated ?? currentState.auth.isAuthenticated),

--- a/docs/plans/archive/2026-07-29-one-click-upgrade-executor-plan.md
+++ b/docs/plans/archive/2026-07-29-one-click-upgrade-executor-plan.md
@@ -1,0 +1,115 @@
+---
+title: One-Click Upgrade Host Executor - Plan
+date: 2026-07-29
+status: completed
+type: plan
+topic: one-click-upgrade
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+---
+
+# One-Click Upgrade Host Executor
+
+## Outcome
+
+Proto Fleet now lets an authorized operator confirm an eligible upgrade in the
+Updates settings route. A privileged process outside the Compose stack
+validates and activates the release, while the client follows durable progress
+through the expected Fleet restart. Hosts without a reachable executor retain
+the release-specific manual install command as the authoritative fallback.
+
+## Final architecture
+
+### Client ownership
+
+- The normal shell owns only a passive version pill. It performs lightweight
+  release discovery and routes the operator to `/settings/updates`; it does not
+  retain installer commands or own upgrade progress globally.
+- The Updates route fetches authoritative status before exposing actions. It
+  shows one-click controls only when Fleet reports a reachable host executor,
+  and otherwise keeps the manual command path intact.
+- Confirmation names the exact target and explains the restart window. Release
+  candidates add the forward-only migration and no-downgrade warning.
+- Confirmation, progress, reconnect, terminal error, recovery, and success are
+  route-owned states. Leaving the route stops only browser polling; it does not
+  cancel the durable host operation. Returning to the route recovers current
+  state through the upgrade-status RPC.
+- An ambiguous trigger keeps conflicting controls locked while the executor is
+  unreachable. After a bounded wait, the manual path can be unlocked only by
+  explicitly confirming on-host that no upgrade is still running.
+
+### Privilege and execution boundary
+
+- `fleetd` re-checks `instance:update`, the selected release channel, and the
+  currently eligible target. The browser cannot provide a download URL,
+  command, downgrade, or arbitrary release tag.
+- The root systemd service runs outside the Compose stack it restarts. Fleet
+  reaches its narrow HTTP API through
+  `/run/proto-fleet-updater/updater.sock`; the application container never
+  receives the host Docker socket.
+- Before teardown, the updater downloads and verifies the release, safely
+  extracts it, preserves deployment configuration, builds release-specific
+  images, and completes preflight. Activation revalidates the staged manifest
+  and image identities before switching the deployment.
+- The supported topology is one Proto Fleet installation per host on Linux
+  with systemd and rootful Docker, including WSL distributions configured with
+  systemd. macOS, rootless Docker, Linux without systemd, and alternate
+  multi-install layouts use the manual flow.
+
+### Trust and recovery boundary
+
+- The SHA-256 sidecar detects corruption and binds the expected asset name to
+  its digest. The bundle and sidecar share a GitHub Release origin, so GitHub
+  remains the publisher trust anchor; independent release signing is outside
+  this phase.
+- Runtime configuration (`.env`, TLS material, Influx configuration, and
+  persisted optional-overlay settings) is carried into the staged deployment.
+- Updater state and per-operation logs survive Fleet restarts at
+  `/var/lib/proto-fleet-updater/state.json` and
+  `/var/lib/proto-fleet-updater/logs/<operation-id>.log`.
+- A terminal failure exposes the host log path and an explicit recovery
+  command. The previous deployment remains at
+  `<install-root>/deployment.previous` for inspection, but automatic binary
+  rollback is disabled because migrations are forward-only.
+
+## End-to-end flow
+
+```mermaid
+sequenceDiagram
+  participant U as "Authorized operator"
+  participant S as "Fleet shell"
+  participant R as "Updates route"
+  participant F as "fleetd"
+  participant X as "Host updater (systemd)"
+  participant G as "GitHub Releases"
+
+  S->>F: "Discover eligible version"
+  F-->>S: "Version-only indicator data"
+  U->>S: "Select update pill"
+  S->>R: "Navigate to /settings/updates"
+  R->>F: "GetUpdateStatus"
+  F-->>R: "Eligible release, capability, manual command"
+  U->>R: "Confirm exact target"
+  R->>F: "TriggerUpgrade(target version)"
+  F->>F: "Re-check permission, channel, and eligibility"
+  F->>X: "Start operation over Unix socket"
+  X->>G: "Download bundle and checksum"
+  X->>X: "Verify, stage, preflight, and activate"
+  R-->>F: "Poll durable status; restart disconnect is expected"
+  opt "Operator leaves and later returns"
+    U->>R: "Open /settings/updates"
+    R->>F: "GetUpgradeStatus"
+  end
+  F-->>R: "Active or terminal durable operation"
+  R-->>U: "Progress, reload, or recovery guidance"
+```
+
+## Completed implementation units
+
+1. Durable single-flight updater manager and Unix-socket API.
+2. Packaged updater binary, hardened systemd service, and installer lifecycle.
+3. Non-interactive preflight and activation with immutable staging checks.
+4. Release checksum publication and bounded download/extraction validation.
+5. Permission-gated trigger/status RPCs with server-side target validation.
+6. Passive shell discovery plus route-owned confirmation and operation states.
+7. Focused host, API, installer, and client lifecycle tests.


### PR DESCRIPTION
Reviewable diff: +917/-8 across 5 files (excludes generated, test, and story files).

## Summary

Adds the one-click upgrade workflow to Settings > Updates: exact-version confirmation, RC warnings, durable progress, expected restart recovery, failure guidance, and success reload. The normal application shell remains intentionally passive—it only advertises an available version and routes operators to Settings—while unsupported hosts retain the release-specific manual install command.

*Stack:* [#841](https://github.com/block/proto-fleet/pull/841) → [#842](https://github.com/block/proto-fleet/pull/842) → [#843](https://github.com/block/proto-fleet/pull/843) → [#844](https://github.com/block/proto-fleet/pull/844) → [#845](https://github.com/block/proto-fleet/pull/845) → [#835](https://github.com/block/proto-fleet/pull/835) → [#836](https://github.com/block/proto-fleet/pull/836) → [#837](https://github.com/block/proto-fleet/pull/837) → [#838](https://github.com/block/proto-fleet/pull/838) → [#839](https://github.com/block/proto-fleet/pull/839) → **#840**. This is **6/6** of the one-click phase and the diff is relative to #839. The merged ancestors provide release discovery, permission-gated APIs, durable host execution, and the passive update indicator; #839 installs that executor on supported hosts. Host mutation is intentionally out of scope here, and progress is intentionally not tracked across every Fleet view.

## How it works

The passive version pill navigates an authorized operator to `/settings/updates`. The route loads the current eligible release, capability, and manual command, while separately checking durable updater status so an operation started in another tab or recovered after navigation takes precedence over a newer offer. A one-click action appears only when Fleet reports a reachable executor; confirmation sends only the exact eligible version, and fleetd revalidates it before host mutation.

During an operation the route uses completion-based polling, preserves the last phase through the expected Fleet restart, and recovers host state when the operator returns. Ambiguous trigger outcomes keep competing controls locked. If the executor remains unreachable after the bounded reconciliation window, the manual command stays locked until the operator explicitly confirms on-host that no upgrade is running; a reachable executor reporting no matching operation instead refreshes the eligible release before retry.

```mermaid
flowchart LR
  S["Passive version pill"] --> R["Settings > Updates"]
  R --> U["GetUpdateStatus: release, capability, manual command"]
  R --> O["GetUpgradeStatus: durable host operation"]
  U --> C{"Executor reachable?"}
  C -->|"yes"| X["Confirm exact target"]
  C -->|"no"| M["Copy manual install command"]
  X --> T["TriggerUpgrade(target version)"]
  T --> P["Route-owned progress and recovery"]
  O --> P
  P --> F["Failure details or explicit manual fallback"]
  P --> D["Success and reload"]
```

```mermaid
sequenceDiagram
  participant U as "Authorized operator"
  participant S as "Fleet shell"
  participant R as "Updates route"
  participant F as "fleetd"
  participant X as "Host updater"

  S->>F: "Discover eligible version"
  F-->>S: "Version-only indicator"
  U->>S: "Open update"
  S->>R: "Navigate to /settings/updates"
  R->>F: "GetUpdateStatus + GetUpgradeStatus"
  F-->>R: "Offer, capability, durable operation"
  U->>R: "Confirm exact target"
  R->>F: "TriggerUpgrade(target version)"
  F->>X: "Start validated operation"
  R-->>F: "Poll without overlap"
  opt "Operator leaves the route"
    U->>R: "Return later"
    R->>F: "Recover durable status"
  end
  F-->>R: "Active, failed, or succeeded"
  R-->>U: "Progress, recovery, or reload"
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
|---|---|---|
| `features/settings/components/Updates.tsx` | Owns capability-gated actions, control locking, status reconciliation, and route-level recovery | Confirms the workflow stays local to Settings and preserves the manual path |
| `features/settings/components/UpgradeOperationModal.tsx` | Adds confirmation, RC warning, progress, reconnect, failure, success, and explicit manual-unlock states | Primary operator-facing safety surface |
| `features/updates/api/useUpgradeOperation.ts` | Adds bounded RPCs, non-overlapping polling, session recovery, durable-operation precedence, and ambiguous-outcome handling | Core lifecycle and concurrency review surface |
| `copyInstallCommand.ts` | Updates the stale ownership comment after removing the global modal | Confirms the helper now serves the Settings fallback |
| Focused client tests | Covers route integration, lifecycle transitions, target preservation, auth loss, disconnects, and fallback confirmation | Tests — review alongside each state owner |
| `docs/plans/archive/...one-click-upgrade...md` | Records the completed route-owned architecture and current trust/recovery boundaries | Institutional context for future maintenance |

## Key technical decisions & trade-offs

- Settings owns confirmation and progress; the shell keeps only a passive link, avoiding lifecycle state across every route.
- Durable host status is authoritative; browser session storage records only which terminal result belongs to this tab and survives route remounts.
- Polls schedule only after the prior request completes, with bounded RPCs, avoiding overlapping requests during a restart.
- An active host operation supersedes a newer release offer; the UI never exposes two competing targets.
- Unknown trigger outcomes fail closed. Manual fallback requires explicit host confirmation after the bounded wait rather than silently unlocking a potentially overlapping install.
- Failed operations retain the established manual command and expose the host log/recovery command; automatic rollback remains out of scope because migrations are forward-only.

## Testing & validation

- 79 focused Vitest cases passed across Settings integration, upgrade lifecycle, modal states, the passive indicator, and AppLayout behavior.
- Full client ESLint and TypeScript typechecking passed; `npm run build:protoFleet` passed the production Vite build.
- The full local unit run completed 4,013 tests successfully; one unrelated QR/WASM suite could not load through this worktree's symlinked `node_modules` path and is left to the normal CI checkout.
- Pre-commit formatting and pre-push typecheck hooks passed.
- Real systemd/rootful-Docker activation is intentionally covered by the preceding host PRs rather than browser unit tests.
