### PR TITLE
feat(ha): wire opt-in production runtime

### DIFF
--- a/server/cmd/fleetd/config.go
+++ b/server/cmd/fleetd/config.go
@@ -15,6 +15,7 @@ import (
 	"github.com/block/proto-fleet/server/internal/domain/telemetry/scheduler"
 	"github.com/block/proto-fleet/server/internal/domain/token"
 	"github.com/block/proto-fleet/server/internal/domain/updates"
+	"github.com/block/proto-fleet/server/internal/ha"
 	"github.com/block/proto-fleet/server/internal/infrastructure/db"
 	"github.com/block/proto-fleet/server/internal/infrastructure/encrypt"
 	"github.com/block/proto-fleet/server/internal/infrastructure/files"
@@ -60,6 +61,7 @@ type Config struct {
 	Files          files.Config                 `embed:"" prefix:"files-" envprefix:"FILES_"`
 	FleetTelemetry fleet_telemetry.Config       `embed:"" prefix:"fleet-telemetry-" envprefix:"FLEET_TELEMETRY_"`
 	Metrics        metrics.Config               `embed:"" prefix:"metrics-" envprefix:"FLEET_ALERTS_"`
+	HA             ha.Config                    `embed:"" prefix:"ha-" envprefix:"FLEET_HA_"`
 
 	SystemMonitoring sysmon.Config `embed:"" prefix:"system-monitoring-" envprefix:"FLEET_SYSTEM_MONITORING_"`
 }

--- a/server/cmd/fleetd/main.go
+++ b/server/cmd/fleetd/main.go
@@ -179,6 +179,9 @@ var reflectEnabledServices = []string{
 }
 
 func start(config *Config) error {
+	if err := config.HA.Validate(); err != nil {
+		return fmt.Errorf("invalid HA configuration: %w", err)
+	}
 	// Construct one configured registry before starting services. The CRUD
 	// service uses it now; the Phase 5 reconciler will share this same instance.
 	infrastructureDriverRegistry, err := infrastructureDomain.NewConfiguredDriverRegistry(config.Infrastructure)
@@ -668,11 +671,20 @@ func start(config *Config) error {
 	if err != nil {
 		return fmt.Errorf("create runtime job group: %w", err)
 	}
-	// HA configuration is not exposed yet, so production stays standalone.
-	fleetRuntime, err := ha.NewStandaloneRuntime(runtimeJobGroup, executionService.IsRunning)
+	fleetRuntime, closeHA, err := ha.NewConfiguredRuntime(
+		config.HA,
+		conn,
+		runtimeJobGroup,
+		executionService.IsRunning,
+	)
 	if err != nil {
 		return fmt.Errorf("create Fleet runtime: %w", err)
 	}
+	defer func() {
+		if err := closeHA(); err != nil {
+			slog.Error("Failed to close HA services", "error", err)
+		}
+	}()
 	defer func() {
 		stopRuntimeJobGroup(runtimeJobGroup, executionService, shutdownTimeout)
 	}()

--- a/server/cmd/fleetd/main.go
+++ b/server/cmd/fleetd/main.go
@@ -691,10 +691,7 @@ func start(config *Config) (result error) {
 		}
 	}()
 	defer func() {
-		if errors.Is(result, ha.ErrOwnershipLost) {
-			return
-		}
-		stopRuntimeJobGroup(runtimeJobGroup, executionService, shutdownTimeout)
+		stopRuntimeJobGroupAfterRun(result, runtimeJobGroup, executionService, shutdownTimeout)
 	}()
 
 	middlewares := []server.Middleware{

--- a/server/cmd/fleetd/main.go
+++ b/server/cmd/fleetd/main.go
@@ -178,9 +178,14 @@ var reflectEnabledServices = []string{
 	instancev1connect.InstanceUpdateServiceName,
 }
 
-func start(config *Config) error {
+func start(config *Config) (result error) {
 	if err := config.HA.Validate(); err != nil {
 		return fmt.Errorf("invalid HA configuration: %w", err)
+	}
+	if config.HA.Enabled {
+		if err := config.DB.ValidateHA(); err != nil {
+			return fmt.Errorf("invalid HA database configuration: %w", err)
+		}
 	}
 	// Construct one configured registry before starting services. The CRUD
 	// service uses it now; the Phase 5 reconciler will share this same instance.
@@ -686,6 +691,9 @@ func start(config *Config) error {
 		}
 	}()
 	defer func() {
+		if errors.Is(result, ha.ErrOwnershipLost) {
+			return
+		}
 		stopRuntimeJobGroup(runtimeJobGroup, executionService, shutdownTimeout)
 	}()
 

--- a/server/cmd/fleetd/main_test.go
+++ b/server/cmd/fleetd/main_test.go
@@ -121,6 +121,33 @@ encrypt:
 	require.Equal(t, explicitDSN, config.DB.ExplicitDSN)
 }
 
+func TestFleetdParsesHAEnabledFromEnv(t *testing.T) {
+	t.Setenv("FLEET_HA_ENABLED", "true")
+	t.Setenv("FLEET_HA_ETCD_ENDPOINTS", "https://10.0.0.1:2379,https://10.0.0.2:2379")
+
+	configPath := writeFleetdConfigFile(t, `
+auth:
+  client:
+    expiration-period: "1h"
+    secret-key: "test-client-secret"
+  miner-token-expiration-period: "30m"
+encrypt:
+  service-master-key: "test-master-key"
+`)
+	config := &Config{}
+	parser, err := kong.New(
+		config,
+		kong.Name("fleetd"),
+		kong.Configuration(kongyaml.Loader, configPath),
+	)
+	require.NoError(t, err)
+	_, err = parser.Parse(nil)
+	require.NoError(t, err)
+	require.True(t, config.HA.Enabled)
+	require.Equal(t, []string{"https://10.0.0.1:2379", "https://10.0.0.2:2379"}, config.HA.EtcdEndpoints)
+	require.NoError(t, config.HA.Validate())
+}
+
 func TestFleetdInfrastructureOTControlSubnetsFlag(t *testing.T) {
 	t.Parallel()
 

--- a/server/cmd/fleetd/runtime_jobs.go
+++ b/server/cmd/fleetd/runtime_jobs.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/block/proto-fleet/server/internal/ha"
 	"github.com/block/proto-fleet/server/internal/runtimejobs"
 )
 
@@ -167,6 +168,19 @@ func serveFleetRuntime(
 		}
 		return fmt.Errorf("serve HTTP: %w", serverErr)
 	}
+}
+
+// stopRuntimeJobGroupAfterRun avoids repeating cleanup already completed by a fatal HA abort.
+func stopRuntimeJobGroupAfterRun(
+	runErr error,
+	group runtimeJobGroupStopper,
+	commandExecution runtimejobs.Lifecycle,
+	timeout time.Duration,
+) {
+	if errors.Is(runErr, ha.ErrRuntimeAborted) {
+		return
+	}
+	stopRuntimeJobGroup(group, commandExecution, timeout)
 }
 
 // stopRuntimeJobGroup gives the group one graceful-shutdown budget. Command

--- a/server/cmd/fleetd/runtime_jobs_test.go
+++ b/server/cmd/fleetd/runtime_jobs_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/block/proto-fleet/server/internal/ha"
 	"github.com/block/proto-fleet/server/internal/runtimejobs"
 	"github.com/stretchr/testify/require"
 )
