### PR TITLE
[4/6] feat(racks): add a Multiple variant to the rack create modal

### DIFF
--- a/client/e2eTests/protoFleet/helpers/buildingsTestSetup.ts
+++ b/client/e2eTests/protoFleet/helpers/buildingsTestSetup.ts
@@ -144,14 +144,14 @@ export async function createRackWithAssignedMiners(
     await racksPage.enableCustomRackLayout();
     await racksPage.inputColumns(RACK_COLUMNS);
     await racksPage.inputRows(RACK_ROWS);
-    await racksPage.clickContinueFromRackSettings();
+    await racksPage.clickCreateRackFromSettings();
 
     const selectedMinerIps = (await addSelectableMinersToSlots(racksPage, 2, [1, 2])).map((miner) => miner.ipAddress);
     test.expect(selectedMinerIps).toHaveLength(2);
 
-    await racksPage.clickSaveRack();
+    await racksPage.clickSaveMinerPositions();
     // The persisted rack row is a more durable success signal than the transient
-    // creation toast, especially on mobile flows that immediately continue into
+    // save toast, especially on mobile flows that immediately continue into
     // list navigation and follow-up assertions.
     await racksPage.clickViewList();
     await racksPage.waitForRackListToLoad({ allowEmpty: false });

--- a/client/e2eTests/protoFleet/helpers/racksHelpers.ts
+++ b/client/e2eTests/protoFleet/helpers/racksHelpers.ts
@@ -23,7 +23,7 @@ export async function addSelectableMinersToSlots(
   const selectableMinerIndexes = await racksPage.getSelectableMinerIndexes(minerCount);
   const selectedMiners = await racksPage.getMinersFromSelector(selectableMinerIndexes);
   await racksPage.selectMinersInSelectorByIndex(selectableMinerIndexes);
-  await racksPage.clickContinueInMinerSelector();
+  await racksPage.clickSaveInMinerSelector();
 
   for (let i = 0; i < selectedMiners.length; i++) {
     await racksPage.selectRackMiner(selectedMiners[i].ipAddress);
@@ -48,7 +48,7 @@ export async function addSelectableRigMinersToSlots(
   const selectableMinerIndexes = await racksPage.getSelectableMinerIndexes(minerCount);
   const selectedMiners = await racksPage.getMinersFromSelector(selectableMinerIndexes);
   await racksPage.selectMinersInSelectorByIndex(selectableMinerIndexes);
-  await racksPage.clickContinueInMinerSelector();
+  await racksPage.clickSaveInMinerSelector();
 
   for (let i = 0; i < selectedMiners.length; i++) {
     await racksPage.selectRackMiner(selectedMiners[i].ipAddress);

--- a/client/e2eTests/protoFleet/helpers/rbacTestSetup.ts
+++ b/client/e2eTests/protoFleet/helpers/rbacTestSetup.ts
@@ -287,9 +287,9 @@ export async function createRack(racksPage: RacksPage, rackLabel: string) {
     await racksPage.enableCustomRackLayout();
     await racksPage.inputColumns(2);
     await racksPage.inputRows(2);
-    await racksPage.clickContinueFromRackSettings();
-    await racksPage.clickSaveRack();
+    await racksPage.clickCreateRackFromSettings();
     await racksPage.validateRackToast(rackLabel);
+    await racksPage.clickDismissManageRack();
     await racksPage.clickViewList();
     await racksPage.waitForRackListToLoad({ allowEmpty: false });
     await racksPage.validateRackRow(rackLabel, RBAC_RACK_ZONE, 0);

--- a/client/e2eTests/protoFleet/pages/base.ts
+++ b/client/e2eTests/protoFleet/pages/base.ts
@@ -506,6 +506,14 @@ export class BasePage {
       .toBe(true);
   }
 
+  // Toasts stack, and validateTextInToast matches any visible one carrying the
+  // text, so a loop that repeats the same action can pass on the toast a previous
+  // pass left behind. Clearing between passes keeps each assertion about the
+  // toast that pass produced.
+  async clearToasts() {
+    await this.dismissVisibleToastIfPresent();
+  }
+
   async dismissToast() {
     const toastContainer = this.page.getByTestId("toaster-container");
     const groupedDismissButton = toastContainer.getByRole("button", { name: "Dismiss", exact: true });

--- a/client/e2eTests/protoFleet/pages/racks.ts
+++ b/client/e2eTests/protoFleet/pages/racks.ts
@@ -90,7 +90,18 @@ export class RacksPage extends BasePage {
     await this.validateTitleInModal("Select miners");
   }
 
+  // The rack grid only renders once the manage-rack modal has mounted and its
+  // device set has loaded. "Create rack" hands off to that modal after the create
+  // RPC resolves, so a header action probed any earlier finds nothing — and on
+  // phone/tablet those actions live in a closed overflow sheet, so there is no
+  // button in the DOM for Playwright to auto-wait on as a fallback.
+  private async waitForManageRackModalToLoad() {
+    await expect(this.page.getByTestId(/^rack-slot-\d+$/).first()).toBeVisible();
+  }
+
   async clickManageMiners() {
+    await this.waitForManageRackModalToLoad();
+
     const overflowTrigger = this.page.getByTestId("overflow-menu-trigger");
     if (this.isMobile && (await overflowTrigger.isVisible().catch(() => false))) {
       await overflowTrigger.click();

--- a/client/e2eTests/protoFleet/pages/racks.ts
+++ b/client/e2eTests/protoFleet/pages/racks.ts
@@ -59,8 +59,15 @@ export class RacksPage extends BasePage {
       .trim();
   }
 
-  async clickContinueFromRackSettings() {
-    await this.clickIn("Continue", "modal");
+  // The Rack settings CTA creates the rack, so a new rack reads "Create rack"
+  // and lands on the manage-rack modal with the rack already persisted.
+  async clickCreateRackFromSettings() {
+    await this.clickIn("Create rack", "modal");
+  }
+
+  // Reopened on an existing rack, the same CTA updates the rack's own fields.
+  async clickSaveRackSettings() {
+    await this.clickIn("Save", "modal");
   }
 
   async validateRackSettingsFieldError(
@@ -176,8 +183,9 @@ export class RacksPage extends BasePage {
     await this.modalMinerList.selectRowByCellText("ipAddress", ipAddress);
   }
 
-  async clickContinueInMinerSelector() {
-    await this.clickIn("Continue", "modal");
+  // The miner picker commits the rack's membership itself, hence "Save".
+  async clickSaveInMinerSelector() {
+    await this.clickIn("Save", "modal");
   }
 
   async validateMinerSelectorOverflowError(selectedCount: number, maxSlots: number) {
@@ -303,8 +311,22 @@ export class RacksPage extends BasePage {
     await this.page.getByRole("button", { name: "Clear", exact: true }).click();
   }
 
-  async clickSaveRack() {
+  // The manage-rack modal's Save persists slot placement only.
+  async clickSaveMinerPositions() {
     await this.clickButton("Save");
+  }
+
+  async clickDismissManageRack() {
+    await this.page.getByRole("button", { name: "Close dialog", exact: true }).click();
+  }
+
+  // No slot changed, so there is nothing for Save to write. It stays clickable
+  // and closes the modal rather than toasting a save that dispatched nothing.
+  async saveMinerPositionsWithNothingPlaced() {
+    const save = this.page.getByRole("button", { name: "Save", exact: true });
+    await expect(save).toBeEnabled();
+    await save.click();
+    await this.validateModalIsClosed();
   }
 
   async clickViewMiners() {
@@ -331,13 +353,19 @@ export class RacksPage extends BasePage {
     await this.validateTitleInModal("Rack settings");
   }
 
-  async changeOrderIndexAndContinue(orderIndexLabel: string) {
+  // Reached through Edit Rack Settings, so the rack already exists and the CTA
+  // persists the change straight away.
+  async changeOrderIndexAndSaveSettings(orderIndexLabel: string) {
     await this.selectOption("order-index-select", orderIndexLabel);
-    await this.clickContinueFromRackSettings();
+    await this.clickSaveRackSettings();
   }
 
-  async validateRackToast(label: string, action: "created" | "updated" = "created") {
+  async validateRackToast(label: string, action: "created" | "saved" = "created") {
     await this.validateTextInToast(`Rack "${label}" ${action}`);
+  }
+
+  async validateMinerPositionsToast(label: string) {
+    await this.validateTextInToast(`Miner positions saved for "${label}"`);
   }
 
   async validateRackCardVisible(label: string, zone: string) {

--- a/client/e2eTests/protoFleet/spec/racksCreation.spec.ts
+++ b/client/e2eTests/protoFleet/spec/racksCreation.spec.ts
@@ -31,7 +31,7 @@ test.describe("Racks - creation", () => {
       await racksPage.inputRows(RACK_ROWS);
 
       orderIndexValue = await racksPage.getOrderIndexValue();
-      await racksPage.clickContinueFromRackSettings();
+      await racksPage.clickCreateRackFromSettings();
     });
 
     await test.step("Validate empty rack assignment state", async () => {
@@ -46,7 +46,7 @@ test.describe("Racks - creation", () => {
       selectedMiners = await racksPage.getMinersFromSelector([0, 1]);
       test.expect(selectedMiners).toHaveLength(2);
       await racksPage.selectMinersInSelectorByIndex([0, 1]);
-      await racksPage.clickContinueInMinerSelector();
+      await racksPage.clickSaveInMinerSelector();
     });
 
     await test.step("Assign miners by name and validate positions", async () => {
@@ -55,8 +55,8 @@ test.describe("Racks - creation", () => {
     });
 
     await test.step("Save rack and validate rack grid card", async () => {
-      await racksPage.clickSaveRack();
-      await racksPage.validateRackToast(rackLabel);
+      await racksPage.clickSaveMinerPositions();
+      await racksPage.validateMinerPositionsToast(rackLabel);
       await racksPage.clickViewGrid();
       await racksPage.validateRackCardVisible(rackLabel, AUTOMATION_ZONE);
       await racksPage.validateRackCardGrid(rackLabel, AUTOMATION_ZONE, RACK_COLUMNS, RACK_ROWS);
@@ -80,7 +80,7 @@ test.describe("Racks - creation", () => {
       await racksPage.enableCustomRackLayout();
       await racksPage.inputColumns(RACK_COLUMNS);
       await racksPage.inputRows(RACK_ROWS);
-      await racksPage.clickContinueFromRackSettings();
+      await racksPage.clickCreateRackFromSettings();
     });
 
     await test.step("Add four miners", async () => {
@@ -90,7 +90,7 @@ test.describe("Racks - creation", () => {
       selectedMiners = await racksPage.getMinersFromSelector([0, 1, 2, 3]);
       test.expect(selectedMiners).toHaveLength(4);
       await racksPage.selectMinersInSelectorByIndex([0, 1, 2, 3]);
-      await racksPage.clickContinueInMinerSelector();
+      await racksPage.clickSaveInMinerSelector();
     });
 
     await test.step("Assign miners manually in DOM order and validate default numbering", async () => {
@@ -104,7 +104,8 @@ test.describe("Racks - creation", () => {
     for (const scenario of ORDER_INDEX_SCENARIOS.slice(1)) {
       await test.step(`Change order index to ${scenario.label}`, async () => {
         await racksPage.clickEditRackSettings();
-        await racksPage.changeOrderIndexAndContinue(scenario.label);
+        await racksPage.changeOrderIndexAndSaveSettings(scenario.label);
+        await racksPage.validateRackToast(rackLabel, "saved");
         await racksPage.validateRackConfiguration(RACK_COLUMNS, RACK_ROWS, scenario.label);
         await racksPage.validateRackSlotNumbersInDomOrder(scenario.expectedNumbers);
         await racksPage.validateMinerPositions(selectedMiners, scenario.expectedNumbers);
@@ -123,7 +124,7 @@ test.describe("Racks - creation", () => {
       await racksPage.enableCustomRackLayout();
       await racksPage.inputColumns(NETWORK_RACK_COLUMNS);
       await racksPage.inputRows(NETWORK_RACK_ROWS);
-      await racksPage.clickContinueFromRackSettings();
+      await racksPage.clickCreateRackFromSettings();
 
       await racksPage.clickAddMiners();
       await racksPage.waitForMinerSelectorListToLoad();
@@ -131,7 +132,7 @@ test.describe("Racks - creation", () => {
       test.expect(allVisibleMiners.length).toBeGreaterThan(0);
       test.expect(allVisibleMiners.length).toBeLessThanOrEqual(NETWORK_RACK_COLUMNS * NETWORK_RACK_ROWS);
       await racksPage.clickSelectAllMinersInSelector();
-      await racksPage.clickContinueInMinerSelector();
+      await racksPage.clickSaveInMinerSelector();
     });
 
     await test.step("Assign all miners by network and validate positions by IP and name", async () => {

--- a/client/e2eTests/protoFleet/spec/racksCreation.spec.ts
+++ b/client/e2eTests/protoFleet/spec/racksCreation.spec.ts
@@ -106,6 +106,10 @@ test.describe("Racks - creation", () => {
         await racksPage.clickEditRackSettings();
         await racksPage.changeOrderIndexAndSaveSettings(scenario.label);
         await racksPage.validateRackToast(rackLabel, "saved");
+        // Every pass saves the same rack, so the message is identical each time.
+        // Clearing means the next pass matches the toast it produced rather than
+        // this one, which is still on screen when the next save lands.
+        await racksPage.clearToasts();
         await racksPage.validateRackConfiguration(RACK_COLUMNS, RACK_ROWS, scenario.label);
         await racksPage.validateRackSlotNumbersInDomOrder(scenario.expectedNumbers);
         await racksPage.validateMinerPositions(selectedMiners, scenario.expectedNumbers);

--- a/client/e2eTests/protoFleet/spec/racksManagement.spec.ts
+++ b/client/e2eTests/protoFleet/spec/racksManagement.spec.ts
@@ -29,10 +29,11 @@ test.describe("Racks - management", () => {
       await racksPage.enableCustomRackLayout();
       await racksPage.inputColumns(RACK_COLUMNS);
       await racksPage.inputRows(RACK_ROWS);
-      await racksPage.clickContinueFromRackSettings();
-      await addSelectableMinersToSlots(racksPage, 3, [1, 2, 3]);
-      await racksPage.clickSaveRack();
+      await racksPage.clickCreateRackFromSettings();
       await racksPage.validateRackToast("A-01");
+      await addSelectableMinersToSlots(racksPage, 3, [1, 2, 3]);
+      await racksPage.clickSaveMinerPositions();
+      await racksPage.validateMinerPositionsToast("A-01");
       await racksPage.clickViewGrid();
       await racksPage.validateRackCardVisible("A-01", zoneA);
       createdRackLabels.push("A-01");
@@ -42,10 +43,11 @@ test.describe("Racks - management", () => {
       await racksPage.clickAddRackButton();
       await racksPage.inputZone(zoneA);
       await racksPage.inputRackLabel("A-02");
-      await racksPage.clickContinueFromRackSettings();
-      await addSelectableMinersToSlots(racksPage, 2, [1, 2]);
-      await racksPage.clickSaveRack();
+      await racksPage.clickCreateRackFromSettings();
       await racksPage.validateRackToast("A-02");
+      await addSelectableMinersToSlots(racksPage, 2, [1, 2]);
+      await racksPage.clickSaveMinerPositions();
+      await racksPage.validateMinerPositionsToast("A-02");
       await racksPage.clickViewGrid();
       await racksPage.validateRackCardVisible("A-02", zoneA);
       createdRackLabels.push("A-02");
@@ -55,10 +57,11 @@ test.describe("Racks - management", () => {
       await racksPage.clickAddRackButton();
       await racksPage.inputZone(zoneB);
       await racksPage.inputRackLabel("B-01");
-      await racksPage.clickContinueFromRackSettings();
-      await addSelectableMinersToSlots(racksPage, 1, [1]);
-      await racksPage.clickSaveRack();
+      await racksPage.clickCreateRackFromSettings();
       await racksPage.validateRackToast("B-01");
+      await addSelectableMinersToSlots(racksPage, 1, [1]);
+      await racksPage.clickSaveMinerPositions();
+      await racksPage.validateMinerPositionsToast("B-01");
       await racksPage.clickViewGrid();
       await racksPage.validateRackCardVisible("B-01", zoneB);
       createdRackLabels.push("B-01");
@@ -107,7 +110,8 @@ test.describe("Racks - management", () => {
 
     await test.step("Validate required label and invalid dimensions", async () => {
       // Zone is optional now; the label is required and empty by default, so
-      // continuing without typing one surfaces the label error.
+      // submitting without typing one surfaces the label error instead of
+      // creating the rack.
       await racksPage.clickAddRackButton();
       await racksPage.inputZone(validationZone);
       generatedRackLabel = "A-01";
@@ -115,7 +119,7 @@ test.describe("Racks - management", () => {
       await racksPage.enableCustomRackLayout();
       await racksPage.inputColumns(0);
       await racksPage.inputRows(13);
-      await racksPage.clickContinueFromRackSettings();
+      await racksPage.clickCreateRackFromSettings();
 
       await racksPage.validateRackSettingsFieldError("rack-label", "A label is required");
       await racksPage.validateRackSettingsFieldError("rack-columns", "Columns must be a whole number between 1 and 12");
@@ -123,11 +127,12 @@ test.describe("Racks - management", () => {
       await racksPage.validateTitleInModal("Rack settings");
     });
 
-    await test.step("Correct rack settings and continue", async () => {
+    await test.step("Correct rack settings and create the rack", async () => {
       await racksPage.inputRackLabel(generatedRackLabel);
       await racksPage.inputColumns(VALIDATION_RACK_COLUMNS);
       await racksPage.inputRows(VALIDATION_RACK_ROWS);
-      await racksPage.clickContinueFromRackSettings();
+      await racksPage.clickCreateRackFromSettings();
+      await racksPage.validateRackToast(generatedRackLabel);
 
       await racksPage.validateRackConfiguration(VALIDATION_RACK_COLUMNS, VALIDATION_RACK_ROWS, "Bottom left");
       await racksPage.validateAssignedMinersCount(0, 1);
@@ -140,18 +145,18 @@ test.describe("Racks - management", () => {
       const selectableMinerIndexes = await racksPage.getSelectableMinerIndexes(2);
       selectedMiners = await racksPage.getMinersFromSelector(selectableMinerIndexes);
       await racksPage.selectMinersInSelectorByIndex(selectableMinerIndexes);
-      await racksPage.clickContinueInMinerSelector();
+      await racksPage.clickSaveInMinerSelector();
 
       await racksPage.validateMinerSelectorOverflowError(2, 1);
       await racksPage.toggleMinerInSelectorByIpAddress(selectedMiners[1].ipAddress);
-      await racksPage.clickContinueInMinerSelector();
+      await racksPage.clickSaveInMinerSelector();
     });
 
     await test.step("Assign remaining miner and save the rack", async () => {
       await racksPage.clickAssignByNetwork();
       await racksPage.validateMinersAssignedByNetwork([selectedMiners[0]]);
-      await racksPage.clickSaveRack();
-      await racksPage.validateRackToast(generatedRackLabel);
+      await racksPage.clickSaveMinerPositions();
+      await racksPage.validateMinerPositionsToast(generatedRackLabel);
       await racksPage.validateRackCardVisible(generatedRackLabel, validationZone);
       await racksPage.validateRackCardGrid(
         generatedRackLabel,

--- a/client/e2eTests/protoFleet/spec/racksManualAssignment.spec.ts
+++ b/client/e2eTests/protoFleet/spec/racksManualAssignment.spec.ts
@@ -186,8 +186,9 @@ test.describe("Racks - manual assignment", () => {
       await racksPage.toggleMinerInSelectorByIpAddress(selectedMiners[1].ipAddress);
       await racksPage.clickSaveInMinerSelector();
       await racksPage.validateTextIsVisible("No miners added to this rack yet.");
-      await racksPage.clickSaveMinerPositions();
-      await racksPage.validateMinerPositionsToast(rackLabel);
+      // The picker already persisted the removal, which took the slots with it,
+      // so Save has no placement left to write and closes without a toast.
+      await racksPage.saveMinerPositionsWithNothingPlaced();
     });
 
     await test.step("Validate rack overview is empty after saving", async () => {

--- a/client/e2eTests/protoFleet/spec/racksManualAssignment.spec.ts
+++ b/client/e2eTests/protoFleet/spec/racksManualAssignment.spec.ts
@@ -28,7 +28,7 @@ test.describe("Racks - manual assignment", () => {
       await racksPage.enableCustomRackLayout();
       await racksPage.inputColumns(LARGE_RACK_COLUMNS);
       await racksPage.inputRows(LARGE_RACK_ROWS);
-      await racksPage.clickContinueFromRackSettings();
+      await racksPage.clickCreateRackFromSettings();
     });
 
     await test.step("Manage miners and add the first miner to the rack list", async () => {
@@ -39,7 +39,7 @@ test.describe("Racks - manual assignment", () => {
       selectedMiners = await racksPage.getMinersFromSelector(selectableMinerIndexes);
       test.expect(selectedMiners).toHaveLength(2);
       await racksPage.selectMinersInSelectorByIndex([selectableMinerIndexes[0]]);
-      await racksPage.clickContinueInMinerSelector();
+      await racksPage.clickSaveInMinerSelector();
     });
 
     await test.step("Search and assign the second miner to slot 04", async () => {
@@ -102,8 +102,8 @@ test.describe("Racks - manual assignment", () => {
       await racksPage.validateMinerRowPosition(selectedMiners[1].ipAddress, 9);
       await racksPage.validateRackSlotsHighlighted([1, 9]);
 
-      await racksPage.clickSaveRack();
-      await racksPage.validateRackToast(rackLabel);
+      await racksPage.clickSaveMinerPositions();
+      await racksPage.validateMinerPositionsToast(rackLabel);
     });
 
     await test.step("Open the created rack and validate saved slots", async () => {
@@ -130,9 +130,11 @@ test.describe("Racks - manual assignment", () => {
       await racksPage.enableCustomRackLayout();
       await racksPage.inputColumns(OVERVIEW_RACK_COLUMNS);
       await racksPage.inputRows(OVERVIEW_RACK_ROWS);
-      await racksPage.clickContinueFromRackSettings();
-      await racksPage.clickSaveRack();
+      await racksPage.clickCreateRackFromSettings();
       await racksPage.validateRackToast(rackLabel);
+      // No miner has a slot yet, so there is no placement to save — Save just
+      // closes the modal.
+      await racksPage.saveMinerPositionsWithNothingPlaced();
     });
 
     await test.step("Open the created rack and assign the first miner to slot 02", async () => {
@@ -182,10 +184,10 @@ test.describe("Racks - manual assignment", () => {
       await racksPage.waitForMinerSelectorListToLoad();
       await racksPage.toggleMinerInSelectorByIpAddress(selectedMiners[0].ipAddress);
       await racksPage.toggleMinerInSelectorByIpAddress(selectedMiners[1].ipAddress);
-      await racksPage.clickContinueInMinerSelector();
+      await racksPage.clickSaveInMinerSelector();
       await racksPage.validateTextIsVisible("No miners added to this rack yet.");
-      await racksPage.clickSaveRack();
-      await racksPage.validateRackToast(rackLabel, "updated");
+      await racksPage.clickSaveMinerPositions();
+      await racksPage.validateMinerPositionsToast(rackLabel);
     });
 
     await test.step("Validate rack overview is empty after saving", async () => {

--- a/client/e2eTests/protoFleet/spec/racksOverviewActions.spec.ts
+++ b/client/e2eTests/protoFleet/spec/racksOverviewActions.spec.ts
@@ -25,7 +25,9 @@ test.describe("Racks - overview actions", () => {
     let rackDeviceIdentifiers: string[] = [];
 
     await test.step("Create and save a new rack with two rig miners", async () => {
-      const saveRackRequestPromise = page.waitForRequest(/SaveRack/);
+      // The miner picker commits membership itself, so the rack's members
+      // arrive on the first AssignDevicesToRack call, not on a SaveRack.
+      const assignRequestPromise = page.waitForRequest(/AssignDevicesToRack/);
 
       await racksPage.clickAddRackButton();
       await racksPage.inputZone(AUTOMATION_ZONE);
@@ -36,19 +38,18 @@ test.describe("Racks - overview actions", () => {
       await racksPage.enableCustomRackLayout();
       await racksPage.inputColumns(RACK_COLUMNS);
       await racksPage.inputRows(RACK_ROWS);
-      await racksPage.clickContinueFromRackSettings();
+      await racksPage.clickCreateRackFromSettings();
 
       selectedMiners = await addSelectableRigMinersToSlots(racksPage, 2, [1, 2]);
       test.expect(selectedMiners).toHaveLength(2);
       test.expect(selectedMiners.every((miner) => miner.model === PROTO_RIG_MODEL)).toBe(true);
 
-      await racksPage.clickSaveRack();
+      await racksPage.clickSaveMinerPositions();
 
-      const saveRackRequest = await saveRackRequestPromise;
-      const saveRackRequestBody = saveRackRequest.postDataJSON();
-      rackDeviceIdentifiers = saveRackRequestBody.deviceSelector.deviceList.deviceIdentifiers;
+      const assignRequest = await assignRequestPromise;
+      rackDeviceIdentifiers = assignRequest.postDataJSON().deviceIdentifiers;
 
-      await racksPage.validateRackToast(rackLabel);
+      await racksPage.validateMinerPositionsToast(rackLabel);
       test.expect(rackDeviceIdentifiers).toHaveLength(2);
     });
 
@@ -109,7 +110,9 @@ test.describe("Racks - overview actions", () => {
 
       try {
         await test.step("Create a rack with two assigned Proto rigs", async () => {
-          const saveRackRequestPromise = page.waitForRequest(/SaveRack/);
+          // The miner picker commits membership itself, so the rack's members
+          // arrive on the first AssignDevicesToRack call, not on a SaveRack.
+          const assignRequestPromise = page.waitForRequest(/AssignDevicesToRack/);
 
           await racksPage.clickAddRackButton();
           await racksPage.inputZone(AUTOMATION_ZONE);
@@ -118,15 +121,14 @@ test.describe("Racks - overview actions", () => {
           await racksPage.enableCustomRackLayout();
           await racksPage.inputColumns(OVERVIEW_RACK_COLUMNS);
           await racksPage.inputRows(OVERVIEW_RACK_ROWS);
-          await racksPage.clickContinueFromRackSettings();
+          await racksPage.clickCreateRackFromSettings();
           await addSelectableRigMinersToSlots(racksPage, 2, [1, 2]);
-          await racksPage.clickSaveRack();
+          await racksPage.clickSaveMinerPositions();
 
-          const saveRackRequest = await saveRackRequestPromise;
-          const saveRackRequestBody = saveRackRequest.postDataJSON();
-          rackDeviceIdentifiers = saveRackRequestBody.deviceSelector.deviceList.deviceIdentifiers;
+          const assignRequest = await assignRequestPromise;
+          rackDeviceIdentifiers = assignRequest.postDataJSON().deviceIdentifiers;
 
-          await racksPage.validateRackToast(rackLabel);
+          await racksPage.validateMinerPositionsToast(rackLabel);
           test.expect(rackDeviceIdentifiers).toHaveLength(2);
         });
 
@@ -191,11 +193,11 @@ test.describe("Racks - overview actions", () => {
       await racksPage.enableCustomRackLayout();
       await racksPage.inputColumns(OVERVIEW_RACK_COLUMNS);
       await racksPage.inputRows(OVERVIEW_RACK_ROWS);
-      await racksPage.clickContinueFromRackSettings();
+      await racksPage.clickCreateRackFromSettings();
       await addSelectableRigMinersToSlots(racksPage, 2, [1, 2]);
-      await racksPage.clickSaveRack();
+      await racksPage.clickSaveMinerPositions();
 
-      await racksPage.validateRackToast(rackLabel);
+      await racksPage.validateMinerPositionsToast(rackLabel);
       await racksPage.clickViewGrid();
       await racksPage.openRackCard(rackLabel, AUTOMATION_ZONE);
       await racksPage.openRackOverviewActionsMenu();

--- a/client/e2eTests/protoFleet/spec/racksOverviewActions.spec.ts
+++ b/client/e2eTests/protoFleet/spec/racksOverviewActions.spec.ts
@@ -47,7 +47,7 @@ test.describe("Racks - overview actions", () => {
       await racksPage.clickSaveMinerPositions();
 
       const assignRequest = await assignRequestPromise;
-      rackDeviceIdentifiers = assignRequest.postDataJSON().deviceIdentifiers;
+      rackDeviceIdentifiers = assignRequest.postDataJSON().deviceSelector.deviceList.deviceIdentifiers;
 
       await racksPage.validateMinerPositionsToast(rackLabel);
       test.expect(rackDeviceIdentifiers).toHaveLength(2);
@@ -126,7 +126,7 @@ test.describe("Racks - overview actions", () => {
           await racksPage.clickSaveMinerPositions();
 
           const assignRequest = await assignRequestPromise;
-          rackDeviceIdentifiers = assignRequest.postDataJSON().deviceIdentifiers;
+          rackDeviceIdentifiers = assignRequest.postDataJSON().deviceSelector.deviceList.deviceIdentifiers;
 
           await racksPage.validateMinerPositionsToast(rackLabel);
           test.expect(rackDeviceIdentifiers).toHaveLength(2);

--- a/client/src/protoFleet/api/buildings.ts
+++ b/client/src/protoFleet/api/buildings.ts
@@ -6,6 +6,7 @@ import {
   type Building,
   type BuildingRack,
   type BuildingWithCounts,
+  type PerBuildingCreateErrorReason,
   RackOrderIndex,
 } from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
 import type { FleetListTelemetryRangeFilter } from "@/protoFleet/api/generated/common/v1/fleet_list_stats_pb";
@@ -83,6 +84,40 @@ interface CreateBuildingProps {
   // the per-device reasons; it is empty for a transport / permission failure
   // and for a plain create.
   onError?: (message: string, conflicts: AssignDevicesToBuildingConflict[]) => void;
+  onFinally?: () => void;
+}
+
+// One row of a bulk create. The bulk form only sets the name (generated from
+// a prefix + counter, or typed); power/overhead ride along so the shape can
+// grow without another proto change.
+export interface NewBuildingInput {
+  name: string;
+  description?: string;
+  powerCapacityMw?: number;
+  overheadKw?: number;
+  // Layout dimensions. The bulk form applies one pair across the batch, but
+  // they travel per row so a NewBuilding describes a whole building.
+  aisles?: number;
+  racksPerAisle?: number;
+}
+
+// A row the server refused, keyed by its index in the submitted list so the
+// preview can mark that exact line.
+export interface BulkCreateBuildingError {
+  index: number;
+  name: string;
+  reason: PerBuildingCreateErrorReason;
+}
+
+interface CreateBuildingsProps {
+  siteId: bigint;
+  buildings: NewBuildingInput[];
+  signal?: AbortSignal;
+  onSuccess?: (buildings: Building[]) => void;
+  // Called on failure. `errors` carries the per-row name collisions when the
+  // server rejected the batch (nothing was created); it is empty for a
+  // transport / permission failure.
+  onError?: (message: string, errors: BulkCreateBuildingError[]) => void;
   onFinally?: () => void;
 }
 
@@ -449,6 +484,52 @@ const useBuildings = () => {
     [handleAuthErrors],
   );
 
+  // createBuildings creates every building in the batch against one site in a
+  // single transaction (all-or-nothing), so a mid-list failure can't leave half
+  // the operator's list behind. Name collisions come back per row — within the
+  // batch or against buildings already at the site — with nothing created, so
+  // the caller can mark the offending preview lines and let the operator retry.
+  const createBuildings = useCallback(
+    async ({ siteId, buildings, signal, onSuccess, onError, onFinally }: CreateBuildingsProps) => {
+      try {
+        const response = await buildingsClient.createBuildings(
+          {
+            siteId,
+            buildings: buildings.map((b) => ({
+              name: b.name,
+              description: b.description ?? "",
+              powerKw: mwToKw(b.powerCapacityMw ?? 0),
+              overheadKw: b.overheadKw ?? 0,
+              aisles: b.aisles ?? 0,
+              racksPerAisle: b.racksPerAisle ?? 0,
+            })),
+          },
+          { signal },
+        );
+        if (signal?.aborted) return;
+        if (response.errors.length > 0 || response.buildings.length === 0) {
+          onError?.(
+            "Some building names are already taken",
+            response.errors.map((e) => ({ index: e.index, name: e.name, reason: e.reason })),
+          );
+          return;
+        }
+        onSuccess?.(response.buildings);
+      } catch (err) {
+        if (signal?.aborted) return;
+        handleAuthErrors({
+          error: err,
+          onError: (error) => {
+            onError?.(getErrorMessage(error), []);
+          },
+        });
+      } finally {
+        onFinally?.();
+      }
+    },
+    [handleAuthErrors],
+  );
+
   const updateBuilding = useCallback(
     async ({ id, values, signal, onSuccess, onError, onFinally }: UpdateBuildingProps) => {
       try {
@@ -597,6 +678,7 @@ const useBuildings = () => {
     getBuilding,
     listBuildingRacks,
     createBuilding,
+    createBuildings,
     updateBuilding,
     deleteBuilding,
     assignRacksToBuilding,

--- a/client/src/protoFleet/api/useDeviceSets.ts
+++ b/client/src/protoFleet/api/useDeviceSets.ts
@@ -14,6 +14,7 @@ import {
   type DeviceSetStats,
   DeviceSetType,
   type PerDeviceRackConflict,
+  type PerRackCreateErrorReason,
   type RackCoolingType,
   RackInfoSchema,
   type RackOrderIndex,
@@ -240,6 +241,42 @@ interface SaveRackProps {
   // The caller confirms and retries with forceClearConflictingSite=true.
   onConflicts?: (conflicts: PerDeviceRackConflict[]) => void;
   onError?: (message: string) => void;
+  onFinally?: () => void;
+}
+
+// One rack in a bulk create. Carries the whole rack description, not just the
+// label: the bulk form applies one geometry across the batch, but a NewRack
+// describes a whole rack. Placement is the exception — see CreateRacksProps.
+export interface NewRackInput {
+  label: string;
+  rows: number;
+  columns: number;
+  zone?: string;
+  orderIndex: RackOrderIndex;
+  coolingType: RackCoolingType;
+}
+
+// A row the server refused, keyed by its index in the submitted list so the
+// preview can mark that exact line.
+export interface BulkCreateRackError {
+  index: number;
+  label: string;
+  reason: PerRackCreateErrorReason;
+}
+
+interface CreateRacksProps {
+  // Where the whole batch lands. Omit both for unassigned racks; a building
+  // determines the site server-side, so callers that know the building leave
+  // siteId undefined.
+  siteId?: bigint;
+  buildingId?: bigint;
+  racks: NewRackInput[];
+  signal?: AbortSignal;
+  onSuccess?: (racks: DeviceSet[]) => void;
+  // Called on failure. `errors` carries the per-row label collisions when the
+  // server rejected the batch (nothing was created); it is empty for a
+  // transport / permission failure.
+  onError?: (message: string, errors: BulkCreateRackError[]) => void;
   onFinally?: () => void;
 }
 
@@ -1104,9 +1141,57 @@ const useDeviceSets = () => {
     [handleAuthErrors],
   );
 
+  // createRacks creates every rack in the batch at one placement in a single
+  // transaction (all-or-nothing), so a mid-list failure can't leave half the
+  // operator's list behind. Label collisions come back per row — within the
+  // batch, or against a rack already live anywhere in the org — with nothing
+  // created, so the caller can mark the offending preview lines.
+  const createRacks = useCallback(
+    async ({ siteId, buildingId, racks, signal, onSuccess, onError, onFinally }: CreateRacksProps) => {
+      try {
+        const response = await deviceSetClient.createRacks(
+          {
+            siteId,
+            buildingId,
+            racks: racks.map((r) => ({
+              label: r.label,
+              rows: r.rows,
+              columns: r.columns,
+              zone: r.zone ?? "",
+              orderIndex: r.orderIndex,
+              coolingType: r.coolingType,
+            })),
+          },
+          { signal },
+        );
+        if (signal?.aborted) return;
+        if (response.errors.length > 0 || response.racks.length === 0) {
+          onError?.(
+            "Some rack labels are already taken",
+            response.errors.map((e) => ({ index: e.index, label: e.label, reason: e.reason })),
+          );
+          return;
+        }
+        onSuccess?.(response.racks);
+      } catch (err) {
+        if (signal?.aborted) return;
+        handleAuthErrors({
+          error: err,
+          onError: (error) => {
+            onError?.(getDeviceSetErrorMessage(error, "rack"), []);
+          },
+        });
+      } finally {
+        onFinally?.();
+      }
+    },
+    [handleAuthErrors],
+  );
+
   return {
     createGroup,
     createRack,
+    createRacks,
     updateGroup,
     updateRack,
     deleteGroup,

--- a/client/src/protoFleet/features/fleetManagement/components/FleetCreateFlow/FleetCreateFlowProvider.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/FleetCreateFlow/FleetCreateFlowProvider.tsx
@@ -16,7 +16,9 @@ import BuildingModals from "@/protoFleet/features/buildings/components/BuildingM
 import BuildingSettingsModal from "@/protoFleet/features/buildings/components/BuildingSettingsModal";
 import { useBuildingModals } from "@/protoFleet/features/buildings/hooks/useBuildingModals";
 import { ManageRackModal, type RackFormData } from "@/protoFleet/features/fleetManagement/components/ManageRackModal";
+import ReparentWarningDialog from "@/protoFleet/features/fleetManagement/components/ManageRackModal/ReparentWarningDialog";
 import RackSettingsModal from "@/protoFleet/features/fleetManagement/components/RackSettingsModal";
+import { useCreateRack } from "@/protoFleet/features/fleetManagement/hooks/useCreateRack";
 import SiteModals from "@/protoFleet/features/sites/components/SiteModals";
 import SiteSettingsModal from "@/protoFleet/features/sites/components/SiteSettingsModal";
 import { useSiteModals } from "@/protoFleet/features/sites/hooks/useSiteModals";
@@ -44,9 +46,10 @@ const MAX_DEVICE_BATCH = 10000;
 // with the operator's current miner selection, which in all-selection mode
 // resolves to the full fleet (capped only at MAX_DEVICE_BATCH). Without a
 // gate here, an oversized seed renders one MinersPane row per miner and
-// freezes the browser long before the save-time capacity guard fires. Cap
-// at the absolute max before ManageRackModal mounts — the exact
-// chosen-capacity check still runs at save once rows×columns are picked.
+// freezes the browser long before anything else fires. Cap at the absolute
+// max before the operator even reaches Rack Settings — the exact
+// chosen-capacity check runs server-side on the create, once rows×columns
+// are picked.
 const MAX_RACK_CAPACITY = 12 * 12;
 
 // A seed that moves racked miners into a new building/site sends
@@ -110,12 +113,14 @@ const FleetCreateFlowProvider = ({
   const activeSite = useFleetStore((state) => state.ui.activeSite);
   const scopedSiteId = useMemo(() => (activeSite.kind === "site" ? BigInt(activeSite.id) : undefined), [activeSite]);
 
-  // Rack create flow. rackSettings drives RackSettingsModal; once the
-  // operator continues, rackFormData opens ManageRackModal seeded with the
-  // selected miners. rackSeed survives the settings step so the miners reach
-  // the manage modal.
+  // Rack create flow. RackSettingsModal's "Create rack" creates the rack with
+  // the seeded miners already in it — one atomic SaveRack, so a failed seed
+  // can't leave an empty rack behind — then ManageRackModal opens on the real
+  // rack for positioning. rackSeed survives the settings step so the miners
+  // reach the create call.
   const [rackSettingsOpen, setRackSettingsOpen] = useState(false);
   const [rackFormData, setRackFormData] = useState<RackFormData | null>(null);
+  const [rackId, setRackId] = useState<bigint | null>(null);
   const [rackSeed, setRackSeed] = useState<RackCreateSeed | null>(null);
   // Holds a seed whose miners have a placement the new rack would clear,
   // until the operator confirms; null when no confirmation is pending.
@@ -124,6 +129,7 @@ const FleetCreateFlowProvider = ({
   const openRackSettings = useCallback((seed: RackCreateSeed) => {
     setRackSeed(seed);
     setRackFormData(null);
+    setRackId(null);
     setRackSettingsOpen(true);
   }, []);
 
@@ -153,13 +159,35 @@ const FleetCreateFlowProvider = ({
   const closeRackFlow = useCallback(() => {
     setRackSettingsOpen(false);
     setRackFormData(null);
+    setRackId(null);
     setRackSeed(null);
   }, []);
 
-  const handleRackSettingsContinue = useCallback((formData: RackFormData) => {
-    setRackSettingsOpen(false);
-    setRackFormData(formData);
-  }, []);
+  const {
+    createRack,
+    creating: creatingRack,
+    conflict: rackCreateConflict,
+    confirmConflict: confirmRackCreateConflict,
+    cancelConflict: cancelRackCreateConflict,
+  } = useCreateRack({
+    onCreated: (createdId, formData) => {
+      // The rack and its seeded miners are live. Pulse the lists now — the
+      // operator may well dismiss the manage step without positioning anything,
+      // and the rack still exists.
+      bumpEntities();
+      setRackSettingsOpen(false);
+      setRackSeed(null);
+      setRackFormData(formData);
+      setRackId(createdId);
+    },
+  });
+
+  // The seed's miners ride on the create itself, so membership and the rack
+  // land in one transaction.
+  const handleRackSettingsSubmit = useCallback(
+    (formData: RackFormData) => createRack(formData, rackSeed?.minerIds),
+    [createRack, rackSeed],
+  );
 
   const handleRackSaved = useCallback(() => {
     bumpEntities();
@@ -380,18 +408,30 @@ const FleetCreateFlowProvider = ({
           existingRacks={[]}
           defaultSiteId={scopedSiteId}
           onDismiss={closeRackFlow}
-          onContinue={handleRackSettingsContinue}
+          onSubmit={handleRackSettingsSubmit}
+          saving={creatingRack}
         />
       ) : null}
-      {rackFormData ? (
+      {rackFormData && rackId !== null ? (
         <ManageRackModal
-          show={!!rackFormData}
+          show
           rackSettings={rackFormData}
+          existingRackId={rackId}
           existingRacks={[]}
-          seededMinerIds={rackSeed?.minerIds}
           scopedSiteId={scopedSiteId}
           onDismiss={closeRackFlow}
           onSave={handleRackSaved}
+          // Membership commits land while this modal is open; pulse the lists so
+          // they're right even if the operator dismisses without positioning.
+          onSettingsPersisted={bumpEntities}
+        />
+      ) : null}
+      {rackCreateConflict ? (
+        <ReparentWarningDialog
+          count={rackCreateConflict.count}
+          rackLabel={rackCreateConflict.rackLabel}
+          onCancel={cancelRackCreateConflict}
+          onConfirm={confirmRackCreateConflict}
         />
       ) : null}
       {rackConflictSeed ? (

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageMinersModal.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageMinersModal.test.tsx
@@ -34,7 +34,7 @@ vi.mock("@/shared/components/Modal", () => ({
       <div data-testid="modal">
         {children}
         {buttons?.map((btn: any, i: number) => (
-          <button key={i} onClick={btn.onClick}>
+          <button key={i} onClick={btn.onClick} disabled={Boolean(btn.disabled || btn.loading)}>
             {btn.text}
           </button>
         ))}
@@ -103,7 +103,7 @@ describe("ManageMinersModal", () => {
     expect(latestProps.current.eligibility).toEqual({ rackId: 5n, siteId: 2n, buildingId: 3n });
   });
 
-  it("calls onConfirm with selected IDs on continue", () => {
+  it("calls onConfirm with selected IDs on save", () => {
     const onConfirm = vi.fn();
     mockGetSelection.mockReturnValue({
       selectedItems: ["miner-1", "miner-2"],
@@ -114,7 +114,7 @@ describe("ManageMinersModal", () => {
     });
 
     render(<ManageMinersModal {...defaultProps} onConfirm={onConfirm} />);
-    fireEvent.click(screen.getByText(/Continue/));
+    fireEvent.click(screen.getByText(/Save/));
 
     expect(onConfirm).toHaveBeenCalledWith(["miner-1", "miner-2"], false, undefined, []);
   });
@@ -129,7 +129,7 @@ describe("ManageMinersModal", () => {
     });
 
     render(<ManageMinersModal {...defaultProps} maxSlots={2} />);
-    fireEvent.click(screen.getByText(/Continue/));
+    fireEvent.click(screen.getByText(/Save/));
 
     expect(screen.getByText(/Cannot add 3 miners with only 2 available slots/)).toBeInTheDocument();
   });
@@ -145,12 +145,12 @@ describe("ManageMinersModal", () => {
     });
 
     render(<ManageMinersModal {...defaultProps} maxSlots={2} onConfirm={onConfirm} />);
-    fireEvent.click(screen.getByText(/Continue/));
+    fireEvent.click(screen.getByText(/Save/));
 
     expect(onConfirm).not.toHaveBeenCalled();
   });
 
-  it("blocks Continue and prompts to clear the filter when a placement facet conflicts", () => {
+  it("blocks Save and prompts to clear the filter when a placement facet conflicts", () => {
     const onConfirm = vi.fn();
     mockGetSelection.mockReturnValue({
       selectedItems: ["m1", "m2"],
@@ -161,10 +161,59 @@ describe("ManageMinersModal", () => {
     });
 
     render(<ManageMinersModal {...defaultProps} onConfirm={onConfirm} />);
-    fireEvent.click(screen.getByText(/Continue/));
+    fireEvent.click(screen.getByText(/Save/));
 
     // No save (which would otherwise resolve/commit a hidden selection).
     expect(onConfirm).not.toHaveBeenCalled();
     expect(screen.getByText(/Clear the Building or Rack filter/i)).toBeInTheDocument();
+  });
+
+  it("closes without a write when the selection still matches the rack's members", () => {
+    mockGetSelection.mockReturnValue({
+      selectedItems: ["miner-1"],
+      allSelected: false,
+      totalMiners: 10,
+      reassignedItems: [],
+      blockedByFilter: false,
+    });
+
+    const onConfirm = vi.fn();
+    const onDismiss = vi.fn();
+    const { unmount } = render(
+      <ManageMinersModal
+        {...defaultProps}
+        currentRackMiners={["miner-1"]}
+        onConfirm={onConfirm}
+        onDismiss={onDismiss}
+      />,
+    );
+    // Reviewing the list and keeping it as-is is a legitimate outcome, so Save
+    // closes — but it must not report a membership change it didn't make.
+    fireEvent.click(screen.getByText(/Save/));
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    unmount();
+
+    // Same count, different miner — a real membership change, so it commits.
+    render(<ManageMinersModal {...defaultProps} currentRackMiners={["miner-2"]} onConfirm={onConfirm} />);
+    fireEvent.click(screen.getByText(/Save/));
+    expect(onConfirm).toHaveBeenCalledWith(["miner-1"], false, undefined, []);
+  });
+
+  it("treats select-all as a change, since it resolves server-side", () => {
+    mockGetSelection.mockReturnValue({
+      selectedItems: ["miner-1"],
+      allSelected: true,
+      totalMiners: 10,
+      reassignedItems: [],
+      blockedByFilter: false,
+    });
+
+    const onConfirm = vi.fn();
+    render(<ManageMinersModal {...defaultProps} currentRackMiners={["miner-1"]} onConfirm={onConfirm} />);
+    // The selection resolves server-side, so it can't be compared here — it
+    // commits even though the local ids match the rack's members.
+    fireEvent.click(screen.getByText(/Save/));
+    expect(onConfirm).toHaveBeenCalledWith(["miner-1"], true, undefined, []);
   });
 });

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageMinersModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageMinersModal.tsx
@@ -38,6 +38,8 @@ interface ManageMinersModalProps {
     filter: MinerListFilter | undefined,
     reassignedItems: string[],
   ) => Promise<string | undefined>;
+  // In-flight signal from the host's write, mirrored into the CTA.
+  saving?: boolean;
 }
 
 export default function ManageMinersModal({
@@ -49,11 +51,22 @@ export default function ManageMinersModal({
   scope,
   onDismiss,
   onConfirm,
+  saving = false,
 }: ManageMinersModalProps) {
   const selectionRef = useRef<MinerSelectionListHandle>(null);
   const [overflowError, setOverflowError] = useState("");
 
-  const handleContinue = useCallback(async () => {
+  // Whether an explicit selection differs from what's in the rack right now.
+  const changesMembership = useCallback(
+    (selectedItems: string[]) => {
+      if (selectedItems.length !== currentRackMiners.length) return true;
+      const current = new Set(currentRackMiners);
+      return selectedItems.some((id) => !current.has(id));
+    },
+    [currentRackMiners],
+  );
+
+  const handleSave = useCallback(async () => {
     const selection = selectionRef.current?.getSelection();
     if (!selection) return;
 
@@ -65,6 +78,15 @@ export default function ManageMinersModal({
     // to clear the filter first instead.
     if (blockedByFilter) {
       setOverflowError("Clear the Building or Rack filter to continue — it doesn't match this rack.");
+      return;
+    }
+
+    // Nothing to write: the selection still matches the rack's membership, so
+    // the write would report a change it didn't make. Close instead — reviewing
+    // the list and keeping it as-is is a legitimate outcome. "Select all"
+    // resolves server-side, so it can't be compared here and always commits.
+    if (!allSelected && !changesMembership(selectedItems)) {
+      onDismiss();
       return;
     }
 
@@ -81,7 +103,7 @@ export default function ManageMinersModal({
 
     const error = await onConfirm(selectedItems, allSelected, allSelected ? filter : undefined, reassignedItems);
     if (error) setOverflowError(error);
-  }, [maxSlots, onConfirm]);
+  }, [maxSlots, onConfirm, changesMembership, onDismiss]);
 
   if (!show) return null;
 
@@ -96,9 +118,14 @@ export default function ManageMinersModal({
       divider={false}
       buttons={[
         {
-          text: "Continue",
+          // Names the write it makes: this picker owns rack membership.
+          text: saving ? "Saving..." : "Save",
           variant: "primary",
-          onClick: handleContinue,
+          // Only the in-flight guard: the checks that used to gate this run in
+          // handleSave, where they can say what's wrong.
+          disabled: saving,
+          loading: saving,
+          onClick: handleSave,
           dismissModalOnClick: false,
         },
       ]}

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.membership.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.membership.test.tsx
@@ -68,7 +68,7 @@ vi.mock("./ScanMinerQrModal", async () => {
     onUndoAssignment,
   }: {
     onAssign: (id: string) => Promise<{ failed?: true; message?: string }>;
-    onUndoAssignment: () => Promise<void>;
+    onUndoAssignment: () => Promise<boolean>;
   }) => {
     const [refusal, setRefusal] = useState<string>();
     return (

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.membership.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.membership.test.tsx
@@ -1,0 +1,228 @@
+import { MemoryRouter } from "react-router-dom";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import ManageRackModal from "./ManageRackModal";
+import { RackCoolingType, RackOrderIndex } from "@/protoFleet/api/generated/device_set/v1/device_set_pb";
+import type { MinerStateSnapshot } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
+
+/**
+ * Membership-commit behaviour, driven through stubbed pickers.
+ *
+ * The real ManageMiners / Scan pickers need a paginated miner list and a camera,
+ * and what these tests are about is what ManageRackModal does with their
+ * callbacks: which AssignDevicesToRack calls it makes, in what order, and what it
+ * leaves on screen when one of them fails. Stubbing the pickers is what makes
+ * those outcomes assertable — hence a separate file from ManageRackModal.test.tsx,
+ * whose mocks are the real ones.
+ */
+
+interface AssignCall {
+  targetRackId?: bigint;
+  deviceIdentifiers: string[];
+  onSuccess?: () => void;
+  onError?: (message: string) => void;
+}
+const mockAssignDevicesToRack = vi.fn((args: AssignCall) => args.onSuccess?.());
+const mockGetRackSlots = vi.fn(({ onSuccess }: { onSuccess: (slots: unknown[]) => void }) => onSuccess([]));
+const mockListGroupMembers = vi.fn(({ onSuccess }: { onSuccess: (ids: string[]) => void }) => onSuccess(["miner-1"]));
+
+const miners: Record<string, MinerStateSnapshot> = {
+  "miner-1": { deviceIdentifier: "miner-1", name: "Miner 1" } as MinerStateSnapshot,
+  "miner-2": { deviceIdentifier: "miner-2", name: "Miner 2" } as MinerStateSnapshot,
+};
+
+// Exposes onConfirm as a button and renders whatever string comes back, which is
+// the channel a still-open picker uses to show a write failure.
+vi.mock("./ManageMinersModal", async () => {
+  const { useState } = await import("react");
+  const ManageMinersStub = ({ onConfirm }: { onConfirm: (...args: never[]) => Promise<string | undefined> }) => {
+    const [error, setError] = useState<string>();
+    return (
+      <div>
+        <button
+          type="button"
+          onClick={() =>
+            void (onConfirm as (...a: unknown[]) => Promise<string | undefined>)(
+              ["miner-2"],
+              false,
+              undefined,
+              [],
+            ).then(setError)
+          }
+        >
+          swap to miner-2
+        </button>
+        {error ? <p>picker error: {error}</p> : null}
+      </div>
+    );
+  };
+  return { __esModule: true, default: ManageMinersStub };
+});
+
+// Same idea for the scanner: assign, then undo, both as buttons.
+vi.mock("./ScanMinerQrModal", async () => {
+  const { useState } = await import("react");
+  const ScanMinerQrStub = ({
+    onAssign,
+    onUndoAssignment,
+  }: {
+    onAssign: (id: string) => Promise<{ failed?: true; message?: string }>;
+    onUndoAssignment: () => Promise<void>;
+  }) => {
+    const [refusal, setRefusal] = useState<string>();
+    return (
+      <div>
+        <button
+          type="button"
+          onClick={() =>
+            void onAssign("miner-2").then((outcome) => {
+              if ("failed" in outcome) setRefusal(outcome.message ?? "cancelled");
+            })
+          }
+        >
+          scan miner-2
+        </button>
+        <button type="button" onClick={() => void onUndoAssignment()}>
+          undo scan
+        </button>
+        {refusal ? <p>scan refused: {refusal}</p> : null}
+      </div>
+    );
+  };
+  return { __esModule: true, default: ScanMinerQrStub };
+});
+
+vi.mock("@/protoFleet/components/PageHeader/SitePicker", async (importActual) => ({
+  ...(await importActual<typeof import("@/protoFleet/components/PageHeader/SitePicker")>()),
+  useActiveSite: () => ({ activeSite: { kind: "all" as const }, setActiveSite: vi.fn() }),
+}));
+
+vi.mock("@/protoFleet/api/useDeviceSets", () => ({
+  useDeviceSets: () => ({
+    saveRack: vi.fn(),
+    assignDevicesToRack: mockAssignDevicesToRack,
+    updateRack: vi.fn(),
+    getDeviceSet: vi.fn(),
+    getRackSlots: mockGetRackSlots,
+    listGroupMembers: mockListGroupMembers,
+  }),
+}));
+
+vi.mock("@/protoFleet/api/useFleet", () => ({ default: () => ({ miners }) }));
+vi.mock("@/protoFleet/api/useMinerCommand", () => ({ useMinerCommand: () => ({ blinkLED: vi.fn() }) }));
+
+vi.mock("@/shared/hooks/useWindowDimensions", () => ({
+  useWindowDimensions: () => ({ width: 390, height: 844, isPhone: true, isTablet: false, isDesktop: false }),
+}));
+
+vi.mock("@/protoFleet/components/FullScreenTwoPaneModal", () => ({
+  __esModule: true,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- test stub mirrors the real prop bag loosely
+  default: ({ open, buttons, primaryPane, secondaryPane }: any) =>
+    open ? (
+      <div data-testid="manage-rack-modal">
+        {/* eslint-disable-next-line @typescript-eslint/no-explicit-any -- as above */}
+        {buttons?.map((button: any) => (
+          <button key={button.text} type="button" onClick={button.onClick}>
+            {button.text}
+          </button>
+        ))}
+        <div>{primaryPane}</div>
+        <div>{secondaryPane}</div>
+      </div>
+    ) : null,
+}));
+
+// Two slots, so a swap has room for both members mid-flight if the order were
+// ever reversed — the assertions here are about ordering, not capacity.
+const defaultProps = {
+  show: true,
+  rackSettings: {
+    label: "Rack A",
+    zone: "Zone A",
+    rows: 1,
+    columns: 2,
+    orderIndex: RackOrderIndex.BOTTOM_LEFT,
+    coolingType: RackCoolingType.AIR,
+  },
+  existingRackId: 7n,
+  existingRacks: [],
+  onDismiss: vi.fn(),
+  onSave: vi.fn(),
+};
+
+const renderModal = () =>
+  render(
+    <MemoryRouter>
+      <ManageRackModal {...defaultProps} />
+    </MemoryRouter>,
+  );
+
+const openScanner = () => {
+  fireEvent.click(screen.getByTestId("rack-slot-01"));
+  fireEvent.click(within(screen.getByTestId("rack-slot-actions-sheet-content")).getByText("Scan to assign"));
+};
+
+describe("ManageRackModal — membership commits", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetRackSlots.mockImplementation(({ onSuccess }) => onSuccess([]));
+    mockListGroupMembers.mockImplementation(({ onSuccess }) => onSuccess(["miner-1"]));
+    mockAssignDevicesToRack.mockImplementation((args) => args.onSuccess?.());
+  });
+
+  it("undoing a scan takes the miner back out of the rack", async () => {
+    renderModal();
+    openScanner();
+
+    fireEvent.click(screen.getByText("scan miner-2"));
+    await waitFor(() => expect(mockAssignDevicesToRack).toHaveBeenCalledTimes(1));
+    expect(mockAssignDevicesToRack.mock.calls[0][0]).toMatchObject({
+      targetRackId: 7n,
+      deviceIdentifiers: ["miner-2"],
+    });
+
+    fireEvent.click(screen.getByText("undo scan"));
+
+    // The undo closure predates its own add, so a membership diff taken from that
+    // render would come out empty and write nothing at all.
+    await waitFor(() => expect(mockAssignDevicesToRack).toHaveBeenCalledTimes(2));
+    expect(mockAssignDevicesToRack.mock.calls[1][0]).toMatchObject({
+      targetRackId: undefined,
+      deviceIdentifiers: ["miner-2"],
+    });
+  });
+
+  it("shows a failed scan assignment in the scanner rather than behind it", async () => {
+    mockAssignDevicesToRack.mockImplementation((args) => args.onError?.("rack is locked"));
+    renderModal();
+    openScanner();
+
+    fireEvent.click(screen.getByText("scan miner-2"));
+    await waitFor(() => expect(screen.getByText(/scan refused: rack is locked/)).toBeInTheDocument());
+  });
+
+  it("keeps a landed removal when the paired addition fails", async () => {
+    // Removals go first, so call 1 is the unassign and call 2 is the add.
+    mockAssignDevicesToRack.mockImplementation((args) =>
+      args.targetRackId === undefined ? args.onSuccess?.() : args.onError?.("rack is full"),
+    );
+    renderModal();
+    expect(screen.getByText("Miner 1")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Manage Miners" }));
+    fireEvent.click(screen.getByText("swap to miner-2"));
+
+    await waitFor(() => expect(mockAssignDevicesToRack).toHaveBeenCalledTimes(2));
+    expect(mockAssignDevicesToRack.mock.calls[0][0]).toMatchObject({
+      targetRackId: undefined,
+      deviceIdentifiers: ["miner-1"],
+    });
+
+    // The unassign persisted, so Miner 1 must not still read as a member — and
+    // the failure has to reach the picker, which is still open over the callout.
+    await waitFor(() => expect(screen.getByText(/picker error: rack is full/)).toBeInTheDocument());
+    expect(screen.queryByText("Miner 1")).not.toBeInTheDocument();
+  });
+});

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.test.tsx
@@ -1,14 +1,28 @@
 import { MemoryRouter } from "react-router-dom";
-import { fireEvent, render, screen, within } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import ManageRackModal from "./ManageRackModal";
 import { RackCoolingType, RackOrderIndex } from "@/protoFleet/api/generated/device_set/v1/device_set_pb";
 import type { MinerStateSnapshot } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
 
 const mockSaveRack = vi.fn();
-const mockGetRackSlots = vi.fn();
-const mockListGroupMembers = vi.fn();
+const mockUpdateRack = vi.fn();
+const mockGetDeviceSet = vi.fn();
+// Membership commits and the placement Save both go through this. Succeeds by
+// default; individual tests re-stub it to inspect or fail a call.
+interface AssignCall {
+  targetRackId?: bigint;
+  deviceIdentifiers: string[];
+  slotAssignments?: { deviceIdentifier: string; position?: { row: number; column: number } }[];
+  onSuccess?: () => void;
+  onError?: (message: string) => void;
+}
+const mockAssignDevicesToRack = vi.fn((args: AssignCall) => args.onSuccess?.());
+// The rack always exists when this modal opens, so its membership comes from the
+// server. Resolve both loads immediately with one already-placed miner.
+const mockGetRackSlots = vi.fn(({ onSuccess }: { onSuccess: (slots: unknown[]) => void }) => onSuccess([]));
+const mockListGroupMembers = vi.fn(({ onSuccess }: { onSuccess: (ids: string[]) => void }) => onSuccess(["miner-1"]));
 const mockBlinkLED = vi.fn();
 
 const miners: Record<string, MinerStateSnapshot> = {
@@ -33,6 +47,9 @@ vi.mock("@/protoFleet/components/PageHeader/SitePicker", async (importActual) =>
 vi.mock("@/protoFleet/api/useDeviceSets", () => ({
   useDeviceSets: () => ({
     saveRack: mockSaveRack,
+    assignDevicesToRack: mockAssignDevicesToRack,
+    updateRack: mockUpdateRack,
+    getDeviceSet: mockGetDeviceSet,
     getRackSlots: mockGetRackSlots,
     listGroupMembers: mockListGroupMembers,
   }),
@@ -58,9 +75,19 @@ vi.mock("@/shared/hooks/useWindowDimensions", () => ({
 
 vi.mock("@/protoFleet/components/FullScreenTwoPaneModal", () => ({
   __esModule: true,
-  default: ({ open, primaryPane, secondaryPane }: any) =>
+  default: ({ open, buttons, primaryPane, secondaryPane }: any) =>
     open ? (
       <div data-testid="manage-rack-modal">
+        {buttons?.map((button: any) => (
+          <button
+            key={button.text}
+            type="button"
+            disabled={Boolean(button.loading || button.disabled)}
+            onClick={button.onClick}
+          >
+            {button.text}
+          </button>
+        ))}
         <div>{primaryPane}</div>
         <div>{secondaryPane}</div>
       </div>
@@ -77,8 +104,8 @@ const defaultProps = {
     orderIndex: RackOrderIndex.BOTTOM_LEFT,
     coolingType: RackCoolingType.AIR,
   },
+  existingRackId: 7n,
   existingRacks: [],
-  seededMinerIds: ["miner-1"],
   onDismiss: vi.fn(),
   onSave: vi.fn(),
 };
@@ -91,6 +118,13 @@ const renderManageRackModal = () =>
   );
 
 describe("ManageRackModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetRackSlots.mockImplementation(({ onSuccess }) => onSuccess([]));
+    mockListGroupMembers.mockImplementation(({ onSuccess }) => onSuccess(["miner-1"]));
+    mockAssignDevicesToRack.mockImplementation((args) => args.onSuccess?.());
+  });
+
   it("clears a selected slot when the slot actions sheet is dismissed", () => {
     renderManageRackModal();
 
@@ -111,5 +145,57 @@ describe("ManageRackModal", () => {
 
     expect(screen.getByText("Position 01")).toBeInTheDocument();
     expect(screen.getByTestId("rack-slot-01")).toHaveAttribute("data-slot-state", "assigned");
+  });
+
+  it("Save with no slot change closes without assigning", () => {
+    renderManageRackModal();
+
+    // The rack loaded with one unplaced miner, so there is no placement delta.
+    // Reviewing the grid and keeping it as-is is a legitimate outcome, so Save
+    // closes rather than writing nothing and toasting as though it had.
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    expect(mockAssignDevicesToRack).not.toHaveBeenCalled();
+    expect(defaultProps.onSave).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByTestId("rack-slot-01"));
+    fireEvent.click(within(screen.getByTestId("rack-slot-actions-sheet-content")).getByText("Select from list"));
+    fireEvent.click(screen.getByText("Miner 1"));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(mockAssignDevicesToRack).toHaveBeenCalledTimes(1);
+  });
+
+  it("Save sends only the miners whose slot changed, with the new position", async () => {
+    renderManageRackModal();
+
+    fireEvent.click(screen.getByTestId("rack-slot-01"));
+    fireEvent.click(within(screen.getByTestId("rack-slot-actions-sheet-content")).getByText("Select from list"));
+    fireEvent.click(screen.getByText("Miner 1"));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(mockAssignDevicesToRack).toHaveBeenCalledTimes(1));
+    const request = mockAssignDevicesToRack.mock.calls[0][0];
+    expect(request.targetRackId).toBe(7n);
+    expect(request.deviceIdentifiers).toEqual(["miner-1"]);
+    expect(request.slotAssignments).toEqual([
+      expect.objectContaining({
+        deviceIdentifier: "miner-1",
+        position: expect.objectContaining({ row: 0, column: 0 }),
+      }),
+    ]);
+  });
+
+  it("keeps a miner in the list when its removal fails to persist", async () => {
+    mockAssignDevicesToRack.mockImplementation((args) => args.onError?.("rack is locked"));
+    renderManageRackModal();
+
+    fireEvent.click(screen.getByRole("button", { name: "Actions for Miner 1" }));
+    fireEvent.click(screen.getByText("Remove miner"));
+
+    // The unassign was attempted (no target rack) and refused, so the row stays.
+    await waitFor(() => expect(mockAssignDevicesToRack).toHaveBeenCalledTimes(1));
+    expect(mockAssignDevicesToRack.mock.calls[0][0].targetRackId).toBeUndefined();
+    expect(mockAssignDevicesToRack.mock.calls[0][0].deviceIdentifiers).toEqual(["miner-1"]);
+    expect(screen.getByText("Miner 1")).toBeInTheDocument();
   });
 });

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
@@ -163,7 +163,9 @@ export default function ManageRackModal({
   const [showScanQr, setShowScanQr] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
-  const scanUndoRef = useRef<(() => Promise<void>) | null>(null);
+  // Resolves false when the undo could not be persisted, so the scanner can
+  // stop instead of rescanning over a miner that is still in the rack.
+  const scanUndoRef = useRef<(() => Promise<boolean>) | null>(null);
 
   // Pending reparent confirmation, from either of two sources: the picker
   // reporting miners currently placed elsewhere (#672), and the server refusing
@@ -629,17 +631,23 @@ export default function ManageRackModal({
         if (wasMember) {
           setSlotAssignments(previousSlotAssignments);
           setSelectedSlot(assignedSlot);
-          return;
+          return true;
         }
         const undone = await commitMembership([], [minerId]);
         if (!undone.ok) {
+          // Close the scanner so the parent's callout is visible, matching the
+          // confirm path: the miner is still in the rack at the slot it was
+          // scanned into, and rescanning would hide that behind the scanning
+          // screen. selectedSlot stays put so the grid still reads truthfully.
           if (undone.error) setErrorMsg(undone.error);
-          return;
+          setShowScanQr(false);
+          return false;
         }
         // forgetMiners already dropped the miner and its cell, so only the cells
         // the scan displaced are left to restore.
         setSlotAssignments(previousSlotAssignments);
         setSelectedSlot(assignedSlot);
+        return true;
       };
 
       return {
@@ -683,9 +691,13 @@ export default function ManageRackModal({
     [selectedSlot, confirmReparent, commitMembership, applyRackMiners],
   );
 
+  // No undo registered means there is nothing to fail, so the scanner is free
+  // to rescan. A registered one that reports false keeps the scanner closed on
+  // the error this modal just set.
   const handleScanAssignmentUndo = useCallback(async () => {
-    await scanUndoRef.current?.();
+    const undone = (await scanUndoRef.current?.()) ?? true;
     scanUndoRef.current = null;
+    return undone;
   }, []);
 
   const handleScanNextSlot = useCallback(() => {

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { create } from "@bufbuild/protobuf";
 
 import { fetchAllSelectableMinerIds } from "./fetchAllSelectableMinerIds";
 import ManageMinersModal from "./ManageMinersModal";
@@ -9,7 +10,12 @@ import ScanMinerQrModal, { type ScanAssignmentResult } from "./ScanMinerQrModal"
 import SearchMinersModal from "./SearchMinersModal";
 import { type AssignmentMode, orderIndexToOrigin, originLabel, type RackFormData, type SelectedSlot } from "./types";
 import { useRackMinerScope } from "./useRackMinerScope";
-import { type DeviceSet, type RackSlot } from "@/protoFleet/api/generated/device_set/v1/device_set_pb";
+import {
+  type DeviceSet,
+  type RackSlot,
+  RackSlotPositionSchema,
+  RackSlotSchema,
+} from "@/protoFleet/api/generated/device_set/v1/device_set_pb";
 import {
   type MinerListFilter,
   type MinerStateSnapshot,
@@ -54,23 +60,19 @@ function filterAssignmentsByValues(record: Record<string, string>, keepSet: Set<
 interface ManageRackModalProps {
   show: boolean;
   rackSettings: RackFormData;
-  existingRackId?: bigint;
+  // The rack always exists by the time this modal opens: Rack Settings creates
+  // it on its CTA, so there is no staged-create mode to support.
+  existingRackId: bigint;
   existingRacks: DeviceSet[];
-  // Pre-seeds the new rack's miner list (e.g. from a bulk "Add to rack →
-  // New rack" flow) so the selected miners land in the left pane ready
-  // for slot assignment. Ignored in edit mode (existingRackId set).
-  seededMinerIds?: string[];
   // Page-header site scope (single-site only). Forwarded to the embedded
-  // RackSettingsModal so a new rack created within a site scope keeps its Site
-  // field locked to that scope. Ignored for an existing rack (edit).
+  // RackSettingsModal.
   scopedSiteId?: bigint;
   onDismiss: () => void;
   onSave: () => void;
-  // Fired after the Rack Settings "Continue" persists an EXISTING rack's
-  // settings (label/placement/zone/dims) — which happens before the final
-  // miner Save. Parents should refetch in the background so the rack list /
-  // overview stays consistent even if the operator dismisses the modal
-  // without pressing Save. No-op for a new rack (nothing is persisted yet).
+  // Fired after a write lands that the host's own list/overview reflects — the
+  // Rack Settings save, and each membership commit. Parents should refetch in
+  // the background so the rack list stays consistent even if the operator
+  // dismisses without pressing the final placement Save.
   onSettingsPersisted?: () => void;
   onDelete?: () => Promise<void> | void;
 }
@@ -80,14 +82,13 @@ export default function ManageRackModal({
   rackSettings: initialRackSettings,
   existingRackId,
   existingRacks,
-  seededMinerIds,
   scopedSiteId,
   onDismiss,
   onSave,
   onSettingsPersisted,
   onDelete,
 }: ManageRackModalProps) {
-  const { saveRack, updateRack, getDeviceSet, getRackSlots, listGroupMembers } = useDeviceSets();
+  const { assignDevicesToRack, updateRack, getRackSlots, listGroupMembers } = useDeviceSets();
   // Rack placement (site/building) is a site:manage action, enforced server-
   // side on SaveRack and UpdateDeviceSet. A rack:manage-only operator edits
   // rack contents and metadata (label/zone/dims) without touching placement,
@@ -109,12 +110,11 @@ export default function ManageRackModal({
 
   // Target-rack placement for the selection modals' eligibility filter.
   // rackSettings always reflects the rack's LIVE persisted placement: a
-  // Site/Building change in Rack Settings is persisted immediately on Continue
+  // Site/Building change in Rack Settings is persisted immediately on Save
   // (handleRackSettingsUpdate), which also cascades the rack's members to the
   // new placement. So by the time this filter runs, the rack and its members
   // are already at the placement in rackSettings — no current-vs-pending split,
-  // and a miner already at the new destination reads as assignable. A new rack
-  // has no persisted placement, so rackSettings is the intended placement.
+  // and a miner already at the new destination reads as assignable.
   const eligibility = useMemo<MinerEligibility>(
     () => ({
       rackId: existingRackId,
@@ -124,10 +124,10 @@ export default function ManageRackModal({
     [existingRackId, rackSettings.siteId, rackSettings.buildingId],
   );
 
-  // Core assignment state. A new rack (no existingRackId) can be seeded
-  // with miners from a bulk "Add to rack → New rack" flow; edit mode
-  // ignores the seed and loads the rack's real membership below.
-  const [rackMiners, setRackMiners] = useState<string[]>(() => (existingRackId ? [] : (seededMinerIds ?? [])));
+  // Core assignment state, loaded from the rack's real membership below. A
+  // bulk "Add to rack → New rack" flow seeds its miners onto the create call
+  // itself, so they arrive here as persisted members like any others.
+  const [rackMiners, setRackMiners] = useState<string[]>([]);
   const [slotAssignments, setSlotAssignments] = useState<Record<string, string>>({});
   const [assignmentMode, setAssignmentMode] = useState<AssignmentMode>("manual");
   const [manualAssignmentCache, setManualAssignmentCache] = useState<Record<string, string>>({});
@@ -146,25 +146,41 @@ export default function ManageRackModal({
   const [showScanQr, setShowScanQr] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
-  const scanUndoRef = useRef<(() => void) | null>(null);
+  const scanUndoRef = useRef<(() => Promise<void>) | null>(null);
 
-  // Pending reparent confirmation. Set when a confirm action would pull miners
-  // out of a rack/building/site they're currently assigned to; `onConfirm`
-  // runs the deferred action once the operator accepts the warning (#672).
-  const [reparentConfirm, setReparentConfirm] = useState<{ count: number; onConfirm: () => void } | null>(null);
+  // Pending reparent confirmation, from either of two sources: the picker
+  // reporting miners currently placed elsewhere (#672), and the server refusing
+  // to strip a miner's site for a site-less rack. `onConfirm` runs the deferred
+  // action; `onCancel` lets the server-conflict path report the refusal back to
+  // the write that is awaiting an answer.
+  const [reparentConfirm, setReparentConfirm] = useState<{
+    count: number;
+    onConfirm: () => void;
+    onCancel?: () => void;
+  } | null>(null);
+
+  // Placement as loaded from the server, keyed by miner: a "row-col" cell or
+  // "unplaced". The Save delta is this compared against the working set, so a
+  // miner whose cell never moved is never sent. Membership commits keep it in
+  // step, entering newcomers as "unplaced" so joining a rack doesn't read as
+  // pending placement dirt on the Save gate.
+  const [initialPlacement, setInitialPlacement] = useState<Map<string, string>>(new Map());
 
   // Loading / error state
-  const [isLoading, setIsLoading] = useState(!!existingRackId);
+  const [isLoading, setIsLoading] = useState(true);
   const [loadFailed, setLoadFailed] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
+  // `isSaving` lags a render behind, so the ref is what actually keeps two
+  // writes — a Save and a picker's membership commit — from overlapping.
+  const savingRef = useRef(false);
+  // How many miners the server refused to strip, handed from the failed attempt
+  // to the confirmation prompt. A ref, not state: nothing renders from it — the
+  // dialog reads the count off reparentConfirm.
+  const pendingConflictCountRef = useRef(0);
   const [errorMsg, setErrorMsg] = useState("");
 
-  // No longer need initial state snapshots — saveRack replaces membership atomically.
-
-  // Fetch existing data for edit mode
+  // Load the rack's members and slots.
   useEffect(() => {
-    if (!existingRackId) return;
-
     let cancelled = false;
     let loadedMembers = false;
     let loadedSlots = false;
@@ -183,6 +199,10 @@ export default function ManageRackModal({
       }
       setSlotAssignments(assignments);
       setManualAssignmentCache(assignments);
+
+      const placed = new Map<string, string>();
+      for (const [key, deviceId] of Object.entries(assignments)) placed.set(deviceId, key);
+      setInitialPlacement(new Map(members.map((id) => [id, placed.get(id) ?? "unplaced"])));
       setIsLoading(false);
     };
 
@@ -400,15 +420,124 @@ export default function ManageRackModal({
     setReparentConfirm({ count, onConfirm: proceed });
   }, []);
 
-  // SearchMinersModal confirm — add miner to rack and assign to selected slot.
-  // The modal reports the reassignment flag from the row it selected (exact even
-  // for fleets larger than the display page).
+  // Same dialog, awaited: the server rejects assigning a placed miner into a
+  // site-less rack and writes nothing, so the retry-with-force has to wait for
+  // an answer inside the write it interrupted.
+  const confirmSiteStrip = useCallback(
+    (count: number) =>
+      new Promise<boolean>((resolve) => {
+        setReparentConfirm({
+          count,
+          onConfirm: () => resolve(true),
+          onCancel: () => resolve(false),
+        });
+      }),
+    [],
+  );
+
+  // One AssignDevicesToRack. Unset targetRackId unassigns; set assigns, and
+  // `slots` rides along in the same transaction. Resolves "conflict" when the
+  // server refused a site strip (nothing was written).
+  const dispatchAssign = useCallback(
+    (deviceIdentifiers: string[], targetRackId: bigint | undefined, force: boolean, slots?: RackSlot[]) =>
+      new Promise<"ok" | "conflict">((resolve, reject) => {
+        void assignDevicesToRack({
+          targetRackId,
+          deviceIdentifiers,
+          slotAssignments: slots,
+          forceClearConflictingSite: force,
+          onSuccess: () => resolve("ok"),
+          onConflicts: (conflicts) => {
+            pendingConflictCountRef.current = conflicts.length;
+            resolve("conflict");
+          },
+          onError: (msg) => reject(new Error(msg)),
+        });
+      }),
+    [assignDevicesToRack],
+  );
+
+  // Runs a write, and on a site-strip refusal asks the operator and retries with
+  // the strip forced. Shared by the membership commits and the placement Save so
+  // the confirmation behaves identically wherever the refusal surfaces.
+  const dispatchWithSiteStripConfirm = useCallback(
+    async (deviceIdentifiers: string[], targetRackId: bigint | undefined, slots?: RackSlot[]): Promise<boolean> => {
+      if ((await dispatchAssign(deviceIdentifiers, targetRackId, false, slots)) === "ok") return true;
+      if (!(await confirmSiteStrip(pendingConflictCountRef.current))) return false;
+      return (await dispatchAssign(deviceIdentifiers, targetRackId, true, slots)) === "ok";
+    },
+    [dispatchAssign, confirmSiteStrip],
+  );
+
+  // Membership commit. The miner pickers own rack membership, so a confirmed
+  // selection is written straight away and only placement stays staged for Save.
+  // Newcomers go in without a slot and land in the load-time snapshot as
+  // "unplaced", so freshly-committed membership doesn't read as pending
+  // placement dirt on the Save gate.
+  //
+  // The caller owns the working-set update — each entry point merges rows
+  // differently — and should skip it when this returns false.
+  const commitMembership = useCallback(
+    async (added: string[], removed: string[]): Promise<boolean> => {
+      if (savingRef.current) return false;
+      const currentIds = new Set(rackMiners);
+      const newcomers = added.filter((id) => !currentIds.has(id));
+      const leavers = removed.filter((id) => currentIds.has(id));
+      // Nothing to write. The caller may still have a placement change to stage
+      // (e.g. re-placing a miner that's already a member).
+      if (newcomers.length === 0 && leavers.length === 0) return true;
+
+      // Capacity guard — mirrors the server's. Membership is what fills a rack,
+      // so this is the check that has to happen here rather than on Save.
+      const nextCount = rackMiners.length + newcomers.length - leavers.length;
+      if (totalSlots > 0 && nextCount > totalSlots) {
+        setErrorMsg(
+          `Cannot hold ${nextCount} miners with only ${totalSlots} available slots. Deselect some miners or update your rack settings.`,
+        );
+        return false;
+      }
+
+      savingRef.current = true;
+      setErrorMsg("");
+      setIsSaving(true);
+      try {
+        // Removals first: they free their slots before any newcomer lands. An
+        // unassign has no target rack to strip a site for, so its conflict
+        // branch never fires — it goes through the same helper for uniformity.
+        if (leavers.length > 0 && !(await dispatchWithSiteStripConfirm(leavers, undefined))) return false;
+        if (newcomers.length > 0 && !(await dispatchWithSiteStripConfirm(newcomers, existingRackId))) return false;
+      } catch (err) {
+        setErrorMsg(getErrorMessage(err, "Failed to update the rack's miners. Please try again."));
+        return false;
+      } finally {
+        savingRef.current = false;
+        setIsSaving(false);
+      }
+
+      setInitialPlacement((prev) => {
+        const next = new Map(prev);
+        for (const id of leavers) next.delete(id);
+        for (const id of newcomers) next.set(id, "unplaced");
+        return next;
+      });
+      // Member counts changed on the host's rack list.
+      onSettingsPersisted?.();
+      return true;
+    },
+    [rackMiners, totalSlots, existingRackId, dispatchWithSiteStripConfirm, onSettingsPersisted],
+  );
+
+  // SearchMinersModal confirm — commit the miner into the rack if it isn't a
+  // member yet, then stage it at the selected slot. The modal reports the
+  // reassignment flag from the row it selected (exact even for fleets larger
+  // than the display page).
   const handleSearchMinerConfirm = useCallback(
     (minerId: string, isReassignment: boolean) => {
       if (!selectedSlot) return;
       const slotKey = selectedSlot.key;
-      promptReparent(isReassignment ? 1 : 0, () => {
-        // Add miner to rack if not already present
+      const apply = async () => {
+        // Failure leaves the picker open, with the error behind it, to retry.
+        if (!(await commitMembership([minerId], []))) return;
         setRackMiners((prev) => (prev.includes(minerId) ? prev : [...prev, minerId]));
         // Remove any existing assignment for this miner, then assign to selected slot
         setSlotAssignments((prev) => {
@@ -418,16 +547,21 @@ export default function ManageRackModal({
         });
         setSelectedSlot(null);
         setShowSearchMiners(false);
-      });
+      };
+      promptReparent(isReassignment ? 1 : 0, () => void apply());
     },
-    [selectedSlot, promptReparent],
+    [selectedSlot, promptReparent, commitMembership],
   );
 
   const handleScanMinerAssign = useCallback(
-    (minerId: string): ScanAssignmentResult | null => {
+    async (minerId: string): Promise<ScanAssignmentResult | null> => {
       if (!selectedSlot) return null;
 
-      const previousRackMiners = rackMiners;
+      const wasMember = rackMiners.includes(minerId);
+      // Membership commits before the modal reports the assignment, so the
+      // "assigned" screen never claims a miner that isn't actually in the rack.
+      if (!(await commitMembership([minerId], []))) return null;
+
       const previousSlotAssignments = slotAssignments;
       const assignedSlot = selectedSlot;
       const nextSlotAssignments = removeAssignmentByValue(slotAssignments, minerId);
@@ -436,8 +570,12 @@ export default function ManageRackModal({
       setRackMiners((prev) => (prev.includes(minerId) ? prev : [...prev, minerId]));
       setSlotAssignments(nextSlotAssignments);
 
-      scanUndoRef.current = () => {
-        setRackMiners(previousRackMiners);
+      // Undo has to reverse the write too, not just the staged cell — but only
+      // for a miner this scan actually added. One that was already a member
+      // keeps its membership and just loses the new cell.
+      scanUndoRef.current = async () => {
+        if (!wasMember && !(await commitMembership([], [minerId]))) return;
+        if (!wasMember) setRackMiners((prev) => prev.filter((id) => id !== minerId));
         setSlotAssignments(previousSlotAssignments);
         setSelectedSlot(assignedSlot);
       };
@@ -447,7 +585,7 @@ export default function ManageRackModal({
         hasNextSlot: !!getNextAssignableSlot(assignedSlot, nextSlotAssignments),
       };
     },
-    [getNextAssignableSlot, getSlotLabel, rackMiners, selectedSlot, slotAssignments],
+    [getNextAssignableSlot, getSlotLabel, rackMiners, selectedSlot, slotAssignments, commitMembership],
   );
 
   // Scanned miners already assigned elsewhere use the same reparent warning as
@@ -457,7 +595,8 @@ export default function ManageRackModal({
     (minerId: string, isReassignment: boolean) => {
       if (!selectedSlot) return;
       const slotKey = selectedSlot.key;
-      promptReparent(isReassignment ? 1 : 0, () => {
+      const apply = async () => {
+        if (!(await commitMembership([minerId], []))) return;
         setRackMiners((prev) => (prev.includes(minerId) ? prev : [...prev, minerId]));
         setSlotAssignments((prev) => {
           const next = removeAssignmentByValue(prev, minerId);
@@ -467,13 +606,14 @@ export default function ManageRackModal({
         setSelectedSlot(null);
         setShowScanQr(false);
         scanUndoRef.current = null;
-      });
+      };
+      promptReparent(isReassignment ? 1 : 0, () => void apply());
     },
-    [selectedSlot, promptReparent],
+    [selectedSlot, promptReparent, commitMembership],
   );
 
-  const handleScanAssignmentUndo = useCallback(() => {
-    scanUndoRef.current?.();
+  const handleScanAssignmentUndo = useCallback(async () => {
+    await scanUndoRef.current?.();
     scanUndoRef.current = null;
   }, []);
 
@@ -515,15 +655,18 @@ export default function ManageRackModal({
     setSelectedMinerId(null);
   }, []);
 
-  // Remove miner from rack
+  // Row-level "Remove from rack" — an immediate unassign (the miner keeps
+  // existing; it just leaves the rack). The row drops only once the write lands,
+  // so a failure leaves the list truthful.
   const handleRemoveMiner = useCallback(
-    (deviceId: string) => {
+    async (deviceId: string) => {
+      if (!(await commitMembership([], [deviceId]))) return;
       setRackMiners((prev) => prev.filter((id) => id !== deviceId));
       setSlotAssignments((prev) => removeAssignmentByValue(prev, deviceId));
       setManualAssignmentCache((prev) => removeAssignmentByValue(prev, deviceId));
       if (selectedMinerId === deviceId) setSelectedMinerId(null);
     },
-    [selectedMinerId],
+    [selectedMinerId, commitMembership],
   );
 
   // Unassign miner from slot (keep in rack)
@@ -573,244 +716,165 @@ export default function ManageRackModal({
         return `Cannot add ${finalIds.length} miners with only ${totalSlots} available slots. Deselect some miners or update your rack settings.`;
       }
 
-      promptReparent(reassignedCount, () => {
+      // The picker owns membership, so the delta is written here rather than
+      // staged. Accepting the reparent warning is what authorizes that write.
+      const keepSet = new Set(finalIds);
+      const removed = rackMiners.filter((id) => !keepSet.has(id));
+      const apply = async () => {
+        // Failure leaves the picker open with the selection intact to retry.
+        if (!(await commitMembership(finalIds, removed))) return;
         setRackMiners(finalIds);
         setShowManageMiners(false);
 
         // Remove assignments for miners no longer in rack
-        const keepSet = new Set(finalIds);
         setSlotAssignments((prev) => filterAssignmentsByValues(prev, keepSet));
         setManualAssignmentCache((prev) => filterAssignmentsByValues(prev, keepSet));
-      });
+      };
+      promptReparent(reassignedCount, () => void apply());
       return undefined;
     },
-    [eligibility, totalSlots, promptReparent],
+    [eligibility, totalSlots, rackMiners, promptReparent, commitMembership],
   );
 
-  // RackSettingsModal "Continue" handler. For an EXISTING rack, Continue is
-  // the settings save: it persists label/zone/dimensions AND placement in a
-  // single atomic UpdateDeviceSet, then cascades the rack's CURRENT server
-  // members to the new placement — all server-side, in one transaction. This
-  // is why the eligibility filter above can trust rackSettings as the rack's
-  // live placement: by the time the operator opens Manage Miners, the rack and
-  // its members are already there. Membership is untouched here — "Continue
-  // saves settings, Save saves miners" — so the modal's draft rackMiners can't
-  // leak into a settings-only change.
-  //
-  // A NEW rack doesn't exist yet, so there's nothing to persist; its settings
-  // (including placement) ride on the create in handleSave.
+  // Rack Settings "Save" handler: persists label/zone/dimensions AND placement
+  // in a single atomic UpdateDeviceSet, then cascades the rack's CURRENT server
+  // members to the new placement — all server-side, in one transaction. This is
+  // why the eligibility filter above can trust rackSettings as the rack's live
+  // placement: by the time the operator opens Manage Miners, the rack and its
+  // members are already there. Membership is untouched here, so the modal's
+  // draft rackMiners can't leak into a settings-only change.
   const handleRackSettingsUpdate = useCallback(
     async (formData: RackFormData) => {
-      const rackId = existingRackId;
-      if (rackId !== undefined) {
-        // Only send placement when the operator actually changed site/building
-        // this edit (compared to what the form was seeded with). A metadata-only
-        // edit (label/zone/dims) omits placement, so UpdateDeviceSet preserves
-        // the rack's CURRENT server placement — a stale cached value can't
-        // re-parent a rack that another session moved while this modal was open.
-        // Zone stays authoritative even with placement omitted (the settings
-        // path treats an empty zone as an explicit clear).
-        const placementChanged =
-          canManagePlacement &&
-          (formData.siteId !== rackSettings.siteId || formData.buildingId !== rackSettings.buildingId);
-        let updated: DeviceSet | undefined;
-        try {
-          await new Promise<void>((resolve, reject) => {
-            updateRack({
-              deviceSetId: rackId,
-              label: formData.label,
-              zone: formData.zone,
-              rows: formData.rows,
-              columns: formData.columns,
-              orderIndex: formData.orderIndex,
-              coolingType: formData.coolingType,
-              // Unset level -> 0n unassign when the operator did change placement.
-              siteId: placementChanged ? (formData.siteId ?? 0n) : undefined,
-              buildingId: placementChanged ? (formData.buildingId ?? 0n) : undefined,
-              onSuccess: (ds) => {
-                updated = ds;
-                resolve();
-              },
-              onError: (msg) => reject(new Error(msg)),
-            });
+      // Only send placement when the operator actually changed site/building
+      // this edit (compared to what the form was seeded with). A metadata-only
+      // edit (label/zone/dims) omits placement, so UpdateDeviceSet preserves
+      // the rack's CURRENT server placement — a stale cached value can't
+      // re-parent a rack that another session moved while this modal was open.
+      // Zone stays authoritative even with placement omitted (the settings
+      // path treats an empty zone as an explicit clear).
+      const placementChanged =
+        canManagePlacement &&
+        (formData.siteId !== rackSettings.siteId || formData.buildingId !== rackSettings.buildingId);
+      let updated: DeviceSet | undefined;
+      try {
+        await new Promise<void>((resolve, reject) => {
+          updateRack({
+            deviceSetId: existingRackId,
+            label: formData.label,
+            zone: formData.zone,
+            rows: formData.rows,
+            columns: formData.columns,
+            orderIndex: formData.orderIndex,
+            coolingType: formData.coolingType,
+            // Unset level -> 0n unassign when the operator did change placement.
+            siteId: placementChanged ? (formData.siteId ?? 0n) : undefined,
+            buildingId: placementChanged ? (formData.buildingId ?? 0n) : undefined,
+            onSuccess: (ds) => {
+              updated = ds;
+              resolve();
+            },
+            onError: (msg) => reject(new Error(msg)),
           });
-        } catch (err) {
-          pushToast({
-            message: getErrorMessage(err, "Failed to update rack settings. Please try again."),
-            status: STATUSES.error,
-          });
-          // Keep Rack Settings open (don't apply) so the operator can retry.
-          return;
-        }
-        // Adopt the server's AUTHORITATIVE placement from the response, not the
-        // submitted formData: when placement was omitted (metadata-only edit)
-        // the server kept whatever the rack's current site/building is — which
-        // may differ from the stale formData values if another session moved it.
-        // The eligibility filter reads rackSettings placement, so trusting the
-        // response keeps the miner list scoped to where the rack really is.
-        const serverRackInfo = updated?.typeDetails.case === "rackInfo" ? updated.typeDetails.value : undefined;
-        const applied: RackFormData = serverRackInfo
-          ? {
-              ...formData,
-              siteId: serverRackInfo.siteId,
-              buildingId: serverRackInfo.buildingId,
-              zone: serverRackInfo.zone,
-            }
-          : formData;
-        // Settings are now live on the server. Let the parent refetch so its
-        // rack list/overview reflects the new label/placement even if the
-        // operator dismisses without pressing the final miner Save.
-        onSettingsPersisted?.();
-        setRackSettings(applied);
-        setShowRackSettings(false);
+        });
+      } catch (err) {
+        pushToast({
+          message: getErrorMessage(err, "Failed to update rack settings. Please try again."),
+          status: STATUSES.error,
+        });
+        // Keep Rack Settings open (don't apply) so the operator can retry.
         return;
       }
-
-      setRackSettings(formData);
+      // Adopt the server's AUTHORITATIVE placement from the response, not the
+      // submitted formData: when placement was omitted (metadata-only edit)
+      // the server kept whatever the rack's current site/building is — which
+      // may differ from the stale formData values if another session moved it.
+      // The eligibility filter reads rackSettings placement, so trusting the
+      // response keeps the miner list scoped to where the rack really is.
+      const serverRackInfo = updated?.typeDetails.case === "rackInfo" ? updated.typeDetails.value : undefined;
+      const applied: RackFormData = serverRackInfo
+        ? {
+            ...formData,
+            siteId: serverRackInfo.siteId,
+            buildingId: serverRackInfo.buildingId,
+            zone: serverRackInfo.zone,
+          }
+        : formData;
+      // Settings are now live on the server. Let the parent refetch so its
+      // rack list/overview reflects the new label/placement even if the
+      // operator dismisses without pressing the final miner Save.
+      onSettingsPersisted?.();
+      pushToast({ message: `Rack "${applied.label}" saved`, status: STATUSES.success });
+      setRackSettings(applied);
       setShowRackSettings(false);
     },
     [existingRackId, canManagePlacement, rackSettings, updateRack, onSettingsPersisted],
   );
 
-  // Save handler — single atomic RPC
-  const handleSave = useCallback(async () => {
-    // Capacity guard. handleManageMinersConfirm enforces this when miners are
-    // added through the sub-modal, but a seeded new rack (bulk "New rack")
-    // populates rackMiners directly and bypasses that path — saveRack accepts
-    // members beyond the slot count, so an over-fill would persist silently.
-    if (rackMiners.length > totalSlots) {
-      setErrorMsg(
-        `Cannot add ${rackMiners.length} miners with only ${totalSlots} available slots. Deselect some miners or update your rack settings.`,
+  // One RackSlot per miner whose cell differs from what loaded: position set to
+  // the new cell, position omitted to clear it. Miners the operator never moved
+  // aren't named at all, so a concurrent placement change elsewhere in the rack
+  // survives this save — the whole reason Save no longer goes through SaveRack,
+  // which replaced the rack's entire member set from a possibly-stale snapshot.
+  const placementDelta = useMemo<RackSlot[]>(() => {
+    const cellByMiner = new Map<string, string>();
+    for (const [key, deviceId] of Object.entries(activeAssignments)) cellByMiner.set(deviceId, key);
+
+    const delta: RackSlot[] = [];
+    for (const deviceId of rackMiners) {
+      const before = initialPlacement.get(deviceId) ?? "unplaced";
+      const after = cellByMiner.get(deviceId) ?? "unplaced";
+      if (before === after) continue;
+      if (after === "unplaced") {
+        delta.push(create(RackSlotSchema, { deviceIdentifier: deviceId }));
+        continue;
+      }
+      const [row, column] = after.split("-").map(Number);
+      delta.push(
+        create(RackSlotSchema, {
+          deviceIdentifier: deviceId,
+          position: create(RackSlotPositionSchema, { row, column }),
+        }),
       );
+    }
+    return delta;
+  }, [activeAssignments, rackMiners, initialPlacement]);
+
+  // Save owns slot placement only. Membership commits in the pickers, and
+  // label/zone/dimensions/site/building commit in Rack Settings — so by the time
+  // the operator gets here the only unwritten thing left is where each miner
+  // sits in the grid.
+  const handleSave = useCallback(async () => {
+    if (savingRef.current) return;
+    // Nothing to write. Close rather than write nothing and toast as though
+    // something changed — reviewing the grid and keeping it as-is is a
+    // legitimate outcome, not an error.
+    if (placementDelta.length === 0) {
+      onSave();
       return;
     }
 
+    savingRef.current = true;
     setIsSaving(true);
     setErrorMsg("");
-
     try {
-      // Build slot assignments from the active assignments map
-      const slotAssignmentsList = Object.entries(activeAssignments).map(([key, deviceId]) => {
-        const [row, col] = key.split("-").map(Number);
-        return { deviceIdentifier: deviceId, row, column: col };
-      });
-
-      // Placement rides on CREATE only. An existing rack's Site/Building (and
-      // zone/dimensions) are already persisted on the Rack Settings "Continue"
-      // — Continue saves settings, Save saves miners — so an edit Save omits
-      // placement: it preserves the rack's current server placement and can't
-      // clobber a move made by another session while this modal was open.
-      const sendPlacement = canManagePlacement && existingRackId === undefined;
-
-      // Existing-rack Save is miners-only, but SaveRack always rewrites
-      // rack_info, so re-send the rack's CURRENT server metadata rather than the
-      // modal's cached copy — otherwise a concurrent zone/dimension edit from
-      // another session would be reverted (and stale dims could mis-validate the
-      // new slots). Best-effort: fall back to the cached values on a fetch miss
-      // so a transient error can't block the miner save.
-      let meta = {
-        label: rackSettings.label,
-        zone: rackSettings.zone,
-        rows: rackSettings.rows,
-        columns: rackSettings.columns,
-        orderIndex: rackSettings.orderIndex,
-        coolingType: rackSettings.coolingType,
-      };
-      if (existingRackId !== undefined) {
-        await new Promise<void>((resolve) => {
-          getDeviceSet({
-            deviceSetId: existingRackId,
-            onSuccess: (ds) => {
-              if (ds.typeDetails.case === "rackInfo") {
-                const ri = ds.typeDetails.value;
-                meta = {
-                  label: ds.label,
-                  zone: ri.zone,
-                  rows: ri.rows,
-                  columns: ri.columns,
-                  orderIndex: ri.orderIndex,
-                  coolingType: ri.coolingType,
-                };
-              }
-              resolve();
-            },
-            onNotFound: () => resolve(),
-            onError: () => resolve(),
-          });
-        });
-      }
-
-      const finishSuccess = () => {
-        pushToast({
-          message: existingRackId ? `Rack "${meta.label}" updated` : `Rack "${meta.label}" created`,
-          status: STATUSES.success,
-        });
-        onSave();
-      };
-
-      // Persist the miners. When the rack is site-less, the server rejects a
-      // member that currently has a site/building (it would be stripped) and
-      // returns a conflict list without writing — mirroring the reparent RPC.
-      // We surface the same ReparentWarningDialog and, on confirm, retry with
-      // forceClearConflictingSite so the strip is explicit, not silent.
-      const runSaveRack = (force: boolean): Promise<"ok" | "conflict"> =>
-        new Promise((resolve, reject) => {
-          saveRack({
-            deviceSetId: existingRackId,
-            label: meta.label,
-            zone: meta.zone,
-            rows: meta.rows,
-            columns: meta.columns,
-            orderIndex: meta.orderIndex,
-            coolingType: meta.coolingType,
-            deviceIdentifiers: rackMiners,
-            slotAssignments: slotAssignmentsList,
-            // Create sends its chosen placement (unset level → NULL), gated on
-            // site:manage. Edit omits placement (persisted on Continue).
-            siteId: sendPlacement ? (rackSettings.siteId ?? 0n) : undefined,
-            buildingId: sendPlacement ? (rackSettings.buildingId ?? 0n) : undefined,
-            forceClearConflictingSite: force,
-            onSuccess: () => resolve("ok"),
-            onConflicts: (conflicts) => {
-              setReparentConfirm({
-                count: conflicts.length,
-                onConfirm: () => {
-                  setReparentConfirm(null);
-                  setIsSaving(true);
-                  setErrorMsg("");
-                  runSaveRack(true)
-                    .then((outcome) => {
-                      if (outcome === "ok") finishSuccess();
-                    })
-                    .catch((err) => setErrorMsg(getErrorMessage(err, "Failed to save. Please try again.")))
-                    .finally(() => setIsSaving(false));
-                },
-              });
-              resolve("conflict");
-            },
-            onError: (msg) => reject(new Error(msg)),
-          });
-        });
-
-      // conflict → the dialog above drives the confirm/force retry; don't toast
-      // success or close the modal until that resolves.
-      if ((await runSaveRack(false)) === "ok") finishSuccess();
+      // Every named miner is already a member; re-asserting membership is a
+      // no-op server-side (and is what lets the slots ride the same
+      // transaction), so this cannot move a miner between racks.
+      const ok = await dispatchWithSiteStripConfirm(
+        placementDelta.map((slot) => slot.deviceIdentifier),
+        existingRackId,
+        placementDelta,
+      );
+      if (!ok) return;
+      pushToast({ message: `Miner positions saved for "${rackSettings.label}"`, status: STATUSES.success });
+      onSave();
     } catch (err) {
       setErrorMsg(getErrorMessage(err, "Failed to save. Please try again."));
     } finally {
+      savingRef.current = false;
       setIsSaving(false);
     }
-  }, [
-    existingRackId,
-    rackSettings,
-    rackMiners,
-    totalSlots,
-    activeAssignments,
-    canManagePlacement,
-    getDeviceSet,
-    saveRack,
-    onSave,
-  ]);
+  }, [placementDelta, existingRackId, rackSettings.label, dispatchWithSiteStripConfirm, onSave]);
 
   if (!show) return null;
 
@@ -842,6 +906,9 @@ export default function ManageRackModal({
             onClick: () => setShowManageMiners(true),
           },
           {
+            // No dirty gate: the no-op case closes in handleSave, where it can
+            // be told apart from a real save. The load guards stay — a delta
+            // diffed against a placement that never arrived isn't a write.
             text: isSaving ? "Saving..." : "Save",
             variant: variants.primary,
             disabled: isSaving || isLoading || loadFailed,
@@ -917,10 +984,10 @@ export default function ManageRackModal({
           show={showRackSettings}
           existingRacks={existingRacks}
           initialFormData={rackSettings}
-          existingRack={existingRackId !== undefined}
+          existingRack
           defaultSiteId={scopedSiteId}
           onDismiss={() => setShowRackSettings(false)}
-          onContinue={handleRackSettingsUpdate}
+          onSubmit={handleRackSettingsUpdate}
         />
       ) : null}
 
@@ -932,6 +999,7 @@ export default function ManageRackModal({
           targetRackLabel={rackSettings.label}
           maxSlots={totalSlots}
           scope={scope}
+          saving={isSaving}
           onDismiss={() => setShowManageMiners(false)}
           onConfirm={handleManageMinersConfirm}
         />
@@ -973,7 +1041,11 @@ export default function ManageRackModal({
         <ReparentWarningDialog
           count={reparentConfirm.count}
           rackLabel={rackSettings.label}
-          onCancel={() => setReparentConfirm(null)}
+          onCancel={() => {
+            const abandon = reparentConfirm.onCancel;
+            setReparentConfirm(null);
+            abandon?.();
+          }}
           onConfirm={() => {
             const proceed = reparentConfirm.onConfirm;
             setReparentConfirm(null);

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
@@ -1099,6 +1099,7 @@ export default function ManageRackModal({
             setSelectedSlot(null);
           }}
           onConfirm={handleSearchMinerConfirm}
+          saving={isSaving}
         />
       ) : null}
 

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ManageRackModal.tsx
@@ -6,7 +6,7 @@ import ManageMinersModal from "./ManageMinersModal";
 import MinersPane from "./MinersPane";
 import RackPane from "./RackPane";
 import ReparentWarningDialog from "./ReparentWarningDialog";
-import ScanMinerQrModal, { type ScanAssignmentResult } from "./ScanMinerQrModal";
+import ScanMinerQrModal, { type ScanAssignmentOutcome } from "./ScanMinerQrModal";
 import SearchMinersModal from "./SearchMinersModal";
 import { type AssignmentMode, orderIndexToOrigin, originLabel, type RackFormData, type SelectedSlot } from "./types";
 import { useRackMinerScope } from "./useRackMinerScope";
@@ -48,14 +48,20 @@ function removeAssignmentByValue(record: Record<string, string>, target: string)
   return next;
 }
 
-/** Keep only entries whose value is in `keepSet`, returning a shallow copy. */
-function filterAssignmentsByValues(record: Record<string, string>, keepSet: Set<string>): Record<string, string> {
+/** Drop every entry whose value is in `dropSet`, returning a shallow copy. */
+function dropAssignmentsByValues(record: Record<string, string>, dropSet: Set<string>): Record<string, string> {
   const next: Record<string, string> = {};
   for (const [k, v] of Object.entries(record)) {
-    if (keepSet.has(v)) next[k] = v;
+    if (!dropSet.has(v)) next[k] = v;
   }
   return next;
 }
+
+// What a membership write reports back. Not-ok with no `error` is the operator
+// declining a warning: nothing to tell them, but the caller must not treat it as
+// success. An `error` is theirs to render — the parent's callout sits behind the
+// pickers, so a picker that stays open has to surface it itself.
+type CommitOutcome = { ok: true } | { ok: false; error?: string };
 
 interface ManageRackModalProps {
   show: boolean;
@@ -128,6 +134,17 @@ export default function ManageRackModal({
   // bulk "Add to rack → New rack" flow seeds its miners onto the create call
   // itself, so they arrive here as persisted members like any others.
   const [rackMiners, setRackMiners] = useState<string[]>([]);
+  // What commitMembership diffs against, rather than the `rackMiners` closure.
+  // The scan undo runs from a callback captured before its own add landed, and
+  // against that stale snapshot the delta comes out empty — so the undo wrote
+  // nothing and left the scanned miner in the rack. Updated synchronously, so
+  // every commit sees the membership the previous one produced.
+  const rackMinersRef = useRef<string[]>([]);
+  const applyRackMiners = useCallback((next: string[] | ((prev: string[]) => string[])) => {
+    const value = typeof next === "function" ? next(rackMinersRef.current) : next;
+    rackMinersRef.current = value;
+    setRackMiners(value);
+  }, []);
   const [slotAssignments, setSlotAssignments] = useState<Record<string, string>>({});
   const [assignmentMode, setAssignmentMode] = useState<AssignmentMode>("manual");
   const [manualAssignmentCache, setManualAssignmentCache] = useState<Record<string, string>>({});
@@ -189,7 +206,7 @@ export default function ManageRackModal({
 
     const maybeFinish = () => {
       if (!loadedMembers || !loadedSlots || cancelled) return;
-      setRackMiners(members);
+      applyRackMiners(members);
 
       const assignments: Record<string, string> = {};
       for (const slot of slots) {
@@ -241,7 +258,7 @@ export default function ManageRackModal({
     return () => {
       cancelled = true;
     };
-  }, [existingRackId, listGroupMembers, getRackSlots]);
+  }, [existingRackId, listGroupMembers, getRackSlots, applyRackMiners]);
 
   // Compute the active assignments based on mode
   const activeAssignments = useMemo(() => {
@@ -406,26 +423,23 @@ export default function ManageRackModal({
     setSelectedSlot(null);
   }, []);
 
-  // Show the reparent warning (#672) when `count` > 0, else run `proceed`
-  // directly. `proceed` runs once the operator accepts the warning. Callers pass
-  // the reassignment count from a reliable source (the selection list's
-  // per-row placement, or the scanned miner's snapshot) rather than the parent's
-  // first-page-only `allMiners` cache, so the warning isn't missed for miners
-  // outside that page.
-  const promptReparent = useCallback((count: number, proceed: () => void) => {
-    if (count === 0) {
-      proceed();
-      return;
-    }
-    setReparentConfirm({ count, onConfirm: proceed });
-  }, []);
-
-  // Same dialog, awaited: the server rejects assigning a placed miner into a
-  // site-less rack and writes nothing, so the retry-with-force has to wait for
-  // an answer inside the write it interrupted.
-  const confirmSiteStrip = useCallback(
+  // The reparent warning (#672), awaited. Two things raise it: the picker
+  // reporting miners currently placed elsewhere, and the server refusing to
+  // strip a miner's site for a site-less rack. The second interrupts a write
+  // that needs the answer, so both take the promise form — which also lets the
+  // pickers keep the write's outcome in scope and report it themselves.
+  //
+  // Callers pass the reassignment count from a reliable source (the selection
+  // list's per-row placement, or the scanned miner's snapshot) rather than the
+  // parent's first-page-only `allMiners` cache, so the warning isn't missed for
+  // miners outside that page. Zero resolves straight through.
+  const confirmReparent = useCallback(
     (count: number) =>
       new Promise<boolean>((resolve) => {
+        if (count === 0) {
+          resolve(true);
+          return;
+        }
         setReparentConfirm({
           count,
           onConfirm: () => resolve(true),
@@ -463,10 +477,29 @@ export default function ManageRackModal({
   const dispatchWithSiteStripConfirm = useCallback(
     async (deviceIdentifiers: string[], targetRackId: bigint | undefined, slots?: RackSlot[]): Promise<boolean> => {
       if ((await dispatchAssign(deviceIdentifiers, targetRackId, false, slots)) === "ok") return true;
-      if (!(await confirmSiteStrip(pendingConflictCountRef.current))) return false;
+      if (!(await confirmReparent(pendingConflictCountRef.current))) return false;
       return (await dispatchAssign(deviceIdentifiers, targetRackId, true, slots)) === "ok";
     },
-    [dispatchAssign, confirmSiteStrip],
+    [dispatchAssign, confirmReparent],
+  );
+
+  // Everything that references a miner the rack no longer holds. Called the
+  // moment an unassign lands rather than after the whole commit, so a failure
+  // later in that commit can't leave a removed miner on screen.
+  const forgetMiners = useCallback(
+    (ids: string[]) => {
+      const gone = new Set(ids);
+      applyRackMiners((prev) => prev.filter((id) => !gone.has(id)));
+      setSlotAssignments((prev) => dropAssignmentsByValues(prev, gone));
+      setManualAssignmentCache((prev) => dropAssignmentsByValues(prev, gone));
+      setInitialPlacement((prev) => {
+        const next = new Map(prev);
+        for (const id of ids) next.delete(id);
+        return next;
+      });
+      setSelectedMinerId((prev) => (prev !== null && gone.has(prev) ? null : prev));
+    },
+    [applyRackMiners],
   );
 
   // Membership commit. The miner pickers own rack membership, so a confirmed
@@ -475,40 +508,50 @@ export default function ManageRackModal({
   // "unplaced", so freshly-committed membership doesn't read as pending
   // placement dirt on the Save gate.
   //
-  // The caller owns the working-set update — each entry point merges rows
-  // differently — and should skip it when this returns false.
+  // Callers own the newcomer half of the working-set update — each entry point
+  // merges rows differently — and should skip it unless `ok`. The removal half
+  // is applied here, per phase, because removals and additions are two separate
+  // RPCs and the second can fail after the first has already persisted.
   const commitMembership = useCallback(
-    async (added: string[], removed: string[]): Promise<boolean> => {
-      if (savingRef.current) return false;
-      const currentIds = new Set(rackMiners);
+    async (added: string[], removed: string[]): Promise<CommitOutcome> => {
+      if (savingRef.current) return { ok: false, error: "Another change is still saving. Please try again." };
+      const currentIds = new Set(rackMinersRef.current);
       const newcomers = added.filter((id) => !currentIds.has(id));
       const leavers = removed.filter((id) => currentIds.has(id));
       // Nothing to write. The caller may still have a placement change to stage
       // (e.g. re-placing a miner that's already a member).
-      if (newcomers.length === 0 && leavers.length === 0) return true;
+      if (newcomers.length === 0 && leavers.length === 0) return { ok: true };
 
       // Capacity guard — mirrors the server's. Membership is what fills a rack,
       // so this is the check that has to happen here rather than on Save.
-      const nextCount = rackMiners.length + newcomers.length - leavers.length;
+      const nextCount = currentIds.size + newcomers.length - leavers.length;
       if (totalSlots > 0 && nextCount > totalSlots) {
-        setErrorMsg(
-          `Cannot hold ${nextCount} miners with only ${totalSlots} available slots. Deselect some miners or update your rack settings.`,
-        );
-        return false;
+        return {
+          ok: false,
+          error: `Cannot hold ${nextCount} miners with only ${totalSlots} available slots. Deselect some miners or update your rack settings.`,
+        };
       }
 
       savingRef.current = true;
       setErrorMsg("");
       setIsSaving(true);
       try {
-        // Removals first: they free their slots before any newcomer lands. An
+        // Removals first: they free their slots before any newcomer lands, and
+        // the reverse order would trip the server's capacity check on a swap. An
         // unassign has no target rack to strip a site for, so its conflict
         // branch never fires — it goes through the same helper for uniformity.
-        if (leavers.length > 0 && !(await dispatchWithSiteStripConfirm(leavers, undefined))) return false;
-        if (newcomers.length > 0 && !(await dispatchWithSiteStripConfirm(newcomers, existingRackId))) return false;
+        if (leavers.length > 0) {
+          if (!(await dispatchWithSiteStripConfirm(leavers, undefined))) return { ok: false };
+          // Persisted. Reflect it locally and on the host's list now, so a
+          // failure in the newcomer write below still leaves both truthful.
+          forgetMiners(leavers);
+          onSettingsPersisted?.();
+        }
+        if (newcomers.length > 0 && !(await dispatchWithSiteStripConfirm(newcomers, existingRackId))) {
+          return { ok: false };
+        }
       } catch (err) {
-        setErrorMsg(getErrorMessage(err, "Failed to update the rack's miners. Please try again."));
-        return false;
+        return { ok: false, error: getErrorMessage(err, "Failed to update the rack's miners. Please try again.") };
       } finally {
         savingRef.current = false;
         setIsSaving(false);
@@ -516,15 +559,14 @@ export default function ManageRackModal({
 
       setInitialPlacement((prev) => {
         const next = new Map(prev);
-        for (const id of leavers) next.delete(id);
         for (const id of newcomers) next.set(id, "unplaced");
         return next;
       });
       // Member counts changed on the host's rack list.
       onSettingsPersisted?.();
-      return true;
+      return { ok: true };
     },
-    [rackMiners, totalSlots, existingRackId, dispatchWithSiteStripConfirm, onSettingsPersisted],
+    [totalSlots, existingRackId, dispatchWithSiteStripConfirm, forgetMiners, onSettingsPersisted],
   );
 
   // SearchMinersModal confirm — commit the miner into the rack if it isn't a
@@ -532,50 +574,70 @@ export default function ManageRackModal({
   // reassignment flag from the row it selected (exact even for fleets larger
   // than the display page).
   const handleSearchMinerConfirm = useCallback(
-    (minerId: string, isReassignment: boolean) => {
+    async (minerId: string, isReassignment: boolean) => {
       if (!selectedSlot) return;
       const slotKey = selectedSlot.key;
-      const apply = async () => {
-        // Failure leaves the picker open, with the error behind it, to retry.
-        if (!(await commitMembership([minerId], []))) return;
-        setRackMiners((prev) => (prev.includes(minerId) ? prev : [...prev, minerId]));
-        // Remove any existing assignment for this miner, then assign to selected slot
-        setSlotAssignments((prev) => {
-          const next = removeAssignmentByValue(prev, minerId);
-          next[slotKey] = minerId;
-          return next;
-        });
-        setSelectedSlot(null);
+      if (!(await confirmReparent(isReassignment ? 1 : 0))) return;
+
+      const outcome = await commitMembership([minerId], []);
+      if (!outcome.ok) {
+        // This picker has no callout of its own, and one miner at one slot is
+        // nothing to preserve — close it so the parent's error is what the
+        // operator sees rather than an unchanged list.
+        if (outcome.error) setErrorMsg(outcome.error);
         setShowSearchMiners(false);
-      };
-      promptReparent(isReassignment ? 1 : 0, () => void apply());
+        setSelectedSlot(null);
+        return;
+      }
+
+      applyRackMiners((prev) => (prev.includes(minerId) ? prev : [...prev, minerId]));
+      // Remove any existing assignment for this miner, then assign to selected slot
+      setSlotAssignments((prev) => {
+        const next = removeAssignmentByValue(prev, minerId);
+        next[slotKey] = minerId;
+        return next;
+      });
+      setSelectedSlot(null);
+      setShowSearchMiners(false);
     },
-    [selectedSlot, promptReparent, commitMembership],
+    [selectedSlot, confirmReparent, commitMembership, applyRackMiners],
   );
 
   const handleScanMinerAssign = useCallback(
-    async (minerId: string): Promise<ScanAssignmentResult | null> => {
-      if (!selectedSlot) return null;
+    async (minerId: string): Promise<ScanAssignmentOutcome> => {
+      if (!selectedSlot) return { failed: true, message: "Select a rack slot, then scan a miner." };
 
-      const wasMember = rackMiners.includes(minerId);
+      const wasMember = rackMinersRef.current.includes(minerId);
       // Membership commits before the modal reports the assignment, so the
       // "assigned" screen never claims a miner that isn't actually in the rack.
-      if (!(await commitMembership([minerId], []))) return null;
+      const outcome = await commitMembership([minerId], []);
+      if (!outcome.ok) return { failed: true, message: outcome.error };
 
       const previousSlotAssignments = slotAssignments;
       const assignedSlot = selectedSlot;
       const nextSlotAssignments = removeAssignmentByValue(slotAssignments, minerId);
       nextSlotAssignments[assignedSlot.key] = minerId;
 
-      setRackMiners((prev) => (prev.includes(minerId) ? prev : [...prev, minerId]));
+      applyRackMiners((prev) => (prev.includes(minerId) ? prev : [...prev, minerId]));
       setSlotAssignments(nextSlotAssignments);
 
       // Undo has to reverse the write too, not just the staged cell — but only
       // for a miner this scan actually added. One that was already a member
-      // keeps its membership and just loses the new cell.
+      // keeps its membership and just loses the new cell. commitMembership
+      // diffs against rackMinersRef, so it sees the add this closure predates.
       scanUndoRef.current = async () => {
-        if (!wasMember && !(await commitMembership([], [minerId]))) return;
-        if (!wasMember) setRackMiners((prev) => prev.filter((id) => id !== minerId));
+        if (wasMember) {
+          setSlotAssignments(previousSlotAssignments);
+          setSelectedSlot(assignedSlot);
+          return;
+        }
+        const undone = await commitMembership([], [minerId]);
+        if (!undone.ok) {
+          if (undone.error) setErrorMsg(undone.error);
+          return;
+        }
+        // forgetMiners already dropped the miner and its cell, so only the cells
+        // the scan displaced are left to restore.
         setSlotAssignments(previousSlotAssignments);
         setSelectedSlot(assignedSlot);
       };
@@ -585,31 +647,40 @@ export default function ManageRackModal({
         hasNextSlot: !!getNextAssignableSlot(assignedSlot, nextSlotAssignments),
       };
     },
-    [getNextAssignableSlot, getSlotLabel, rackMiners, selectedSlot, slotAssignments, commitMembership],
+    [getNextAssignableSlot, getSlotLabel, selectedSlot, slotAssignments, commitMembership, applyRackMiners],
   );
 
   // Scanned miners already assigned elsewhere use the same reparent warning as
   // search/list assignment. The success dialog is reserved for immediate
   // assignments that did not require that warning.
   const handleScanMinerConfirm = useCallback(
-    (minerId: string, isReassignment: boolean) => {
+    async (minerId: string, isReassignment: boolean) => {
       if (!selectedSlot) return;
       const slotKey = selectedSlot.key;
-      const apply = async () => {
-        if (!(await commitMembership([minerId], []))) return;
-        setRackMiners((prev) => (prev.includes(minerId) ? prev : [...prev, minerId]));
-        setSlotAssignments((prev) => {
-          const next = removeAssignmentByValue(prev, minerId);
-          next[slotKey] = minerId;
-          return next;
-        });
-        setSelectedSlot(null);
+      if (!(await confirmReparent(isReassignment ? 1 : 0))) return;
+
+      const outcome = await commitMembership([minerId], []);
+      if (!outcome.ok) {
+        // Close the scanner so the parent's callout is visible — the scan phase
+        // has already left the screen the message would have gone to.
+        if (outcome.error) setErrorMsg(outcome.error);
         setShowScanQr(false);
+        setSelectedSlot(null);
         scanUndoRef.current = null;
-      };
-      promptReparent(isReassignment ? 1 : 0, () => void apply());
+        return;
+      }
+
+      applyRackMiners((prev) => (prev.includes(minerId) ? prev : [...prev, minerId]));
+      setSlotAssignments((prev) => {
+        const next = removeAssignmentByValue(prev, minerId);
+        next[slotKey] = minerId;
+        return next;
+      });
+      setSelectedSlot(null);
+      setShowScanQr(false);
+      scanUndoRef.current = null;
     },
-    [selectedSlot, promptReparent, commitMembership],
+    [selectedSlot, confirmReparent, commitMembership, applyRackMiners],
   );
 
   const handleScanAssignmentUndo = useCallback(async () => {
@@ -633,7 +704,7 @@ export default function ManageRackModal({
     (deviceId: string | null) => {
       if (selectedSlot && deviceId) {
         // Assign this miner to the selected slot
-        setRackMiners((prev) => (prev.includes(deviceId) ? prev : [...prev, deviceId]));
+        applyRackMiners((prev) => (prev.includes(deviceId) ? prev : [...prev, deviceId]));
         setSlotAssignments((prev) => {
           const next = removeAssignmentByValue(prev, deviceId);
           next[selectedSlot.key] = deviceId;
@@ -645,7 +716,7 @@ export default function ManageRackModal({
         setSelectedMinerId(deviceId);
       }
     },
-    [selectedSlot],
+    [selectedSlot, applyRackMiners],
   );
 
   // Clear all assignments
@@ -656,17 +727,14 @@ export default function ManageRackModal({
   }, []);
 
   // Row-level "Remove from rack" — an immediate unassign (the miner keeps
-  // existing; it just leaves the rack). The row drops only once the write lands,
-  // so a failure leaves the list truthful.
+  // existing; it just leaves the rack). The commit's forgetMiners drops the row
+  // once the write lands, so a failure leaves the list truthful.
   const handleRemoveMiner = useCallback(
     async (deviceId: string) => {
-      if (!(await commitMembership([], [deviceId]))) return;
-      setRackMiners((prev) => prev.filter((id) => id !== deviceId));
-      setSlotAssignments((prev) => removeAssignmentByValue(prev, deviceId));
-      setManualAssignmentCache((prev) => removeAssignmentByValue(prev, deviceId));
-      if (selectedMinerId === deviceId) setSelectedMinerId(null);
+      const outcome = await commitMembership([], [deviceId]);
+      if (!outcome.ok && outcome.error) setErrorMsg(outcome.error);
     },
-    [selectedMinerId, commitMembership],
+    [commitMembership],
   );
 
   // Unassign miner from slot (keep in rack)
@@ -681,7 +749,10 @@ export default function ManageRackModal({
 
   // ManageMinersModal confirm handler. Returns an error string for the still-open
   // modal to surface (or undefined on success) — the parent's own callout sits
-  // behind the modal, so select-all overflow/load errors must go back up.
+  // behind the modal, so select-all overflow/load errors and the membership
+  // write's own failure must go back up. That is why the reparent warning is
+  // awaited here rather than deferring the write to a callback: the outcome has
+  // to still be in scope to return.
   const handleManageMinersConfirm = useCallback(
     async (
       selectedIds: string[],
@@ -719,21 +790,21 @@ export default function ManageRackModal({
       // The picker owns membership, so the delta is written here rather than
       // staged. Accepting the reparent warning is what authorizes that write.
       const keepSet = new Set(finalIds);
-      const removed = rackMiners.filter((id) => !keepSet.has(id));
-      const apply = async () => {
-        // Failure leaves the picker open with the selection intact to retry.
-        if (!(await commitMembership(finalIds, removed))) return;
-        setRackMiners(finalIds);
-        setShowManageMiners(false);
+      const removed = rackMinersRef.current.filter((id) => !keepSet.has(id));
+      if (!(await confirmReparent(reassignedCount))) return undefined;
 
-        // Remove assignments for miners no longer in rack
-        setSlotAssignments((prev) => filterAssignmentsByValues(prev, keepSet));
-        setManualAssignmentCache((prev) => filterAssignmentsByValues(prev, keepSet));
-      };
-      promptReparent(reassignedCount, () => void apply());
+      // Failure leaves the picker open with the selection intact to retry, so
+      // the message goes back to it rather than the callout behind it.
+      const outcome = await commitMembership(finalIds, removed);
+      if (!outcome.ok) return outcome.error;
+
+      // The removed miners' cells went with them in the commit's forgetMiners,
+      // so the surviving assignments are already the right ones.
+      applyRackMiners(finalIds);
+      setShowManageMiners(false);
       return undefined;
     },
-    [eligibility, totalSlots, rackMiners, promptReparent, commitMembership],
+    [eligibility, totalSlots, confirmReparent, commitMembership, applyRackMiners],
   );
 
   // Rack Settings "Save" handler: persists label/zone/dimensions AND placement

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/MinersPane.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/MinersPane.tsx
@@ -68,6 +68,9 @@ function MinerRow({
   onBlinkLED: (deviceId: string) => void;
 }) {
   const name = miner?.name;
+  // Miners outside the first display page have no cached snapshot, so fall back
+  // to the identifier rather than labelling a control "for undefined".
+  const label = name || deviceId;
   const ipAddress = miner?.ipAddress;
   const macAddress = miner?.macAddress;
   const model = miner?.model;
@@ -161,6 +164,7 @@ function MinerRow({
         {isAssigned ? (
           <button
             type="button"
+            aria-label={`Unassign ${label} from its slot`}
             className="flex h-8 w-8 items-center justify-center rounded-lg text-text-primary-70 hover:cursor-pointer"
             onClick={(e) => {
               e.stopPropagation();
@@ -173,6 +177,7 @@ function MinerRow({
           <>
             <button
               type="button"
+              aria-label={`Actions for ${label}`}
               className="flex h-8 w-8 items-center justify-center rounded-lg text-text-primary-70 hover:cursor-pointer"
               onClick={(e) => {
                 e.stopPropagation();

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ScanMinerQrModal.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ScanMinerQrModal.test.tsx
@@ -63,7 +63,7 @@ function renderScanMinerQrModal(overrides: Partial<ComponentProps<typeof ScanMin
     eligibility: {},
     targetSlotLabel: "Slot 1",
     onDismiss: vi.fn(),
-    onConfirm: vi.fn(),
+    onConfirm: vi.fn().mockResolvedValue(undefined),
     onAssign: vi.fn().mockReturnValue({ slotLabel: "Slot 1", hasNextSlot: true }),
     onUndoAssignment: vi.fn().mockResolvedValue(true),
     onScanNextSlot: vi.fn().mockReturnValue(true),
@@ -224,6 +224,76 @@ describe("ScanMinerQrModal", () => {
     expect(onAssign).toHaveBeenCalledWith("dev-1");
   });
 
+  it("holds the found dialog while the confirmed assignment is still writing", async () => {
+    mockCanUseLiveCamera.mockReturnValue(true);
+    mockLookup
+      .mockResolvedValueOnce({ status: "found", snapshot: snapshot({ deviceIdentifier: "dev-1" }) })
+      .mockResolvedValueOnce({
+        status: "found",
+        snapshot: snapshot({ deviceIdentifier: "dev-2", serialNumber: "SN456" }),
+      });
+    let resolveAssign: (outcome: { slotLabel: string; hasNextSlot: boolean }) => void = () => {};
+    const onAssign = vi.fn().mockReturnValue(
+      new Promise((resolve) => {
+        resolveAssign = resolve;
+      }),
+    );
+
+    renderScanMinerQrModal({ onAssign });
+
+    await act(async () => {
+      capturedOnDetected?.(["SN:SN123", "SN:SN456"]);
+    });
+    await waitFor(() => expect(screen.getByText("Multiple miners found")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: "Assign to slot" }));
+
+    // Rescanning here would move the scanner on while the write is still in
+    // flight, leaving it to land against a slot the operator has left behind.
+    await waitFor(() => expect(screen.getByRole("button", { name: "Assigning..." })).toBeDisabled());
+    expect(screen.getByRole("button", { name: "Scan another" })).toBeDisabled();
+
+    await act(async () => {
+      resolveAssign({ slotLabel: "Slot 1", hasNextSlot: true });
+    });
+
+    await waitFor(() => expect(screen.getByText("Miner assigned")).toBeInTheDocument());
+    expect(onAssign).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops an assignment result that lands after the scanner was reopened", async () => {
+    mockCanUseLiveCamera.mockReturnValue(true);
+    mockLookup.mockResolvedValue({ status: "found", snapshot: snapshot() });
+    let resolveAssign: (outcome: { slotLabel: string; hasNextSlot: boolean }) => void = () => {};
+    const onAssign = vi.fn().mockReturnValue(
+      new Promise((resolve) => {
+        resolveAssign = resolve;
+      }),
+    );
+
+    const { props, rerender } = renderScanMinerQrModal({ onAssign });
+
+    await act(async () => {
+      capturedOnDetected?.(["SN:SN123"]);
+    });
+    expect(onAssign).toHaveBeenCalledWith("dev-1");
+
+    // Dismissing mid-write stays allowed, so the write can still land against a
+    // scan the operator has already replaced.
+    await act(async () => {
+      rerender(<ScanMinerQrModal {...props} show={false} />);
+    });
+    await act(async () => {
+      rerender(<ScanMinerQrModal {...props} show />);
+    });
+    await act(async () => {
+      resolveAssign({ slotLabel: "Slot 1", hasNextSlot: true });
+    });
+
+    expect(screen.queryByText("Miner assigned")).not.toBeInTheDocument();
+    expect(screen.getByText("Scan for Slot 1")).toBeInTheDocument();
+  });
+
   it("de-dupes a value decoded more than once in the same frame", async () => {
     mockCanUseLiveCamera.mockReturnValue(true);
     mockLookup.mockResolvedValue({ status: "found", snapshot: snapshot() });
@@ -261,7 +331,7 @@ describe("ScanMinerQrModal", () => {
       snapshot: snapshot({ placement: { rack: { id: 9n, label: "Rack B" } } }),
     });
     const onAssign = vi.fn();
-    const onConfirm = vi.fn();
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
 
     renderScanMinerQrModal({ onAssign, onConfirm });
 
@@ -273,7 +343,9 @@ describe("ScanMinerQrModal", () => {
     expect(screen.getByText("Assigning it here will move it from Rack B.")).toBeInTheDocument();
     expect(onAssign).not.toHaveBeenCalled();
 
-    fireEvent.click(screen.getByRole("button", { name: "Assign to slot" }));
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Assign to slot" }));
+    });
     expect(onConfirm).toHaveBeenCalledWith("dev-1", true);
   });
 
@@ -287,7 +359,7 @@ describe("ScanMinerQrModal", () => {
       snapshot: snapshot({ pairingStatus: PairingStatus.AUTHENTICATION_NEEDED }),
     });
     const onAssign = vi.fn().mockReturnValue({ slotLabel: "Slot 1", hasNextSlot: true });
-    const onConfirm = vi.fn();
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
 
     renderScanMinerQrModal({ onAssign, onConfirm });
 
@@ -311,7 +383,7 @@ describe("ScanMinerQrModal", () => {
       }),
     });
     const onAssign = vi.fn();
-    const onConfirm = vi.fn();
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
 
     renderScanMinerQrModal({ onAssign, onConfirm });
 
@@ -324,7 +396,9 @@ describe("ScanMinerQrModal", () => {
     expect(screen.queryByText(/isn't fully paired/i)).not.toBeInTheDocument();
     expect(onAssign).not.toHaveBeenCalled();
 
-    fireEvent.click(screen.getByRole("button", { name: "Assign to slot" }));
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Assign to slot" }));
+    });
     expect(onConfirm).toHaveBeenCalledWith("dev-1", true);
   });
 

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ScanMinerQrModal.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ScanMinerQrModal.test.tsx
@@ -65,7 +65,7 @@ function renderScanMinerQrModal(overrides: Partial<ComponentProps<typeof ScanMin
     onDismiss: vi.fn(),
     onConfirm: vi.fn(),
     onAssign: vi.fn().mockReturnValue({ slotLabel: "Slot 1", hasNextSlot: true }),
-    onUndoAssignment: vi.fn(),
+    onUndoAssignment: vi.fn().mockResolvedValue(true),
     onScanNextSlot: vi.fn().mockReturnValue(true),
     ...overrides,
   };
@@ -122,7 +122,7 @@ describe("ScanMinerQrModal", () => {
   it("undoes the just-made assignment from the success dialog", async () => {
     mockCanUseLiveCamera.mockReturnValue(true);
     mockLookup.mockResolvedValueOnce({ status: "found", snapshot: snapshot() });
-    const onUndoAssignment = vi.fn();
+    const onUndoAssignment = vi.fn().mockResolvedValue(true);
 
     renderScanMinerQrModal({ onUndoAssignment });
 
@@ -134,6 +134,30 @@ describe("ScanMinerQrModal", () => {
     fireEvent.click(screen.getByRole("button", { name: "Undo" }));
 
     expect(onUndoAssignment).toHaveBeenCalled();
+    // Undo landed, so the scanner goes back to scanning for the next miner.
+    await waitFor(() => expect(screen.queryByText("Miner assigned")).not.toBeInTheDocument());
+  });
+
+  it("keeps the assigned screen up when the undo could not be persisted", async () => {
+    mockCanUseLiveCamera.mockReturnValue(true);
+    mockLookup.mockResolvedValueOnce({ status: "found", snapshot: snapshot() });
+    // The miner is still in the rack. Rescanning here would swap the assigned
+    // screen for the scanning one and hide the parent's error behind it.
+    const onUndoAssignment = vi.fn().mockResolvedValue(false);
+
+    renderScanMinerQrModal({ onUndoAssignment });
+
+    await act(async () => {
+      capturedOnDetected?.(["SN:SN123"]);
+    });
+
+    await waitFor(() => expect(screen.getByText("Miner assigned")).toBeInTheDocument());
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Undo" }));
+    });
+
+    expect(onUndoAssignment).toHaveBeenCalled();
+    expect(screen.getByText("Miner assigned")).toBeInTheDocument();
   });
 
   it("tries every decoded barcode until one resolves", async () => {

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ScanMinerQrModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ScanMinerQrModal.tsx
@@ -16,6 +16,15 @@ export interface ScanAssignmentResult {
   hasNextSlot: boolean;
 }
 
+/** The assignment didn't happen. `message` is shown when present; without one the
+ *  operator cancelled and needs no telling, so the scanner just resumes. */
+export interface ScanAssignmentRefused {
+  failed: true;
+  message?: string;
+}
+
+export type ScanAssignmentOutcome = ScanAssignmentResult | ScanAssignmentRefused;
+
 interface ScanMinerQrModalProps {
   show: boolean;
   /** Label of the rack being edited; shown in assignment and confirmation copy. */
@@ -29,7 +38,7 @@ interface ScanMinerQrModalProps {
   onConfirm: (deviceIdentifier: string, isReassignment: boolean) => void;
   // Both commit: assigning writes the miner into the rack, undoing takes it
   // back out. Awaited so the "assigned" phase only shows once it landed.
-  onAssign: (deviceIdentifier: string) => Promise<ScanAssignmentResult | null>;
+  onAssign: (deviceIdentifier: string) => Promise<ScanAssignmentOutcome>;
   onUndoAssignment: () => Promise<void>;
   onScanNextSlot: () => boolean;
 }
@@ -136,8 +145,8 @@ export default function ScanMinerQrModal({
       }
 
       const assignment = await onAssign(snapshot.deviceIdentifier);
-      if (!assignment) {
-        setPhase({ kind: "error", message: "Select a rack slot, then scan a miner." });
+      if ("failed" in assignment) {
+        setPhase(assignment.message ? { kind: "error", message: assignment.message } : { kind: "scanning" });
         return;
       }
 
@@ -201,8 +210,8 @@ export default function ScanMinerQrModal({
       const isReassignment = isMinerSnapshotIneligible(phase.snapshot, eligibility);
       if (phase.requiresConfirmation && !isReassignment) {
         const assignment = await onAssign(phase.snapshot.deviceIdentifier);
-        if (!assignment) {
-          setPhase({ kind: "error", message: "Select a rack slot, then scan a miner." });
+        if ("failed" in assignment) {
+          setPhase(assignment.message ? { kind: "error", message: assignment.message } : { kind: "scanning" });
           return;
         }
 

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ScanMinerQrModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ScanMinerQrModal.tsx
@@ -27,8 +27,10 @@ interface ScanMinerQrModalProps {
   /** `isReassignment` is true when the scanned miner is currently assigned to a
    *  different rack/building/site, so the caller can confirm the reparent. */
   onConfirm: (deviceIdentifier: string, isReassignment: boolean) => void;
-  onAssign: (deviceIdentifier: string) => ScanAssignmentResult | null;
-  onUndoAssignment: () => void;
+  // Both commit: assigning writes the miner into the rack, undoing takes it
+  // back out. Awaited so the "assigned" phase only shows once it landed.
+  onAssign: (deviceIdentifier: string) => Promise<ScanAssignmentResult | null>;
+  onUndoAssignment: () => Promise<void>;
   onScanNextSlot: () => boolean;
 }
 
@@ -133,7 +135,7 @@ export default function ScanMinerQrModal({
         return;
       }
 
-      const assignment = onAssign(snapshot.deviceIdentifier);
+      const assignment = await onAssign(snapshot.deviceIdentifier);
       if (!assignment) {
         setPhase({ kind: "error", message: "Select a rack slot, then scan a miner." });
         return;
@@ -194,11 +196,11 @@ export default function ScanMinerQrModal({
     [detectFromBlob, runLookup],
   );
 
-  const handleConfirm = useCallback(() => {
+  const handleConfirm = useCallback(async () => {
     if (phase.kind === "found") {
       const isReassignment = isMinerSnapshotIneligible(phase.snapshot, eligibility);
       if (phase.requiresConfirmation && !isReassignment) {
-        const assignment = onAssign(phase.snapshot.deviceIdentifier);
+        const assignment = await onAssign(phase.snapshot.deviceIdentifier);
         if (!assignment) {
           setPhase({ kind: "error", message: "Select a rack slot, then scan a miner." });
           return;
@@ -217,8 +219,8 @@ export default function ScanMinerQrModal({
     }
   }, [phase, onAssign, onConfirm, eligibility]);
 
-  const handleUndoAssignment = useCallback(() => {
-    onUndoAssignment();
+  const handleUndoAssignment = useCallback(async () => {
+    await onUndoAssignment();
     rescan();
   }, [onUndoAssignment, rescan]);
 
@@ -239,8 +241,8 @@ export default function ScanMinerQrModal({
       cameraError={errorMessage}
       fileInputRef={fileInputRef}
       onDismiss={onDismiss}
-      onConfirmFound={handleConfirm}
-      onUndoAssignment={handleUndoAssignment}
+      onConfirmFound={() => void handleConfirm()}
+      onUndoAssignment={() => void handleUndoAssignment()}
       onScanNextSlot={handleScanNextSlot}
       onRescan={rescan}
       onFile={handleFile}

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ScanMinerQrModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ScanMinerQrModal.tsx
@@ -39,7 +39,9 @@ interface ScanMinerQrModalProps {
   // Both commit: assigning writes the miner into the rack, undoing takes it
   // back out. Awaited so the "assigned" phase only shows once it landed.
   onAssign: (deviceIdentifier: string) => Promise<ScanAssignmentOutcome>;
-  onUndoAssignment: () => Promise<void>;
+  /** Resolves false when the undo could not be persisted — the miner is still in
+   *  the rack, and the caller has surfaced the error on its own surface. */
+  onUndoAssignment: () => Promise<boolean>;
   onScanNextSlot: () => boolean;
 }
 
@@ -228,9 +230,11 @@ export default function ScanMinerQrModal({
     }
   }, [phase, onAssign, onConfirm, eligibility]);
 
+  // Only rescan once the undo actually landed. A failed one leaves the miner in
+  // the rack, and rescanning would replace the assigned screen with the scanning
+  // one — dropping the operator back into a scan as if the undo had worked.
   const handleUndoAssignment = useCallback(async () => {
-    await onUndoAssignment();
-    rescan();
+    if (await onUndoAssignment()) rescan();
   }, [onUndoAssignment, rescan]);
 
   const handleScanNextSlot = useCallback(() => {

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ScanMinerQrModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ScanMinerQrModal.tsx
@@ -35,7 +35,9 @@ interface ScanMinerQrModalProps {
   onDismiss: () => void;
   /** `isReassignment` is true when the scanned miner is currently assigned to a
    *  different rack/building/site, so the caller can confirm the reparent. */
-  onConfirm: (deviceIdentifier: string, isReassignment: boolean) => void;
+  // Awaited, like onAssign: it commits membership too, so the found dialog has
+  // to stay put until it lands rather than letting a rescan run underneath it.
+  onConfirm: (deviceIdentifier: string, isReassignment: boolean) => Promise<void>;
   // Both commit: assigning writes the miner into the rack, undoing takes it
   // back out. Awaited so the "assigned" phase only shows once it landed.
   onAssign: (deviceIdentifier: string) => Promise<ScanAssignmentOutcome>;
@@ -62,6 +64,7 @@ export default function ScanMinerQrModal({
   onScanNextSlot,
 }: ScanMinerQrModalProps) {
   const [phase, setPhase] = useState<ScanPhase>({ kind: "scanning" });
+  const [assigning, setAssigning] = useState(false);
   const [scannerRestartKey, setScannerRestartKey] = useState(0);
   const liveCamera = canUseLiveCamera();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -147,6 +150,11 @@ export default function ScanMinerQrModal({
       }
 
       const assignment = await onAssign(snapshot.deviceIdentifier);
+      // The write outlives the scan it came from: closing and reopening the
+      // scanner bumps the sequence, and applying a result past that point would
+      // paint an "assigned" screen over the fresh scan, wired to the previous
+      // slot's undo.
+      if (seq !== lookupSeq.current) return;
       if ("failed" in assignment) {
         setPhase(assignment.message ? { kind: "error", message: assignment.message } : { kind: "scanning" });
         return;
@@ -207,11 +215,18 @@ export default function ScanMinerQrModal({
     [detectFromBlob, runLookup],
   );
 
+  // `assigning` holds the found dialog while either commit runs, and the
+  // sequence check covers what a held dialog cannot: dismissing mid-write, which
+  // is still allowed, then reopening onto a scan this result no longer describes.
   const handleConfirm = useCallback(async () => {
-    if (phase.kind === "found") {
-      const isReassignment = isMinerSnapshotIneligible(phase.snapshot, eligibility);
+    if (phase.kind !== "found") return;
+    const seq = lookupSeq.current;
+    const isReassignment = isMinerSnapshotIneligible(phase.snapshot, eligibility);
+    setAssigning(true);
+    try {
       if (phase.requiresConfirmation && !isReassignment) {
         const assignment = await onAssign(phase.snapshot.deviceIdentifier);
+        if (seq !== lookupSeq.current) return;
         if ("failed" in assignment) {
           setPhase(assignment.message ? { kind: "error", message: assignment.message } : { kind: "scanning" });
           return;
@@ -226,7 +241,11 @@ export default function ScanMinerQrModal({
         return;
       }
 
-      onConfirm(phase.snapshot.deviceIdentifier, isReassignment);
+      // Resolves once the reparent is confirmed and its membership commit lands.
+      // The caller closes the scanner itself on both outcomes.
+      await onConfirm(phase.snapshot.deviceIdentifier, isReassignment);
+    } finally {
+      setAssigning(false);
     }
   }, [phase, onAssign, onConfirm, eligibility]);
 
@@ -253,6 +272,7 @@ export default function ScanMinerQrModal({
       cameraStatus={status}
       cameraError={errorMessage}
       fileInputRef={fileInputRef}
+      assigning={assigning}
       onDismiss={onDismiss}
       onConfirmFound={() => void handleConfirm()}
       onUndoAssignment={() => void handleUndoAssignment()}

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ScanMinerQrModalView.stories.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ScanMinerQrModalView.stories.tsx
@@ -44,12 +44,14 @@ const Harness = ({
   liveCamera = true,
   cameraStatus,
   cameraError = "",
+  assigning = false,
 }: {
   phase: ScanPhase;
   targetSlotLabel?: string;
   liveCamera?: boolean;
   cameraStatus?: string;
   cameraError?: string;
+  assigning?: boolean;
 }) => {
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const scanRegionRef = useRef<HTMLDivElement | null>(null);
@@ -66,6 +68,7 @@ const Harness = ({
       cameraStatus={cameraStatus ?? (phase.kind === "scanning" ? "scanning" : "idle")}
       cameraError={cameraError}
       fileInputRef={fileInputRef}
+      assigning={assigning}
       onDismiss={action("onDismiss")}
       onConfirmFound={action("onConfirmFound")}
       onUndoAssignment={action("onUndoAssignment")}
@@ -143,6 +146,18 @@ export const FoundInAnotherRack: Story = {
       snapshot: mockSnapshot({ placement: { rack: { id: 7n, label: "Rack B-02" } } } as Partial<MinerStateSnapshot>),
       isReassignment: true,
     },
+  },
+};
+
+/** The confirmed assignment is mid-write: the dialog holds until it lands. */
+export const FoundAssignmentPending: Story = {
+  args: {
+    phase: {
+      kind: "found",
+      snapshot: mockSnapshot({ placement: { rack: { id: 7n, label: "Rack B-02" } } } as Partial<MinerStateSnapshot>),
+      isReassignment: true,
+    },
+    assigning: true,
   },
 };
 

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ScanMinerQrModalView.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/ScanMinerQrModalView.tsx
@@ -39,6 +39,9 @@ export interface ScanMinerQrModalViewProps {
   cameraError: string;
   /** Hidden file input for the photo-capture fallback. */
   fileInputRef: RefObject<HTMLInputElement | null>;
+  /** A confirmed assignment is mid-write. Holds the found dialog still so the
+   *  operator cannot move the scan on and have that write land behind them. */
+  assigning: boolean;
   onDismiss: () => void;
   onConfirmFound: () => void;
   onUndoAssignment: () => void;
@@ -64,6 +67,7 @@ export default function ScanMinerQrModalView({
   cameraStatus,
   cameraError,
   fileInputRef,
+  assigning,
   onDismiss,
   onConfirmFound,
   onUndoAssignment,
@@ -149,6 +153,7 @@ export default function ScanMinerQrModalView({
         requiresConfirmation={!!phase.requiresConfirmation}
         otherRackLabel={getMinerRackLabel(phase.snapshot)}
         targetSlotLabel={targetSlotLabel}
+        assigning={assigning}
         onDismiss={onDismiss}
         onConfirm={onConfirmFound}
         onRescan={onRescan}
@@ -356,6 +361,7 @@ function FoundMinerDialog({
   requiresConfirmation,
   otherRackLabel,
   targetSlotLabel,
+  assigning,
   onDismiss,
   onConfirm,
   onRescan,
@@ -367,6 +373,7 @@ function FoundMinerDialog({
   requiresConfirmation: boolean;
   otherRackLabel: string;
   targetSlotLabel: string;
+  assigning: boolean;
   onDismiss: () => void;
   onConfirm: () => void;
   onRescan: () => void;
@@ -386,18 +393,23 @@ function FoundMinerDialog({
         ? `Assigning it here will move it to ${currentRackLabel}.`
         : "Choose another miner for this rack slot.";
   const canConfirmAssignment = isReassignment || requiresConfirmation;
+  // Both hold while the confirmed assignment writes: moving the scan on would
+  // leave that write to land against a slot the operator has left behind.
   const buttons: ButtonProps[] = [
     dismissButton(onDismiss),
     {
       text: "Scan another",
       variant: canConfirmAssignment ? variants.secondary : variants.primary,
+      disabled: assigning,
       onClick: onRescan,
     },
     ...(canConfirmAssignment
       ? [
           {
-            text: "Assign to slot",
+            text: assigning ? "Assigning..." : "Assign to slot",
             variant: variants.primary,
+            disabled: assigning,
+            loading: assigning,
             onClick: onConfirm,
           },
         ]

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/SearchMinersModal.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/SearchMinersModal.test.tsx
@@ -1,0 +1,92 @@
+import { type ComponentProps, forwardRef, type ReactNode, type Ref, useEffect, useImperativeHandle } from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import SearchMinersModal from "./SearchMinersModal";
+
+const mockGetSelection = vi.fn(() => ({
+  selectedItems: ["miner-1"],
+  allSelected: false,
+  totalMiners: 1,
+  reassignedItems: [] as string[],
+  blockedByFilter: false,
+}));
+
+// The real list needs a paginated fleet fetch, and what these tests are about is
+// the CTA's behaviour around the caller's write, so the selection is stubbed. The
+// stub reports one selected miner on mount, which is what un-gates Assign.
+vi.mock("@/protoFleet/components/MinerSelectionList", () => ({
+  __esModule: true,
+  default: forwardRef(
+    ({ onSelectionChange }: { onSelectionChange?: (s: { selectedItems: string[] }) => void }, ref: Ref<unknown>) => {
+      useImperativeHandle(ref, () => ({ getSelection: mockGetSelection }));
+      useEffect(() => {
+        onSelectionChange?.({ selectedItems: ["miner-1"] });
+      }, [onSelectionChange]);
+      return <div data-testid="miner-selection-list" />;
+    },
+  ),
+}));
+
+vi.mock("@/shared/components/Modal", () => ({
+  default: ({
+    children,
+    open,
+    buttons,
+  }: {
+    children: ReactNode;
+    open?: boolean;
+    buttons?: { text: string; onClick?: () => void; disabled?: boolean; loading?: boolean }[];
+  }) =>
+    open !== false ? (
+      <div data-testid="modal">
+        {children}
+        {buttons?.map((btn, i) => (
+          <button key={i} onClick={btn.onClick} disabled={Boolean(btn.disabled || btn.loading)}>
+            {btn.text}
+          </button>
+        ))}
+      </div>
+    ) : null,
+}));
+
+const renderModal = (overrides: Partial<ComponentProps<typeof SearchMinersModal>> = {}) =>
+  render(
+    <SearchMinersModal
+      show
+      eligibility={{ rackId: 1n }}
+      targetRackLabel="Rack 1"
+      onDismiss={vi.fn()}
+      onConfirm={vi.fn()}
+      {...overrides}
+    />,
+  );
+
+describe("SearchMinersModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("reports the selected miner to the caller on Assign", async () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+    renderModal({ onConfirm });
+
+    fireEvent.click(screen.getByRole("button", { name: "Assign" }));
+
+    await waitFor(() => expect(onConfirm).toHaveBeenCalledWith("miner-1", false));
+  });
+
+  it("blocks a second Assign while the caller's write is in flight", () => {
+    // The caller refuses a re-entrant commit and reports it as a failure, which
+    // would close this picker and show an error for a write that is still
+    // running. So the CTA has to be unavailable for the duration.
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+    renderModal({ onConfirm, saving: true });
+
+    const cta = screen.getByRole("button", { name: "Assigning..." });
+    expect(cta).toBeDisabled();
+
+    fireEvent.click(cta);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/SearchMinersModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/ManageRackModal/SearchMinersModal.tsx
@@ -21,8 +21,13 @@ interface SearchMinersModalProps {
   scope?: SiteFilterFields;
   onDismiss: () => void;
   /** `isReassignment` is true when the picked miner is currently assigned to a
-   *  different rack/building/site, so the caller can confirm the reparent. */
-  onConfirm: (selectedMinerId: string, isReassignment: boolean) => void;
+   *  different rack/building/site, so the caller can confirm the reparent.
+   *  Awaited: the assignment is a write, and the CTA stays busy until it lands. */
+  onConfirm: (selectedMinerId: string, isReassignment: boolean) => void | Promise<void>;
+  /** Caller's in-flight membership write, mirroring ManageMinersModal. Without
+   *  it a second Assign click re-enters the caller's commit, which refuses the
+   *  re-entry and reports a failure for a write that is still in flight. */
+  saving?: boolean;
 }
 
 export default function SearchMinersModal({
@@ -32,17 +37,19 @@ export default function SearchMinersModal({
   scope,
   onDismiss,
   onConfirm,
+  saving = false,
 }: SearchMinersModalProps) {
   const selectionRef = useRef<MinerSelectionListHandle>(null);
   const [hasSelection, setHasSelection] = useState(false);
 
-  const handleConfirm = useCallback(() => {
+  const handleConfirm = useCallback(async () => {
     const selection = selectionRef.current?.getSelection();
     // blockedByFilter: a conflicting placement facet is showing no results, so
     // the (hidden) selection must not be acted on.
     if (!selection || selection.blockedByFilter || selection.selectedItems.length === 0) return;
     const minerId = selection.selectedItems[0];
-    onConfirm(minerId, selection.reassignedItems.includes(minerId));
+    // Awaited so the CTA's busy state covers the caller's write.
+    await onConfirm(minerId, selection.reassignedItems.includes(minerId));
   }, [onConfirm]);
 
   if (!show) return null;
@@ -56,10 +63,11 @@ export default function SearchMinersModal({
       divider={false}
       buttons={[
         {
-          text: "Assign",
+          text: saving ? "Assigning..." : "Assign",
           variant: "primary",
-          disabled: !hasSelection,
-          onClick: handleConfirm,
+          disabled: !hasSelection || saving,
+          loading: saving,
+          onClick: () => void handleConfirm(),
           dismissModalOnClick: false,
         },
       ]}

--- a/client/src/protoFleet/features/fleetManagement/components/RackSettingsModal.stories.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/RackSettingsModal.stories.tsx
@@ -26,8 +26,8 @@ export const CreateNew = () => {
           action("onDismiss")();
           setShow(false);
         }}
-        onContinue={(formData) => {
-          action("onContinue")(formData);
+        onSubmit={(formData) => {
+          action("onSubmit")(formData);
           setShow(false);
         }}
       />

--- a/client/src/protoFleet/features/fleetManagement/components/RackSettingsModal.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/RackSettingsModal.test.tsx
@@ -171,6 +171,17 @@ describe("RackSettingsModal — bulk create", () => {
     await user.type(count, "5005");
     expect(count).toHaveValue("500");
 
+    // A rejected character is the same failure by a different route: nothing
+    // caps letters, and sanitizing to the string already held would leave the
+    // typed one on screen.
+    await user.type(count, "a");
+    expect(count).toHaveValue("500");
+    await user.clear(count);
+    await user.type(count, "1e3");
+    expect(count).toHaveValue("13");
+    await user.clear(count);
+    await user.type(count, "500");
+
     // Counter scale is one digit, so it desyncs on the very next keystroke.
     // Cleared first because it is seeded with the default scale, and a full
     // one-character field would refuse the typing outright.

--- a/client/src/protoFleet/features/fleetManagement/components/RackSettingsModal.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/RackSettingsModal.test.tsx
@@ -1,6 +1,7 @@
 import type { ComponentProps } from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import userEvent from "@testing-library/user-event";
 
 import RackSettingsModal from "./RackSettingsModal";
 import {
@@ -154,6 +155,39 @@ describe("RackSettingsModal — bulk create", () => {
     await waitFor(() => expect(screen.queryByText("A label prefix is required")).not.toBeInTheDocument());
     fireEvent.click(create);
     await waitFor(() => expect(onSubmitBulk).toHaveBeenCalledTimes(1));
+  });
+
+  it("stops the bulk number fields displaying more than they submit", async () => {
+    const user = userEvent.setup();
+    const onSubmitBulk = vi.fn<SubmitBulk>().mockResolvedValue([]);
+    renderModal({ onSubmitBulk, initialCreateVariant: "multiple" });
+
+    // The cap is 500, so the field takes three digits. A fourth is dropped by
+    // maxLength, which the browser only honours on a text input — and the
+    // sanitized value coming back is unchanged, so nothing would re-sync a
+    // number input's own display. Typing (not a synthetic change event) is what
+    // exercises that.
+    const count = screen.getByTestId("rack-bulk-count-input");
+    await user.type(count, "5005");
+    expect(count).toHaveValue("500");
+
+    // Counter scale is one digit, so it desyncs on the very next keystroke.
+    // Cleared first because it is seeded with the default scale, and a full
+    // one-character field would refuse the typing outright.
+    const scale = screen.getByTestId("rack-bulk-counter-scale-input");
+    await user.clear(scale);
+    await user.type(scale, "34");
+    expect(scale).toHaveValue("3");
+
+    await user.type(screen.getByTestId("rack-bulk-prefix-input"), "R-");
+    fillGeometry();
+
+    // What the fields read is what the request carries.
+    expect(screen.getByText("500 racks to create")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("Create racks"));
+    await waitFor(() => expect(onSubmitBulk).toHaveBeenCalledTimes(1));
+    expect(onSubmitBulk.mock.calls[0][0]).toHaveLength(500);
+    expect(onSubmitBulk.mock.calls[0][0][0].label).toBe("R-001");
   });
 
   it("bounds the counter scale on submit rather than constraining the input", async () => {

--- a/client/src/protoFleet/features/fleetManagement/components/RackSettingsModal.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/RackSettingsModal.test.tsx
@@ -1,0 +1,242 @@
+import type { ComponentProps } from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import RackSettingsModal from "./RackSettingsModal";
+import {
+  PerRackCreateErrorReason,
+  RackCoolingType,
+  RackOrderIndex,
+} from "@/protoFleet/api/generated/device_set/v1/device_set_pb";
+
+type RackSettingsModalProps = ComponentProps<typeof RackSettingsModal>;
+// Typing the stub off the prop itself keeps the resolved value honest: a mock
+// that returned the wrong error shape would fail here rather than at runtime.
+type SubmitBulk = NonNullable<RackSettingsModalProps["onSubmitBulk"]>;
+
+// The modal fetches zone suggestions and rack types on mount and blocks its CTA
+// until both land, so both callbacks fire synchronously here.
+const mockListRackZones = vi.fn(({ onSuccess, onFinally }) => {
+  onSuccess?.([]);
+  onFinally?.();
+});
+const mockListRackTypes = vi.fn(({ onSuccess, onFinally }) => {
+  onSuccess?.([]);
+  onFinally?.();
+});
+
+vi.mock("@/protoFleet/api/useDeviceSets", async (importActual) => ({
+  ...(await importActual<typeof import("@/protoFleet/api/useDeviceSets")>()),
+  useDeviceSets: () => ({
+    listRackZones: mockListRackZones,
+    listRackTypes: mockListRackTypes,
+  }),
+}));
+
+vi.mock("@/protoFleet/api/SitesContext", () => ({
+  useSitesContext: () => ({ sites: [] }),
+}));
+
+vi.mock("@/protoFleet/api/buildings", () => ({
+  useBuildings: () => ({ listBuildingsBySite: vi.fn() }),
+}));
+
+vi.mock("@/protoFleet/store", () => ({
+  useHasPermission: () => true,
+}));
+
+// Geometry is the one thing the bulk form still requires per submit, and no rack
+// types come back from the stub, so every test fills it.
+const fillGeometry = () => {
+  fireEvent.change(screen.getByLabelText("Columns"), { target: { value: "3" } });
+  fireEvent.change(screen.getByLabelText("Rows"), { target: { value: "4" } });
+};
+
+const renderModal = (props: Partial<RackSettingsModalProps> = {}) =>
+  render(<RackSettingsModal show existingRacks={[]} onDismiss={vi.fn()} {...props} />);
+
+describe("RackSettingsModal — bulk create", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("hides the Single / Multiple toggle when no batch handler is wired", () => {
+    renderModal({ onSubmit: vi.fn() });
+    expect(screen.queryByText("Multiple")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Label")).toBeInTheDocument();
+  });
+
+  it("opens on the Multiple form when the host preselected it", () => {
+    renderModal({ onSubmit: vi.fn(), onSubmitBulk: vi.fn(), initialCreateVariant: "multiple" });
+    // The single-rack Label field is replaced by the batch's generators.
+    expect(screen.queryByLabelText("Label")).not.toBeInTheDocument();
+    expect(screen.getByTestId("rack-bulk-count-input")).toBeInTheDocument();
+    expect(screen.getByTestId("rack-bulk-prefix-input")).toBeInTheDocument();
+  });
+
+  it("offers no batch form when editing an existing rack", () => {
+    renderModal({
+      existingRack: true,
+      initialFormData: {
+        label: "R-1",
+        zone: "",
+        rows: 4,
+        columns: 3,
+        orderIndex: RackOrderIndex.BOTTOM_LEFT,
+        coolingType: RackCoolingType.AIR,
+      },
+      onSubmit: vi.fn(),
+      onSubmitBulk: vi.fn(),
+      initialCreateVariant: "multiple",
+    });
+    // A rack that exists has one label to edit, not a series to generate — so
+    // the toggle is absent even though the host wired the batch handler.
+    expect(screen.queryByText("Multiple")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Label")).toBeInTheDocument();
+  });
+
+  it("previews exactly the labels it will submit, and submits them with the shared geometry", async () => {
+    const onSubmitBulk = vi.fn<SubmitBulk>().mockResolvedValue([]);
+    renderModal({ onSubmitBulk, initialCreateVariant: "multiple" });
+
+    fireEvent.change(screen.getByTestId("rack-bulk-count-input"), { target: { value: "3" } });
+    fireEvent.change(screen.getByTestId("rack-bulk-prefix-input"), { target: { value: "R-" } });
+    fillGeometry();
+
+    // Counter starts at 1; the default scale is 1 digit, so no padding yet.
+    expect(screen.getByTestId("rack-bulk-preview-row-0")).toHaveTextContent("R-1");
+    expect(screen.getByTestId("rack-bulk-preview-row-2")).toHaveTextContent("R-3");
+    expect(screen.getByText("3 racks to create")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Create racks"));
+    await waitFor(() => expect(onSubmitBulk).toHaveBeenCalledTimes(1));
+    // The preview is the payload: same strings, same order.
+    expect(onSubmitBulk).toHaveBeenCalledWith(
+      ["R-1", "R-2", "R-3"].map((label) => ({
+        label,
+        rows: 4,
+        columns: 3,
+        zone: "",
+        orderIndex: RackOrderIndex.BOTTOM_LEFT,
+        coolingType: RackCoolingType.AIR,
+      })),
+      // Nothing was picked, so the batch lands unplaced.
+      { siteId: undefined, buildingId: undefined },
+    );
+  });
+
+  it("names every missing bulk field on one click instead of disabling the CTA", async () => {
+    const onSubmitBulk = vi.fn();
+    renderModal({ onSubmitBulk, initialCreateVariant: "multiple" });
+
+    const create = screen.getByText("Create racks");
+    expect(create).not.toBeDisabled();
+    fireEvent.click(create);
+    expect(onSubmitBulk).not.toHaveBeenCalled();
+    // All of them, not one per click.
+    expect(screen.getByText("A label prefix is required")).toBeInTheDocument();
+    expect(screen.getByText("Enter how many racks to create")).toBeInTheDocument();
+    expect(screen.getByText("Columns must be a whole number between 1 and 12")).toBeInTheDocument();
+    expect(screen.getByText("Rows must be a whole number between 1 and 12")).toBeInTheDocument();
+    // The single-rack Label check must not fire — that field isn't on screen.
+    expect(screen.queryByText("A label is required")).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId("rack-bulk-count-input"), { target: { value: "2" } });
+    fireEvent.change(screen.getByTestId("rack-bulk-prefix-input"), { target: { value: "R-" } });
+    fillGeometry();
+    // waitFor because Input keeps cleared error text mounted ~200ms so the
+    // collapse can animate.
+    await waitFor(() => expect(screen.queryByText("A label prefix is required")).not.toBeInTheDocument());
+    fireEvent.click(create);
+    await waitFor(() => expect(onSubmitBulk).toHaveBeenCalledTimes(1));
+  });
+
+  it("bounds the counter scale on submit rather than constraining the input", async () => {
+    const onSubmitBulk = vi.fn();
+    renderModal({ onSubmitBulk, initialCreateVariant: "multiple" });
+
+    fireEvent.change(screen.getByTestId("rack-bulk-count-input"), { target: { value: "2" } });
+    fireEvent.change(screen.getByTestId("rack-bulk-prefix-input"), { target: { value: "R-" } });
+    fillGeometry();
+    // 9 digits of zero-padding is past the bound; the field accepts the digit
+    // and the submit explains why it can't be used.
+    fireEvent.change(screen.getByTestId("rack-bulk-counter-scale-input"), { target: { value: "9" } });
+
+    fireEvent.click(screen.getByText("Create racks"));
+    expect(onSubmitBulk).not.toHaveBeenCalled();
+    expect(screen.getByText("Must be 1–6")).toBeInTheDocument();
+  });
+
+  it("refuses a batch whose generated labels are longer than the server accepts", async () => {
+    const onSubmitBulk = vi.fn();
+    renderModal({ onSubmitBulk, initialCreateVariant: "multiple" });
+
+    fireEvent.change(screen.getByTestId("rack-bulk-count-input"), { target: { value: "2" } });
+    fillGeometry();
+    // A prefix that fits on its own (the field allows 100), plus 6 digits of
+    // zero-padding, produces 103-character labels. The counter width is what
+    // pushes it over, so the prefix field alone can't catch this.
+    fireEvent.change(screen.getByTestId("rack-bulk-prefix-input"), { target: { value: "R".repeat(97) } });
+    fireEvent.change(screen.getByTestId("rack-bulk-counter-scale-input"), { target: { value: "6" } });
+
+    // Flagged per row as the operator types, before any submit.
+    expect(screen.getByTestId("rack-bulk-preview-row-0")).toHaveTextContent("Over 100 characters");
+
+    fireEvent.click(screen.getByText("Create racks"));
+    // Never dispatched: CreateRacks would refuse the whole batch on
+    // NewRack.label's max_len and come back as a generic error.
+    expect(onSubmitBulk).not.toHaveBeenCalled();
+    expect(screen.getByText("Labels must be 100 characters or fewer, counter included")).toBeInTheDocument();
+
+    // Narrowing the counter brings every row back inside the cap.
+    fireEvent.change(screen.getByTestId("rack-bulk-counter-scale-input"), { target: { value: "1" } });
+    await waitFor(() =>
+      expect(screen.getByTestId("rack-bulk-preview-row-0")).not.toHaveTextContent("Over 100 characters"),
+    );
+    fireEvent.click(screen.getByText("Create racks"));
+    await waitFor(() => expect(onSubmitBulk).toHaveBeenCalledTimes(1));
+  });
+
+  it("marks the rows the server rejected and keeps the form open", async () => {
+    const onSubmitBulk = vi
+      .fn<SubmitBulk>()
+      .mockResolvedValue([{ index: 1, label: "R-02", reason: PerRackCreateErrorReason.DUPLICATE_LABEL_IN_ORG }]);
+    const onDismiss = vi.fn();
+    renderModal({ onSubmitBulk, onDismiss, initialCreateVariant: "multiple" });
+
+    fireEvent.change(screen.getByTestId("rack-bulk-count-input"), { target: { value: "2" } });
+    fireEvent.change(screen.getByTestId("rack-bulk-prefix-input"), { target: { value: "R-" } });
+    fillGeometry();
+    fireEvent.click(screen.getByText("Create racks"));
+
+    // Org-wide wording, not "at this building": the colliding rack may be in
+    // another site entirely.
+    await waitFor(() =>
+      expect(screen.getByTestId("rack-bulk-preview-row-1")).toHaveTextContent("Already used by another rack"),
+    );
+    expect(screen.getByTestId("rack-bulk-preview-row-0")).not.toHaveTextContent("Already used");
+    // The host owns closing; a rejected batch leaves the form up for a retry.
+    expect(onDismiss).not.toHaveBeenCalled();
+
+    // Editing a bulk field invalidates the marks — they point at indexes in the
+    // payload that was submitted, not the one now on screen.
+    fireEvent.change(screen.getByTestId("rack-bulk-prefix-input"), { target: { value: "RK-" } });
+    await waitFor(() =>
+      expect(screen.getByTestId("rack-bulk-preview-row-1")).not.toHaveTextContent("Already used by another rack"),
+    );
+  });
+
+  it("keeps the single-rack path submitting one rack when the toggle stays on Single", async () => {
+    const onSubmit = vi.fn();
+    const onSubmitBulk = vi.fn();
+    renderModal({ onSubmit, onSubmitBulk });
+
+    fireEvent.change(screen.getByLabelText("Label"), { target: { value: "R-99" } });
+    fillGeometry();
+    fireEvent.click(screen.getByText("Create rack"));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
+    expect(onSubmitBulk).not.toHaveBeenCalled();
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ label: "R-99", rows: 4, columns: 3 }));
+  });
+});

--- a/client/src/protoFleet/features/fleetManagement/components/RackSettingsModal.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/RackSettingsModal.test.tsx
@@ -33,8 +33,13 @@ vi.mock("@/protoFleet/api/useDeviceSets", async (importActual) => ({
   }),
 }));
 
+// Settable so a test can assert what a locked Site select actually reads: the
+// trigger renders the matching option's label, so a site id with no option
+// behind it would show nothing at all.
+let mockSites: { site: { id: bigint; name: string } }[] = [];
+
 vi.mock("@/protoFleet/api/SitesContext", () => ({
-  useSitesContext: () => ({ sites: [] }),
+  useSitesContext: () => ({ sites: mockSites }),
 }));
 
 vi.mock("@/protoFleet/api/buildings", () => ({
@@ -259,5 +264,52 @@ describe("RackSettingsModal — bulk create", () => {
     await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1));
     expect(onSubmitBulk).not.toHaveBeenCalled();
     expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({ label: "R-99", rows: 4, columns: 3 }));
+  });
+});
+
+describe("RackSettingsModal — creating from inside a building", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSites = [];
+  });
+
+  it("renders the host's label on the locked Building select", () => {
+    // The building options are fetched per site, so before that lands (and, for
+    // a site-less building, ever) the label can only come from the host.
+    renderModal({ defaultBuilding: { id: 42n, label: "Shed 4" } });
+
+    const building = screen.getByLabelText("Building");
+    expect(building).toBeDisabled();
+    expect(building).toHaveTextContent("Shed 4");
+  });
+
+  it("locks Site to the building's site so it cannot contradict the building", () => {
+    mockSites = [{ site: { id: 7n, name: "Denver" } }];
+    renderModal({ defaultBuilding: { id: 42n, label: "Shed 4" }, defaultSiteId: 7n });
+
+    const site = screen.getByLabelText("Site");
+    expect(site).toBeDisabled();
+    expect(site).toHaveTextContent("Denver");
+  });
+
+  it("locks Site to Unassigned for a building that sits in no site", async () => {
+    const onSubmitBulk = vi.fn<SubmitBulk>().mockResolvedValue([]);
+    // No defaultSiteId: the building belongs to no site. Site still locks, so
+    // the operator cannot pick one the building would contradict.
+    renderModal({ defaultBuilding: { id: 42n, label: "Shed 4" }, onSubmitBulk, initialCreateVariant: "multiple" });
+
+    const site = screen.getByLabelText("Site");
+    expect(site).toBeDisabled();
+    expect(site).toHaveTextContent("Unassigned");
+
+    fireEvent.change(screen.getByTestId("rack-bulk-count-input"), { target: { value: "2" } });
+    fireEvent.change(screen.getByTestId("rack-bulk-prefix-input"), { target: { value: "R-" } });
+    fillGeometry();
+    fireEvent.click(screen.getByText("Create racks"));
+
+    await waitFor(() => expect(onSubmitBulk).toHaveBeenCalledTimes(1));
+    // The building id alone reaches CreateRacks. A site_id of 0 would be
+    // present-but-invalid and fail the whole batch.
+    expect(onSubmitBulk).toHaveBeenCalledWith(expect.any(Array), { siteId: undefined, buildingId: 42n });
   });
 });

--- a/client/src/protoFleet/features/fleetManagement/components/RackSettingsModal.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/RackSettingsModal.test.tsx
@@ -167,6 +167,27 @@ describe("RackSettingsModal — bulk create", () => {
     expect(screen.getByText("Must be 1–6")).toBeInTheDocument();
   });
 
+  it("refuses a count over the cap rather than silently truncating the batch", async () => {
+    const onSubmitBulk = vi.fn();
+    renderModal({ onSubmitBulk, initialCreateVariant: "multiple" });
+
+    fireEvent.change(screen.getByTestId("rack-bulk-prefix-input"), { target: { value: "R-" } });
+    fillGeometry();
+    // The field takes 3 digits, so a count past the 500 cap is reachable. Label
+    // generation clamps to 500, which would have created 500 racks while the
+    // field still read 999.
+    fireEvent.change(screen.getByTestId("rack-bulk-count-input"), { target: { value: "999" } });
+
+    fireEvent.click(screen.getByText("Create racks"));
+    expect(onSubmitBulk).not.toHaveBeenCalled();
+    expect(screen.getByText("Create up to 500 racks at a time")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId("rack-bulk-count-input"), { target: { value: "500" } });
+    fireEvent.click(screen.getByText("Create racks"));
+    await waitFor(() => expect(onSubmitBulk).toHaveBeenCalledTimes(1));
+    expect(onSubmitBulk.mock.calls[0][0]).toHaveLength(500);
+  });
+
   it("refuses a batch whose generated labels are longer than the server accepts", async () => {
     const onSubmitBulk = vi.fn();
     renderModal({ onSubmitBulk, initialCreateVariant: "multiple" });

--- a/client/src/protoFleet/features/fleetManagement/components/RackSettingsModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/RackSettingsModal.tsx
@@ -721,13 +721,16 @@ const RackSettingsModal = ({
             // Row count sits above the label properties: it decides how many
             // rows the preview has, while the properties below decide what each
             // one is called.
-            // text + inputMode rather than type="number" so maxLength actually
-            // holds: the browser ignores maxlength on a number input, and Input
-            // keeps its own display value that only re-syncs when initValue
-            // changes. An extra digit slices back to the same sanitized string,
-            // so nothing re-syncs and the field would keep showing a count the
-            // preview and the request don't share. inputMode keeps the numeric
-            // keyboard; digitsOnly still guards paste.
+            // `sanitize` rather than digits-only work in onChange, so what the
+            // field shows and what the preview and CreateRacks payload use can
+            // never diverge — Input owns the displayed value, and a sanitize
+            // that returns the string it already holds gives it nothing to
+            // re-sync from (see the prop's own note).
+            //
+            // text + inputMode rather than type="number" for two more reasons:
+            // the browser ignores maxlength on a number input, and a number
+            // input reports "" for a partially-invalid value, which would feed
+            // sanitize the wrong thing. inputMode keeps the numeric keyboard.
             <Input
               id="rack-bulk-count"
               label="Number of racks"
@@ -735,8 +738,9 @@ const RackSettingsModal = ({
               inputMode="numeric"
               initValue={bulkCountText}
               maxLength={bulkCountInputMaxLength}
+              sanitize={(value) => digitsOnly(value, bulkCountInputMaxLength)}
               onChange={(value) => {
-                setBulkCountText(digitsOnly(value, bulkCountInputMaxLength));
+                setBulkCountText(value);
                 clearBulkRowErrors();
                 if (bulkCountError) setBulkCountError(undefined);
               }}
@@ -790,8 +794,9 @@ const RackSettingsModal = ({
                   inputMode="numeric"
                   initValue={bulkCounterStartText}
                   maxLength={counterStartInputMaxLength}
+                  sanitize={(value) => digitsOnly(value, counterStartInputMaxLength)}
                   onChange={(value) => {
-                    setBulkCounterStartText(digitsOnly(value, counterStartInputMaxLength));
+                    setBulkCounterStartText(value);
                     clearBulkRowErrors();
                   }}
                   testId="rack-bulk-counter-start-input"
@@ -806,8 +811,9 @@ const RackSettingsModal = ({
                   inputMode="numeric"
                   initValue={bulkCounterScaleText}
                   maxLength={1}
+                  sanitize={(value) => digitsOnly(value, 1)}
                   onChange={(value) => {
-                    setBulkCounterScaleText(digitsOnly(value, 1));
+                    setBulkCounterScaleText(value);
                     clearBulkRowErrors();
                     if (bulkCounterScaleError) setBulkCounterScaleError(undefined);
                   }}

--- a/client/src/protoFleet/features/fleetManagement/components/RackSettingsModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/RackSettingsModal.tsx
@@ -721,10 +721,18 @@ const RackSettingsModal = ({
             // Row count sits above the label properties: it decides how many
             // rows the preview has, while the properties below decide what each
             // one is called.
+            // text + inputMode rather than type="number" so maxLength actually
+            // holds: the browser ignores maxlength on a number input, and Input
+            // keeps its own display value that only re-syncs when initValue
+            // changes. An extra digit slices back to the same sanitized string,
+            // so nothing re-syncs and the field would keep showing a count the
+            // preview and the request don't share. inputMode keeps the numeric
+            // keyboard; digitsOnly still guards paste.
             <Input
               id="rack-bulk-count"
               label="Number of racks"
-              type="number"
+              type="text"
+              inputMode="numeric"
               initValue={bulkCountText}
               maxLength={bulkCountInputMaxLength}
               onChange={(value) => {
@@ -778,7 +786,8 @@ const RackSettingsModal = ({
                 <Input
                   id="rack-bulk-counter-start"
                   label="Counter start (optional)"
-                  type="number"
+                  type="text"
+                  inputMode="numeric"
                   initValue={bulkCounterStartText}
                   maxLength={counterStartInputMaxLength}
                   onChange={(value) => {
@@ -787,13 +796,14 @@ const RackSettingsModal = ({
                   }}
                   testId="rack-bulk-counter-start-input"
                 />
-                {/* A number input rather than bulk rename's radio row: it's a
+                {/* A numeric field rather than bulk rename's radio row: it's a
                     digit count sitting next to another number field, and the
                     range is enforced on submit like any other bound. */}
                 <Input
                   id="rack-bulk-counter-scale"
                   label="Counter scale (optional)"
-                  type="number"
+                  type="text"
+                  inputMode="numeric"
                   initValue={bulkCounterScaleText}
                   maxLength={1}
                   onChange={(value) => {

--- a/client/src/protoFleet/features/fleetManagement/components/RackSettingsModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/RackSettingsModal.tsx
@@ -51,12 +51,14 @@ interface RackSettingsModalProps {
   // initialFormData already carries a siteId.
   defaultSiteId?: bigint;
   // Locks the placement to one building, for a create launched from inside that
-  // building (its rack picker). The label comes with it because the building
-  // options are fetched per site — without it the locked select would read blank
-  // until that fetch lands. Requires defaultSiteId: a building can't be chosen
-  // without its site.
-  defaultBuildingId?: bigint;
-  defaultBuildingLabel?: string;
+  // building (its rack picker). Id and label travel together because the
+  // building options are fetched per site — and a site-less building never
+  // appears in that fetch at all — so the locked select can only render a label
+  // the host hands it.
+  //
+  // defaultSiteId is NOT required alongside it. A building may sit in no site,
+  // and the rack inherits whichever site the building has — see siteLocked.
+  defaultBuilding?: { id: bigint; label: string };
   // True when editing an existing rack (which has a real, possibly-NULL
   // placement). Seeds the placement selects to "Unassigned" when the rack is
   // unplaced (vs. the empty placeholder on create) — see isExistingRack.
@@ -145,8 +147,7 @@ const RackSettingsModal = ({
   existingRacks,
   initialFormData,
   defaultSiteId,
-  defaultBuildingId,
-  defaultBuildingLabel,
+  defaultBuilding,
   existingRack,
   onDismiss,
   onSubmit,
@@ -170,31 +171,35 @@ const RackSettingsModal = ({
   // so a chosen site/building can be reverted.
   const isExistingRack = !!existingRack;
 
-  // Creating within a page-header site scope: the rack belongs to that site,
-  // so lock the field to it (defaultSiteId is only set for a single-site
-  // scope). An unscoped create leaves Site editable/optional; edit is never
-  // locked.
-  const siteLocked = !isExistingRack && canManagePlacement && defaultSiteId !== undefined;
-
   // Creating from inside a building: the rack is being added to THAT building,
   // so lock the field rather than letting the operator create it somewhere the
   // host's list would never show it.
-  const buildingLocked = !isExistingRack && canManagePlacement && defaultBuildingId !== undefined;
+  const buildingLocked = !isExistingRack && canManagePlacement && defaultBuilding !== undefined;
+
+  // Locked either by a page-header site scope (defaultSiteId is only set for a
+  // single-site scope) or by a locked building, which owns the site: the rack
+  // lands in that building, so its site is whatever the building's is —
+  // including none. Locking both together is what keeps the operator from
+  // picking a site that contradicts the building. An unscoped create leaves
+  // Site editable/optional; edit is never locked.
+  const siteLocked = !isExistingRack && canManagePlacement && (defaultSiteId !== undefined || buildingLocked);
 
   // Placement. Site is retained even when a building is chosen (it's the
   // building's site) so downstream eligibility filtering can pin the site;
   // saveRack drops it from the wire RackInfo.
   const [siteIdText, setSiteIdText] = useState<string>(() => {
     if (initialFormData?.siteId !== undefined) return initialFormData.siteId.toString();
-    // Create + page-header scope: prefill the site the field is locked to.
-    if (siteLocked) return defaultSiteId!.toString();
+    // Create + page-header scope: prefill the site the field is locked to. A
+    // locked building with no site reads "Unassigned" — truthful, and it maps to
+    // no site_id on submit so the server derives one from the building.
+    if (siteLocked) return defaultSiteId?.toString() ?? UNASSIGNED_VALUE;
     // Edit of an unplaced rack shows "Unassigned"; unscoped create shows the
     // empty placeholder.
     return isExistingRack ? UNASSIGNED_VALUE : "";
   });
   const [buildingIdText, setBuildingIdText] = useState<string>(() => {
     if (initialFormData?.buildingId !== undefined) return initialFormData.buildingId.toString();
-    if (buildingLocked) return defaultBuildingId!.toString();
+    if (buildingLocked) return defaultBuilding.id.toString();
     return isExistingRack ? UNASSIGNED_VALUE : "";
   });
   const [buildings, setBuildings] = useState<BuildingWithCounts[]>([]);
@@ -368,9 +373,10 @@ const RackSettingsModal = ({
 
   const buildingOptions = useMemo<SelectOption[]>(() => {
     // A locked building is the only option, rendered from the host's label so
-    // the field reads correctly before (and regardless of) the building fetch.
+    // the field reads correctly before (and regardless of) the building fetch —
+    // the id and label travel together, so it can't come out blank.
     if (buildingLocked) {
-      return [{ value: defaultBuildingId!.toString(), label: defaultBuildingLabel ?? "" }];
+      return [{ value: defaultBuilding.id.toString(), label: defaultBuilding.label }];
     }
     if (!siteSelected) return [UNASSIGNED_OPTION];
     const real = buildings
@@ -378,7 +384,7 @@ const RackSettingsModal = ({
       .map((b) => ({ value: b.building!.id.toString(), label: b.building!.name }))
       .sort((a, b) => a.label.localeCompare(b.label));
     return [UNASSIGNED_OPTION, ...real];
-  }, [siteSelected, buildings, buildingLocked, defaultBuildingId, defaultBuildingLabel]);
+  }, [siteSelected, buildings, buildingLocked, defaultBuilding]);
 
   // The exact labels the batch will submit. The preview renders this same
   // array, so what the operator reads is what CreateRacks receives.

--- a/client/src/protoFleet/features/fleetManagement/components/RackSettingsModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/RackSettingsModal.tsx
@@ -528,6 +528,11 @@ const RackSettingsModal = ({
       if (bulkLabels.length === 0) {
         setBulkCountError("Enter how many racks to create");
         hasError = true;
+      } else if (Number(bulkCountText) > bulkRackCountMaximum) {
+        // buildBulkRackLabels clamps to the cap, so a larger typed count would
+        // silently create only the first bulkRackCountMaximum racks.
+        setBulkCountError(`Create up to ${bulkRackCountMaximum} racks at a time`);
+        hasError = true;
       }
       // Reported on the prefix because that is the lever: the counter width is
       // set by the scale and the start value, both of which the operator chose on
@@ -636,6 +641,7 @@ const RackSettingsModal = ({
     isBulk,
     onSubmitBulk,
     bulkLabels,
+    bulkCountText,
     bulkOverlongRows,
     bulkPrefix,
     bulkCounterScaleText,

--- a/client/src/protoFleet/features/fleetManagement/components/RackSettingsModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/RackSettingsModal.tsx
@@ -5,47 +5,115 @@ import { useBuildings } from "@/protoFleet/api/buildings";
 import { type BuildingWithCounts } from "@/protoFleet/api/generated/buildings/v1/buildings_pb";
 import {
   type DeviceSet,
+  PerRackCreateErrorReason,
   RackCoolingType,
   RackOrderIndex,
   type RackType,
 } from "@/protoFleet/api/generated/device_set/v1/device_set_pb";
 import { useSitesContext } from "@/protoFleet/api/SitesContext";
-import { useDeviceSets } from "@/protoFleet/api/useDeviceSets";
+import { type BulkCreateRackError, type NewRackInput, useDeviceSets } from "@/protoFleet/api/useDeviceSets";
+import {
+  buildBulkRackLabels,
+  bulkRackCountMaximum,
+  overlongRackLabelIndexes,
+  rackLabelMaxLength,
+} from "@/protoFleet/features/fleetManagement/components/bulkRackLabels";
 import { type RackFormData } from "@/protoFleet/features/fleetManagement/components/ManageRackModal/types";
+import {
+  counterScaleMaximum,
+  counterScaleMinimum,
+  counterStartInputMaxLength,
+  defaultCounterScale,
+} from "@/protoFleet/features/fleetManagement/components/MinerActionsMenu/RenameOptionsModals/constants";
 import { useHasPermission } from "@/protoFleet/store";
 
-import { Alert } from "@/shared/assets/icons";
-import Callout from "@/shared/components/Callout";
 import Input from "@/shared/components/Input";
 import Modal from "@/shared/components/Modal";
 import ProgressCircular from "@/shared/components/ProgressCircular";
+import SegmentedControl from "@/shared/components/SegmentedControl";
 import Select, { type SelectOption } from "@/shared/components/Select";
-import { pushToast, STATUSES } from "@/shared/features/toaster";
 
 export type { RackFormData };
+
+// Where a batch of racks lands. One placement for the whole batch, because
+// CreateRacks carries it per request rather than per row.
+export interface BulkRackPlacement {
+  siteId?: bigint;
+  buildingId?: bigint;
+}
 
 interface RackSettingsModalProps {
   show: boolean;
   existingRacks: DeviceSet[];
-  rack?: DeviceSet;
   initialFormData?: RackFormData;
   // Prepopulates the Site dropdown when creating a rack with no prior
   // placement (e.g. the page-header site scope). Ignored when
   // initialFormData already carries a siteId.
   defaultSiteId?: bigint;
+  // Locks the placement to one building, for a create launched from inside that
+  // building (its rack picker). The label comes with it because the building
+  // options are fetched per site — without it the locked select would read blank
+  // until that fetch lands. Requires defaultSiteId: a building can't be chosen
+  // without its site.
+  defaultBuildingId?: bigint;
+  defaultBuildingLabel?: string;
   // True when editing an existing rack (which has a real, possibly-NULL
   // placement). Seeds the placement selects to "Unassigned" when the rack is
-  // unplaced (vs. the empty placeholder on create) — see isExistingRack. The
-  // embedded modal inside ManageRackModal can't tell create from edit on its
-  // own (it always runs in onContinue mode), so the caller passes it.
+  // unplaced (vs. the empty placeholder on create) — see isExistingRack.
   existingRack?: boolean;
   onDismiss: () => void;
-  // May be async: for an existing rack the parent persists the settings (label/
-  // zone/dims + placement) on Continue, so we await it and keep the button busy
-  // until it resolves — a rejection leaves the modal open for a retry.
-  onContinue?: (formData: RackFormData) => void | Promise<void>;
-  onSuccess?: () => void;
+  // May be async: the caller persists the settings (an UpdateDeviceSet for an
+  // existing rack, a create for a new one), so we await it and keep the button
+  // busy until it resolves — a rejection leaves the modal open for a retry.
+  onSubmit?: (formData: RackFormData) => void | Promise<unknown>;
+  // Supplying onSubmitBulk is what turns on the Single / Multiple toggle. Entry
+  // points with no batch handler wired render exactly as before — better than a
+  // toggle whose CTA has nothing to call. Ignored when editing: a batch create
+  // has no meaning for a rack that already exists.
+  //
+  // Resolves to the server's per-row rejections: an empty array means every rack
+  // was created (the batch is all-or-nothing, so there is no partial case) and
+  // the host closes the modal. A non-empty array leaves the modal open with the
+  // offending preview rows marked.
+  onSubmitBulk?: (racks: NewRackInput[], placement: BulkRackPlacement) => Promise<BulkCreateRackError[]>;
+  // Which side of the Single / Multiple toggle the modal opens on, so a host with
+  // two create entry points ("Create rack" / "Create multiple racks") lands the
+  // operator on the form they asked for. Ignored without onSubmitBulk.
+  initialCreateVariant?: CreateVariant;
+  // Caller-driven busy state, OR'd with our own in-flight submit. Needed for
+  // writes the caller retries on its own — a create that came back with a
+  // reparent conflict is re-dispatched from the confirmation dialog, long after
+  // our awaited onSubmit resolved.
+  saving?: boolean;
 }
+
+// Create-mode variants. "single" is the original one-rack form; "multiple"
+// swaps the Label field for generated labels + a read-only preview. Everything
+// else on the form (placement, zone, geometry) applies to the whole batch.
+type CreateVariant = "single" | "multiple";
+
+const createVariantSegments = [
+  { key: "single", title: "Single" },
+  { key: "multiple", title: "Multiple" },
+];
+
+// Digits only, so a pasted "1e3" or "-4" can't reach the counter math.
+const digitsOnly = (input: string, maxLength: number): string => input.replace(/\D/g, "").slice(0, maxLength);
+
+const bulkCountInputMaxLength = String(bulkRackCountMaximum).length;
+
+const bulkRowErrorMessage = (reason: PerRackCreateErrorReason): string => {
+  switch (reason) {
+    // Not "at this building": rack labels are unique per organization, so the
+    // rack this one collides with may be in a different site entirely.
+    case PerRackCreateErrorReason.DUPLICATE_LABEL_IN_ORG:
+      return "Already used by another rack";
+    case PerRackCreateErrorReason.DUPLICATE_LABEL_IN_BATCH:
+      return "Repeated in this batch";
+    default:
+      return "Rejected";
+  }
+};
 
 // Explicit "Unassigned" entry for the placement dropdowns. The shared Select
 // has no clear affordance, so without this a user who picks a site/building
@@ -75,18 +143,18 @@ const coolingTypeOptions: SelectOption[] = [
 const RackSettingsModal = ({
   show,
   existingRacks,
-  rack,
   initialFormData,
   defaultSiteId,
+  defaultBuildingId,
+  defaultBuildingLabel,
   existingRack,
   onDismiss,
-  onContinue,
-  onSuccess,
+  onSubmit,
+  onSubmitBulk,
+  initialCreateVariant,
+  saving,
 }: RackSettingsModalProps) => {
-  const isEditMode = !!rack;
-  const rackInfo = rack?.typeDetails.case === "rackInfo" ? rack.typeDetails.value : undefined;
-
-  const { updateRack, listRackZones, listRackTypes } = useDeviceSets();
+  const { listRackZones, listRackTypes } = useDeviceSets();
   const { sites } = useSitesContext();
   const { listBuildingsBySite } = useBuildings();
   // Placing a rack under a site/building is a site:manage action (the server
@@ -100,7 +168,7 @@ const RackSettingsModal = ({
   // treats placement as an optional, unfilled field: the default is the empty
   // placeholder (reads as "not chosen"), though "Unassigned" is still pickable
   // so a chosen site/building can be reverted.
-  const isExistingRack = existingRack || isEditMode;
+  const isExistingRack = !!existingRack;
 
   // Creating within a page-header site scope: the rack belongs to that site,
   // so lock the field to it (defaultSiteId is only set for a single-site
@@ -108,32 +176,36 @@ const RackSettingsModal = ({
   // locked.
   const siteLocked = !isExistingRack && canManagePlacement && defaultSiteId !== undefined;
 
+  // Creating from inside a building: the rack is being added to THAT building,
+  // so lock the field rather than letting the operator create it somewhere the
+  // host's list would never show it.
+  const buildingLocked = !isExistingRack && canManagePlacement && defaultBuildingId !== undefined;
+
   // Placement. Site is retained even when a building is chosen (it's the
   // building's site) so downstream eligibility filtering can pin the site;
   // saveRack drops it from the wire RackInfo.
   const [siteIdText, setSiteIdText] = useState<string>(() => {
     if (initialFormData?.siteId !== undefined) return initialFormData.siteId.toString();
-    // Create + page-header scope: prefill (and lock to) the scoped site. Only
-    // when the operator can manage placement — otherwise the rack is created
-    // unplaced.
-    if (!isExistingRack && canManagePlacement && defaultSiteId !== undefined) return defaultSiteId.toString();
+    // Create + page-header scope: prefill the site the field is locked to.
+    if (siteLocked) return defaultSiteId!.toString();
     // Edit of an unplaced rack shows "Unassigned"; unscoped create shows the
     // empty placeholder.
     return isExistingRack ? UNASSIGNED_VALUE : "";
   });
   const [buildingIdText, setBuildingIdText] = useState<string>(() => {
     if (initialFormData?.buildingId !== undefined) return initialFormData.buildingId.toString();
+    if (buildingLocked) return defaultBuildingId!.toString();
     return isExistingRack ? UNASSIGNED_VALUE : "";
   });
   const [buildings, setBuildings] = useState<BuildingWithCounts[]>([]);
 
-  const [label, setLabel] = useState(initialFormData?.label ?? rack?.label ?? "");
+  const [label, setLabel] = useState(initialFormData?.label ?? "");
   const [zone, setZone] = useState(() => {
     // Editing an existing rack: its stored zone is authoritative, INCLUDING an
     // intentional "" — a blank zone is now a valid state. Use presence, not
     // truthiness, and never fall through to the last-rack default, which would
-    // resurrect a just-cleared zone and re-persist it on Continue.
-    if (isExistingRack) return initialFormData?.zone ?? rackInfo?.zone ?? "";
+    // resurrect a just-cleared zone and re-persist it on save.
+    if (isExistingRack) return initialFormData?.zone ?? "";
     // Create: seed from the form if it carries a zone, otherwise default to the
     // most recently created rack's zone as a convenience.
     if (initialFormData?.zone) return initialFormData.zone;
@@ -148,22 +220,45 @@ const RackSettingsModal = ({
     }
     return "";
   });
-  const initRows = initialFormData?.rows ?? rackInfo?.rows;
-  const initCols = initialFormData?.columns ?? rackInfo?.columns;
+  const initRows = initialFormData?.rows;
+  const initCols = initialFormData?.columns;
   const [rackTypeSelection, setRackTypeSelection] = useState(initCols && initRows ? `${initCols}x${initRows}` : "new");
   const [rows, setRows] = useState(initRows ? String(initRows) : "");
   const [columns, setColumns] = useState(initCols ? String(initCols) : "");
   const [orderIndex, setOrderIndex] = useState<RackOrderIndex>(
-    initialFormData?.orderIndex ?? rackInfo?.orderIndex ?? RackOrderIndex.BOTTOM_LEFT,
+    initialFormData?.orderIndex ?? RackOrderIndex.BOTTOM_LEFT,
   );
-  const [coolingType, setCoolingType] = useState<RackCoolingType>(
-    initialFormData?.coolingType ?? rackInfo?.coolingType ?? RackCoolingType.AIR,
-  );
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [errorMsg, setErrorMsg] = useState("");
+  const [coolingType, setCoolingType] = useState<RackCoolingType>(initialFormData?.coolingType ?? RackCoolingType.AIR);
+  const [ownSubmit, setOwnSubmit] = useState(false);
+  const isSubmitting = ownSubmit || !!saving;
   const [labelError, setLabelError] = useState<string | undefined>();
   const [columnsError, setColumnsError] = useState<string | undefined>();
   const [rowsError, setRowsError] = useState<string | undefined>();
+
+  // Bulk (Multiple) create. Only reachable on a create, where onSubmitBulk is
+  // wired: an existing rack has one label to edit, not a series to generate.
+  const bulkAvailable = onSubmitBulk !== undefined && !isExistingRack;
+  const [createVariant, setCreateVariant] = useState<CreateVariant>(
+    (bulkAvailable ? initialCreateVariant : undefined) ?? "single",
+  );
+  const isBulk = bulkAvailable && createVariant === "multiple";
+  const [bulkCountText, setBulkCountText] = useState("");
+  const [bulkPrefix, setBulkPrefix] = useState("");
+  const [bulkCounterStartText, setBulkCounterStartText] = useState("1");
+  const [bulkCounterScaleText, setBulkCounterScaleText] = useState(String(defaultCounterScale));
+  const [bulkCountError, setBulkCountError] = useState<string | undefined>();
+  const [bulkPrefixError, setBulkPrefixError] = useState<string | undefined>();
+  const [bulkCounterScaleError, setBulkCounterScaleError] = useState<string | undefined>();
+  // Per-row rejections from the last attempt. Indexes point into the payload
+  // that was submitted, so any edit to the bulk fields clears them rather than
+  // leaving marks against rows they no longer describe.
+  const [bulkRowErrors, setBulkRowErrors] = useState<BulkCreateRackError[]>([]);
+
+  // Returns the same array when there is nothing to clear, so typing in a bulk
+  // field doesn't re-render the (up to 500-row) preview on every keystroke.
+  const clearBulkRowErrors = useCallback(() => {
+    setBulkRowErrors((prev) => (prev.length === 0 ? prev : []));
+  }, []);
 
   const [zoneSuggestions, setZoneSuggestions] = useState<string[]>([]);
   const [rackTypes, setRackTypes] = useState<RackType[]>([]);
@@ -186,7 +281,7 @@ const RackSettingsModal = ({
     listRackTypes({
       onSuccess: (types) => {
         setRackTypes(types);
-        if (!initialFormData && !rackInfo && types.length > 0) {
+        if (!initialFormData && types.length > 0) {
           const first = types[0];
           setRackTypeSelection(`${first.columns}x${first.rows}`);
           setRows(String(first.rows));
@@ -195,7 +290,7 @@ const RackSettingsModal = ({
       },
       onFinally: () => setRackTypesLoaded(true),
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- only run on mount; initialFormData and rackInfo are initial values
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only run on mount; initialFormData is an initial value
   }, [listRackZones, listRackTypes]);
 
   // Load the selected site's buildings so the Building dropdown can scope its
@@ -272,13 +367,38 @@ const RackSettingsModal = ({
   }, [sites]);
 
   const buildingOptions = useMemo<SelectOption[]>(() => {
+    // A locked building is the only option, rendered from the host's label so
+    // the field reads correctly before (and regardless of) the building fetch.
+    if (buildingLocked) {
+      return [{ value: defaultBuildingId!.toString(), label: defaultBuildingLabel ?? "" }];
+    }
     if (!siteSelected) return [UNASSIGNED_OPTION];
     const real = buildings
       .filter((b) => b.building !== undefined)
       .map((b) => ({ value: b.building!.id.toString(), label: b.building!.name }))
       .sort((a, b) => a.label.localeCompare(b.label));
     return [UNASSIGNED_OPTION, ...real];
-  }, [siteSelected, buildings]);
+  }, [siteSelected, buildings, buildingLocked, defaultBuildingId, defaultBuildingLabel]);
+
+  // The exact labels the batch will submit. The preview renders this same
+  // array, so what the operator reads is what CreateRacks receives.
+  const bulkLabels = useMemo(
+    () =>
+      buildBulkRackLabels(Number(bulkCountText || "0"), {
+        namePrefix: bulkPrefix,
+        counterStart: Number(bulkCounterStartText || "1"),
+        counterScale: Number(bulkCounterScaleText),
+      }),
+    [bulkCountText, bulkPrefix, bulkCounterStartText, bulkCounterScaleText],
+  );
+
+  const bulkServerRows = useMemo(() => new Map(bulkRowErrors.map((e) => [e.index, e.reason])), [bulkRowErrors]);
+
+  // Rows too long for the server to store. Derived from the labels rather than a
+  // submit attempt, so the marks appear as the prefix/counter are edited — the
+  // whole batch is refused on one overlong row, and which rows those are is not
+  // obvious when the padding is what pushed them over.
+  const bulkOverlongRows = useMemo(() => new Set(overlongRackLabelIndexes(bulkLabels)), [bulkLabels]);
 
   const filteredSuggestions = useMemo(() => {
     if (!zone.trim()) return zoneSuggestions;
@@ -357,15 +477,74 @@ const RackSettingsModal = ({
     [rackTypes],
   );
 
+  // Exactly the fields handleSubmit puts on RackFormData, compared against what
+  // the form was seeded with — so this reads clean only when the write would be
+  // a no-op. Creating a rack is always a real write, so it's never clean.
+  // Placement is included even when the selects are hidden
+  // (rack:manage-only): they're then seeded from initialFormData and can't
+  // diverge, so this reads clean either way.
+  const isDirty = useMemo(() => {
+    if (!isExistingRack || !initialFormData) return true;
+    return (
+      label.trim() !== initialFormData.label ||
+      zone.trim() !== initialFormData.zone ||
+      Number(rows) !== initialFormData.rows ||
+      Number(columns) !== initialFormData.columns ||
+      orderIndex !== initialFormData.orderIndex ||
+      coolingType !== initialFormData.coolingType ||
+      (isRealId(siteIdText) ? BigInt(siteIdText) : undefined) !== initialFormData.siteId ||
+      (isRealId(buildingIdText) ? BigInt(buildingIdText) : undefined) !== initialFormData.buildingId
+    );
+  }, [
+    isExistingRack,
+    initialFormData,
+    label,
+    zone,
+    rows,
+    columns,
+    orderIndex,
+    coolingType,
+    siteIdText,
+    buildingIdText,
+  ]);
+
   const handleSubmit = useCallback(async () => {
     setLabelError(undefined);
     setColumnsError(undefined);
     setRowsError(undefined);
-    setErrorMsg("");
+    setBulkCountError(undefined);
+    setBulkPrefixError(undefined);
+    setBulkCounterScaleError(undefined);
 
     let hasError = false;
 
-    if (!label.trim()) {
+    // Multiple generates the labels, so the Label field isn't on screen to
+    // validate; the prefix and row count take its place.
+    if (isBulk) {
+      if (bulkPrefix.trim() === "") {
+        setBulkPrefixError("A label prefix is required");
+        hasError = true;
+      }
+      if (bulkLabels.length === 0) {
+        setBulkCountError("Enter how many racks to create");
+        hasError = true;
+      }
+      // Reported on the prefix because that is the lever: the counter width is
+      // set by the scale and the start value, both of which the operator chose on
+      // purpose. Can't collide with the missing-prefix message above — bare
+      // counters are never this long.
+      if (bulkOverlongRows.size > 0) {
+        setBulkPrefixError(`Labels must be ${rackLabelMaxLength} characters or fewer, counter included`);
+        hasError = true;
+      }
+      // Empty scale is the default (no padding), so only a typed value is
+      // bounded. digitsOnly + maxLength 1 means it can only ever be 0–9.
+      const scale = bulkCounterScaleText === "" ? defaultCounterScale : Number(bulkCounterScaleText);
+      if (scale < counterScaleMinimum || scale > counterScaleMaximum) {
+        setBulkCounterScaleError(`Must be ${counterScaleMinimum}–${counterScaleMaximum}`);
+        hasError = true;
+      }
+    } else if (!label.trim()) {
       setLabelError("A label is required");
       hasError = true;
     }
@@ -382,6 +561,45 @@ const RackSettingsModal = ({
 
     if (hasError) return;
 
+    // Placeholder ("") and the Unassigned sentinel both encode as undefined.
+    const siteId = isRealId(siteIdText) ? BigInt(siteIdText) : undefined;
+    const buildingId = isRealId(buildingIdText) ? BigInt(buildingIdText) : undefined;
+
+    if (isBulk && onSubmitBulk) {
+      setOwnSubmit(true);
+      try {
+        // Clear first so marks from the previous attempt don't hang over rows
+        // this one may have fixed.
+        setBulkRowErrors([]);
+        // `?? []` because a host that resolves nothing means "no rejections" —
+        // storing undefined would take the preview down with it.
+        setBulkRowErrors(
+          (await onSubmitBulk(
+            bulkLabels.map((bulkLabel) => ({
+              label: bulkLabel,
+              rows: rowsNum,
+              columns: colsNum,
+              zone: zone.trim(),
+              orderIndex,
+              coolingType,
+            })),
+            { siteId, buildingId },
+          )) ?? [],
+        );
+      } finally {
+        setOwnSubmit(false);
+      }
+      return;
+    }
+
+    // Valid but unchanged. An existing rack's Save would re-persist identical
+    // values and toast as though something changed, so close instead. Not an
+    // error state — keeping what's already there is a legitimate outcome.
+    if (!isDirty) {
+      onDismiss?.();
+      return;
+    }
+
     const formData: RackFormData = {
       label: label.trim(),
       zone: zone.trim(),
@@ -389,49 +607,20 @@ const RackSettingsModal = ({
       columns: colsNum,
       orderIndex,
       coolingType,
-      // Placeholder ("") and the Unassigned sentinel both encode as undefined.
-      siteId: isRealId(siteIdText) ? BigInt(siteIdText) : undefined,
-      buildingId: isRealId(buildingIdText) ? BigInt(buildingIdText) : undefined,
+      siteId,
+      buildingId,
     };
 
-    if (!isEditMode) {
-      // Continue may persist settings (existing rack) or just advance (new
-      // rack). Await either way and keep the button busy so a slow save can't
-      // be double-submitted; the parent reopens/leaves this modal on failure.
-      setIsSubmitting(true);
-      try {
-        await onContinue?.(formData);
-      } finally {
-        setIsSubmitting(false);
-      }
-      return;
+    // The caller owns the write — an UpdateDeviceSet for an existing rack, a
+    // create for a new one. Await it and keep the button busy so a slow save
+    // can't be double-submitted; the caller leaves this modal open on failure
+    // so the operator can retry.
+    setOwnSubmit(true);
+    try {
+      await onSubmit?.(formData);
+    } finally {
+      setOwnSubmit(false);
     }
-
-    setIsSubmitting(true);
-
-    updateRack({
-      deviceSetId: rack!.id,
-      label: formData.label,
-      zone: formData.zone,
-      rows: formData.rows,
-      columns: formData.columns,
-      orderIndex: formData.orderIndex,
-      coolingType: formData.coolingType,
-      onSuccess: () => {
-        pushToast({
-          message: `Rack "${formData.label}" updated`,
-          status: STATUSES.success,
-        });
-        onSuccess?.();
-        onDismiss();
-      },
-      onError: (error) => {
-        setErrorMsg(error || "Failed to update rack. Please try again.");
-      },
-      onFinally: () => {
-        setIsSubmitting(false);
-      },
-    });
   }, [
     label,
     zone,
@@ -441,15 +630,35 @@ const RackSettingsModal = ({
     coolingType,
     siteIdText,
     buildingIdText,
-    isEditMode,
-    rack,
-    updateRack,
-    onContinue,
-    onSuccess,
+    onSubmit,
+    isDirty,
     onDismiss,
+    isBulk,
+    onSubmitBulk,
+    bulkLabels,
+    bulkOverlongRows,
+    bulkPrefix,
+    bulkCounterScaleText,
   ]);
 
   if (!show) return null;
+
+  // What a preview row is marked with, if anything. Length comes first: it says
+  // why the batch can't be sent at all, where a server reason describes an
+  // attempt that has already been made.
+  const bulkRowError = (index: number): string | undefined => {
+    if (bulkOverlongRows.has(index)) return `Over ${rackLabelMaxLength} characters`;
+    const reason = bulkServerRows.get(index);
+    return reason === undefined ? undefined : bulkRowErrorMessage(reason);
+  };
+
+  // Named for the write the button makes: creating one rack, creating a batch,
+  // or saving settings onto a rack that already exists.
+  const submitText = (): string => {
+    if (isExistingRack) return isSubmitting ? "Saving..." : "Save";
+    if (isSubmitting) return "Creating...";
+    return isBulk ? "Create racks" : "Create rack";
+  };
 
   return (
     <Modal
@@ -457,14 +666,18 @@ const RackSettingsModal = ({
       title="Rack settings"
       phoneSheet
       // Block dismiss (X / backdrop) while a settings save is in flight — the
-      // updateRack call persists regardless, so closing mid-request would be a
-      // surprise. Re-enabled once it resolves (or fails, leaving the form open).
+      // write persists regardless, so closing mid-request would be a surprise.
+      // Re-enabled once it resolves (or fails, leaving the form open).
       onDismiss={isSubmitting ? () => {} : onDismiss}
       divider={false}
       buttons={[
         {
-          text: isSubmitting ? "Saving..." : isEditMode ? "Save" : "Continue",
+          text: submitText(),
           variant: "primary",
+          // Only the in-flight and not-yet-loaded guards: validation and the
+          // no-diff check run in handleSubmit, where they can say what's wrong. A
+          // form diffed against an unfetched baseline can't produce a correct
+          // write, hence isInitialLoading.
           disabled: isSubmitting || isInitialLoading,
           loading: isSubmitting,
           onClick: handleSubmit,
@@ -478,15 +691,110 @@ const RackSettingsModal = ({
         </div>
       ) : (
         <div className="flex flex-col gap-4 pt-1">
-          {errorMsg ? <Callout intent="danger" prefixIcon={<Alert />} title={errorMsg} /> : null}
+          {bulkAvailable ? (
+            <SegmentedControl
+              segments={createVariantSegments}
+              initialSegmentKey={createVariant}
+              onSelect={(key) => {
+                setCreateVariant(key === "multiple" ? "multiple" : "single");
+                // Each mode keeps its own fields, so switching never rewrites
+                // the other side's input — but marks from a batch attempt
+                // describe a payload that is no longer on screen.
+                clearBulkRowErrors();
+              }}
+            />
+          ) : null}
 
-          <Input
-            id="rack-label"
-            label="Label"
-            initValue={label}
-            onChange={(value) => setLabel(value)}
-            error={labelError}
-          />
+          {isBulk ? (
+            // Row count sits above the label properties: it decides how many
+            // rows the preview has, while the properties below decide what each
+            // one is called.
+            <Input
+              id="rack-bulk-count"
+              label="Number of racks"
+              type="number"
+              initValue={bulkCountText}
+              maxLength={bulkCountInputMaxLength}
+              onChange={(value) => {
+                setBulkCountText(digitsOnly(value, bulkCountInputMaxLength));
+                clearBulkRowErrors();
+                if (bulkCountError) setBulkCountError(undefined);
+              }}
+              required
+              error={bulkCountError}
+              autoFocus
+              testId="rack-bulk-count-input"
+            />
+          ) : (
+            <Input
+              id="rack-label"
+              label="Label"
+              initValue={label}
+              maxLength={rackLabelMaxLength}
+              onChange={(value) => {
+                setLabel(value);
+                if (labelError) setLabelError(undefined);
+              }}
+              error={labelError}
+            />
+          )}
+
+          {isBulk ? (
+            // Labelled the way the bulk-rename counter fields are (see
+            // CustomPropertyOptionsModal) and the bulk building form — same
+            // prefix + start + scale triple, so the vocabulary carries over.
+            <fieldset className="rounded-xl border border-border-5 p-4">
+              <legend className="px-1 text-emphasis-300 text-text-primary">Bulk properties</legend>
+              <div className="grid grid-cols-1 gap-4 tablet:grid-cols-3">
+                <Input
+                  id="rack-bulk-prefix"
+                  label="Label prefix"
+                  initValue={bulkPrefix}
+                  // The label cap, not the cap minus a guessed counter width: how
+                  // wide the counter runs depends on the scale and start value, so
+                  // the overflow is reported per row (and on submit) instead.
+                  maxLength={rackLabelMaxLength}
+                  onChange={(value) => {
+                    setBulkPrefix(value);
+                    clearBulkRowErrors();
+                    if (bulkPrefixError) setBulkPrefixError(undefined);
+                  }}
+                  required
+                  error={bulkPrefixError}
+                  testId="rack-bulk-prefix-input"
+                />
+                <Input
+                  id="rack-bulk-counter-start"
+                  label="Counter start (optional)"
+                  type="number"
+                  initValue={bulkCounterStartText}
+                  maxLength={counterStartInputMaxLength}
+                  onChange={(value) => {
+                    setBulkCounterStartText(digitsOnly(value, counterStartInputMaxLength));
+                    clearBulkRowErrors();
+                  }}
+                  testId="rack-bulk-counter-start-input"
+                />
+                {/* A number input rather than bulk rename's radio row: it's a
+                    digit count sitting next to another number field, and the
+                    range is enforced on submit like any other bound. */}
+                <Input
+                  id="rack-bulk-counter-scale"
+                  label="Counter scale (optional)"
+                  type="number"
+                  initValue={bulkCounterScaleText}
+                  maxLength={1}
+                  onChange={(value) => {
+                    setBulkCounterScaleText(digitsOnly(value, 1));
+                    clearBulkRowErrors();
+                    if (bulkCounterScaleError) setBulkCounterScaleError(undefined);
+                  }}
+                  error={bulkCounterScaleError}
+                  testId="rack-bulk-counter-scale-input"
+                />
+              </div>
+            </fieldset>
+          ) : null}
 
           {canManagePlacement ? (
             <>
@@ -503,13 +811,13 @@ const RackSettingsModal = ({
 
               <Select
                 id="rack-building-select"
-                label="Building (optional)"
+                label={buildingLocked ? "Building" : "Building (optional)"}
                 options={buildingOptions}
                 value={buildingIdText}
                 onChange={handleBuildingChange}
                 // A building can't be chosen without a real site — it scopes the
                 // options and supplies the derived site_id.
-                disabled={!siteSelected}
+                disabled={buildingLocked || !siteSelected}
                 forceBelow
                 testId="rack-building-select"
               />
@@ -521,6 +829,9 @@ const RackSettingsModal = ({
               id="rack-zone"
               label="Zone (optional)"
               initValue={zone}
+              // RackInfo.zone shares the label's buf.validate max_len, and it is
+              // free text with no other guard.
+              maxLength={rackLabelMaxLength}
               inputRef={zoneInputRef}
               onChange={(value) => {
                 setZone(value);
@@ -582,7 +893,10 @@ const RackSettingsModal = ({
                 label="Columns"
                 type="number"
                 initValue={columns}
-                onChange={(value) => setColumns(value)}
+                onChange={(value) => {
+                  setColumns(value);
+                  if (columnsError) setColumnsError(undefined);
+                }}
                 disabled={rackTypeDisabled}
                 error={columnsError}
               />
@@ -593,7 +907,10 @@ const RackSettingsModal = ({
                 label="Rows"
                 type="number"
                 initValue={rows}
-                onChange={(value) => setRows(value)}
+                onChange={(value) => {
+                  setRows(value);
+                  if (rowsError) setRowsError(undefined);
+                }}
                 disabled={rackTypeDisabled}
                 error={rowsError}
               />
@@ -617,6 +934,46 @@ const RackSettingsModal = ({
             onChange={(v) => setCoolingType(Number(v) as RackCoolingType)}
             testId="cooling-type-select"
           />
+
+          {isBulk ? (
+            // Preview, not a form: these are exactly the labels the batch
+            // submits, so there is nothing to edit here — an operator who wants
+            // different labels changes the properties above.
+            <section className="flex flex-col gap-2" data-testid="rack-bulk-preview">
+              <span className="text-emphasis-300 text-text-primary">
+                {bulkLabels.length} {bulkLabels.length === 1 ? "rack" : "racks"} to create
+              </span>
+              {bulkLabels.length === 0 ? (
+                <p className="rounded-xl border border-dashed border-border-5 p-4 text-center text-300 text-text-primary-50">
+                  Enter a number of racks and a label prefix to preview them
+                </p>
+              ) : (
+                // No scroll of its own: the modal body already scrolls, and a
+                // nested scroller would trap the wheel over the longest part of
+                // the form.
+                <ol className="divide-y divide-border-5 rounded-xl border border-border-5">
+                  {bulkLabels.map((bulkLabel, index) => {
+                    const rowError = bulkRowError(index);
+                    return (
+                      <li
+                        key={`${bulkLabel}-${index}`}
+                        className="flex items-center gap-3 px-3 py-2"
+                        data-testid={`rack-bulk-preview-row-${index}`}
+                      >
+                        <span className="w-8 shrink-0 text-300 text-text-primary-50">{index + 1}</span>
+                        <span className="min-w-0 flex-1 truncate text-300 text-text-primary">{bulkLabel}</span>
+                        {rowError !== undefined ? (
+                          // Same token Input renders its validation text in, so a
+                          // row error reads like a field error.
+                          <span className="shrink-0 text-200 text-intent-critical-fill">{rowError}</span>
+                        ) : null}
+                      </li>
+                    );
+                  })}
+                </ol>
+              )}
+            </section>
+          ) : null}
         </div>
       )}
     </Modal>

--- a/client/src/protoFleet/features/fleetManagement/components/bulkRackLabels.ts
+++ b/client/src/protoFleet/features/fleetManagement/components/bulkRackLabels.ts
@@ -1,0 +1,30 @@
+// Label generation for the bulk (Multiple) rack-create form. The counter math
+// is shared with the bulk building-create form — see utils/bulkNameSeries.ts for
+// how prefix / start / scale compose.
+//
+// Note what is deliberately absent: a takenLabelIndexes pre-check. Rack labels
+// are unique per (org, type), not per building or site, so no list this form can
+// hold is authoritative — the rack a label collides with may sit in another site
+// entirely. The server owns that check and reports it per row (see CreateRacks),
+// and this form renders those rows from the response.
+
+import { buildBulkNameSeries, type BulkNameOptions, overlongNameIndexes } from "@/protoFleet/utils/bulkNameSeries";
+
+// Cap matches the buf.validate max_items on CreateRacksRequest.racks. A typo
+// guard, not a capacity limit — the building's grid enforces the real one.
+export const bulkRackCountMaximum = 500;
+
+// Matches NewRack.label's buf.validate max_len (and RackInfo.label's). Exceeding
+// it fails the whole batch with a generic InvalidArgument, so the form has to
+// catch it before the call.
+export const rackLabelMaxLength = 100;
+
+export type { BulkNameOptions };
+
+export const buildBulkRackLabels = (count: number, options: BulkNameOptions): string[] =>
+  buildBulkNameSeries(count, options, bulkRackCountMaximum);
+
+// Rows the server would reject on length alone. The prefix field can't guard
+// this by itself: the counter's width is part of the label, and raising the
+// scale (or the start value) widens every row after the prefix was typed.
+export const overlongRackLabelIndexes = (labels: string[]): number[] => overlongNameIndexes(labels, rackLabelMaxLength);

--- a/client/src/protoFleet/features/fleetManagement/hooks/useCreateRack.test.ts
+++ b/client/src/protoFleet/features/fleetManagement/hooks/useCreateRack.test.ts
@@ -1,0 +1,62 @@
+import { act } from "react";
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useCreateRack } from "./useCreateRack";
+import { RackCoolingType, RackOrderIndex } from "@/protoFleet/api/generated/device_set/v1/device_set_pb";
+import { type RackFormData } from "@/protoFleet/features/fleetManagement/components/ManageRackModal/types";
+
+const mockSaveRack = vi.fn(({ onSuccess, onFinally }) => {
+  onSuccess?.({ id: 7n }, 0);
+  onFinally?.();
+});
+
+vi.mock("@/protoFleet/api/useDeviceSets", () => ({
+  useDeviceSets: () => ({ saveRack: mockSaveRack }),
+}));
+
+vi.mock("@/shared/features/toaster", () => ({
+  pushToast: vi.fn(),
+  STATUSES: { success: "success", error: "error" },
+}));
+
+const formData = (overrides: Partial<RackFormData> = {}): RackFormData => ({
+  label: "R-1",
+  zone: "Zone A",
+  rows: 4,
+  columns: 3,
+  orderIndex: RackOrderIndex.BOTTOM_LEFT,
+  coolingType: RackCoolingType.AIR,
+  ...overrides,
+});
+
+describe("useCreateRack", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // An explicit 0 would make site_id/building_id present on RackInfo, which
+  // SaveRack's handler reads as placement intent and gates behind site:manage.
+  // A rack:manage-only operator has no placement controls, so their create must
+  // not carry the fields at all.
+  it("omits placement when the operator chose none", async () => {
+    const { result } = renderHook(() => useCreateRack({ onCreated: vi.fn() }));
+
+    await act(async () => {
+      await result.current.createRack(formData());
+    });
+
+    expect(mockSaveRack).toHaveBeenCalledTimes(1);
+    expect(mockSaveRack.mock.calls[0][0]).toMatchObject({ siteId: undefined, buildingId: undefined });
+  });
+
+  it("sends the placement the operator picked", async () => {
+    const { result } = renderHook(() => useCreateRack({ onCreated: vi.fn() }));
+
+    await act(async () => {
+      await result.current.createRack(formData({ siteId: 3n, buildingId: 9n }));
+    });
+
+    expect(mockSaveRack.mock.calls[0][0]).toMatchObject({ siteId: 3n, buildingId: 9n });
+  });
+});

--- a/client/src/protoFleet/features/fleetManagement/hooks/useCreateRack.ts
+++ b/client/src/protoFleet/features/fleetManagement/hooks/useCreateRack.ts
@@ -74,11 +74,12 @@ export function useCreateRack({
           // Slots are the operator's next step, in the manage modal. Seeded
           // miners land as members without a position.
           slotAssignments: [],
-          // A new rack has no prior placement to preserve, so send the chosen
-          // one explicitly — including "unassigned", which the form encodes as
-          // undefined and the wire as 0.
-          siteId: formData.siteId ?? 0n,
-          buildingId: formData.buildingId ?? 0n,
+          // Left undefined when the operator chose no placement. A new rack has
+          // nothing to unassign, and an explicit 0 would make the field present
+          // — which SaveRack reads as placement intent and gates behind
+          // site:manage, denying a rack:manage-only operator their own create.
+          siteId: formData.siteId,
+          buildingId: formData.buildingId,
           forceClearConflictingSite: force,
           onSuccess: (deviceSet) => {
             pushToast({ message: `Rack "${formData.label}" created`, status: STATUSES.success });

--- a/client/src/protoFleet/features/fleetManagement/hooks/useCreateRack.ts
+++ b/client/src/protoFleet/features/fleetManagement/hooks/useCreateRack.ts
@@ -1,0 +1,130 @@
+import { useCallback, useRef, useState } from "react";
+
+import { type PerDeviceRackConflict } from "@/protoFleet/api/generated/device_set/v1/device_set_pb";
+import { useDeviceSets } from "@/protoFleet/api/useDeviceSets";
+import { type RackFormData } from "@/protoFleet/features/fleetManagement/components/ManageRackModal/types";
+
+import { pushToast, STATUSES } from "@/shared/features/toaster";
+
+/**
+ * Creates a rack from the Rack Settings form, optionally seeding it with
+ * miners, and reports the new rack's id.
+ *
+ * SaveRack-with-no-id is the one call that can land dimensions, zone,
+ * placement and a seeded member set in a single transaction, so a failed seed
+ * can't strand an empty rack. That makes it right for create — and only for
+ * create. Every subsequent edit goes through the delta RPCs (UpdateDeviceSet
+ * for settings, AssignDevicesToRack for members and slots), because SaveRack
+ * replaces the rack's whole member set and would clobber concurrent changes.
+ *
+ * Both rack entry points (RacksPage's "Add rack" and the bulk
+ * "Add to rack → New rack" flow) share this so the create semantics — the
+ * toast, the in-flight guard, the site-strip confirmation — can't drift apart.
+ */
+export interface UseCreateRackResult {
+  /**
+   * Creates the rack and resolves with its id, or undefined when the create
+   * did not happen (an error, or a site-strip conflict awaiting confirmation).
+   * On a conflict the returned promise resolves undefined and `conflict`
+   * becomes non-null; call `confirmConflict` to retry with the strip forced.
+   */
+  createRack: (formData: RackFormData, seededMinerIds?: string[]) => Promise<bigint | undefined>;
+  creating: boolean;
+  /**
+   * Non-null while a site-strip confirmation is pending, carrying what the
+   * warning dialog needs: how many seeded miners would be displaced, and the
+   * label of the rack they'd move into.
+   */
+  conflict: { count: number; rackLabel: string } | null;
+  confirmConflict: () => void;
+  cancelConflict: () => void;
+}
+
+export function useCreateRack({
+  // Receives the submitted form data alongside the new id: the caller opens
+  // ManageRackModal on it, and the forced-retry path fires this from the
+  // confirmation dialog, where the form data is no longer in scope.
+  onCreated,
+}: {
+  onCreated: (rackId: bigint, formData: RackFormData) => void;
+}): UseCreateRackResult {
+  const { saveRack } = useDeviceSets();
+  const [creating, setCreating] = useState(false);
+  // The `creating` state lags a render behind the click, so the ref is what
+  // actually blocks a double-click from dispatching two creates.
+  const creatingRef = useRef(false);
+  const [conflict, setConflict] = useState<{ count: number; rackLabel: string } | null>(null);
+  // Holds the inputs for the forced retry while the confirmation is showing.
+  const pendingRef = useRef<{ formData: RackFormData; seededMinerIds: string[] } | null>(null);
+
+  const dispatch = useCallback(
+    (formData: RackFormData, seededMinerIds: string[], force: boolean): Promise<bigint | undefined> => {
+      if (creatingRef.current) return Promise.resolve(undefined);
+      creatingRef.current = true;
+      setCreating(true);
+      return new Promise<bigint | undefined>((resolve) => {
+        saveRack({
+          label: formData.label,
+          zone: formData.zone,
+          rows: formData.rows,
+          columns: formData.columns,
+          orderIndex: formData.orderIndex,
+          coolingType: formData.coolingType,
+          deviceIdentifiers: seededMinerIds,
+          // Slots are the operator's next step, in the manage modal. Seeded
+          // miners land as members without a position.
+          slotAssignments: [],
+          // A new rack has no prior placement to preserve, so send the chosen
+          // one explicitly — including "unassigned", which the form encodes as
+          // undefined and the wire as 0.
+          siteId: formData.siteId ?? 0n,
+          buildingId: formData.buildingId ?? 0n,
+          forceClearConflictingSite: force,
+          onSuccess: (deviceSet) => {
+            pushToast({ message: `Rack "${formData.label}" created`, status: STATUSES.success });
+            setConflict(null);
+            pendingRef.current = null;
+            onCreated(deviceSet.id, formData);
+            resolve(deviceSet.id);
+          },
+          // Seeded miners that currently have a site/building the new rack
+          // lacks would be stripped. The server wrote nothing; hold the inputs
+          // so the caller's confirmation can retry with force.
+          onConflicts: (conflicts: PerDeviceRackConflict[]) => {
+            pendingRef.current = { formData, seededMinerIds };
+            setConflict({ count: conflicts.length, rackLabel: formData.label });
+            resolve(undefined);
+          },
+          onError: (message) => {
+            pushToast({ message: message || "Failed to create rack. Please try again.", status: STATUSES.error });
+            resolve(undefined);
+          },
+          onFinally: () => {
+            creatingRef.current = false;
+            setCreating(false);
+          },
+        });
+      });
+    },
+    [saveRack, onCreated],
+  );
+
+  const createRack = useCallback(
+    (formData: RackFormData, seededMinerIds?: string[]) => dispatch(formData, seededMinerIds ?? [], false),
+    [dispatch],
+  );
+
+  const confirmConflict = useCallback(() => {
+    const pending = pendingRef.current;
+    if (!pending) return;
+    setConflict(null);
+    void dispatch(pending.formData, pending.seededMinerIds, true);
+  }, [dispatch]);
+
+  const cancelConflict = useCallback(() => {
+    pendingRef.current = null;
+    setConflict(null);
+  }, []);
+
+  return { createRack, creating, conflict, confirmConflict, cancelConflict };
+}

--- a/client/src/protoFleet/features/fleetManagement/hooks/useCreateRacks.ts
+++ b/client/src/protoFleet/features/fleetManagement/hooks/useCreateRacks.ts
@@ -1,0 +1,72 @@
+import { useCallback, useRef, useState } from "react";
+
+import { type DeviceSet } from "@/protoFleet/api/generated/device_set/v1/device_set_pb";
+import { type BulkCreateRackError, type NewRackInput, useDeviceSets } from "@/protoFleet/api/useDeviceSets";
+import { type BulkRackPlacement } from "@/protoFleet/features/fleetManagement/components/RackSettingsModal";
+
+import { pushToast, STATUSES } from "@/shared/features/toaster";
+
+/**
+ * Bulk sibling of useCreateRack: one CreateRacks call for the whole batch.
+ *
+ * The RPC is all-or-nothing, so the result is either every rack in `created` or
+ * none of them plus the per-row reasons the create modal marks its preview with.
+ * That is the whole reason this isn't a loop over useCreateRack — a mid-list
+ * failure would leave the operator working out which half of a prefix run
+ * exists.
+ */
+export interface BulkRackCreateResult {
+  created: DeviceSet[];
+  errors: BulkCreateRackError[];
+}
+
+export interface UseCreateRacksResult {
+  createRacks: (racks: NewRackInput[], placement: BulkRackPlacement) => Promise<BulkRackCreateResult>;
+  creating: boolean;
+}
+
+export function useCreateRacks(): UseCreateRacksResult {
+  const { createRacks: dispatchCreateRacks } = useDeviceSets();
+  const [creating, setCreating] = useState(false);
+  // The `creating` state lags a render behind the click, so the ref is what
+  // actually blocks a double-click from dispatching two batches.
+  const creatingRef = useRef(false);
+
+  const createRacks = useCallback(
+    async (racks: NewRackInput[], placement: BulkRackPlacement): Promise<BulkRackCreateResult> => {
+      if (creatingRef.current) return { created: [], errors: [] };
+      creatingRef.current = true;
+      setCreating(true);
+      return new Promise<BulkRackCreateResult>((resolve) => {
+        void dispatchCreateRacks({
+          siteId: placement.siteId,
+          buildingId: placement.buildingId,
+          // Rows arrive fully formed from the modal: it owns the label
+          // generation and the one geometry the batch shares, so there is
+          // nothing to reshape here.
+          racks,
+          onSuccess: (created) => {
+            pushToast({
+              message: `${created.length} ${created.length === 1 ? "rack" : "racks"} created`,
+              status: STATUSES.success,
+            });
+            resolve({ created, errors: [] });
+          },
+          // A label collision comes back per row and the modal renders it against
+          // the offending preview lines, so the toast only carries the summary.
+          onError: (message, errors) => {
+            pushToast({ message: `Failed to create racks: ${message}`, status: STATUSES.error });
+            resolve({ created: [], errors });
+          },
+          onFinally: () => {
+            creatingRef.current = false;
+            setCreating(false);
+          },
+        });
+      });
+    },
+    [dispatchCreateRacks],
+  );
+
+  return { createRacks, creating };
+}

--- a/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/RackOverviewPage.tsx
@@ -579,9 +579,9 @@ const RackOverviewPage = () => {
             resolveRack(rack.id);
             void refetchStats();
           }}
-          // Settings "Continue" persists before the final Save; refresh the
-          // overview in the background (modal stays open) so a later dismiss
-          // can't leave stale label/placement on screen.
+          // The Rack settings Save and the miner pickers each persist on their
+          // own; refresh the overview in the background (modal stays open) so a
+          // later dismiss can't leave stale label/placement/members on screen.
           onSettingsPersisted={() => {
             resolveRack(rack.id);
             void refetchStats();

--- a/client/src/protoFleet/features/fleetManagement/pages/RacksPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/RacksPage.tsx
@@ -1127,12 +1127,14 @@ const RacksPage = () => {
   const lastItemIndex = currentPage * DEFAULT_PAGE_SIZE + racks.length;
   const shouldRenderGridPagination = !isLoading && totalCount > 0;
 
-  // `!isModalOpen` because a refetch fired from inside a modal — the first
-  // rack's create, or any membership commit reporting through
-  // onSettingsPersisted — leaves isLoading true while hasEverLoaded is still
-  // false, since that only flips on a non-empty page. Taking the page spinner
-  // there would unmount the modal the operator is working in and drop them back
-  // at the start of the add-miners step.
+  // Both guards carry `!isModalOpen` for the same reason: a refetch fired from
+  // inside a modal — the first rack's create, or any membership commit reporting
+  // through onSettingsPersisted — resolves while hasEverLoaded is still false,
+  // since that only flips on a non-empty page. Taking over the page there, with
+  // either the spinner or the error, would unmount the modal the operator is
+  // working in and drop them back at the start of the add-miners step. The rack
+  // write has already succeeded by then, so a failed *list* refresh is not
+  // theirs to act on; it resurfaces on the refetch that follows the close.
   if (isLoading && !hasEverLoaded && !isModalOpen) {
     return (
       <div className="flex h-full items-center justify-center">
@@ -1141,7 +1143,7 @@ const RacksPage = () => {
     );
   }
 
-  if (error && !hasEverLoaded) {
+  if (error && !hasEverLoaded && !isModalOpen) {
     return (
       <div className="flex h-full items-center justify-center">
         <p className="text-300 text-text-primary-50">{error}</p>

--- a/client/src/protoFleet/features/fleetManagement/pages/RacksPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/RacksPage.tsx
@@ -7,7 +7,7 @@ import { type BuildingWithCounts } from "@/protoFleet/api/generated/buildings/v1
 import { type DeviceSet } from "@/protoFleet/api/generated/device_set/v1/device_set_pb";
 import { type SiteWithCounts } from "@/protoFleet/api/generated/sites/v1/sites_pb";
 import { useSites } from "@/protoFleet/api/sites";
-import { useDeviceSets } from "@/protoFleet/api/useDeviceSets";
+import { type NewRackInput, useDeviceSets } from "@/protoFleet/api/useDeviceSets";
 import type { DeviceSetListItem } from "@/protoFleet/components/DeviceSetList";
 import type { DeviceSetColumn } from "@/protoFleet/components/DeviceSetList";
 import { DEFAULT_PAGE_SIZE, DeviceSetList, issueOptions, useIssueFilter } from "@/protoFleet/components/DeviceSetList";
@@ -33,8 +33,11 @@ import { useOptionalFleetOutletContext } from "@/protoFleet/features/fleetManage
 import { ManageRackModal, type RackFormData } from "@/protoFleet/features/fleetManagement/components/ManageRackModal";
 import ReparentWarningDialog from "@/protoFleet/features/fleetManagement/components/ManageRackModal/ReparentWarningDialog";
 import { RackCard } from "@/protoFleet/features/fleetManagement/components/RackCard";
-import RackSettingsModal from "@/protoFleet/features/fleetManagement/components/RackSettingsModal";
+import RackSettingsModal, {
+  type BulkRackPlacement,
+} from "@/protoFleet/features/fleetManagement/components/RackSettingsModal";
 import { useCreateRack } from "@/protoFleet/features/fleetManagement/hooks/useCreateRack";
+import { useCreateRacks } from "@/protoFleet/features/fleetManagement/hooks/useCreateRacks";
 import { BUILDING_URL_PARAM } from "@/protoFleet/features/fleetManagement/utils/buildingFilterUrl";
 import {
   FILTER_URL_PARAM_KEYS,
@@ -914,6 +917,24 @@ const RacksPage = () => {
     },
   });
 
+  // The Multiple variant of the same modal. A batch has no miners to seed and no
+  // slots to place, so it closes on success instead of handing off to
+  // ManageRackModal the way a single create does.
+  const { createRacks, creating: creatingRacks } = useCreateRacks();
+  const handleCreateRacks = useCallback(
+    async (racks: NewRackInput[], placement: BulkRackPlacement) => {
+      const { created, errors } = await createRacks(racks, placement);
+      if (created.length > 0) {
+        setShowRackSettingsModal(false);
+        resetAndFetch();
+        fetchZones();
+      }
+      // Non-empty leaves the modal open with the rejected rows marked.
+      return errors;
+    },
+    [createRacks, resetAndFetch, fetchZones],
+  );
+
   const handleDeleteRack = useCallback(() => {
     if (!manageRackId) return Promise.resolve();
     return new Promise<void>((resolve, reject) => {
@@ -1150,7 +1171,10 @@ const RacksPage = () => {
             defaultSiteId={scopedSiteId}
             onDismiss={() => setShowRackSettingsModal(false)}
             onSubmit={createRack}
-            saving={creatingRack}
+            // Present unconditionally — this is what shows the Single / Multiple
+            // toggle inside the create modal.
+            onSubmitBulk={handleCreateRacks}
+            saving={creatingRack || creatingRacks}
           />
         ) : null}
         {manageRackFormData && manageRackId !== undefined ? (
@@ -1486,7 +1510,8 @@ const RacksPage = () => {
           defaultSiteId={scopedSiteId}
           onDismiss={() => setShowRackSettingsModal(false)}
           onSubmit={createRack}
-          saving={creatingRack}
+          onSubmitBulk={handleCreateRacks}
+          saving={creatingRack || creatingRacks}
         />
       ) : null}
       {manageRackFormData && manageRackId !== undefined ? (

--- a/client/src/protoFleet/features/fleetManagement/pages/RacksPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/RacksPage.tsx
@@ -1127,7 +1127,13 @@ const RacksPage = () => {
   const lastItemIndex = currentPage * DEFAULT_PAGE_SIZE + racks.length;
   const shouldRenderGridPagination = !isLoading && totalCount > 0;
 
-  if (isLoading && !hasEverLoaded) {
+  // `!isModalOpen` because a refetch fired from inside a modal — the first
+  // rack's create, or any membership commit reporting through
+  // onSettingsPersisted — leaves isLoading true while hasEverLoaded is still
+  // false, since that only flips on a non-empty page. Taking the page spinner
+  // there would unmount the modal the operator is working in and drop them back
+  // at the start of the add-miners step.
+  if (isLoading && !hasEverLoaded && !isModalOpen) {
     return (
       <div className="flex h-full items-center justify-center">
         <ProgressCircular indeterminate />

--- a/client/src/protoFleet/features/fleetManagement/pages/RacksPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/RacksPage.tsx
@@ -31,8 +31,10 @@ import FleetGroupActionsMenu from "@/protoFleet/features/fleetManagement/compone
 import FleetGroupListActionBar from "@/protoFleet/features/fleetManagement/components/FleetGroupActionsMenu/FleetGroupListActionBar";
 import { useOptionalFleetOutletContext } from "@/protoFleet/features/fleetManagement/components/FleetLayout";
 import { ManageRackModal, type RackFormData } from "@/protoFleet/features/fleetManagement/components/ManageRackModal";
+import ReparentWarningDialog from "@/protoFleet/features/fleetManagement/components/ManageRackModal/ReparentWarningDialog";
 import { RackCard } from "@/protoFleet/features/fleetManagement/components/RackCard";
 import RackSettingsModal from "@/protoFleet/features/fleetManagement/components/RackSettingsModal";
+import { useCreateRack } from "@/protoFleet/features/fleetManagement/hooks/useCreateRack";
 import { BUILDING_URL_PARAM } from "@/protoFleet/features/fleetManagement/utils/buildingFilterUrl";
 import {
   FILTER_URL_PARAM_KEYS,
@@ -874,12 +876,6 @@ const RacksPage = () => {
     return <NoFilterResultsEmptyState hasActiveFilters={hasActiveFilters} onClearFilters={handleClearFilters} />;
   }, [hasActiveFilters, isLoading, totalCount, handleClearFilters]);
 
-  const handleRackSettingsContinue = useCallback((formData: RackFormData) => {
-    setShowRackSettingsModal(false);
-    setManageRackFormData(formData);
-    setManageRackId(undefined);
-  }, []);
-
   const handleManageRackDismiss = useCallback(() => {
     setManageRackFormData(null);
     setManageRackId(undefined);
@@ -891,13 +887,32 @@ const RacksPage = () => {
     resetAndFetch();
     fetchZones();
   }, [resetAndFetch, fetchZones]);
-  // Rack Settings "Continue" persists an existing rack's settings before the
-  // final miner Save, so refresh the list in the background (without closing
-  // the modal) to keep it consistent if the operator then dismisses.
+  // Rack Settings "Save" persists an existing rack's settings before the final
+  // miner Save, so refresh the list in the background (without closing the
+  // modal) to keep it consistent if the operator then dismisses.
   const handleRackSettingsPersisted = useCallback(() => {
     resetAndFetch();
     fetchZones();
   }, [resetAndFetch, fetchZones]);
+
+  // "Create rack" in Rack Settings creates it for real, then hands off to
+  // ManageRackModal for miners and placement. The rack exists from here on, so
+  // the list refreshes immediately rather than waiting for a later Save.
+  const {
+    createRack,
+    creating: creatingRack,
+    conflict: rackCreateConflict,
+    confirmConflict,
+    cancelConflict,
+  } = useCreateRack({
+    onCreated: (rackId, formData) => {
+      setShowRackSettingsModal(false);
+      setManageRackFormData(formData);
+      setManageRackId(rackId);
+      resetAndFetch();
+      fetchZones();
+    },
+  });
 
   const handleDeleteRack = useCallback(() => {
     if (!manageRackId) return Promise.resolve();
@@ -1134,12 +1149,13 @@ const RacksPage = () => {
             existingRacks={racks}
             defaultSiteId={scopedSiteId}
             onDismiss={() => setShowRackSettingsModal(false)}
-            onContinue={handleRackSettingsContinue}
+            onSubmit={createRack}
+            saving={creatingRack}
           />
         ) : null}
-        {manageRackFormData ? (
+        {manageRackFormData && manageRackId !== undefined ? (
           <ManageRackModal
-            show={!!manageRackFormData}
+            show
             rackSettings={manageRackFormData}
             existingRackId={manageRackId}
             existingRacks={racks}
@@ -1147,7 +1163,15 @@ const RacksPage = () => {
             onDismiss={handleManageRackDismiss}
             onSave={handleManageRackSave}
             onSettingsPersisted={handleRackSettingsPersisted}
-            onDelete={manageRackId ? handleDeleteRack : undefined}
+            onDelete={handleDeleteRack}
+          />
+        ) : null}
+        {rackCreateConflict ? (
+          <ReparentWarningDialog
+            count={rackCreateConflict.count}
+            rackLabel={rackCreateConflict.rackLabel}
+            onCancel={cancelConflict}
+            onConfirm={confirmConflict}
           />
         ) : null}
       </>
@@ -1461,12 +1485,13 @@ const RacksPage = () => {
           existingRacks={racks}
           defaultSiteId={scopedSiteId}
           onDismiss={() => setShowRackSettingsModal(false)}
-          onContinue={handleRackSettingsContinue}
+          onSubmit={createRack}
+          saving={creatingRack}
         />
       ) : null}
-      {manageRackFormData ? (
+      {manageRackFormData && manageRackId !== undefined ? (
         <ManageRackModal
-          show={!!manageRackFormData}
+          show
           rackSettings={manageRackFormData}
           existingRackId={manageRackId}
           existingRacks={racks}
@@ -1474,6 +1499,14 @@ const RacksPage = () => {
           onDismiss={handleManageRackDismiss}
           onSave={handleManageRackSave}
           onSettingsPersisted={handleRackSettingsPersisted}
+        />
+      ) : null}
+      {rackCreateConflict ? (
+        <ReparentWarningDialog
+          count={rackCreateConflict.count}
+          rackLabel={rackCreateConflict.rackLabel}
+          onCancel={cancelConflict}
+          onConfirm={confirmConflict}
         />
       ) : null}
       {reparentTarget ? (

--- a/client/src/protoFleet/features/fleetManagement/pages/RacksPage.tsx
+++ b/client/src/protoFleet/features/fleetManagement/pages/RacksPage.tsx
@@ -1156,359 +1156,13 @@ const RacksPage = () => {
   // instead of the filtered-empty state with the chip showing.
   const hasRacks = hasEverLoaded || totalCount > 0 || racks.length > 0 || hasActiveFilters;
 
-  if (!hasRacks) {
-    return (
-      <>
-        <NullState
-          className={clsx("sticky left-0", PAGE_SCROLL_CHROME_WIDTH)}
-          icon={<Racks width="w-5" />}
-          title="You haven't set up any racks"
-          description="Add a rack and assign miners to rack positions to get started."
-          action={
-            <Button variant="primary" onClick={() => setShowRackSettingsModal(true)}>
-              Add rack
-            </Button>
-          }
-        />
-        {showRackSettingsModal ? (
-          <RackSettingsModal
-            show={showRackSettingsModal}
-            existingRacks={racks}
-            defaultSiteId={scopedSiteId}
-            onDismiss={() => setShowRackSettingsModal(false)}
-            onSubmit={createRack}
-            // Present unconditionally — this is what shows the Single / Multiple
-            // toggle inside the create modal.
-            onSubmitBulk={handleCreateRacks}
-            saving={creatingRack || creatingRacks}
-          />
-        ) : null}
-        {manageRackFormData && manageRackId !== undefined ? (
-          <ManageRackModal
-            show
-            rackSettings={manageRackFormData}
-            existingRackId={manageRackId}
-            existingRacks={racks}
-            scopedSiteId={scopedSiteId}
-            onDismiss={handleManageRackDismiss}
-            onSave={handleManageRackSave}
-            onSettingsPersisted={handleRackSettingsPersisted}
-            onDelete={handleDeleteRack}
-          />
-        ) : null}
-        {rackCreateConflict ? (
-          <ReparentWarningDialog
-            count={rackCreateConflict.count}
-            rackLabel={rackCreateConflict.rackLabel}
-            onCancel={cancelConflict}
-            onConfirm={confirmConflict}
-          />
-        ) : null}
-      </>
-    );
-  }
-
-  return (
-    <div>
-      <div className={clsx("sticky left-0 z-3 px-6 pt-6 laptop:px-10 laptop:pt-10", PAGE_SCROLL_CHROME_WIDTH)}>
-        {insideFleetShell ? null : <h1 className="pb-4 text-heading-300 text-text-primary">Racks</h1>}
-        <div className="flex flex-col gap-2 pb-6">
-          {/* Action button — full-width on tablet/phone */}
-          <div className="block laptop:hidden">
-            <Button variant={variants.secondary} size={sizes.compact} onClick={() => setShowRackSettingsModal(true)}>
-              Add rack
-            </Button>
-          </div>
-          {/* View toggle — full width on tablet/phone */}
-          <div className="block laptop:hidden">
-            <SegmentedControl
-              key={`mobile-${racksViewMode}`}
-              className="!w-full whitespace-nowrap [&>button]:flex-1"
-              segmentClassName="text-center"
-              segments={[
-                { key: "grid", title: "View grid" },
-                { key: "list", title: "View list" },
-              ]}
-              initialSegmentKey={racksViewMode}
-              onSelect={handleRacksViewModeSelect}
-            />
-          </div>
-          {/* Desktop layout — single row with toggle + filters left, buttons right */}
-          <div className="hidden flex-row flex-wrap items-center gap-2 laptop:flex">
-            <SegmentedControl
-              key={`desktop-${racksViewMode}`}
-              className="shrink-0 whitespace-nowrap"
-              segments={[
-                { key: "grid", title: "View grid" },
-                { key: "list", title: "View list" },
-              ]}
-              initialSegmentKey={racksViewMode}
-              onSelect={handleRacksViewModeSelect}
-            />
-            <FilterChipsBar
-              filters={filterChipsBarFilters}
-              onChange={handleFilterChange}
-              numericFilters={TELEMETRY_FILTER_CHIPS}
-              selectedNumericValues={selectedNumericValues}
-              onNumericChange={handleNumericFilterChange}
-              onClearAll={handleClearFilters}
-            />
-            {racksViewMode === "grid" ? (
-              <DropdownFilter
-                title="Sort"
-                options={RACK_SORT_OPTIONS}
-                selectedOptions={[currentSort.field]}
-                onSelect={handleSortSelect}
-                showSelectAll={false}
-                closeOnSelect
-              />
-            ) : null}
-            <Button
-              className="ml-auto"
-              variant={variants.secondary}
-              size={sizes.compact}
-              onClick={() => setShowRackSettingsModal(true)}
-            >
-              Add rack
-            </Button>
-          </div>
-          {/* Filters — shown separately on tablet/phone */}
-          <div className="flex flex-row flex-wrap items-center gap-2 laptop:hidden">
-            <FilterChipsBar
-              filters={filterChipsBarFilters}
-              onChange={handleFilterChange}
-              numericFilters={TELEMETRY_FILTER_CHIPS}
-              selectedNumericValues={selectedNumericValues}
-              onNumericChange={handleNumericFilterChange}
-              onClearAll={handleClearFilters}
-            />
-            {racksViewMode === "grid" ? (
-              <DropdownFilter
-                title="Sort"
-                options={RACK_SORT_OPTIONS}
-                selectedOptions={[currentSort.field]}
-                onSelect={handleSortSelect}
-                showSelectAll={false}
-                closeOnSelect
-              />
-            ) : null}
-          </div>
-        </div>
-      </div>
-      <div
-        className={clsx(
-          "sticky left-0 px-6 pb-4 text-emphasis-300 text-text-primary-70 laptop:px-10",
-          PAGE_SCROLL_CHROME_WIDTH,
-        )}
-        data-testid="racks-count-label"
-      >
-        {formatListCountLabel(totalCount, {
-          unfilteredTotal: totalUnfilteredRacks,
-          hasActiveFilters,
-          singular: "rack",
-          plural: "racks",
-        })}
-      </div>
-      {error ? (
-        <Callout className="mx-6 mb-4 laptop:mx-10" intent="danger" prefixIcon={<Alert />} title={error} />
-      ) : null}
-      {racksViewMode === "list" ? (
-        // No horizontal padding or overflow wrapper here: that inset the table
-        // (white gaps beside the row rules) and added a second scroll
-        // container. Row content is indented via DeviceSetList's paddingLeft
-        // so the rules still span the full width, and the page is the single
-        // scroll container.
-        <div className="pb-6 laptop:pb-10">
-          <DeviceSetList
-            deviceSets={racks}
-            statsMap={statsMap}
-            renderName={renderName}
-            renderMiners={renderMiners}
-            renderSite={renderSite}
-            renderBuilding={renderBuilding}
-            columns={insideFleetShell ? RACK_COLUMNS_FLEET : RACK_COLUMNS_STANDALONE}
-            currentSort={currentSort}
-            onSort={handleRackSort}
-            itemName={{ singular: "rack", plural: "racks" }}
-            total={totalCount}
-            loading={isLoading}
-            pageSize={DEFAULT_PAGE_SIZE}
-            currentPage={currentPage}
-            hasPreviousPage={currentPage > 0}
-            hasNextPage={hasNextPage}
-            onNextPage={handleRackNextPage}
-            onPrevPage={handleRackPrevPage}
-            emptyStateRow={emptyStateRow}
-            selectedIds={selectedRackIds}
-            onSelectedIdsChange={handleSelectedRackIdsChange}
-            paddingLeft={{ phone: "24px", tablet: "24px", laptop: "40px", desktop: "40px" }}
-            overflowContainer={false}
-          />
-        </div>
-      ) : (
-        <div className="px-6 laptop:px-10">
-          {isLoading && racks.length === 0 ? (
-            <div className="flex items-center justify-center py-20">
-              <ProgressCircular indeterminate />
-            </div>
-          ) : racks.length === 0 ? (
-            <NoFilterResultsEmptyState hasActiveFilters={hasActiveFilters} onClearFilters={handleClearFilters} />
-          ) : (
-            <div ref={measureRef}>
-              <div className="grid gap-1" style={{ gridTemplateColumns: `repeat(${numColumns}, 1fr)` }}>
-                {racks.map((rack) => {
-                  const stats = statsMap.get(rack.id);
-                  const { zone, rows, cols, loading, statusSegments, slots, hashrate, efficiency, power, temperature } =
-                    mapRackToCardProps(rack, stats, temperatureUnit);
-                  return (
-                    <RackCard
-                      key={rack.id.toString()}
-                      label={rack.label}
-                      zone={zone}
-                      cols={cols}
-                      rows={rows}
-                      slots={slots}
-                      loading={loading}
-                      statusSegments={statusSegments}
-                      hashrate={hashrate}
-                      efficiency={efficiency}
-                      power={power}
-                      temperature={temperature}
-                      onClick={() => navigate(`/racks/${rack.id}`)}
-                    />
-                  );
-                })}
-              </div>
-            </div>
-          )}
-          {shouldRenderGridPagination || (currentPage > 0 && racks.length === 0) ? (
-            <div className="sticky left-0 flex flex-col items-center gap-4 py-6">
-              <span className="text-300 text-text-primary">
-                Showing {firstItemIndex}–{lastItemIndex} of {totalCount} racks
-              </span>
-              <div className="flex gap-3">
-                <Button
-                  variant={variants.secondary}
-                  size={sizes.compact}
-                  ariaLabel="Previous page"
-                  prefixIcon={<ChevronDown className="rotate-90" />}
-                  onClick={handleRackPrevPage}
-                  disabled={currentPage === 0}
-                />
-                <Button
-                  variant={variants.secondary}
-                  size={sizes.compact}
-                  ariaLabel="Next page"
-                  prefixIcon={<ChevronDown className="rotate-270" />}
-                  onClick={handleRackNextPage}
-                  disabled={!hasNextPage}
-                />
-              </div>
-            </div>
-          ) : null}
-        </div>
-      )}
-      {selectedRackScopes.length > 0 || isBulkActionBusy ? (
-        <FleetGroupListActionBar
-          selectedScopes={selectedRackScopes}
-          kind="rack"
-          bulkExtraActions={[
-            {
-              label: "Add to building",
-              icon: <Plus />,
-              testId: "fleet-bulk-rack-actions-add-to-building",
-              onClick: () => setBulkReparentKind("building"),
-              hidden: !canManageSitePlacement,
-            },
-            {
-              label: "Add to site",
-              icon: <Plus />,
-              testId: "fleet-bulk-rack-actions-add-to-site",
-              onClick: () => setBulkReparentKind("site"),
-              hidden: !canManageSitePlacement,
-            },
-          ]}
-          onClearSelection={handleClearRackSelection}
-          onSelectAllVisible={handleSelectAllVisibleRacks}
-          onActionBusyChange={setIsBulkActionBusy}
-        />
-      ) : null}
-      {bulkReparentKind ? (
-        <ParentPickerModal
-          kind={bulkReparentKind}
-          show
-          selectionMode="single"
-          sourceLabel={
-            selectedRackScopes.length === 1 ? selectedRackScopes[0]!.name : `${selectedRackScopes.length} racks`
-          }
-          createNewLaunchLabel={
-            createFlow ? (bulkReparentKind === "building" ? "New building" : "New site") : undefined
-          }
-          onCreateNewLaunch={
-            createFlow
-              ? () => {
-                  const rackIds = selectedRackScopes.map((scope) => scope.id);
-                  setBulkReparentKind(null);
-                  setSelectedRackIds([]);
-                  if (bulkReparentKind === "building") {
-                    // A rack in another building OR directly in another site
-                    // will be moved into the new building's site.
-                    const conflictCount = selectedRackScopes.filter(
-                      (scope) => scope.buildingId !== 0n || scope.siteId !== 0n,
-                    ).length;
-                    createFlow.launchCreateBuilding({ rackIds, minerIds: [], conflictCount });
-                  } else {
-                    // A rack directly in another site OR in a building (whose
-                    // building_id AssignRacksToSite clears on the cross-site
-                    // move) is displaced — warn for both.
-                    const conflictCount = selectedRackScopes.filter(
-                      (scope) => scope.siteId !== 0n || scope.buildingId !== 0n,
-                    ).length;
-                    createFlow.launchCreateSite({ buildingIds: [], rackIds, minerIds: [], conflictCount });
-                  }
-                }
-              : undefined
-          }
-          onDismiss={() => setBulkReparentKind(null)}
-          onConfirm={(parentIds) =>
-            new Promise<void>((resolve, reject) => {
-              const parentId = parentIds[0];
-              if (parentId === undefined) {
-                resolve();
-                return;
-              }
-              const buildingMode = bulkReparentKind === "building";
-              // Drop no-op building moves: a same-building request without a
-              // grid position is an explicit unplace server-side, so leaving
-              // already-in-building racks in the batch would silently clear
-              // their placement.
-              const rackIds = buildingMode
-                ? selectedRackScopes.filter((scope) => scope.buildingId !== parentId).map((scope) => scope.id)
-                : selectedRackScopes.map((scope) => scope.id);
-              if (buildingMode && rackIds.length === 0) {
-                pushToast({ message: "Selected racks are already in that building.", status: STATUSES.queued });
-                setBulkReparentKind(null);
-                setSelectedRackIds([]);
-                resolve();
-                return;
-              }
-              const subjectLabel = `${rackIds.length} ${rackIds.length === 1 ? "rack" : "racks"}`;
-              const dispatch = buildingMode
-                ? dispatchRackBuildingAssign(rackIds, parentId, subjectLabel)
-                : dispatchRackSiteAssign(rackIds, parentId, subjectLabel);
-              dispatch
-                .then((ok) => {
-                  if (ok) {
-                    setBulkReparentKind(null);
-                    setSelectedRackIds([]);
-                  }
-                  resolve();
-                })
-                .catch((err) => reject(err instanceof Error ? err : new Error(String(err))));
-            })
-          }
-        />
-      ) : null}
+  // Shared by the null state and the populated page, and rendered as the second
+  // child of a fragment in both: creating the first rack flips hasRacks, and a
+  // separate copy per branch would be a different tree position, so React would
+  // unmount the modal the operator is working in. Keeping the position stable
+  // preserves the create modal's add-miners step across that flip.
+  const rackModalSurfaces = (
+    <>
       {showRackSettingsModal ? (
         <RackSettingsModal
           show={showRackSettingsModal}
@@ -1516,6 +1170,8 @@ const RacksPage = () => {
           defaultSiteId={scopedSiteId}
           onDismiss={() => setShowRackSettingsModal(false)}
           onSubmit={createRack}
+          // Present unconditionally — this is what shows the Single / Multiple
+          // toggle inside the create modal.
           onSubmitBulk={handleCreateRacks}
           saving={creatingRack || creatingRacks}
         />
@@ -1530,6 +1186,7 @@ const RacksPage = () => {
           onDismiss={handleManageRackDismiss}
           onSave={handleManageRackSave}
           onSettingsPersisted={handleRackSettingsPersisted}
+          onDelete={handleDeleteRack}
         />
       ) : null}
       {rackCreateConflict ? (
@@ -1540,126 +1197,462 @@ const RacksPage = () => {
           onConfirm={confirmConflict}
         />
       ) : null}
-      {reparentTarget ? (
-        <ParentPickerModal
-          kind={reparentTarget.kind}
-          show
-          selectionMode="single"
-          sourceLabel={reparentTarget.rack.label || "rack"}
-          description={
-            reparentTarget.rack.deviceCount > 0
-              ? `${reparentTarget.rack.deviceCount} ${reparentTarget.rack.deviceCount === 1 ? "miner" : "miners"} will move with this rack.`
-              : undefined
-          }
-          currentParentId={
-            reparentTarget.rack.typeDetails.case === "rackInfo"
-              ? reparentTarget.kind === "building"
-                ? reparentTarget.rack.typeDetails.value.buildingId
-                : reparentTarget.rack.typeDetails.value.siteId
-              : undefined
-          }
-          createNewLaunchLabel={
-            createFlow ? (reparentTarget.kind === "building" ? "New building" : "New site") : undefined
-          }
-          onCreateNewLaunch={
-            createFlow
-              ? () => {
-                  const rack = reparentTarget.rack;
-                  const targetKind = reparentTarget.kind;
-                  const rackInfo = rack.typeDetails.case === "rackInfo" ? rack.typeDetails.value : undefined;
-                  setReparentTarget(null);
-                  if (targetKind === "building") {
-                    const buildingId = rackInfo?.buildingId ?? 0n;
-                    const siteId = rackInfo?.siteId ?? 0n;
-                    createFlow.launchCreateBuilding({
-                      rackIds: [rack.id],
-                      minerIds: [],
-                      conflictCount: buildingId !== 0n || siteId !== 0n ? 1 : 0,
-                    });
-                  } else {
-                    const siteId = rackInfo?.siteId ?? 0n;
-                    const buildingId = rackInfo?.buildingId ?? 0n;
-                    createFlow.launchCreateSite({
-                      buildingIds: [],
-                      rackIds: [rack.id],
-                      minerIds: [],
-                      // AssignRacksToSite clears building_id on the cross-site
-                      // move, so a building-held rack is displaced too.
-                      conflictCount: siteId !== 0n || buildingId !== 0n ? 1 : 0,
-                    });
-                  }
-                }
-              : undefined
-          }
-          onDismiss={() => setReparentTarget(null)}
-          onConfirm={(parentIds) =>
-            new Promise<void>((resolve, reject) => {
-              const parentId = parentIds[0];
-              if (parentId === undefined) {
-                resolve();
-                return;
-              }
-              const rackName = reparentTarget.rack.label || "rack";
-              const currentBuildingId =
-                reparentTarget.rack.typeDetails.case === "rackInfo"
-                  ? reparentTarget.rack.typeDetails.value.buildingId
-                  : 0n;
-              // No-op building move: a same-building request without a grid
-              // position is an explicit unplace server-side, so don't dispatch
-              // it (it would silently clear this rack's placement).
-              if (reparentTarget.kind === "building" && currentBuildingId === parentId) {
-                pushToast({ message: `"${rackName}" is already in that building.`, status: STATUSES.queued });
-                setReparentTarget(null);
-                resolve();
-                return;
-              }
-              const dispatch =
-                reparentTarget.kind === "building"
-                  ? dispatchRackBuildingAssign([reparentTarget.rack.id], parentId, `"${rackName}"`)
-                  : dispatchRackSiteAssign([reparentTarget.rack.id], parentId, `"${rackName}"`);
-              dispatch
-                .then((ok) => {
-                  if (ok) setReparentTarget(null);
-                  resolve();
-                })
-                .catch((err) => reject(err instanceof Error ? err : new Error(String(err))));
-            })
+    </>
+  );
+
+  if (!hasRacks) {
+    return (
+      <>
+        <NullState
+          className={clsx("sticky left-0", PAGE_SCROLL_CHROME_WIDTH)}
+          icon={<Racks width="w-5" />}
+          title="You haven't set up any racks"
+          description="Add a rack and assign miners to rack positions to get started."
+          action={
+            <Button variant="primary" onClick={() => setShowRackSettingsModal(true)}>
+              Add rack
+            </Button>
           }
         />
-      ) : null}
-      {siteClearConfirmation ? (
-        <Dialog
-          open
-          title="Move racks between sites?"
-          subtitle={siteClearSubtitle(
-            siteClearConfirmation.affectedBuildingLabels,
-            siteClearConfirmation.affectedRackCount,
-            siteClearConfirmation.unresolved,
+        {rackModalSurfaces}
+      </>
+    );
+  }
+
+  return (
+    <>
+      <div>
+        <div className={clsx("sticky left-0 z-3 px-6 pt-6 laptop:px-10 laptop:pt-10", PAGE_SCROLL_CHROME_WIDTH)}>
+          {insideFleetShell ? null : <h1 className="pb-4 text-heading-300 text-text-primary">Racks</h1>}
+          <div className="flex flex-col gap-2 pb-6">
+            {/* Action button — full-width on tablet/phone */}
+            <div className="block laptop:hidden">
+              <Button variant={variants.secondary} size={sizes.compact} onClick={() => setShowRackSettingsModal(true)}>
+                Add rack
+              </Button>
+            </div>
+            {/* View toggle — full width on tablet/phone */}
+            <div className="block laptop:hidden">
+              <SegmentedControl
+                key={`mobile-${racksViewMode}`}
+                className="!w-full whitespace-nowrap [&>button]:flex-1"
+                segmentClassName="text-center"
+                segments={[
+                  { key: "grid", title: "View grid" },
+                  { key: "list", title: "View list" },
+                ]}
+                initialSegmentKey={racksViewMode}
+                onSelect={handleRacksViewModeSelect}
+              />
+            </div>
+            {/* Desktop layout — single row with toggle + filters left, buttons right */}
+            <div className="hidden flex-row flex-wrap items-center gap-2 laptop:flex">
+              <SegmentedControl
+                key={`desktop-${racksViewMode}`}
+                className="shrink-0 whitespace-nowrap"
+                segments={[
+                  { key: "grid", title: "View grid" },
+                  { key: "list", title: "View list" },
+                ]}
+                initialSegmentKey={racksViewMode}
+                onSelect={handleRacksViewModeSelect}
+              />
+              <FilterChipsBar
+                filters={filterChipsBarFilters}
+                onChange={handleFilterChange}
+                numericFilters={TELEMETRY_FILTER_CHIPS}
+                selectedNumericValues={selectedNumericValues}
+                onNumericChange={handleNumericFilterChange}
+                onClearAll={handleClearFilters}
+              />
+              {racksViewMode === "grid" ? (
+                <DropdownFilter
+                  title="Sort"
+                  options={RACK_SORT_OPTIONS}
+                  selectedOptions={[currentSort.field]}
+                  onSelect={handleSortSelect}
+                  showSelectAll={false}
+                  closeOnSelect
+                />
+              ) : null}
+              <Button
+                className="ml-auto"
+                variant={variants.secondary}
+                size={sizes.compact}
+                onClick={() => setShowRackSettingsModal(true)}
+              >
+                Add rack
+              </Button>
+            </div>
+            {/* Filters — shown separately on tablet/phone */}
+            <div className="flex flex-row flex-wrap items-center gap-2 laptop:hidden">
+              <FilterChipsBar
+                filters={filterChipsBarFilters}
+                onChange={handleFilterChange}
+                numericFilters={TELEMETRY_FILTER_CHIPS}
+                selectedNumericValues={selectedNumericValues}
+                onNumericChange={handleNumericFilterChange}
+                onClearAll={handleClearFilters}
+              />
+              {racksViewMode === "grid" ? (
+                <DropdownFilter
+                  title="Sort"
+                  options={RACK_SORT_OPTIONS}
+                  selectedOptions={[currentSort.field]}
+                  onSelect={handleSortSelect}
+                  showSelectAll={false}
+                  closeOnSelect
+                />
+              ) : null}
+            </div>
+          </div>
+        </div>
+        <div
+          className={clsx(
+            "sticky left-0 px-6 pb-4 text-emphasis-300 text-text-primary-70 laptop:px-10",
+            PAGE_SCROLL_CHROME_WIDTH,
           )}
-          onDismiss={() => {
-            if (siteClearInFlight) return;
-            cancelSiteClearConfirmation();
-          }}
-          buttons={[
-            {
-              text: "Cancel",
-              variant: variants.secondary,
-              onClick: cancelSiteClearConfirmation,
-              disabled: siteClearInFlight,
-            },
-            {
-              text: "Continue",
-              variant: variants.primary,
-              onClick: () => {
-                void siteClearConfirmation.onConfirm();
+          data-testid="racks-count-label"
+        >
+          {formatListCountLabel(totalCount, {
+            unfilteredTotal: totalUnfilteredRacks,
+            hasActiveFilters,
+            singular: "rack",
+            plural: "racks",
+          })}
+        </div>
+        {error ? (
+          <Callout className="mx-6 mb-4 laptop:mx-10" intent="danger" prefixIcon={<Alert />} title={error} />
+        ) : null}
+        {racksViewMode === "list" ? (
+          // No horizontal padding or overflow wrapper here: that inset the table
+          // (white gaps beside the row rules) and added a second scroll
+          // container. Row content is indented via DeviceSetList's paddingLeft
+          // so the rules still span the full width, and the page is the single
+          // scroll container.
+          <div className="pb-6 laptop:pb-10">
+            <DeviceSetList
+              deviceSets={racks}
+              statsMap={statsMap}
+              renderName={renderName}
+              renderMiners={renderMiners}
+              renderSite={renderSite}
+              renderBuilding={renderBuilding}
+              columns={insideFleetShell ? RACK_COLUMNS_FLEET : RACK_COLUMNS_STANDALONE}
+              currentSort={currentSort}
+              onSort={handleRackSort}
+              itemName={{ singular: "rack", plural: "racks" }}
+              total={totalCount}
+              loading={isLoading}
+              pageSize={DEFAULT_PAGE_SIZE}
+              currentPage={currentPage}
+              hasPreviousPage={currentPage > 0}
+              hasNextPage={hasNextPage}
+              onNextPage={handleRackNextPage}
+              onPrevPage={handleRackPrevPage}
+              emptyStateRow={emptyStateRow}
+              selectedIds={selectedRackIds}
+              onSelectedIdsChange={handleSelectedRackIdsChange}
+              paddingLeft={{ phone: "24px", tablet: "24px", laptop: "40px", desktop: "40px" }}
+              overflowContainer={false}
+            />
+          </div>
+        ) : (
+          <div className="px-6 laptop:px-10">
+            {isLoading && racks.length === 0 ? (
+              <div className="flex items-center justify-center py-20">
+                <ProgressCircular indeterminate />
+              </div>
+            ) : racks.length === 0 ? (
+              <NoFilterResultsEmptyState hasActiveFilters={hasActiveFilters} onClearFilters={handleClearFilters} />
+            ) : (
+              <div ref={measureRef}>
+                <div className="grid gap-1" style={{ gridTemplateColumns: `repeat(${numColumns}, 1fr)` }}>
+                  {racks.map((rack) => {
+                    const stats = statsMap.get(rack.id);
+                    const {
+                      zone,
+                      rows,
+                      cols,
+                      loading,
+                      statusSegments,
+                      slots,
+                      hashrate,
+                      efficiency,
+                      power,
+                      temperature,
+                    } = mapRackToCardProps(rack, stats, temperatureUnit);
+                    return (
+                      <RackCard
+                        key={rack.id.toString()}
+                        label={rack.label}
+                        zone={zone}
+                        cols={cols}
+                        rows={rows}
+                        slots={slots}
+                        loading={loading}
+                        statusSegments={statusSegments}
+                        hashrate={hashrate}
+                        efficiency={efficiency}
+                        power={power}
+                        temperature={temperature}
+                        onClick={() => navigate(`/racks/${rack.id}`)}
+                      />
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+            {shouldRenderGridPagination || (currentPage > 0 && racks.length === 0) ? (
+              <div className="sticky left-0 flex flex-col items-center gap-4 py-6">
+                <span className="text-300 text-text-primary">
+                  Showing {firstItemIndex}–{lastItemIndex} of {totalCount} racks
+                </span>
+                <div className="flex gap-3">
+                  <Button
+                    variant={variants.secondary}
+                    size={sizes.compact}
+                    ariaLabel="Previous page"
+                    prefixIcon={<ChevronDown className="rotate-90" />}
+                    onClick={handleRackPrevPage}
+                    disabled={currentPage === 0}
+                  />
+                  <Button
+                    variant={variants.secondary}
+                    size={sizes.compact}
+                    ariaLabel="Next page"
+                    prefixIcon={<ChevronDown className="rotate-270" />}
+                    onClick={handleRackNextPage}
+                    disabled={!hasNextPage}
+                  />
+                </div>
+              </div>
+            ) : null}
+          </div>
+        )}
+        {selectedRackScopes.length > 0 || isBulkActionBusy ? (
+          <FleetGroupListActionBar
+            selectedScopes={selectedRackScopes}
+            kind="rack"
+            bulkExtraActions={[
+              {
+                label: "Add to building",
+                icon: <Plus />,
+                testId: "fleet-bulk-rack-actions-add-to-building",
+                onClick: () => setBulkReparentKind("building"),
+                hidden: !canManageSitePlacement,
               },
-              loading: siteClearInFlight,
-              disabled: siteClearInFlight,
-            },
-          ]}
-        />
-      ) : null}
-    </div>
+              {
+                label: "Add to site",
+                icon: <Plus />,
+                testId: "fleet-bulk-rack-actions-add-to-site",
+                onClick: () => setBulkReparentKind("site"),
+                hidden: !canManageSitePlacement,
+              },
+            ]}
+            onClearSelection={handleClearRackSelection}
+            onSelectAllVisible={handleSelectAllVisibleRacks}
+            onActionBusyChange={setIsBulkActionBusy}
+          />
+        ) : null}
+        {bulkReparentKind ? (
+          <ParentPickerModal
+            kind={bulkReparentKind}
+            show
+            selectionMode="single"
+            sourceLabel={
+              selectedRackScopes.length === 1 ? selectedRackScopes[0]!.name : `${selectedRackScopes.length} racks`
+            }
+            createNewLaunchLabel={
+              createFlow ? (bulkReparentKind === "building" ? "New building" : "New site") : undefined
+            }
+            onCreateNewLaunch={
+              createFlow
+                ? () => {
+                    const rackIds = selectedRackScopes.map((scope) => scope.id);
+                    setBulkReparentKind(null);
+                    setSelectedRackIds([]);
+                    if (bulkReparentKind === "building") {
+                      // A rack in another building OR directly in another site
+                      // will be moved into the new building's site.
+                      const conflictCount = selectedRackScopes.filter(
+                        (scope) => scope.buildingId !== 0n || scope.siteId !== 0n,
+                      ).length;
+                      createFlow.launchCreateBuilding({ rackIds, minerIds: [], conflictCount });
+                    } else {
+                      // A rack directly in another site OR in a building (whose
+                      // building_id AssignRacksToSite clears on the cross-site
+                      // move) is displaced — warn for both.
+                      const conflictCount = selectedRackScopes.filter(
+                        (scope) => scope.siteId !== 0n || scope.buildingId !== 0n,
+                      ).length;
+                      createFlow.launchCreateSite({ buildingIds: [], rackIds, minerIds: [], conflictCount });
+                    }
+                  }
+                : undefined
+            }
+            onDismiss={() => setBulkReparentKind(null)}
+            onConfirm={(parentIds) =>
+              new Promise<void>((resolve, reject) => {
+                const parentId = parentIds[0];
+                if (parentId === undefined) {
+                  resolve();
+                  return;
+                }
+                const buildingMode = bulkReparentKind === "building";
+                // Drop no-op building moves: a same-building request without a
+                // grid position is an explicit unplace server-side, so leaving
+                // already-in-building racks in the batch would silently clear
+                // their placement.
+                const rackIds = buildingMode
+                  ? selectedRackScopes.filter((scope) => scope.buildingId !== parentId).map((scope) => scope.id)
+                  : selectedRackScopes.map((scope) => scope.id);
+                if (buildingMode && rackIds.length === 0) {
+                  pushToast({ message: "Selected racks are already in that building.", status: STATUSES.queued });
+                  setBulkReparentKind(null);
+                  setSelectedRackIds([]);
+                  resolve();
+                  return;
+                }
+                const subjectLabel = `${rackIds.length} ${rackIds.length === 1 ? "rack" : "racks"}`;
+                const dispatch = buildingMode
+                  ? dispatchRackBuildingAssign(rackIds, parentId, subjectLabel)
+                  : dispatchRackSiteAssign(rackIds, parentId, subjectLabel);
+                dispatch
+                  .then((ok) => {
+                    if (ok) {
+                      setBulkReparentKind(null);
+                      setSelectedRackIds([]);
+                    }
+                    resolve();
+                  })
+                  .catch((err) => reject(err instanceof Error ? err : new Error(String(err))));
+              })
+            }
+          />
+        ) : null}
+        {reparentTarget ? (
+          <ParentPickerModal
+            kind={reparentTarget.kind}
+            show
+            selectionMode="single"
+            sourceLabel={reparentTarget.rack.label || "rack"}
+            description={
+              reparentTarget.rack.deviceCount > 0
+                ? `${reparentTarget.rack.deviceCount} ${reparentTarget.rack.deviceCount === 1 ? "miner" : "miners"} will move with this rack.`
+                : undefined
+            }
+            currentParentId={
+              reparentTarget.rack.typeDetails.case === "rackInfo"
+                ? reparentTarget.kind === "building"
+                  ? reparentTarget.rack.typeDetails.value.buildingId
+                  : reparentTarget.rack.typeDetails.value.siteId
+                : undefined
+            }
+            createNewLaunchLabel={
+              createFlow ? (reparentTarget.kind === "building" ? "New building" : "New site") : undefined
+            }
+            onCreateNewLaunch={
+              createFlow
+                ? () => {
+                    const rack = reparentTarget.rack;
+                    const targetKind = reparentTarget.kind;
+                    const rackInfo = rack.typeDetails.case === "rackInfo" ? rack.typeDetails.value : undefined;
+                    setReparentTarget(null);
+                    if (targetKind === "building") {
+                      const buildingId = rackInfo?.buildingId ?? 0n;
+                      const siteId = rackInfo?.siteId ?? 0n;
+                      createFlow.launchCreateBuilding({
+                        rackIds: [rack.id],
+                        minerIds: [],
+                        conflictCount: buildingId !== 0n || siteId !== 0n ? 1 : 0,
+                      });
+                    } else {
+                      const siteId = rackInfo?.siteId ?? 0n;
+                      const buildingId = rackInfo?.buildingId ?? 0n;
+                      createFlow.launchCreateSite({
+                        buildingIds: [],
+                        rackIds: [rack.id],
+                        minerIds: [],
+                        // AssignRacksToSite clears building_id on the cross-site
+                        // move, so a building-held rack is displaced too.
+                        conflictCount: siteId !== 0n || buildingId !== 0n ? 1 : 0,
+                      });
+                    }
+                  }
+                : undefined
+            }
+            onDismiss={() => setReparentTarget(null)}
+            onConfirm={(parentIds) =>
+              new Promise<void>((resolve, reject) => {
+                const parentId = parentIds[0];
+                if (parentId === undefined) {
+                  resolve();
+                  return;
+                }
+                const rackName = reparentTarget.rack.label || "rack";
+                const currentBuildingId =
+                  reparentTarget.rack.typeDetails.case === "rackInfo"
+                    ? reparentTarget.rack.typeDetails.value.buildingId
+                    : 0n;
+                // No-op building move: a same-building request without a grid
+                // position is an explicit unplace server-side, so don't dispatch
+                // it (it would silently clear this rack's placement).
+                if (reparentTarget.kind === "building" && currentBuildingId === parentId) {
+                  pushToast({ message: `"${rackName}" is already in that building.`, status: STATUSES.queued });
+                  setReparentTarget(null);
+                  resolve();
+                  return;
+                }
+                const dispatch =
+                  reparentTarget.kind === "building"
+                    ? dispatchRackBuildingAssign([reparentTarget.rack.id], parentId, `"${rackName}"`)
+                    : dispatchRackSiteAssign([reparentTarget.rack.id], parentId, `"${rackName}"`);
+                dispatch
+                  .then((ok) => {
+                    if (ok) setReparentTarget(null);
+                    resolve();
+                  })
+                  .catch((err) => reject(err instanceof Error ? err : new Error(String(err))));
+              })
+            }
+          />
+        ) : null}
+        {siteClearConfirmation ? (
+          <Dialog
+            open
+            title="Move racks between sites?"
+            subtitle={siteClearSubtitle(
+              siteClearConfirmation.affectedBuildingLabels,
+              siteClearConfirmation.affectedRackCount,
+              siteClearConfirmation.unresolved,
+            )}
+            onDismiss={() => {
+              if (siteClearInFlight) return;
+              cancelSiteClearConfirmation();
+            }}
+            buttons={[
+              {
+                text: "Cancel",
+                variant: variants.secondary,
+                onClick: cancelSiteClearConfirmation,
+                disabled: siteClearInFlight,
+              },
+              {
+                text: "Continue",
+                variant: variants.primary,
+                onClick: () => {
+                  void siteClearConfirmation.onConfirm();
+                },
+                loading: siteClearInFlight,
+                disabled: siteClearInFlight,
+              },
+            ]}
+          />
+        ) : null}
+      </div>
+      {rackModalSurfaces}
+    </>
   );
 };
 

--- a/client/src/protoFleet/utils/bulkNameSeries.test.ts
+++ b/client/src/protoFleet/utils/bulkNameSeries.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { buildBulkNameSeries, formatBulkCounter, overlongNameIndexes } from "./bulkNameSeries";
+
+describe("formatBulkCounter", () => {
+  it("treats scale as a zero-pad width, matching bulk rename", () => {
+    expect(formatBulkCounter(1, 1)).toBe("1");
+    expect(formatBulkCounter(1, 3)).toBe("001");
+    expect(formatBulkCounter(42, 4)).toBe("0042");
+  });
+
+  it("leaves a number wider than the scale intact rather than truncating it", () => {
+    expect(formatBulkCounter(1000, 2)).toBe("1000");
+  });
+
+  it("clamps an out-of-range scale into the supported 1-6 window", () => {
+    expect(formatBulkCounter(7, 0)).toBe("7");
+    expect(formatBulkCounter(7, 99)).toBe("000007");
+  });
+});
+
+describe("overlongNameIndexes", () => {
+  it("measures the finished name, counter included", () => {
+    // The prefix fits on its own; the zero-padding is what puts it over.
+    const names = buildBulkNameSeries(2, { namePrefix: "x".repeat(97), counterStart: 1, counterScale: 6 }, 500);
+    expect(names.map((n) => n.length)).toEqual([103, 103]);
+    expect(overlongNameIndexes(names, 100)).toEqual([0, 1]);
+  });
+
+  it("flags only the rows that cross the cap, so a widening counter shows up mid-run", () => {
+    // 9 → 10 widens the counter past the padding, so the run straddles the cap.
+    const names = buildBulkNameSeries(3, { namePrefix: "y".repeat(9), counterStart: 9, counterScale: 1 }, 500);
+    expect(names).toEqual(["yyyyyyyyy9", "yyyyyyyyy10", "yyyyyyyyy11"]);
+    expect(overlongNameIndexes(names, 10)).toEqual([1, 2]);
+  });
+
+  it("returns nothing when every name fits", () => {
+    expect(overlongNameIndexes(["A-1", "A-2"], 100)).toEqual([]);
+  });
+});

--- a/client/src/protoFleet/utils/bulkNameSeries.ts
+++ b/client/src/protoFleet/utils/bulkNameSeries.ts
@@ -1,0 +1,71 @@
+// Counter math shared by the bulk create forms (buildings at a site, racks in a
+// building). Both generate a run of names from a prefix plus an incrementing,
+// zero-padded counter, and both feed the same string list to their preview and
+// their RPC — so the math lives in one place rather than being reimplemented per
+// feature, where the padding and clamping edges could drift apart.
+//
+// The prefix + counter-start + counter-scale triple is deliberately the same
+// shape the bulk-rename flow uses (see bulkRenamePreview.ts): scale is a
+// zero-pad WIDTH, not a multiplier, so start 1 at scale 3 reads "001". An
+// operator who has used bulk rename already knows what these three fields do.
+
+import {
+  counterScaleMaximum,
+  counterScaleMinimum,
+} from "@/protoFleet/features/fleetManagement/components/MinerActionsMenu/RenameOptionsModals/constants";
+
+export interface BulkNameOptions {
+  namePrefix: string;
+  counterStart: number;
+  counterScale: number;
+}
+
+// Zero-pads to `scale` digits. A number already wider than the scale is left
+// alone rather than truncated — silently renaming building 1000 to "000" would
+// be worse than an inconsistent width.
+export const formatBulkCounter = (value: number, scale: number): string =>
+  String(value).padStart(clampScale(scale), "0");
+
+const clampScale = (scale: number): number => {
+  if (!Number.isFinite(scale)) return counterScaleMinimum;
+  return Math.min(Math.max(Math.trunc(scale), counterScaleMinimum), counterScaleMaximum);
+};
+
+// The names the batch will submit, in order. This is the single source of truth
+// for both the on-screen preview and the request payload — the preview cannot
+// show one thing and the RPC create another.
+//
+// The prefix is used exactly as typed: "Building - " has to reach the counter
+// with its trailing space intact, since that spacing is the separator the
+// operator chose. (Bulk rename trims its prefix, but there the sections are
+// joined by an explicit "-", so interior spacing isn't theirs to control.)
+// Space around the *finished* name is still the server's to strip.
+export const buildBulkNameSeries = (count: number, options: BulkNameOptions, maxRows: number): string[] => {
+  const rows = Math.min(Math.max(Math.trunc(count) || 0, 0), maxRows);
+  const start = Number.isFinite(options.counterStart) ? Math.trunc(options.counterStart) : 1;
+  return Array.from(
+    { length: rows },
+    (_, i) => `${options.namePrefix}${formatBulkCounter(start + i, options.counterScale)}`,
+  );
+};
+
+// Generated names the server would refuse for length. Checked on the finished
+// name, not the prefix: the counter is part of what gets stored, so a prefix
+// that fits on its own still overflows once the zero-padding widens it (or the
+// counter outgrows the padding). Length is compared untrimmed because that is
+// what buf.validate measures.
+export const overlongNameIndexes = (names: string[], maxLength: number): number[] =>
+  names.reduce<number[]>((acc, name, i) => {
+    if (name.length > maxLength) acc.push(i);
+    return acc;
+  }, []);
+
+// Generated names that collide with one already in use. Compared on the trimmed
+// value because that is what the server stores.
+export const takenNameIndexes = (names: string[], existingNames: string[]): number[] => {
+  const taken = new Set(existingNames.map((n) => n.trim()));
+  return names.reduce<number[]>((acc, name, i) => {
+    if (taken.has(name.trim())) acc.push(i);
+    return acc;
+  }, []);
+};

--- a/client/src/shared/components/Input/Input.test.tsx
+++ b/client/src/shared/components/Input/Input.test.tsx
@@ -111,6 +111,42 @@ describe("Input", () => {
   });
 });
 
+describe("Input sanitize", () => {
+  test("rejects a character instead of displaying it", () => {
+    const onChange = vi.fn();
+    render(
+      <Input
+        id="count"
+        label="Count"
+        testId="count-input"
+        sanitize={(value) => value.replace(/\D/g, "")}
+        onChange={onChange}
+      />,
+    );
+    const input = screen.getByTestId("count-input") as HTMLInputElement;
+
+    fireEvent.change(input, { target: { value: "5" } });
+    expect(input.value).toBe("5");
+    expect(onChange).toHaveBeenLastCalledWith("5", "count");
+
+    // The case a caller cannot fix from outside: sanitizing "5a" returns the
+    // "5" already on screen, so a caller sanitizing in onChange would have no
+    // prop change to re-sync the display from. The rejected character must not
+    // survive, and onChange must never be told something the field is not
+    // showing.
+    fireEvent.change(input, { target: { value: "5a" } });
+    expect(input.value).toBe("5");
+    expect(onChange).toHaveBeenLastCalledWith("5", "count");
+  });
+
+  test("leaves the value untouched when no sanitize is given", () => {
+    render(<Input id="free" label="Free" testId="free-input" />);
+    const input = screen.getByTestId("free-input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "5a" } });
+    expect(input.value).toBe("5a");
+  });
+});
+
 describe("Input ARIA attributes", () => {
   test("renders aria-required when required prop is set", () => {
     render(<Input id="email" label="Email" required />);

--- a/client/src/shared/components/Input/Input.tsx
+++ b/client/src/shared/components/Input/Input.tsx
@@ -45,6 +45,14 @@ interface InputProps {
   maxLength?: number;
   onChange?: (value: string, id: string) => void;
   onChangeBlur?: (value: string, id: string) => void;
+  // Rejects characters before they are displayed, for fields that accept only
+  // part of what a keyboard can produce (digits, say). It has to run here: this
+  // component owns the displayed value and only re-seeds it from `initValue`
+  // when that prop changes, so a caller sanitizing in `onChange` gets no
+  // re-sync when the sanitized result is unchanged — the rejected character
+  // stays on screen while the caller holds the clean value. Applied before both
+  // the internal update and `onChange`, so they never disagree.
+  sanitize?: (value: string) => string;
   onKeyDown?: (key: string) => void;
   readOnly?: boolean;
   testId?: string;
@@ -85,6 +93,7 @@ const Input = ({
   onChange,
   onChangeBlur,
   onKeyDown,
+  sanitize,
   readOnly,
   testId,
   tooltip,
@@ -152,11 +161,12 @@ const Input = ({
 
   const handleChange = useCallback(
     (event?: ChangeEvent<HTMLInputElement>) => {
-      const newValue = (event?.target as HTMLInputElement).value || "";
+      const raw = (event?.target as HTMLInputElement).value || "";
+      const newValue = sanitize ? sanitize(raw) : raw;
       setValue(newValue);
       onChange?.(newValue, id);
     },
-    [onChange, id],
+    [onChange, id, sanitize],
   );
 
   const handleKeyDown = useCallback(

--- a/client/src/shared/components/Modal/Modal.tsx
+++ b/client/src/shared/components/Modal/Modal.tsx
@@ -180,7 +180,22 @@ const Modal = ({
           {showHeader ? (
             <div
               ref={headerRef}
-              className={clsx("sticky top-0 z-10 bg-surface-elevated-base pt-6", { "phone:hidden": hideHeaderOnPhone })}
+              // Two things keep the sticky background actually opaque:
+              //
+              // flex-col — headerSpacingClassName is a margin on an empty
+              // trailing div, and in normal flow that margin collapses out of
+              // this box. The header painted 16px shorter than it occupied, so
+              // body content scrolled through the gap. Flex items don't collapse.
+              //
+              // -mx-6 px-6 — the scroll container's own px-6 would otherwise
+              // leave a 24px gutter down each side of the header, where borders
+              // and other body content stayed visible. The header has to reach
+              // the container's padding edge; the padding puts its contents back.
+              // Safe against the callers that pass `!p-0`, since those all set
+              // showHeader={false}.
+              className={clsx("sticky top-0 z-10 -mx-6 flex flex-col bg-surface-elevated-base px-6 pt-6", {
+                "phone:hidden": hideHeaderOnPhone,
+              })}
             >
               <div className="relative">
                 <Header

--- a/client/src/shared/components/SegmentedControl/SegmentedControl.tsx
+++ b/client/src/shared/components/SegmentedControl/SegmentedControl.tsx
@@ -54,8 +54,16 @@ const SegmentedControl = ({
   if (segments.length === 0) return null;
 
   return (
+    // isolate contains the segment labels' z-10 (Segment.tsx), which only needs
+    // to beat the sliding pill below it. Without a stacking context here that
+    // z-10 leaks into whatever ancestor has one, where it tied with a modal's
+    // sticky header — same z-index, later in the DOM — and the labels painted
+    // over the header as the body scrolled under it.
     <div
-      className={clsx("relative flex h-full w-fit flex-row gap-2 rounded-3xl bg-core-primary-5 p-[2px]", className)}
+      className={clsx(
+        "relative isolate flex h-full w-fit flex-row gap-2 rounded-3xl bg-core-primary-5 p-[2px]",
+        className,
+      )}
       data-testid="segmented-control"
     >
       <div


### PR DESCRIPTION
> Replaces #858. An accidental force-push to `feat/2-create-buildings-rpc` briefly made it contain this branch's commits, so GitHub marked #858 merged and deleted the head branch. It cannot be reopened. Same content, rebased onto `feat/3-create-racks-rpc`; the earlier review history is on #858.

Reviewable diff: +1486/-429 across 20 files (excludes generated, test, and story files).

## Summary

Two changes to the rack modals that belong together.

**Multiple mode.** `RackSettingsModal` gets a Single/Multiple segmented control. Multiple takes a label prefix, a count, a counter start, and a counter scale, previews the generated labels, and creates them in one `CreateRacks` call (#862) — so standing up 40 racks is one action instead of 40.

**CTAs write when clicked.** The rack modals move off staged changes: every CTA performs its write immediately, matching the strategy the site and building modals already use. This is what makes placement-in-one-call from #855 usable, and it removes the class of bug where a "clean" Save silently discarded staged edits.

### Stack — 6 PRs, merge in order

| # | PR | What it adds |
|---|----|--------------|
| 1 | #855 | `AssignDevicesToRack` also writes rack slot placement |
| 2 | #856 | `CreateBuildings` batch RPC |
| 3 | #862 | `CreateRacks` batch RPC |
| **4** | **#863 ← this PR** | Rack create modal gains a Multiple mode |
| 5 | #864 | Building surfaces: create racks and buildings inline |
| 6 | #860 | Site surfaces: create buildings inline |

Together the series lets an operator build out the physical hierarchy without leaving the modal they are in — buildings from inside a site, racks from inside a building — and create them in batches from a generated name series. PRs 1–3 are the backend RPCs; 4–6 are the UI that calls them.

## How it works

Label generation lives in a shared util, `utils/bulkNameSeries.ts`, wrapped per feature by `bulkRackLabels.ts`. Labels are generated live from the current form state, so the preview and what gets sent are the same strings.

Generated labels are length-checked **client side, on the finished label** — not on the prefix. Counter width is part of the stored name, so a 97-character prefix that fits on its own overflows once the scale widens the counter. Overlong rows are marked in the preview and submit is refused, instead of the whole batch coming back as a generic `InvalidArgument` toast.

On the write side, `useCreateRack` handles one rack and `useCreateRacks` the batch. The pickers inside `ManageRackModal` now commit membership as they are used, and Save owns placement — a split that only works because `AssignDevicesToRack` can write both halves.

```mermaid
flowchart TD
  A["RackSettingsModal"] -->|Single| B["useCreateRack → SaveRack"]
  A -->|Multiple| C["prefix + count + start + scale"]
  C --> D["bulkNameSeries → labels[]"]
  D --> E["length check on finished labels"]
  E -->|overlong| F["mark rows, refuse submit"]
  E -->|ok| G["useCreateRacks → CreateRacks"]
  G -->|per-row errors| H["mark the offending rows"]
```

## Areas of the code involved

| Area | What changed | Why it matters |
|---|---|---|
| `features/fleetManagement/components/RackSettingsModal.tsx` | Single/Multiple modes, validate-on-submit, length guard | The main review target |
| `utils/bulkNameSeries.ts` + `components/bulkRackLabels.ts` | Shared name-series generation and the 100-char label bound | Reused by #864 for buildings |
| `hooks/useCreateRack.ts`, `hooks/useCreateRacks.ts` | Single and batch write paths | |
| `components/ManageRackModal/*` | Pickers commit on click; Save owns placement | Largest behavioral change — where staged state was removed |
| `api/useDeviceSets.ts`, `api/buildings.ts` | Batch mutation hooks | |
| `pages/RacksPage.tsx`, `pages/RackOverviewPage.tsx`, `FleetCreateFlowProvider.tsx` | Hosts follow the new CTA contract | |
| `shared/components/Modal.tsx`, `SegmentedControl.tsx` | Sticky-header bleed, segment z-index containment | Shared components — small, scoped |
| `client/e2eTests/**/racks*` | Playwright specs follow the new commit boundaries | |

## Key technical decisions

- **Validate the finished label, not the prefix** — scale and start can be raised after the prefix is typed, so a prefix-length cap would be wrong in both directions.
- **Mark rows live from the generated labels**, not from a failed submit — a 500-row batch shows which rows overflow before you click.
- **CTAs stay clickable and validate on click** rather than being disabled, per the project's no-disabled-CTA rule; `saving` and not-yet-loaded are the only disabled states.
- **One shared name-series util** with thin per-feature wrappers, so racks and buildings can't drift apart on padding or counter behavior.

## Testing & validation

- `tsc --noEmit` clean; full client suite passes (3869 tests), including new coverage for zero-padding, counter bounds, and a regression test that a 97-char prefix at scale 6 is refused client side and recovers at scale 1.
- Rack Playwright specs and page objects updated in this PR so they land with the behavior they assert. Not executed locally (needs docker-compose) — worth a CI/manual e2e pass.


