### PR TITLE
[5/6] feat(buildings): create racks and buildings inline from the building surfaces

### DIFF
--- a/client/e2eTests/protoFleet/helpers/buildingDetailTestSetup.ts
+++ b/client/e2eTests/protoFleet/helpers/buildingDetailTestSetup.ts
@@ -48,7 +48,6 @@ export type BuildingDetailScenarioData = {
   renamedBuildingName: string;
   siblingBuildingName: string;
   rackLabel: string;
-  powerCapacityMw: string;
 };
 
 function createRunPrefixes(testInfo: TestInfo): BuildingDetailRunPrefixes {
@@ -79,7 +78,6 @@ export function createBuildingDetailScenarioData(testInfo: TestInfo): BuildingDe
     renamedBuildingName: generateRandomText(`${prefixes.buildingPrefix}_renamed`),
     siblingBuildingName: generateRandomText(`${prefixes.buildingPrefix}_sibling`),
     rackLabel: generateRandomText(`${prefixes.rackPrefix}_primary`),
-    powerCapacityMw: "4.2",
   };
 }
 

--- a/client/e2eTests/protoFleet/pages/fleetLocations.ts
+++ b/client/e2eTests/protoFleet/pages/fleetLocations.ts
@@ -151,7 +151,9 @@ export class FleetLocationsPage extends BasePage {
     await this.closeFullScreenModalIfVisible();
   }
 