@@ -231,6 +232,39 @@ func TestStopRuntimeJobGroupDoesNotRetrySuccessfulStop(t *testing.T) {
 	require.Len(t, group.contexts, 1)
 	_, hasDeadline := group.contexts[0].Deadline()
 	require.True(t, hasDeadline)
+}
+
+func TestStopRuntimeJobGroupAfterRunOnlySkipsHAAbort(t *testing.T) {
+	t.Run("HA abort", func(t *testing.T) {
+		// Arrange
+		group := &scriptedRuntimeJobGroupStopper{
+			stop: func(context.Context) error { return nil },
+		}
+
+		// Act
+		stopRuntimeJobGroupAfterRun(
+			errors.Join(errors.New("runtime failed"), ha.ErrRuntimeAborted),
+			group,
+			noopLifecycle{},
+			time.Second,
+		)
+
+		// Assert
+		require.Empty(t, group.contexts)
+	})
+
+	t.Run("standalone failure", func(t *testing.T) {
+		// Arrange
+		group := &scriptedRuntimeJobGroupStopper{
+			stop: func(context.Context) error { return nil },
+		}
+
+		// Act
+		stopRuntimeJobGroupAfterRun(errors.New("runtime failed"), group, noopLifecycle{}, time.Second)
+
+		// Assert
+		require.Len(t, group.contexts, 1)
+	})
 }
 
 func TestStopRuntimeJobGroupStopsCommandAfterGroupFailure(t *testing.T) {

--- a/server/internal/domain/curtailment/reconciler/reconciler.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler.go
@@ -141,6 +141,7 @@ type Reconciler struct {
 }
 
 var _ runtimejobs.Lifecycle = (*Reconciler)(nil)
+var _ runtimejobs.Aborter = (*Reconciler)(nil)
 
 // Option configures a Reconciler at construction time.
 type Option func(*Reconciler)
@@ -277,6 +278,20 @@ func (r *Reconciler) Stop(ctx context.Context) error {
 			workCancel()
 		}
 		return fmt.Errorf("curtailment reconciler: stop: %w", ctx.Err())
+	}
+}
+
+// Abort immediately cancels admission and detached work before a fatal exit.
+func (r *Reconciler) Abort() {
+	r.mu.Lock()
+	loopCancel := r.loopCancel
+	workCancel := r.workCancel
+	r.mu.Unlock()
+	if loopCancel != nil {
+		loopCancel()
+	}
+	if workCancel != nil {
+		workCancel()
 	}
 }
 

--- a/server/internal/domain/curtailment/reconciler/reconciler_test.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler_test.go
@@ -4426,6 +4426,49 @@ func TestReconciler_StopDeadlineCancelsInFlightWork(t *testing.T) {
 	require.NoError(t, r.Stop(context.Background()))
 }
 
