### PR TITLE
[6/6] feat(sites): create buildings inline from the site surfaces

### DIFF
--- a/client/src/protoFleet/features/sites/components/ManageBuildingsModal/ManageBuildingsModal.test.tsx
+++ b/client/src/protoFleet/features/sites/components/ManageBuildingsModal/ManageBuildingsModal.test.tsx
@@ -1,0 +1,187 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { create } from "@bufbuild/protobuf";
+
+import ManageBuildingsModal from "./ManageBuildingsModal";
+import { BuildingSchema, BuildingWithCountsSchema } from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
+import { SiteSchema, SiteWithCountsSchema } from "@/protoFleet/api/generated/sites/v1/sites_pb";
+
+const { listAllBuildingsMock, listSitesMock } = vi.hoisted(() => ({
+  listAllBuildingsMock: vi.fn(),
+  listSitesMock: vi.fn(),
+}));
+
+vi.mock("@/protoFleet/api/buildings", () => ({
+  useBuildings: () => ({ listAllBuildings: listAllBuildingsMock }),
+}));
+
+vi.mock("@/protoFleet/api/sites", () => ({
+  useSites: () => ({ listSites: listSitesMock }),
+}));
+
+// The picker self-fetches the org-wide building list plus the site catalog for
+// its Site column; both mocks resolve synchronously through onSuccess.
+const seed = (rows: { id: bigint; name: string; siteId: bigint }[]) => {
+  listAllBuildingsMock.mockImplementation((args?: { onSuccess?: (rows: unknown[]) => void }) => {
+    args?.onSuccess?.(
+      rows.map((r) =>
+        create(BuildingWithCountsSchema, {
+          building: create(BuildingSchema, { id: r.id, name: r.name, siteId: r.siteId }),
+          rackCount: 0n,
+        }),
+      ),
+    );
+    return Promise.resolve(undefined);
+  });
+  listSitesMock.mockImplementation((args?: { onSuccess?: (rows: unknown[]) => void }) => {
+    args?.onSuccess?.([create(SiteWithCountsSchema, { site: create(SiteSchema, { id: 7n, name: "East DC" }) })]);
+    return Promise.resolve(undefined);
+  });
+};
+
+const baseProps = {
+  open: true as const,
+  siteId: 7n,
+  initialSelectedBuildingIds: [] as bigint[],
+  onDismiss: () => undefined,
+};
+
+describe("ManageBuildingsModal — create hand-offs", () => {
+  beforeEach(() => {
+    listAllBuildingsMock.mockReset();
+    listSitesMock.mockReset();
+  });
+
+  it("shows each create button only when its launch handler is supplied", async () => {
+    seed([{ id: 1n, name: "Building A", siteId: 0n }]);
+    const { rerender } = render(<ManageBuildingsModal {...baseProps} onConfirm={vi.fn()} />);
+
+    await waitFor(() => expect(screen.getByTestId("manage-buildings-modal-confirm")).toBeInTheDocument());
+    expect(screen.queryByTestId("manage-buildings-modal-create-new")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("manage-buildings-modal-create-multiple")).not.toBeInTheDocument();
+
+    // Separate props rather than one callback with a variant: a host without the
+    // batch RPC wired can offer the first and not the second.
+    rerender(<ManageBuildingsModal {...baseProps} onConfirm={vi.fn()} onCreateNewLaunch={vi.fn()} />);
+    expect(screen.getByTestId("manage-buildings-modal-create-new")).toHaveTextContent("Create building");
+    expect(screen.queryByTestId("manage-buildings-modal-create-multiple")).not.toBeInTheDocument();
+
+    rerender(
+      <ManageBuildingsModal
+        {...baseProps}
+        onConfirm={vi.fn()}
+        onCreateNewLaunch={vi.fn()}
+        onCreateMultipleLaunch={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("manage-buildings-modal-create-multiple")).toHaveTextContent("Create multiple buildings");
+  });
+
+  it("hands off to the batch create flow without committing the selection", async () => {
+    seed([{ id: 1n, name: "Building A", siteId: 0n }]);
+    const onConfirm = vi.fn();
+    const onCreateMultipleLaunch = vi.fn();
+    render(
+      <ManageBuildingsModal
+        {...baseProps}
+        onConfirm={onConfirm}
+        onCreateNewLaunch={vi.fn()}
+        onCreateMultipleLaunch={onCreateMultipleLaunch}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByTestId("manage-buildings-modal-create-multiple")).toBeEnabled());
+    fireEvent.click(screen.getAllByRole("checkbox")[0]);
+    fireEvent.click(screen.getByTestId("manage-buildings-modal-create-multiple"));
+
+    expect(onCreateMultipleLaunch).toHaveBeenCalled();
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("abandons the pending selection when launching create — Save is what commits", async () => {
+    seed([{ id: 1n, name: "Building A", siteId: 0n }]);
+    const onConfirm = vi.fn();
+    const onCreateNewLaunch = vi.fn();
+    render(<ManageBuildingsModal {...baseProps} onConfirm={onConfirm} onCreateNewLaunch={onCreateNewLaunch} />);
+
+    await waitFor(() => expect(screen.getByTestId("manage-buildings-modal-create-new")).toBeEnabled());
+
+    // Check the unassigned building, then hand off to the create flow without
+    // pressing Save.
+    fireEvent.click(screen.getAllByRole("checkbox")[0]);
+    fireEvent.click(screen.getByTestId("manage-buildings-modal-create-new"));
+
+    // Nothing is written — leaving without Save means the selection never
+    // landed, which is what makes the abandon safe to reason about.
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(onCreateNewLaunch).toHaveBeenCalled();
+  });
+});
+
+describe("ManageBuildingsModal — Save", () => {
+  beforeEach(() => {
+    listAllBuildingsMock.mockReset();
+    listSitesMock.mockReset();
+  });
+
+  it("closes without an AssignBuildingsToSite no-op when the selection matches the site", async () => {
+    seed([{ id: 1n, name: "Building A", siteId: 0n }]);
+    const onConfirm = vi.fn();
+    const onDismiss = vi.fn();
+    render(<ManageBuildingsModal {...baseProps} onConfirm={onConfirm} onDismiss={onDismiss} />);
+
+    const save = await screen.findByTestId("manage-buildings-modal-confirm");
+    // Loaded with nothing checked and nothing seeded. Reviewing the list and
+    // keeping it as-is is a legitimate outcome, so Save closes — but it must not
+    // report a membership change it didn't make.
+    await waitFor(() => expect(save).toBeEnabled());
+    fireEvent.click(save);
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getAllByRole("checkbox")[0]);
+    fireEvent.click(save);
+    expect(onConfirm).toHaveBeenCalledWith({
+      added: [{ buildingId: 1n, label: "Building A" }],
+      removed: [],
+    });
+  });
+
+  it("keeps Save disabled while the building list is still loading", () => {
+    // The one gate that stays: without the list there's no delta to compute, so
+    // a click could only misread the selection.
+    // No onSuccess → items stays undefined, so the delta can't be computed.
+    listAllBuildingsMock.mockReturnValue(Promise.resolve(undefined));
+    listSitesMock.mockReturnValue(Promise.resolve(undefined));
+    render(<ManageBuildingsModal {...baseProps} onConfirm={vi.fn()} />);
+
+    expect(screen.getByTestId("manage-buildings-modal-confirm")).toBeDisabled();
+  });
+
+  it("re-checking a seeded building is no change again", async () => {
+    // Uncheck then re-check: the delta returns to empty, so Save is a no-op
+    // close again rather than latching on "the operator touched something".
+    seed([{ id: 1n, name: "Building A", siteId: 7n }]);
+    const onConfirm = vi.fn();
+    const onDismiss = vi.fn();
+    render(
+      <ManageBuildingsModal
+        {...baseProps}
+        initialSelectedBuildingIds={[1n]}
+        onConfirm={onConfirm}
+        onDismiss={onDismiss}
+      />,
+    );
+
+    const save = await screen.findByTestId("manage-buildings-modal-confirm");
+    await waitFor(() => expect(save).toBeEnabled());
+
+    const checkbox = screen.getAllByRole("checkbox")[0];
+    fireEvent.click(checkbox);
+    fireEvent.click(checkbox);
+    fireEvent.click(save);
+
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/protoFleet/features/sites/components/ManageBuildingsModal/ManageBuildingsModal.tsx
+++ b/client/src/protoFleet/features/sites/components/ManageBuildingsModal/ManageBuildingsModal.tsx
@@ -17,16 +17,29 @@ interface ManageBuildingsModalProps {
   open: boolean;
   // Parent site context drives the eligibility split.
   siteId: bigint;
-  // Building IDs currently in the site's working set. The modal seeds its
-  // selection with these so the operator sees current state and can add /
-  // remove in one flow.
+  // Building IDs currently assigned to the site. The modal seeds its selection
+  // with these so the operator sees current state and can add / remove in one
+  // flow, and diffs against them to gate Save.
   initialSelectedBuildingIds: bigint[];
   onDismiss: () => void;
-  // Returns the delta against initialSelectedBuildingIds: `added` is the
+  // Save. Receives the delta against initialSelectedBuildingIds: `added` is the
   // newly-checked buildings (id + label so the caller can render without a
   // separate lookup); `removed` is the seeded ids the operator unchecked.
   // Untouched buildings are in neither list — the caller leaves them as-is.
-  onConfirm: (delta: { added: { buildingId: bigint; label: string }[]; removed: bigint[] }) => void;
+  // This modal owns site membership, so the caller persists the delta here
+  // rather than staging it for a later save.
+  onConfirm: (delta: { added: { buildingId: bigint; label: string }[]; removed: bigint[] }) => Promise<void> | void;
+  // In-flight signal from the caller's write, mirrored into the CTA.
+  saving?: boolean;
+  // Hands off to the full building-create flow instead of picking an existing
+  // building. Leaving this way abandons the pending selection: Save is what
+  // commits it, so nothing was written. Omitted = no create affordance.
+  //
+  // Two callbacks rather than one with a variant argument, because a host that
+  // hasn't wired the batch RPC can't offer the second: presence of each prop is
+  // what decides whether its button renders.
+  onCreateNewLaunch?: () => void;
+  onCreateMultipleLaunch?: () => void;
 }
 
 const PAGE_SIZE = 25;
@@ -60,6 +73,9 @@ const ManageBuildingsModal = ({
   initialSelectedBuildingIds,
   onDismiss,
   onConfirm,
+  saving = false,
+  onCreateNewLaunch,
+  onCreateMultipleLaunch,
 }: ManageBuildingsModalProps) => {
   const { listAllBuildings } = useBuildings();
   const { listSites } = useSites();
@@ -139,10 +155,26 @@ const ManageBuildingsModal = ({
   const hasPreviousPage = page > 0;
   const hasNextPage = page < totalPages - 1;
 
+  // The exact membership change Save would write — note it isn't a plain
+  // set-difference: seeded ids the picker's response omitted, and rows that
+  // became ineligible, are excluded on purpose (see
+  // computeBuildingSelectionDelta), so a raw selection comparison would read as
+  // a change when there's nothing to send.
+  const delta = useMemo(
+    () => (items ? computeBuildingSelectionDelta(items, initialSelectedBuildingIds, selectedItems) : null),
+    [items, initialSelectedBuildingIds, selectedItems],
+  );
   const handleConfirm = useCallback(() => {
-    if (!items) return;
-    onConfirm(computeBuildingSelectionDelta(items, initialSelectedBuildingIds, selectedItems));
-  }, [items, selectedItems, initialSelectedBuildingIds, onConfirm]);
+    if (!delta) return;
+    // Nothing to write. AssignBuildingsToSite would report having changed
+    // membership it didn't touch, so close instead — reviewing the list and
+    // keeping it as-is is a legitimate outcome, not an error.
+    if (delta.added.length === 0 && delta.removed.length === 0) {
+      onDismiss();
+      return;
+    }
+    void onConfirm(delta);
+  }, [delta, onConfirm, onDismiss]);
 
   const handleSelectAll = useCallback(() => {
     if (!items) return;
@@ -159,14 +191,48 @@ const ManageBuildingsModal = ({
       size="large"
       className="flex !h-[calc(100dvh-(--spacing(32)))] max-h-[calc(100dvh-(--spacing(32)))] flex-col !overflow-hidden"
       bodyClassName="flex flex-1 min-h-0 flex-col"
-      onDismiss={onDismiss}
+      onDismiss={saving ? undefined : onDismiss}
       divider={false}
       testId="manage-buildings-modal"
       buttons={[
+        // ButtonGroup sorts the primary button last, so these land to the left
+        // of Save. Named for what they open rather than a generic "New
+        // building" — each preselects its side of the create modal's Single /
+        // Multiple toggle, so the label is the whole affordance.
+        ...(onCreateNewLaunch
+          ? [
+              {
+                text: "Create building",
+                variant: variants.secondary,
+                onClick: onCreateNewLaunch,
+                disabled: saving,
+                dismissModalOnClick: false,
+                testId: "manage-buildings-modal-create-new",
+              },
+            ]
+          : []),
+        ...(onCreateMultipleLaunch
+          ? [
+              {
+                text: "Create multiple buildings",
+                variant: variants.secondary,
+                onClick: onCreateMultipleLaunch,
+                disabled: saving,
+                dismissModalOnClick: false,
+                testId: "manage-buildings-modal-create-multiple",
+              },
+            ]
+          : []),
         {
-          text: "Continue",
+          // "Save" because this is where membership is written
+          // (AssignBuildingsToSite), not a step on the way to a later commit.
+          text: saving ? "Saving…" : "Save",
           variant: "primary",
           onClick: handleConfirm,
+          // Only the in-flight guard, plus not-yet-loaded: without the list
+          // there's no delta to compute, so a click could only misread the
+          // selection. The no-change case closes in handleConfirm instead.
+          disabled: saving || delta === null,
           dismissModalOnClick: false,
           testId: "manage-buildings-modal-confirm",
         },

--- a/client/src/protoFleet/features/sites/components/ManageSiteModal/ManageSiteModal.test.tsx
+++ b/client/src/protoFleet/features/sites/components/ManageSiteModal/ManageSiteModal.test.tsx
@@ -11,12 +11,42 @@ import { emptySiteFormValues, type SiteFormValues } from "@/protoFleet/api/sites
 // caller's onSuccess synchronously with whatever rows the test queued.
 const { listBuildingsBySiteMock } = vi.hoisted(() => ({ listBuildingsBySiteMock: vi.fn() }));
 
-vi.mock("@/protoFleet/api/buildings", () => ({
+// Keep the module's real helpers (emptyBuildingFormValues is used by both this
+// modal and the BuildingSettingsModal it renders) and override only the hook.
+vi.mock("@/protoFleet/api/buildings", async (importActual) => ({
+  ...(await importActual<typeof import("@/protoFleet/api/buildings")>()),
   useBuildings: () => ({
     listBuildingsBySite: listBuildingsBySiteMock,
     listAllBuildings: vi.fn(),
     getBuilding: vi.fn(),
   }),
+}));
+
+// Stub the building picker: the real one self-fetches the org-wide building
+// list and site catalog, which this suite doesn't wire up. All we need from it
+// here are the two create hand-offs that reach the inline create flow. Each
+// renders only when its callback is wired, mirroring the real picker.
+vi.mock("../ManageBuildingsModal", () => ({
+  default: ({
+    onCreateNewLaunch,
+    onCreateMultipleLaunch,
+  }: {
+    onCreateNewLaunch?: () => void;
+    onCreateMultipleLaunch?: () => void;
+  }) => (
+    <>
+      {onCreateNewLaunch ? (
+        <button type="button" data-testid="stub-picker-create-new" onClick={onCreateNewLaunch}>
+          Create building
+        </button>
+      ) : null}
+      {onCreateMultipleLaunch ? (
+        <button type="button" data-testid="stub-picker-create-multiple" onClick={onCreateMultipleLaunch}>
+          Create multiple buildings
+        </button>
+      ) : null}
+    </>
+  ),
 }));
 
 const seedBuildings = (rows: { id: bigint; name: string; siteId: bigint; rackCount: bigint }[]) => {
@@ -39,113 +69,174 @@ const draft = (overrides: Partial<SiteFormValues> = {}): SiteFormValues => ({
   ...overrides,
 });
 
+const site7 = create(SiteSchema, { id: 7n, name: "East DC" });
+
 const noop = () => undefined;
+
+// Common props — the site is always persisted by the time the modal opens.
+const baseProps = {
+  open: true as const,
+  site: site7,
+  draft: draft({ name: "East DC" }),
+  onAssignBuildings: vi.fn().mockResolvedValue(true),
+  onRemoveBuilding: vi.fn().mockResolvedValue(true),
+  onCreateBuilding: vi.fn().mockResolvedValue(null),
+  onEditDetails: noop,
+  onDeleteRequested: noop,
+  onDismiss: noop,
+};
 
 describe("ManageSiteModal", () => {
   beforeEach(() => listBuildingsBySiteMock.mockReset());
 
-  it("invokes onSave and closes when the save reports closeOnSuccess", async () => {
-    const onSave = vi.fn().mockResolvedValue({ closeOnSuccess: true });
+  it("Save writes nothing and just closes (placement has no backend yet)", async () => {
+    seedBuildings([]);
+    const onAssignBuildings = vi.fn();
     const onDismiss = vi.fn();
 
-    render(
-      <ManageSiteModal
-        open
-        mode="create"
-        draft={draft()}
-        onSave={onSave}
-        onEditDetails={noop}
-        onDeleteRequested={noop}
-        onDismiss={onDismiss}
-      />,
-    );
+    render(<ManageSiteModal {...baseProps} onAssignBuildings={onAssignBuildings} onDismiss={onDismiss} />);
 
     fireEvent.click(screen.getByTestId("manage-site-modal-save"));
 
-    await waitFor(() => expect(onSave).toHaveBeenCalled());
     await waitFor(() => expect(onDismiss).toHaveBeenCalled());
+    // Membership commits in the picker, so this CTA has nothing to persist.
+    expect(onAssignBuildings).not.toHaveBeenCalled();
   });
 
-  it("disables Save in edit mode until the building list has loaded", () => {
-    // No seed → listBuildingsBySite never calls onSuccess, so the working
-    // set stays in the loading (undefined) state.
-    const site = create(SiteSchema, { id: 7n, name: "East DC" });
-    render(
-      <ManageSiteModal
-        open
-        mode="edit"
-        site={site}
-        draft={draft({ name: "East DC" })}
-        onSave={vi.fn()}
-        onEditDetails={noop}
-        onDeleteRequested={noop}
-        onDismiss={noop}
-      />,
-    );
+  it("disables Save until the building list has loaded", () => {
+    // No seed → listBuildingsBySite never calls onSuccess, so the list stays
+    // in the loading (undefined) state.
+    render(<ManageSiteModal {...baseProps} />);
 
     expect(screen.getByTestId("manage-site-modal-save")).toBeDisabled();
   });
 
   it("Site settings fires the parent callback", () => {
+    seedBuildings([]);
     const onEditDetails = vi.fn();
-    render(
-      <ManageSiteModal
-        open
-        mode="create"
-        draft={draft()}
-        onSave={() => Promise.resolve(null)}
-        onEditDetails={onEditDetails}
-        onDeleteRequested={noop}
-        onDismiss={noop}
-      />,
-    );
+    render(<ManageSiteModal {...baseProps} onEditDetails={onEditDetails} />);
 
     fireEvent.click(screen.getAllByTestId("manage-site-modal-edit-details")[0]);
     expect(onEditDetails).toHaveBeenCalled();
   });
 
   it("Delete site fires onDeleteRequested", () => {
+    seedBuildings([]);
     const onDeleteRequested = vi.fn();
-    render(
-      <ManageSiteModal
-        open
-        mode="create"
-        draft={draft()}
-        onSave={() => Promise.resolve(null)}
-        onEditDetails={noop}
-        onDeleteRequested={onDeleteRequested}
-        onDismiss={noop}
-      />,
-    );
+    render(<ManageSiteModal {...baseProps} onDeleteRequested={onDeleteRequested} />);
 
     fireEvent.click(screen.getAllByTestId("manage-site-modal-delete")[0]);
     expect(onDeleteRequested).toHaveBeenCalled();
   });
 
-  it("create mode lets buildings be staged before the site is saved", () => {
-    render(
-      <ManageSiteModal
-        open
-        mode="create"
-        draft={draft()}
-        onSave={() => Promise.resolve(null)}
-        onEditDetails={noop}
-        onDeleteRequested={noop}
-        onDismiss={noop}
-      />,
-    );
+  it("creates a building inline via the picker hand-off and injects it into the working set", async () => {
+    seedBuildings([]);
+    const created = create(BuildingSchema, { id: 5n, name: "New Bldg", siteId: 7n });
+    const onCreateBuilding = vi.fn().mockResolvedValue(created);
+    render(<ManageSiteModal {...baseProps} onCreateBuilding={onCreateBuilding} />);
 
-    // No "save first" gate — the empty working set renders the same
-    // add-buildings affordance as edit mode, and Manage buildings is enabled.
-    expect(screen.queryByText("Save the site first to add buildings.")).not.toBeInTheDocument();
+    // Create is reached through the picker's "New building" hand-off, not a
+    // dedicated button on this modal.
     expect(screen.getByText("No buildings added to this site")).toBeInTheDocument();
-    expect(screen.getAllByTestId("manage-site-modal-manage-buildings")[0]).toBeEnabled();
-    expect(screen.getAllByTestId("manage-site-modal-empty-state-add")[0]).toBeEnabled();
-    // Save is allowed immediately (creates the site with an empty building set).
-    expect(screen.getByTestId("manage-site-modal-save")).toBeEnabled();
+    expect(screen.queryByTestId("manage-site-modal-create-building")).not.toBeInTheDocument();
+    fireEvent.click(screen.getAllByTestId("manage-site-modal-manage-buildings")[0]);
+    fireEvent.click(screen.getByTestId("stub-picker-create-new"));
+    expect(screen.getByTestId("building-settings-modal")).toBeInTheDocument();
+
+    // Name the building and save.
+    fireEvent.change(screen.getByTestId("building-settings-name-input"), { target: { value: "New Bldg" } });
+    fireEvent.click(screen.getByTestId("building-settings-modal-save"));
+
+    await waitFor(() => expect(onCreateBuilding).toHaveBeenCalled());
+    // The created building is injected and the create modal closes.
+    await waitFor(() => expect(screen.getByTestId("manage-site-modal-building-row-5")).toBeInTheDocument());
+    expect(screen.queryByTestId("building-settings-modal")).not.toBeInTheDocument();
+  });
+
+  it("creates a batch of buildings inline and injects every returned row", async () => {
+    seedBuildings([{ id: 1n, name: "Existing", siteId: 7n, rackCount: 0n }]);
+    const onCreateBuildings = vi.fn().mockResolvedValue({
+      created: [
+        create(BuildingSchema, { id: 11n, name: "B-1", siteId: 7n }),
+        create(BuildingSchema, { id: 12n, name: "B-2", siteId: 7n }),
+      ],
+      errors: [],
+    });
+    render(<ManageSiteModal {...baseProps} onCreateBuildings={onCreateBuildings} />);
+
+    fireEvent.click(screen.getAllByTestId("manage-site-modal-manage-buildings")[0]);
+    // "Create multiple buildings" opens the create modal already on its
+    // Multiple side, so there's no toggle to press.
+    fireEvent.click(screen.getByTestId("stub-picker-create-multiple"));
+    fireEvent.change(screen.getByTestId("building-settings-bulk-count-input"), { target: { value: "2" } });
+    fireEvent.change(screen.getByTestId("building-settings-bulk-prefix-input"), { target: { value: "B-" } });
+    fireEvent.click(screen.getByTestId("building-settings-modal-save"));
+
+    await waitFor(() =>
+      expect(onCreateBuildings).toHaveBeenCalledWith([
+        { name: "B-1", aisles: 0, racksPerAisle: 0 },
+        { name: "B-2", aisles: 0, racksPerAisle: 0 },
+      ]),
+    );
+    // Both rows join the existing member without a refetch, so any staged
+    // picker state would survive.
+    await waitFor(() => expect(screen.getByTestId("manage-site-modal-building-row-11")).toBeInTheDocument());
+    expect(screen.getByTestId("manage-site-modal-building-row-12")).toBeInTheDocument();
+    expect(screen.getByTestId("manage-site-modal-building-row-1")).toBeInTheDocument();
+    expect(screen.queryByTestId("building-settings-modal")).not.toBeInTheDocument();
+  });
+
+  it("offers the batch create hand-off only when the host wired CreateBuildings", () => {
+    seedBuildings([]);
+    const { unmount } = render(<ManageSiteModal {...baseProps} onCreateBuilding={vi.fn()} />);
+    fireEvent.click(screen.getAllByTestId("manage-site-modal-manage-buildings")[0]);
+    // Without the batch RPC the create modal has no Multiple side to open on,
+    // so the second button must not be offered.
+    expect(screen.getByTestId("stub-picker-create-new")).toBeInTheDocument();
+    expect(screen.queryByTestId("stub-picker-create-multiple")).not.toBeInTheDocument();
+    unmount();
+
+    render(<ManageSiteModal {...baseProps} onCreateBuildings={vi.fn()} />);
+    fireEvent.click(screen.getAllByTestId("manage-site-modal-manage-buildings")[0]);
+    expect(screen.getByTestId("stub-picker-create-multiple")).toBeInTheDocument();
+  });
+
+  it("blocks a batch whose generated name is already at the site", async () => {
+    seedBuildings([{ id: 1n, name: "B-2", siteId: 7n, rackCount: 0n }]);
+    const onCreateBuildings = vi.fn();
+    render(<ManageSiteModal {...baseProps} onCreateBuildings={onCreateBuildings} />);
+
+    fireEvent.click(screen.getAllByTestId("manage-site-modal-manage-buildings")[0]);
+    fireEvent.click(screen.getByTestId("stub-picker-create-new"));
+    fireEvent.mouseDown(screen.getByText("Multiple"));
+    fireEvent.change(screen.getByTestId("building-settings-bulk-count-input"), { target: { value: "3" } });
+    fireEvent.change(screen.getByTestId("building-settings-bulk-prefix-input"), { target: { value: "B-" } });
+
+    // The site's own member list feeds the collision check, so the round trip
+    // never happens.
+    expect(screen.getByTestId("building-settings-bulk-preview-row-1")).toHaveTextContent("Already used at this site");
+    fireEvent.click(screen.getByTestId("building-settings-modal-save"));
+    expect(onCreateBuildings).not.toHaveBeenCalled();
+  });
+
+  it("keeps the create modal open and injects nothing when create fails", async () => {
+    seedBuildings([]);
+    const onCreateBuilding = vi.fn().mockResolvedValue(null);
+    render(<ManageSiteModal {...baseProps} onCreateBuilding={onCreateBuilding} />);
+
+    fireEvent.click(screen.getAllByTestId("manage-site-modal-manage-buildings")[0]);
+    fireEvent.click(screen.getByTestId("stub-picker-create-new"));
+    fireEvent.change(screen.getByTestId("building-settings-name-input"), { target: { value: "Nope" } });
+    fireEvent.click(screen.getByTestId("building-settings-modal-save"));
+
+    await waitFor(() => expect(onCreateBuilding).toHaveBeenCalled());
+    // Modal stays open; no row was added.
+    expect(screen.getByTestId("building-settings-modal")).toBeInTheDocument();
+    expect(screen.getByText("No buildings added to this site")).toBeInTheDocument();
   });
 
   it("shows comma-separated meta on each corner of the preview", () => {
+    seedBuildings([]);
     const site = create(SiteSchema, {
       id: 7n,
       name: "East DC",
@@ -155,8 +246,7 @@ describe("ManageSiteModal", () => {
     });
     render(
       <ManageSiteModal
-        open
-        mode="edit"
+        {...baseProps}
         site={site}
         draft={draft({
           name: "East DC",
@@ -164,41 +254,39 @@ describe("ManageSiteModal", () => {
           locationState: "MA",
           powerCapacityMw: 5,
         })}
-        onSave={() => Promise.resolve(null)}
-        onEditDetails={noop}
-        onDeleteRequested={noop}
-        onDismiss={noop}
       />,
     );
     expect(screen.getByText("East DC, Boston, MA")).toBeInTheDocument();
     expect(screen.getByText("5 MW, 0 buildings")).toBeInTheDocument();
   });
 
-  it("renders rack count as a subtitle and kebab-removes a building from the working set", () => {
+  it("renders rack count as a subtitle and kebab-remove unassigns immediately", async () => {
     seedBuildings([{ id: 1n, name: "Building A", siteId: 7n, rackCount: 3n }]);
-    const site = create(SiteSchema, { id: 7n, name: "East DC" });
-    render(
-      <ManageSiteModal
-        open
-        mode="edit"
-        site={site}
-        draft={draft({ name: "East DC" })}
-        onSave={() => Promise.resolve(null)}
-        onEditDetails={noop}
-        onDeleteRequested={noop}
-        onDismiss={noop}
-      />,
-    );
+    const onRemoveBuilding = vi.fn().mockResolvedValue(true);
+    render(<ManageSiteModal {...baseProps} onRemoveBuilding={onRemoveBuilding} />);
 
     // Rack count renders as the row subtitle (not a trailing column).
     expect(screen.getByTestId("manage-site-modal-building-row-1")).toBeInTheDocument();
     expect(screen.getByText("3 racks")).toBeInTheDocument();
 
-    // Open the kebab and remove — the row drops from the list locally.
     fireEvent.click(screen.getByTestId("manage-site-modal-building-menu-1"));
     fireEvent.click(screen.getByTestId("manage-site-modal-remove-building-1"));
-    expect(screen.queryByTestId("manage-site-modal-building-row-1")).not.toBeInTheDocument();
+
+    await waitFor(() => expect(onRemoveBuilding).toHaveBeenCalledWith(1n, "Building A"));
+    await waitFor(() => expect(screen.queryByTestId("manage-site-modal-building-row-1")).not.toBeInTheDocument());
     // Empty state takes over once the last building is removed.
     expect(screen.getByText("No buildings added to this site")).toBeInTheDocument();
+  });
+
+  it("keeps the row when the unassign fails", async () => {
+    seedBuildings([{ id: 1n, name: "Building A", siteId: 7n, rackCount: 3n }]);
+    const onRemoveBuilding = vi.fn().mockResolvedValue(false);
+    render(<ManageSiteModal {...baseProps} onRemoveBuilding={onRemoveBuilding} />);
+
+    fireEvent.click(screen.getByTestId("manage-site-modal-building-menu-1"));
+    fireEvent.click(screen.getByTestId("manage-site-modal-remove-building-1"));
+
+    await waitFor(() => expect(onRemoveBuilding).toHaveBeenCalled());
+    expect(screen.getByTestId("manage-site-modal-building-row-1")).toBeInTheDocument();
   });
 });

--- a/client/src/protoFleet/features/sites/components/ManageSiteModal/ManageSiteModal.tsx
+++ b/client/src/protoFleet/features/sites/components/ManageSiteModal/ManageSiteModal.tsx
@@ -1,11 +1,19 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { create } from "@bufbuild/protobuf";
 
 import ManageBuildingsModal from "../ManageBuildingsModal";
-import { useBuildings } from "@/protoFleet/api/buildings";
-import { type BuildingWithCounts } from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
-import { type Site } from "@/protoFleet/api/generated/sites/v1/sites_pb";
+import {
+  type BuildingFormValues,
+  type BulkCreateBuildingError,
+  emptyBuildingFormValues,
+  type NewBuildingInput,
+  useBuildings,
+} from "@/protoFleet/api/buildings";
+import { type Building, type BuildingWithCounts } from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
+import { type Site, SiteWithCountsSchema } from "@/protoFleet/api/generated/sites/v1/sites_pb";
 import { type SiteFormValues } from "@/protoFleet/api/sites";
 import FullScreenTwoPaneModal from "@/protoFleet/components/FullScreenTwoPaneModal";
+import BuildingSettingsModal from "@/protoFleet/features/buildings/components/BuildingSettingsModal";
 import { formatSiteAddress } from "@/protoFleet/features/sites/formatAddress";
 import { Ellipsis } from "@/shared/assets/icons";
 import Button, { sizes, variants } from "@/shared/components/Button";
@@ -13,36 +21,39 @@ import Header from "@/shared/components/Header";
 import PlaceholderBlock from "@/shared/components/PlaceholderBlock";
 import { useEscapeDismiss } from "@/shared/hooks/useEscapeDismiss";
 
-export type ManageSiteModalMode = "create" | "edit";
-
-// One building in the modal's working set. Seeded from the server fetch and
-// mutated locally by the Manage buildings picker; persisted on Save.
+// One building shown in the modal's list. Seeded from the server fetch and
+// re-synced after each membership write (the picker's Save and the row-level
+// Remove both commit immediately, so this list mirrors the server rather than
+// staging a pending edit).
 interface BuildingEntry {
   buildingId: bigint;
   label: string;
   rackCount: bigint;
 }
 
-// Net membership change between the load-time snapshot and the working set,
-// computed on Save and applied by the host via AssignBuildingsToSite.
-export interface BuildingMembershipDelta {
-  added: bigint[];
-  removed: bigint[];
-}
-
 interface ManageSiteModalProps {
   open: boolean;
-  mode: ManageSiteModalMode;
   draft: SiteFormValues;
-  // In edit mode the parent has a Site row to drive the right-pane preview
-  // header off; in create mode there is no row yet so the preview uses the
-  // draft values directly.
-  site?: Site;
-  // Persisted at save time. In edit mode the delta is applied via
-  // AssignBuildingsToSite; in create mode the host first creates the site
-  // (the delta is empty since building management is gated until the site
-  // exists). Returns whether the modal should close on success.
-  onSave: (delta: BuildingMembershipDelta) => Promise<{ closeOnSuccess: boolean } | null>;
+  // The site is always persisted by the time this modal opens (the create
+  // flow's Continue creates it up front), so it drives the right-pane preview
+  // header and the site_id for building writes.
+  site: Site;
+  // Applies the buildings picker's membership delta via AssignBuildingsToSite.
+  // Resolves true on success; a false result leaves the picker open to retry.
+  onAssignBuildings: (delta: { added: bigint[]; removed: bigint[] }) => Promise<boolean>;
+  // Row-level "Remove building" — unassigns it from this site immediately.
+  onRemoveBuilding: (buildingId: bigint, label: string) => Promise<boolean>;
+  // Creates a new building against this site and returns the created row (or
+  // null on failure). The building is associated to the site atomically, so
+  // the modal injects the returned row into its working set without a refetch.
+  onCreateBuilding: (values: BuildingFormValues) => Promise<Building | null>;
+  // Bulk sibling of onCreateBuilding, wired to the all-or-nothing
+  // CreateBuildings RPC. `created` is empty when nothing was written, and
+  // `errors` names the rows the server rejected so the preview can mark them.
+  // Omit to leave the create modal single-only.
+  onCreateBuildings?: (
+    buildings: NewBuildingInput[],
+  ) => Promise<{ created: Building[]; errors: BulkCreateBuildingError[] }>;
   // Opens SiteSettingsModal stacked on top to edit name / address / etc.
   onEditDetails: () => void;
   // Opens the cascade delete dialog (edit) or discards the pending create.
@@ -77,15 +88,15 @@ const BuildingRow = ({
   label: string;
   rackCount: bigint;
   saving: boolean;
-  onRemove: (buildingId: bigint) => void;
+  onRemove: (buildingId: bigint, label: string) => void;
 }) => {
   const [showMenu, setShowMenu] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
 
   const handleRemove = useCallback(() => {
     setShowMenu(false);
-    onRemove(buildingId);
-  }, [buildingId, onRemove]);
+    onRemove(buildingId, label);
+  }, [buildingId, label, onRemove]);
 
   useEscapeDismiss(showMenu ? () => setShowMenu(false) : undefined);
 
@@ -146,10 +157,12 @@ const BuildingRow = ({
 
 const ManageSiteModal = ({
   open,
-  mode,
   draft,
   site,
-  onSave,
+  onAssignBuildings,
+  onRemoveBuilding,
+  onCreateBuilding,
+  onCreateBuildings,
   onEditDetails,
   onDeleteRequested,
   onDismiss,
@@ -159,22 +172,18 @@ const ManageSiteModal = ({
   unassignedMinerCount,
 }: ManageSiteModalProps) => {
   const { listBuildingsBySite } = useBuildings();
-  // undefined = loading; [] = loaded-empty. Working set the operator edits
-  // via the picker before Save.
+  // undefined = loading; [] = loaded-empty. Mirrors the site's committed
+  // membership — every mutation in this modal writes before updating it.
   const [entries, setEntries] = useState<BuildingEntry[] | undefined>(undefined);
   const [showManageBuildings, setShowManageBuildings] = useState(false);
+  // null = closed; otherwise which side of the create modal's Single / Multiple
+  // toggle the picker's two create buttons asked for.
+  const [createBuilding, setCreateBuilding] = useState<"single" | "multiple" | null>(null);
 
-  // Snapshot of the building ids present at load time so Save can diff the
-  // working set into add / remove buckets for AssignBuildingsToSite.
-  const initialIdsRef = useRef<Set<string>>(new Set());
-
-  // Only fetch when edit mode has a persisted site; create mode renders an
-  // empty working set until the first Save lands a row. Skipping the effect
-  // for the no-fetch branches keeps the setState-in-effect lint clean.
-  const shouldFetchBuildings = open && mode === "edit" && site !== undefined;
-  const fetchSiteId = shouldFetchBuildings ? site.id : undefined;
+  const shouldFetchBuildings = open;
+  const fetchSiteId = site.id;
   useEffect(() => {
-    if (!shouldFetchBuildings || fetchSiteId === undefined) return;
+    if (!shouldFetchBuildings) return;
     const controller = new AbortController();
     void listBuildingsBySite({
       siteId: fetchSiteId,
@@ -188,45 +197,41 @@ const ManageSiteModal = ({
             rackCount: r.rackCount,
           }));
         setEntries(seeded);
-        initialIdsRef.current = new Set(seeded.map((e) => e.buildingId.toString()));
       },
       onError: () => {
         setEntries([]);
-        initialIdsRef.current = new Set();
       },
     });
     return () => controller.abort();
   }, [shouldFetchBuildings, fetchSiteId, listBuildingsBySite, buildingsRefreshKey]);
 
-  // Create mode never fetches (there's no persisted site yet) but still keeps
-  // a working set: buildings the operator stages via the picker before the
-  // first Save, which the host then assigns to the freshly-created site.
-  // `entries` starts undefined there, so fall back to an empty (loaded, not
-  // loading) list rather than the edit-mode loading skeleton.
-  const displayEntries: BuildingEntry[] | undefined = useMemo(
-    () => (shouldFetchBuildings ? entries : (entries ?? [])),
-    [shouldFetchBuildings, entries],
-  );
   const sortedEntries = useMemo(
-    () => (displayEntries ? [...displayEntries].sort((a, b) => a.label.localeCompare(b.label)) : undefined),
-    [displayEntries],
+    () => (entries ? [...entries].sort((a, b) => a.label.localeCompare(b.label)) : undefined),
+    [entries],
   );
 
-  const previewTitle = (site?.name || draft.name || "Untitled site").trim();
+  const previewTitle = (site.name || draft.name || "Untitled site").trim();
   const previewLocation = useMemo(() => formatSiteAddress(draft) || "—", [draft]);
   const previewCapacity = draft.powerCapacityMw > 0 ? `${draft.powerCapacityMw} MW` : "—";
   const buildingCount = sortedEntries?.length ?? 0;
-  const currentBuildingIds = useMemo(() => (displayEntries ?? []).map((e) => e.buildingId), [displayEntries]);
+  const currentBuildingIds = useMemo(() => (entries ?? []).map((e) => e.buildingId), [entries]);
+  // The inline building-create dropdown is always locked to this site, so a
+  // one-element list built from `site` is all BuildingSettingsModal needs — and
+  // it sidesteps the brief window right after create-on-Continue where the
+  // page's site catalog hasn't refetched the new row yet.
+  const buildingCreateSites = useMemo(() => [create(SiteWithCountsSchema, { site })], [site]);
 
-  // Picker confirm — apply the delta against the working set. `added` joins
-  // entries without disturbing existing rows; `removed` drops only those
-  // entries. Buildings in neither list are untouched, so a seeded building
-  // the picker's listBuildings response omitted (race / paging gap) is
-  // preserved. Mirrors ManageBuildingModal.handleManageRacksConfirm.
-  const handleManageBuildingsConfirm = (delta: {
+  // Picker Save — the write already happened by the time this resolves, so
+  // mirror it into the list. `added` joins without disturbing existing rows;
+  // `removed` drops only those entries. Buildings in neither list are
+  // untouched, so a member the picker's listBuildings response omitted (race /
+  // paging gap) is preserved. A failed write leaves the picker open to retry.
+  const handleManageBuildingsConfirm = async (delta: {
     added: { buildingId: bigint; label: string }[];
     removed: bigint[];
   }) => {
+    const ok = await onAssignBuildings({ added: delta.added.map((a) => a.buildingId), removed: delta.removed });
+    if (!ok) return;
     const removedSet = new Set(delta.removed.map((id) => id.toString()));
     setEntries((prev) => {
       const kept = (prev ?? []).filter((e) => !removedSet.has(e.buildingId.toString()));
@@ -241,22 +246,55 @@ const ManageSiteModal = ({
     setShowManageBuildings(false);
   };
 
-  // Kebab "Remove building" — drop it from the working set. Persisted on
-  // Save as a `removed` delta entry, which moves the building to
-  // "Unassigned" (the building itself is not deleted).
-  const handleRemoveBuilding = useCallback((buildingId: bigint) => {
-    setEntries((prev) => (prev ?? []).filter((e) => e.buildingId !== buildingId));
-  }, []);
+  // Kebab "Remove building" — unassigns immediately (moves the building to
+  // "Unassigned"; the building itself is not deleted). Drop the row only once
+  // the write lands so a failure leaves the list truthful.
+  const handleRemoveBuilding = useCallback(
+    async (buildingId: bigint, label: string) => {
+      const ok = await onRemoveBuilding(buildingId, label);
+      if (!ok) return;
+      setEntries((prev) => (prev ?? []).filter((e) => e.buildingId !== buildingId));
+    },
+    [onRemoveBuilding],
+  );
 
-  const handleSave = async () => {
-    const initial = initialIdsRef.current;
-    const current = new Set((displayEntries ?? []).map((e) => e.buildingId.toString()));
-    const added = [...current].filter((id) => !initial.has(id)).map((id) => BigInt(id));
-    const removed = [...initial].filter((id) => !current.has(id)).map((id) => BigInt(id));
-    const result = await onSave({ added, removed });
-    if (!result) return;
-    if (result.closeOnSuccess) onDismiss();
+  // Inline building-create confirm. CreateBuilding already associated the new
+  // building to this site, so inject it into the list rather than refetching.
+  // A failed create returns null (toast shown by the host) and leaves the
+  // create modal open.
+  const handleCreateBuildingSave = async (values: BuildingFormValues) => {
+    const created = await onCreateBuilding(values);
+    if (!created) return;
+    setEntries((prev) => {
+      const next = prev ?? [];
+      if (next.some((e) => e.buildingId === created.id)) return next;
+      return [...next, { buildingId: created.id, label: created.name, rackCount: 0n }];
+    });
+    setCreateBuilding(null);
   };
+
+  // Bulk sibling of handleCreateBuildingSave. Closing is driven by `created`
+  // rather than by an empty `errors`: a skipped dispatch (double-click guard)
+  // returns neither, and the modal should stay open in that case too.
+  const handleCreateBuildingsSave = async (buildings: NewBuildingInput[]): Promise<BulkCreateBuildingError[]> => {
+    if (!onCreateBuildings) return [];
+    const { created, errors } = await onCreateBuildings(buildings);
+    if (created.length === 0) return errors;
+    setEntries((prev) => {
+      const next = prev ?? [];
+      const known = new Set(next.map((e) => e.buildingId.toString()));
+      const newcomers = created
+        .filter((b) => !known.has(b.id.toString()))
+        .map((b) => ({ buildingId: b.id, label: b.name, rackCount: 0n }));
+      return [...next, ...newcomers];
+    });
+    setCreateBuilding(null);
+    return errors;
+  };
+
+  // Feeds the bulk preview's collision check. Undefined while the list is still
+  // loading, so a generated name isn't cleared against a set we haven't read.
+  const existingBuildingNames = useMemo(() => entries?.map((e) => e.label), [entries]);
 
   const buildingsBusy = saving || sortedEntries === undefined;
 
@@ -286,20 +324,21 @@ const ManageSiteModal = ({
             text: "Manage buildings",
             variant: variants.secondary,
             onClick: () => setShowManageBuildings(true),
-            // Enabled in both modes — create stages buildings into the working
-            // set and assigns them on the first Save. Only blocked while the
-            // edit-mode list is still loading (sortedEntries undefined).
+            // Only blocked while the building list is still loading
+            // (sortedEntries undefined).
             disabled: saving || sortedEntries === undefined,
             testId: "manage-site-modal-manage-buildings",
           },
           {
-            text: saving ? "Saving…" : "Save",
+            // Placeholder. Building membership now commits in the picker (and
+            // row-level Remove commits on click), so this modal owns only
+            // building placement within the site — which has no backend yet and
+            // is not tracked by an issue. Until then Save writes nothing and
+            // just closes; deliberately no success toast, since there's nothing
+            // to report.
+            text: "Save",
             variant: variants.primary,
-            onClick: handleSave,
-            // Block Save until the edit-mode building list has loaded.
-            // handleSave diffs the working set against initialIdsRef; firing
-            // it while entries are still undefined would diff against an empty
-            // (or stale) working set and unassign buildings on save.
+            onClick: onDismiss,
             disabled: buildingsBusy,
             testId: "manage-site-modal-save",
           },
@@ -316,6 +355,8 @@ const ManageSiteModal = ({
               ) : sortedEntries.length === 0 ? (
                 <div className="flex flex-col items-center gap-3 rounded-xl border border-dashed border-border-5 p-6 text-center text-300 text-text-primary-50">
                   <span>No buildings added to this site</span>
+                  {/* Single affordance — the picker itself carries the
+                      "New building" hand-off for creating one from scratch. */}
                   <Button
                     variant={variants.primary}
                     size={sizes.compact}
@@ -374,10 +415,7 @@ const ManageSiteModal = ({
                 {sortedEntries === undefined ? (
                   <PlaceholderBlock label="Loading buildings…" className="h-20 w-[120px]" />
                 ) : sortedEntries.length === 0 ? (
-                  <PlaceholderBlock
-                    label={mode === "create" ? "No buildings yet" : "No buildings in this site"}
-                    className="h-20 w-[120px]"
-                  />
+                  <PlaceholderBlock label="No buildings in this site" className="h-20 w-[120px]" />
                 ) : (
                   sortedEntries.map((b) => (
                     <PlaceholderBlock key={b.buildingId.toString()} label={b.label} className="h-20 w-[120px]" />
@@ -390,15 +428,54 @@ const ManageSiteModal = ({
       />
 
       {showManageBuildings ? (
-        // siteId 0n in create mode (no persisted site yet): the picker treats
-        // every unassigned building as eligible and disables buildings already
-        // in another site, which is exactly the create-time rule.
         <ManageBuildingsModal
           open={showManageBuildings}
-          siteId={site?.id ?? 0n}
+          siteId={site.id}
           initialSelectedBuildingIds={currentBuildingIds}
           onDismiss={() => setShowManageBuildings(false)}
           onConfirm={handleManageBuildingsConfirm}
+          saving={saving}
+          // Either create button swaps the picker for the create modal,
+          // abandoning any unsaved checkbox changes — the picker's Save is what
+          // commits membership, so leaving without it writes nothing.
+          onCreateNewLaunch={() => {
+            setShowManageBuildings(false);
+            setCreateBuilding("single");
+          }}
+          // Only offered when the host wired the batch RPC; without it the
+          // create modal has no Multiple side to open on.
+          onCreateMultipleLaunch={
+            onCreateBuildings
+              ? () => {
+                  setShowManageBuildings(false);
+                  setCreateBuilding("multiple");
+                }
+              : undefined
+          }
+        />
+      ) : null}
+
+      {createBuilding ? (
+        // Create a building already attached to this site. The Site dropdown is
+        // locked to `site` (initialSiteId set), matching the site-scoped
+        // building-create entry point elsewhere.
+        <BuildingSettingsModal
+          open
+          mode="create"
+          initialValues={emptyBuildingFormValues()}
+          sites={buildingCreateSites}
+          initialSiteId={site.id}
+          parentSiteLabel={previewTitle}
+          onSave={async (values) => {
+            await handleCreateBuildingSave(values);
+          }}
+          // Present only when the host wired the batch RPC — that's what shows
+          // the Single / Multiple toggle inside the create modal.
+          onSaveBulk={onCreateBuildings ? (buildings) => handleCreateBuildingsSave(buildings) : undefined}
+          initialCreateVariant={createBuilding}
+          existingBuildingNames={existingBuildingNames}
+          onDismiss={() => setCreateBuilding(null)}
+          saving={saving}
         />
       ) : null}
     </>

--- a/client/src/protoFleet/features/sites/components/ManageSiteModal/index.ts
+++ b/client/src/protoFleet/features/sites/components/ManageSiteModal/index.ts
@@ -1,4 +1,3 @@
 import ManageSiteModal from "./ManageSiteModal";
 
-export type { ManageSiteModalMode } from "./ManageSiteModal";
 export default ManageSiteModal;

--- a/client/src/protoFleet/features/sites/components/SiteModals/SiteBuildingsPicker.tsx
+++ b/client/src/protoFleet/features/sites/components/SiteModals/SiteBuildingsPicker.tsx
@@ -1,0 +1,112 @@
+// The buildings picker as a standalone flow, with no ManageSiteModal behind
+// it. Hosts that already render the site (SiteDetailPage) open membership
+// editing directly; stacking the whole manage surface underneath would put a
+// layer on screen the operator never asked for.
+//
+// Exists as its own component rather than inline in SiteModals because the
+// "New building" hand-off needs local state, and SiteModals is otherwise a
+// pure switch over modal state.
+
+import { useState } from "react";
+import { create } from "@bufbuild/protobuf";
+
+import ManageBuildingsModal from "../ManageBuildingsModal";
+import {
+  type BuildingFormValues,
+  type BulkCreateBuildingError,
+  emptyBuildingFormValues,
+  type NewBuildingInput,
+} from "@/protoFleet/api/buildings";
+import { type Building } from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
+import { type Site, SiteWithCountsSchema } from "@/protoFleet/api/generated/sites/v1/sites_pb";
+import BuildingSettingsModal from "@/protoFleet/features/buildings/components/BuildingSettingsModal";
+import { type BulkBuildingCreateResult, type SiteBuildingRef } from "@/protoFleet/features/sites/hooks/useSiteModals";
+
+interface SiteBuildingsPickerProps {
+  site: Site;
+  // Buildings already in the site, from the host's own list.
+  currentBuildings: SiteBuildingRef[];
+  onAssignBuildings: (delta: { added: bigint[]; removed: bigint[] }) => Promise<boolean>;
+  onCreateBuilding: (values: BuildingFormValues) => Promise<Building | null>;
+  onCreateBuildings: (buildings: NewBuildingInput[]) => Promise<BulkBuildingCreateResult>;
+  onDismiss: () => void;
+  saving: boolean;
+}
+
+const SiteBuildingsPicker = ({
+  site,
+  currentBuildings,
+  onAssignBuildings,
+  onCreateBuilding,
+  onCreateBuildings,
+  onDismiss,
+  saving,
+}: SiteBuildingsPickerProps) => {
+  // null = showing the picker; otherwise which side of the create modal's
+  // Single / Multiple toggle to open on.
+  const [creating, setCreating] = useState<"single" | "multiple" | null>(null);
+
+  const handleConfirm = async (delta: { added: { buildingId: bigint; label: string }[]; removed: bigint[] }) => {
+    const ok = await onAssignBuildings({ added: delta.added.map((a) => a.buildingId), removed: delta.removed });
+    // A failed write leaves the picker open so the selection can be retried.
+    if (ok) onDismiss();
+  };
+
+  // Create already attaches the building to this site, so there is nothing
+  // left to commit — close the whole flow rather than returning to a picker
+  // whose only new row would already read "In this site". The host's list
+  // refreshes because pickerCreateBuilding(s) calls refetchBuildings.
+  const handleCreateSave = async (values: BuildingFormValues) => {
+    const created = await onCreateBuilding(values);
+    if (created) onDismiss();
+  };
+
+  const handleCreateBulkSave = async (buildings: NewBuildingInput[]): Promise<BulkCreateBuildingError[]> => {
+    const { created, errors } = await onCreateBuildings(buildings);
+    if (created.length > 0) onDismiss();
+    return errors;
+  };
+
+  if (creating) {
+    return (
+      <BuildingSettingsModal
+        open
+        mode="create"
+        initialValues={emptyBuildingFormValues()}
+        // One-element catalog: the Site dropdown is locked to this site
+        // anyway, so there is no reason to plumb the host's whole list in.
+        sites={[create(SiteWithCountsSchema, { site })]}
+        initialSiteId={site.id}
+        parentSiteLabel={site.name}
+        onSave={async (values) => {
+          await handleCreateSave(values);
+        }}
+        // Present unconditionally — this is what shows the Single / Multiple
+        // toggle inside the create modal.
+        onSaveBulk={handleCreateBulkSave}
+        initialCreateVariant={creating}
+        existingBuildingNames={currentBuildings.map((b) => b.name)}
+        onDismiss={() => setCreating(null)}
+        saving={saving}
+      />
+    );
+  }
+
+  return (
+    <ManageBuildingsModal
+      open
+      siteId={site.id}
+      initialSelectedBuildingIds={currentBuildings.map((b) => b.id)}
+      onDismiss={onDismiss}
+      onConfirm={handleConfirm}
+      saving={saving}
+      // Swapping to create abandons the pending selection, same as in
+      // ManageSiteModal: the picker's Save is what writes membership. Both
+      // buttons are offered here — this host always wires the batch RPC.
+      onCreateNewLaunch={() => setCreating("single")}
+      onCreateMultipleLaunch={() => setCreating("multiple")}
+    />
+  );
+};
+
+export default SiteBuildingsPicker;

--- a/client/src/protoFleet/features/sites/components/SiteModals/SiteModals.test.tsx
+++ b/client/src/protoFleet/features/sites/components/SiteModals/SiteModals.test.tsx
@@ -20,24 +20,35 @@ const makeModals = (overrides: Partial<SiteModalsApi> = {}): SiteModalsApi => ({
   manageUnassignedMinerCount: undefined,
   openCreate: vi.fn(),
   openManageEdit: vi.fn(),
+  openBuildingsPicker: vi.fn(),
   requestDeleteCurrent: vi.fn(),
   dismiss: vi.fn(),
-  cancelAll: vi.fn(),
   dismissDeleteConfirm: vi.fn(),
   detailsContinueCreate: vi.fn(),
   detailsSaveEdit: vi.fn(),
   manageEditDetails: vi.fn(),
-  manageSave: vi.fn().mockResolvedValue(null),
+  manageCreateBuilding: vi.fn().mockResolvedValue(null),
+  manageCreateBuildings: vi.fn().mockResolvedValue({ created: [], errors: [] }),
+  pickerCreateBuilding: vi.fn().mockResolvedValue(null),
+  pickerCreateBuildings: vi.fn().mockResolvedValue({ created: [], errors: [] }),
+  manageAssignBuildings: vi.fn().mockResolvedValue(true),
+  manageRemoveBuilding: vi.fn().mockResolvedValue(true),
   deleteConfirm: vi.fn().mockResolvedValue(undefined),
   ...overrides,
 });
 
-vi.mock("@/protoFleet/api/buildings", () => ({
+vi.mock("@/protoFleet/api/buildings", async (importActual) => ({
+  ...(await importActual<typeof import("@/protoFleet/api/buildings")>()),
   useBuildings: () => ({
     listBuildingsBySite: vi.fn().mockResolvedValue(undefined),
     listAllBuildings: vi.fn(),
     getBuilding: vi.fn(),
   }),
+}));
+
+vi.mock("@/protoFleet/api/sites", async (importActual) => ({
+  ...(await importActual<typeof import("@/protoFleet/api/sites")>()),
+  useSites: () => ({ listSites: vi.fn() }),
 }));
 
 describe("SiteModals", () => {
@@ -85,19 +96,6 @@ describe("SiteModals", () => {
     expect(screen.getByText(/Delete site "North DC"\?/)).toBeInTheDocument();
   });
 
-  it("Delete in manageCreateEditingDetails calls cancelAll (no cascade dialog)", () => {
-    const modals = makeModals({
-      state: { kind: "manageCreateEditingDetails", draft: { ...emptySiteFormValues(), name: "Pending" } },
-    });
-
-    render(<SiteModals modals={modals} sites={undefined} />);
-
-    fireEvent.click(screen.getByTestId("site-settings-modal-delete"));
-
-    expect(modals.cancelAll).toHaveBeenCalled();
-    expect(modals.requestDeleteCurrent).not.toHaveBeenCalled();
-  });
-
   it("Cancelling the cascade dialog dismisses only the dialog, leaving the underlying modals", () => {
     const site = create(SiteSchema, { id: 42n, name: "North DC" });
     const siteWithCounts = create(SiteWithCountsSchema, {
@@ -117,5 +115,29 @@ describe("SiteModals", () => {
 
     expect(modals.dismissDeleteConfirm).toHaveBeenCalled();
     expect(modals.dismiss).not.toHaveBeenCalled();
+  });
+
+  it("buildingsPicker renders the picker with no manage surface behind it", () => {
+    const site = create(SiteSchema, { id: 42n, name: "North DC" });
+    const modals = makeModals({ state: { kind: "buildingsPicker", site, currentBuildings: [] } });
+
+    render(<SiteModals modals={modals} sites={undefined} />);
+
+    expect(screen.getByTestId("manage-buildings-modal")).toBeInTheDocument();
+    expect(screen.queryByTestId("manage-site-modal-buildings-section")).not.toBeInTheDocument();
+  });
+
+  it("New building in the standalone picker reaches a create modal that still offers Multiple", () => {
+    const site = create(SiteSchema, { id: 42n, name: "North DC" });
+    const modals = makeModals({ state: { kind: "buildingsPicker", site, currentBuildings: [] } });
+
+    render(<SiteModals modals={modals} sites={undefined} />);
+    fireEvent.click(screen.getByTestId("manage-buildings-modal-create-new"));
+
+    // The Single / Multiple toggle only appears when onSaveBulk is wired, and
+    // it's easy to lose by routing the hand-off through a host that doesn't
+    // pass it (BuildingModals doesn't).
+    expect(screen.getByTestId("building-settings-modal")).toBeInTheDocument();
+    expect(screen.getByText("Multiple")).toBeInTheDocument();
   });
 });

--- a/client/src/protoFleet/features/sites/components/SiteModals/SiteModals.tsx
+++ b/client/src/protoFleet/features/sites/components/SiteModals/SiteModals.tsx
@@ -1,6 +1,7 @@
 import ManageSiteModal from "../ManageSiteModal";
 import SiteDeleteDialog from "../SiteDeleteDialog";
 import SiteSettingsModal from "../SiteSettingsModal";
+import SiteBuildingsPicker from "./SiteBuildingsPicker";
 import { type SiteWithCounts } from "@/protoFleet/api/generated/sites/v1/sites_pb";
 import { type useSiteModals } from "@/protoFleet/features/sites/hooks/useSiteModals";
 
@@ -17,44 +18,34 @@ interface SiteModalsProps {
 
 const SiteModals = ({ modals, sites, buildingsRefreshKey }: SiteModalsProps) => {
   const { state, deleteTarget } = modals;
-  const showManage =
-    state.kind === "manageCreate" ||
-    state.kind === "manageEdit" ||
-    state.kind === "manageCreateEditingDetails" ||
-    state.kind === "manageEditEditingDetails";
+  const showManage = state.kind === "manageEdit" || state.kind === "manageEditEditingDetails";
 
-  // Delete in the create flow (whether or not details is stacked) discards
-  // the pending create; edit-flow routes through requestDeleteCurrent which
-  // opens the cascade dialog from the page-level cache.
-  const handleDelete = () => {
-    if (state.kind === "manageCreate" || state.kind === "manageCreateEditingDetails") {
-      modals.cancelAll();
-      return;
-    }
-    modals.requestDeleteCurrent(sites);
-  };
+  // The manage modal is always backed by a persisted site (Continue creates it
+  // up front), so Delete always opens the cascade dialog from the page-level
+  // cache rather than discarding a pending create.
+  const handleDelete = () => modals.requestDeleteCurrent(sites);
 
-  const manageDraft = showManage ? state.draft : undefined;
-  const manageSite = state.kind === "manageEdit" || state.kind === "manageEditEditingDetails" ? state.site : undefined;
-  const manageMode = state.kind === "manageEdit" || state.kind === "manageEditEditingDetails" ? "edit" : "create";
+  const manageSite = showManage ? state.site : undefined;
 
   return (
     <>
       {/* Render ManageSiteModal first so SiteSettingsModal's portal lands
           later in the DOM and naturally stacks on top at the same z-50. */}
-      {showManage && manageDraft ? (
+      {showManage && manageSite ? (
         <ManageSiteModal
-          // Key on the site id so switching directly between sites (or
-          // create → edit) remounts the modal with a fresh building working
-          // set + load-time snapshot, instead of briefly rendering the prior
-          // site's entries until the new fetch resolves. Mirrors how the host
-          // keys ManageBuildingModal on building.id.
-          key={manageSite ? manageSite.id.toString() : "create"}
+          // Key on the site id so switching directly between sites remounts the
+          // modal with a fresh building working set + load-time snapshot,
+          // instead of briefly rendering the prior site's entries until the new
+          // fetch resolves. Mirrors how the host keys ManageBuildingModal on
+          // building.id.
+          key={manageSite.id.toString()}
           open
-          mode={manageMode}
-          draft={manageDraft}
+          draft={state.draft}
           site={manageSite}
-          onSave={modals.manageSave}
+          onAssignBuildings={modals.manageAssignBuildings}
+          onRemoveBuilding={modals.manageRemoveBuilding}
+          onCreateBuilding={modals.manageCreateBuilding}
+          onCreateBuildings={modals.manageCreateBuildings}
           onEditDetails={modals.manageEditDetails}
           onDeleteRequested={handleDelete}
           onDismiss={modals.dismiss}
@@ -64,23 +55,26 @@ const SiteModals = ({ modals, sites, buildingsRefreshKey }: SiteModalsProps) => 
           unassignedMinerCount={modals.manageUnassignedMinerCount}
         />
       ) : null}
+      {state.kind === "buildingsPicker" ? (
+        <SiteBuildingsPicker
+          site={state.site}
+          currentBuildings={state.currentBuildings}
+          onAssignBuildings={modals.manageAssignBuildings}
+          // picker* rather than manage*: with no ManageSiteModal working set to
+          // inject into, the created rows only appear if the host's list is
+          // refetched.
+          onCreateBuilding={modals.pickerCreateBuilding}
+          onCreateBuildings={modals.pickerCreateBuildings}
+          onDismiss={modals.dismiss}
+          saving={modals.saving}
+        />
+      ) : null}
       {state.kind === "detailsCreate" ? (
         <SiteSettingsModal
           open
           mode="create"
           initialValues={state.draft}
           onContinue={modals.detailsContinueCreate}
-          onDismiss={modals.dismiss}
-          saving={modals.saving}
-        />
-      ) : null}
-      {state.kind === "manageCreateEditingDetails" ? (
-        <SiteSettingsModal
-          open
-          mode="createReturn"
-          initialValues={state.draft}
-          onContinue={modals.detailsContinueCreate}
-          onDeleteRequested={handleDelete}
           onDismiss={modals.dismiss}
           saving={modals.saving}
         />

--- a/client/src/protoFleet/features/sites/components/SiteSettingsModal/SiteSettingsModal.test.tsx
+++ b/client/src/protoFleet/features/sites/components/SiteSettingsModal/SiteSettingsModal.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import SiteSettingsModal from "./SiteSettingsModal";
@@ -10,7 +10,7 @@ const baseValues = (overrides: Partial<SiteFormValues> = {}): SiteFormValues => 
 });
 
 describe("SiteSettingsModal — create mode", () => {
-  it("disables Continue until name is set", () => {
+  it("stays clickable with an empty name and explains the problem instead of creating", async () => {
     const onContinue = vi.fn();
     render(
       <SiteSettingsModal
@@ -23,10 +23,44 @@ describe("SiteSettingsModal — create mode", () => {
     );
 
     const continueBtn = screen.getByTestId("site-settings-modal-continue");
-    expect(continueBtn).toBeDisabled();
-
-    fireEvent.change(screen.getByTestId("site-settings-name-input"), { target: { value: "North DC" } });
+    // Deliberately not disabled: a dead button can't say what's missing.
     expect(continueBtn).not.toBeDisabled();
+
+    fireEvent.click(continueBtn);
+
+    expect(onContinue).not.toHaveBeenCalled();
+    expect(screen.getByText("Enter a site name")).toBeInTheDocument();
+
+    // Typing clears the message rather than leaving it stale under a now-valid
+    // field. waitFor because Input keeps the text mounted ~200ms so the
+    // collapse can animate (Input.tsx:114) — it isn't gone synchronously.
+    fireEvent.change(screen.getByTestId("site-settings-name-input"), { target: { value: "North DC" } });
+    await waitFor(() => expect(screen.queryByText("Enter a site name")).not.toBeInTheDocument());
+
+    fireEvent.click(continueBtn);
+    expect(onContinue).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports every invalid field in one pass", () => {
+    const onContinue = vi.fn();
+    render(
+      <SiteSettingsModal
+        open
+        mode="create"
+        initialValues={baseValues()}
+        onContinue={onContinue}
+        onDismiss={() => undefined}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId("site-settings-capacity-input"), { target: { value: "abc" } });
+    fireEvent.click(screen.getByTestId("site-settings-modal-continue"));
+
+    // Both, not just the first — otherwise fixing one reveals the next and the
+    // operator pays a click per problem.
+    expect(screen.getByText("Enter a site name")).toBeInTheDocument();
+    expect(screen.getByText("Enter a number ≥ 0")).toBeInTheDocument();
+    expect(onContinue).not.toHaveBeenCalled();
   });
 
   it("invokes onContinue with typed text + selected dropdown values", () => {
@@ -107,6 +141,79 @@ describe("SiteSettingsModal — edit mode", () => {
     expect((screen.getByTestId("site-settings-capacity-input") as HTMLInputElement).value).toBe("8");
   });
 
+  it("Save with nothing changed closes without calling UpdateSite", () => {
+    const onSave = vi.fn();
+    const onDismiss = vi.fn();
+    render(
+      <SiteSettingsModal
+        open
+        mode="edit"
+        initialValues={baseValues({ name: "East DC", powerCapacityMw: 8 })}
+        onSave={onSave}
+        onDeleteRequested={() => undefined}
+        onDismiss={onDismiss}
+      />,
+    );
+
+    const save = screen.getByTestId("site-settings-modal-save");
+    expect(save).not.toBeDisabled();
+
+    fireEvent.click(save);
+
+    // Keeping what's already there is a legitimate outcome, so this closes
+    // rather than erroring — but it must not claim to have written anything.
+    expect(onSave).not.toHaveBeenCalled();
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats whitespace-only and capacity re-formatting as no change", () => {
+    const onSave = vi.fn();
+    const onDismiss = vi.fn();
+    render(
+      <SiteSettingsModal
+        open
+        mode="edit"
+        initialValues={baseValues({ name: "East DC", powerCapacityMw: 8 })}
+        onSave={onSave}
+        onDeleteRequested={() => undefined}
+        onDismiss={onDismiss}
+      />,
+    );
+
+    // The no-diff check compares the same normalized shape buildValues
+    // produces, so neither of these is a real edit.
+    fireEvent.change(screen.getByTestId("site-settings-name-input"), { target: { value: "East DC  " } });
+    fireEvent.change(screen.getByTestId("site-settings-capacity-input"), { target: { value: "8.0" } });
+    fireEvent.click(screen.getByTestId("site-settings-modal-save"));
+
+    expect(onSave).not.toHaveBeenCalled();
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("a real edit reverted back to the original is no change again", () => {
+    const onSave = vi.fn();
+    const onDismiss = vi.fn();
+    render(
+      <SiteSettingsModal
+        open
+        mode="edit"
+        initialValues={baseValues({ name: "East DC", powerCapacityMw: 8 })}
+        onSave={onSave}
+        onDeleteRequested={() => undefined}
+        onDismiss={onDismiss}
+      />,
+    );
+
+    const nameInput = screen.getByTestId("site-settings-name-input");
+    fireEvent.change(nameInput, { target: { value: "East DC 2" } });
+    fireEvent.change(nameInput, { target: { value: "East DC" } });
+    fireEvent.click(screen.getByTestId("site-settings-modal-save"));
+
+    // Not latched dirty by having been touched.
+    expect(onSave).not.toHaveBeenCalled();
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
   it("Save calls onSave with the typed values", () => {
     const onSave = vi.fn();
     render(
@@ -134,62 +241,6 @@ describe("SiteSettingsModal — edit mode", () => {
         mode="edit"
         initialValues={baseValues({ name: "East DC" })}
         onSave={() => undefined}
-        onDeleteRequested={onDeleteRequested}
-        onDismiss={() => undefined}
-      />,
-    );
-
-    fireEvent.click(screen.getByTestId("site-settings-modal-delete"));
-    expect(onDeleteRequested).toHaveBeenCalled();
-  });
-});
-
-describe("SiteSettingsModal — createReturn mode", () => {
-  it("renders Delete + Save instead of Cancel + Continue", () => {
-    render(
-      <SiteSettingsModal
-        open
-        mode="createReturn"
-        initialValues={baseValues({ name: "North DC" })}
-        onContinue={() => undefined}
-        onDeleteRequested={() => undefined}
-        onDismiss={() => undefined}
-      />,
-    );
-
-    expect(screen.queryByTestId("site-settings-modal-continue")).toBeNull();
-    expect(screen.queryByTestId("site-settings-modal-cancel")).toBeNull();
-    expect(screen.getByTestId("site-settings-modal-delete")).toBeInTheDocument();
-    expect(screen.getByTestId("site-settings-modal-save")).toBeInTheDocument();
-  });
-
-  it("Save invokes onContinue with the current values", () => {
-    const onContinue = vi.fn();
-    render(
-      <SiteSettingsModal
-        open
-        mode="createReturn"
-        initialValues={baseValues({ name: "North DC" })}
-        onContinue={onContinue}
-        onDeleteRequested={() => undefined}
-        onDismiss={() => undefined}
-      />,
-    );
-
-    fireEvent.change(screen.getByTestId("site-settings-name-input"), { target: { value: "North DC 2" } });
-    fireEvent.click(screen.getByTestId("site-settings-modal-save"));
-
-    expect(onContinue).toHaveBeenCalledWith(expect.objectContaining({ name: "North DC 2" }));
-  });
-
-  it("Delete invokes onDeleteRequested (discard pending create)", () => {
-    const onDeleteRequested = vi.fn();
-    render(
-      <SiteSettingsModal
-        open
-        mode="createReturn"
-        initialValues={baseValues({ name: "North DC" })}
-        onContinue={() => undefined}
         onDeleteRequested={onDeleteRequested}
         onDismiss={() => undefined}
       />,

--- a/client/src/protoFleet/features/sites/components/SiteSettingsModal/SiteSettingsModal.tsx
+++ b/client/src/protoFleet/features/sites/components/SiteSettingsModal/SiteSettingsModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 import { type SiteFormValues } from "@/protoFleet/api/sites";
 import {
@@ -14,11 +14,10 @@ import Modal from "@/shared/components/Modal";
 import Select from "@/shared/components/Select";
 import Textarea from "@/shared/components/Textarea";
 
-// "createReturn" is the state when the operator clicks "Edit details" from
-// ManageSiteModal during the create flow — they're already mid-create, so the
-// CTAs read Delete (discard pending site) + Save (apply changes and return to
-// the manage view) instead of Cancel + Continue.
-export type SiteSettingsModalMode = "create" | "createReturn" | "edit";
+// "create" is the initial site-details step. Continue persists the site
+// (CreateSite) and hands off to ManageSiteModal in edit mode; once the site
+// exists, "Edit details" reopens this modal in "edit" mode (UpdateSite).
+export type SiteSettingsModalMode = "create" | "edit";
 
 interface SiteSettingsModalCommonProps {
   open: boolean;
@@ -29,12 +28,7 @@ interface SiteSettingsModalCommonProps {
 
 export type SiteSettingsModalProps = SiteSettingsModalCommonProps &
   (
-    | { mode: "create"; onContinue: (values: SiteFormValues) => void }
-    | {
-        mode: "createReturn";
-        onContinue: (values: SiteFormValues) => void;
-        onDeleteRequested: () => void;
-      }
+    | { mode: "create"; onContinue: (values: SiteFormValues) => Promise<void> | void }
     | {
         mode: "edit";
         onSave: (values: SiteFormValues) => Promise<void> | void;
@@ -64,16 +58,19 @@ const SiteSettingsModal = (props: SiteSettingsModalProps) => {
     initialValues.powerCapacityMw > 0 ? String(initialValues.powerCapacityMw) : "",
   );
   const [capacityError, setCapacityError] = useState<string | null>(null);
+  const [nameError, setNameError] = useState<string | null>(null);
 
+  // Validate-on-submit rather than gating the CTA: a disabled button can't say
+  // what's wrong with the form. Collects every problem in one pass so the
+  // operator sees all of them at once instead of one per click.
   const buildValues = useCallback((): SiteFormValues | null => {
     const capacity = parseCapacity(capacityText);
-    if (capacity === null) {
-      setCapacityError("Enter a number ≥ 0");
-      return null;
-    }
-    setCapacityError(null);
+    const trimmedName = name.trim();
+    setCapacityError(capacity === null ? "Enter a number ≥ 0" : null);
+    setNameError(trimmedName === "" ? "Enter a site name" : null);
+    if (capacity === null || trimmedName === "") return null;
     return {
-      name: name.trim(),
+      name: trimmedName,
       address: address.trim(),
       locationCity: city.trim(),
       locationState: state.trim(),
@@ -86,18 +83,46 @@ const SiteSettingsModal = (props: SiteSettingsModalProps) => {
     };
   }, [name, address, city, state, postalCode, country, timezone, capacityText, notes, initialValues.networkConfig]);
 
+  // Compared against the same normalized shape buildValues produces, so
+  // trailing whitespace or a capacity retyped as "12.50" doesn't read as an
+  // edit. buildValues sets the field errors as a side effect, so the comparison
+  // uses its own parse instead of calling it here.
+  const isDirty = useMemo(() => {
+    const capacity = parseCapacity(capacityText);
+    return (
+      name.trim() !== initialValues.name ||
+      address.trim() !== initialValues.address ||
+      city.trim() !== initialValues.locationCity ||
+      state.trim() !== initialValues.locationState ||
+      postalCode.trim() !== initialValues.postalCode ||
+      (country || "US") !== (initialValues.country || "US") ||
+      timezone !== initialValues.timezone ||
+      capacity !== initialValues.powerCapacityMw ||
+      notes !== initialValues.notes
+    );
+  }, [name, address, city, state, postalCode, country, timezone, capacityText, notes, initialValues]);
+
   const handlePrimary = useCallback(async () => {
     const values = buildValues();
+    // Invalid: the errors buildValues just set are now on the fields.
     if (!values) return;
     if (props.mode === "edit") {
+      // Valid but unchanged. UpdateSite would succeed and report having saved
+      // something it didn't, so close instead of round-tripping. Not an error
+      // state — keeping what's already there is a legitimate outcome.
+      if (!isDirty) {
+        onDismiss();
+        return;
+      }
       await props.onSave(values);
     } else {
-      props.onContinue(values);
+      await props.onContinue(values);
     }
-  }, [buildValues, props]);
+  }, [buildValues, isDirty, onDismiss, props]);
 
-  const nameValid = name.trim().length > 0;
-  const primaryDisabled = !nameValid || saving;
+  // Only the in-flight guard. Validation and the no-diff check both run on
+  // click so they can explain themselves; a disabled CTA can't.
+  const primaryDisabled = saving;
 
   const buttons =
     props.mode === "create"
@@ -106,10 +131,14 @@ const SiteSettingsModal = (props: SiteSettingsModalProps) => {
             text: "Cancel",
             variant: variants.secondary,
             onClick: onDismiss,
+            disabled: saving,
             testId: "site-settings-modal-cancel",
           },
           {
-            text: "Continue",
+            // Named for the write it performs (CreateSite) rather than "Continue"
+            // — the site exists once this lands, even if the operator bails out
+            // of the manage step that follows.
+            text: saving ? "Creating…" : "Create site",
             variant: variants.primary,
             onClick: handlePrimary,
             disabled: primaryDisabled,
@@ -150,15 +179,19 @@ const SiteSettingsModal = (props: SiteSettingsModalProps) => {
           id="site-settings-name"
           label="Name"
           initValue={name}
-          onChange={(v) => setName(v)}
+          onChange={(v) => {
+            setName(v);
+            if (nameError) setNameError(null);
+          }}
           maxLength={255}
           required
           autoFocus
+          error={nameError ?? false}
           testId="site-settings-name-input"
         />
         <Input
           id="site-settings-address"
-          label="Address"
+          label="Address (optional)"
           initValue={address}
           onChange={(v) => setAddress(v)}
           maxLength={255}
@@ -185,7 +218,7 @@ const SiteSettingsModal = (props: SiteSettingsModalProps) => {
         <div className="grid grid-cols-2 gap-4">
           <Input
             id="site-settings-city"
-            label="City"
+            label="City (optional)"
             initValue={city}
             onChange={(v) => setCity(v)}
             maxLength={255}
@@ -193,7 +226,7 @@ const SiteSettingsModal = (props: SiteSettingsModalProps) => {
           />
           <Select
             id="site-settings-state"
-            label={country === "CA" ? "Province" : "State"}
+            label={country === "CA" ? "Province (optional)" : "State (optional)"}
             options={country === "CA" ? CA_PROVINCE_OPTIONS : US_STATE_OPTIONS}
             value={state}
             onChange={(v) => {
@@ -210,7 +243,7 @@ const SiteSettingsModal = (props: SiteSettingsModalProps) => {
         </div>
         <Input
           id="site-settings-postal-code"
-          label="Postal code"
+          label="Postal code (optional)"
           initValue={postalCode}
           onChange={(v) => setPostalCode(v)}
           maxLength={32}
@@ -218,7 +251,7 @@ const SiteSettingsModal = (props: SiteSettingsModalProps) => {
         />
         <Select
           id="site-settings-timezone"
-          label="Timezone"
+          label="Timezone (optional)"
           options={TIMEZONE_OPTIONS}
           value={timezone}
           onChange={setTimezone}
@@ -227,7 +260,7 @@ const SiteSettingsModal = (props: SiteSettingsModalProps) => {
         />
         <Input
           id="site-settings-capacity"
-          label="Power capacity"
+          label="Power capacity (optional)"
           initValue={capacityText}
           onChange={(v) => {
             setCapacityText(v);
@@ -239,7 +272,7 @@ const SiteSettingsModal = (props: SiteSettingsModalProps) => {
         />
         <Textarea
           id="site-settings-notes"
-          label="Notes"
+          label="Notes (optional)"
           initValue={notes}
           onChange={(v) => setNotes(v)}
           rows={4}

--- a/client/src/protoFleet/features/sites/hooks/useSiteModals.test.ts
+++ b/client/src/protoFleet/features/sites/hooks/useSiteModals.test.ts
@@ -282,6 +282,56 @@ describe("useSiteModals", () => {
     expect(refetchSites).toHaveBeenCalled();
   });
 
+  // Refreshing at create time would bump the key ManageSiteModal's own fetch
+  // keys off, reseeding its entries and dropping whatever is staged in the
+  // picker — so the host's list is caught up when the modal closes instead.
+  it("catches the host's building list up when the manage modal closes after an inline create", async () => {
+    vi.mocked(buildingsClient.createBuilding).mockResolvedValue(
+      create(CreateBuildingResponseSchema, {
+        building: create(BuildingSchema, { id: 42n, name: "Bldg A", siteId: 3n }),
+        assignedRackCount: 0n,
+        reassignedDeviceCount: 0n,
+        conflicts: [],
+      }),
+    );
+    const refetchBuildings = vi.fn();
+    const site = create(SiteSchema, { id: 3n, name: "North DC" });
+    const { result } = renderHook(() => useSiteModals({ refetchSites: vi.fn(), refetchBuildings }), { wrapper });
+    act(() => result.current.openManageEdit(site));
+
+    await act(async () => {
+      await result.current.manageCreateBuilding({ ...emptyBuildingFormValues(), name: "Bldg A" });
+    });
+    expect(refetchBuildings).not.toHaveBeenCalled();
+
+    act(() => result.current.dismiss());
+    expect(refetchBuildings).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves the host's building list alone when the manage modal closes with no create", () => {
+    const refetchBuildings = vi.fn();
+    const site = create(SiteSchema, { id: 3n, name: "North DC" });
+    const { result } = renderHook(() => useSiteModals({ refetchSites: vi.fn(), refetchBuildings }), { wrapper });
+
+    act(() => result.current.openManageEdit(site));
+    act(() => result.current.dismiss());
+
+    expect(refetchBuildings).not.toHaveBeenCalled();
+  });
+
+  // Continue creates the site up front, so Delete can be clicked before the
+  // host's refetchSites has landed the new row.
+  it("opens the cascade dialog for a site the host cache has not caught up with", () => {
+    const site = create(SiteSchema, { id: 3n, name: "North DC" });
+    const { result } = renderHook(() => useSiteModals({ refetchSites: vi.fn() }), { wrapper });
+
+    act(() => result.current.openManageEdit(site));
+    act(() => result.current.requestDeleteCurrent([]));
+
+    expect(result.current.deleteTarget?.site?.id).toBe(3n);
+    expect(result.current.deleteTarget?.site?.name).toBe("North DC");
+  });
+
   it("manageCreateBuildings sends the whole batch against the managed site and returns every row", async () => {
     vi.mocked(buildingsClient.createBuildings).mockResolvedValue(
       create(CreateBuildingsResponseSchema, {

--- a/client/src/protoFleet/features/sites/hooks/useSiteModals.test.ts
+++ b/client/src/protoFleet/features/sites/hooks/useSiteModals.test.ts
@@ -5,7 +5,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { create } from "@bufbuild/protobuf";
 
 import { useSiteModals } from "./useSiteModals";
-import { sitesClient } from "@/protoFleet/api/clients";
+import { emptyBuildingFormValues } from "@/protoFleet/api/buildings";
+import { buildingsClient, sitesClient } from "@/protoFleet/api/clients";
+import {
+  BuildingSchema,
+  CreateBuildingResponseSchema,
+  CreateBuildingsResponseSchema,
+  PerBuildingCreateErrorReason,
+} from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
 import {
   AssignBuildingsToSiteResponseSchema,
   type CreateSiteResponse,
@@ -28,6 +35,10 @@ vi.mock("@/protoFleet/api/clients", () => ({
     deleteSite: vi.fn(),
     assignDevicesToSite: vi.fn(),
     assignBuildingsToSite: vi.fn(),
+  },
+  buildingsClient: {
+    createBuilding: vi.fn(),
+    createBuildings: vi.fn(),
   },
 }));
 
@@ -87,49 +98,42 @@ describe("useSiteModals", () => {
     });
   });
 
-  it("detailsContinueCreate round-trips manageCreate ↔ details preserving edited fields", () => {
-    const { result } = renderHook(() => useSiteModals({ refetchSites: vi.fn() }), { wrapper });
+  it("detailsContinueCreate persists the site and opens manageEdit against the new row", async () => {
+    const { create: createResp } = makeSiteResponse(7n, "North DC", "10.0.0.0/24");
+    vi.mocked(sitesClient.createSite).mockResolvedValue(createResp);
+    const refetchSites = vi.fn();
+    const { result } = renderHook(() => useSiteModals({ refetchSites }), { wrapper });
     act(() => result.current.openCreate());
-    act(() =>
-      result.current.detailsContinueCreate({
+
+    await act(async () => {
+      await result.current.detailsContinueCreate({
         ...emptySiteFormValues(),
         name: "North DC",
-        locationCity: "Chicago",
-        locationState: "IL",
-        powerCapacityMw: 5,
-      }),
-    );
-    act(() => result.current.manageEditDetails());
-    expect(result.current.state.kind).toBe("manageCreateEditingDetails");
-    act(() =>
-      result.current.detailsContinueCreate({
-        ...emptySiteFormValues(),
-        name: "North DC 2",
-        locationCity: "Chicago",
-        locationState: "IL",
-        powerCapacityMw: 5,
-      }),
-    );
-    expect(result.current.state.kind).toBe("manageCreate");
-    if (result.current.state.kind === "manageCreate") {
-      expect(result.current.state.draft.name).toBe("North DC 2");
-      expect(result.current.state.draft.powerCapacityMw).toBe(5);
+        networkConfig: "10.0.0.0/24",
+      });
+    });
+
+    expect(sitesClient.createSite).toHaveBeenCalledTimes(1);
+    expect(refetchSites).toHaveBeenCalled();
+    // The manage modal now runs in edit mode against the freshly-created site.
+    expect(result.current.state.kind).toBe("manageEdit");
+    if (result.current.state.kind === "manageEdit") {
+      expect(result.current.state.site.id).toBe(7n);
+      expect(result.current.state.draft.name).toBe("North DC");
     }
   });
 
-  it("dismiss from manageCreateEditingDetails returns to manageCreate", () => {
+  it("detailsContinueCreate stays on details when CreateSite fails", async () => {
+    vi.mocked(sitesClient.createSite).mockRejectedValue(new Error("boom"));
     const { result } = renderHook(() => useSiteModals({ refetchSites: vi.fn() }), { wrapper });
     act(() => result.current.openCreate());
-    act(() =>
-      result.current.detailsContinueCreate({
-        ...emptySiteFormValues(),
-        name: "X",
-      }),
-    );
-    act(() => result.current.manageEditDetails());
-    expect(result.current.state.kind).toBe("manageCreateEditingDetails");
-    act(() => result.current.dismiss());
-    expect(result.current.state.kind).toBe("manageCreate");
+
+    await act(async () => {
+      await result.current.detailsContinueCreate({ ...emptySiteFormValues(), name: "North DC" });
+    });
+
+    // No transition — the operator can fix the input and retry.
+    expect(result.current.state.kind).toBe("detailsCreate");
   });
 
   it("manageEditDetails on manageEdit stacks to manageEditEditingDetails; dismiss drops back to manageEdit", () => {
@@ -142,63 +146,224 @@ describe("useSiteModals", () => {
     expect(result.current.state.kind).toBe("manageEdit");
   });
 
-  it("manageSave on manageCreate runs CreateSite and reports closeOnSuccess", async () => {
-    const { create: createResp } = makeSiteResponse(7n, "North DC", "10.0.0.0/24");
-    vi.mocked(sitesClient.createSite).mockResolvedValue(createResp);
-    const refetchSites = vi.fn();
-    const { result } = renderHook(() => useSiteModals({ refetchSites }), { wrapper });
-    act(() => result.current.openCreate());
-    act(() =>
-      result.current.detailsContinueCreate({
-        ...emptySiteFormValues(),
-        name: "North DC",
-        networkConfig: "10.0.0.0/24",
-      }),
-    );
+  it("openBuildingsPicker opens the picker alone, with no manage surface behind it", () => {
+    const { result } = renderHook(() => useSiteModals({ refetchSites: vi.fn() }), { wrapper });
+    const site = create(SiteSchema, { id: 5n, name: "Dallas" });
 
-    let saveResult: { closeOnSuccess: boolean } | null | undefined;
-    await act(async () => {
-      saveResult = await result.current.manageSave({ added: [], removed: [] });
-    });
+    act(() => result.current.openBuildingsPicker(site, [{ id: 9n, name: "Bldg A" }]));
 
-    await waitFor(() => {
-      expect(sitesClient.createSite).toHaveBeenCalledTimes(1);
+    // Not manageEdit: the host already renders the site, so stacking
+    // ManageSiteModal under a membership edit would be a layer nobody asked for.
+    expect(result.current.state).toMatchObject({
+      kind: "buildingsPicker",
+      currentBuildings: [{ id: 9n, name: "Bldg A" }],
     });
-    // With no staged buildings the create skips the buildings RPC entirely.
-    expect(sitesClient.assignBuildingsToSite).not.toHaveBeenCalled();
-    expect(saveResult?.closeOnSuccess).toBe(true);
-    expect(refetchSites).toHaveBeenCalled();
+    if (result.current.state.kind !== "buildingsPicker") throw new Error("expected buildingsPicker");
+    expect(result.current.state.site.id).toBe(5n);
   });
 
-  it("manageSave on manageCreate assigns staged buildings to the new site", async () => {
-    const { create: createResp } = makeSiteResponse(7n, "North DC");
-    vi.mocked(sitesClient.createSite).mockResolvedValue(createResp);
+  it("manageAssignBuildings targets the site from the standalone picker state", async () => {
     vi.mocked(sitesClient.assignBuildingsToSite).mockResolvedValue(
       create(AssignBuildingsToSiteResponseSchema, { reassignedRackCount: 0n, reassignedDeviceCount: 0n }),
     );
-    const refetchSites = vi.fn();
-    const { result } = renderHook(() => useSiteModals({ refetchSites }), { wrapper });
-    act(() => result.current.openCreate());
-    act(() => result.current.detailsContinueCreate({ ...emptySiteFormValues(), name: "North DC" }));
+    const { result } = renderHook(() => useSiteModals({ refetchSites: vi.fn() }), { wrapper });
 
-    let saveResult: { closeOnSuccess: boolean } | null | undefined;
+    act(() => result.current.openBuildingsPicker(create(SiteSchema, { id: 7n, name: "Dallas" }), []));
     await act(async () => {
-      saveResult = await result.current.manageSave({ added: [11n, 12n], removed: [] });
+      await result.current.manageAssignBuildings({ added: [10n], removed: [] });
     });
 
-    await waitFor(() => {
-      expect(sitesClient.createSite).toHaveBeenCalledTimes(1);
-    });
-    // Staged buildings are assigned to the freshly-created site (id 7).
+    // The write handlers resolve their target from state, so a new state kind
+    // that isn't wired into that lookup silently no-ops instead of writing.
     expect(sitesClient.assignBuildingsToSite).toHaveBeenCalledWith(
-      { buildingIds: [11n, 12n], targetSiteId: 7n },
+      { buildingIds: [10n], targetSiteId: 7n },
       expect.anything(),
     );
-    expect(saveResult?.closeOnSuccess).toBe(true);
+  });
+
+  it("pickerCreateBuilding refreshes the host's building list, unlike its manage sibling", async () => {
+    vi.mocked(buildingsClient.createBuilding).mockResolvedValue(
+      create(CreateBuildingResponseSchema, {
+        building: create(BuildingSchema, { id: 42n, name: "Bldg A", siteId: 7n }),
+        assignedRackCount: 0n,
+        reassignedDeviceCount: 0n,
+        conflicts: [],
+      }),
+    );
+    const refetchBuildings = vi.fn();
+    const { result } = renderHook(() => useSiteModals({ refetchSites: vi.fn(), refetchBuildings }), { wrapper });
+
+    act(() => result.current.openBuildingsPicker(create(SiteSchema, { id: 7n, name: "Dallas" }), []));
+    await act(async () => {
+      await result.current.pickerCreateBuilding({ ...emptyBuildingFormValues(), name: "Bldg A" });
+    });
+
+    // ManageSiteModal injects created rows into its own working set; the
+    // standalone picker has none, so the host's list is the only thing that
+    // renders the new building.
+    expect(refetchBuildings).toHaveBeenCalled();
+  });
+
+  it("pickerCreateBuildings refreshes the host's building list after a batch", async () => {
+    vi.mocked(buildingsClient.createBuildings).mockResolvedValue(
+      create(CreateBuildingsResponseSchema, {
+        buildings: [create(BuildingSchema, { id: 51n, name: "B-1", siteId: 7n })],
+        errors: [],
+      }),
+    );
+    const refetchBuildings = vi.fn();
+    const { result } = renderHook(() => useSiteModals({ refetchSites: vi.fn(), refetchBuildings }), { wrapper });
+
+    act(() => result.current.openBuildingsPicker(create(SiteSchema, { id: 7n, name: "Dallas" }), []));
+    await act(async () => {
+      await result.current.pickerCreateBuildings([{ name: "B-1", aisles: 4, racksPerAisle: 10 }]);
+    });
+
+    expect(refetchBuildings).toHaveBeenCalled();
+  });
+
+  it("pickerCreateBuildings leaves the host's list alone when the batch was rejected", async () => {
+    vi.mocked(buildingsClient.createBuildings).mockResolvedValue(
+      create(CreateBuildingsResponseSchema, {
+        buildings: [],
+        errors: [{ index: 0, name: "B-1", reason: PerBuildingCreateErrorReason.DUPLICATE_NAME_AT_SITE }],
+      }),
+    );
+    const refetchBuildings = vi.fn();
+    const { result } = renderHook(() => useSiteModals({ refetchSites: vi.fn(), refetchBuildings }), { wrapper });
+
+    act(() => result.current.openBuildingsPicker(create(SiteSchema, { id: 7n, name: "Dallas" }), []));
+    await act(async () => {
+      await result.current.pickerCreateBuildings([{ name: "B-1", aisles: 4, racksPerAisle: 10 }]);
+    });
+
+    // Nothing was written, so refetching would only cost a round trip.
+    expect(refetchBuildings).not.toHaveBeenCalled();
+  });
+
+  it("manageCreateBuilding creates a building against the managed site and returns it", async () => {
+    vi.mocked(buildingsClient.createBuilding).mockResolvedValue(
+      create(CreateBuildingResponseSchema, {
+        building: create(BuildingSchema, { id: 42n, name: "Bldg A", siteId: 3n }),
+        assignedRackCount: 0n,
+        reassignedDeviceCount: 0n,
+        conflicts: [],
+      }),
+    );
+    const refetchSites = vi.fn();
+    const site = create(SiteSchema, { id: 3n, name: "North DC" });
+    const { result } = renderHook(() => useSiteModals({ refetchSites }), { wrapper });
+    act(() => result.current.openManageEdit(site));
+
+    let created: Awaited<ReturnType<typeof result.current.manageCreateBuilding>> | undefined;
+    await act(async () => {
+      created = await result.current.manageCreateBuilding({
+        name: "Bldg A",
+        description: "",
+        powerCapacityMw: 0,
+        overheadKw: 0,
+        aisles: 0,
+        racksPerAisle: 0,
+        physicalRackCount: 0,
+        defaultRackRows: 0,
+        defaultRackColumns: 0,
+        defaultRackOrderIndex: 0,
+      });
+    });
+
+    // Created against the currently-managed site (id 3).
+    expect(buildingsClient.createBuilding).toHaveBeenCalledWith(
+      expect.objectContaining({ siteId: 3n, name: "Bldg A" }),
+      expect.anything(),
+    );
+    expect(created?.id).toBe(42n);
+    // Site catalog is refreshed for the building count; the modal injects the
+    // row itself, so the building list is deliberately not refetched here.
     expect(refetchSites).toHaveBeenCalled();
   });
 
-  it("manageSave on manageEdit applies the building delta via AssignBuildingsToSite", async () => {
+  it("manageCreateBuildings sends the whole batch against the managed site and returns every row", async () => {
+    vi.mocked(buildingsClient.createBuildings).mockResolvedValue(
+      create(CreateBuildingsResponseSchema, {
+        buildings: [
+          create(BuildingSchema, { id: 51n, name: "B-1", siteId: 3n }),
+          create(BuildingSchema, { id: 52n, name: "B-2", siteId: 3n }),
+        ],
+        errors: [],
+      }),
+    );
+    const refetchSites = vi.fn();
+    const site = create(SiteSchema, { id: 3n, name: "North DC" });
+    const { result } = renderHook(() => useSiteModals({ refetchSites }), { wrapper });
+    act(() => result.current.openManageEdit(site));
+
+    let outcome: Awaited<ReturnType<typeof result.current.manageCreateBuildings>> | undefined;
+    await act(async () => {
+      outcome = await result.current.manageCreateBuildings([
+        { name: "B-1", aisles: 4, racksPerAisle: 10 },
+        { name: "B-2", aisles: 4, racksPerAisle: 10 },
+      ]);
+    });
+
+    // One call for the whole batch — the transaction is what makes the set
+    // all-or-nothing, so it must not be split per name.
+    expect(buildingsClient.createBuildings).toHaveBeenCalledTimes(1);
+    expect(buildingsClient.createBuildings).toHaveBeenCalledWith(
+      expect.objectContaining({
+        siteId: 3n,
+        buildings: [
+          expect.objectContaining({ name: "B-1", aisles: 4, racksPerAisle: 10 }),
+          expect.objectContaining({ name: "B-2", aisles: 4, racksPerAisle: 10 }),
+        ],
+      }),
+      expect.anything(),
+    );
+    expect(outcome?.created.map((b) => b.id)).toEqual([51n, 52n]);
+    expect(outcome?.errors).toEqual([]);
+    expect(refetchSites).toHaveBeenCalled();
+  });
+
+  it("manageCreateBuildings reports per-row rejections and creates nothing", async () => {
+    vi.mocked(buildingsClient.createBuildings).mockResolvedValue(
+      create(CreateBuildingsResponseSchema, {
+        buildings: [],
+        errors: [{ index: 1, name: "B-2", reason: PerBuildingCreateErrorReason.DUPLICATE_NAME_AT_SITE }],
+      }),
+    );
+    const refetchSites = vi.fn();
+    const site = create(SiteSchema, { id: 3n, name: "North DC" });
+    const { result } = renderHook(() => useSiteModals({ refetchSites }), { wrapper });
+    act(() => result.current.openManageEdit(site));
+
+    let outcome: Awaited<ReturnType<typeof result.current.manageCreateBuildings>> | undefined;
+    await act(async () => {
+      outcome = await result.current.manageCreateBuildings([
+        { name: "B-1", aisles: 4, racksPerAisle: 10 },
+        { name: "B-2", aisles: 4, racksPerAisle: 10 },
+      ]);
+    });
+
+    // Empty `created` is what keeps the create modal open; the reasons let it
+    // mark the offending preview row.
+    expect(outcome?.created).toEqual([]);
+    expect(outcome?.errors).toEqual([
+      { index: 1, name: "B-2", reason: PerBuildingCreateErrorReason.DUPLICATE_NAME_AT_SITE },
+    ]);
+  });
+
+  it("manageCreateBuildings does nothing when no site is being managed", async () => {
+    const { result } = renderHook(() => useSiteModals({ refetchSites: vi.fn() }), { wrapper });
+
+    let outcome: Awaited<ReturnType<typeof result.current.manageCreateBuildings>> | undefined;
+    await act(async () => {
+      outcome = await result.current.manageCreateBuildings([{ name: "B-1" }]);
+    });
+
+    expect(buildingsClient.createBuildings).not.toHaveBeenCalled();
+    expect(outcome).toEqual({ created: [], errors: [] });
+  });
+
+  it("manageAssignBuildings applies the picker delta via AssignBuildingsToSite", async () => {
     vi.mocked(sitesClient.assignBuildingsToSite).mockResolvedValue(
       create(AssignBuildingsToSiteResponseSchema, { reassignedRackCount: 0n, reassignedDeviceCount: 0n }),
     );
@@ -208,9 +373,9 @@ describe("useSiteModals", () => {
     const { result } = renderHook(() => useSiteModals({ refetchSites, refetchBuildings }), { wrapper });
     act(() => result.current.openManageEdit(site));
 
-    let saveResult: { closeOnSuccess: boolean } | null | undefined;
+    let ok: boolean | undefined;
     await act(async () => {
-      saveResult = await result.current.manageSave({ added: [10n], removed: [20n] });
+      ok = await result.current.manageAssignBuildings({ added: [10n], removed: [20n] });
     });
 
     // Two calls: removed → "Unassigned" (no target), added → this site.
@@ -225,23 +390,44 @@ describe("useSiteModals", () => {
       { buildingIds: [10n], targetSiteId: 3n },
       expect.anything(),
     );
-    expect(saveResult?.closeOnSuccess).toBe(true);
+    expect(ok).toBe(true);
     expect(refetchSites).toHaveBeenCalled();
     // Membership changed building rows, so the building table refresh fires too.
     expect(refetchBuildings).toHaveBeenCalled();
   });
 
-  it("manageSave on manageEdit with an empty delta closes without an RPC", async () => {
+  it("manageAssignBuildings with an empty delta fires no RPC", async () => {
     const { result } = renderHook(() => useSiteModals({ refetchSites: vi.fn() }), { wrapper });
     act(() => result.current.openManageEdit(create(SiteSchema, { id: 3n, name: "North DC" })));
 
-    let saveResult: { closeOnSuccess: boolean } | null | undefined;
+    let ok: boolean | undefined;
     await act(async () => {
-      saveResult = await result.current.manageSave({ added: [], removed: [] });
+      ok = await result.current.manageAssignBuildings({ added: [], removed: [] });
     });
 
     expect(sitesClient.assignBuildingsToSite).not.toHaveBeenCalled();
-    expect(saveResult?.closeOnSuccess).toBe(true);
+    expect(ok).toBe(true);
+  });
+
+  it("manageRemoveBuilding unassigns the building immediately", async () => {
+    vi.mocked(sitesClient.assignBuildingsToSite).mockResolvedValue(
+      create(AssignBuildingsToSiteResponseSchema, { reassignedRackCount: 0n, reassignedDeviceCount: 0n }),
+    );
+    const refetchSites = vi.fn();
+    const { result } = renderHook(() => useSiteModals({ refetchSites }), { wrapper });
+    act(() => result.current.openManageEdit(create(SiteSchema, { id: 3n, name: "North DC" })));
+
+    let ok: boolean | undefined;
+    await act(async () => {
+      ok = await result.current.manageRemoveBuilding(20n, "Building A");
+    });
+
+    expect(sitesClient.assignBuildingsToSite).toHaveBeenCalledWith(
+      { buildingIds: [20n], targetSiteId: undefined },
+      expect.anything(),
+    );
+    expect(ok).toBe(true);
+    expect(refetchSites).toHaveBeenCalled();
   });
 
   it("detailsSaveEdit refreshes manage with server-canonical site on success", async () => {
@@ -367,19 +553,5 @@ describe("useSiteModals", () => {
     });
 
     expect(useFleetStore.getState().ui.activeSite).toEqual({ kind: "site", id: "11", slug: "active" });
-  });
-
-  it("cancelAll closes every modal and clears deleteTarget", () => {
-    const site = create(SiteSchema, { id: 5n, name: "T" });
-    const { result } = renderHook(() => useSiteModals({ refetchSites: vi.fn() }), { wrapper });
-    act(() => result.current.openManageEdit(site));
-    act(() =>
-      result.current.requestDeleteCurrent([
-        create(SiteWithCountsSchema, { site, deviceCount: 0n, rackCount: 0n, buildingCount: 0n }),
-      ]),
-    );
-    act(() => result.current.cancelAll());
-    expect(result.current.state.kind).toBe("none");
-    expect(result.current.deleteTarget).toBeNull();
   });
 });

--- a/client/src/protoFleet/features/sites/hooks/useSiteModals.ts
+++ b/client/src/protoFleet/features/sites/hooks/useSiteModals.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
+import { create } from "@bufbuild/protobuf";
 
 import {
   type BuildingFormValues,
@@ -8,7 +9,7 @@ import {
   useBuildings,
 } from "@/protoFleet/api/buildings";
 import { type Building } from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
-import { type Site, type SiteWithCounts } from "@/protoFleet/api/generated/sites/v1/sites_pb";
+import { type Site, type SiteWithCounts, SiteWithCountsSchema } from "@/protoFleet/api/generated/sites/v1/sites_pb";
 import { emptySiteFormValues, type SiteFormValues, siteFormValuesFromSite, useSites } from "@/protoFleet/api/sites";
 import { scopeCurrentOrDashboardPath, useRouteSiteScope } from "@/protoFleet/routing/siteScope";
 import type { ActiveSite } from "@/protoFleet/store/types/activeSite";
@@ -163,6 +164,9 @@ const useSiteModals = ({ refetchSites, refetchBuildings }: UseSiteModalsOptions)
   useEffect(() => {
     stateRef.current = state;
   }, [state]);
+  // Set when the manage modal's inline create lands, read when it closes — see
+  // dismiss for why the host refresh waits until then.
+  const createdInManageRef = useRef(false);
 
   const { createSite, updateSite, deleteSite, assignBuildingsToSite } = useSites();
   const { createBuilding, createBuildings } = useBuildings();
@@ -202,8 +206,12 @@ const useSiteModals = ({ refetchSites, refetchBuildings }: UseSiteModalsOptions)
       if (prev.kind !== "manageEdit" && prev.kind !== "manageEditEditingDetails") return prev;
       const id = prev.site.id.toString();
       const match = sites?.find((s) => (s.site?.id ?? 0n).toString() === id);
-      if (!match) return prev;
-      setDeleteTarget(match);
+      // Continue creates the site up front, so the manage modal can be open on a
+      // row the host's refetchSites hasn't landed yet. Falling through to the
+      // state's own site keeps Delete working in that window; the counts it
+      // can't know are only the dialog's advisory copy, and a site this fresh
+      // has nothing under it in the common case.
+      setDeleteTarget(match ?? create(SiteWithCountsSchema, { site: prev.site }));
       // Drop the stacked details modal when the cascade dialog opens so the
       // dialog reads as the topmost surface above the persistent
       // ManageSiteModal. Cancelling the dialog returns to manageEdit.
@@ -215,6 +223,16 @@ const useSiteModals = ({ refetchSites, refetchBuildings }: UseSiteModalsOptions)
   }, []);
 
   const dismiss = useCallback(() => {
+    // Buildings created inside the manage modal only went into its own working
+    // set, so the host's list is stale the moment that set goes away. Deferred
+    // to the close rather than fired at create time because refetchBuildings
+    // bumps the key the modal's own fetch keys off, which would reseed its
+    // entries and drop everything staged in the picker. Read off the ref and
+    // done before setState, so a re-invoked updater can't fire it twice.
+    if (stateRef.current.kind !== "manageEditEditingDetails" && createdInManageRef.current) {
+      createdInManageRef.current = false;
+      refetchBuildings?.();
+    }
     // The stacked edit-details state drops just the top (details) and returns
     // to the underlying manage state. Everything else closes to none.
     setState((prev) => {
@@ -223,7 +241,7 @@ const useSiteModals = ({ refetchSites, refetchBuildings }: UseSiteModalsOptions)
       }
       return { kind: "none" };
     });
-  }, []);
+  }, [refetchBuildings]);
 
   const dismissDeleteConfirm = useCallback(() => {
     setDeleteTarget(null);
@@ -383,7 +401,9 @@ const useSiteModals = ({ refetchSites, refetchBuildings }: UseSiteModalsOptions)
             pushToast({ message: `Building "${building.name}" created`, status: STATUSES.success });
             // Refresh the site catalog (building counts) but deliberately NOT
             // the modal's building list — the modal injects the new row
-            // locally so unsaved picker selections survive.
+            // locally so unsaved picker selections survive. The host's list is
+            // caught up on close instead.
+            createdInManageRef.current = true;
             refetchSites();
             resolve(building);
           },
@@ -426,6 +446,7 @@ const useSiteModals = ({ refetchSites, refetchBuildings }: UseSiteModalsOptions)
             });
             // Site catalog only — the modal injects the new rows locally so
             // unsaved picker selections survive, same as single create.
+            createdInManageRef.current = true;
             refetchSites();
             resolve({ created: buildings, errors: [] });
           },
@@ -450,7 +471,12 @@ const useSiteModals = ({ refetchSites, refetchBuildings }: UseSiteModalsOptions)
   const pickerCreateBuilding = useCallback(
     async (values: BuildingFormValues): Promise<Building | null> => {
       const created = await manageCreateBuilding(values);
-      if (created) refetchBuildings?.();
+      if (created) {
+        // Refreshed now, so there is nothing for dismiss to catch up on — no
+        // modal is holding a working set this could reseed.
+        createdInManageRef.current = false;
+        refetchBuildings?.();
+      }
       return created;
     },
     [manageCreateBuilding, refetchBuildings],
@@ -461,7 +487,10 @@ const useSiteModals = ({ refetchSites, refetchBuildings }: UseSiteModalsOptions)
       const result = await manageCreateBuildings(buildings);
       // All-or-nothing: an empty `created` means the transaction rolled back,
       // so refetching would only cost a round trip.
-      if (result.created.length > 0) refetchBuildings?.();
+      if (result.created.length > 0) {
+        createdInManageRef.current = false;
+        refetchBuildings?.();
+      }
       return result;
     },
     [manageCreateBuildings, refetchBuildings],

--- a/client/src/protoFleet/features/sites/hooks/useSiteModals.ts
+++ b/client/src/protoFleet/features/sites/hooks/useSiteModals.ts
@@ -1,6 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 
+import {
+  type BuildingFormValues,
+  type BulkCreateBuildingError,
+  type NewBuildingInput,
+  useBuildings,
+} from "@/protoFleet/api/buildings";
+import { type Building } from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
 import { type Site, type SiteWithCounts } from "@/protoFleet/api/generated/sites/v1/sites_pb";
 import { emptySiteFormValues, type SiteFormValues, siteFormValuesFromSite, useSites } from "@/protoFleet/api/sites";
 import { scopeCurrentOrDashboardPath, useRouteSiteScope } from "@/protoFleet/routing/siteScope";
@@ -15,16 +22,45 @@ import { pushToast, STATUSES } from "@/shared/features/toaster";
 // modal they came from.
 export type SiteModalState =
   | { kind: "none" }
+  // Initial create step. "Continue" now persists the site (CreateSite) and
+  // transitions straight to manageEdit against the real row, so the manage
+  // surface always has a site id — inline building-create and
+  // AssignBuildingsToSite both need one. Mirrors the seeded "New site" flow in
+  // FleetCreateFlowProvider, which already creates-then-openManageEdit.
   | { kind: "detailsCreate"; draft: SiteFormValues }
-  | { kind: "manageCreate"; draft: SiteFormValues }
-  // Stacked: ManageSiteModal stays open while SiteSettingsModal renders on
-  // top. CTAs in details read Delete (discard pending create) + Save (apply
-  // changes and return to manage).
-  | { kind: "manageCreateEditingDetails"; draft: SiteFormValues }
   | { kind: "manageEdit"; site: Site; draft: SiteFormValues }
-  // Stacked edit-flow counterpart. Save calls UpdateSite directly; on
-  // success details closes and manage stays open with refreshed draft.
-  | { kind: "manageEditEditingDetails"; site: Site; draft: SiteFormValues };
+  // Stacked: ManageSiteModal stays open while SiteSettingsModal renders on top.
+  // Save calls UpdateSite directly; on success details closes and manage stays
+  // open with refreshed draft.
+  | { kind: "manageEditEditingDetails"; site: Site; draft: SiteFormValues }
+  // The buildings picker on its own, with no manage surface behind it — for
+  // hosts that already show the site (the detail page) and only want to edit
+  // membership. Carries the site because the write handlers below resolve their
+  // target from state, not from an argument, and the host's current membership
+  // because there is no ManageSiteModal working set to read it from — the ids
+  // seed the picker's selection, the names feed the bulk-create collision check.
+  | { kind: "buildingsPicker"; site: Site; currentBuildings: SiteBuildingRef[] };
+
+// Minimum a host has to hand over about the buildings already in the site.
+export interface SiteBuildingRef {
+  id: bigint;
+  name: string;
+}
+
+// The site a write should target, for every state that has one. Extracted so
+// the guard lives once: each handler previously repeated the same pair of kind
+// checks, which is why adding buildingsPicker would otherwise have meant
+// editing four call sites and silently no-op'ing at any one that was missed.
+const managedSite = (state: SiteModalState): Site | null => {
+  switch (state.kind) {
+    case "manageEdit":
+    case "manageEditEditingDetails":
+    case "buildingsPicker":
+      return state.site;
+    default:
+      return null;
+  }
+};
 
 interface UseSiteModalsOptions {
   refetchSites: () => void;
@@ -32,6 +68,14 @@ interface UseSiteModalsOptions {
   // (e.g. SiteSettingsSingleView's table) re-fetches after a membership
   // change. Optional so hosts without a building table can omit it.
   refetchBuildings?: () => void;
+}
+
+// Outcome of a bulk building create. `created` is empty whenever the batch was
+// rejected (or the dispatch was skipped), which is what tells the modal to stay
+// open; `errors` carries the offending rows when the server named them.
+export interface BulkBuildingCreateResult {
+  created: Building[];
+  errors: BulkCreateBuildingError[];
 }
 
 export interface SiteModalsApi {
@@ -47,6 +91,10 @@ export interface SiteModalsApi {
   // created from a bulk "New site" action seeded with loose racks/miners.
   // Omitted by normal edit callers → no count lines.
   openManageEdit: (site: Site, opts?: { unassignedRackCount?: number; unassignedMinerCount?: number }) => void;
+  // Opens the buildings picker with nothing behind it. For hosts that already
+  // render the site (the detail page), where stacking the whole manage surface
+  // under a membership edit is a layer the operator didn't ask for.
+  openBuildingsPicker: (site: Site, currentBuildings: SiteBuildingRef[]) => void;
   manageUnassignedRackCount: number | undefined;
   manageUnassignedMinerCount: number | undefined;
   // Resolve a SiteWithCounts from the page's sites cache and open the
@@ -56,22 +104,38 @@ export interface SiteModalsApi {
   // Closes the topmost modal: drops details if details is stacked on
   // manage, otherwise closes everything to none.
   dismiss: () => void;
-  // Closes every modal regardless of stack — used when the operator
-  // discards a pending create from the SiteSettingsModal Delete button.
-  cancelAll: () => void;
   // SiteDeleteDialog onDismiss — closes only the cascade dialog.
   dismissDeleteConfirm: () => void;
-  // SiteSettingsModal handlers
-  detailsContinueCreate: (values: SiteFormValues) => void;
+  // SiteSettingsModal handlers. Continue persists the site (CreateSite) and,
+  // on success, opens ManageSiteModal in edit mode against the new row.
+  detailsContinueCreate: (values: SiteFormValues) => Promise<void>;
   detailsSaveEdit: (values: SiteFormValues) => Promise<void>;
   // ManageSiteModal handlers
   manageEditDetails: () => void;
-  // Persists building-membership changes accumulated in the manage modal.
-  // In create mode this runs CreateSite, then assigns any buildings the
-  // operator staged (the delta's `added`) to the new site. In edit mode it
-  // applies the delta via AssignBuildingsToSite. Returns whether the modal
-  // should close on success, or null if the save failed.
-  manageSave: (delta: { added: bigint[]; removed: bigint[] }) => Promise<{ closeOnSuccess: boolean } | null>;
+  // Inline building-create from ManageSiteModal. Creates the building against
+  // the currently-managed site via the transactional CreateBuilding RPC and
+  // returns the created row so the modal can inject it into its working set.
+  // Returns null on failure (a toast is shown); a duplicate name surfaces as
+  // a server error and creates nothing.
+  manageCreateBuilding: (values: BuildingFormValues) => Promise<Building | null>;
+  // Bulk sibling of manageCreateBuilding. CreateBuildings is all-or-nothing, so
+  // the result is either every row in `created` or none of them plus the
+  // per-row reasons the modal marks its preview with.
+  manageCreateBuildings: (buildings: NewBuildingInput[]) => Promise<BulkBuildingCreateResult>;
+  // Create hand-offs for the standalone picker. Same RPCs as their manage*
+  // siblings, but they refresh the host's building list: the manage* versions
+  // skip that on purpose because ManageSiteModal injects the created rows into
+  // its own working set, and here there is no working set to inject into.
+  pickerCreateBuilding: (values: BuildingFormValues) => Promise<Building | null>;
+  pickerCreateBuildings: (buildings: NewBuildingInput[]) => Promise<BulkBuildingCreateResult>;
+  // Commit-per-modal: the buildings picker owns site membership, so its Save
+  // applies the delta via AssignBuildingsToSite right away rather than staging
+  // it into ManageSiteModal. `added` moves buildings into this site; `removed`
+  // moves them to "Unassigned". Resolves true on success.
+  manageAssignBuildings: (delta: { added: bigint[]; removed: bigint[] }) => Promise<boolean>;
+  // Kebab "Remove building" — an immediate unassign (targetSiteId unset), so
+  // the row action means what it says instead of queueing behind a Save.
+  manageRemoveBuilding: (buildingId: bigint, label: string) => Promise<boolean>;
   // SiteDeleteDialog handlers
   deleteConfirm: () => Promise<void>;
 }
@@ -101,6 +165,7 @@ const useSiteModals = ({ refetchSites, refetchBuildings }: UseSiteModalsOptions)
   }, [state]);
 
   const { createSite, updateSite, deleteSite, assignBuildingsToSite } = useSites();
+  const { createBuilding, createBuildings } = useBuildings();
   const setActiveSite = useFleetStore((store) => store.ui.setActiveSite);
   const activeSite = useFleetStore((store) => store.ui.activeSite);
   // Signals the PageHeader's SitePicker (which fetches sites once on mount and
@@ -124,6 +189,10 @@ const useSiteModals = ({ refetchSites, refetchBuildings }: UseSiteModalsOptions)
     [],
   );
 
+  const openBuildingsPicker = useCallback((site: Site, currentBuildings: SiteBuildingRef[]) => {
+    setState({ kind: "buildingsPicker", site, currentBuildings });
+  }, []);
+
   const requestDeleteCurrent = useCallback((sites: SiteWithCounts[] | undefined) => {
     // Pulls the currently-edited site id from state and resolves the matching
     // SiteWithCounts row from the page's list cache. Triggered when Delete is
@@ -146,10 +215,9 @@ const useSiteModals = ({ refetchSites, refetchBuildings }: UseSiteModalsOptions)
   }, []);
 
   const dismiss = useCallback(() => {
-    // Stacked states drop just the top (details) and return to the underlying
-    // manage state. Everything else closes to none.
+    // The stacked edit-details state drops just the top (details) and returns
+    // to the underlying manage state. Everything else closes to none.
     setState((prev) => {
-      if (prev.kind === "manageCreateEditingDetails") return { kind: "manageCreate", draft: prev.draft };
       if (prev.kind === "manageEditEditingDetails") {
         return { kind: "manageEdit", site: prev.site, draft: prev.draft };
       }
@@ -157,26 +225,57 @@ const useSiteModals = ({ refetchSites, refetchBuildings }: UseSiteModalsOptions)
     });
   }, []);
 
-  const cancelAll = useCallback(() => {
-    setState({ kind: "none" });
-    setDeleteTarget(null);
-  }, []);
-
   const dismissDeleteConfirm = useCallback(() => {
     setDeleteTarget(null);
   }, []);
 
-  const detailsContinueCreate = useCallback((values: SiteFormValues) => {
-    // Carry the existing networkConfig draft through; SiteSettingsModal only
-    // owns the descriptive fields, so the value typed in ManageSiteModal
-    // survives bouncing between the two surfaces.
-    setState((prev) => {
-      if (prev.kind === "detailsCreate" || prev.kind === "manageCreateEditingDetails") {
-        return { kind: "manageCreate", draft: { ...values, networkConfig: prev.draft.networkConfig } };
+  // Continue on the create-details modal persists the site immediately, then
+  // opens ManageSiteModal in edit mode against the new row. Creating the site
+  // up front (rather than deferring to the manage modal's Save) gives inline
+  // building-create a real site_id to attach to. On failure the details modal
+  // stays open so the operator can fix the input and retry (e.g. a duplicate
+  // name). Guarded so a double-click can't fire two CreateSite calls.
+  const detailsContinueCreate = useCallback(
+    async (values: SiteFormValues) => {
+      if (savingRef.current) return;
+      const current = stateRef.current;
+      if (current.kind !== "detailsCreate") return;
+      // Carry the existing networkConfig draft through; SiteSettingsModal only
+      // owns the descriptive fields, so the value typed elsewhere survives.
+      const draft: SiteFormValues = { ...values, networkConfig: current.draft.networkConfig };
+      savingRef.current = true;
+      setSaving(true);
+      try {
+        await new Promise<void>((resolve) => {
+          void createSite({
+            values: draft,
+            onSuccess: ({ site, networkConfigWarnings }) => {
+              pushToast({
+                message:
+                  networkConfigWarnings.length > 0
+                    ? `Site "${site.name}" created with warnings`
+                    : `Site "${site.name}" created`,
+                status: STATUSES.success,
+              });
+              refetchSites();
+              refetchBuildings?.();
+              bumpSitesRevision();
+              setState({ kind: "manageEdit", site, draft: siteFormValuesFromSite(site) });
+              resolve();
+            },
+            onError: (msg) => {
+              pushToast({ message: `Failed to create site: ${msg}`, status: STATUSES.error });
+              resolve();
+            },
+          });
+        });
+      } finally {
+        savingRef.current = false;
+        setSaving(false);
       }
-      return prev;
-    });
-  }, []);
+    },
+    [createSite, refetchSites, refetchBuildings, bumpSitesRevision],
+  );
 
   const detailsSaveEdit = useCallback(
     async (values: SiteFormValues) => {
@@ -256,7 +355,6 @@ const useSiteModals = ({ refetchSites, refetchBuildings }: UseSiteModalsOptions)
     setState((prev) => {
       // Stack details on top of manage. Manage stays in the underlying state
       // so it remains visible behind SiteSettingsModal.
-      if (prev.kind === "manageCreate") return { kind: "manageCreateEditingDetails", draft: prev.draft };
       if (prev.kind === "manageEdit") {
         return { kind: "manageEditEditingDetails", site: prev.site, draft: prev.draft };
       }
@@ -264,135 +362,192 @@ const useSiteModals = ({ refetchSites, refetchBuildings }: UseSiteModalsOptions)
     });
   }, []);
 
-  const manageSave = useCallback(
-    async (delta: { added: bigint[]; removed: bigint[] }) => {
+  // Inline building-create from the manage modal. The building is created and
+  // associated to the current site in one transactional RPC (#821), so it
+  // needs no follow-up AssignBuildingsToSite. Returns the created row to the
+  // modal, which injects it into its local working set (rather than triggering
+  // a list refetch) so any buildings staged via the picker are preserved.
+  const manageCreateBuilding = useCallback(
+    async (values: BuildingFormValues): Promise<Building | null> => {
       if (savingRef.current) return null;
-
-      // Create flow: persist the site, then assign any buildings the operator
-      // staged in the manage modal before the site existed. `added` carries
-      // those buildings (the working set started empty, so there's never a
-      // `removed`); they're assigned to the freshly-created site's id. The two
-      // steps are sequenced explicitly (rather than chained through
-      // createSite's onFinally) so the saving guard stays held across both —
-      // an async onSuccess would otherwise release it the moment the building
-      // assign awaited.
-      if (state.kind === "manageCreate") {
-        const draft = state.draft;
-        savingRef.current = true;
-        setSaving(true);
-        try {
-          const created = await new Promise<{ site: Site; warnings: string[] } | null>((resolve) => {
-            void createSite({
-              values: draft,
-              onSuccess: ({ site, networkConfigWarnings }) => resolve({ site, warnings: networkConfigWarnings }),
-              onError: (msg) => {
-                pushToast({ message: `Failed to create site: ${msg}`, status: STATUSES.error });
-                resolve(null);
-              },
-            });
-          });
-          if (!created) return null;
-
-          // The site is committed past this point. A subsequent
-          // AssignBuildingsToSite failure must not read as a failed create —
-          // surface a partial-success warning and still close, matching the
-          // bulk "New site" seeded flow in FleetCreateFlowProvider.
-          let buildingsFailed: string | null = null;
-          if (delta.added.length > 0) {
-            await new Promise<void>((resolve) => {
-              void assignBuildingsToSite({
-                buildingIds: delta.added,
-                targetSiteId: created.site.id,
-                onSuccess: () => resolve(),
-                onError: (msg) => {
-                  buildingsFailed = msg;
-                  resolve();
-                },
-              });
-            });
-          }
-
-          pushToast(
-            buildingsFailed
-              ? {
-                  message: `Site "${created.site.name}" created, but adding buildings failed: ${buildingsFailed}`,
-                  status: STATUSES.error,
-                }
-              : {
-                  message:
-                    created.warnings.length > 0
-                      ? `Site "${created.site.name}" created with warnings`
-                      : `Site "${created.site.name}" created`,
-                  status: STATUSES.success,
-                },
-          );
-          refetchSites();
-          refetchBuildings?.();
-          bumpSitesRevision();
-          return { closeOnSuccess: true };
-        } finally {
-          savingRef.current = false;
-          setSaving(false);
-        }
-      }
-
-      // Edit flow: site details are owned by SiteSettingsModal, so the
-      // manage modal's Save only persists building membership. A no-op
-      // delta (operator opened Save without changes) closes silently.
-      if (state.kind === "manageEdit") {
-        if (delta.added.length === 0 && delta.removed.length === 0) {
-          return { closeOnSuccess: true };
-        }
-        const id = state.site.id;
-        const name = state.site.name;
-        savingRef.current = true;
-        setSaving(true);
-        try {
-          // `added` moves buildings into this site; `removed` moves them to
-          // "Unassigned" (targetSiteId unset). Both cascade site_id down to
-          // racks + devices server-side. Run sequentially so a mid-chain
-          // failure surfaces without a half-applied toast.
-          const dispatch = (buildingIds: bigint[], targetSiteId?: bigint) =>
-            new Promise<void>((resolve, reject) => {
-              if (buildingIds.length === 0) {
-                resolve();
-                return;
-              }
-              void assignBuildingsToSite({
-                buildingIds,
-                targetSiteId,
-                onSuccess: () => resolve(),
-                onError: (msg) => reject(new Error(msg)),
-              });
-            });
-          try {
-            await dispatch(delta.removed, undefined);
-            await dispatch(delta.added, id);
-          } catch (err) {
-            const detail = err instanceof Error ? err.message : "Failed to save buildings";
-            pushToast({ message: `Failed to save site: ${detail}`, status: STATUSES.error });
-            // The two AssignBuildingsToSite calls aren't atomic across each
-            // other: the `removed` batch may have already cascaded buildings
-            // out of the site before the `added` batch failed. Refresh so the
-            // counts + building table reflect what actually committed rather
-            // than the now-stale pre-save view.
+      const site = managedSite(stateRef.current);
+      if (!site) return null;
+      const siteId = site.id;
+      savingRef.current = true;
+      setSaving(true);
+      return await new Promise<Building | null>((resolve) => {
+        void createBuilding({
+          values,
+          siteId,
+          onSuccess: ({ building }) => {
+            pushToast({ message: `Building "${building.name}" created`, status: STATUSES.success });
+            // Refresh the site catalog (building counts) but deliberately NOT
+            // the modal's building list — the modal injects the new row
+            // locally so unsaved picker selections survive.
             refetchSites();
-            refetchBuildings?.();
-            return null;
-          }
-          pushToast({ message: `Site "${name}" saved`, status: STATUSES.success });
-          refetchSites();
-          refetchBuildings?.();
-          return { closeOnSuccess: true };
-        } finally {
-          savingRef.current = false;
-          setSaving(false);
-        }
-      }
-
-      return null;
+            resolve(building);
+          },
+          onError: (msg) => {
+            pushToast({ message: `Failed to create building: ${msg}`, status: STATUSES.error });
+            resolve(null);
+          },
+          onFinally: () => {
+            savingRef.current = false;
+            setSaving(false);
+          },
+        });
+      });
     },
-    [state, createSite, assignBuildingsToSite, refetchSites, refetchBuildings, bumpSitesRevision],
+    [createBuilding, refetchSites],
+  );
+
+  // Inline bulk building-create. Same shape as manageCreateBuilding, but one
+  // CreateBuildings call for the whole set: the transaction is all-or-nothing,
+  // so the operator never has to work out which half of a prefix run exists.
+  const manageCreateBuildings = useCallback(
+    async (buildings: NewBuildingInput[]): Promise<BulkBuildingCreateResult> => {
+      if (savingRef.current) return { created: [], errors: [] };
+      const site = managedSite(stateRef.current);
+      if (!site) return { created: [], errors: [] };
+      const siteId = site.id;
+      savingRef.current = true;
+      setSaving(true);
+      return await new Promise<BulkBuildingCreateResult>((resolve) => {
+        void createBuildings({
+          siteId,
+          // Rows arrive fully formed from the modal: it owns the name
+          // generation and the one layout the batch shares, so there is nothing
+          // to reshape here.
+          buildings,
+          onSuccess: (buildings) => {
+            pushToast({
+              message: `${buildings.length} ${buildings.length === 1 ? "building" : "buildings"} created`,
+              status: STATUSES.success,
+            });
+            // Site catalog only — the modal injects the new rows locally so
+            // unsaved picker selections survive, same as single create.
+            refetchSites();
+            resolve({ created: buildings, errors: [] });
+          },
+          onError: (msg, errors) => {
+            pushToast({ message: `Failed to create buildings: ${msg}`, status: STATUSES.error });
+            resolve({ created: [], errors });
+          },
+          onFinally: () => {
+            savingRef.current = false;
+            setSaving(false);
+          },
+        });
+      });
+    },
+    [createBuildings, refetchSites],
+  );
+
+  // Standalone-picker create. The manage* versions refresh only the site
+  // catalog, leaving the building list to ManageSiteModal's local injection;
+  // with no modal holding a working set, the host's list is the only thing that
+  // renders these rows, so it has to be told.
+  const pickerCreateBuilding = useCallback(
+    async (values: BuildingFormValues): Promise<Building | null> => {
+      const created = await manageCreateBuilding(values);
+      if (created) refetchBuildings?.();
+      return created;
+    },
+    [manageCreateBuilding, refetchBuildings],
+  );
+
+  const pickerCreateBuildings = useCallback(
+    async (buildings: NewBuildingInput[]): Promise<BulkBuildingCreateResult> => {
+      const result = await manageCreateBuildings(buildings);
+      // All-or-nothing: an empty `created` means the transaction rolled back,
+      // so refetching would only cost a round trip.
+      if (result.created.length > 0) refetchBuildings?.();
+      return result;
+    },
+    [manageCreateBuildings, refetchBuildings],
+  );
+
+  // Shared AssignBuildingsToSite dispatcher. `targetSiteId` unset moves the
+  // buildings to "Unassigned"; either way the server cascades site_id down to
+  // racks + devices.
+  const dispatchAssign = useCallback(
+    (buildingIds: bigint[], targetSiteId?: bigint) =>
+      new Promise<void>((resolve, reject) => {
+        if (buildingIds.length === 0) {
+          resolve();
+          return;
+        }
+        void assignBuildingsToSite({
+          buildingIds,
+          targetSiteId,
+          onSuccess: () => resolve(),
+          onError: (msg) => reject(new Error(msg)),
+        });
+      }),
+    [assignBuildingsToSite],
+  );
+
+  const manageAssignBuildings = useCallback(
+    async (delta: { added: bigint[]; removed: bigint[] }): Promise<boolean> => {
+      if (savingRef.current) return false;
+      const site = managedSite(stateRef.current);
+      if (!site) return false;
+      if (delta.added.length === 0 && delta.removed.length === 0) return true;
+      const id = site.id;
+      savingRef.current = true;
+      setSaving(true);
+      try {
+        // Sequential so a mid-chain failure surfaces without a half-applied
+        // success toast.
+        await dispatchAssign(delta.removed, undefined);
+        await dispatchAssign(delta.added, id);
+      } catch (err) {
+        const detail = err instanceof Error ? err.message : "Failed to assign buildings";
+        pushToast({ message: `Failed to update buildings: ${detail}`, status: STATUSES.error });
+        // The two calls aren't atomic across each other: the `removed` batch
+        // may have already cascaded buildings out of the site before `added`
+        // failed. Refresh so the counts + building table reflect what actually
+        // committed rather than the now-stale pre-save view.
+        refetchSites();
+        refetchBuildings?.();
+        return false;
+      } finally {
+        savingRef.current = false;
+        setSaving(false);
+      }
+      const count = delta.added.length + delta.removed.length;
+      pushToast({
+        message: `${count} ${count === 1 ? "building" : "buildings"} updated`,
+        status: STATUSES.success,
+      });
+      refetchSites();
+      refetchBuildings?.();
+      return true;
+    },
+    [dispatchAssign, refetchSites, refetchBuildings],
+  );
+
+  const manageRemoveBuilding = useCallback(
+    async (buildingId: bigint, label: string): Promise<boolean> => {
+      if (savingRef.current) return false;
+      savingRef.current = true;
+      setSaving(true);
+      try {
+        await dispatchAssign([buildingId], undefined);
+      } catch (err) {
+        const detail = err instanceof Error ? err.message : "Failed to remove building";
+        pushToast({ message: `Failed to remove "${label}": ${detail}`, status: STATUSES.error });
+        return false;
+      } finally {
+        savingRef.current = false;
+        setSaving(false);
+      }
+      pushToast({ message: `"${label}" removed from this site`, status: STATUSES.success });
+      refetchSites();
+      refetchBuildings?.();
+      return true;
+    },
+    [dispatchAssign, refetchSites, refetchBuildings],
   );
 
   const deleteConfirm = useCallback(async () => {
@@ -440,14 +595,19 @@ const useSiteModals = ({ refetchSites, refetchBuildings }: UseSiteModalsOptions)
     manageUnassignedMinerCount,
     openCreate,
     openManageEdit,
+    openBuildingsPicker,
     requestDeleteCurrent,
     dismiss,
-    cancelAll,
     dismissDeleteConfirm,
     detailsContinueCreate,
     detailsSaveEdit,
     manageEditDetails,
-    manageSave,
+    manageCreateBuilding,
+    manageCreateBuildings,
+    pickerCreateBuilding,
+    pickerCreateBuildings,
+    manageAssignBuildings,
+    manageRemoveBuilding,
     deleteConfirm,
   };
 };

--- a/client/src/protoFleet/features/sites/pages/SiteDetailPage.stories.tsx
+++ b/client/src/protoFleet/features/sites/pages/SiteDetailPage.stories.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { create } from "@bufbuild/protobuf";
 import type { Meta, StoryObj } from "@storybook/react";
@@ -18,6 +18,7 @@ import {
   SiteSchema,
   SiteWithCountsSchema,
 } from "@/protoFleet/api/generated/sites/v1/sites_pb";
+import { SitesContext } from "@/protoFleet/api/SitesContext";
 import { useFleetStore } from "@/protoFleet/store";
 
 const SITE_ID = 1n;
@@ -213,6 +214,25 @@ const makeBuildingStats = (fixture: BuildingFixture): GetBuildingStatsResponse =
 const sum = (buildings: BuildingFixture[], selector: (building: BuildingFixture) => number) =>
   buildings.reduce((total, building) => total + selector(building), 0);
 
+// Shared by installMocks (for the listSites stub) and the story's
+// SitesContext value, so both describe the same site.
+const siteWithCounts = (scenario: SiteDetailScenario) =>
+  create(SiteWithCountsSchema, {
+    site: create(SiteSchema, {
+      id: SITE_ID,
+      name: scenario.name,
+      locationCity: scenario.city,
+      locationState: scenario.state,
+      address: scenario.address,
+      postalCode: scenario.postalCode,
+      country: "US",
+      powerCapacityMw: scenario.powerCapacityMw,
+    }),
+    buildingCount: BigInt(scenario.buildings.length),
+    rackCount: BigInt(sum(scenario.buildings, (building) => building.rackCount)),
+    deviceCount: BigInt(sum(scenario.buildings, (building) => building.deviceCount)),
+  });
+
 const installMocks = (scenario: SiteDetailScenario) => {
   const siteBuildings = scenario.buildings.map(makeBuilding);
   const buildingStatsById = new Map(
@@ -226,21 +246,7 @@ const installMocks = (scenario: SiteDetailScenario) => {
   const sleepingCount = sum(scenario.buildings, (building) => building.sleepingCount);
   const totalPowerKw = sum(scenario.buildings, (building) => building.powerKw ?? 0);
 
-  const site = create(SiteWithCountsSchema, {
-    site: create(SiteSchema, {
-      id: SITE_ID,
-      name: scenario.name,
-      locationCity: scenario.city,
-      locationState: scenario.state,
-      address: scenario.address,
-      postalCode: scenario.postalCode,
-      country: "US",
-      powerCapacityMw: scenario.powerCapacityMw,
-    }),
-    buildingCount: BigInt(scenario.buildings.length),
-    rackCount: BigInt(rackCount),
-    deviceCount: BigInt(deviceCount),
-  });
+  const site = siteWithCounts(scenario);
 
   useFleetStore.setState((state) => {
     state.auth.permissions = ["site:read", "site:manage"];
@@ -282,14 +288,32 @@ const SiteDetailStory = ({ scenario = "mixed", frameClassName }: SiteDetailStory
     installMocks(selectedScenario);
   }, [selectedScenario]);
 
+  // The page reads its site catalog from SitesProvider, so the story has to
+  // supply the context itself — mocking sitesClient.listSites isn't enough.
+  const sitesValue = useMemo(
+    () => ({
+      sites: [siteWithCounts(selectedScenario)],
+      sitesError: null,
+      sitesLoaded: true,
+      sitesSettled: true,
+      sitesPermissionDenied: false,
+      siteCatalogAccessGranted: true,
+      refetchSites: () => undefined,
+      registerSitesPoll: () => () => undefined,
+    }),
+    [selectedScenario],
+  );
+
   const story = (
-    <MemoryRouter initialEntries={[`/sites/${SITE_ID.toString()}`]}>
-      <Routes>
-        <Route path="/sites/:id" element={<SiteDetailPage />} />
-        <Route path="/buildings/:id" element={<div className="p-10 text-300">Building detail route</div>} />
-        <Route path="/fleet" element={<div className="p-10 text-300">Fleet route</div>} />
-      </Routes>
-    </MemoryRouter>
+    <SitesContext.Provider value={sitesValue}>
+      <MemoryRouter initialEntries={[`/sites/${SITE_ID.toString()}`]}>
+        <Routes>
+          <Route path="/sites/:id" element={<SiteDetailPage />} />
+          <Route path="/buildings/:id" element={<div className="p-10 text-300">Building detail route</div>} />
+          <Route path="/fleet" element={<div className="p-10 text-300">Fleet route</div>} />
+        </Routes>
+      </MemoryRouter>
+    </SitesContext.Provider>
   );
 
   return frameClassName ? <div className={frameClassName}>{story}</div> : story;

--- a/client/src/protoFleet/features/sites/pages/SiteDetailPage.test.tsx
+++ b/client/src/protoFleet/features/sites/pages/SiteDetailPage.test.tsx
@@ -5,6 +5,11 @@ import { create } from "@bufbuild/protobuf";
 import userEvent from "@testing-library/user-event";
 
 import SiteDetailPage from "./SiteDetailPage";
+import {
+  BuildingSchema,
+  type BuildingWithCounts,
+  BuildingWithCountsSchema,
+} from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
 import { SiteSchema, type SiteWithCounts, SiteWithCountsSchema } from "@/protoFleet/api/generated/sites/v1/sites_pb";
 import { DEFAULT_ACTIVE_SITE } from "@/protoFleet/store/types/activeSite";
 import { useFleetStore } from "@/protoFleet/store/useFleetStore";
@@ -73,9 +78,12 @@ vi.mock("@/protoFleet/features/sites/components/SiteModals", () => ({
   default: () => null,
 }));
 
+const openBuildingsPickerMock = vi.hoisted(() => vi.fn());
+
 vi.mock("@/protoFleet/features/sites/hooks/useSiteModals", () => ({
   useSiteModals: () => ({
     openManageEdit: vi.fn(),
+    openBuildingsPicker: openBuildingsPickerMock,
   }),
 }));
 
@@ -294,5 +302,59 @@ describe("SiteDetailPage", () => {
     await waitFor(() => expect(screen.getByTestId("site-detail-breadcrumb-switcher")).toHaveTextContent("Austin"));
     expect(screen.queryByTestId("location-probe")).not.toBeInTheDocument();
     expect(useFleetStore.getState().ui.activeSite).toEqual({ kind: "site", id: "8", slug: "austin" });
+  });
+
+  // beforeEach already resolves the page's building fetch with [], so these
+  // cases inherit the empty site and only opt into permissions.
+  describe("buildings zero-state", () => {
+    it("offers a Manage buildings CTA that opens the picker for the viewed site", async () => {
+      useFleetStore.setState((state) => {
+        state.auth.permissions = ["site:manage"];
+      });
+
+      const user = userEvent.setup();
+      renderPage("/sites/7");
+
+      const empty = await screen.findByTestId("site-detail-buildings-empty");
+      expect(empty).toHaveTextContent("No buildings to display");
+      expect(empty).toHaveTextContent("Create buildings or assign existing buildings to this site.");
+
+      await user.click(screen.getByTestId("site-detail-buildings-empty-manage"));
+
+      // Passes the resolved site, not the route param, so the picker opens
+      // against the row the page is actually showing.
+      expect(openBuildingsPickerMock).toHaveBeenCalledTimes(1);
+      expect(openBuildingsPickerMock.mock.calls[0][0]).toMatchObject({ id: 7n, name: "Dallas" });
+      // No seeded membership — this CTA only exists on the empty site, so
+      // every checkbox in the picker starts clear.
+      expect(openBuildingsPickerMock.mock.calls[0][1]).toEqual([]);
+    });
+
+    it("drops the CTA and the create-oriented copy without site:manage", async () => {
+      renderPage("/sites/7");
+
+      const empty = await screen.findByTestId("site-detail-buildings-empty");
+      expect(empty).toHaveTextContent("No buildings have been assigned to this site.");
+      expect(empty).not.toHaveTextContent("Create buildings");
+      expect(screen.queryByTestId("site-detail-buildings-empty-manage")).not.toBeInTheDocument();
+    });
+
+    it("shows the building grid instead once the site has one", async () => {
+      useFleetStore.setState((state) => {
+        state.auth.permissions = ["site:manage"];
+      });
+      listBuildingsBySiteMock.mockImplementation(({ onSuccess }: { onSuccess: (rows: BuildingWithCounts[]) => void }) =>
+        onSuccess([
+          create(BuildingWithCountsSchema, {
+            building: create(BuildingSchema, { id: 4n, name: "Bldg-1", siteId: 7n }),
+          }),
+        ]),
+      );
+
+      renderPage("/sites/7");
+
+      expect(await screen.findByTestId("site-detail-buildings-section")).toBeInTheDocument();
+      expect(screen.queryByTestId("site-detail-buildings-empty")).not.toBeInTheDocument();
+    });
   });
 });

--- a/client/src/protoFleet/features/sites/pages/SiteDetailPage.tsx
+++ b/client/src/protoFleet/features/sites/pages/SiteDetailPage.tsx
@@ -114,10 +114,6 @@ const SiteDetailPage = () => {
 
   const [buildingsRefreshKey, setBuildingsRefreshKey] = useState(0);
   const refetchBuildings = useCallback(() => setBuildingsRefreshKey((n) => n + 1), []);
-  // Membership saves in ManageSiteModal also affect building rows, so share
-  // the same refresh signal used for direct building mutations.
-  const modals = useSiteModals({ refetchSites, refetchBuildings });
-
   const siteId = site?.site?.id;
   const siteIdText = siteId?.toString();
   const visibleBuildings = buildings && buildings.siteId === siteIdText ? buildings.rows : undefined;
@@ -136,11 +132,19 @@ const SiteDetailPage = () => {
     error: siteStatsError,
     refetch: refetchSiteStats,
   } = useSiteStats({ siteId: siteId ?? 0n, enabled: siteId !== undefined, pollIntervalMs: POLL_INTERVAL_MS });
-  const handleBuildingMutationSuccess = useCallback(() => {
+  // Site-level caches any building mutation invalidates: the catalog carries
+  // building counts, and the metrics row reads its building count from
+  // siteStats before falling back to the building list — so refreshing the
+  // catalog alone leaves the header at 0 until the next poll.
+  const refreshSiteCaches = useCallback(() => {
     refetchSites();
     refetchSiteStats();
   }, [refetchSites, refetchSiteStats]);
-  const buildingModals = useBuildingModals({ refetchBuildings, onMutationSuccess: handleBuildingMutationSuccess });
+  const buildingModals = useBuildingModals({ refetchBuildings, onMutationSuccess: refreshSiteCaches });
+  // Declared here, after refreshSiteCaches, so the site modals' create and
+  // assign paths refresh the same pair. Membership saves in ManageSiteModal
+  // also affect building rows, hence the shared refetchBuildings signal.
+  const modals = useSiteModals({ refetchSites: refreshSiteCaches, refetchBuildings });
 
   // Performance charts — mirrors the group/rack/building overview pages, but
   // scopes telemetry by site rather than by explicit device-set membership.

--- a/client/src/protoFleet/features/sites/pages/SiteDetailPage.tsx
+++ b/client/src/protoFleet/features/sites/pages/SiteDetailPage.tsx
@@ -319,11 +319,31 @@ const SiteDetailPage = () => {
               {visibleBuildings === undefined ? (
                 <div className="text-200 text-text-primary-50">Loading buildings…</div>
               ) : visibleBuildings.length === 0 ? (
+                // The surrounding panel is already the card, so this centers
+                // inside it rather than nesting a second surface. NullState
+                // isn't the fit here: it brings its own tinted panel and
+                // left-aligns, both of which fight this container.
                 <div
-                  className="rounded-2xl border border-dashed border-border-5 p-6 text-center text-300 text-text-primary-70"
+                  className="flex flex-col items-center gap-2 py-10 text-center phone:py-4"
                   data-testid="site-detail-buildings-empty"
                 >
-                  No buildings in this site yet.
+                  <div className="text-heading-200 text-text-primary">No buildings to display</div>
+                  <div className="text-300 text-text-primary-70">
+                    {canManageSites
+                      ? "Create buildings or assign existing buildings to this site."
+                      : "No buildings have been assigned to this site."}
+                  </div>
+                  {canManageSites ? (
+                    <Button
+                      variant={variants.primary}
+                      text="Manage buildings"
+                      className="mt-4"
+                      // Empty membership: this branch only renders when the
+                      // site has no buildings.
+                      onClick={() => modals.openBuildingsPicker(site.site!, [])}
+                      testId="site-detail-buildings-empty-manage"
+                    />
+                  ) : null}
                 </div>
               ) : (
                 <div className="grid grid-cols-[repeat(auto-fill,minmax(12rem,1fr))] gap-3">


### PR DESCRIPTION
Reviewable diff: +794/-333 across 8 files (excludes generated, test, and story files).

## Summary

Closes the loop at the site level. `ManageSiteModal` gets a Create building CTA that opens the building create modal with the site pre-filled, in both Single and Multiple mode — so a brand-new site can be filled out without leaving for the buildings page. `SiteDetailPage`'s empty buildings section gets a manage-buildings CTA so a site with no buildings points at the modal that fills it, instead of dead-ending.

This is the PR that makes #864's Multiple mode for buildings reachable.

### Stack — 6 PRs, merge in order

| # | PR | What it adds |
|---|----|--------------|
| 1 | #855 | `AssignDevicesToRack` also writes rack slot placement |
| 2 | #856 | `CreateBuildings` batch RPC |
| 3 | #862 | `CreateRacks` batch RPC |
| 4 | #863 | Rack create modal gains a Multiple mode |
| 5 | #864 | Building surfaces: create racks and buildings inline |
| **6** | **#860 ← this PR** | Site surfaces: create buildings inline |

Together the series lets an operator build out the physical hierarchy without leaving the modal they are in — buildings from inside a site, racks from inside a building — and create them in batches from a generated name series. PRs 1–3 are the backend RPCs; 4–6 are the UI that calls them.

## How it works

`SiteBuildingsPicker` is the new component the Create building CTA lives in. It opens `BuildingSettingsModal` (from #864) with the site locked, so the building is created into the site the operator is already in; on success the picker refreshes and the new building is selectable.

Multiple mode goes through the same path — generated names, live length check, per-row errors from `CreateBuildings` (#856) marking the offending rows.

`useSiteModals` carries most of the change: it now owns the create hand-off and the write-on-click contract the rest of the stack adopted, and `SiteSettingsModal` moves to validate-on-submit rather than a disabled Save.

```mermaid
flowchart TD
  A["SiteDetailPage (no buildings)"] --> B["Manage buildings CTA"]
  B --> C["ManageSiteModal + SiteBuildingsPicker"]
  C --> D["Create building CTA"]
  D --> E["BuildingSettingsModal, site locked"]
  E -->|Single| F["CreateBuilding"]
  E -->|Multiple| G["CreateBuildings"]
  F --> C
  G --> C
```

## Areas of the code involved

| Area | What changed | Why it matters |
|---|---|---|
| `useSiteModals.ts` | Create hand-off, write-on-click contract | Largest change in the PR |
| `SiteModals/SiteBuildingsPicker.tsx` | New picker hosting the Create building CTA | New component |
| `ManageSiteModal.tsx`, `ManageBuildingsModal.tsx` | Wire the CTA in both Single and Multiple mode | Makes #864's bulk form reachable |
| `SiteSettingsModal.tsx` | Validate on submit instead of disabling Save | Matches the rest of the stack |
| `SiteDetailPage.tsx` | Empty-state manage-buildings CTA | |

## Key technical decisions

- **Site locked on create**, same pattern as #864's building-locked rack create — one rule for every level of the hierarchy.
- **Validate on submit, CTA stays clickable**, per the project's no-disabled-CTA rule; a valid-but-unchanged submit closes instead of writing.
- **Empty state points at the picker**, not at a separate create modal — one path to fill a site, whether it has 0 or 20 buildings.

## Testing & validation

- `tsc --noEmit` clean; full client suite passes (3873 tests at this tip).
- `git diff` between this branch tip and the original single-branch implementation is **empty** — the 6-PR split reproduces the feature byte-for-byte.
- Per-layer verification for the whole stack: `go build ./...` and Go unit tests pass at PRs 1–3; `tsc --noEmit` passes at all six; full client suite passes at 4, 5, and 6. No intermediate merge leaves a broken state.
- Playwright specs are distributed across #863/#864 with the behavior they assert. Not executed locally (needs docker-compose) — worth an e2e pass before the last merge.

