### PR TITLE
chore(deps): bump actions/checkout from 7.0.0 to 7.0.1

### DIFF
--- a/.github/workflows/protofleet-e2e-tests.yml
+++ b/.github/workflows/protofleet-e2e-tests.yml
@@ -350,7 +350,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 


### PR DESCRIPTION
Reviewable diff: +1/-1 across 1 file (excludes generated, test, and story files).

## Summary
The ProtoFleet visual-test job now uses the same current `actions/checkout` release as every other workflow. The action remains pinned to an immutable commit SHA to preserve the repository's supply-chain convention.

## How it works
The visual-test job resolves `actions/checkout` v7.0.1 by its full commit SHA before setting up Hermit, restoring caches, and running Playwright. The adjacent version comment keeps automated and human dependency audits readable.

## Diagrams
```mermaid
flowchart LR
  A["Visual-test job starts"] --> B["Checkout repository at pinned v7.0.1 SHA"]
  B --> C["Set up tools and caches"]
  C --> D["Run visual tests"]
```

## Areas of the code involved
| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `.github/workflows/protofleet-e2e-tests.yml` | Aligned the visual-test checkout pin with v7.0.1 | Confirm the SHA matches the upstream release and remains immutable |

## Key technical decisions & trade-offs
- Pin the exact v7.0.1 commit instead of a moving major-version tag, preserving reproducibility and limiting dependency substitution risk.
- Keep the version comment beside the SHA instead of introducing shared indirection, matching existing workflow conventions.

## Testing & validation
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/protofleet-e2e-tests.yml`
- `git diff --check`
- Confirmed the SHA resolves to the upstream `actions/checkout` v7.0.1 tag.
- No application tests were run because this is a mechanical CI dependency-pin update.

## Post-Deploy Monitoring & Validation
No additional operational monitoring required: this change has no production/runtime impact. Validate the visual-test job on this PR's first CI run; the PR author owns validation, and any checkout regression should trigger an immediate revert before merge.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Cursor / GPT-5.6 Sol](https://img.shields.io/badge/Cursor-GPT--5.6_Sol-000000)