+func TestReconciler_AbortCancelsDetachedWork(t *testing.T) {
+	// Arrange
+	store := newFakeStore()
+	workStarted := make(chan struct{})
+	workCanceled := make(chan struct{})
+	store.listEventsHook = func(ctx context.Context) {
+		close(workStarted)
+		<-ctx.Done()
+		close(workCanceled)
+	}
+	r := New(Config{TickInterval: time.Hour}, store, &fakeDispatcher{})
+	loopCtx, loopCancel := context.WithCancel(t.Context())
+	workCtx, workCancel := context.WithCancel(context.WithoutCancel(t.Context()))
+	r.loopCancel = loopCancel
+	r.workCancel = workCancel
+	workDone := make(chan struct{})
+	go func() {
+		defer close(workDone)
+		r.safeTick(workCtx)
+	}()
+	<-workStarted
+
+	// Act
+	r.Abort()
+
+	// Assert
+	select {
+	case <-loopCtx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("Abort did not close curtailment admission")
+	}
+	select {
+	case <-workCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("Abort did not cancel detached curtailment work")
+	}
+	select {
+	case <-workDone:
+	case <-time.After(time.Second):
+		t.Fatal("canceled curtailment work did not return")
+	}
+}
+
 func TestReconciler_StopCancellationPreventsOverlappingRestart(t *testing.T) {
 	store := newFakeStore()
 	disp := &fakeDispatcher{}

--- a/server/internal/domain/schedule/processor.go
+++ b/server/internal/domain/schedule/processor.go
@@ -110,6 +110,7 @@ type Processor struct {
 }
 
 var _ runtimejobs.Lifecycle = (*Processor)(nil)
+var _ runtimejobs.Aborter = (*Processor)(nil)
 
 func NewProcessor(
 	procStore interfaces.ScheduleProcessorStore,
@@ -227,6 +228,18 @@ func (p *Processor) Stop(ctx context.Context) error {
 		run.cancelWork()
 		return fmt.Errorf("stop schedule processor: %w", ctx.Err())
 	}
+}
+
+// Abort immediately cancels admission and detached work before a fatal exit.
+func (p *Processor) Abort() {
+	p.lifecycleMu.Lock()
+	run := p.activation
+	p.lifecycleMu.Unlock()
+	if run == nil {
+		return
+	}
+	p.beginStop(run)
+	run.cancelWork()
 }
 
 func (p *Processor) beginStop(run *processorActivation) {

--- a/server/internal/domain/schedule/processor_test.go
+++ b/server/internal/domain/schedule/processor_test.go
@@ -296,6 +296,31 @@ func TestProcessor_StopDeadlineForceCancelsAdmittedWork(t *testing.T) {
 	assert.NoError(t, p.Stop(context.Background()))
 }
 
+func TestProcessor_AbortCancelsAdmittedWork(t *testing.T) {
+	// Arrange
+	run := newProcessorActivation(t.Context())
+	close(run.startupDone)
+	p := &Processor{
+		activation: run,
+		jobs:       make(map[int64]jobEntry),
+	}
+	workCanceled := make(chan struct{})
+	run.wg.Add(1)
+	go func() {
+		defer run.wg.Done()
+		<-run.workCtx.Done()
+		close(workCanceled)
+	}()
+
+	// Act
+	p.Abort()
+
+	// Assert
+	waitForSignal(t, run.admissionCtx.Done(), "Abort did not close schedule admission")
+	waitForSignal(t, workCanceled, "Abort did not cancel admitted schedule work")
+	assert.NoError(t, p.Stop(t.Context()))
+}
+
 func TestProcessor_ActivationCancellationPreventsNewTimerWork(t *testing.T) {
 	p, _, _, _, _ := newTestProcessor(t, time.Now())
 	run := newProcessorActivation(t.Context())

--- a/server/internal/ha/config.go
+++ b/server/internal/ha/config.go
@@ -1,0 +1,151 @@
+package ha
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"database/sql"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+
+	"github.com/block/proto-fleet/server/internal/infrastructure/db"
+	"github.com/block/proto-fleet/server/internal/runtimejobs"
+)
+
+// Config keeps HA opt-in so existing single-instance deployments remain
+// standalone and do not need etcd or Patroni credentials.
+type Config struct {
+	Enabled          bool          `help:"Enable active/passive Fleet runtime ownership." default:"false" env:"ENABLED"`
+	ClusterPath      string        `help:"Patroni DCS cluster path." default:"/service/proto-fleet" env:"CLUSTER_PATH"`
+	EtcdEndpoints    []string      `help:"Comma-separated HTTPS etcd endpoints." env:"ETCD_ENDPOINTS" sep:","`
+	EtcdUsername     string        `help:"Read-only etcd observer username." default:"fleet-observer" env:"ETCD_USERNAME"`
+	EtcdPasswordFile string        `help:"Path to the etcd observer password file." default:"/etc/proto-fleet/ha/fleet-etcd-password" env:"ETCD_PASSWORD_FILE" type:"path"`
+	ServiceCAFile    string        `help:"Path to the CA that signs etcd and Patroni service certificates." default:"/etc/proto-fleet/ha/service-ca.crt" env:"SERVICE_CA_FILE" type:"path"`
+	LeaseDuration    time.Duration `help:"Fleet active lease duration." default:"10s" env:"LEASE_DURATION"`
+	RenewInterval    time.Duration `help:"Fleet active lease renewal interval." default:"3s" env:"RENEW_INTERVAL"`
+	RetryInterval    time.Duration `help:"Passive ownership retry interval." default:"1s" env:"RETRY_INTERVAL"`
+	DialTimeout      time.Duration `help:"etcd connection timeout." default:"5s" env:"DIAL_TIMEOUT"`
+}
+
+// NewConfiguredRuntime creates a standalone runtime unless HA is explicitly
+// enabled. In HA mode, cleanup closes the etcd client.
+func NewConfiguredRuntime(
+	config Config,
+	conn *sql.DB,
+	group *runtimejobs.Group,
+	healthy func() bool,
+) (*Runtime, func() error, error) {
+	if !config.Enabled {
+		runtime, err := NewStandaloneRuntime(group, healthy)
+		return runtime, func() error { return nil }, err
+	}
+	if err := config.Validate(); err != nil {
+		return nil, nil, err
+	}
+
+	password, err := readRuntimeSecret(config.EtcdPasswordFile)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read HA etcd password: %w", err)
+	}
+	tlsConfig, err := loadServiceTLS(config.ServiceCAFile)
+	if err != nil {
+		return nil, nil, err
+	}
+	etcd, err := NewEtcdClient(clientv3.Config{
+		Endpoints:   config.EtcdEndpoints,
+		Username:    config.EtcdUsername,
+		Password:    password,
+		TLS:         tlsConfig.Clone(),
+		DialTimeout: config.DialTimeout,
+	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("create HA etcd client: %w", err)
+	}
+
+	transport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		_ = etcd.Close()
+		return nil, nil, errors.New("default HTTP transport is not configurable for HA")
+	}
+	patroniTransport := transport.Clone()
+	patroniTransport.TLSClientConfig = tlsConfig.Clone()
+	cleanup := func() error {
+		patroniTransport.CloseIdleConnections()
+		return etcd.Close()
+	}
+	patroni := NewPatroniHTTPClient(&http.Client{
+		Transport: patroniTransport,
+		Timeout:   defaultHAHTTPTimeout,
+	})
+	queries := db.NewFailoverResettingQuerier(db.NewRetryDB(conn))
+	observer, err := NewObserver(config.ClusterPath, etcd, queries, patroni)
+	if err != nil {
+		_ = cleanup()
+		return nil, nil, err
+	}
+	coordinator, err := NewCoordinator(observer, NewLeaseStore(queries), CoordinatorConfig{
+		LeaseDuration: config.LeaseDuration,
+		RenewInterval: config.RenewInterval,
+		RetryInterval: config.RetryInterval,
+	})
+	if err != nil {
+		_ = cleanup()
+		return nil, nil, err
+	}
+	runtime, err := NewRuntime(coordinator, group, healthy)
+	if err != nil {
+		_ = cleanup()
+		return nil, nil, err
+	}
+	return runtime, cleanup, nil
+}
+
+func (config Config) Validate() error {
+	if !config.Enabled {
+		return nil
+	}
+	if config.ClusterPath == "" || len(config.EtcdEndpoints) == 0 || config.EtcdUsername == "" ||
+		config.EtcdPasswordFile == "" || config.ServiceCAFile == "" || config.DialTimeout <= 0 {
+		return errors.New("enabled HA requires cluster path, etcd endpoints and credentials, service CA, and a positive dial timeout")
+	}
+	for _, endpoint := range config.EtcdEndpoints {
+		parsed, err := url.Parse(endpoint)
+		if err != nil || parsed.Scheme != "https" || parsed.Host == "" {
+			return fmt.Errorf("HA etcd endpoint must be an HTTPS URL: %q", endpoint)
+		}
+	}
+	return nil
+}
+
+func readRuntimeSecret(path string) (string, error) {
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read secret file: %w", err)
+	}
+	secret := strings.TrimSpace(string(contents))
+	if secret == "" {
+		return "", errors.New("secret file is empty")
+	}
+	return secret, nil
+}
+
+func loadServiceTLS(path string) (*tls.Config, error) {
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read HA service CA: %w", err)
+	}
+	roots := x509.NewCertPool()
+	if !roots.AppendCertsFromPEM(contents) {
+		return nil, errors.New("HA service CA contains no certificates")
+	}
+	return &tls.Config{
+		MinVersion: tls.VersionTLS13,
+		RootCAs:    roots,
+	}, nil
+}

