### PR TITLE
ci: update security review to GPT-5.6 Sol

### DIFF
--- a/.github/workflows/codex-security-review.yml
+++ b/.github/workflows/codex-security-review.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     types: [edited, opened, reopened, ready_for_review, synchronize]
 
+env:
+  CODEX_CLI_VERSION: "0.146.0"
+  CODEX_MODEL: gpt-5.6-sol
+  CODEX_REASONING_EFFORT: xhigh
+
 jobs:
   security-review:
     if: github.event.pull_request.head.repo.full_name == github.repository
@@ -16,8 +21,6 @@ jobs:
       contents: read
     env:
       OPENAI_API_KEY_PRESENT: ${{ secrets.OPENAI_API_KEY != '' }}
-      CODEX_MODEL: gpt-5.5
-      CODEX_REASONING_EFFORT: xhigh
       REVIEW_BASE_SHA: ${{ github.event.pull_request.base.sha }}
       REVIEW_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       REVIEW_COMMIT_RANGE: ${{ format('{0}...{1}', github.event.pull_request.base.sha, github.event.pull_request.head.sha) }}
@@ -57,8 +60,10 @@ jobs:
         uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1.11
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          codex-version: ${{ env.CODEX_CLI_VERSION }}
           model: ${{ env.CODEX_MODEL }}
-          codex-args: '["-c","model_reasoning_effort=${{ env.CODEX_REASONING_EFFORT }}","-c","service_tier=fast"]'
+          effort: ${{ env.CODEX_REASONING_EFFORT }}
+          codex-args: '["-c","service_tier=fast"]'
 
           safety-strategy: drop-sudo
           sandbox: read-only
@@ -187,6 +192,13 @@ jobs:
           REVIEW_COMMIT_RANGE: ${{ env.REVIEW_COMMIT_RANGE }}
           REVIEW_RUN_ID: ${{ github.run_id }}
         run: |
+          actual_cli_version="$(codex --version)"
+          if [[ "$actual_cli_version" != *"$CODEX_CLI_VERSION"* ]]; then
+            echo "Codex CLI version mismatch: expected $CODEX_CLI_VERSION, got $actual_cli_version" >&2
+            exit 1
+          fi
+          export CODEX_CLI_VERSION_ACTUAL="$actual_cli_version"
+
           python3 - <<'PY'
           import json
           import os
@@ -206,6 +218,9 @@ jobs:
               "commit_range": os.environ["REVIEW_COMMIT_RANGE"],
               "run_id": os.environ["REVIEW_RUN_ID"],
               "overall_risk": risk,
+              "model": os.environ["CODEX_MODEL"],
+              "reasoning_effort": os.environ["CODEX_REASONING_EFFORT"],
+              "codex_cli_version": os.environ["CODEX_CLI_VERSION_ACTUAL"],
           }
           output = Path("codex-security-review-result.json")
           output.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
@@ -242,7 +257,6 @@ jobs:
       issues: write
       pull-requests: write
     env:
-      CODEX_MODEL: gpt-5.5
       REVIEW_COMMIT_RANGE: ${{ format('{0}...{1}', github.event.pull_request.base.sha, github.event.pull_request.head.sha) }}
       REVIEW_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       REVIEW_PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -266,6 +280,8 @@ jobs:
             const review = fs.readFileSync(process.env.REVIEW_MARKDOWN_FILE, 'utf8');
             const commitRange = process.env.REVIEW_COMMIT_RANGE || `${context.sha}..${context.sha}`;
             const modelName = process.env.CODEX_MODEL || 'unknown';
+            const reasoningEffort = process.env.CODEX_REASONING_EFFORT || 'unknown';
+            const codexCliVersion = process.env.CODEX_CLI_VERSION || 'unknown';
             const reviewedHeadSha = process.env.REVIEW_HEAD_SHA;
             const prNumber = Number(process.env.REVIEW_PR_NUMBER);
             const scopeSummaryLine = `Reviewed pull request diff only (\`${commitRange}\`, exact PR three-dot diff)`;
@@ -281,6 +297,8 @@ jobs:
             > **Scope summary**
             > - ${scopeSummaryLine}
             > - Model: ${modelName}
+            > - Reasoning effort: ${reasoningEffort}
+            > - Codex CLI: ${codexCliVersion} (pinned)
             >
             > 💡 *Click "edited" above to see previous reviews for this PR.*
 

--- a/.github/workflows/codex-security-review.yml
+++ b/.github/workflows/codex-security-review.yml
@@ -193,7 +193,7 @@ jobs:
           REVIEW_RUN_ID: ${{ github.run_id }}
         run: |
           actual_cli_version="$(codex --version)"
