### PR TITLE
Require explicit modal dismissal

### DIFF
--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/CoolingModeModal/CoolingModeModal.stories.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/CoolingModeModal/CoolingModeModal.stories.tsx
@@ -66,5 +66,5 @@ export const ImmersionCooled = () => (
 
 // Testing dismiss behavior
 export const DismissBehavior = () => (
-  <StoryWrapper infoMessage="Click 'Done' without selecting an option, click outside the modal, or press ESC to dismiss. The onDismiss action will be logged." />
+  <StoryWrapper infoMessage="Click 'Done' without selecting an option, or press ESC to dismiss. The onDismiss action will be logged." />
 );

--- a/client/src/shared/components/Dialog/Dialog.test.tsx
+++ b/client/src/shared/components/Dialog/Dialog.test.tsx
@@ -1,10 +1,31 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import Dialog from "./Dialog";
 import { variants } from "@/shared/components/Button";
 
 describe("Dialog", () => {
+  it("does not dismiss from scrim clicks", () => {
+    const onDismiss = vi.fn();
+    render(<Dialog title="Intentional dismiss" onDismiss={onDismiss} testId="dialog" />);
+
+    const overlay = screen.getByTestId("dialog").parentElement;
+    expect(overlay).not.toBeNull();
+
+    fireEvent.mouseDown(overlay!);
+
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it("still supports Escape dismissal", () => {
+    const onDismiss = vi.fn();
+    render(<Dialog title="Keyboard dismiss" onDismiss={onDismiss} />);
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
   it("keeps two short actions horizontal on mobile while flexing buttons to fill the row", () => {
     render(
       <Dialog

--- a/client/src/shared/components/Dialog/Dialog.tsx
+++ b/client/src/shared/components/Dialog/Dialog.tsx
@@ -1,5 +1,5 @@
 import { motion } from "motion/react";
-import { ReactNode, useCallback, useRef } from "react";
+import { ReactNode, useCallback } from "react";
 import clsx from "clsx";
 
 import { variants } from "@/shared/components/Button";
@@ -9,7 +9,6 @@ import { ButtonProps } from "@/shared/components/ButtonGroup/types";
 import Header from "@/shared/components/Header";
 import PageOverlay from "@/shared/components/PageOverlay";
 import ProgressCircular from "@/shared/components/ProgressCircular";
-import { useClickOutsideDismiss } from "@/shared/hooks/useClickOutsideDismiss";
 import { useEscapeDismiss } from "@/shared/hooks/useEscapeDismiss";
 import useSlideUpAnimation from "@/shared/hooks/useSlideUpAnimation";
 
@@ -50,7 +49,6 @@ const Dialog = ({
   buttons,
   onDismiss,
 }: DialogProps) => {
-  const dialogRef = useRef<HTMLDivElement>(null);
   const slideUpAnimation = useSlideUpAnimation();
   const footerConfig = getDialogFooterConfig(buttons, buttonGroupVariant);
   const footerButtons = footerConfig.stacked
@@ -63,15 +61,9 @@ const Dialog = ({
 
   useEscapeDismiss(open === false ? undefined : dismissDialog);
 
-  useClickOutsideDismiss({
-    ref: dialogRef,
-    onDismiss: open === false ? undefined : dismissDialog,
-  });
-
   return (
     <PageOverlay open={open} zIndex="z-60" shouldPreventScroll={preventScroll} position="top">
       <motion.div
-        ref={dialogRef}
         {...slideUpAnimation}
         className={clsx("mt-16 h-fit w-108 overflow-hidden rounded-3xl bg-surface-elevated-base shadow-200", className)}
         data-testid={testId}

--- a/client/src/shared/components/Modal/Modal.stories.tsx
+++ b/client/src/shared/components/Modal/Modal.stories.tsx
@@ -276,7 +276,7 @@ export const NoHeader = () => {
             <p className="mt-2">
               This is useful for custom layouts where you want full control over the modal content.
             </p>
-            <p className="mt-2">The modal can still be closed with Escape key or clicking outside.</p>
+            <p className="mt-2">The modal can still be closed with the Escape key.</p>
           </div>
         </ModalComponent>
       ) : null}

--- a/client/src/shared/components/Modal/Modal.test.tsx
+++ b/client/src/shared/components/Modal/Modal.test.tsx
@@ -53,6 +53,37 @@ describe("Modal", () => {
     expect(screen.getByTestId("modal").parentElement).toHaveStyle({ maxWidth: "1920px" });
   });
 
+  it("dismisses from the close button, not from scrim clicks", () => {
+    const onDismiss = vi.fn();
+    render(
+      <Modal title="Intentional dismiss" onDismiss={onDismiss}>
+        <div>Modal content</div>
+      </Modal>,
+    );
+
+    const overlay = screen.getByTestId("modal").parentElement?.parentElement;
+    expect(overlay).not.toBeNull();
+
+    fireEvent.mouseDown(overlay!);
+    expect(onDismiss).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Close dialog" }));
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  it("still supports Escape dismissal", () => {
+    const onDismiss = vi.fn();
+    render(
+      <Modal title="Keyboard dismiss" onDismiss={onDismiss}>
+        <div>Modal content</div>
+      </Modal>,
+    );
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
   it("keeps a fixed footer outside the scroll area while preserving the standard sticky header", () => {
     const onDismiss = vi.fn();
     render(

--- a/client/src/shared/components/Modal/Modal.tsx
+++ b/client/src/shared/components/Modal/Modal.tsx
@@ -10,7 +10,6 @@ import Divider from "@/shared/components/Divider";
 import Header from "@/shared/components/Header";
 import ModalHeaderActions from "@/shared/components/ModalHeaderActions";
 import PageOverlay from "@/shared/components/PageOverlay";
-import { useClickOutsideDismiss } from "@/shared/hooks/useClickOutsideDismiss";
 import { useEscapeDismiss } from "@/shared/hooks/useEscapeDismiss";
 import useSlideUpAnimation from "@/shared/hooks/useSlideUpAnimation";
 
@@ -80,7 +79,6 @@ const Modal = ({
   forceTitleCollapsed = false,
   fixedFooter,
 }: ModalProps) => {
-  const modalRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const headerRef = useRef<HTMLDivElement>(null);
   const sentinelRef = useRef<HTMLDivElement>(null);
@@ -135,11 +133,6 @@ const Modal = ({
 
   useEscapeDismiss(open === false ? undefined : dismissModal);
 
-  useClickOutsideDismiss({
-    ref: modalRef,
-    onDismiss: open === false ? undefined : dismissModal,
-    ignoreSelectors: [".popover-content"],
-  });
   const headerIconProps =
     icon === null
       ? {}
@@ -152,7 +145,6 @@ const Modal = ({
   return (
     <PageOverlay open={open} position="top" {...(zIndex && { zIndex })}>
       <div
-        ref={modalRef}
         className={clsx(
           "h-fit overflow-hidden rounded-3xl bg-surface-elevated-base shadow-300",
           sizeClasses[size],


### PR DESCRIPTION
Reviewable diff: +1/-17 across 2 files (excludes generated, test, and story files).

**Summary**

This PR makes modal dismissal more intentional by removing scrim/outside-click dismissal from shared modal and dialog primitives. Modal dismissal now consistently happens through explicit controls such as the header close button, footer actions, or Escape, reducing the chance of accidentally closing form-heavy modal flows.

**How it works**

`Modal` and `Dialog` no longer register with the shared click-outside dismiss stack. Their overlays still render normally and still prevent page scroll, but pointer interactions on the scrim are ignored by the modal layer. `Modal` keeps its header close icon wired to `onDismiss`, and both primitives continue to use the existing Escape-dismiss stack for keyboard dismissal.

**Diagrams**

```mermaid
flowchart TD
  User["User opens modal or dialog"] --> Overlay["PageOverlay renders scrim"]
  Overlay --> Surface["Modal/Dialog surface"]
  User --> ScrimClick["Click scrim"]
  ScrimClick --> NoDismiss["No dismiss callback"]
  User --> ExplicitClose["Click X, footer action, or Escape"]
  ExplicitClose --> Dismiss["Run onDismiss"]
```

**Areas of the code involved**

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/src/shared/components/Modal/Modal.tsx` | Removed click-outside dismissal registration. | Establishes X/explicit-action dismissal for standard and fullscreen modals. |
| `client/src/shared/components/Dialog/Dialog.tsx` | Removed click-outside dismissal registration. | Aligns dialog scrim behavior with modal scrim behavior. |
| `client/src/shared/components/Modal/Modal.test.tsx` | Added coverage for ignored scrim clicks, close button dismissal, and Escape. | Guards the new modal interaction contract. |
| `client/src/shared/components/Dialog/Dialog.test.tsx` | Added coverage for ignored scrim clicks and Escape. | Guards the new dialog interaction contract. |
| Modal stories | Updated story copy that referenced outside-click dismissal. | Keeps Storybook examples aligned with the new behavior. |

**Key technical decisions & trade-offs**

| Decision | Alternative |
| --- | --- |
| Removed click-outside behavior from shared modal/dialog primitives. | Auditing each call site would leave room for future inconsistency. |
| Kept Escape dismissal. | Removing all non-pointer explicit dismissal would reduce keyboard accessibility. |
| Left popovers and action sheets unchanged. | Broadening to transient controls would change menu/sheet ergonomics beyond the modal request. |

**Testing & validation**

- `bin/just lint`
- `bin/npm --prefix client test -- --run src/shared/components/Modal/Modal.test.tsx src/shared/components/Dialog/Dialog.test.tsx src/shared/components/ActionSheet/ActionSheet.test.tsx src/shared/components/Popover/Popover.test.tsx`
- `git diff --check`
- Client-boundary and `console.log` scan across changed files returned no matches.