--- a/server/internal/ha/config.go
+++ b/server/internal/ha/config.go
@@ -129,8 +129,8 @@ func (config Config) Validate() error {
 		config.EtcdPasswordFile == "" || config.ServiceCAFile == "" || config.DialTimeout <= 0 {
 		return errors.New("enabled HA requires cluster path, etcd endpoints and credentials, service CA, and a positive dial timeout")
 	}
-	if config.LeaseDuration < time.Millisecond {
-		return errors.New("HA lease duration must be at least 1ms")
+	if config.LeaseDuration <= 0 || config.LeaseDuration%time.Millisecond != 0 {
+		return errors.New("HA lease duration must be a positive whole number of milliseconds")
 	}
 	if config.RenewInterval <= 0 || config.RetryInterval <= 0 {
 		return errors.New("HA renew and retry intervals must be positive")

--- a/server/internal/ha/config.go
+++ b/server/internal/ha/config.go
@@ -1,11 +1,13 @@
 package ha
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"database/sql"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -34,7 +36,7 @@ type Config struct {
 }
 
 // NewConfiguredRuntime creates a standalone runtime unless HA is explicitly
-// enabled. In HA mode, cleanup closes the etcd client.
+// enabled. In HA mode, cleanup closes the prepared queries and etcd client.
 func NewConfiguredRuntime(
 	config Config,
 	conn *sql.DB,
@@ -75,15 +77,28 @@ func NewConfiguredRuntime(
 	}
 	patroniTransport := transport.Clone()
 	patroniTransport.TLSClientConfig = tlsConfig.Clone()
-	cleanup := func() error {
-		patroniTransport.CloseIdleConnections()
-		return etcd.Close()
-	}
 	patroni := NewPatroniHTTPClient(&http.Client{
 		Transport: patroniTransport,
 		Timeout:   defaultHAHTTPTimeout,
 	})
-	queries := db.NewFailoverResettingQuerier(db.NewRetryDB(conn))
+	queries, err := db.NewPreparedQuerier(context.Background(), conn)
+	if err != nil {
+		patroniTransport.CloseIdleConnections()
+		_ = etcd.Close()
+		return nil, nil, fmt.Errorf("prepare HA database queries: %w", err)
+	}
+	cleanup := func() error {
+		patroniTransport.CloseIdleConnections()
+		queriesErr := queries.Close()
+		if queriesErr != nil {
+			queriesErr = fmt.Errorf("close HA prepared queries: %w", queriesErr)
+		}
+		etcdErr := etcd.Close()
+		if etcdErr != nil {
+			etcdErr = fmt.Errorf("close HA etcd client: %w", etcdErr)
+		}
+		return errors.Join(queriesErr, etcdErr)
+	}
 	observer, err := NewObserver(config.ClusterPath, etcd, queries, patroni)
 	if err != nil {
 		_ = cleanup()
@@ -114,10 +129,22 @@ func (config Config) Validate() error {
 		config.EtcdPasswordFile == "" || config.ServiceCAFile == "" || config.DialTimeout <= 0 {
 		return errors.New("enabled HA requires cluster path, etcd endpoints and credentials, service CA, and a positive dial timeout")
 	}
+	if config.LeaseDuration < time.Millisecond {
+		return errors.New("HA lease duration must be at least 1ms")
+	}
+	if config.RenewInterval <= 0 || config.RetryInterval <= 0 {
+		return errors.New("HA renew and retry intervals must be positive")
+	}
+	if config.RenewInterval >= config.LeaseDuration {
+		return errors.New("HA renew interval must be less than the lease duration")
+	}
 	for _, endpoint := range config.EtcdEndpoints {
 		parsed, err := url.Parse(endpoint)
 		if err != nil || parsed.Scheme != "https" || parsed.Host == "" {
 			return fmt.Errorf("HA etcd endpoint must be an HTTPS URL: %q", endpoint)
+		}
+		if net.ParseIP(parsed.Hostname()) == nil {
+			return fmt.Errorf("HA etcd endpoint must use an IP address: %q", endpoint)
 		}
 	}
 	return nil

--- a/server/internal/ha/config_test.go
+++ b/server/internal/ha/config_test.go
@@ -27,7 +27,7 @@ func TestHAConfigValidation(t *testing.T) {
 	valid := Config{
 		Enabled:          true,
 		ClusterPath:      "/service/proto-fleet",
-		EtcdEndpoints:    []string{"https://ha-a:2379", "https://ha-b:2379"},
+		EtcdEndpoints:    []string{"https://10.0.0.1:2379", "https://10.0.0.2:2379"},
 		EtcdUsername:     "fleet-observer",
 		EtcdPasswordFile: "/run/secrets/etcd-password",
 		ServiceCAFile:    "/etc/proto-fleet/ha/service-ca.crt",
@@ -43,4 +43,56 @@ func TestHAConfigValidation(t *testing.T) {
 	insecure := valid
 	insecure.EtcdEndpoints = []string{"http://ha-a:2379"}
 	require.ErrorContains(t, insecure.Validate(), "must be an HTTPS URL")
+
+	hostname := valid
+	hostname.EtcdEndpoints = []string{"https://ha-a:2379"}
+	require.ErrorContains(t, hostname.Validate(), "must use an IP address")
+
+	tests := []struct {
+		name      string
+		configure func(*Config)
+		wantError string
+	}{
+		{
+			name: "lease duration rounds to zero",
+			configure: func(config *Config) {
+				config.LeaseDuration = time.Microsecond
+			},
+			wantError: "lease duration must be at least 1ms",
+		},
+		{
+			name: "renew interval is not positive",
+			configure: func(config *Config) {
+				config.RenewInterval = 0
+			},
+			wantError: "renew and retry intervals must be positive",
+		},
+		{
+			name: "retry interval is not positive",
+			configure: func(config *Config) {
+				config.RetryInterval = -time.Second
+			},
+			wantError: "renew and retry intervals must be positive",
+		},
+		{
+			name: "renew interval reaches lease duration",
+			configure: func(config *Config) {
+				config.RenewInterval = config.LeaseDuration
+			},
+			wantError: "renew interval must be less than the lease duration",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Arrange
+			config := valid
+			test.configure(&config)
+
+			// Act
+			err := config.Validate()
+
+			// Assert
+			require.ErrorContains(t, err, test.wantError)
+		})
+	}
 }

--- a/server/internal/ha/config_test.go
+++ b/server/internal/ha/config_test.go
@@ -1,0 +1,46 @@
+package ha
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/block/proto-fleet/server/internal/runtimejobs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewConfiguredRuntimeUsesStandaloneModeWithoutReadingHAFiles(t *testing.T) {
+	group, err := runtimejobs.NewGroup(nil)
+	require.NoError(t, err)
+
+	runtime, cleanup, err := NewConfiguredRuntime(Config{
+		EtcdPasswordFile: filepath.Join(t.TempDir(), "missing-password"),
+		ServiceCAFile:    filepath.Join(t.TempDir(), "missing-ca"),
+	}, nil, group, alwaysHealthy)
+	require.NoError(t, err)
+	require.NotNil(t, runtime)
+	require.Nil(t, runtime.owner)
+	require.NoError(t, cleanup())
+}
+
+func TestHAConfigValidation(t *testing.T) {
+	valid := Config{
+		Enabled:          true,
+		ClusterPath:      "/service/proto-fleet",
+		EtcdEndpoints:    []string{"https://ha-a:2379", "https://ha-b:2379"},
+		EtcdUsername:     "fleet-observer",
+		EtcdPasswordFile: "/run/secrets/etcd-password",
+		ServiceCAFile:    "/etc/proto-fleet/ha/service-ca.crt",
+		LeaseDuration:    10 * time.Second,
+		RenewInterval:    3 * time.Second,
+		RetryInterval:    time.Second,
+		DialTimeout:      5 * time.Second,
+	}
+	require.NoError(t, valid.Validate())
+
+	require.Error(t, (Config{Enabled: true}).Validate())
+
+	insecure := valid
+	insecure.EtcdEndpoints = []string{"http://ha-a:2379"}
+	require.ErrorContains(t, insecure.Validate(), "must be an HTTPS URL")
+}

--- a/server/internal/ha/config_test.go
+++ b/server/internal/ha/config_test.go
@@ -54,11 +54,12 @@ func TestHAConfigValidation(t *testing.T) {
 		wantError string
 	}{
 		{
-			name: "lease duration rounds to zero",
+			name: "lease duration has sub-millisecond precision",
 			configure: func(config *Config) {
-				config.LeaseDuration = time.Microsecond
+				config.LeaseDuration = 1500 * time.Microsecond
+				config.RenewInterval = 1200 * time.Microsecond
 			},
-			wantError: "lease duration must be at least 1ms",
+			wantError: "lease duration must be a positive whole number of milliseconds",
 		},
 		{
 			name: "renew interval is not positive",

--- a/server/internal/ha/runtime.go
+++ b/server/internal/ha/runtime.go
@@ -14,6 +14,10 @@ const (
 	defaultCleanupTimeout      = 10 * time.Second
 )
 
+// ErrRuntimeAborted marks an HA exit that completed its bounded hard-abort
+// cleanup attempt for the active runtime job group.
+var ErrRuntimeAborted = errors.New("HA Fleet runtime aborted")
+
 var errCriticalRuntimeUnhealthy = errors.New("critical Fleet runtime is unhealthy")
 
 type RuntimeConfig struct {
@@ -28,7 +32,7 @@ type runtimeOwner interface {
 
 type runtimeGroup interface {
 	Start(ctx context.Context) error
-	Abort()
+	Abort(ctx context.Context) error
 	Stop(ctx context.Context) error
 }
 
@@ -177,8 +181,7 @@ func (r *Runtime) runHA(ctx context.Context) error {
 		return fmt.Errorf("start active Fleet runtime: %w", err)
 	}
 	if !r.healthCheck() {
-		r.group.Abort()
-		return errCriticalRuntimeUnhealthy
+		return r.abortGroup(errCriticalRuntimeUnhealthy)
 	}
 
 	r.gate.activate(activeCtx)
@@ -187,14 +190,24 @@ func (r *Runtime) runHA(ctx context.Context) error {
 	if ctx.Err() != nil {
 		return r.stopGroupAndDrainAdmissions(admissionDrained)
 	}
-	r.group.Abort()
+	abortErr := r.abortGroup(activeErr)
 
 	select {
 	case coordinatorErr := <-coordinatorResult:
-		return errors.Join(activeErr, coordinatorErr)
+		return errors.Join(abortErr, coordinatorErr)
 	default:
-		return activeErr
+		return abortErr
 	}
+}
+
+func (r *Runtime) abortGroup(cause error) error {
+	abortCtx, cancel := context.WithTimeout(context.Background(), r.config.CleanupTimeout)
+	defer cancel()
+	cleanupErr := r.group.Abort(abortCtx)
+	if cleanupErr != nil {
+		cleanupErr = fmt.Errorf("abort Fleet runtime: %w", cleanupErr)
+	}
+	return errors.Join(ErrRuntimeAborted, cause, cleanupErr)
 }
 
 func (r *Runtime) waitWhileHealthy(parent, activeCtx context.Context) error {

--- a/server/internal/ha/runtime_test.go
+++ b/server/internal/ha/runtime_test.go
@@ -2,6 +2,7 @@ package ha
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -63,24 +64,27 @@ type runtimeTestGroup struct {
 	aborted   int
 	startErr  error
 	stopErr   error
+	abortErr  error
 	startedCh chan context.Context
 	stoppedCh chan struct{}
-	abortedCh chan struct{}
+	abortedCh chan context.Context
 }
 
 func newRuntimeTestGroup() *runtimeTestGroup {
 	return &runtimeTestGroup{
 		startedCh: make(chan context.Context, 1),
 		stoppedCh: make(chan struct{}, 1),
-		abortedCh: make(chan struct{}, 1),
+		abortedCh: make(chan context.Context, 1),
 	}
 }
 
-func (g *runtimeTestGroup) Abort() {
+func (g *runtimeTestGroup) Abort(ctx context.Context) error {
 	g.mu.Lock()
 	g.aborted++
+	err := g.abortErr
 	g.mu.Unlock()
-	g.abortedCh <- struct{}{}
+	g.abortedCh <- ctx
+	return err
 }
 
 func (g *runtimeTestGroup) Start(ctx context.Context) error {
@@ -148,7 +152,7 @@ func TestHARuntimeReturnsWhenOwnershipEndsBeforeActivationIsObserved(t *testing.
 	require.False(t, runtime.Active())
 }
 
-func TestHARuntimeExitsOnOwnershipLossWithoutInProcessCleanup(t *testing.T) {
+func TestHARuntimeAbortsOnOwnershipLoss(t *testing.T) {
 	// Arrange
 	owner := newRuntimeTestOwner()
 	group := newRuntimeTestGroup()
@@ -167,16 +171,15 @@ func TestHARuntimeExitsOnOwnershipLossWithoutInProcessCleanup(t *testing.T) {
 	cancelActive(ErrOwnershipLost)
 
 	// Assert
-	require.ErrorContains(t, <-runResult, "active lifetime ended")
-	requireReceive(t, group.abortedCh)
+	runErr := <-runResult
+	require.ErrorIs(t, runErr, ErrRuntimeAborted)
+	require.ErrorIs(t, runErr, ErrOwnershipLost)
+	abortCtx := requireReceiveContext(t, group.abortedCh)
+	_, hasDeadline := abortCtx.Deadline()
+	require.True(t, hasDeadline)
 	require.Eventually(t, func() bool { return requestCtx.Err() != nil }, eventuallyTimeout, eventuallyInterval)
 	require.False(t, runtime.Active())
 	require.Error(t, jobCtx.Err())
-	select {
-	case <-group.stoppedCh:
-		t.Fatal("ownership loss performed graceful in-process cleanup")
-	default:
-	}
 }
 
 func TestHARuntimeExitsWhenCriticalHealthFails(t *testing.T) {
@@ -198,14 +201,35 @@ func TestHARuntimeExitsWhenCriticalHealthFails(t *testing.T) {
 	healthy.Store(false)
 
 	// Assert
-	require.ErrorIs(t, <-runResult, errCriticalRuntimeUnhealthy)
-	requireReceive(t, group.abortedCh)
+	runErr := <-runResult
+	require.ErrorIs(t, runErr, ErrRuntimeAborted)
+	require.ErrorIs(t, runErr, errCriticalRuntimeUnhealthy)
+	requireReceiveContext(t, group.abortedCh)
 	require.False(t, runtime.Active())
-	select {
-	case <-group.stoppedCh:
-		t.Fatal("critical failure performed graceful in-process cleanup")
-	default:
-	}
+}
+
+func TestHARuntimeJoinsAbortCleanupError(t *testing.T) {
+	// Arrange
+	owner := newRuntimeTestOwner()
+	group := newRuntimeTestGroup()
+	cleanupErr := errors.New("cleanup failed")
+	group.abortErr = cleanupErr
+	runtime := newRuntime(owner, group, alwaysHealthy, runtimeTestConfig())
+	runResult := make(chan error, 1)
+	go func() { runResult <- runtime.Run(t.Context()) }()
+	activeCtx, cancelActive := context.WithCancelCause(t.Context())
+	owner.activations <- runtimeTestActivation{ctx: activeCtx}
+	requireReceiveContext(t, group.startedCh)
+	require.Eventually(t, runtime.Active, eventuallyTimeout, eventuallyInterval)
+
+	// Act
+	cancelActive(ErrOwnershipLost)
+
+	// Assert
+	runErr := <-runResult
+	require.ErrorIs(t, runErr, ErrRuntimeAborted)
+	require.ErrorIs(t, runErr, ErrOwnershipLost)
+	require.ErrorIs(t, runErr, cleanupErr)
 }
 
 func TestStandaloneRuntimePreservesGracefulLifecycle(t *testing.T) {

--- a/server/internal/infrastructure/db/config.go
+++ b/server/internal/infrastructure/db/config.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"crypto/tls"
 	"fmt"
 	"net/url"
 	"os"
@@ -48,24 +49,55 @@ func (c *Config) UsesExplicitDSN() bool {
 }
 
 func (c *Config) Validate() error {
-	dsn := c.DSN()
-	if strings.TrimSpace(dsn) == "" {
-		return fmt.Errorf("database DSN is empty")
-	}
-	if environmentHasHostaddr() {
-		return fmt.Errorf("database PGHOSTADDR hostaddr is not supported; use host")
-	}
-	parsedConfig, err := pgconn.ParseConfig(dsn)
+	parsedConfig, err := c.parsedConfig()
 	if err != nil {
-		return fmt.Errorf("invalid database DSN")
-	}
-	if parsedConfigHasHostaddr(parsedConfig) {
-		return fmt.Errorf("database DSN hostaddr is not supported; use host")
+		return err
 	}
 	if parsedConfigLooksMultiHost(parsedConfig) && !parsedConfigHasReadWriteTarget(parsedConfig) {
 		return fmt.Errorf("multi-host database DSN requires target_session_attrs=read-write")
 	}
 	return nil
+}
+
+// ValidateHA requires every database fallback to preserve writer selection and
+// authenticate the PostgreSQL server before Fleet starts its HA runtime.
+func (c *Config) ValidateHA() error {
+	if !c.UsesExplicitDSN() {
+		return fmt.Errorf("HA database requires an explicit multi-host DB_DSN")
+	}
+
+	parsedConfig, err := c.parsedConfig()
+	if err != nil {
+		return err
+	}
+	if !parsedConfigLooksMultiHost(parsedConfig) {
+		return fmt.Errorf("HA database requires an explicit multi-host DB_DSN")
+	}
+	if !parsedConfigHasReadWriteTarget(parsedConfig) {
+		return fmt.Errorf("HA database DSN requires target_session_attrs=read-write")
+	}
+	if !parsedConfigUsesAuthenticatedTLS(parsedConfig) {
+		return fmt.Errorf("HA database DSN requires sslmode=verify-full and sslrootcert")
+	}
+	return nil
+}
+
+func (c *Config) parsedConfig() (*pgconn.Config, error) {
+	dsn := c.DSN()
+	if strings.TrimSpace(dsn) == "" {
+		return nil, fmt.Errorf("database DSN is empty")
+	}
+	if environmentHasHostaddr() {
+		return nil, fmt.Errorf("database PGHOSTADDR hostaddr is not supported; use host")
+	}
+	parsedConfig, err := pgconn.ParseConfig(dsn)
+	if err != nil {
+		return nil, fmt.Errorf("invalid database DSN")
+	}
+	if parsedConfigHasHostaddr(parsedConfig) {
+		return nil, fmt.Errorf("database DSN hostaddr is not supported; use host")
+	}
+	return parsedConfig, nil
 }
 
 func (c *Config) ConnectionTarget() string {
@@ -94,6 +126,22 @@ func parsedConfigHasReadWriteTarget(config *pgconn.Config) bool {
 	}
 	return reflect.ValueOf(config.ValidateConnect).Pointer() ==
 		reflect.ValueOf(pgconn.ValidateConnectTargetSessionAttrsReadWrite).Pointer()
+}
+
+func parsedConfigUsesAuthenticatedTLS(config *pgconn.Config) bool {
+	if config == nil || !tlsConfigAuthenticatesServer(config.TLSConfig) {
+		return false
+	}
+	for _, fallback := range config.Fallbacks {
+		if fallback == nil || !tlsConfigAuthenticatesServer(fallback.TLSConfig) {
+			return false
+		}
+	}
+	return true
+}
+
+func tlsConfigAuthenticatesServer(config *tls.Config) bool {
+	return config != nil && !config.InsecureSkipVerify && config.ServerName != "" && config.RootCAs != nil
 }
 
 func parsedConfigHasHostaddr(config *pgconn.Config) bool {

--- a/server/internal/infrastructure/db/config_test.go
+++ b/server/internal/infrastructure/db/config_test.go
@@ -139,3 +139,69 @@ func TestConfigValidateRejectsPGHostaddrEnvironment(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "hostaddr is not supported")
 }
+
+func TestConfigValidateHAAcceptsSecureMultiHostWriterDSN(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{
+		ExplicitDSN: "postgres://fleet@fleet-a:5432,fleet-b:5432/fleet?sslmode=verify-full&sslrootcert=system&target_session_attrs=read-write",
+	}
+
+	require.NoError(t, cfg.ValidateHA())
+}
+
+func TestConfigValidateHARejectsUnsupportedDatabaseTargets(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name      string
+		config    Config
+		wantError string
+	}{
+		{
+			name: "legacy fields",
+			config: Config{
+				Address: "fleet-a:5432",
+			},
+			wantError: "explicit multi-host DB_DSN",
+		},
+		{
+			name: "single host",
+			config: Config{
+				ExplicitDSN: "postgres://fleet@fleet-a:5432/fleet?sslmode=verify-full&sslrootcert=system&target_session_attrs=read-write",
+			},
+			wantError: "explicit multi-host DB_DSN",
+		},
+		{
+			name: "no writer selection",
+			config: Config{
+				ExplicitDSN: "postgres://fleet@fleet-a:5432,fleet-b:5432/fleet?sslmode=verify-full&sslrootcert=system",
+			},
+			wantError: "target_session_attrs=read-write",
+		},
+		{
+			name: "plaintext",
+			config: Config{
+				ExplicitDSN: "postgres://fleet@fleet-a:5432,fleet-b:5432/fleet?sslmode=disable&target_session_attrs=read-write",
+			},
+			wantError: "sslmode=verify-full and sslrootcert",
+		},
+		{
+			name: "no trust root",
+			config: Config{
+				ExplicitDSN: "postgres://fleet@fleet-a:5432,fleet-b:5432/fleet?sslmode=verify-full&target_session_attrs=read-write",
+			},
+			wantError: "sslmode=verify-full and sslrootcert",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := testCase.config.ValidateHA()
+
+			require.ErrorContains(t, err, testCase.wantError)
+		})
+	}
+}

--- a/server/internal/runtimejobs/group.go
+++ b/server/internal/runtimejobs/group.go
@@ -194,6 +194,30 @@ func (g *Group) Stop(ctx context.Context) error {
 
 	g.endActivation()
 	g.setGroupState(StateStopping)
+	return g.finishStop(ctx)
+}
+
+// Abort cancels the current activation, hard-aborts supported jobs, and waits
+// for every job to clean up within the caller's deadline.
+func (g *Group) Abort(ctx context.Context) error {
+	g.operationMu.Lock()
+	defer g.operationMu.Unlock()
+
+	if terminalErr := g.Err(); terminalErr != nil {
+		return terminalErr
+	}
+	_, cancel := g.activation()
+	if cancel == nil {
+		return nil
+	}
+
+	g.endActivation()
+	g.setGroupState(StateStopping)
+	abortJobs(g.jobs)
+	return g.finishStop(ctx)
+}
+
+func (g *Group) finishStop(ctx context.Context) error {
 	err := g.stopJobs(ctx, g.jobs)
 	if err != nil {
 		g.setTerminalErr(err)
@@ -201,11 +225,6 @@ func (g *Group) Stop(ctx context.Context) error {
 	}
 	g.setGroupState(StateStopped)
 	return nil
-}
-
-// Abort immediately cancels work that cannot survive a fatal runtime error.
-func (g *Group) Abort() {
-	abortJobs(g.jobs)
 }
 
 func abortJobs(jobs []Job) {

--- a/server/internal/runtimejobs/group_test.go
+++ b/server/internal/runtimejobs/group_test.go
@@ -253,6 +253,75 @@ func TestGroupStopAggregatesErrorsAndBecomesTerminal(t *testing.T) {
 	assert.ErrorIs(t, group.Err(), errA)
 }
 
+func TestGroupAbortCancelsThenHardAbortsAndStops(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	var events eventLog
+	var activationDone <-chan struct{}
+	job, err := NewJob("job", testAbortableLifecycle{
+		start: func(ctx context.Context) error {
+			activationDone = ctx.Done()
+			return nil
+		},
+		abort: func() {
+			select {
+			case <-activationDone:
+				events.add("abort")
+			default:
+				events.add("abort-before-cancel")
+			}
+		},
+		stop: func(context.Context) error {
+			events.add("stop")
+			return nil
+		},
+	})
+	require.NoError(t, err)
+	group := newTestGroup(t, job)
+	require.NoError(t, group.Start(context.Background()))
+
+	// Act
+	err = group.Abort(context.Background())
+
+	// Assert
+	require.NoError(t, err)
+	assert.Equal(t, []string{"abort", "stop"}, events.snapshot())
+	assert.Equal(t, StateStopped, group.Status().State)
+}
+
+func TestGroupAbortHonorsCallerDeadline(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	aborted := make(chan struct{})
+	job, err := NewJob("job", testAbortableLifecycle{
+		start: noopJob,
+		abort: func() { close(aborted) },
+		stop: func(ctx context.Context) error {
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	})
+	require.NoError(t, err)
+	group := newTestGroup(t, job)
+	require.NoError(t, group.Start(context.Background()))
+	abortCtx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	// Act
+	err = group.Abort(abortCtx)
+
+	// Assert
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	select {
+	case <-aborted:
+	default:
+		t.Fatal("hard abort was not called")
+	}
+	assert.ErrorIs(t, group.Err(), context.DeadlineExceeded)
+}
+
 func TestGroupStopTimeoutIsGroupWideAndTerminal(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Reviewable diff: +265/-17 across 4 files (excludes generated, test, and story files).

## Summary

Fleet operators can opt a new deployment into the active/passive runtime through `FLEET_HA_*` configuration. HA remains off by default, while enabled deployments now fail startup before connecting or migrating if lease timing, etcd addressing, database failover routing, or PostgreSQL server authentication is unsafe.

**Stack**

- [#874 - make command recovery restart-safe](https://github.com/block/proto-fleet/pull/874)
- [#875 - wire the opt-in production runtime](https://github.com/block/proto-fleet/pull/875) **(current)**

This diff is relative to #874. The parent provides lease ownership, command restart recovery, fatal active-process exit, and active request admission. This PR selects and constructs that runtime from production configuration. Installer automation, rolling-upgrade migration coordination, and live three-host qualification remain outside this PR.

## How it works

1. With HA disabled, Fleet creates the standalone runtime without reading HA secrets or contacting etcd and Patroni.
2. With HA enabled, Fleet validates lease intervals, requires IP-addressed HTTPS etcd endpoints, and requires an explicit multi-host PostgreSQL DSN with read-write writer selection and hostname-verifying TLS backed by a trust root.
3. These checks run before Fleet opens the database or applies migrations, so unsupported HA deployments fail without changing database state.
4. Fleet reads the observer password and service CA, creates authenticated etcd and Patroni clients, and prepares the SQL used by the writer observer and lease store.
5. The observer compares Patroni's etcd-published primary with the PostgreSQL writer Fleet reached. The coordinator opens active work only after that proof and the Fleet lease agree.
6. Normal process shutdown stops runtime jobs gracefully. Ownership loss aborts active work and skips the later graceful job-stop defer so the supervisor can restart Fleet as a passive candidate without stale cleanup running beside the replacement active.

```mermaid
flowchart TD
    START["fleetd starts"] --> ENABLED{"FLEET_HA_ENABLED?"}
    ENABLED -->|"No"| STANDALONE["Standalone runtime"]
    ENABLED -->|"Yes"| VALIDATE["Validate timing, IP endpoints, and secure multi-host DB routing"]
    VALIDATE --> DB["Connect and migrate PostgreSQL"]
    DB --> CLIENTS["Create etcd and Patroni clients plus prepared HA queries"]
    CLIENTS --> PROOF["Compare DCS primary with connected PostgreSQL writer"]
    PROOF --> LEASE["Acquire Fleet active lease"]
    LEASE --> ACTIVE["Start active jobs and open admission"]
    ACTIVE --> LOSS{"Ownership lost?"}
    LOSS -->|"No, normal shutdown"| STOP["Gracefully stop jobs"]
    LOSS -->|"Yes"| ABORT["Abort jobs and exit process"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/cmd/fleetd/config.go`, `main.go` | Exposes HA settings, validates the HA database contract before connection, selects the configured runtime, and preserves abort-only ownership-loss exit | Review startup ordering and shutdown behavior |
| `server/internal/ha/config.go` | Validates HA timing and IP endpoints, constructs authenticated clients and prepared HA queries, and owns cleanup | Review disabled-mode isolation, TLS boundaries, and resource ownership |
| `server/internal/infrastructure/db/config.go` | Adds the enabled-HA database contract for multi-host writer routing and authenticated TLS on every fallback | Review PostgreSQL failover and transport guarantees |
| Focused tests | Cover environment parsing and the important HA timing, endpoint, routing, and TLS rejection cases | Review the operator-facing configuration contract |

## Key technical decisions & trade-offs

- HA remains explicit opt-in, so standalone installations keep their existing database and runtime behavior.
- The supported HA profile requires literal-IP etcd endpoints because its generated certificates contain IP SANs.
- HA requires an explicit multi-host `DB_DSN`, `target_session_attrs=read-write`, and authenticated TLS instead of accepting legacy single-host fields or opportunistic encryption.
- The observer and lease store share the repository's prepared/retrying query path and close it with the HA clients.
- Ownership loss is crash-only for active jobs; normal shutdown remains graceful.
- Fleet still applies migrations before runtime ownership. Coordinating migrations across rolling application upgrades is intentionally outside the clean-deployment scope of this PR.

## Testing & validation

- Focused `internal/ha`, database configuration, and `cmd/fleetd` tests passed.
- The complete server build passed.
- Hermit-backed server lint passed with zero issues.
- The DB-backed HA integration suite was not run locally because the available test database credentials were invalid; live three-host qualification remains follow-up work.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with_Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