-          if [[ "$actual_cli_version" != *"$CODEX_CLI_VERSION"* ]]; then
+          if [[ "$actual_cli_version" != "codex-cli $CODEX_CLI_VERSION" ]]; then
             echo "Codex CLI version mismatch: expected $CODEX_CLI_VERSION, got $actual_cli_version" >&2
             exit 1
           fi
@@ -267,10 +267,17 @@ jobs:
           name: codex-security-review-markdown
           path: .
 
+      - name: Download security review result
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: codex-security-review-result
+          path: .
+
       - name: Post Codex security review
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           REVIEW_MARKDOWN_FILE: codex-security-review.md
+          REVIEW_RESULT_FILE: codex-security-review-result.json
           REVIEW_HEAD_SHA: ${{ env.REVIEW_HEAD_SHA }}
           REVIEW_PR_NUMBER: ${{ env.REVIEW_PR_NUMBER }}
         with:
@@ -278,10 +285,12 @@ jobs:
           script: |
             const fs = require('fs');
             const review = fs.readFileSync(process.env.REVIEW_MARKDOWN_FILE, 'utf8');
+            const result = JSON.parse(fs.readFileSync(process.env.REVIEW_RESULT_FILE, 'utf8'));
             const commitRange = process.env.REVIEW_COMMIT_RANGE || `${context.sha}..${context.sha}`;
-            const modelName = process.env.CODEX_MODEL || 'unknown';
-            const reasoningEffort = process.env.CODEX_REASONING_EFFORT || 'unknown';
-            const codexCliVersion = process.env.CODEX_CLI_VERSION || 'unknown';
+            const modelName = result.model || 'unknown';
+            const reasoningEffort = result.reasoning_effort || 'unknown';
+            const codexCliVersion = result.codex_cli_version || 'unknown';
+            const pinnedCodexCliVersion = process.env.CODEX_CLI_VERSION || 'unknown';
             const reviewedHeadSha = process.env.REVIEW_HEAD_SHA;
             const prNumber = Number(process.env.REVIEW_PR_NUMBER);
             const scopeSummaryLine = `Reviewed pull request diff only (\`${commitRange}\`, exact PR three-dot diff)`;
@@ -298,7 +307,7 @@ jobs:
             > - ${scopeSummaryLine}
             > - Model: ${modelName}
             > - Reasoning effort: ${reasoningEffort}
-            > - Codex CLI: ${codexCliVersion} (pinned)
+            > - Codex CLI: ${codexCliVersion} (pinned ${pinnedCodexCliVersion})
             >
             > 💡 *Click "edited" above to see previous reviews for this PR.*
 

--- a/.github/workflows/codex-security-review.yml
+++ b/.github/workflows/codex-security-review.yml
@@ -4,11 +4,6 @@ on:
   pull_request:
     types: [edited, opened, reopened, ready_for_review, synchronize]
 
-env:
-  CODEX_CLI_VERSION: "0.146.0"
-  CODEX_MODEL: gpt-5.6-sol
-  CODEX_REASONING_EFFORT: xhigh
-
 jobs:
   security-review:
     if: github.event.pull_request.head.repo.full_name == github.repository
@@ -21,6 +16,8 @@ jobs:
       contents: read
     env:
       OPENAI_API_KEY_PRESENT: ${{ secrets.OPENAI_API_KEY != '' }}
+      CODEX_MODEL: gpt-5.6-sol
+      CODEX_REASONING_EFFORT: xhigh
       REVIEW_BASE_SHA: ${{ github.event.pull_request.base.sha }}
       REVIEW_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       REVIEW_COMMIT_RANGE: ${{ format('{0}...{1}', github.event.pull_request.base.sha, github.event.pull_request.head.sha) }}
@@ -60,10 +57,8 @@ jobs:
         uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1.11
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
-          codex-version: ${{ env.CODEX_CLI_VERSION }}
           model: ${{ env.CODEX_MODEL }}
-          effort: ${{ env.CODEX_REASONING_EFFORT }}
-          codex-args: '["-c","service_tier=fast"]'
+          codex-args: '["-c","model_reasoning_effort=${{ env.CODEX_REASONING_EFFORT }}","-c","service_tier=fast"]'
 
           safety-strategy: drop-sudo
           sandbox: read-only
@@ -192,13 +187,6 @@ jobs:
           REVIEW_COMMIT_RANGE: ${{ env.REVIEW_COMMIT_RANGE }}
           REVIEW_RUN_ID: ${{ github.run_id }}
         run: |
-          actual_cli_version="$(codex --version)"
-          if [[ "$actual_cli_version" != "codex-cli $CODEX_CLI_VERSION" ]]; then
-            echo "Codex CLI version mismatch: expected $CODEX_CLI_VERSION, got $actual_cli_version" >&2
-            exit 1
-          fi
-          export CODEX_CLI_VERSION_ACTUAL="$actual_cli_version"
-
           python3 - <<'PY'
           import json
           import os
