### PR TITLE
test: cover RBAC permission dependencies

### DIFF
--- a/client/e2eTests/protoFleet/pages/settingsTeam.ts
+++ b/client/e2eTests/protoFleet/pages/settingsTeam.ts
@@ -271,21 +271,21 @@ export class SettingsTeamPage extends BasePage {
     }
 
     for (const roleName of roleNamesToDelete) {
-      const row = this.roleRow(roleName);
+      const row = this.getRoleRow(roleName);
       await expect(row).toBeVisible();
       await row.getByTestId("list-actions-trigger").click();
       await this.clickButton("Delete");
       await this.clickButton("Delete role");
-      await expect(this.roleRow(roleName)).toBeHidden();
+      await expect(this.getRoleRow(roleName)).toBeHidden();
     }
   }
 
   async clickMemberActionsMenu(username: string) {
-    await this.memberRow(username).getByTestId("list-actions-trigger").click();
+    await this.getMemberRow(username).getByTestId("list-actions-trigger").click();
   }
 
   async validateMemberActionsHidden(username: string) {
-    await expect(this.memberRow(username).getByTestId("list-actions-trigger")).toHaveCount(0);
+    await expect(this.getMemberRow(username).getByTestId("list-actions-trigger")).toHaveCount(0);
   }
 
   async clickResetPassword() {
@@ -305,7 +305,7 @@ export class SettingsTeamPage extends BasePage {
   }
 
   async clickRoleActionsMenu(roleName: string) {
-    await this.roleRow(roleName).getByTestId("list-actions-trigger").click();
+    await this.getRoleRow(roleName).getByTestId("list-actions-trigger").click();
   }
 
   async clickEditRoleAction() {
@@ -348,6 +348,6 @@ export class SettingsTeamPage extends BasePage {
   }
 
   async validateMemberNotInList(username: string) {
-    await expect(this.memberRow(username)).toBeHidden();
+    await expect(this.getMemberRow(username)).toBeHidden();
   }
 }

--- a/client/e2eTests/protoFleet/pages/settingsTeam.ts
+++ b/client/e2eTests/protoFleet/pages/settingsTeam.ts
@@ -195,6 +195,11 @@ export class SettingsTeamPage extends BasePage {
     await expect(this.rolePermissionRow(permissionKey).getByRole("checkbox")).toBeDisabled();
   }
 
+  async validateRolePermissionEnabled(permissionKey: string) {
+    await this.page.getByTestId("role-permission-search").fill(permissionKey);
+    await expect(this.rolePermissionRow(permissionKey).getByRole("checkbox")).toBeEnabled();
+  }
+
   async clickCreateRoleConfirm() {
     await this.page.getByTestId("modal").getByRole("button", { name: "Create role", exact: true }).click();
   }

--- a/client/e2eTests/protoFleet/pages/settingsTeam.ts
+++ b/client/e2eTests/protoFleet/pages/settingsTeam.ts
@@ -5,7 +5,7 @@ import { BasePage } from "./base";
 const escapeRegex = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
 export class SettingsTeamPage extends BasePage {
-  private memberRow(username: string) {
+  private getMemberRow(username: string) {
     return this.page
       .getByTestId("list-body")
       .locator("tr")
@@ -14,7 +14,7 @@ export class SettingsTeamPage extends BasePage {
       });
   }
 
-  private roleRow(roleName: string) {
+  private getRoleRow(roleName: string) {
     return this.page
       .getByTestId("list-body")
       .locator("tr")
@@ -27,7 +27,7 @@ export class SettingsTeamPage extends BasePage {
     return permissionKey.replace(/[^a-z0-9]+/gi, "-").toLowerCase();
   }
 
-  private rolePermissionRow(permissionKey: string) {
+  private getRolePermissionRow(permissionKey: string) {
     return this.page.getByTestId(`role-permission-${this.sanitizePermissionKey(permissionKey)}`);
   }
 
@@ -117,11 +117,11 @@ export class SettingsTeamPage extends BasePage {
   }
 
   async validateMemberRole(username: string, role: string) {
-    await expect(this.memberRow(username).getByTestId("role")).toHaveText(role);
+    await expect(this.getMemberRow(username).getByTestId("role")).toHaveText(role);
   }
 
   async validateMemberLastLogin(username: string, lastLogin: string) {
-    await expect(this.memberRow(username).getByTestId("lastLoginAt")).toHaveText(lastLogin);
+    await expect(this.getMemberRow(username).getByTestId("lastLoginAt")).toHaveText(lastLogin);
   }
 
   async getTemporaryPassword(): Promise<string> {
@@ -129,7 +129,7 @@ export class SettingsTeamPage extends BasePage {
   }
 
   async validateMemberVisible(username: string) {
-    await expect(this.memberRow(username)).toBeVisible();
+    await expect(this.getMemberRow(username)).toBeVisible();
   }
 
   // FIELD_TECH (and any role without user:read) doesn't see the Team
@@ -159,7 +159,7 @@ export class SettingsTeamPage extends BasePage {
   async selectRolePermission(permissionKey: string) {
     await this.page.getByTestId("role-permission-search").fill(permissionKey);
 
-    const permissionRow = this.rolePermissionRow(permissionKey);
+    const permissionRow = this.getRolePermissionRow(permissionKey);
     await expect(permissionRow).toBeVisible();
 
     const checkbox = permissionRow.getByRole("checkbox");
@@ -171,7 +171,7 @@ export class SettingsTeamPage extends BasePage {
   async setRolePermission(permissionKey: string, checked: boolean) {
     await this.page.getByTestId("role-permission-search").fill(permissionKey);
 
-    const permissionRow = this.rolePermissionRow(permissionKey);
+    const permissionRow = this.getRolePermissionRow(permissionKey);
     await expect(permissionRow).toBeVisible();
 
     const checkbox = permissionRow.getByRole("checkbox");
@@ -182,22 +182,22 @@ export class SettingsTeamPage extends BasePage {
 
   async validateRolePermissionChecked(permissionKey: string) {
     await this.page.getByTestId("role-permission-search").fill(permissionKey);
-    await expect(this.rolePermissionRow(permissionKey).getByRole("checkbox")).toBeChecked();
+    await expect(this.getRolePermissionRow(permissionKey).getByRole("checkbox")).toBeChecked();
   }
 
   async validateRolePermissionUnchecked(permissionKey: string) {
     await this.page.getByTestId("role-permission-search").fill(permissionKey);
-    await expect(this.rolePermissionRow(permissionKey).getByRole("checkbox")).not.toBeChecked();
+    await expect(this.getRolePermissionRow(permissionKey).getByRole("checkbox")).not.toBeChecked();
   }
 
   async validateRolePermissionDisabled(permissionKey: string) {
     await this.page.getByTestId("role-permission-search").fill(permissionKey);
-    await expect(this.rolePermissionRow(permissionKey).getByRole("checkbox")).toBeDisabled();
+    await expect(this.getRolePermissionRow(permissionKey).getByRole("checkbox")).toBeDisabled();
   }
 
   async validateRolePermissionEnabled(permissionKey: string) {
     await this.page.getByTestId("role-permission-search").fill(permissionKey);
-    await expect(this.rolePermissionRow(permissionKey).getByRole("checkbox")).toBeEnabled();
+    await expect(this.getRolePermissionRow(permissionKey).getByRole("checkbox")).toBeEnabled();
   }
 
   async clickCreateRoleConfirm() {
@@ -220,11 +220,11 @@ export class SettingsTeamPage extends BasePage {
   }
 
   async validateRoleVisible(roleName: string) {
-    await expect(this.roleRow(roleName)).toBeVisible();
+    await expect(this.getRoleRow(roleName)).toBeVisible();
   }
 
   async validateRoleNotVisible(roleName: string) {
-    await expect(this.roleRow(roleName)).toHaveCount(0);
+    await expect(this.getRoleRow(roleName)).toHaveCount(0);
   }
 
   async validateSystemRoleLockVisible() {

--- a/client/e2eTests/protoFleet/pages/settingsTeam.ts
+++ b/client/e2eTests/protoFleet/pages/settingsTeam.ts
@@ -27,6 +27,10 @@ export class SettingsTeamPage extends BasePage {
     return permissionKey.replace(/[^a-z0-9]+/gi, "-").toLowerCase();
   }
 
+  private rolePermissionRow(permissionKey: string) {
+    return this.page.getByTestId(`role-permission-${this.sanitizePermissionKey(permissionKey)}`);
+  }
+
   async validateTeamSettingsPageOpened() {
     await expect(this.page).toHaveURL(/.*\/team/);
     await this.validateTitle("Team");
@@ -155,13 +159,40 @@ export class SettingsTeamPage extends BasePage {
   async selectRolePermission(permissionKey: string) {
     await this.page.getByTestId("role-permission-search").fill(permissionKey);
 
-    const permissionRow = this.page.getByTestId(`role-permission-${this.sanitizePermissionKey(permissionKey)}`);
+    const permissionRow = this.rolePermissionRow(permissionKey);
     await expect(permissionRow).toBeVisible();
 
     const checkbox = permissionRow.getByRole("checkbox");
     if (!(await checkbox.isChecked())) {
       await permissionRow.click();
     }
+  }
+
+  async setRolePermission(permissionKey: string, checked: boolean) {
+    await this.page.getByTestId("role-permission-search").fill(permissionKey);
+
+    const permissionRow = this.rolePermissionRow(permissionKey);
+    await expect(permissionRow).toBeVisible();
+
+    const checkbox = permissionRow.getByRole("checkbox");
+    if ((await checkbox.isChecked()) !== checked) {
+      await permissionRow.click();
+    }
+  }
+
+  async validateRolePermissionChecked(permissionKey: string) {
+    await this.page.getByTestId("role-permission-search").fill(permissionKey);
+    await expect(this.rolePermissionRow(permissionKey).getByRole("checkbox")).toBeChecked();
+  }
+
+  async validateRolePermissionUnchecked(permissionKey: string) {
+    await this.page.getByTestId("role-permission-search").fill(permissionKey);
+    await expect(this.rolePermissionRow(permissionKey).getByRole("checkbox")).not.toBeChecked();
+  }
+
+  async validateRolePermissionDisabled(permissionKey: string) {
+    await this.page.getByTestId("role-permission-search").fill(permissionKey);
+    await expect(this.rolePermissionRow(permissionKey).getByRole("checkbox")).toBeDisabled();
   }
 
   async clickCreateRoleConfirm() {

--- a/client/e2eTests/protoFleet/spec/rbacAdmin.spec.ts
+++ b/client/e2eTests/protoFleet/spec/rbacAdmin.spec.ts
@@ -295,4 +295,42 @@ test.describe("Proto Fleet - Admin RBAC", () => {
       await settingsTeamPage.validateRoleNotVisible(updatedRoleName);
     });
   });
+
+  test("Role-manage role auto-selects the required read permission for curtailment management", async ({
+    browser,
+    commonSteps,
+    settingsPage,
+    settingsTeamPage,
+  }) => {
+    const roleName = generateRandomText(RBAC_ROLE_PREFIX);
+
+    await test.step("Provision a role-manage role", async () => {
+      await provisionAdminRole(browser, test.info(), commonSteps, {
+        roleDescription: "Manage roles and validate permission dependency behavior.",
+        permissionKeys: ["activity:read", "role:manage"],
+      });
+    });
+
+    await test.step("Open the role builder", async () => {
+      await settingsPage.navigateToTeamSettings();
+      await settingsTeamPage.validateTeamSettingsPageOpened();
+      await settingsTeamPage.openRolesTab();
+      await settingsTeamPage.clickCreateRole();
+      await settingsTeamPage.inputRoleName(roleName);
+      await settingsTeamPage.inputRoleDescription("Validate auto-selected permission dependencies.");
+    });
+
+    await test.step("Selecting curtailment management also grants the required read permission", async () => {
+      await settingsTeamPage.selectRolePermission("curtailment:manage");
+      await settingsTeamPage.validateRolePermissionChecked("curtailment:manage");
+      await settingsTeamPage.validateRolePermissionChecked("curtailment:read");
+      await settingsTeamPage.validateRolePermissionDisabled("curtailment:read");
+    });
+
+    await test.step("Clearing curtailment management releases the dependent read permission", async () => {
+      await settingsTeamPage.setRolePermission("curtailment:manage", false);
+      await settingsTeamPage.validateRolePermissionUnchecked("curtailment:manage");
+      await settingsTeamPage.validateRolePermissionUnchecked("curtailment:read");
+    });
+  });
 });

--- a/client/e2eTests/protoFleet/spec/rbacAdmin.spec.ts
+++ b/client/e2eTests/protoFleet/spec/rbacAdmin.spec.ts
@@ -331,6 +331,7 @@ test.describe("Proto Fleet - Admin RBAC", () => {
       await settingsTeamPage.setRolePermission("curtailment:manage", false);
       await settingsTeamPage.validateRolePermissionUnchecked("curtailment:manage");
       await settingsTeamPage.validateRolePermissionUnchecked("curtailment:read");
+      await settingsTeamPage.validateRolePermissionEnabled("curtailment:read");
     });
   });
 });


### PR DESCRIPTION
Reviewable diff: +33/-1 across 1 files (excludes generated, test, and story files).

## Summary
This PR adds E2E coverage for RBAC permission dependency behavior in the Proto Fleet role builder. It verifies that enabling a dependent write-level curtailment permission automatically enables the required read-level permission and keeps that dependency locked until the parent permission is removed.

## How it works
The new spec creates a role-manage user, opens the team settings role builder, enables `curtailment:manage`, and verifies that `curtailment:read` is auto-selected and disabled. It then removes the manage permission and confirms both permissions return to the unchecked state.

```mermaid
flowchart LR
  A["Open role builder"] --> B["Enable curtailment:manage"]
  B --> C["UI auto-selects curtailment:read"]
  C --> D["Read permission remains disabled"]
  D --> E["Disable curtailment:manage"]
  E --> F["Both permissions return unchecked"]
```

## Areas of the code involved
| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/e2eTests/protoFleet/pages/settingsTeam.ts` | Added reusable helpers for setting and asserting permission checkbox state in the role builder | The new helpers define how the UI dependency behavior is exercised and verified |
| `client/e2eTests/protoFleet/spec/rbacAdmin.spec.ts` | Added an admin RBAC E2E scenario covering curtailment permission dependencies | This is the end-to-end behavior the PR is adding coverage for |

## Key technical decisions & trade-offs
- Reused the existing team settings page object instead of asserting raw locators in the spec, to keep the scenario readable and aligned with the rest of the Proto Fleet E2E suite.
- Covered one concrete dependency pair (`curtailment:manage` -> `curtailment:read`) as a representative RBAC rule rather than trying to exhaustively cover every dependency in one PR.

## Testing & validation
- `./node_modules/.bin/eslint e2eTests/protoFleet/pages/settingsTeam.ts e2eTests/protoFleet/spec/rbacAdmin.spec.ts`
- `../bin/npx vitest run src/protoFleet/features/settings/utils/permissionCatalog.test.ts`
- `../../../bin/npx playwright test spec/rbacAdmin.spec.ts --project=desktop --grep "Role-manage role auto-selects the required read permission for curtailment management"`
- `git push origin codex/rbac-permission-dependencies` (passed repo push hooks including lint and client/server checks)
