### PR TITLE
Strengthen dark mode overlay scrims

### DIFF
--- a/client/src/shared/components/ActionSheet/ActionSheet.tsx
+++ b/client/src/shared/components/ActionSheet/ActionSheet.tsx
@@ -73,7 +73,7 @@ const ActionSheet = ({
 
   return createPortal(
     <div
-      className="fixed inset-0 z-60 flex items-end bg-grayscale-gray-20"
+      className="fixed inset-0 z-60 flex items-end bg-grayscale-gray-20 dark:bg-black/60"
       data-testid={testId}
       role="presentation"
       onClick={(event) => {

--- a/client/src/shared/components/PageOverlay/PageOverlay.tsx
+++ b/client/src/shared/components/PageOverlay/PageOverlay.tsx
@@ -43,7 +43,7 @@ const PageOverlayContent = ({
       exit={{ opacity: 0 }}
       transition={{ duration: 0.3, ease: "easeInOut" }}
       className={clsx(
-        "fixed top-0 left-0 m-0! flex h-dvh w-screen justify-center overflow-hidden! bg-grayscale-gray-20",
+        "fixed top-0 left-0 m-0! flex h-dvh w-screen justify-center overflow-hidden! bg-grayscale-gray-20 dark:bg-black/60",
         zIndex,
         {
           "items-center-safe p-0!": position === "center",

--- a/client/src/shared/components/Popover/Popover.tsx
+++ b/client/src/shared/components/Popover/Popover.tsx
@@ -124,7 +124,7 @@ const Popover = ({
   if (isPhone) {
     return createPortal(
       <div
-        className="fixed inset-0 z-60 flex items-end bg-grayscale-gray-20"
+        className="fixed inset-0 z-60 flex items-end bg-grayscale-gray-20 dark:bg-black/60"
         data-testid={testId ? `${testId}-sheet` : "popover-sheet"}
         onMouseDown={canDismissPopover ? (event) => event.stopPropagation() : undefined}
         onTouchStart={canDismissPopover ? (event) => event.stopPropagation() : undefined}


### PR DESCRIPTION
Reviewable diff: +3/-3 across 3 files (excludes generated, test, and story files).

**Summary**
This follow-up keeps light-mode overlays at 20% opacity while making dark-mode overlays use a 60% black scrim. The change improves modal/dialog separation in dark mode without making stacked overlays hide the underlying UI almost completely.

**How it works**
The shared overlay components continue using `bg-grayscale-gray-20` by default for light mode. Each overlay now adds `dark:bg-black/60`, so Tailwind applies the darker scrim only when the app theme is dark.

**Diagrams**
```mermaid
flowchart TD
  Trigger["Dialog, modal, action sheet, or mobile popover opens"] --> Overlay["Shared overlay backdrop renders"]
  Overlay --> Light["Light theme: grayscale gray at 20%"]
  Overlay --> Dark["Dark theme: black at 60%"]
  Light --> Content["Foreground surface remains visually separated"]
  Dark --> Content
```

**Areas of the code involved**

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/src/shared/components/PageOverlay/PageOverlay.tsx` | Adds `dark:bg-black/60` to the page overlay backdrop | Covers modal/dialog/full-screen overlay usage |
| `client/src/shared/components/ActionSheet/ActionSheet.tsx` | Adds `dark:bg-black/60` to the sheet backdrop | Covers mobile action-sheet dimming |
| `client/src/shared/components/Popover/Popover.tsx` | Adds `dark:bg-black/60` to the mobile sheet backdrop | Keeps mobile popover overlay contrast aligned |

**Key technical decisions & trade-offs**
- Use Tailwind's dark-mode variant on existing shared overlay classes rather than adding new tokens or component props.
- Use 60% black per dark scrim so two stacked scrims leave roughly 16% of the underlying UI visible.

**Testing & validation**
- `bin/just lint`
- `bin/npm --prefix client test -- --run src/shared/components/ActionSheet/ActionSheet.test.tsx src/shared/components/Popover/Popover.test.tsx src/shared/components/Modal/Modal.test.tsx src/shared/components/Dialog/Dialog.test.tsx`
- `git diff --check origin/main...HEAD`
- Verified touched shared files for app-boundary imports and new `console.log` usage.