@@ -218,9 +206,6 @@ jobs:
               "commit_range": os.environ["REVIEW_COMMIT_RANGE"],
               "run_id": os.environ["REVIEW_RUN_ID"],
               "overall_risk": risk,
-              "model": os.environ["CODEX_MODEL"],
-              "reasoning_effort": os.environ["CODEX_REASONING_EFFORT"],
-              "codex_cli_version": os.environ["CODEX_CLI_VERSION_ACTUAL"],
           }
           output = Path("codex-security-review-result.json")
           output.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
@@ -257,6 +242,7 @@ jobs:
       issues: write
       pull-requests: write
     env:
+      CODEX_MODEL: gpt-5.6-sol
       REVIEW_COMMIT_RANGE: ${{ format('{0}...{1}', github.event.pull_request.base.sha, github.event.pull_request.head.sha) }}
       REVIEW_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       REVIEW_PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -267,17 +253,10 @@ jobs:
           name: codex-security-review-markdown
           path: .
 
-      - name: Download security review result
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: codex-security-review-result
-          path: .
-
       - name: Post Codex security review
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           REVIEW_MARKDOWN_FILE: codex-security-review.md
-          REVIEW_RESULT_FILE: codex-security-review-result.json
           REVIEW_HEAD_SHA: ${{ env.REVIEW_HEAD_SHA }}
           REVIEW_PR_NUMBER: ${{ env.REVIEW_PR_NUMBER }}
         with:
@@ -285,12 +264,8 @@ jobs:
           script: |
             const fs = require('fs');
             const review = fs.readFileSync(process.env.REVIEW_MARKDOWN_FILE, 'utf8');
-            const result = JSON.parse(fs.readFileSync(process.env.REVIEW_RESULT_FILE, 'utf8'));
             const commitRange = process.env.REVIEW_COMMIT_RANGE || `${context.sha}..${context.sha}`;
-            const modelName = result.model || 'unknown';
-            const reasoningEffort = result.reasoning_effort || 'unknown';
-            const codexCliVersion = result.codex_cli_version || 'unknown';
-            const pinnedCodexCliVersion = process.env.CODEX_CLI_VERSION || 'unknown';
+            const modelName = process.env.CODEX_MODEL || 'unknown';
             const reviewedHeadSha = process.env.REVIEW_HEAD_SHA;
             const prNumber = Number(process.env.REVIEW_PR_NUMBER);
             const scopeSummaryLine = `Reviewed pull request diff only (\`${commitRange}\`, exact PR three-dot diff)`;
@@ -306,8 +281,6 @@ jobs:
             > **Scope summary**
             > - ${scopeSummaryLine}
             > - Model: ${modelName}
-            > - Reasoning effort: ${reasoningEffort}
-            > - Codex CLI: ${codexCliVersion} (pinned ${pinnedCodexCliVersion})
             >
             > 💡 *Click "edited" above to see previous reviews for this PR.*
 


### PR DESCRIPTION
Reviewable diff: +2/-2 across 1 files (excludes generated, test, and story files).

## Summary

The automated security review now runs GPT-5.6 Sol instead of GPT-5.5. Its prompt, `xhigh` reasoning effort, CLI behavior, artifacts, and review-policy integration remain unchanged.

## How it works

1. Pull-request events continue to run the existing security-review workflow against the exact PR diff.
2. The review job selects `gpt-5.6-sol` through its existing model environment variable.
3. The post job uses the same model value when labeling the generated PR comment.

```mermaid
flowchart LR
  PR["Pull request event"] --> Review["Existing security-review workflow"]
  Review --> Model["GPT-5.6 Sol at xhigh"]
  Model --> Comment["Existing result artifacts and PR comment"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `.github/workflows/codex-security-review.yml` | Updates the review and comment model values from `gpt-5.5` to `gpt-5.6-sol` | Confirm execution and displayed provenance stay aligned while all other workflow behavior remains unchanged |

## Key technical decisions & trade-offs

- Change only the model version; preserve the current prompt, `xhigh` reasoning effort, action version, CLI behavior, and policy semantics.
- Update both job-local model values so the invoked model and the model shown in the PR comment cannot diverge.

## Testing & validation

- `python3 .github/scripts/evaluate_review_policy_test.py` — 46 tests passed.
- Parsed the workflow with Ruby YAML and asserted both jobs select `gpt-5.6-sol`.
- Verified the final diff contains only the two model-version replacements.
- `git diff --check origin/main...HEAD` — passed.