-  async editBuildingDetailsFromDetail(updates: { name?: string; powerCapacityMw?: string }) {
+  // Building settings only exposes name + layout now: capacity was pulled from
+  // the form until something actually consumes it.
+  async editBuildingDetailsFromDetail(updates: { name?: string }) {
     await this.clickResponsiveTestId("building-page-edit");
     const fullScreenModal = this.page.getByTestId("full-screen-two-pane-modal");
     await expect(fullScreenModal).toBeVisible();
@@ -162,10 +164,6 @@ export class FleetLocationsPage extends BasePage {
 
     if (updates.name !== undefined) {
       await settingsModal.getByTestId("building-settings-name-input").fill(updates.name);
-    }
-
-    if (updates.powerCapacityMw !== undefined) {
-      await settingsModal.getByTestId("building-settings-power-input").fill(updates.powerCapacityMw);
     }
 
     await this.clickResponsiveTestId("building-settings-modal-save", settingsModal);

--- a/client/e2eTests/protoFleet/spec/buildingDetail.spec.ts
+++ b/client/e2eTests/protoFleet/spec/buildingDetail.spec.ts
@@ -24,10 +24,7 @@ test.describe("Buildings - detail", () => {
     await fleetLocationsPage.validateBuildingDetailOpened(scenario.buildingName);
     await fleetLocationsPage.validateBuildingDetailMetrics({ totalMiners: 2 });
 
-    await fleetLocationsPage.editBuildingDetailsFromDetail({
-      name: scenario.renamedBuildingName,
-      powerCapacityMw: scenario.powerCapacityMw,
-    });
+    await fleetLocationsPage.editBuildingDetailsFromDetail({ name: scenario.renamedBuildingName });
 
     await fleetLocationsPage.validateBuildingDetailOpened(scenario.renamedBuildingName);
     await fleetLocationsPage.validateBuildingDetailMetrics({ totalMiners: 2 });

--- a/client/src/protoFleet/features/buildings/components/BuildingModals/BuildingModals.test.tsx
+++ b/client/src/protoFleet/features/buildings/components/BuildingModals/BuildingModals.test.tsx
@@ -1,10 +1,11 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { create } from "@bufbuild/protobuf";
 
 import BuildingModals from "./BuildingModals";
 import { emptyBuildingFormValues } from "@/protoFleet/api/buildings";
 import { BuildingSchema, BuildingWithCountsSchema } from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
+import { DeviceSetSchema, RackInfoSchema } from "@/protoFleet/api/generated/device_set/v1/device_set_pb";
 import { SiteSchema, SiteWithCountsSchema } from "@/protoFleet/api/generated/sites/v1/sites_pb";
 import { type BuildingModalsApi } from "@/protoFleet/features/buildings/hooks/useBuildingModals";
 
@@ -22,6 +23,8 @@ const mockApi = {
   updateBuilding: vi.fn(),
   deleteBuilding: vi.fn(),
   assignRacksToBuilding: vi.fn(),
+  // The racks picker's Building facet options.
+  listBuildings: vi.fn(({ onSuccess }: { onSuccess?: (rows: unknown[]) => void }) => onSuccess?.([])),
 };
 vi.mock("@/protoFleet/api/buildings", async () => {
   const actual = await vi.importActual<typeof import("@/protoFleet/api/buildings")>("@/protoFleet/api/buildings");
@@ -30,6 +33,44 @@ vi.mock("@/protoFleet/api/buildings", async () => {
     useBuildings: () => mockApi,
   };
 });
+
+// The standalone racks picker fetches its own rack list and site catalog. Same
+// stable-identity rule as mockApi above: the picker's facet effect lists
+// listSites / listBuildings as deps, so a fresh vi.fn() per render would re-run
+// it forever.
+const mockDeviceSets = {
+  listRacks: vi.fn(),
+  saveRack: vi.fn(),
+  createRacks: vi.fn(),
+};
+vi.mock("@/protoFleet/api/useDeviceSets", () => ({
+  useDeviceSets: () => mockDeviceSets,
+}));
+const mockSitesApi = {
+  listSites: vi.fn(({ onSuccess }: { onSuccess?: (rows: unknown[]) => void }) => onSuccess?.([])),
+};
+vi.mock("@/protoFleet/api/sites", async (importActual) => ({
+  ...(await importActual<typeof import("@/protoFleet/api/sites")>()),
+  useSites: () => mockSitesApi,
+}));
+
+const seedRacks = (racks: { id: bigint; label: string }[]) => {
+  mockDeviceSets.listRacks.mockImplementation(({ onSuccess, onFinally }) => {
+    onSuccess?.(
+      racks.map((r) =>
+        create(DeviceSetSchema, {
+          id: r.id,
+          label: r.label,
+          // No building, this building's site: eligible to assign.
+          typeDetails: { case: "rackInfo", value: create(RackInfoSchema, { rows: 1, columns: 1, siteId: 7n }) },
+        }),
+      ),
+      "",
+      racks.length,
+    );
+    onFinally?.();
+  });
+};
 
 const makeRow = (id: bigint, name: string, rackCount: bigint = 0n) =>
   create(BuildingWithCountsSchema, { building: create(BuildingSchema, { id, name, siteId: 7n }), rackCount });
@@ -48,6 +89,8 @@ const makeApi = (overrides: Partial<BuildingModalsApi> = {}): BuildingModalsApi 
   openDetailsCreate: vi.fn(),
   openDetailsEdit: vi.fn(),
   openManage: vi.fn(),
+  openRacksPicker: vi.fn(),
+  pickerAssignRacks: vi.fn().mockResolvedValue(true),
   dismiss: vi.fn(),
   dismissDeleteConfirm: vi.fn(),
   detailsCreate: vi.fn().mockResolvedValue(null),
@@ -96,6 +139,38 @@ describe("BuildingModals", () => {
 
     expect(screen.getByTestId("building-delete-dialog")).toBeInTheDocument();
     expect(screen.getByText(/Delete building "Main"\?/)).toBeInTheDocument();
+  });
+
+  it("racksPicker renders the picker (with its create hand-offs) and no manage surface behind it", async () => {
+    seedRacks([{ id: 1n, label: "Alpha" }]);
+    const modals = makeApi({ state: { kind: "racksPicker", row: makeRow(11n, "Main"), currentRackIds: [] } });
+
+    render(<BuildingModals modals={modals} sites={makeSites()} />);
+
+    expect(await screen.findByTestId("manage-racks-modal")).toBeInTheDocument();
+    expect(screen.getByTestId("manage-racks-modal-create-new")).toBeInTheDocument();
+    expect(screen.getByTestId("manage-racks-modal-create-multiple")).toBeInTheDocument();
+    // The point of the standalone flow: the host already renders the building,
+    // so ManageBuildingModal must not be stacked underneath.
+    expect(screen.queryByTestId("manage-building-modal")).not.toBeInTheDocument();
+  });
+
+  it("writes the racksPicker delta and closes only once the write lands", async () => {
+    seedRacks([{ id: 1n, label: "Alpha" }]);
+    const pickerAssignRacks = vi.fn().mockResolvedValue(true);
+    const modals = makeApi({
+      state: { kind: "racksPicker", row: makeRow(11n, "Main"), currentRackIds: [] },
+      pickerAssignRacks,
+    });
+
+    render(<BuildingModals modals={modals} sites={makeSites()} />);
+    await screen.findByText("Alpha");
+    // The row's own checkbox, not the header select-all.
+    fireEvent.click(screen.getByTestId("list-body").querySelectorAll("input[type='checkbox']")[0]);
+    fireEvent.click(screen.getByTestId("manage-racks-modal-confirm"));
+
+    await waitFor(() => expect(pickerAssignRacks).toHaveBeenCalledWith({ added: [1n], removed: [] }));
+    await waitFor(() => expect(modals.dismiss).toHaveBeenCalled());
   });
 
   it("Cancelling the cascade dialog dismisses only the dialog, leaving underlying state", () => {

--- a/client/src/protoFleet/features/buildings/components/BuildingModals/BuildingModals.tsx
+++ b/client/src/protoFleet/features/buildings/components/BuildingModals/BuildingModals.tsx
@@ -1,4 +1,5 @@
 import BuildingDeleteDialog from "../BuildingDeleteDialog";
+import BuildingRacksPicker from "../BuildingRacksPicker";
 import BuildingSettingsModal from "../BuildingSettingsModal";
 import ManageBuildingModal from "../ManageBuildingModal";
 import { type SiteWithCounts } from "@/protoFleet/api/generated/sites/v1/sites_pb";
@@ -76,6 +77,30 @@ const BuildingModals = ({ modals, sites }: BuildingModalsProps) => {
             await modals.detailsSaveEdit(values);
           }}
           onDeleteRequested={modals.requestDeleteCurrent}
+          onDismiss={modals.dismiss}
+          saving={modals.saving}
+        />
+      ) : null}
+      {state.kind === "racksPicker" && state.row.building ? (
+        <BuildingRacksPicker
+          siteId={state.row.building.siteId ?? 0n}
+          buildingId={state.row.building.id}
+          buildingName={state.row.building.name}
+          currentRackIds={state.currentRackIds}
+          onConfirm={(delta) => {
+            void (async () => {
+              const ok = await modals.pickerAssignRacks({
+                added: delta.added.map((a) => a.rackId),
+                removed: delta.removed,
+              });
+              // A failed write leaves the picker open so the selection can be
+              // retried.
+              if (ok) modals.dismiss();
+            })();
+          }}
+          // Created racks are already in the building; there is no working set
+          // here to inject them into, so the host's cache is what has to re-pull.
+          onCreated={modals.refreshBuildings}
           onDismiss={modals.dismiss}
           saving={modals.saving}
         />

--- a/client/src/protoFleet/features/buildings/components/BuildingRackGrid/BuildingRackGrid.tsx
+++ b/client/src/protoFleet/features/buildings/components/BuildingRackGrid/BuildingRackGrid.tsx
@@ -7,12 +7,17 @@ import { type BuildingRackHealth } from "@/protoFleet/api/generated/buildings/v1
 import { HealthBar } from "@/protoFleet/components/HealthBar";
 import { ChevronDown } from "@/shared/assets/icons";
 import { iconSizes } from "@/shared/assets/icons/constants";
+import Button, { variants } from "@/shared/components/Button";
 import SegmentedControl from "@/shared/components/SegmentedControl";
 
 export interface BuildingRackGridProps {
   rackHealth: BuildingRackHealth[];
   aisles: number;
   racksPerAisle: number;
+  // Opens the racks picker from the empty state. Omitted (or withheld for an
+  // operator who can't manage placement) leaves the empty card copy-only —
+  // there is nothing else to offer a viewer with no racks to look at.
+  onManageRacks?: () => void;
   testId?: string;
 }
 
@@ -49,6 +54,7 @@ const BuildingRackGrid = ({
   rackHealth,
   aisles,
   racksPerAisle,
+  onManageRacks,
   testId = "building-rack-grid",
 }: BuildingRackGridProps) => {
   const navigate = useNavigate();
@@ -169,11 +175,28 @@ const BuildingRackGrid = ({
 
   if (rackHealth.length === 0) {
     return (
+      // The same full-width card the populated grid uses, so an empty building
+      // reads as a section with nothing in it rather than a placeholder slot.
+      // Mirrors SiteDetailPage's empty buildings card.
       <div
-        className="rounded-2xl border border-dashed border-border-5 p-6 text-center text-300 text-text-primary-70"
+        className="flex flex-col items-center gap-2 rounded-xl bg-surface-elevated-base p-10 text-center shadow-100 phone:p-6"
         data-testid={`${testId}-empty`}
       >
-        No racks in this building yet.
+        <div className="text-heading-200 text-text-primary">No racks in this building yet</div>
+        <div className="text-300 text-text-primary-70">
+          {onManageRacks
+            ? "Create racks or assign existing racks to this building."
+            : "No racks have been assigned to this building."}
+        </div>
+        {onManageRacks ? (
+          <Button
+            variant={variants.primary}
+            text="Manage racks"
+            className="mt-4"
+            onClick={onManageRacks}
+            testId={`${testId}-empty-manage`}
+          />
+        ) : null}
       </div>
     );
   }

--- a/client/src/protoFleet/features/buildings/components/BuildingRacksPicker/BuildingRacksPicker.tsx
+++ b/client/src/protoFleet/features/buildings/components/BuildingRacksPicker/BuildingRacksPicker.tsx
@@ -1,0 +1,167 @@
+// The racks picker plus its create hand-off. Hosts render this rather than
+// ManageRacksModal directly so the two create entry points ("Create rack" /
+// "Create multiple racks") behave the same everywhere the picker is reachable —
+// from inside ManageBuildingModal, and standalone from the building page's empty
+// state.
+//
+// Exists as its own component rather than inline in each host because the
+// hand-off needs local state (which side of the create modal's toggle to open
+// on) and both create paths need the same "already in this building" handling.
+
+import { useMemo, useState } from "react";
+
+import { assignedRackScope, buildingRackScope } from "../ManageBuildingModal/buildingRackScope";
+import RackReparentWarningDialog from "../ManageBuildingModal/RackReparentWarningDialog";
+import ManageRacksModal from "../ManageRacksModal";
+import { type RackSelectionDelta } from "../ManageRacksModal/rackSelectionDelta";
+import { type NewRackInput } from "@/protoFleet/api/useDeviceSets";
+import RackSettingsModal, {
+  type BulkRackPlacement,
+} from "@/protoFleet/features/fleetManagement/components/RackSettingsModal";
+import { useCreateRack } from "@/protoFleet/features/fleetManagement/hooks/useCreateRack";
+import { useCreateRacks } from "@/protoFleet/features/fleetManagement/hooks/useCreateRacks";
+import { useFleetStore } from "@/protoFleet/store/useFleetStore";
+
+// What a host needs to fold a freshly created rack into its own list.
+export interface CreatedRack {
+  rackId: bigint;
+  label: string;
+}
+
+interface BuildingRacksPickerProps {
+  siteId: bigint;
+  buildingId: bigint;
+  buildingName: string;
+  currentRackIds: bigint[];
+  // Save. Called only once any reparent in the delta has been confirmed — the
+  // warning lives here, next to the choice that triggers it, so every host gets
+  // it without wiring the dialog itself.
+  onConfirm: (delta: RackSelectionDelta) => void;
+  // Every created rack is placed in this building by the create call itself, so
+  // there is no membership left to commit — the host folds these into its list
+  // and the flow closes.
+  onCreated: (racks: CreatedRack[]) => void;
+  onDismiss: () => void;
+  saving?: boolean;
+}
+
+const BuildingRacksPicker = ({
+  siteId,
+  buildingId,
+  buildingName,
+  currentRackIds,
+  onConfirm,
+  onCreated,
+  onDismiss,
+  saving = false,
+}: BuildingRacksPickerProps) => {
+  // null = showing the picker; otherwise which side of the create modal's
+  // Single / Multiple toggle to open on.
+  const [creating, setCreating] = useState<"single" | "multiple" | null>(null);
+
+  // Fetch scopes are derived here rather than taken as props so every host
+  // agrees: they come from the building's OWN site, not the header SitePicker,
+  // which on /buildings/:id may be an unrelated persisted selection. Only the
+  // broadened ("Show assigned racks") scope consults the header, to decide
+  // whether a cross-site reparent is on the table.
+  const allSites = useFleetStore((state) => state.ui.activeSite.kind === "all");
+  const scope = useMemo(() => buildingRackScope(siteId), [siteId]);
+  const assignedScope = useMemo(() => assignedRackScope(siteId, allSites), [siteId, allSites]);
+
+  // Shared with RacksPage's "Add rack" so the create semantics — toast,
+  // double-click guard — can't drift. Its site-strip conflict path is
+  // unreachable here: that only fires for seeded miners, and this create seeds
+  // none.
+  const { createRack, creating: creatingOne } = useCreateRack({
+    onCreated: (rackId, formData) => {
+      onCreated([{ rackId, label: formData.label }]);
+      onDismiss();
+    },
+  });
+  const { createRacks, creating: creatingMany } = useCreateRacks();
+
+  // Pending reparent confirm — set when the Save carries racks that are placed
+  // somewhere else, since assigning them here moves the rack and every miner in
+  // it. Cancelling leaves the picker open with the selection intact.
+  const [reparenting, setReparenting] = useState<RackSelectionDelta | null>(null);
+
+  const handleConfirm = (delta: RackSelectionDelta) => {
+    if (delta.reassigned.length > 0) {
+      setReparenting(delta);
+      return;
+    }
+    onConfirm(delta);
+  };
+
+  const handleCreateBulk = async (racks: NewRackInput[], placement: BulkRackPlacement) => {
+    const { created, errors } = await createRacks(racks, placement);
+    if (created.length > 0) {
+      onCreated(created.map((rack) => ({ rackId: rack.id, label: rack.label })));
+      onDismiss();
+    }
+    // Non-empty leaves the create modal open with the rejected rows marked.
+    return errors;
+  };
+
+  if (creating) {
+    return (
+      <RackSettingsModal
+        show
+        // Zone defaulting reads this to prefill from the most recent rack; the
+        // picker fetches its own paginated list, so there is nothing worth
+        // plumbing through for a convenience default.
+        existingRacks={[]}
+        // Both placement fields are locked: the operator opened create from
+        // inside this building, and a rack created elsewhere would vanish from
+        // the list they were looking at.
+        defaultSiteId={siteId}
+        defaultBuildingId={buildingId}
+        defaultBuildingLabel={buildingName}
+        onSubmit={createRack}
+        // Present unconditionally — this is what shows the Single / Multiple
+        // toggle inside the create modal.
+        onSubmitBulk={handleCreateBulk}
+        initialCreateVariant={creating}
+        onDismiss={() => setCreating(null)}
+        saving={saving || creatingOne || creatingMany}
+      />
+    );
+  }
+
+  return (
+    <>
+      <ManageRacksModal
+        open
+        siteId={siteId}
+        currentBuildingId={buildingId}
+        scope={scope}
+        assignedScope={assignedScope}
+        allSites={allSites}
+        buildingName={buildingName}
+        initialSelectedRackIds={currentRackIds}
+        onDismiss={onDismiss}
+        onConfirm={handleConfirm}
+        saving={saving}
+        // Swapping to create abandons the pending selection: the picker's Save is
+        // what writes membership, so nothing was staged on the server.
+        onCreateNewLaunch={() => setCreating("single")}
+        onCreateMultipleLaunch={() => setCreating("multiple")}
+      />
+      {reparenting ? (
+        <RackReparentWarningDialog
+          racks={reparenting.reassigned}
+          buildingName={buildingName}
+          onCancel={() => setReparenting(null)}
+          // Clearing first: accepting the warning is what authorizes the write,
+          // and the host may keep the picker open on failure to retry.
+          onConfirm={() => {
+            setReparenting(null);
+            onConfirm(reparenting);
+          }}
+        />
+      ) : null}
+    </>
+  );
+};
+
+export default BuildingRacksPicker;

--- a/client/src/protoFleet/features/buildings/components/BuildingRacksPicker/index.ts
+++ b/client/src/protoFleet/features/buildings/components/BuildingRacksPicker/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./BuildingRacksPicker";
+export type { CreatedRack } from "./BuildingRacksPicker";

--- a/client/src/protoFleet/features/buildings/components/BuildingSettingsModal/BuildingSettingsModal.test.tsx
+++ b/client/src/protoFleet/features/buildings/components/BuildingSettingsModal/BuildingSettingsModal.test.tsx
@@ -1,9 +1,15 @@
-import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, type Mock, vi } from "vitest";
 import { create } from "@bufbuild/protobuf";
 
 import BuildingSettingsModal from "./BuildingSettingsModal";
-import { type BuildingFormValues, emptyBuildingFormValues } from "@/protoFleet/api/buildings";
+import {
+  type BuildingFormValues,
+  type BulkCreateBuildingError,
+  emptyBuildingFormValues,
+  type NewBuildingInput,
+} from "@/protoFleet/api/buildings";
+import { PerBuildingCreateErrorReason } from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
 import { SiteSchema, SiteWithCountsSchema } from "@/protoFleet/api/generated/sites/v1/sites_pb";
 
 const baseValues = (): BuildingFormValues => emptyBuildingFormValues();
@@ -14,82 +20,82 @@ const makeSites = () => [
 ];
 
 describe("BuildingSettingsModal — create mode", () => {
-  it("disables Save until both a site and a name are entered", () => {
+  it("stays clickable with no site or name and names both problems", async () => {
+    const onSave = vi.fn();
     render(
       <BuildingSettingsModal
         open
         mode="create"
         initialValues={baseValues()}
         sites={makeSites()}
-        onSave={vi.fn()}
+        onSave={onSave}
         onDismiss={vi.fn()}
       />,
     );
     const save = screen.getByTestId("building-settings-modal-save");
-    expect(save).toBeDisabled();
-    // Name alone is not enough — the Buildings-tab CTA opens with no
-    // pre-filled site and Save must stay disabled until one is picked.
+    // Deliberately not disabled: a dead button can't say what's missing.
+    expect(save).not.toBeDisabled();
+
+    fireEvent.click(save);
+    expect(onSave).not.toHaveBeenCalled();
+    // Both, not just the first — otherwise fixing one reveals the next and the
+    // operator pays a click per problem.
+    expect(screen.getByText("Enter a building name")).toBeInTheDocument();
+    expect(screen.getByText("Select a site")).toBeInTheDocument();
+
+    // Name alone is not enough — the Buildings-tab CTA opens with no pre-filled
+    // site, so the site error survives on its own. waitFor because Input keeps
+    // the cleared text mounted ~200ms so the collapse can animate.
     fireEvent.change(screen.getByTestId("building-settings-name-input"), { target: { value: "Main" } });
-    expect(save).toBeDisabled();
-    // Pick a site from the dropdown.
+    await waitFor(() => expect(screen.queryByText("Enter a building name")).not.toBeInTheDocument());
+    fireEvent.click(save);
+    expect(onSave).not.toHaveBeenCalled();
+    expect(screen.getByText("Select a site")).toBeInTheDocument();
+
     fireEvent.click(screen.getByTestId("building-settings-site-select"));
     fireEvent.click(screen.getByText("North DC"));
-    expect(save).not.toBeDisabled();
+    fireEvent.click(save);
+    expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ name: "Main" }), 7n);
   });
 
-  it("surfaces a stale-site error and disables Save when the chosen site disappears from the list", () => {
+  it("surfaces a stale-site error and refuses the submit when the chosen site disappears from the list", () => {
+    const onSave = vi.fn();
     const { rerender } = render(
       <BuildingSettingsModal
         open
         mode="create"
         initialValues={baseValues()}
         sites={makeSites()}
-        onSave={vi.fn()}
+        onSave={onSave}
         onDismiss={vi.fn()}
       />,
     );
     fireEvent.change(screen.getByTestId("building-settings-name-input"), { target: { value: "Main" } });
     fireEvent.click(screen.getByTestId("building-settings-site-select"));
     fireEvent.click(screen.getByText("South DC"));
-    expect(screen.getByTestId("building-settings-modal-save")).not.toBeDisabled();
+    expect(screen.queryByText(/no longer available/)).not.toBeInTheDocument();
 
     // Sites list refreshes and drops the chosen site (e.g. another operator
-    // deleted it). The dropdown's local state still holds the stale id, but
-    // Save must lock and an inline error must surface.
+    // deleted it). The dropdown's local state still holds the stale id, so the
+    // error surfaces without waiting for a click — unlike every other check
+    // here, this one can go wrong while the operator is doing nothing.
     rerender(
       <BuildingSettingsModal
         open
         mode="create"
         initialValues={baseValues()}
         sites={[create(SiteWithCountsSchema, { site: create(SiteSchema, { id: 7n, name: "North DC" }) })]}
-        onSave={vi.fn()}
+        onSave={onSave}
         onDismiss={vi.fn()}
       />,
     );
-    expect(screen.getByTestId("building-settings-modal-save")).toBeDisabled();
     expect(screen.getByText(/Selected site is no longer available/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("building-settings-modal-save"));
+    expect(onSave).not.toHaveBeenCalled();
   });
 
   it("locks the Site dropdown when initialSiteId is supplied (entry from /sites/:id)", () => {
-    render(
-      <BuildingSettingsModal
-        open
-        mode="create"
-        initialValues={baseValues()}
-        sites={makeSites()}
-        initialSiteId={7n}
-        onSave={vi.fn()}
-        onDismiss={vi.fn()}
-      />,
-    );
-    const select = screen.getByTestId("building-settings-site-select");
-    expect(select).toBeDisabled();
-    // Site already chosen → Save unlocks as soon as a name is entered.
-    fireEvent.change(screen.getByTestId("building-settings-name-input"), { target: { value: "Main" } });
-    expect(screen.getByTestId("building-settings-modal-save")).not.toBeDisabled();
-  });
-
-  it("rejects negative power input with an inline error", () => {
     const onSave = vi.fn();
     render(
       <BuildingSettingsModal
@@ -102,10 +108,34 @@ describe("BuildingSettingsModal — create mode", () => {
         onDismiss={vi.fn()}
       />,
     );
+    const select = screen.getByTestId("building-settings-site-select");
+    expect(select).toBeDisabled();
+    // Site already resolved from the prop, so a name is all that's left to give.
     fireEvent.change(screen.getByTestId("building-settings-name-input"), { target: { value: "Main" } });
-    fireEvent.change(screen.getByTestId("building-settings-power-input"), { target: { value: "-5" } });
     fireEvent.click(screen.getByTestId("building-settings-modal-save"));
-    expect(onSave).not.toHaveBeenCalled();
+    expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ name: "Main" }), 7n);
+  });
+
+  it("preserves the capacity fields it no longer exposes", () => {
+    const onSave = vi.fn();
+    render(
+      <BuildingSettingsModal
+        open
+        mode="create"
+        initialValues={{ ...baseValues(), powerCapacityMw: 5, overheadKw: 12 }}
+        sites={makeSites()}
+        initialSiteId={7n}
+        onSave={onSave}
+        onDismiss={vi.fn()}
+      />,
+    );
+    // Power capacity and Overhead are not in the form (nothing consumes them
+    // yet), so they must pass through rather than reset to 0.
+    expect(screen.queryByTestId("building-settings-power-input")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("building-settings-overhead-input")).not.toBeInTheDocument();
+    fireEvent.change(screen.getByTestId("building-settings-name-input"), { target: { value: "Main" } });
+    fireEvent.click(screen.getByTestId("building-settings-modal-save"));
+    expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ powerCapacityMw: 5, overheadKw: 12 }), 7n);
   });
 
   it("rejects non-integer aisles", () => {
@@ -125,6 +155,7 @@ describe("BuildingSettingsModal — create mode", () => {
     fireEvent.change(screen.getByTestId("building-settings-aisles-input"), { target: { value: "3.5" } });
     fireEvent.click(screen.getByTestId("building-settings-modal-save"));
     expect(onSave).not.toHaveBeenCalled();
+    expect(screen.getByText("Whole number ≥ 0")).toBeInTheDocument();
   });
 
   it("rejects layout dimensions over 100", () => {
@@ -145,6 +176,7 @@ describe("BuildingSettingsModal — create mode", () => {
     fireEvent.change(screen.getByTestId("building-settings-racks-per-aisle-input"), { target: { value: "50" } });
     fireEvent.click(screen.getByTestId("building-settings-modal-save"));
     expect(onSave).not.toHaveBeenCalled();
+    expect(screen.getByText("Must be ≤ 100")).toBeInTheDocument();
   });
 
   it("calls onSave with the parsed form values and chosen siteId on a valid submit", () => {
@@ -177,8 +209,262 @@ describe("BuildingSettingsModal — create mode", () => {
   });
 });
 
+type BulkSaveMock = Mock<(buildings: NewBuildingInput[], siteId: bigint) => Promise<BulkCreateBuildingError[]>>;
+
+describe("BuildingSettingsModal — create mode, Multiple", () => {
+  // The toggle is rendered as a SegmentedControl, whose segments commit on
+  // mousedown rather than click.
+  const selectMultiple = () => fireEvent.mouseDown(screen.getByText("Multiple"));
+
+  const renderBulk = (overrides: { onSaveBulk?: BulkSaveMock; existingBuildingNames?: string[] } = {}) => {
+    const onSaveBulk: BulkSaveMock = overrides.onSaveBulk ?? vi.fn(async () => []);
+    render(
+      <BuildingSettingsModal
+        open
+        mode="create"
+        initialValues={baseValues()}
+        sites={makeSites()}
+        initialSiteId={7n}
+        onSave={vi.fn()}
+        onSaveBulk={onSaveBulk}
+        existingBuildingNames={overrides.existingBuildingNames}
+        onDismiss={vi.fn()}
+      />,
+    );
+    return onSaveBulk;
+  };
+
+  it("opens on the Multiple form when the host preselected it", () => {
+    render(
+      <BuildingSettingsModal
+        open
+        mode="create"
+        initialValues={baseValues()}
+        sites={makeSites()}
+        initialSiteId={7n}
+        onSave={vi.fn()}
+        onSaveBulk={vi.fn(async () => [])}
+        initialCreateVariant="multiple"
+        onDismiss={vi.fn()}
+      />,
+    );
+    // The picker's "Create multiple buildings" button lands here directly, so the
+    // bulk fields are up without touching the toggle.
+    expect(screen.getByTestId("building-settings-bulk-count-input")).toBeInTheDocument();
+    expect(screen.queryByTestId("building-settings-name-input")).not.toBeInTheDocument();
+    expect(screen.getByTestId("building-settings-modal-save")).toHaveTextContent("Create buildings");
+  });
+
+  it("hides the Single / Multiple toggle when the host wired no batch handler", () => {
+    render(
+      <BuildingSettingsModal
+        open
+        mode="create"
+        initialValues={baseValues()}
+        sites={makeSites()}
+        initialSiteId={7n}
+        onSave={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+    expect(screen.queryByTestId("segmented-control")).not.toBeInTheDocument();
+  });
+
+  it("takes the row count and counter start as numeric fields", () => {
+    renderBulk();
+    selectMultiple();
+    expect(screen.getByTestId("building-settings-bulk-count-input")).toHaveAttribute("type", "number");
+    expect(screen.getByTestId("building-settings-bulk-counter-start-input")).toHaveAttribute("type", "number");
+  });
+
+  it("asks for the count and prefix it needs instead of locking the CTA", async () => {
+    const onSaveBulk = renderBulk();
+    selectMultiple();
+    const save = screen.getByTestId("building-settings-modal-save");
+    expect(save).toHaveTextContent("Create buildings");
+    expect(save).not.toBeDisabled();
+
+    fireEvent.click(save);
+    expect(onSaveBulk).not.toHaveBeenCalled();
+    expect(screen.getByText("Enter how many buildings to create")).toBeInTheDocument();
+    expect(screen.getByText("Enter a name prefix")).toBeInTheDocument();
+
+    // A count with no prefix would create buildings named "1", "2", … — not
+    // what anyone means, so the prefix problem outlives the count one.
+    fireEvent.change(screen.getByTestId("building-settings-bulk-count-input"), { target: { value: "3" } });
+    await waitFor(() => expect(screen.queryByText("Enter how many buildings to create")).not.toBeInTheDocument());
+    fireEvent.click(save);
+    expect(onSaveBulk).not.toHaveBeenCalled();
+    expect(screen.getByText("Enter a name prefix")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId("building-settings-bulk-prefix-input"), { target: { value: "Bldg-" } });
+    fireEvent.click(save);
+    expect(onSaveBulk).toHaveBeenCalledTimes(1);
+  });
+
+  it("previews the generated names as read-only rows and submits exactly those names", async () => {
+    const onSaveBulk = renderBulk();
+    selectMultiple();
+    fireEvent.change(screen.getByTestId("building-settings-bulk-count-input"), { target: { value: "3" } });
+    fireEvent.change(screen.getByTestId("building-settings-bulk-prefix-input"), { target: { value: "Bldg-" } });
+    fireEvent.change(screen.getByTestId("building-settings-bulk-counter-start-input"), { target: { value: "5" } });
+    fireEvent.change(screen.getByTestId("building-settings-bulk-counter-scale-input"), { target: { value: "4" } });
+
+    const preview = screen.getByTestId("building-settings-bulk-preview");
+    expect(preview).toHaveTextContent("3 buildings to create");
+    expect(screen.getByTestId("building-settings-bulk-preview-row-0")).toHaveTextContent("Bldg-0005");
+    expect(screen.getByTestId("building-settings-bulk-preview-row-2")).toHaveTextContent("Bldg-0007");
+    // The preview mirrors the payload; it is not a form.
+    expect(preview.querySelectorAll("input")).toHaveLength(0);
+
+    fireEvent.click(screen.getByTestId("building-settings-modal-save"));
+    expect(onSaveBulk).toHaveBeenCalledWith(
+      [
+        { name: "Bldg-0005", aisles: 0, racksPerAisle: 0 },
+        { name: "Bldg-0006", aisles: 0, racksPerAisle: 0 },
+        { name: "Bldg-0007", aisles: 0, racksPerAisle: 0 },
+      ],
+      7n,
+    );
+  });
+
+  it("applies one layout to every building in the batch", () => {
+    const onSaveBulk = renderBulk();
+    selectMultiple();
+    fireEvent.change(screen.getByTestId("building-settings-bulk-count-input"), { target: { value: "2" } });
+    fireEvent.change(screen.getByTestId("building-settings-bulk-prefix-input"), { target: { value: "B-" } });
+    fireEvent.change(screen.getByTestId("building-settings-aisles-input"), { target: { value: "4" } });
+    fireEvent.change(screen.getByTestId("building-settings-racks-per-aisle-input"), { target: { value: "10" } });
+    fireEvent.click(screen.getByTestId("building-settings-modal-save"));
+
+    expect(onSaveBulk).toHaveBeenCalledWith(
+      [
+        { name: "B-1", aisles: 4, racksPerAisle: 10 },
+        { name: "B-2", aisles: 4, racksPerAisle: 10 },
+      ],
+      7n,
+    );
+  });
+
+  it("blocks the batch when the shared layout is over the dimension cap", () => {
+    const onSaveBulk = renderBulk();
+    selectMultiple();
+    fireEvent.change(screen.getByTestId("building-settings-bulk-count-input"), { target: { value: "2" } });
+    fireEvent.change(screen.getByTestId("building-settings-bulk-prefix-input"), { target: { value: "B-" } });
+
+    // The layout is optional, but a bad value must not reach 500 rows at once.
+    fireEvent.change(screen.getByTestId("building-settings-aisles-input"), { target: { value: "101" } });
+    fireEvent.click(screen.getByTestId("building-settings-modal-save"));
+    expect(onSaveBulk).not.toHaveBeenCalled();
+    expect(screen.getByText("Must be ≤ 100")).toBeInTheDocument();
+  });
+
+  it("marks the row and refuses the batch when a generated name is already at the site", async () => {
+    const onSaveBulk = renderBulk({ existingBuildingNames: ["Bldg-2"] });
+    selectMultiple();
+    fireEvent.change(screen.getByTestId("building-settings-bulk-count-input"), { target: { value: "3" } });
+    fireEvent.change(screen.getByTestId("building-settings-bulk-prefix-input"), { target: { value: "Bldg-" } });
+
+    expect(screen.getByTestId("building-settings-bulk-preview-row-1")).toHaveTextContent("Already used at this site");
+    fireEvent.click(screen.getByTestId("building-settings-modal-save"));
+    expect(onSaveBulk).not.toHaveBeenCalled();
+    // The offending row is already marked, so a bare no-op click would look
+    // inert — the form-level callout says why nothing happened.
+    expect(screen.getByTestId("building-settings-modal-form-error")).toBeInTheDocument();
+
+    // Shifting the counter past the collision clears it without touching the
+    // count — the whole point of previewing before the round trip.
+    fireEvent.change(screen.getByTestId("building-settings-bulk-counter-start-input"), { target: { value: "3" } });
+    await waitFor(() => expect(screen.queryByTestId("building-settings-modal-form-error")).not.toBeInTheDocument());
+    fireEvent.click(screen.getByTestId("building-settings-modal-save"));
+    expect(onSaveBulk).toHaveBeenCalledWith(
+      [
+        { name: "Bldg-3", aisles: 0, racksPerAisle: 0 },
+        { name: "Bldg-4", aisles: 0, racksPerAisle: 0 },
+        { name: "Bldg-5", aisles: 0, racksPerAisle: 0 },
+      ],
+      7n,
+    );
+  });
+
+  it("refuses a batch whose generated names are longer than the server accepts", async () => {
+    const onSaveBulk = renderBulk();
+    selectMultiple();
+    fireEvent.change(screen.getByTestId("building-settings-bulk-count-input"), { target: { value: "2" } });
+    // A prefix that fits on its own (the field allows 255), plus 6 digits of
+    // zero-padding, produces 258-character names. The counter width is what
+    // pushes it over, so the prefix field alone can't catch this.
+    fireEvent.change(screen.getByTestId("building-settings-bulk-prefix-input"), { target: { value: "B".repeat(252) } });
+    fireEvent.change(screen.getByTestId("building-settings-bulk-counter-scale-input"), { target: { value: "6" } });
+
+    // Flagged per row as the operator types, before any submit.
+    expect(screen.getByTestId("building-settings-bulk-preview-row-0")).toHaveTextContent("Over 255 characters");
+
+    fireEvent.click(screen.getByTestId("building-settings-modal-save"));
+    // Never dispatched: CreateBuildings would refuse the whole batch on
+    // NewBuilding.name's max_len and come back as a generic error.
+    expect(onSaveBulk).not.toHaveBeenCalled();
+    expect(screen.getByText("Names must be 255 characters or fewer, counter included")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId("building-settings-bulk-counter-scale-input"), { target: { value: "1" } });
+    await waitFor(() =>
+      expect(screen.getByTestId("building-settings-bulk-preview-row-0")).not.toHaveTextContent("Over 255 characters"),
+    );
+    fireEvent.click(screen.getByTestId("building-settings-modal-save"));
+    expect(onSaveBulk).toHaveBeenCalledTimes(1);
+  });
+
+  it("bounds the counter scale on submit rather than constraining the input", async () => {
+    const onSaveBulk = renderBulk();
+    selectMultiple();
+    fireEvent.change(screen.getByTestId("building-settings-bulk-count-input"), { target: { value: "2" } });
+    fireEvent.change(screen.getByTestId("building-settings-bulk-prefix-input"), { target: { value: "B-" } });
+
+    const scale = screen.getByTestId("building-settings-bulk-counter-scale-input");
+    fireEvent.change(scale, { target: { value: "9" } });
+    fireEvent.click(screen.getByTestId("building-settings-modal-save"));
+    expect(onSaveBulk).not.toHaveBeenCalled();
+    expect(screen.getByText("Must be 1–6")).toBeInTheDocument();
+
+    // Non-digits never land in the field at all, so 0 and 7–9 are the only ways
+    // to be out of range.
+    fireEvent.change(scale, { target: { value: "3" } });
+    await waitFor(() => expect(screen.queryByText("Must be 1–6")).not.toBeInTheDocument());
+    fireEvent.click(screen.getByTestId("building-settings-modal-save"));
+    expect(onSaveBulk).toHaveBeenCalledWith(
+      [
+        { name: "B-001", aisles: 0, racksPerAisle: 0 },
+        { name: "B-002", aisles: 0, racksPerAisle: 0 },
+      ],
+      7n,
+    );
+  });
+
+  it("marks the rows the server rejected and clears them on the next edit", async () => {
+    const onSaveBulk = vi
+      .fn()
+      .mockResolvedValue([{ index: 1, name: "Bldg-2", reason: PerBuildingCreateErrorReason.DUPLICATE_NAME_AT_SITE }]);
+    renderBulk({ onSaveBulk });
+    selectMultiple();
+    fireEvent.change(screen.getByTestId("building-settings-bulk-count-input"), { target: { value: "3" } });
+    fireEvent.change(screen.getByTestId("building-settings-bulk-prefix-input"), { target: { value: "Bldg-" } });
+    fireEvent.click(screen.getByTestId("building-settings-modal-save"));
+
+    // The batch is all-or-nothing, so the modal stays open with the offending
+    // row called out rather than reporting a partial success.
+    await waitFor(() =>
+      expect(screen.getByTestId("building-settings-bulk-preview-row-1")).toHaveTextContent("Already used at this site"),
+    );
+
+    // Those indexes describe the payload that was sent; editing the fields
+    // changes the payload, so the marks can't be carried over.
+    fireEvent.change(screen.getByTestId("building-settings-bulk-counter-start-input"), { target: { value: "9" } });
+    expect(screen.getByTestId("building-settings-bulk-preview-row-1")).not.toHaveTextContent("Already used");
+  });
+});
+
 describe("BuildingSettingsModal — edit mode", () => {
-  it("preserves description + rack-default fields on save (pass-through pattern)", () => {
+  it("preserves description, capacity + rack-default fields on save (pass-through pattern)", () => {
     const onSave = vi.fn();
     const initial: BuildingFormValues = {
       ...emptyBuildingFormValues(),
@@ -208,11 +494,61 @@ describe("BuildingSettingsModal — edit mode", () => {
       expect.objectContaining({
         name: "Renamed",
         description: "preserved-desc",
+        powerCapacityMw: 5,
+        overheadKw: 12,
         physicalRackCount: 99,
         defaultRackRows: 42,
         defaultRackColumns: 21,
       }),
     );
+  });
+
+  it("Save with nothing changed closes without calling UpdateBuilding", () => {
+    const initial: BuildingFormValues = {
+      ...emptyBuildingFormValues(),
+      name: "Existing",
+      powerCapacityMw: 5,
+      aisles: 3,
+      racksPerAisle: 4,
+    };
+    const onSave = vi.fn();
+    const onDismiss = vi.fn();
+    render(
+      <BuildingSettingsModal
+        open
+        mode="edit"
+        initialValues={initial}
+        onSave={onSave}
+        onDismiss={onDismiss}
+        onDeleteRequested={vi.fn()}
+      />,
+    );
+
+    const save = screen.getByTestId("building-settings-modal-save");
+    expect(save).not.toBeDisabled();
+
+    // Keeping what's already there is a legitimate outcome, so this closes
+    // rather than erroring — but UpdateBuilding must not report a write it
+    // didn't make.
+    fireEvent.click(save);
+    expect(onSave).not.toHaveBeenCalled();
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+
+    // Re-typing the same value in a different format is not a change — the
+    // check compares the parsed form, not the raw text.
+    fireEvent.change(screen.getByTestId("building-settings-aisles-input"), { target: { value: "03" } });
+    fireEvent.click(save);
+    expect(onSave).not.toHaveBeenCalled();
+
+    fireEvent.change(screen.getByTestId("building-settings-aisles-input"), { target: { value: "6" } });
+    fireEvent.click(save);
+    expect(onSave).toHaveBeenCalledTimes(1);
+
+    // Back to the original → clean again, not latched dirty by having been
+    // touched.
+    fireEvent.change(screen.getByTestId("building-settings-aisles-input"), { target: { value: "3" } });
+    fireEvent.click(save);
+    expect(onSave).toHaveBeenCalledTimes(1);
   });
 
   it("Delete button fires onDeleteRequested", () => {

--- a/client/src/protoFleet/features/buildings/components/BuildingSettingsModal/BuildingSettingsModal.tsx
+++ b/client/src/protoFleet/features/buildings/components/BuildingSettingsModal/BuildingSettingsModal.tsx
@@ -1,10 +1,31 @@
 import { useCallback, useMemo, useState } from "react";
 
-import { type BuildingFormValues } from "@/protoFleet/api/buildings";
+import {
+  buildBulkBuildingNames,
+  buildingNameMaxLength,
+  bulkBuildingCountMaximum,
+  overlongBuildingNameIndexes,
+  takenNameIndexes,
+} from "./bulkBuildingNames";
+import {
+  type BuildingFormValues,
+  type BulkCreateBuildingError,
+  type NewBuildingInput,
+} from "@/protoFleet/api/buildings";
+import { PerBuildingCreateErrorReason } from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
 import { type SiteWithCounts } from "@/protoFleet/api/generated/sites/v1/sites_pb";
+import {
+  counterScaleMaximum,
+  counterScaleMinimum,
+  counterStartInputMaxLength,
+  defaultCounterScale,
+} from "@/protoFleet/features/fleetManagement/components/MinerActionsMenu/RenameOptionsModals/constants";
+import { Alert } from "@/shared/assets/icons";
 import { variants } from "@/shared/components/Button";
+import Callout from "@/shared/components/Callout";
 import Input from "@/shared/components/Input";
 import Modal from "@/shared/components/Modal";
+import SegmentedControl from "@/shared/components/SegmentedControl";
 import Select from "@/shared/components/Select";
 
 // Create vs. edit drives the CTA shape: create gets Cancel + Save, edit gets
@@ -30,6 +51,25 @@ interface BuildingSettingsModalCommonProps {
 interface BuildingSettingsModalCreateExtras {
   sites: SiteWithCounts[];
   initialSiteId?: bigint;
+  // Supplying onSaveBulk is what turns on the Single / Multiple toggle. Create
+  // entry points that have no batch handler wired render exactly as before —
+  // better than showing a toggle whose CTA has nothing to call.
+  //
+  // Resolves to the server's per-row rejections: an empty array means every
+  // building was created (the batch is all-or-nothing, so there is no partial
+  // case) and the host closes the modal. A non-empty array leaves the modal
+  // open with the offending preview rows marked.
+  onSaveBulk?: (buildings: NewBuildingInput[], siteId: bigint) => Promise<BulkCreateBuildingError[]>;
+  // Which side of the Single / Multiple toggle the modal opens on. Lets a host
+  // with two create entry points ("Create building" / "Create multiple
+  // buildings") land the operator on the form they asked for. Ignored without
+  // onSaveBulk — there's no toggle to preselect.
+  initialCreateVariant?: CreateVariant;
+  // Names of the buildings already at the target site, used to mark a colliding
+  // preview row before the request goes out. Only meaningful when the site is
+  // locked — with an editable dropdown the host can't know which site's names
+  // to pass, so the collision surfaces from the server instead.
+  existingBuildingNames?: string[];
 }
 
 // Discriminated union mirrors SiteSettingsModal. Edit gets onSave +
@@ -48,10 +88,10 @@ export type BuildingSettingsModalProps = BuildingSettingsModalCommonProps &
       }
   );
 
-// Building type is deferred (proto `building_type` enum has not
-// shipped — see plan §898). We surface a disabled dropdown so the
-// design intent is visible in the modal without storing a value.
-const BUILDING_TYPE_OPTIONS = [{ value: "", label: "—" }];
+// Building type is deliberately absent from this form. The comps show it, but
+// the concept needs its own definition (and its own proto enum) before a
+// dropdown here means anything — a permanently disabled stub only advertised a
+// field nobody could use.
 
 // Layout-dimension cap. Matches the buf.validate int32.lte on
 // Create/UpdateBuildingRequest in proto/buildings/v1/buildings.proto.
@@ -59,15 +99,29 @@ const BUILDING_TYPE_OPTIONS = [{ value: "", label: "—" }];
 // grid; anything above that risks a browser hang on render.
 const LAYOUT_DIMENSION_MAX = 100;
 
-// Parse positive-number form input. Blank → 0 (treated as "unset" by
-// the server). Negative / non-numeric returns null so the form can
-// surface an inline error.
-const parseNonNegative = (input: string): number | null => {
-  const trimmed = input.trim();
-  if (trimmed === "") return 0;
-  const parsed = Number(trimmed);
-  if (!Number.isFinite(parsed) || parsed < 0) return null;
-  return parsed;
+// Create-mode variants. "single" is the original one-building form; "multiple"
+// swaps the per-building fields for generated names + a read-only preview.
+type CreateVariant = "single" | "multiple";
+
+const createVariantSegments = [
+  { key: "single", title: "Single" },
+  { key: "multiple", title: "Multiple" },
+];
+
+// Digits only, so a pasted "1e3" or "-4" can't reach the counter math.
+const digitsOnly = (input: string, maxLength: number): string => input.replace(/\D/g, "").slice(0, maxLength);
+
+const bulkCountInputMaxLength = String(bulkBuildingCountMaximum).length;
+
+const bulkRowErrorMessage = (reason: PerBuildingCreateErrorReason): string => {
+  switch (reason) {
+    case PerBuildingCreateErrorReason.DUPLICATE_NAME_AT_SITE:
+      return "Already used at this site";
+    case PerBuildingCreateErrorReason.DUPLICATE_NAME_IN_BATCH:
+      return "Repeated in this batch";
+    default:
+      return "Rejected";
+  }
 };
 
 const parseNonNegativeInt = (input: string): number | null => {
@@ -89,85 +143,84 @@ const BuildingSettingsModal = (props: BuildingSettingsModalProps) => {
   const siteLocked = isCreate && initialSiteId !== undefined;
   const [siteIdText, setSiteIdText] = useState<string>(initialSiteId !== undefined ? initialSiteId.toString() : "");
   const [name, setName] = useState(initialValues.name);
-  const [powerText, setPowerText] = useState(
-    initialValues.powerCapacityMw > 0 ? String(initialValues.powerCapacityMw) : "",
-  );
-  const [overheadText, setOverheadText] = useState(
-    initialValues.overheadKw > 0 ? String(initialValues.overheadKw) : "",
-  );
   const [aislesText, setAislesText] = useState(initialValues.aisles > 0 ? String(initialValues.aisles) : "");
   const [racksPerAisleText, setRacksPerAisleText] = useState(
     initialValues.racksPerAisle > 0 ? String(initialValues.racksPerAisle) : "",
   );
-  const [powerError, setPowerError] = useState<string | null>(null);
-  const [overheadError, setOverheadError] = useState<string | null>(null);
   const [aislesError, setAislesError] = useState<string | null>(null);
   const [racksPerAisleError, setRacksPerAisleError] = useState<string | null>(null);
+  const [nameError, setNameError] = useState<string | null>(null);
+  const [siteSubmitError, setSiteSubmitError] = useState<string | null>(null);
+  const [bulkCountError, setBulkCountError] = useState<string | null>(null);
+  const [bulkPrefixError, setBulkPrefixError] = useState<string | null>(null);
+  const [bulkCounterScaleError, setBulkCounterScaleError] = useState<string | null>(null);
+  // Problems with no single field to hang off — currently only a batch whose
+  // names collide with the site's existing ones, where the offending rows are
+  // already marked in the preview but a bare click would otherwise look inert.
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const onSaveBulk = isCreate ? props.onSaveBulk : undefined;
+  const existingBuildingNames = isCreate ? props.existingBuildingNames : undefined;
+  const [createVariant, setCreateVariant] = useState<CreateVariant>(
+    (isCreate ? props.initialCreateVariant : undefined) ?? "single",
+  );
+  const [bulkCountText, setBulkCountText] = useState("");
+  const [bulkPrefix, setBulkPrefix] = useState("");
+  const [bulkCounterStartText, setBulkCounterStartText] = useState("1");
+  const [bulkCounterScaleText, setBulkCounterScaleText] = useState(String(defaultCounterScale));
+  // Per-row rejections from the last attempt. Indexes point into the payload
+  // that was submitted, so any edit to the bulk fields clears them rather than
+  // leaving marks against rows they no longer describe.
+  const [bulkRowErrors, setBulkRowErrors] = useState<BulkCreateBuildingError[]>([]);
+  const isBulk = onSaveBulk !== undefined && createVariant === "multiple";
+
+  // Returns the same array when there is nothing to clear, so typing in a bulk
+  // field doesn't re-render the (up to 500-row) preview on every keystroke.
+  const clearBulkRowErrors = useCallback(() => {
+    setBulkRowErrors((prev) => (prev.length === 0 ? prev : []));
+  }, []);
+
+  // Floor-plan grid, shared by both modes: single create writes it onto the one
+  // building, Multiple applies it to every row of the batch. Both fields are
+  // checked every call rather than returning at the first failure, so two bad
+  // dimensions surface together instead of one per click.
+  const buildLayout = useCallback((): { aisles: number; racksPerAisle: number } | null => {
+    const aisles = parseNonNegativeInt(aislesText);
+    const racksPerAisle = parseNonNegativeInt(racksPerAisleText);
+    const dimensionError = (parsed: number | null) =>
+      parsed === null ? "Whole number ≥ 0" : parsed > LAYOUT_DIMENSION_MAX ? `Must be ≤ ${LAYOUT_DIMENSION_MAX}` : null;
+    const aislesMessage = dimensionError(aisles);
+    const racksMessage = dimensionError(racksPerAisle);
+    setAislesError(aislesMessage);
+    setRacksPerAisleError(racksMessage);
+    if (aisles === null || racksPerAisle === null || aislesMessage || racksMessage) return null;
+    return { aisles, racksPerAisle };
+  }, [aislesText, racksPerAisleText]);
 
   const buildValues = useCallback((): BuildingFormValues | null => {
-    const power = parseNonNegative(powerText);
-    if (power === null) {
-      setPowerError("Enter a number ≥ 0");
-      return null;
-    }
-    setPowerError(null);
-
-    const overhead = parseNonNegative(overheadText);
-    if (overhead === null) {
-      setOverheadError("Enter a number ≥ 0");
-      return null;
-    }
-    setOverheadError(null);
-
-    const aisles = parseNonNegativeInt(aislesText);
-    if (aisles === null) {
-      setAislesError("Whole number ≥ 0");
-      return null;
-    }
-    if (aisles > LAYOUT_DIMENSION_MAX) {
-      setAislesError(`Must be ≤ ${LAYOUT_DIMENSION_MAX}`);
-      return null;
-    }
-    setAislesError(null);
-
-    const racksPerAisle = parseNonNegativeInt(racksPerAisleText);
-    if (racksPerAisle === null) {
-      setRacksPerAisleError("Whole number ≥ 0");
-      return null;
-    }
-    if (racksPerAisle > LAYOUT_DIMENSION_MAX) {
-      setRacksPerAisleError(`Must be ≤ ${LAYOUT_DIMENSION_MAX}`);
-      return null;
-    }
-    setRacksPerAisleError(null);
+    // buildLayout first and unconditionally: it sets both dimension errors, and
+    // short-circuiting on the name would hide them.
+    const layout = buildLayout();
+    const trimmedName = name.trim();
+    setNameError(trimmedName === "" ? "Enter a building name" : null);
+    if (!layout || trimmedName === "") return null;
 
     return {
-      name: name.trim(),
-      // description + the rack-default block are deferred fields not
-      // exposed in this form — preserve the server snapshot so an edit
-      // here doesn't clobber values another caller wrote.
+      name: trimmedName,
+      // description, capacity and the rack-default block are fields this form
+      // doesn't expose — preserve the server snapshot so an edit here doesn't
+      // clobber values another caller wrote.
       description: initialValues.description,
-      powerCapacityMw: power,
-      overheadKw: overhead,
-      aisles,
-      racksPerAisle,
+      powerCapacityMw: initialValues.powerCapacityMw,
+      overheadKw: initialValues.overheadKw,
+      aisles: layout.aisles,
+      racksPerAisle: layout.racksPerAisle,
       physicalRackCount: initialValues.physicalRackCount,
       defaultRackRows: initialValues.defaultRackRows,
       defaultRackColumns: initialValues.defaultRackColumns,
       defaultRackOrderIndex: initialValues.defaultRackOrderIndex,
     };
-  }, [
-    name,
-    powerText,
-    overheadText,
-    aislesText,
-    racksPerAisleText,
-    initialValues.description,
-    initialValues.physicalRackCount,
-    initialValues.defaultRackRows,
-    initialValues.defaultRackColumns,
-    initialValues.defaultRackOrderIndex,
-  ]);
+  }, [buildLayout, name, initialValues]);
 
   const siteOptions = useMemo(
     () =>
@@ -178,39 +231,142 @@ const BuildingSettingsModal = (props: BuildingSettingsModalProps) => {
     [sites],
   );
 
+  // The exact names the batch will submit. The preview renders this same array,
+  // so what the operator reads is what CreateBuildings receives.
+  const bulkNames = useMemo(
+    () =>
+      buildBulkBuildingNames(Number(bulkCountText || "0"), {
+        namePrefix: bulkPrefix,
+        counterStart: Number(bulkCounterStartText || "1"),
+        counterScale: Number(bulkCounterScaleText),
+      }),
+    [bulkCountText, bulkPrefix, bulkCounterStartText, bulkCounterScaleText],
+  );
+
+  // Rows whose name is already at the site. Blocks the CTA, so the operator
+  // adjusts the prefix or start number instead of eating a rejected round trip.
+  const bulkTakenRows = useMemo(
+    () => new Set(takenNameIndexes(bulkNames, existingBuildingNames ?? [])),
+    [bulkNames, existingBuildingNames],
+  );
+
+  // Rows too long for the server to store. Derived from the names rather than a
+  // submit attempt, so the marks appear as the prefix/counter are edited — one
+  // overlong row fails the whole batch.
+  const bulkOverlongRows = useMemo(() => new Set(overlongBuildingNameIndexes(bulkNames)), [bulkNames]);
+
+  const bulkServerRows = useMemo(() => new Map(bulkRowErrors.map((e) => [e.index, e.reason])), [bulkRowErrors]);
+
+  // Resolve the chosen site, guarding against a stale `sites` snapshot — a click
+  // that races a `sites` refresh must not slip a deleted siteId through.
+  const resolveSiteId = useCallback((): bigint | null => {
+    if (siteIdText === "" || !siteOptions.some((o) => o.value === siteIdText)) return null;
+    try {
+      return BigInt(siteIdText);
+    } catch {
+      return null;
+    }
+  }, [siteIdText, siteOptions]);
+
+  const siteInOptions = siteIdText !== "" && siteOptions.some((o) => o.value === siteIdText);
+  // Two different failures, two different messages: a site that vanished from
+  // the list needs a reload, one that was never picked just needs picking. Only
+  // read when resolveSiteId came back null, so a non-empty id here means stale.
+  const siteMissingMessage =
+    siteIdText !== "" ? "Selected site is no longer available. Refresh and try again." : "Select a site";
+  // The stale case can go true without a click — a `sites` refresh that drops
+  // the chosen id — so it surfaces on its own instead of waiting for submit.
+  const siteError = (isCreate && siteIdText !== "" && !siteInOptions ? siteMissingMessage : siteSubmitError) ?? false;
+
+  // Compared against the same normalized shape buildValues produces, so
+  // trailing whitespace or a dimension retyped with a leading zero doesn't read
+  // as an edit. buildValues sets the *Error states as a side effect, so this
+  // parses independently rather than calling it.
+  const isDirty = useMemo(
+    () =>
+      name.trim() !== initialValues.name ||
+      parseNonNegativeInt(aislesText) !== initialValues.aisles ||
+      parseNonNegativeInt(racksPerAisleText) !== initialValues.racksPerAisle,
+    [name, aislesText, racksPerAisleText, initialValues],
+  );
+
+  // Every branch validates on click and reports what's wrong, rather than the
+  // CTA being disabled until the form happens to be valid. Each check runs
+  // unconditionally so one submit surfaces every problem at once.
   const handlePrimary = useCallback(async () => {
+    if (onSaveBulk && createVariant === "multiple") {
+      const siteId = resolveSiteId();
+      const layout = buildLayout();
+      const prefixMissing = bulkPrefix.trim() === "";
+      const noRows = bulkNames.length === 0;
+      const collides = bulkTakenRows.size > 0;
+      // Reported on the prefix because that is the lever: the counter width is
+      // set by the scale and start value, both chosen on purpose. Can't collide
+      // with the missing-prefix message — bare counters are never this long.
+      const overlong = bulkOverlongRows.size > 0;
+      // Empty scale is the default (no padding), so only a typed value is
+      // bounded. digitsOnly + maxLength 1 means it can only ever be 0–9.
+      const scale = bulkCounterScaleText === "" ? defaultCounterScale : Number(bulkCounterScaleText);
+      const scaleOutOfRange = scale < counterScaleMinimum || scale > counterScaleMaximum;
+      setSiteSubmitError(siteId === null ? siteMissingMessage : null);
+      setBulkPrefixError(
+        prefixMissing
+          ? "Enter a name prefix"
+          : overlong
+            ? `Names must be ${buildingNameMaxLength} characters or fewer, counter included`
+            : null,
+      );
+      setBulkCountError(noRows ? "Enter how many buildings to create" : null);
+      setBulkCounterScaleError(scaleOutOfRange ? `Must be ${counterScaleMinimum}–${counterScaleMaximum}` : null);
+      setFormError(collides ? "Some of these names are already used at this site." : null);
+      if (siteId === null || !layout || prefixMissing || noRows || collides || scaleOutOfRange || overlong) return;
+      // Clear first so marks from the previous attempt don't hang over rows
+      // this one may have fixed.
+      setBulkRowErrors([]);
+      setBulkRowErrors(
+        await onSaveBulk(
+          bulkNames.map((bulkName) => ({ name: bulkName, ...layout })),
+          siteId,
+        ),
+      );
+      return;
+    }
     const values = buildValues();
-    if (!values) return;
     if (props.mode === "create") {
-      // Belt-and-suspenders against a stale `sites` snapshot — the
-      // disabled Save button gates the same condition, but a click that
-      // races a `sites` refresh shouldn't slip a deleted siteId through.
-      if (siteIdText === "" || !siteOptions.some((o) => o.value === siteIdText)) return;
-      let siteId: bigint;
-      try {
-        siteId = BigInt(siteIdText);
-      } catch {
-        return;
-      }
+      const siteId = resolveSiteId();
+      setSiteSubmitError(siteId === null ? siteMissingMessage : null);
+      if (!values || siteId === null) return;
       await props.onSave(values, siteId);
       return;
     }
+    if (!values) return;
+    // Valid but unchanged: UpdateBuilding would report a write it didn't make.
+    if (!isDirty) {
+      onDismiss();
+      return;
+    }
     await props.onSave(values);
-  }, [buildValues, props, siteIdText, siteOptions]);
+  }, [
+    buildValues,
+    buildLayout,
+    props,
+    createVariant,
+    resolveSiteId,
+    bulkNames,
+    bulkOverlongRows,
+    bulkPrefix,
+    bulkCounterScaleText,
+    bulkTakenRows,
+    onSaveBulk,
+    isDirty,
+    onDismiss,
+    siteMissingMessage,
+  ]);
 
-  const nameValid = name.trim().length > 0;
-  // Create mode gates Save on a site selection that still exists in the
-  // current `sites` list. Otherwise a stale or deleted site id (e.g. the
-  // list refreshed and dropped the chosen site after selection) could be
-  // submitted to CreateBuilding. Edit mode ignores the dropdown entirely.
-  const siteInOptions = siteIdText !== "" && siteOptions.some((o) => o.value === siteIdText);
-  const siteValid = !isCreate || siteInOptions;
-  // Surface an inline error when the chosen site has disappeared from the
-  // list — including the locked / site-scoped case, where the operator
-  // can't pick another site and needs the page to be reloaded.
-  const siteStale = isCreate && siteIdText !== "" && !siteInOptions;
-  const siteError = siteStale ? "Selected site is no longer available. Refresh and try again." : undefined;
-  const primaryDisabled = !nameValid || !siteValid || saving;
+  // Only the in-flight guard. Everything the old gate checked — name, site,
+  // layout, bulk prefix and row count, name collisions, and the edit-mode diff —
+  // now runs in handlePrimary, where it can name the problem.
+  const primaryDisabled = saving;
 
   const buttons =
     props.mode === "create"
@@ -223,7 +379,9 @@ const BuildingSettingsModal = (props: BuildingSettingsModalProps) => {
             testId: "building-settings-modal-cancel",
           },
           {
-            text: saving ? "Saving…" : "Save",
+            // Named for the write it performs (CreateBuilding / CreateBuildings)
+            // rather than a generic "Save" — the buildings exist once this lands.
+            text: isBulk ? (saving ? "Creating…" : "Create buildings") : saving ? "Creating…" : "Create building",
             variant: variants.primary,
             onClick: handlePrimary,
             disabled: primaryDisabled,
@@ -252,6 +410,42 @@ const BuildingSettingsModal = (props: BuildingSettingsModalProps) => {
   const title = "Building settings";
   const description = parentSiteLabel ? `in ${parentSiteLabel}` : undefined;
 
+  // Aisles / racks per aisle define the building's floor plan grid in
+  // ManageBuildingModal. Living in the settings modal lets the operator shape
+  // the layout up-front before assigning racks, mirroring how RackSettingsModal
+  // owns rows/columns for the rack grid. Shared by both modes — in Multiple the
+  // one value applies to every building in the batch.
+  const layoutFields = (
+    <div className="grid grid-cols-2 gap-4">
+      <Input
+        id="building-settings-aisles"
+        label="Aisles (optional)"
+        type="number"
+        initValue={aislesText}
+        onChange={(v) => {
+          setAislesText(v);
+          if (aislesError) setAislesError(null);
+          clearBulkRowErrors();
+        }}
+        error={aislesError ?? false}
+        testId="building-settings-aisles-input"
+      />
+      <Input
+        id="building-settings-racks-per-aisle"
+        label="Racks per aisle (optional)"
+        type="number"
+        initValue={racksPerAisleText}
+        onChange={(v) => {
+          setRacksPerAisleText(v);
+          if (racksPerAisleError) setRacksPerAisleError(null);
+          clearBulkRowErrors();
+        }}
+        error={racksPerAisleError ?? false}
+        testId="building-settings-racks-per-aisle-input"
+      />
+    </div>
+  );
+
   return (
     <Modal
       open={open}
@@ -262,93 +456,202 @@ const BuildingSettingsModal = (props: BuildingSettingsModalProps) => {
       testId="building-settings-modal"
     >
       <div className="flex flex-col gap-4 py-2">
+        {/* Form-level slot, for a problem that belongs to the batch rather than
+            to any one field. Same shape the alerts and settings modals use. */}
+        {formError ? (
+          <Callout
+            intent="danger"
+            prefixIcon={<Alert />}
+            title={formError}
+            testId="building-settings-modal-form-error"
+          />
+        ) : null}
+        {onSaveBulk ? (
+          <SegmentedControl
+            segments={createVariantSegments}
+            initialSegmentKey={createVariant}
+            onSelect={(key) => {
+              setCreateVariant(key === "multiple" ? "multiple" : "single");
+              // Each mode keeps its own fields, so switching never rewrites the
+              // other side's input — but marks from a batch attempt describe a
+              // payload that is no longer on screen.
+              clearBulkRowErrors();
+            }}
+          />
+        ) : null}
         {isCreate ? (
           <Select
             id="building-settings-site"
             label="Site"
             options={siteOptions}
             value={siteIdText}
-            onChange={(v) => setSiteIdText(v)}
+            onChange={(v) => {
+              setSiteIdText(v);
+              if (siteSubmitError) setSiteSubmitError(null);
+            }}
             disabled={siteLocked}
-            error={siteError ?? false}
+            error={siteError}
             forceBelow
             testId="building-settings-site-select"
           />
         ) : null}
-        <Input
-          id="building-settings-name"
-          label="Name"
-          initValue={name}
-          onChange={(v) => setName(v)}
-          maxLength={255}
-          required
-          autoFocus
-          testId="building-settings-name-input"
-        />
-        <Select
-          id="building-settings-type"
-          label="Type"
-          options={BUILDING_TYPE_OPTIONS}
-          value=""
-          onChange={() => undefined}
-          disabled
-          forceBelow
-          testId="building-settings-type-select"
-        />
-        <Input
-          id="building-settings-power"
-          label="Power capacity"
-          initValue={powerText}
-          onChange={(v) => {
-            setPowerText(v);
-            if (powerError) setPowerError(null);
-          }}
-          units="MW"
-          error={powerError ?? false}
-          testId="building-settings-power-input"
-        />
-        <Input
-          id="building-settings-overhead"
-          label="Overhead"
-          initValue={overheadText}
-          onChange={(v) => {
-            setOverheadText(v);
-            if (overheadError) setOverheadError(null);
-          }}
-          units="kW"
-          error={overheadError ?? false}
-          testId="building-settings-overhead-input"
-        />
-        {/* Aisles / racks per aisle define the building's floor plan grid in
-            ManageBuildingModal. Living in the settings modal lets the operator
-            shape the layout up-front before assigning racks, mirroring how
-            RackSettingsModal owns rows/columns for the rack grid. */}
-        <div className="grid grid-cols-2 gap-4">
-          <Input
-            id="building-settings-aisles"
-            label="Aisles"
-            type="number"
-            initValue={aislesText}
-            onChange={(v) => {
-              setAislesText(v);
-              if (aislesError) setAislesError(null);
-            }}
-            error={aislesError ?? false}
-            testId="building-settings-aisles-input"
-          />
-          <Input
-            id="building-settings-racks-per-aisle"
-            label="Racks per aisle"
-            type="number"
-            initValue={racksPerAisleText}
-            onChange={(v) => {
-              setRacksPerAisleText(v);
-              if (racksPerAisleError) setRacksPerAisleError(null);
-            }}
-            error={racksPerAisleError ?? false}
-            testId="building-settings-racks-per-aisle-input"
-          />
-        </div>
+        {isBulk ? (
+          <>
+            {/* Row count lives above the bulk properties: it decides how many
+                rows the preview has, while the properties below decide what
+                each one is called. */}
+            <Input
+              id="building-settings-bulk-count"
+              label="Number of buildings"
+              type="number"
+              initValue={bulkCountText}
+              maxLength={bulkCountInputMaxLength}
+              onChange={(v) => {
+                setBulkCountText(digitsOnly(v, bulkCountInputMaxLength));
+                clearBulkRowErrors();
+                if (bulkCountError) setBulkCountError(null);
+                if (formError) setFormError(null);
+              }}
+              required
+              error={bulkCountError ?? false}
+              autoFocus
+              testId="building-settings-bulk-count-input"
+            />
+            {/* Three-up, and labelled the way the bulk-rename counter fields are
+                (see CustomPropertyOptionsModal) — same prefix + start + scale
+                triple, so the vocabulary carries over. "Counter start" drops
+                bulk rename's trailing "number": a third of the modal's width
+                can't hold that plus "(optional)" on one line. */}
+            <fieldset className="rounded-xl border border-border-5 p-4">
+              <legend className="px-1 text-emphasis-300 text-text-primary">Bulk properties</legend>
+              <div className="grid grid-cols-1 gap-4 tablet:grid-cols-3">
+                <Input
+                  id="building-settings-bulk-prefix"
+                  label="Name prefix"
+                  initValue={bulkPrefix}
+                  // The name cap, not the cap minus a guessed counter width: how
+                  // wide the counter runs depends on the scale and start value, so
+                  // the overflow is reported per row (and on submit) instead.
+                  maxLength={buildingNameMaxLength}
+                  onChange={(v) => {
+                    setBulkPrefix(v);
+                    clearBulkRowErrors();
+                    if (bulkPrefixError) setBulkPrefixError(null);
+                    if (formError) setFormError(null);
+                  }}
+                  required
+                  error={bulkPrefixError ?? false}
+                  testId="building-settings-bulk-prefix-input"
+                />
+                <Input
+                  id="building-settings-bulk-counter-start"
+                  label="Counter start (optional)"
+                  type="number"
+                  initValue={bulkCounterStartText}
+                  maxLength={counterStartInputMaxLength}
+                  onChange={(v) => {
+                    setBulkCounterStartText(digitsOnly(v, counterStartInputMaxLength));
+                    clearBulkRowErrors();
+                    if (formError) setFormError(null);
+                  }}
+                  testId="building-settings-bulk-counter-start-input"
+                />
+                {/* A number input rather than bulk rename's radio row: it's a
+                    digit count sitting next to another number field, and the
+                    1–6 range is enforced on submit like any other bound. Single
+                    digit by construction, so only 0 and 7–9 can be wrong. */}
+                <Input
+                  id="building-settings-bulk-counter-scale"
+                  label="Counter scale (optional)"
+                  type="number"
+                  initValue={bulkCounterScaleText}
+                  maxLength={1}
+                  onChange={(v) => {
+                    setBulkCounterScaleText(digitsOnly(v, 1));
+                    clearBulkRowErrors();
+                    if (bulkCounterScaleError) setBulkCounterScaleError(null);
+                  }}
+                  error={bulkCounterScaleError ?? false}
+                  testId="building-settings-bulk-counter-scale-input"
+                />
+              </div>
+            </fieldset>
+            {/* One layout for the whole batch. Left optional: an operator who
+                doesn't know the floor plan yet can create the buildings now and
+                set dimensions per building later. */}
+            <fieldset className="rounded-xl border border-border-5 p-4">
+              <legend className="px-1 text-emphasis-300 text-text-primary">Layout</legend>
+              {layoutFields}
+            </fieldset>
+            {/* Preview, not a form: these are exactly the names the batch
+                submits, so there is nothing to edit here — an operator who
+                wants different names changes the properties above. */}
+            <section className="flex flex-col gap-2" data-testid="building-settings-bulk-preview">
+              <span className="text-emphasis-300 text-text-primary">
+                {bulkNames.length} {bulkNames.length === 1 ? "building" : "buildings"} to create
+              </span>
+              {bulkNames.length === 0 ? (
+                <p className="rounded-xl border border-dashed border-border-5 p-4 text-center text-300 text-text-primary-50">
+                  Enter a number of buildings and a name prefix to preview them
+                </p>
+              ) : (
+                // No scroll of its own: the modal body already scrolls, and a
+                // nested scroller would trap the wheel over the longest part of
+                // the form.
+                <ol className="divide-y divide-border-5 rounded-xl border border-border-5">
+                  {bulkNames.map((bulkName, index) => {
+                    // Length first: it says why the batch can't be sent at all,
+                    // where the other two describe a name the server could store.
+                    const serverReason = bulkServerRows.get(index);
+                    const rowError = bulkOverlongRows.has(index)
+                      ? `Over ${buildingNameMaxLength} characters`
+                      : serverReason !== undefined
+                        ? bulkRowErrorMessage(serverReason)
+                        : bulkTakenRows.has(index)
+                          ? "Already used at this site"
+                          : null;
+                    return (
+                      <li
+                        key={`${bulkName}-${index}`}
+                        className="flex items-center gap-3 px-3 py-2"
+                        data-testid={`building-settings-bulk-preview-row-${index}`}
+                      >
+                        <span className="w-8 shrink-0 text-300 text-text-primary-50">{index + 1}</span>
+                        <span className="min-w-0 flex-1 truncate text-300 text-text-primary">{bulkName}</span>
+                        {rowError ? (
+                          // text-intent-critical-fill is the token Input renders
+                          // its own validation text in, so a row error here
+                          // reads the same as a field error. text-text-negative
+                          // was a typo — no such token, so this rendered in the
+                          // inherited color.
+                          <span className="shrink-0 text-200 text-intent-critical-fill">{rowError}</span>
+                        ) : null}
+                      </li>
+                    );
+                  })}
+                </ol>
+              )}
+            </section>
+          </>
+        ) : (
+          <>
+            <Input
+              id="building-settings-name"
+              label="Name"
+              initValue={name}
+              onChange={(v) => {
+                setName(v);
+                if (nameError) setNameError(null);
+              }}
+              maxLength={buildingNameMaxLength}
+              required
+              error={nameError ?? false}
+              autoFocus
+              testId="building-settings-name-input"
+            />
+            {layoutFields}
+          </>
+        )}
       </div>
     </Modal>
   );

--- a/client/src/protoFleet/features/buildings/components/BuildingSettingsModal/bulkBuildingNames.test.ts
+++ b/client/src/protoFleet/features/buildings/components/BuildingSettingsModal/bulkBuildingNames.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { buildBulkBuildingNames, bulkBuildingCountMaximum, takenNameIndexes } from "./bulkBuildingNames";
+
+// The zero-pad math itself is covered in utils/bulkNameSeries.test.ts; these
+// exercise it through the building form's wrapper (its cap, its prefix rules).
+describe("buildBulkBuildingNames", () => {
+  it("counts up from the start value", () => {
+    expect(buildBulkBuildingNames(3, { namePrefix: "Bldg-", counterStart: 5, counterScale: 2 })).toEqual([
+      "Bldg-05",
+      "Bldg-06",
+      "Bldg-07",
+    ]);
+  });
+
+  it("allows an empty prefix, leaving bare counters", () => {
+    expect(buildBulkBuildingNames(2, { namePrefix: "", counterStart: 1, counterScale: 1 })).toEqual(["1", "2"]);
+  });
+
+  it("keeps the prefix exactly as typed, trailing space included", () => {
+    // "Building - " is a legitimate prefix: the space is the separator, so
+    // trimming it would silently produce "Building -1".
+    expect(buildBulkBuildingNames(1, { namePrefix: "Building - ", counterStart: 1, counterScale: 1 })).toEqual([
+      "Building - 1",
+    ]);
+  });
+
+  it("returns nothing for a zero or negative count", () => {
+    const options = { namePrefix: "B", counterStart: 1, counterScale: 1 };
+    expect(buildBulkBuildingNames(0, options)).toEqual([]);
+    expect(buildBulkBuildingNames(-5, options)).toEqual([]);
+  });
+
+  it("never repeats a name, even across the pad-width boundary", () => {
+    // Why the form has no in-batch duplicate pre-check: a shared prefix plus a
+    // strictly incrementing counter can't collide, so the server's
+    // DUPLICATE_NAME_IN_BATCH reason is unreachable from this form.
+    const names = buildBulkBuildingNames(120, { namePrefix: "B-", counterStart: 95, counterScale: 2 });
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it("caps at the server's batch limit", () => {
+    const names = buildBulkBuildingNames(10_000, { namePrefix: "B", counterStart: 1, counterScale: 1 });
+    expect(names).toHaveLength(bulkBuildingCountMaximum);
+  });
+});
+
+describe("takenNameIndexes", () => {
+  it("flags rows whose name already exists at the site", () => {
+    expect(takenNameIndexes(["A-1", "A-2", "A-3"], ["A-2"])).toEqual([1]);
+  });
+
+  it("compares on the trimmed value, since that is what the server stores", () => {
+    expect(takenNameIndexes(["A-1"], ["  A-1  "])).toEqual([0]);
+  });
+});

--- a/client/src/protoFleet/features/buildings/components/BuildingSettingsModal/bulkBuildingNames.ts
+++ b/client/src/protoFleet/features/buildings/components/BuildingSettingsModal/bulkBuildingNames.ts
@@ -1,0 +1,37 @@
+// Name generation for the bulk (Multiple) building-create form. The counter
+// math itself is shared with the bulk rack-create form — see
+// utils/bulkNameSeries.ts for how prefix / start / scale compose.
+
+import {
+  buildBulkNameSeries,
+  type BulkNameOptions,
+  overlongNameIndexes,
+  takenNameIndexes,
+} from "@/protoFleet/utils/bulkNameSeries";
+
+// Cap matches the buf.validate max_items on CreateBuildingsRequest.buildings.
+// A typo guard, not a capacity limit.
+export const bulkBuildingCountMaximum = 500;
+
+// Matches NewBuilding.name's buf.validate max_len. Exceeding it fails the whole
+// batch with a generic InvalidArgument, so the form has to catch it first.
+export const buildingNameMaxLength = 255;
+
+export type { BulkNameOptions };
+
+export const buildBulkBuildingNames = (count: number, options: BulkNameOptions): string[] =>
+  buildBulkNameSeries(count, options, bulkBuildingCountMaximum);
+
+// Rows the server would reject on length alone. The prefix field can't guard
+// this by itself: the counter's width is part of the name, and raising the scale
+// (or the start value) widens every row after the prefix was typed.
+export const overlongBuildingNameIndexes = (names: string[]): number[] =>
+  overlongNameIndexes(names, buildingNameMaxLength);
+
+// Names that collide with a building already at the site.
+//
+// This is the only collision the form can pre-check: the server's other
+// rejection reason (duplicate *within* the batch) is unreachable from generated
+// names, since a shared prefix plus a strictly incrementing counter can't repeat
+// itself. The handler still enforces it for hand-built requests.
+export { takenNameIndexes };

--- a/client/src/protoFleet/features/buildings/components/ManageBuildingModal/ManageBuildingModal.test.tsx
+++ b/client/src/protoFleet/features/buildings/components/ManageBuildingModal/ManageBuildingModal.test.tsx
@@ -7,10 +7,10 @@ import ManageBuildingModal from "./ManageBuildingModal";
 import { BuildingSchema } from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
 import { DeviceSetSchema, RackInfoSchema } from "@/protoFleet/api/generated/device_set/v1/device_set_pb";
 
-// Reparent racks STAGE on confirm (parity with the miner-side promptReparent →
-// setRackMiners): accepting the reparent warning folds the rack into the working
-// set but writes nothing until the outer Save, which persists it via a
-// member-only AssignRacksToBuilding. These tests drive that flow end to end.
+// The rack picker owns building membership, so accepting the reparent warning
+// commits the move immediately via a member-only AssignRacksToBuilding.
+// Placement is the only thing that stays staged for the outer Save. These tests
+// drive that flow end to end.
 const mockApi = vi.hoisted(() => ({
   listBuildingsBySite: vi.fn(),
   listBuildings: vi.fn(),
@@ -39,13 +39,13 @@ const createRack = (id: bigint, label: string, buildingId: bigint, siteId?: bigi
     typeDetails: { case: "rackInfo", value: create(RackInfoSchema, { rows: 1, columns: 1, buildingId, siteId }) },
   });
 
-const renderModal = (onSaved = vi.fn()) =>
+const renderModal = (onSaved = vi.fn(), onDismiss = vi.fn()) =>
   render(
     <ManageBuildingModal
       open
       building={building}
       siteName="North DC"
-      onDismiss={vi.fn()}
+      onDismiss={onDismiss}
       onEditDetails={vi.fn()}
       onDeleteRequested={vi.fn()}
       onSaved={onSaved}
@@ -65,7 +65,7 @@ const openPickerAndPickBeta = async () => {
   await screen.findByText("Move this rack?");
 };
 
-describe("ManageBuildingModal reparent commit-on-Continue", () => {
+describe("ManageBuildingModal reparent commit-on-confirm", () => {
   beforeEach(() => {
     mockApi.listBuildingsBySite.mockReset();
     mockApi.listBuildings.mockReset();
@@ -82,24 +82,29 @@ describe("ManageBuildingModal reparent commit-on-Continue", () => {
     );
   });
 
-  it("stages the reparent on Move without any RPC until Save", async () => {
+  it("commits the reparent on Move via a member-only assign", async () => {
     renderModal();
     await openPickerAndPickBeta();
 
-    // Neither picking nor confirming the warning writes anything.
+    // Picking alone writes nothing — the warning has to be accepted first.
     expect(mockApi.assignRacksToBuilding).not.toHaveBeenCalled();
     await userEvent.click(screen.getByRole("button", { name: "Move" }));
-    expect(mockApi.assignRacksToBuilding).not.toHaveBeenCalled();
 
-    // The staged rack persists on the outer Save via a member-only assign into
-    // this building (targetBuildingId → the rack moves out of its old building).
-    await userEvent.click(screen.getByTestId("manage-building-save"));
+    // Accepting commits membership: a member-only assign into this building
+    // (targetBuildingId → the rack moves out of its old building). No cell is
+    // chosen yet; placement is the operator's next step, on the outer Save.
     await waitFor(() => expect(mockApi.assignRacksToBuilding).toHaveBeenCalled());
     const movedThisBuilding = mockApi.assignRacksToBuilding.mock.calls
       .map((c) => c[0])
       .find((arg) => arg.targetBuildingId === 20n && arg.racks.some((r: { rackId: bigint }) => r.rackId === 2n));
     expect(movedThisBuilding).toBeTruthy();
-    expect(movedThisBuilding.racks).toContainEqual({ rackId: 2n }); // member-only; no cell chosen
+    expect(movedThisBuilding.racks).toContainEqual({ rackId: 2n });
+
+    // Membership is committed, so the placement Save has nothing left to write:
+    // clicking it closes without dispatching another assign.
+    const callsAfterMove = mockApi.assignRacksToBuilding.mock.calls.length;
+    await userEvent.click(screen.getByTestId("manage-building-save"));
+    expect(mockApi.assignRacksToBuilding.mock.calls.length).toBe(callsAfterMove);
   });
 
   it("leaves the working set untouched and writes nothing when the warning is cancelled", async () => {
@@ -114,16 +119,18 @@ describe("ManageBuildingModal reparent commit-on-Continue", () => {
     expect(screen.getByTestId("manage-racks-modal-confirm")).toBeInTheDocument();
   });
 
-  it("does not refresh the host on dismiss after staging a reparent (nothing committed until Save)", async () => {
-    // Staging writes nothing server-side, so a plain dismiss must not fire the
-    // host refresh — there is no server change to reconcile.
+  it("refreshes the host as soon as the reparent commits, not on dismiss", async () => {
+    // The membership write changes the host's rack counts, so onSaved fires
+    // with the commit rather than waiting for a Save that may never come.
     const onSaved = vi.fn();
     renderModal(onSaved);
     await openPickerAndPickBeta();
     await userEvent.click(screen.getByRole("button", { name: "Move" }));
 
+    await waitFor(() => expect(onSaved).toHaveBeenCalled());
+    onSaved.mockClear();
     await userEvent.click(screen.getByLabelText("Close dialog"));
-    expect(mockApi.assignRacksToBuilding).not.toHaveBeenCalled();
+    // Nothing left staged, so the dismiss itself has nothing to reconcile.
     expect(onSaved).not.toHaveBeenCalled();
   });
 
@@ -134,5 +141,71 @@ describe("ManageBuildingModal reparent commit-on-Continue", () => {
 
     await userEvent.click(screen.getByLabelText("Close dialog"));
     expect(onSaved).not.toHaveBeenCalled();
+  });
+});
+
+describe("ManageBuildingModal Save", () => {
+  beforeEach(() => {
+    mockApi.listBuildingsBySite.mockReset();
+    mockApi.listBuildings.mockReset();
+    mockApi.listBuildingRacks.mockReset();
+    mockApi.assignRacksToBuilding.mockReset();
+    mockListRacks.mockReset();
+    // Alpha loads already placed at aisle 0, position 0 — so the working set
+    // starts clean against the snapshot.
+    mockApi.listBuildingRacks.mockImplementation(({ onSuccess }) =>
+      onSuccess?.([{ rackId: 1n, rackLabel: "Alpha", aisleIndex: 0, positionInAisle: 0 }]),
+    );
+    mockApi.listBuildingsBySite.mockImplementation(({ onSuccess }) => onSuccess?.([]));
+    mockApi.listBuildings.mockImplementation(({ onSuccess }) => onSuccess?.([]));
+    mockApi.assignRacksToBuilding.mockImplementation(({ onSuccess }) => onSuccess?.(0n));
+    mockListRacks.mockImplementation(({ onSuccess }) => onSuccess?.([createRack(1n, "Alpha", 20n, 7n)]));
+  });
+
+  it("row-level Remove rack unassigns immediately", async () => {
+    renderModal();
+    await screen.findByTestId("manage-building-assigned-rack-1");
+
+    await userEvent.click(screen.getByTestId("manage-building-remove-rack-1"));
+
+    // Unassign = a member-only assign with no target building.
+    await waitFor(() => expect(mockApi.assignRacksToBuilding).toHaveBeenCalled());
+    const call = mockApi.assignRacksToBuilding.mock.calls[0][0];
+    expect(call.targetBuildingId).toBeUndefined();
+    expect(call.racks).toEqual([{ rackId: 1n }]);
+    // The row drops once the write lands, and Save has nothing left to do.
+    await waitFor(() => expect(screen.queryByTestId("manage-building-assigned-rack-1")).not.toBeInTheDocument());
+    await userEvent.click(screen.getByTestId("manage-building-save"));
+    expect(mockApi.assignRacksToBuilding).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the row when the unassign fails", async () => {
+    mockApi.assignRacksToBuilding.mockImplementation(({ onError }) => onError?.("network down"));
+    renderModal();
+    await screen.findByTestId("manage-building-assigned-rack-1");
+
+    await userEvent.click(screen.getByTestId("manage-building-remove-rack-1"));
+
+    await waitFor(() => expect(screen.getByText(/Failed to update racks/)).toBeInTheDocument());
+    expect(screen.getByTestId("manage-building-assigned-rack-1")).toBeInTheDocument();
+  });
+
+  it("Save with no placement change closes without dispatching an assign", async () => {
+    const onDismiss = vi.fn();
+    renderModal(vi.fn(), onDismiss);
+    await screen.findByTestId("manage-building-assigned-rack-1");
+
+    // Loaded and clean. Keeping the layout as-is is a legitimate outcome, so
+    // Save closes rather than toasting a save that dispatched no RPCs.
+    await userEvent.click(screen.getByTestId("manage-building-save"));
+    expect(mockApi.assignRacksToBuilding).not.toHaveBeenCalled();
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+
+    // Move Alpha to a different cell: select the row, then click a free cell.
+    await userEvent.click(screen.getByTestId("manage-building-assigned-rack-1"));
+    await userEvent.click(screen.getByTestId("manage-building-grid-cell-1-1"));
+    await userEvent.click(screen.getByTestId("manage-building-save"));
+
+    await waitFor(() => expect(mockApi.assignRacksToBuilding).toHaveBeenCalled());
   });
 });

--- a/client/src/protoFleet/features/buildings/components/ManageBuildingModal/ManageBuildingModal.tsx
+++ b/client/src/protoFleet/features/buildings/components/ManageBuildingModal/ManageBuildingModal.tsx
@@ -1,9 +1,15 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import ManageRacksModal from "../ManageRacksModal";
+import BuildingRacksPicker, { type CreatedRack } from "../BuildingRacksPicker";
 import { type RackSelectionDelta } from "../ManageRacksModal/rackSelectionDelta";
 import SearchRacksModal from "../SearchRacksModal";
-import { type AssignmentEntry, buildByNameAssignments, buildManualAssignments } from "./assignmentMath";
+import {
+  type AssignmentEntry,
+  buildByNameAssignments,
+  buildManualAssignments,
+  buildPlacementDelta,
+  isPlacementDeltaEmpty,
+} from "./assignmentMath";
 import BuildingGridPane from "./BuildingGridPane";
 import { assignedRackScope, buildingRackScope } from "./buildingRackScope";
 import BuildingRacksPane, { type AssignedRackRow } from "./BuildingRacksPane";
@@ -124,7 +130,9 @@ const ManageBuildingModal = ({
   // Snapshot of the server's positions at load time so Save only fires
   // assignRacksToBuilding for racks whose position actually changed. Keyed
   // by rackId → "aisle:position" (or "unplaced") so we can string-compare.
-  const initialPlacementRef = useRef<Map<string, string>>(new Map());
+  // State rather than a ref because the Save CTA's dirty gate is derived
+  // from it — a ref wouldn't re-derive when the load resolves.
+  const [initialPlacement, setInitialPlacement] = useState<Map<string, string>>(new Map());
 
   // Synchronous in-flight guard for Save dispatches. setState batching
   // means the `isSaving` prop driving the button's `disabled` lags one
@@ -163,7 +171,7 @@ const ManageBuildingModal = ({
               : "unplaced",
           );
         }
-        initialPlacementRef.current = snapshot;
+        setInitialPlacement(snapshot);
         setIsLoading(false);
       },
       onError: (msg) => {
@@ -211,6 +219,12 @@ const ManageBuildingModal = ({
     }
     return m;
   }, [activeAssignments]);
+
+  // The exact batches Save would dispatch.
+  const placementDelta = useMemo(
+    () => buildPlacementDelta(entries, rackToCell, initialPlacement),
+    [entries, rackToCell, initialPlacement],
+  );
 
   // Assigned-racks list shown in the left pane. positionLabel is derived
   // from the activeAssignments so byName mode shows the auto-placement.
@@ -318,16 +332,14 @@ const ManageBuildingModal = ({
     setShowSearchRacks(true);
   }, []);
 
-  // Gate a reparent behind the warning dialog, then STAGE it on confirm — the
-  // rack joins the working set but nothing is written until the outer Save.
-  // Parity with the miner side (promptReparent → setRackMiners): a reparent is
-  // staged, and the actual move rides handleSave's member-only
-  // AssignRacksToBuilding (targetBuildingId → the rack moves out of its old
-  // building, cascading its miners) exactly like any newly-added rack. A staged
-  // rack is seeded into the picker, so buildRackPickerItem shows it as
-  // "in this building" on reopen — never a reassignment row that a later
-  // toggle-off / Select all / deselect could silently drop. Cancelling leaves
-  // the working set untouched and the picker open.
+  // Gate a reparent behind the warning dialog; confirming runs the caller's
+  // membership commit, which moves the rack into this building via a
+  // member-only AssignRacksToBuilding (targetBuildingId → the rack leaves its
+  // old building, cascading its miners) exactly like any newly-added rack.
+  // Once committed the rack is seeded into the picker, so buildRackPickerItem
+  // shows it as "in this building" on reopen — never a reassignment row that a
+  // later toggle-off / Select all / deselect could silently drop. Cancelling
+  // writes nothing and leaves the picker open.
   const promptReparent = useCallback((racks: ReparentedRack[], apply: () => void) => {
     setReparentConfirm({
       racks,
@@ -338,10 +350,101 @@ const ManageBuildingModal = ({
     });
   }, []);
 
-  // SearchRacksModal confirm — add the rack to the working set if missing
-  // and assign to the cell that was selected when the popover opened. When the
-  // rack is currently placed elsewhere, commit the move behind the reparent
-  // confirm (its miners move with it) before staging the cell.
+  // Chunked AssignRacksToBuilding dispatcher shared by the membership commits
+  // and the placement Save. Buildings can be 100×100 = 10,000 cells and this
+  // modal loads every page, so a large batch would otherwise blow past the
+  // proto's 1000-rack request cap. Chunks run sequentially so a mid-chain
+  // failure stops the chain; onChunkCommitted lets the caller tell "nothing
+  // landed" from "partial commit".
+  const dispatchAssign = useCallback(
+    async (racks: RackPlacementInput[], targetBuildingId?: bigint, onChunkCommitted?: () => void) => {
+      if (racks.length === 0) return;
+      for (let i = 0; i < racks.length; i += RACKS_PER_RPC) {
+        const chunk = racks.slice(i, i + RACKS_PER_RPC);
+        await new Promise<void>((resolve, reject) => {
+          void assignRacksToBuilding({
+            racks: chunk,
+            targetBuildingId,
+            onSuccess: () => resolve(),
+            onError: (msg) => reject(new Error(msg)),
+          });
+        });
+        onChunkCommitted?.();
+      }
+    },
+    [assignRacksToBuilding],
+  );
+
+  // Membership commit. The rack pickers own building membership, so a confirmed
+  // selection is written straight away and only placement stays staged for
+  // Save. Newcomers go in as member-only assigns (no cell) and land in the
+  // load-time snapshot as "unplaced", so freshly-committed membership doesn't
+  // read as pending placement dirt on the Save gate.
+  //
+  // The caller owns the working-set update — each entry point merges rows
+  // differently — and should skip it when this returns false.
+  const commitMembership = useCallback(
+    async (added: AssignmentEntry[], removed: bigint[]): Promise<boolean> => {
+      if (savingRef.current) return false;
+      const currentIds = new Set(entries.map((e) => e.rackId.toString()));
+      const newcomers = added.filter((a) => !currentIds.has(a.rackId.toString()));
+      // Nothing to write. The caller may still have a placement change to
+      // stage (e.g. re-placing a rack that's already a member).
+      if (newcomers.length === 0 && removed.length === 0) return true;
+
+      // Capacity guard — mirrors handleSave's and the server's
+      // AssignRacksToBuilding cap. Skipped when the grid is unconfigured
+      // (capacity 0): racks can join before a layout is set.
+      const capacity = aislesNum * racksPerAisleNum;
+      const nextCount = entries.length + newcomers.length - removed.length;
+      if (capacity > 0 && nextCount > capacity) {
+        setErrorMsg(
+          `This building has ${capacity} rack positions (${aislesNum} aisles × ${racksPerAisleNum} per aisle), ` +
+            `but the change would assign ${nextCount} racks. Remove some racks or increase the layout.`,
+        );
+        return false;
+      }
+
+      savingRef.current = true;
+      setErrorMsg("");
+      setIsSaving(true);
+      try {
+        // Removals first: they free their cells before any newcomer lands.
+        await dispatchAssign(
+          removed.map((rackId) => ({ rackId })),
+          undefined,
+        );
+        await dispatchAssign(
+          newcomers.map((a) => ({ rackId: a.rackId })),
+          building.id,
+        );
+      } catch (err) {
+        const detail = err instanceof Error ? err.message : "Failed to update racks";
+        setErrorMsg(`Failed to update racks: ${detail}.`);
+        return false;
+      } finally {
+        savingRef.current = false;
+        setIsSaving(false);
+      }
+
+      const removedSet = new Set(removed.map((id) => id.toString()));
+      setInitialPlacement((prev) => {
+        const next = new Map(prev);
+        for (const id of removedSet) next.delete(id);
+        for (const a of newcomers) next.set(a.rackId.toString(), "unplaced");
+        return next;
+      });
+      // Rack counts changed on the host's building cache.
+      onSaved?.(building);
+      return true;
+    },
+    [entries, aislesNum, racksPerAisleNum, dispatchAssign, building, onSaved],
+  );
+
+  // SearchRacksModal confirm — commit the rack into this building if it isn't
+  // a member yet, then stage it at the cell that was selected when the popover
+  // opened. A rack currently placed elsewhere goes behind the reparent confirm
+  // (its miners move with it) before either happens.
   const handleSearchRackConfirm = useCallback(
     (rackId: bigint, label: string, reparent?: ReparentedRack) => {
       const targetKey = selectedCellKey;
@@ -349,7 +452,9 @@ const ManageBuildingModal = ({
         setShowSearchRacks(false);
         return;
       }
-      const apply = () => {
+      const apply = async () => {
+        const ok = await commitMembership([{ rackId, label }], []);
+        if (!ok) return;
         const { aisle, position } = parseCellKey(targetKey);
         setEntries((prev) => {
           const idStr = rackId.toString();
@@ -371,73 +476,84 @@ const ManageBuildingModal = ({
         setShowSearchRacks(false);
       };
       if (reparent) {
-        promptReparent([reparent], apply);
+        promptReparent([reparent], () => void apply());
       } else {
-        apply();
+        void apply();
       }
     },
-    [selectedCellKey, promptReparent],
+    [selectedCellKey, promptReparent, commitMembership],
   );
 
-  const handleRemoveRack = useCallback((rackId: bigint) => {
-    setEntries((prev) => prev.filter((e) => e.rackId !== rackId));
-    setSelectedRackId((prev) => (prev === rackId ? null : prev));
-  }, []);
+  // Row-level "Remove rack" — an immediate unassign (the rack moves out of the
+  // building; it is not deleted). The row drops only once the write lands.
+  const handleRemoveRack = useCallback(
+    async (rackId: bigint) => {
+      const ok = await commitMembership([], [rackId]);
+      if (!ok) return;
+      setEntries((prev) => prev.filter((e) => e.rackId !== rackId));
+      setSelectedRackId((prev) => (prev === rackId ? null : prev));
+    },
+    [commitMembership],
+  );
 
   const currentRackIds = useMemo(() => entries.map((e) => e.rackId), [entries]);
 
-  // ManageRacksModal confirm — apply the delta against the working
-  // set. `added` joins entries (unplaced) without disturbing existing
-  // positions; `removed` drops only those entries. Racks not in either
-  // list are untouched, so a seeded rack that didn't appear in the
-  // picker's listRacks response (race / paging gap) is preserved.
-  // `delta.reassigned` (racks currently placed elsewhere) commits the move
-  // behind the reparent confirm — their miners move with them — before the
-  // working-set change lands.
+  // ManageRacksModal Save — the picker owns building membership, so the delta is
+  // written here rather than staged. `added` joins entries unplaced (placement
+  // is still the operator's to set, on this modal's Save); `removed` drops only
+  // those entries. Racks in neither list are untouched, so a seeded rack the
+  // picker's listRacks response omitted (race / paging gap) is preserved.
+  // Racks currently in another building arrive already confirmed — the picker
+  // owns that warning, since it is the surface where they were chosen.
   const handleManageRacksConfirm = useCallback(
     (delta: RackSelectionDelta) => {
-      const apply = () => {
+      void (async () => {
         const removedSet = new Set(delta.removed.map((id) => id.toString()));
-        setEntries((prev) => {
-          const kept = prev.filter((e) => !removedSet.has(e.rackId.toString()));
-          const knownIds = new Set(kept.map((e) => e.rackId.toString()));
-          const newcomers: AssignmentEntry[] = [];
-          for (const a of delta.added) {
-            if (knownIds.has(a.rackId.toString())) continue;
-            newcomers.push({ rackId: a.rackId, label: a.label });
-          }
-          return [...kept, ...newcomers];
-        });
+        const kept = entries.filter((e) => !removedSet.has(e.rackId.toString()));
+        const knownIds = new Set(kept.map((e) => e.rackId.toString()));
+        const newcomers: AssignmentEntry[] = [];
+        for (const a of delta.added) {
+          if (knownIds.has(a.rackId.toString())) continue;
+          newcomers.push({ rackId: a.rackId, label: a.label });
+        }
+        // Failure leaves the picker open with the selection intact to retry.
+        const ok = await commitMembership(newcomers, delta.removed);
+        if (!ok) return;
+        setEntries([...kept, ...newcomers]);
         setSelectedRackId(null);
         setSelectedCellKey(null);
         setShowManageRacks(false);
-      };
-      if (delta.reassigned.length > 0) {
-        promptReparent(delta.reassigned, apply);
-      } else {
-        apply();
-      }
+      })();
     },
-    [promptReparent],
+    [entries, commitMembership],
   );
 
-  // Save: walk activeAssignments, diff against the load-time snapshot, and
-  // fire AssignRacksToBuilding once per target building bucket.
-  //
-  // All racks staying in this building (placements, unplacements,
-  // swaps, "move into occupied cell") ship as a single mixed batch.
-  // The server's AssignRacksToBuilding transaction now runs a two-pass
-  // write internally — pass 1 clears every requested rack's cell, then
-  // pass 2 writes the new (aisle, position) values — so the partial
-  // unique index uk_device_set_rack_building_position can't collide
-  // mid-batch. That removes the old client-side vacate-then-place
-  // split (and its "retry to finish saving" partial-failure path).
-  //
-  // Racks removed from this building go in a second call with
-  // targetBuildingId=undefined since they need a different building
-  // bucket. Layout writes live in BuildingSettingsModal.
+  // Racks created from inside the picker. The create call placed them in this
+  // building already, so there is no membership write to make — they join the
+  // working set unplaced, exactly like a picker addition, and this modal's Save
+  // is where the operator gives them grid positions.
+  const handleRacksCreated = useCallback((racks: CreatedRack[]) => {
+    setEntries((prev) => {
+      const known = new Set(prev.map((e) => e.rackId.toString()));
+      const newcomers = racks
+        .filter((r) => !known.has(r.rackId.toString()))
+        .map((r) => ({ rackId: r.rackId, label: r.label }));
+      return newcomers.length > 0 ? [...prev, ...newcomers] : prev;
+    });
+  }, []);
+
+  // Save owns rack placement only — membership commits in the pickers and
+  // layout lives in BuildingSettingsModal. Dispatches placementDelta's buckets
+  // as AssignRacksToBuilding calls against building.id.
   const handleSave = useCallback(async () => {
     if (savingRef.current) return;
+    // Nothing to dispatch. Falling through would toast a save that wrote
+    // nothing, so close instead — reviewing the layout and keeping it as-is is a
+    // legitimate outcome, not an error.
+    if (isPlacementDeltaEmpty(placementDelta)) {
+      onDismiss();
+      return;
+    }
 
     // Capacity guard — mirrors ManageRackModal's slot check and the
     // server's AssignRacksToBuilding cap. A building holds at most
@@ -459,140 +575,35 @@ const ManageBuildingModal = ({
     setErrorMsg("");
     setIsSaving(true);
     try {
-      const initial = initialPlacementRef.current;
-      const currentIds = new Set(entries.map((e) => e.rackId.toString()));
+      const { unassign, inBuildingVacate, inBuildingPlace } = placementDelta;
 
-      const inBuilding: RackPlacementInput[] = [];
-      const unassign: RackPlacementInput[] = [];
-
-      for (const entry of entries) {
-        const idStr = entry.rackId.toString();
-        const placedKey = rackToCell.get(idStr);
-        const next = placedKey
-          ? (() => {
-              const { aisle, position } = parseCellKey(placedKey);
-              return `${aisle}:${position}`;
-            })()
-          : "unplaced";
-        const prior = initial.get(idStr) ?? "missing";
-        if (prior === next) continue;
-
-        // Single mixed batch.
-        //   - placedKey present → place at the new (aisle, position).
-        //     Covers both first-time placement and moves; the server's
-        //     pass-1 clear handles any prior occupant inside the batch.
-        //   - placedKey absent + prior previously placed → send a
-        //     member-only entry. The server NULLs the rack's cell in
-        //     pass 1 (no pass-2 write because no position is supplied).
-        //   - placedKey absent + prior === "missing" → rack is new to
-        //     the working set with no chosen cell yet. Send a member-
-        //     only assign so the BE links the rack to this building
-        //     even without a position. Without this branch, racks
-        //     added via Manage racks but never dragged to a cell
-        //     silently drop on save.
-        if (placedKey) {
-          const { aisle, position } = parseCellKey(placedKey);
-          inBuilding.push({
-            rackId: entry.rackId,
-            aisleIndex: aisle,
-            positionInAisle: position,
-          });
-        } else {
-          inBuilding.push({ rackId: entry.rackId });
-        }
-      }
-
-      // Racks removed from this building (in snapshot, not in entries)
-      // need an explicit unassign — different target building bucket so
-      // they can't ride the in-building batch.
-      for (const idStr of initial.keys()) {
-        if (currentIds.has(idStr)) continue;
-        unassign.push({ rackId: BigInt(idStr) });
-      }
-
-      // Buildings can be 100×100 = 10,000 cells, and this modal loads
-      // every page, so a large floor-plan save with >1000 changed/
-      // removed racks would otherwise hit request validation. Chunk
-      // each phase into RPC-sized batches (RACKS_PER_RPC), dispatched
-      // sequentially so a mid-chain failure stops the chain (handled by
-      // the catch blocks below). Vacate-before-place is enforced across
-      // chunks by the two-pass dispatch below — the server only orders
-      // clear-then-place within a single RPC, so unassigns and cell-
-      // clears must all complete before any place runs.
       // Tracks whether any chunk has committed so the catch below can
-      // distinguish "nothing landed" from "partial commit" — operator
+      // distinguish "nothing landed" from "partial commit" — the operator
       // needs to know to refresh before retrying when chunks N..M ran
       // before chunk N+1 failed.
       let savedAtLeastOne = false;
-      const dispatch = async (racks: RackPlacementInput[], targetBuildingId?: bigint) => {
-        if (racks.length === 0) return;
-        for (let i = 0; i < racks.length; i += RACKS_PER_RPC) {
-          const chunk = racks.slice(i, i + RACKS_PER_RPC);
-          await new Promise<void>((resolve, reject) => {
-            void assignRacksToBuilding({
-              racks: chunk,
-              targetBuildingId,
-              onSuccess: () => resolve(),
-              onError: (msg) => reject(new Error(msg)),
-            });
-          });
-          savedAtLeastOne = true;
-        }
+      const onChunk = () => {
+        savedAtLeastOne = true;
       };
 
-      // Two-pass shape across chunks: vacate ALL cells before placing
-      // ANY rack at a new cell. The server's clear-then-place ordering
-      // only applies within a single AssignRacksToBuilding tx, so a
-      // >1000-rack save where chunk 2 still owns the cell chunk 1 is
-      // trying to claim would trip uk_device_set_rack_building_position.
-      //
-      // Partition the in-building bucket so the vacate pass also clears
-      // the OLD cell of every mover — a rack with both a snapshot
-      // position and a new place entry. Otherwise a cross-chunk swap
-      // (rack A's new cell is rack B's old cell, A lands in chunk 1, B
-      // in chunk 2) would still trip the partial unique index because
-      // B's old cell wouldn't vacate until chunk 2 runs.
-      //   - vacate entries (no aisle/position) — racks staying in the
-      //     building but clearing their cell. Includes:
-      //       * explicit cell-clear entries built above,
-      //       * a synthetic pre-place vacate for every mover, dedup'd by
-      //         rackId so we never send two clears for the same rack.
-      //   - place entries (with aisle/position) — racks landing at a
-      //     specific cell. These can only run after every vacate above
-      //     (plus the unassign bucket) has committed.
-      const inBuildingVacate: RackPlacementInput[] = [];
-      const inBuildingPlace: RackPlacementInput[] = [];
-      const seenVacate = new Set<string>();
-      for (const entry of inBuilding) {
-        const idStr = entry.rackId.toString();
-        const prior = initial.get(idStr) ?? "missing";
-        const wasPlaced = prior !== "unplaced" && prior !== "missing";
-
-        if (entry.aisleIndex !== undefined && entry.positionInAisle !== undefined) {
-          // Mover (had a prior cell) → schedule a pre-place vacate so
-          // its old cell is free before any placement chunk runs.
-          if (wasPlaced && !seenVacate.has(idStr)) {
-            inBuildingVacate.push({ rackId: entry.rackId });
-            seenVacate.add(idStr);
-          }
-          inBuildingPlace.push(entry);
-        } else if (!seenVacate.has(idStr)) {
-          // Already a cell-clear-in-place entry.
-          inBuildingVacate.push({ rackId: entry.rackId });
-          seenVacate.add(idStr);
-        }
-      }
-
       try {
-        // Pass 1: all vacates (unassign bucket + in-building cell-
-        // clears). dispatch short-circuits when the list is empty.
-        await dispatch(unassign, undefined);
-        await dispatch(inBuildingVacate, building.id);
+        // Two-pass shape across chunks: vacate ALL cells (buildPlacementDelta
+        // already folded each mover's old cell into inBuildingVacate) before
+        // placing ANY rack at a new cell. The server's clear-then-place
+        // ordering only applies within a single AssignRacksToBuilding tx, so
+        // a >1000-rack save where chunk 2 still owns the cell chunk 1 is
+        // trying to claim would trip uk_device_set_rack_building_position.
+        //
+        // Pass 1: all vacates. The unassign bucket is normally empty now that
+        // removals commit in the pickers — it stays wired as a reconcile path
+        // for any entry that leaves the list without a write.
+        await dispatchAssign(unassign, undefined, onChunk);
+        await dispatchAssign(inBuildingVacate, building.id, onChunk);
 
         // Pass 2: all places. By now every cell that will be reused
         // has been vacated, so no two writes collide on the partial
         // unique index — even across >1000-rack chunked saves.
-        await dispatch(inBuildingPlace, building.id);
+        await dispatchAssign(inBuildingPlace, building.id, onChunk);
       } catch (err) {
         const detail = err instanceof Error ? err.message : "Failed to save rack positions";
         if (savedAtLeastOne) {
@@ -605,14 +616,14 @@ const ManageBuildingModal = ({
         return;
       }
 
-      pushToast({ message: `Building "${building.name}" saved`, status: STATUSES.success });
+      pushToast({ message: `Rack positions saved`, status: STATUSES.success });
       onSaved?.(building);
       onDismiss();
     } finally {
       savingRef.current = false;
       setIsSaving(false);
     }
-  }, [building, rackToCell, entries, aislesNum, racksPerAisleNum, assignRacksToBuilding, onSaved, onDismiss]);
+  }, [building, placementDelta, entries, aislesNum, racksPerAisleNum, dispatchAssign, onSaved, onDismiss]);
 
   if (!open) return null;
 
@@ -627,9 +638,9 @@ const ManageBuildingModal = ({
       <FullScreenTwoPaneModal
         open={open}
         title={subtitle ? `${title} — ${subtitle}` : title}
-        // Dismiss without Save writes nothing: reparents stage into the working
-        // set instead of committing on confirm, so the server is untouched until
-        // Save and a plain dismiss needs no host refresh.
+        // Dismissing abandons only staged placement — membership changes have
+        // already committed (and already fired onSaved), so there's nothing
+        // left for a dismiss to reconcile.
         onDismiss={onDismiss}
         isBusy={isSaving}
         buttons={[
@@ -660,6 +671,13 @@ const ManageBuildingModal = ({
             text: isSaving ? "Saving…" : "Save",
             variant: variants.primary,
             onClick: handleSave,
+            // Dirty-gated: Save writes rack placement, so with no pending
+            // change there's nothing to commit. isLoading stays in the gate
+            // because the baseline snapshot isn't loaded yet — everything
+            // would read clean for the wrong reason.
+            // No dirty gate: the no-op case closes in handleSave, where it can
+            // be told apart from a real save. The load guards stay — a delta
+            // diffed against a placement that never arrived isn't a write.
             disabled: isSaving || isLoading || !!loadError,
             loading: isSaving,
             testId: "manage-building-save",
@@ -728,17 +746,15 @@ const ManageBuildingModal = ({
       />
 
       {showManageRacks ? (
-        <ManageRacksModal
-          open={showManageRacks}
+        <BuildingRacksPicker
           siteId={siteId}
-          currentBuildingId={building.id}
-          scope={rackScope}
-          assignedScope={assignedScope}
-          allSites={activeSite.kind === "all"}
+          buildingId={building.id}
           buildingName={building.name}
-          initialSelectedRackIds={currentRackIds}
+          currentRackIds={currentRackIds}
           onDismiss={() => setShowManageRacks(false)}
           onConfirm={handleManageRacksConfirm}
+          onCreated={handleRacksCreated}
+          saving={isSaving}
         />
       ) : null}
 
@@ -763,8 +779,8 @@ const ManageBuildingModal = ({
         <RackReparentWarningDialog
           racks={reparentConfirm.racks}
           buildingName={building.name}
-          // onConfirm stages the move into the working set and clears this
-          // dialog; the actual write happens on the outer Save.
+          // onConfirm clears this dialog and lets the membership commit run —
+          // accepting the warning is what authorizes the reparent write.
           onCancel={() => setReparentConfirm(null)}
           onConfirm={reparentConfirm.onConfirm}
         />

--- a/client/src/protoFleet/features/buildings/components/ManageBuildingModal/assignmentMath.test.ts
+++ b/client/src/protoFleet/features/buildings/components/ManageBuildingModal/assignmentMath.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "vitest";
 
-import { type AssignmentEntry, buildByNameAssignments, buildManualAssignments } from "./assignmentMath";
-import { cellKey } from "./types";
+import {
+  type AssignmentEntry,
+  buildByNameAssignments,
+  buildManualAssignments,
+  buildPlacementDelta,
+  isPlacementDeltaEmpty,
+} from "./assignmentMath";
+import { cellKey, type GridCellKey } from "./types";
 
 const entry = (id: bigint, label: string, aisle?: number, position?: number): AssignmentEntry => ({
   rackId: id,
@@ -82,5 +88,85 @@ describe("buildManualAssignments", () => {
   it("returns empty when grid is 0×N or N×0", () => {
     expect(buildManualAssignments([entry(1n, "A", 0, 0)], 0, 3)).toEqual({});
     expect(buildManualAssignments([entry(1n, "A", 0, 0)], 3, 0)).toEqual({});
+  });
+});
+
+describe("buildPlacementDelta", () => {
+  const cells = (pairs: [bigint, number, number][]): Map<string, GridCellKey> =>
+    new Map(pairs.map(([id, aisle, position]) => [id.toString(), cellKey(aisle, position)]));
+
+  it("is empty when the working set matches the snapshot", () => {
+    const delta = buildPlacementDelta(
+      [entry(1n, "A", 0, 0), entry(2n, "B")],
+      cells([[1n, 0, 0]]),
+      new Map([
+        ["1", "0:0"],
+        ["2", "unplaced"],
+      ]),
+    );
+    expect(delta).toEqual({ unassign: [], inBuildingVacate: [], inBuildingPlace: [] });
+    expect(isPlacementDeltaEmpty(delta)).toBe(true);
+  });
+
+  it("sends a member-only assign for a rack added but never placed", () => {
+    // Racks added via Manage racks and never dragged to a cell must still
+    // link to the building, or they silently drop on save.
+    const delta = buildPlacementDelta([entry(9n, "New")], cells([]), new Map());
+    expect(delta.inBuildingVacate).toEqual([{ rackId: 9n }]);
+    expect(delta.inBuildingPlace).toEqual([]);
+    expect(isPlacementDeltaEmpty(delta)).toBe(false);
+  });
+
+  it("splits a mover into a pre-place vacate plus a place", () => {
+    const delta = buildPlacementDelta([entry(1n, "A", 1, 2)], cells([[1n, 1, 2]]), new Map([["1", "0:0"]]));
+    expect(delta.inBuildingVacate).toEqual([{ rackId: 1n }]);
+    expect(delta.inBuildingPlace).toEqual([{ rackId: 1n, aisleIndex: 1, positionInAisle: 2 }]);
+  });
+
+  it("emits no pre-place vacate for a first-time placement", () => {
+    const delta = buildPlacementDelta([entry(1n, "A", 0, 1)], cells([[1n, 0, 1]]), new Map([["1", "unplaced"]]));
+    expect(delta.inBuildingVacate).toEqual([]);
+    expect(delta.inBuildingPlace).toEqual([{ rackId: 1n, aisleIndex: 0, positionInAisle: 1 }]);
+  });
+
+  it("vacates in place when a placed rack loses its cell", () => {
+    const delta = buildPlacementDelta([entry(1n, "A")], cells([]), new Map([["1", "0:0"]]));
+    expect(delta.inBuildingVacate).toEqual([{ rackId: 1n }]);
+    expect(delta.inBuildingPlace).toEqual([]);
+  });
+
+  it("unassigns racks dropped from the working set", () => {
+    const delta = buildPlacementDelta(
+      [entry(1n, "A", 0, 0)],
+      cells([[1n, 0, 0]]),
+      new Map([
+        ["1", "0:0"],
+        ["2", "0:1"],
+      ]),
+    );
+    expect(delta.unassign).toEqual([{ rackId: 2n }]);
+    expect(delta.inBuildingVacate).toEqual([]);
+    expect(delta.inBuildingPlace).toEqual([]);
+  });
+
+  it("orders a swap so both old cells vacate before either place", () => {
+    // A and B trade cells — the partial unique index would collide if a
+    // place ran before the counterpart's old cell was cleared.
+    const delta = buildPlacementDelta(
+      [entry(1n, "A", 0, 1), entry(2n, "B", 0, 0)],
+      cells([
+        [1n, 0, 1],
+        [2n, 0, 0],
+      ]),
+      new Map([
+        ["1", "0:0"],
+        ["2", "0:1"],
+      ]),
+    );
+    expect(delta.inBuildingVacate).toEqual([{ rackId: 1n }, { rackId: 2n }]);
+    expect(delta.inBuildingPlace).toEqual([
+      { rackId: 1n, aisleIndex: 0, positionInAisle: 1 },
+      { rackId: 2n, aisleIndex: 0, positionInAisle: 0 },
+    ]);
   });
 });

--- a/client/src/protoFleet/features/buildings/components/ManageBuildingModal/assignmentMath.ts
+++ b/client/src/protoFleet/features/buildings/components/ManageBuildingModal/assignmentMath.ts
@@ -2,7 +2,8 @@
 // the bounds-drop and alphabetical-fill logic can be unit-tested
 // without standing up the full modal.
 
-import { cellKey, type GridCellKey } from "./types";
+import { cellKey, type GridCellKey, parseCellKey } from "./types";
+import { type RackPlacementInput } from "@/protoFleet/api/buildings";
 
 export interface AssignmentEntry {
   rackId: bigint;
@@ -53,4 +54,81 @@ export const buildManualAssignments = (
     out[cellKey(e.aisleIndex, e.positionInAisle)] = e.rackId;
   }
   return out;
+};
+
+// The AssignRacksToBuilding batches a Save would dispatch, diffed from the
+// load-time snapshot. Empty across all three buckets means the working set
+// matches the server — the Save CTA is gated on that so a clean modal can't
+// fire a no-op write (or toast a save that never happened).
+export interface PlacementDelta {
+  // Racks that left this building — dispatched with targetBuildingId
+  // undefined, so they can't ride the in-building batch.
+  unassign: RackPlacementInput[];
+  // Racks staying in the building whose cell must be cleared. Includes both
+  // explicit unplacements and a synthetic pre-place vacate for every mover,
+  // so pass 1 frees every cell pass 2 will claim.
+  inBuildingVacate: RackPlacementInput[];
+  // Racks landing at a specific (aisle, position). Must run after every
+  // vacate above, or a cross-chunk swap trips
+  // uk_device_set_rack_building_position.
+  inBuildingPlace: RackPlacementInput[];
+}
+
+export const isPlacementDeltaEmpty = (delta: PlacementDelta): boolean =>
+  delta.unassign.length === 0 && delta.inBuildingVacate.length === 0 && delta.inBuildingPlace.length === 0;
+
+// Diff the working set against the load-time snapshot (rackId →
+// "aisle:position" | "unplaced") and bucket the result into the two-pass
+// dispatch shape handleSave sends.
+export const buildPlacementDelta = (
+  entries: AssignmentEntry[],
+  rackToCell: Map<string, GridCellKey>,
+  initial: Map<string, string>,
+): PlacementDelta => {
+  const unassign: RackPlacementInput[] = [];
+  const inBuildingVacate: RackPlacementInput[] = [];
+  const inBuildingPlace: RackPlacementInput[] = [];
+  const seenVacate = new Set<string>();
+
+  for (const entry of entries) {
+    const idStr = entry.rackId.toString();
+    const placedKey = rackToCell.get(idStr);
+    const next = placedKey
+      ? (() => {
+          const { aisle, position } = parseCellKey(placedKey);
+          return `${aisle}:${position}`;
+        })()
+      : "unplaced";
+    const prior = initial.get(idStr) ?? "missing";
+    if (prior === next) continue;
+
+    if (placedKey) {
+      // Placement or move. A mover's old cell needs a pre-place vacate so
+      // it's free before any placement chunk runs.
+      const wasPlaced = prior !== "unplaced" && prior !== "missing";
+      if (wasPlaced && !seenVacate.has(idStr)) {
+        inBuildingVacate.push({ rackId: entry.rackId });
+        seenVacate.add(idStr);
+      }
+      const { aisle, position } = parseCellKey(placedKey);
+      inBuildingPlace.push({ rackId: entry.rackId, aisleIndex: aisle, positionInAisle: position });
+    } else if (!seenVacate.has(idStr)) {
+      // No cell chosen. Either a cell-clear (prior was placed) or a rack
+      // newly added to the working set that was never dragged to a cell —
+      // both ship as a member-only assign so the BE links/keeps the rack in
+      // this building. Without the latter, racks added via Manage racks but
+      // never placed would silently drop on save.
+      inBuildingVacate.push({ rackId: entry.rackId });
+      seenVacate.add(idStr);
+    }
+  }
+
+  // Racks in the snapshot but no longer in the working set.
+  const currentIds = new Set(entries.map((e) => e.rackId.toString()));
+  for (const idStr of initial.keys()) {
+    if (currentIds.has(idStr)) continue;
+    unassign.push({ rackId: BigInt(idStr) });
+  }
+
+  return { unassign, inBuildingVacate, inBuildingPlace };
 };

--- a/client/src/protoFleet/features/buildings/components/ManageRacksModal/ManageRacksModal.test.tsx
+++ b/client/src/protoFleet/features/buildings/components/ManageRacksModal/ManageRacksModal.test.tsx
@@ -105,6 +105,9 @@ const renderModal = (overrides?: {
   allSites?: boolean;
   initialSelectedRackIds?: bigint[];
   onConfirm?: (delta: RackSelectionDelta) => void;
+  onDismiss?: () => void;
+  onCreateNewLaunch?: () => void;
+  onCreateMultipleLaunch?: () => void;
 }) =>
   render(
     <ManageRacksModal
@@ -116,8 +119,10 @@ const renderModal = (overrides?: {
       allSites={overrides?.allSites ?? false}
       buildingName="North"
       initialSelectedRackIds={overrides?.initialSelectedRackIds ?? []}
-      onDismiss={vi.fn()}
+      onDismiss={overrides?.onDismiss ?? vi.fn()}
       onConfirm={overrides?.onConfirm ?? vi.fn()}
+      onCreateNewLaunch={overrides?.onCreateNewLaunch}
+      onCreateMultipleLaunch={overrides?.onCreateMultipleLaunch}
     />,
   );
 
@@ -234,11 +239,11 @@ describe("ManageRacksModal show-assigned toggle (server-side)", () => {
 
     await userEvent.click(rowCheckbox(1)); // reparent pick (Beta)
     await userEvent.click(screen.getByLabelText("Show assigned racks")); // toggle off
-    await userEvent.click(screen.getByTestId("manage-racks-modal-confirm"));
 
-    const delta = onConfirm.mock.calls[0][0];
-    expect(delta.reassigned).toEqual([]);
-    expect(delta.added.map((a: { rackId: bigint }) => a.rackId)).not.toContain(2n);
+    // Dropping Beta empties the delta, so there's nothing left to write and Save
+    // just closes.
+    await userEvent.click(screen.getByTestId("manage-racks-modal-confirm"));
+    expect(onConfirm).not.toHaveBeenCalled();
   });
 
   it("allows an explicit single per-row reparent pick through the delta", async () => {
@@ -281,14 +286,34 @@ describe("ManageRacksModal show-assigned toggle (server-side)", () => {
   it("never reports a seeded rack absent from the fetch as removed", async () => {
     // A seeded rack (id 3) that the eligibility-pinned fetch doesn't return
     // (paging gap / soft-delete window) must be left alone, not unassigned.
+    // Gamma (no building) gives the save something real to write, so the delta
+    // is reachable through the dirty gate.
+    setupListRacks([createRack(1n, "Alpha", 7n, 42n), createRack(4n, "Gamma", 0n)]);
     const onConfirm = vi.fn();
     renderModal({ initialSelectedRackIds: [1n, 3n], onConfirm });
-    await waitFor(() => expect(screen.getByText("Alpha")).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText("Gamma")).toBeInTheDocument());
+
+    await userEvent.click(rowCheckbox(1)); // Gamma
     await userEvent.click(screen.getByTestId("manage-racks-modal-confirm"));
 
     const delta = onConfirm.mock.calls[0][0];
+    expect(delta.added.map((a: { rackId: bigint }) => a.rackId)).toEqual([4n]);
     expect(delta.removed).toEqual([]);
-    expect(delta.added).toEqual([]);
+  });
+
+  it("closes without an AssignRacksToBuilding no-op when nothing was touched", async () => {
+    // A loaded, untouched picker has no membership change to write, but keeping
+    // the list as-is is a legitimate outcome — so Save closes rather than
+    // reporting a write it didn't make.
+    const onConfirm = vi.fn();
+    const onDismiss = vi.fn();
+    renderModal({ initialSelectedRackIds: [1n], onConfirm, onDismiss });
+    await waitFor(() => expect(screen.getByText("Alpha")).toBeInTheDocument());
+
+    await waitFor(() => expect(screen.getByTestId("manage-racks-modal-confirm")).toBeEnabled());
+    await userEvent.click(screen.getByTestId("manage-racks-modal-confirm"));
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -602,7 +627,10 @@ describe("ManageRacksModal review fixes (#789)", () => {
       req.onFinally?.();
     });
     const onConfirm = vi.fn();
-    renderModal({ onConfirm });
+    // Seeded with Alpha so Select none leaves a real change (removed: [1n]) —
+    // otherwise the dirty gate would hold Save shut and mask whether the
+    // select-all guard released it.
+    renderModal({ initialSelectedRackIds: [1n], onConfirm });
     await waitFor(() => expect(screen.getByText("Alpha")).toBeInTheDocument());
 
     await userEvent.click(screen.getByRole("button", { name: "Select all" }));
@@ -614,6 +642,7 @@ describe("ManageRacksModal review fixes (#789)", () => {
 
     await userEvent.click(screen.getByTestId("manage-racks-modal-confirm"));
     expect(onConfirm.mock.calls[0][0].added).toEqual([]);
+    expect(onConfirm.mock.calls[0][0].removed).toEqual([1n]);
   });
 
   it("disables pagination while a page is loading (no stale-token double advance)", async () => {
@@ -750,5 +779,42 @@ describe("ManageRacksModal review fixes (#789)", () => {
     await waitFor(() => expect(screen.getByText("Beta")).toBeInTheDocument());
     expect(screen.getByTestId("active-filter-building")).toBeInTheDocument();
     expect(lastRackReq().buildingIds).toEqual([9n]);
+  });
+});
+
+describe("ManageRacksModal create hand-offs", () => {
+  it("shows each create button only when its launch handler is supplied", async () => {
+    setupListRacks([createRack(1n, "Alpha", 7n, 42n)]);
+    const { unmount } = renderModal();
+    await waitFor(() => expect(screen.getByText("Alpha")).toBeInTheDocument());
+    expect(screen.queryByTestId("manage-racks-modal-create-new")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("manage-racks-modal-create-multiple")).not.toBeInTheDocument();
+    unmount();
+
+    // Separate props rather than one callback with a variant: a host without the
+    // batch RPC wired can offer the first and not the second.
+    renderModal({ onCreateNewLaunch: vi.fn() });
+    await waitFor(() => expect(screen.getByTestId("manage-racks-modal-create-new")).toHaveTextContent("Create rack"));
+    expect(screen.queryByTestId("manage-racks-modal-create-multiple")).not.toBeInTheDocument();
+  });
+
+  it("abandons the pending selection when launching create — Save is what commits", async () => {
+    setupListRacks([createRack(1n, "Alpha", 0n, 42n)]);
+    const onConfirm = vi.fn();
+    const onCreateMultipleLaunch = vi.fn();
+    renderModal({ onConfirm, onCreateNewLaunch: vi.fn(), onCreateMultipleLaunch });
+    await waitFor(() => expect(screen.getByText("Alpha")).toBeInTheDocument());
+
+    // Check the no-building rack — its own row checkbox, not the header
+    // select-all — then hand off without pressing Save.
+    const rowCheckbox = screen.getByTestId("list-body").querySelectorAll<HTMLInputElement>("input[type='checkbox']")[0];
+    await userEvent.click(rowCheckbox);
+    expect(rowCheckbox).toBeChecked();
+    await userEvent.click(screen.getByTestId("manage-racks-modal-create-multiple"));
+
+    expect(onCreateMultipleLaunch).toHaveBeenCalled();
+    // Nothing is written — the selection never landed, which is what makes the
+    // abandon safe to reason about.
+    expect(onConfirm).not.toHaveBeenCalled();
   });
 });

--- a/client/src/protoFleet/features/buildings/components/ManageRacksModal/ManageRacksModal.tsx
+++ b/client/src/protoFleet/features/buildings/components/ManageRacksModal/ManageRacksModal.tsx
@@ -40,16 +40,29 @@ interface ManageRacksModalProps {
   // `showSiteFilter: !scope`.
   allSites: boolean;
   buildingName: string;
-  // Rack IDs currently in the building's working set. The modal seeds its
-  // selection with these so the operator sees the current state and can
-  // add / remove in one flow.
+  // Rack IDs currently assigned to the building. The modal seeds its selection
+  // with these so the operator sees the current state and can add / remove in
+  // one flow, and diffs against them to gate Save.
   initialSelectedRackIds: bigint[];
   onDismiss: () => void;
-  // Returns the delta against initialSelectedRackIds. `delta.reassigned` reports
-  // the added racks that are being reparented so the host can gate the reparent
-  // confirm before committing. Computed against the items-by-id accumulator
-  // (every rack seen across pages / select-all), NOT just the current page.
+  // Save. Returns the delta against initialSelectedRackIds. `delta.reassigned`
+  // reports the added racks that are being reparented so the host can gate the
+  // reparent confirm before committing. Computed against the items-by-id
+  // accumulator (every rack seen across pages / select-all), NOT just the
+  // current page. This modal owns building membership, so the host persists the
+  // delta here rather than staging it for a later save.
   onConfirm: (delta: RackSelectionDelta) => void;
+  // In-flight signal from the host's write, mirrored into the CTA.
+  saving?: boolean;
+  // Hands off to the full rack-create flow instead of picking an existing rack.
+  // Leaving this way abandons the pending selection: Save is what commits it, so
+  // nothing was written. Omitted = no create affordance.
+  //
+  // Two callbacks rather than one with a variant argument, because a host that
+  // hasn't wired the batch RPC can't offer the second: presence of each prop is
+  // what decides whether its button renders.
+  onCreateNewLaunch?: () => void;
+  onCreateMultipleLaunch?: () => void;
 }
 
 const PAGE_SIZE = 50;
@@ -88,6 +101,9 @@ const ManageRacksModal = ({
   initialSelectedRackIds,
   onDismiss,
   onConfirm,
+  saving = false,
+  onCreateNewLaunch,
+  onCreateMultipleLaunch,
 }: ManageRacksModalProps) => {
   const { listRacks } = useDeviceSets();
   const { listBuildingsBySite, listBuildings } = useBuildings();
@@ -562,18 +578,37 @@ const ManageRacksModal = ({
     };
   }, [showAssigned]);
 
+  // The exact membership change Save would write — note it isn't a plain
+  // set-difference (seeded ids the response omitted are excluded on purpose;
+  // see computeRackSelectionDelta), so comparing selections directly would read
+  // as a change with nothing to send.
+  //
+  // null while the delta isn't computable: during a footer "Select all" fetch
+  // the selection/accumulator aren't final, so committing would drop the
+  // pending additions. A placement-facet conflict is a *loaded* empty view (no
+  // fetch runs, so pageItems stays undefined) — Save must still work there so
+  // Select-none-then-Save can clear the current racks; the accumulator holds
+  // the seeds + preserved selections the delta needs.
+  //
+  // accumulatorRef mutates in step with pageItems / selectedItems (page loads
+  // update the former, select-all the latter), so these deps keep it fresh.
+  const delta = useMemo(() => {
+    if (selectingAll) return null;
+    if (pageItems === undefined && !placementFacetConflict) return null;
+    return computeRackSelectionDelta([...accumulatorRef.current.values()], initialSelectedRackIds, selectedItems);
+  }, [pageItems, placementFacetConflict, selectingAll, selectedItems, initialSelectedRackIds]);
+
   const handleConfirm = useCallback(() => {
-    // Guard against confirming mid-load: while a footer "Select all" fetch is in
-    // flight the selection/accumulator aren't final, so committing would drop the
-    // pending additions (Continue is also disabled then). A placement-facet
-    // conflict is a *loaded* empty view (no fetch runs, so pageItems stays
-    // undefined) — Continue must still work there so Select-none-then-Continue
-    // can clear the current racks; the accumulator holds the seeds + preserved
-    // selections needed for the delta.
-    if (selectingAll) return;
-    if (pageItems === undefined && !placementFacetConflict) return;
-    onConfirm(computeRackSelectionDelta([...accumulatorRef.current.values()], initialSelectedRackIds, selectedItems));
-  }, [pageItems, placementFacetConflict, selectingAll, selectedItems, initialSelectedRackIds, onConfirm]);
+    if (!delta) return;
+    // Nothing to write. AssignRacksToBuilding would report a membership change
+    // it didn't make, so close instead — reviewing the list and keeping it
+    // as-is is a legitimate outcome, not an error.
+    if (delta.added.length === 0 && delta.removed.length === 0) {
+      onDismiss();
+      return;
+    }
+    onConfirm(delta);
+  }, [delta, onConfirm, onDismiss]);
 
   // Footer "Select all" (offered only with the toggle off — see below) selects
   // every ELIGIBLE rack across all pages, not just the visible page. Server
@@ -654,15 +689,49 @@ const ManageRacksModal = ({
       size="large"
       className="flex !h-[calc(100dvh-(--spacing(32)))] max-h-[calc(100dvh-(--spacing(32)))] flex-col !overflow-hidden"
       bodyClassName="flex flex-1 min-h-0 flex-col"
-      onDismiss={onDismiss}
+      onDismiss={saving ? undefined : onDismiss}
       divider={false}
       testId="manage-racks-modal"
       buttons={[
+        // ButtonGroup sorts the primary button last, so these land to the left
+        // of Save. Named for what they open rather than a generic "New rack" —
+        // each preselects its side of the create modal's Single / Multiple
+        // toggle, so the label is the whole affordance.
+        ...(onCreateNewLaunch
+          ? [
+              {
+                text: "Create rack",
+                variant: variants.secondary,
+                onClick: onCreateNewLaunch,
+                disabled: saving,
+                dismissModalOnClick: false,
+                testId: "manage-racks-modal-create-new",
+              },
+            ]
+          : []),
+        ...(onCreateMultipleLaunch
+          ? [
+              {
+                text: "Create multiple racks",
+                variant: variants.secondary,
+                onClick: onCreateMultipleLaunch,
+                disabled: saving,
+                dismissModalOnClick: false,
+                testId: "manage-racks-modal-create-multiple",
+              },
+            ]
+          : []),
         {
-          text: "Continue",
+          // "Save" because this is where membership is written
+          // (AssignRacksToBuilding), not a step on the way to a later commit.
+          text: saving ? "Saving…" : "Save",
           variant: "primary",
           onClick: handleConfirm,
-          disabled: selectingAll,
+          // Only the in-flight guard, plus the not-computable cases where
+          // `delta` is null (select-all in flight, list not loaded) — a click
+          // there could only misread the selection. The no-change case closes in
+          // handleConfirm instead.
+          disabled: saving || delta === null,
           dismissModalOnClick: false,
           testId: "manage-racks-modal-confirm",
         },

--- a/client/src/protoFleet/features/buildings/hooks/useBuildingModals.ts
+++ b/client/src/protoFleet/features/buildings/hooks/useBuildingModals.ts
@@ -30,7 +30,12 @@ export type BuildingModalState =
   | { kind: "detailsCreate"; siteId?: bigint; siteName?: string; draft: BuildingFormValues }
   | { kind: "detailsEdit"; row: BuildingWithCounts; siteName?: string; draft: BuildingFormValues }
   | { kind: "manage"; row: BuildingWithCounts; siteName?: string }
-  | { kind: "manageEditingDetails"; row: BuildingWithCounts; siteName?: string; draft: BuildingFormValues };
+  | { kind: "manageEditingDetails"; row: BuildingWithCounts; siteName?: string; draft: BuildingFormValues }
+  // The racks picker with no ManageBuildingModal behind it: hosts that already
+  // render the building (its detail page) open membership editing directly
+  // rather than putting the whole manage surface on screen uninvited. Carries
+  // the rack ids already in the building so the picker can seed its selection.
+  | { kind: "racksPicker"; row: BuildingWithCounts; currentRackIds: bigint[] };
 
 interface UseBuildingModalsOptions {
   // Refetches the host page's buildings cache. Called after every successful
@@ -71,6 +76,12 @@ export interface BuildingModalsApi {
   openManage: (row: BuildingWithCounts, siteName?: string, unassignedMinerCount?: number) => void;
   // Count carried alongside the manage state for the seeded-create flow.
   manageUnassignedMinerCount: number | undefined;
+  openRacksPicker: (row: BuildingWithCounts, currentRackIds: bigint[]) => void;
+  // Commit-per-modal: the racks picker owns building membership, so its Save
+  // applies the delta via AssignRacksToBuilding right away rather than staging it
+  // for a later save. `added` moves racks into this building; `removed` leaves
+  // them with no building. Resolves true on success.
+  pickerAssignRacks: (delta: { added: bigint[]; removed: bigint[] }) => Promise<boolean>;
   // Closes the topmost modal: drops details if details is stacked on manage,
   // otherwise collapses to none. Mirrors useSiteModals.dismiss.
   dismiss: () => void;
@@ -96,6 +107,9 @@ export interface BuildingModalsApi {
   refreshBuildings: () => void;
 }
 
+// Proto caps `racks` at 1000 per AssignRacksToBuildingRequest.
+const RACKS_PER_RPC = 1000;
+
 const useBuildingModals = ({
   refetchBuildings,
   onMutationSuccess,
@@ -118,7 +132,28 @@ const useBuildingModals = ({
   // state transitions away (drops details) before the operator confirms.
   const deleteFromManageRef = useRef(false);
 
-  const { createBuilding, updateBuilding, deleteBuilding } = useBuildings();
+  const { createBuilding, updateBuilding, deleteBuilding, assignRacksToBuilding } = useBuildings();
+
+  // Membership writer for the standalone racks picker. `targetBuildingId` unset
+  // leaves the racks with no building. Chunked because AssignRacksToBuildingRequest
+  // caps `racks` at 1000 and the picker can select a whole site's worth; chunks run
+  // sequentially so a mid-chain failure stops the chain.
+  const dispatchAssignRacks = useCallback(
+    async (rackIds: bigint[], targetBuildingId?: bigint) => {
+      for (let i = 0; i < rackIds.length; i += RACKS_PER_RPC) {
+        const chunk = rackIds.slice(i, i + RACKS_PER_RPC);
+        await new Promise<void>((resolve, reject) => {
+          void assignRacksToBuilding({
+            racks: chunk.map((rackId) => ({ rackId })),
+            targetBuildingId,
+            onSuccess: () => resolve(),
+            onError: (msg) => reject(new Error(msg)),
+          });
+        });
+      }
+    },
+    [assignRacksToBuilding],
+  );
 
   const openDetailsCreate = useCallback((siteId?: bigint, siteName?: string) => {
     setState({ kind: "detailsCreate", siteId, siteName, draft: emptyBuildingFormValues() });
@@ -311,6 +346,40 @@ const useBuildingModals = ({
     refetchBuildings?.();
   }, [refetchBuildings]);
 
+  const openRacksPicker = useCallback((row: BuildingWithCounts, currentRackIds: bigint[]) => {
+    setState({ kind: "racksPicker", row, currentRackIds });
+  }, []);
+
+  const pickerAssignRacks = useCallback(
+    async (delta: { added: bigint[]; removed: bigint[] }): Promise<boolean> => {
+      if (savingRef.current) return false;
+      if (state.kind !== "racksPicker") return false;
+      const buildingId = unwrap(state.row).id;
+      savingRef.current = true;
+      setSaving(true);
+      try {
+        // Removals first so they free their grid cells before any newcomer
+        // lands, matching ManageBuildingModal's ordering. Chunked to the proto's
+        // per-request cap.
+        await dispatchAssignRacks(delta.removed, undefined);
+        await dispatchAssignRacks(delta.added, buildingId);
+      } catch (err) {
+        const detail = err instanceof Error ? err.message : "unknown error";
+        pushToast({ message: `Failed to update racks: ${detail}`, status: STATUSES.error });
+        return false;
+      } finally {
+        savingRef.current = false;
+        setSaving(false);
+      }
+      // rack_count and the grid change without touching create/update/delete, so
+      // the host's cache only re-pulls if we ask it to.
+      refetchBuildings?.();
+      onMutationSuccess?.();
+      return true;
+    },
+    [state, dispatchAssignRacks, refetchBuildings, onMutationSuccess],
+  );
+
   return {
     state,
     deleteTarget,
@@ -320,6 +389,8 @@ const useBuildingModals = ({
     openDetailsCreate,
     openDetailsEdit,
     openManage,
+    openRacksPicker,
+    pickerAssignRacks,
     dismiss,
     dismissDeleteConfirm,
     detailsCreate,

--- a/client/src/protoFleet/features/buildings/pages/BuildingPage.tsx
+++ b/client/src/protoFleet/features/buildings/pages/BuildingPage.tsx
@@ -25,7 +25,7 @@ import FleetErrors from "@/protoFleet/features/kpis/components/FleetErrors";
 import { usePageBackground } from "@/protoFleet/hooks/usePageBackground";
 import { entityScopeTarget, useSyncScopeToEntity } from "@/protoFleet/hooks/useSyncScopeToEntity";
 import { scopedPath } from "@/protoFleet/routing/siteScope";
-import { useDuration, useSetDuration } from "@/protoFleet/store";
+import { useDuration, useHasPermission, useSetDuration } from "@/protoFleet/store";
 import { useFleetStore } from "@/protoFleet/store/useFleetStore";
 import Button, { sizes, variants } from "@/shared/components/Button";
 import DurationSelector, { fleetDurations } from "@/shared/components/DurationSelector";
@@ -65,6 +65,7 @@ const BuildingPage = () => {
   // fires its own ListSites.
   const { sites } = useSitesContext();
   const activeSite = useFleetStore((state) => state.ui.activeSite);
+  const canManageSites = useHasPermission("site:manage");
 
   const buildingId = useMemo(() => parseBigIntId(id), [id]);
 
@@ -285,13 +286,22 @@ const BuildingPage = () => {
   const racksFromList =
     rackCountResponse !== undefined && rackCountResponse.id === effectiveBuilding.id ? rackCountResponse.count : null;
   const fallbackRackCount = racksFromList ?? (stats ? BigInt(stats.rackCount) : 0n);
+  const buildingRow = () =>
+    create(BuildingWithCountsSchema, {
+      building: effectiveBuilding,
+      rackCount: fallbackRackCount,
+    });
+
   const handleEditBuilding = () => {
-    buildingModals.openManage(
-      create(BuildingWithCountsSchema, {
-        building: effectiveBuilding,
-        rackCount: fallbackRackCount,
-      }),
-    );
+    buildingModals.openManage(buildingRow());
+  };
+
+  // The racks picker on its own, not the whole manage surface: the operator is
+  // already looking at the building, so stacking ManageBuildingModal behind the
+  // picker would put a layer on screen they never asked for. Empty membership —
+  // this only renders when the building has no racks.
+  const handleManageRacks = () => {
+    buildingModals.openRacksPicker(buildingRow(), []);
   };
 
   return (
@@ -357,6 +367,10 @@ const BuildingPage = () => {
                   rackHealth={stats.rackHealth}
                   aisles={effectiveBuilding.aisles}
                   racksPerAisle={effectiveBuilding.racksPerAisle}
+                  // Assigning racks to a building is a site:manage action (the
+                  // server enforces the same on AssignRacksToBuilding), so a
+                  // viewer without it gets the empty card with no CTA.
+                  onManageRacks={canManageSites ? handleManageRacks : undefined}
                 />
               ) : (
                 <PlaceholderBlock


### PR DESCRIPTION
Reviewable diff: +1220/-419 across 13 files (excludes generated, test, and story files).

## Summary

Three things on the building surfaces:

**Create racks without leaving.** `ManageRacksModal` gets a Create rack CTA that opens the rack create modal with the building pre-filled. An operator arranging a building no longer has to go to the racks page and come back.

**Multiple mode for buildings.** `BuildingSettingsModal` picks up the same Single/Multiple split the rack modal got in #858, generating names from a prefix + counter and creating the batch through `CreateBuildings` (#856).

**No dead end on an empty building.** `BuildingPage`'s empty racks section gets a manage-racks CTA, so a building with no racks points at the modal that fills it.

### Stack — 6 PRs, merge in order

| # | PR | What it adds |
|---|----|--------------|
| 1 | #855 | `AssignDevicesToRack` also writes rack slot placement |
| 2 | #856 | `CreateBuildings` batch RPC |
| 3 | #857 | `CreateRacks` batch RPC |
| 4 | #858 | Rack create modal gains a Multiple mode |
| **5** | **#859 ← this PR** | Building surfaces: create racks and buildings inline |
| 6 | #860 | Site surfaces: create buildings inline |

Together the series lets an operator build out the physical hierarchy without leaving the modal they are in — buildings from inside a site, racks from inside a building — and create them in batches from a generated name series. PRs 1–3 are the backend RPCs; 4–6 are the UI that calls them.

## How it works

`BuildingRacksPicker` is the new component the Create rack CTA lives in. Choosing it opens `RackSettingsModal` in create mode with the building locked, so the rack is created into the building the operator is already looking at; on success the picker refreshes and the new rack is selectable immediately.

Bulk building names reuse `bulkNameSeries` from #858 via `bulkBuildingNames.ts`, with the 255-character bound buildings actually have. Same live length check on the finished names, same per-row marking from `CreateBuildings`' per-row errors.

`ManageBuildingModal` also drops its staged-changes/dirty-gate model: the picker commits rack membership as it is used and Save owns placement, matching what #858 did for racks.

Note: `BuildingSettingsModal`'s Multiple mode ships here but nothing opens it yet — the host wiring is #860. It is tested but unreachable for one merge window.

```mermaid
flowchart TD
  A["BuildingPage (no racks)"] --> B["Manage racks CTA"]
  B --> C["ManageRacksModal + BuildingRacksPicker"]
  C --> D["Create rack CTA"]
  D --> E["RackSettingsModal, building locked"]
  E --> F["CreateRacks / SaveRack"]
  F --> C
  G["BuildingSettingsModal Multiple"] --> H["bulkBuildingNames → CreateBuildings"]
  H -.->|host wired in #860| G
```

## Areas of the code involved

| Area | What changed | Why it matters |
|---|---|---|
| `BuildingSettingsModal.tsx` + `bulkBuildingNames.ts` | Single/Multiple modes, 255-char guard, validate-on-submit | Main review target; mirrors #858's rack modal |
| `BuildingRacksPicker/` | New picker hosting the Create rack CTA | New component |
| `ManageRacksModal.tsx` | Create rack hand-off with the building pre-filled | |
| `ManageBuildingModal.tsx` + `assignmentMath.ts` | Dirty gates removed; picker commits, Save places | Largest behavioral change |
| `useBuildingModals.ts`, `BuildingModals.tsx` | Modal orchestration for the new flows | |
| `BuildingPage.tsx`, `BuildingRackGrid.tsx` | Empty-state CTA and grid follow-on | |
| `client/e2eTests/**/buildingDetail*`, `pages/fleetLocations.ts` | Specs follow the changed modal | |

## Key technical decisions

- **Create-in-place with the parent locked**, rather than navigating to the racks page — the operator keeps their context, and the rack can't be created into the wrong building.
- **Reuse `bulkNameSeries` with a per-feature bound** (255 for buildings, 100 for rack labels) rather than a second generator, so the two forms behave identically.
- **Same commit boundary as #858** — picker commits membership, Save owns placement — so all three levels of the hierarchy behave the same way.
- **Ship the modal before its host** — additive and unreachable for one merge, which keeps this PR reviewable at ~1.2k lines instead of merging surfaces together.

## Testing & validation

- `tsc --noEmit` clean; full client suite passes, including new coverage for building bulk generation and a regression test that a 252-char prefix overflowing 255 is refused client side.
- `buildingDetail` Playwright specs updated here so they land with the behavior they assert. Not executed locally (needs docker-compose).
