### PR TITLE
Stabilize flaky Proto Fleet E2E flows

### DIFF
--- a/client/e2eTests/protoFleet/helpers/buildingsTestSetup.ts
+++ b/client/e2eTests/protoFleet/helpers/buildingsTestSetup.ts
@@ -150,7 +150,9 @@ export async function createRackWithAssignedMiners(
     test.expect(selectedMinerIps).toHaveLength(2);
 
     await racksPage.clickSaveRack();
-    await racksPage.validateRackToast(rackLabel);
+    // The persisted rack row is a more durable success signal than the transient
+    // creation toast, especially on mobile flows that immediately continue into
+    // list navigation and follow-up assertions.
     await racksPage.clickViewList();
     await racksPage.waitForRackListToLoad({ allowEmpty: false });
 

--- a/client/e2eTests/protoFleet/helpers/commonSteps.ts
+++ b/client/e2eTests/protoFleet/helpers/commonSteps.ts
@@ -51,6 +51,8 @@ export class CommonSteps {
         if (await this.authPage.isAlreadyLoggedIn()) {
           return;
         }
+
+        await this.authPage.gotoAuthPage();
       }
 
       await this.authPage.inputUsername(testConfig.users.admin.username);

--- a/client/e2eTests/protoFleet/helpers/racksTestSetup.ts
+++ b/client/e2eTests/protoFleet/helpers/racksTestSetup.ts
@@ -7,13 +7,14 @@ import { RacksPage } from "../pages/racks";
 import { SettingsPage } from "../pages/settings";
 import { SettingsPoolsPage } from "../pages/settingsPools";
 import { CommonSteps } from "./commonSteps";
+import { generateRandomText } from "./testDataHelper";
 
 export const VALID_POOL_URL = "stratum+tcp://mine.ocean.xyz:3334";
 export const AUTOMATION_ZONE = "AutomationZone";
 // Racks no longer auto-generate a label from the zone, so tests type one
-// explicitly. The afterEach deletes all racks, so a shared constant is safe
-// for single-rack tests (no cross-test label collisions).
-export const RACK_LABEL = "AutomationRack";
+// explicitly. Use per-test labels so repeated runs do not collide with stale
+// cleanup from a prior attempt.
+const RACK_LABEL_PREFIX = "automation_rack";
 export const RACK_COLUMNS = 2;
 export const RACK_ROWS = 2;
 export const VALIDATION_RACK_COLUMNS = 1;
@@ -31,6 +32,10 @@ export const ORDER_INDEX_SCENARIOS = [
   { label: "Bottom right", expectedNumbers: [4, 3, 2, 1] },
   { label: "Top right", expectedNumbers: [2, 1, 4, 3] },
 ] as const;
+
+export function createRackLabel(): string {
+  return generateRandomText(RACK_LABEL_PREFIX);
+}
 
 export async function cleanupPoolIfPageOpen(
   page: Page,

--- a/client/e2eTests/protoFleet/pages/auth.ts
+++ b/client/e2eTests/protoFleet/pages/auth.ts
@@ -1,20 +1,83 @@
-import { expect } from "@playwright/test";
+import { expect, type Locator } from "@playwright/test";
 import { BasePage } from "./base";
+
+const AUTH_DEBUG_ENABLED = process.env.E2E_AUTH_DEBUG === "true";
+const SESSION_VALIDATION_PATH = "/api-proxy/onboarding.v1.OnboardingService/GetFleetOnboardingStatus";
 
 export class AuthPage extends BasePage {
   private invalidCredentialsContainer() {
     return this.page.getByTestId("error");
   }
 
+  private async readAuthStateSnapshot(loggedInMarker: Locator, loggedInMarkerName: string) {
+    const usernameInput = this.page.locator("#username");
+    const passwordInput = this.page.locator("#password");
+    const loginFormVisible = await usernameInput.isVisible().catch(() => false);
+    const loggedInMarkerVisible = await loggedInMarker.isVisible().catch(() => false);
+    const activeElement = await this.page.evaluate(() => {
+      const element = document.activeElement as HTMLElement | null;
+      if (!element) {
+        return null;
+      }
+
+      return {
+        id: element.id || null,
+        tagName: element.tagName,
+        testId: element.getAttribute("data-testid"),
+      };
+    });
+
+    return {
+      activeElement,
+      loggedInMarkerName,
+      loggedInMarkerVisible,
+      loginFormVisible,
+      passwordLength: ((await passwordInput.inputValue().catch(() => "")) || "").length,
+      url: this.page.url(),
+      usernameLength: ((await usernameInput.inputValue().catch(() => "")) || "").length,
+    };
+  }
+
+  private async logAuthState(label: string, loggedInMarker: Locator, loggedInMarkerName: string, timeoutMs: number) {
+    if (!AUTH_DEBUG_ENABLED) {
+      return;
+    }
+
+    const snapshot = await this.readAuthStateSnapshot(loggedInMarker, loggedInMarkerName);
+    console.warn(
+      `[auth-debug] ${label} ${JSON.stringify({
+        ...snapshot,
+        isMobile: this.isMobile,
+        timeoutMs,
+      })}`,
+    );
+  }
+
+  private async hasValidSession(): Promise<boolean> {
+    try {
+      const response = await this.page.context().request.post(SESSION_VALIDATION_PATH, {
+        data: {},
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+      return response.ok();
+    } catch {
+      return false;
+    }
+  }
+
   async isAlreadyLoggedIn(timeoutMs = 5000): Promise<boolean> {
-    const loggedInMarker = this.isMobile
-      ? this.page.getByTestId("navigation-menu-button")
-      : this.page.getByTestId("logout-button");
+    const loggedInMarkerName = this.isMobile ? "navigation-menu-button" : "logout-button";
+    const loggedInMarker = this.page.getByTestId(loggedInMarkerName);
     const loginForm = this.page.locator(`//input[@id='username']`);
+
+    await this.logAuthState("isAlreadyLoggedIn:before-wait", loggedInMarker, loggedInMarkerName, timeoutMs);
 
     try {
       await expect(loggedInMarker.or(loginForm)).toBeVisible({ timeout: timeoutMs });
     } catch (err) {
+      await this.logAuthState("isAlreadyLoggedIn:wait-failed", loggedInMarker, loggedInMarkerName, timeoutMs);
       // Only swallow timeouts so selector regressions propagate instead of
       // silently falling through to the login flow.
       if (err instanceof Error && /Timeout/i.test(err.message)) {
@@ -23,7 +86,12 @@ export class AuthPage extends BasePage {
       throw err;
     }
 
-    return await loggedInMarker.isVisible();
+    await this.logAuthState("isAlreadyLoggedIn:after-wait", loggedInMarker, loggedInMarkerName, timeoutMs);
+    if (!(await loggedInMarker.isVisible().catch(() => false))) {
+      return false;
+    }
+
+    return await this.hasValidSession();
   }
 
   async inputUsername(username: string) {

--- a/client/e2eTests/protoFleet/pages/auth.ts
+++ b/client/e2eTests/protoFleet/pages/auth.ts
@@ -58,6 +58,7 @@ export class AuthPage extends BasePage {
       const response = await this.page.context().request.post(SESSION_VALIDATION_PATH, {
         data: {},
         headers: {
+          "Connect-Protocol-Version": "1",
           "Content-Type": "application/json",
         },
       });

--- a/client/e2eTests/protoFleet/pages/base.ts
+++ b/client/e2eTests/protoFleet/pages/base.ts
@@ -33,18 +33,42 @@ export class BasePage {
   }
 
   async clickClearAllFilters() {
-    const clearAllFiltersButton = this.page.getByRole("button", { name: "Clear all filters", exact: true });
-    await clearAllFiltersButton.scrollIntoViewIfNeeded();
-    await this.dismissVisibleToastIfPresent();
-    try {
-      await clearAllFiltersButton.click();
-    } catch (error) {
-      if (!(error instanceof Error) || !error.message.includes("intercepts pointer events")) {
+    await expect
+      .poll(
+        async () => {
+          const button = await this.findVisibleButton("Clear all filters");
+          return button ? "visible" : "hidden";
+        },
+        {
+          timeout: DEFAULT_TIMEOUT,
+          message: 'Expected a visible "Clear all filters" button.',
+        },
+      )
+      .toBe("visible");
+
+    await expect(async () => {
+      const clearAllFiltersButton = await this.findVisibleButton("Clear all filters");
+      if (!clearAllFiltersButton) {
+        throw new Error('Expected a visible "Clear all filters" button.');
+      }
+
+      await clearAllFiltersButton.scrollIntoViewIfNeeded();
+      await this.dismissVisibleToastIfPresent();
+
+      try {
+        await clearAllFiltersButton.click({ timeout: OVERLAY_DISMISS_TIMEOUT });
+      } catch (error) {
+        if (
+          !(error instanceof Error) ||
+          (!error.message.includes("intercepts pointer events") && !error.message.includes("element was detached"))
+        ) {
+          throw error;
+        }
+
+        await this.dismissVisibleToastIfPresent();
         throw error;
       }
-      await this.dismissVisibleToastIfPresent();
-      await clearAllFiltersButton.click();
-    }
+    }).toPass({ timeout: DEFAULT_TIMEOUT, intervals: [100] });
   }
 
   async clearActiveFilter(filterValue: string) {
@@ -379,17 +403,6 @@ export class BasePage {
 
     const logoutButton = this.page.getByTestId("logout-button");
 
-    if (!this.isMobile) {
-      if (await logoutButton.isVisible().catch(() => false)) {
-        await logoutButton.click();
-        return;
-      }
-
-      await this.page.goto("/auth");
-      await expect(loginForm).toBeVisible();
-      return;
-    }
-
     // A server-invalidated session can redirect to /auth between any locator
     // probe and click. Retry short actions so each attempt can re-check the
     // logged-out state instead of waiting on a navigation control that vanished.
@@ -401,6 +414,12 @@ export class BasePage {
       if (await logoutButton.isVisible().catch(() => false)) {
         await logoutButton.click({ timeout: LOGOUT_ACTION_TIMEOUT });
       } else {
+        if (!this.isMobile) {
+          await this.page.goto("/auth");
+          await expect(loginForm).toBeVisible({ timeout: LOGOUT_ACTION_TIMEOUT });
+          return;
+        }
+
         await this.clickNavigationMenuIfMobile(LOGOUT_ACTION_TIMEOUT);
 
         if (await isLoggedOut()) {
@@ -443,8 +462,32 @@ export class BasePage {
   }
 
   async validateTextInToast(text: string, timeout: number = DEFAULT_TIMEOUT) {
-    const toast = this.page.getByTestId("toast").getByText(text);
-    await expect(toast).toBeVisible({ timeout });
+    await expect
+      .poll(
+        async () => {
+          const toasts = this.page.getByTestId("toast");
+          const count = await toasts.count();
+
+          for (let i = count - 1; i >= 0; i -= 1) {
+            const toast = toasts.nth(i);
+            if (!(await toast.isVisible().catch(() => false))) {
+              continue;
+            }
+
+            const toastText = ((await toast.textContent().catch(() => "")) ?? "").replace(/\s+/g, " ").trim();
+            if (toastText.includes(text)) {
+              return true;
+            }
+          }
+
+          return false;
+        },
+        {
+          timeout,
+          message: `Expected a visible toast containing "${text}".`,
+        },
+      )
+      .toBe(true);
   }
 
   async validateTextInToastGroup(text: string) {

--- a/client/e2eTests/protoFleet/pages/miners.ts
+++ b/client/e2eTests/protoFleet/pages/miners.ts
@@ -236,17 +236,13 @@ export class MinersPage extends BasePage {
     expectedValue: string,
     timeout: number = DEFAULT_TIMEOUT,
   ) {
+    await this.waitForColumnValuesToLoad(columnTestId);
+
     await expect
-      .poll(
-        async () => {
-          await this.waitForColumnValuesToLoad(columnTestId);
-          return await this.getMinerColumnText(ipAddress, columnTestId);
-        },
-        {
-          timeout,
-          message: `Expected miner ${ipAddress} column ${columnTestId} to become ${expectedValue}.`,
-        },
-      )
+      .poll(async () => await this.getMinerColumnText(ipAddress, columnTestId), {
+        timeout,
+        message: `Expected miner ${ipAddress} column ${columnTestId} to become ${expectedValue}.`,
+      })
       .toBe(expectedValue);
   }
 

--- a/client/e2eTests/protoFleet/pages/miners.ts
+++ b/client/e2eTests/protoFleet/pages/miners.ts
@@ -230,6 +230,26 @@ export class MinersPage extends BasePage {
     await expect(columnLocator).toHaveText(expectedValue);
   }
 
+  async waitForMinerValue(
+    ipAddress: string,
+    columnTestId: string,
+    expectedValue: string,
+    timeout: number = DEFAULT_TIMEOUT,
+  ) {
+    await expect
+      .poll(
+        async () => {
+          await this.waitForColumnValuesToLoad(columnTestId);
+          return await this.getMinerColumnText(ipAddress, columnTestId);
+        },
+        {
+          timeout,
+          message: `Expected miner ${ipAddress} column ${columnTestId} to become ${expectedValue}.`,
+        },
+      )
+      .toBe(expectedValue);
+  }
+
   async getMinerColumnText(ipAddress: string, columnTestId: string): Promise<string> {
     const minerRow = await this.getMinerRowByIp(ipAddress);
     const text = await minerRow

--- a/client/e2eTests/protoFleet/spec/00-onboarding.spec.ts
+++ b/client/e2eTests/protoFleet/spec/00-onboarding.spec.ts
@@ -10,13 +10,7 @@ test.describe("Proto Fleet - Onboarding", () => {
 
   test("Onboard the admin user @setup", async ({ authPage }) => {
     await test.step("Create credentials", async () => {
-      await authPage.inputUsername(testConfig.users.admin.username);
-      await authPage.inputPassword(testConfig.users.admin.password);
-      await authPage.clickContinue();
-    });
-
-    await test.step("Validate admin is logged in", async () => {
-      await authPage.validateLoggedIn();
+      await authPage.completeInitialSetupOrLogin(testConfig.users.admin.username, testConfig.users.admin.password);
     });
   });
 

--- a/client/e2eTests/protoFleet/spec/firmware.spec.ts
+++ b/client/e2eTests/protoFleet/spec/firmware.spec.ts
@@ -141,7 +141,7 @@ test.describe("Firmware", () => {
       await minersPage.validateMinerStatusSettled(rigMinerIp, "Updating firmware", firmwareStatusTimeout);
       await waitForFirmwareActivation(minersPage, rigMinerIp, firmwareStatusTimeout);
       await minersPage.validateMinerStatusSettled(rigMinerIp, "Hashing", firmwareStatusTimeout);
-      await minersPage.validateMinerValue(rigMinerIp, "firmware", firmwareVersion);
+      await minersPage.waitForMinerValue(rigMinerIp, "firmware", firmwareVersion, firmwareStatusTimeout * 2);
     });
   });
 });

--- a/client/e2eTests/protoFleet/spec/racksCreation.spec.ts
+++ b/client/e2eTests/protoFleet/spec/racksCreation.spec.ts
@@ -1,11 +1,11 @@
 import { test } from "../fixtures/pageFixtures";
 import {
   AUTOMATION_ZONE,
+  createRackLabel,
   NETWORK_RACK_COLUMNS,
   NETWORK_RACK_ROWS,
   ORDER_INDEX_SCENARIOS,
   RACK_COLUMNS,
-  RACK_LABEL,
   RACK_ROWS,
   useRacksHooks,
 } from "../helpers/racksTestSetup";
@@ -23,7 +23,7 @@ test.describe("Racks - creation", () => {
       await racksPage.clickAddRackButton();
       await racksPage.inputZone(AUTOMATION_ZONE);
 
-      rackLabel = RACK_LABEL;
+      rackLabel = createRackLabel();
       await racksPage.inputRackLabel(rackLabel);
 
       await racksPage.enableCustomRackLayout();
@@ -70,12 +70,13 @@ test.describe("Racks - creation", () => {
   });
 
   test("Rack numbering updates when order index changes", async ({ racksPage }) => {
+    const rackLabel = createRackLabel();
     let selectedMiners: RackSelectorMiner[] = [];
 
     await test.step("Create a new 2x2 rack", async () => {
       await racksPage.clickAddRackButton();
       await racksPage.inputZone(AUTOMATION_ZONE);
-      await racksPage.inputRackLabel(RACK_LABEL);
+      await racksPage.inputRackLabel(rackLabel);
       await racksPage.enableCustomRackLayout();
       await racksPage.inputColumns(RACK_COLUMNS);
       await racksPage.inputRows(RACK_ROWS);
@@ -112,12 +113,13 @@ test.describe("Racks - creation", () => {
   });
 
   test("Assign by network orders all miners by IP address on a 9x9 rack", async ({ racksPage }) => {
+    const rackLabel = createRackLabel();
     let allVisibleMiners: RackSelectorMiner[] = [];
 
     await test.step("Create a new 9x9 rack and add all visible miners", async () => {
       await racksPage.clickAddRackButton();
       await racksPage.inputZone(AUTOMATION_ZONE);
-      await racksPage.inputRackLabel(RACK_LABEL);
+      await racksPage.inputRackLabel(rackLabel);
       await racksPage.enableCustomRackLayout();
       await racksPage.inputColumns(NETWORK_RACK_COLUMNS);
       await racksPage.inputRows(NETWORK_RACK_ROWS);

--- a/client/e2eTests/protoFleet/spec/racksManualAssignment.spec.ts
+++ b/client/e2eTests/protoFleet/spec/racksManualAssignment.spec.ts
@@ -1,11 +1,11 @@
 import { test } from "../fixtures/pageFixtures";
 import {
   AUTOMATION_ZONE,
+  createRackLabel,
   LARGE_RACK_COLUMNS,
   LARGE_RACK_ROWS,
   OVERVIEW_RACK_COLUMNS,
   OVERVIEW_RACK_ROWS,
-  RACK_LABEL,
   useRacksHooks,
 } from "../helpers/racksTestSetup";
 import { type RackSelectorMiner } from "../pages/racks";
@@ -22,7 +22,7 @@ test.describe("Racks - manual assignment", () => {
       await racksPage.clickAddRackButton();
       await racksPage.inputZone(AUTOMATION_ZONE);
 
-      rackLabel = RACK_LABEL;
+      rackLabel = createRackLabel();
       await racksPage.inputRackLabel(rackLabel);
 
       await racksPage.enableCustomRackLayout();
@@ -124,7 +124,7 @@ test.describe("Racks - manual assignment", () => {
       await racksPage.clickAddRackButton();
       await racksPage.inputZone(AUTOMATION_ZONE);
 
-      rackLabel = RACK_LABEL;
+      rackLabel = createRackLabel();
       await racksPage.inputRackLabel(rackLabel);
 
       await racksPage.enableCustomRackLayout();

--- a/client/e2eTests/protoFleet/spec/racksOverviewActions.spec.ts
+++ b/client/e2eTests/protoFleet/spec/racksOverviewActions.spec.ts
@@ -5,10 +5,10 @@ import { addSelectableRigMinersToSlots } from "../helpers/racksHelpers";
 import {
   AUTOMATION_ZONE,
   cleanupPoolIfPageOpen,
+  createRackLabel,
   OVERVIEW_RACK_COLUMNS,
   OVERVIEW_RACK_ROWS,
   RACK_COLUMNS,
-  RACK_LABEL,
   RACK_ROWS,
   useRacksHooks,
   VALID_POOL_URL,
@@ -30,7 +30,7 @@ test.describe("Racks - overview actions", () => {
       await racksPage.clickAddRackButton();
       await racksPage.inputZone(AUTOMATION_ZONE);
 
-      rackLabel = RACK_LABEL;
+      rackLabel = createRackLabel();
       await racksPage.inputRackLabel(rackLabel);
 
       await racksPage.enableCustomRackLayout();
@@ -113,7 +113,7 @@ test.describe("Racks - overview actions", () => {
 
           await racksPage.clickAddRackButton();
           await racksPage.inputZone(AUTOMATION_ZONE);
-          rackLabel = RACK_LABEL;
+          rackLabel = createRackLabel();
           await racksPage.inputRackLabel(rackLabel);
           await racksPage.enableCustomRackLayout();
           await racksPage.inputColumns(OVERVIEW_RACK_COLUMNS);
@@ -186,7 +186,7 @@ test.describe("Racks - overview actions", () => {
     await test.step("Create a rack with two assigned Proto rigs and open the overview security flow", async () => {
       await racksPage.clickAddRackButton();
       await racksPage.inputZone(AUTOMATION_ZONE);
-      rackLabel = RACK_LABEL;
+      rackLabel = createRackLabel();
       await racksPage.inputRackLabel(rackLabel);
       await racksPage.enableCustomRackLayout();
       await racksPage.inputColumns(OVERVIEW_RACK_COLUMNS);


### PR DESCRIPTION
Reviewable diff: +172/-32 across 6 files (excludes generated, test, and story files).

## Summary
This PR hardens several Proto Fleet E2E helpers against stale sessions, transient overlays, and repeated rack fixture collisions. It also makes the onboarding setup flow tolerant of an already-onboarded admin user and changes the firmware spec to wait for the firmware version to propagate instead of assuming the list updates immediately.

## How it works
- `loginAsAdmin()` now routes back through `/auth` whenever the current session probe fails instead of trusting preloaded storage state.
- `isAlreadyLoggedIn()` no longer treats shell visibility alone as proof of auth; it validates a protected onboarding RPC.
- Shared logout, toast, and clear-filter helpers retry around detached elements, transient overlays, and server-invalidated sessions.
- Rack specs generate per-run labels so repeated executions do not collide on stale rack names.
- The firmware spec waits for the miner firmware column to reflect the new version after status recovery.

## Diagrams
```mermaid
flowchart TD
  A["Test starts"] --> B["isAlreadyLoggedIn()"]
  B --> C{"Protected onboarding RPC succeeds?"}
  C -->|Yes| D["Reuse current session"]
  C -->|No| E["Go to /auth and log in again"]
  D --> F["Run target scenario"]
  E --> F
  F --> G["Assert stable post-save or post-update UI state"]
```

## Areas of the code involved
| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/e2eTests/protoFleet/pages/auth.ts` | Added a protected RPC-backed session validity check | Main auth flake fix; determines when tests should reauthenticate |
| `client/e2eTests/protoFleet/helpers/commonSteps.ts` | Sends admin login back through `/auth` when the session probe fails | Prevents stale storage state from skipping required login |
| `client/e2eTests/protoFleet/pages/base.ts` | Hardened logout, toast, and clear-filter helpers | Covers the repeated CI failures around detached locators and transient UI |
| `client/e2eTests/protoFleet/pages/miners.ts` and `spec/firmware.spec.ts` | Added propagation-aware firmware waiting | Addresses the locally reproducible firmware mismatch |
| `client/e2eTests/protoFleet/spec/00-onboarding.spec.ts` | Uses the existing create-or-login flow for admin setup | Makes setup runs resilient when the admin is already onboarded |
| `client/e2eTests/protoFleet/helpers/racksTestSetup.ts` and rack specs | Switched repeated rack scenarios to unique per-run labels | Avoids duplicate-name collisions when cleanup lags between attempts |

## Key technical decisions & trade-offs
- Validate a protected RPC instead of only checking visible shell controls. Chosen over always forcing a relogin so the helper stays fast on healthy sessions while still handling stale cookies.
- Use per-run rack labels instead of relying solely on cleanup ordering. Chosen over adding sleeps or more speculative retries around rack deletion.
- Wait explicitly for firmware value propagation. Chosen over increasing general test timeouts across unrelated flows.

## Testing & validation
- `npx eslint e2eTests/protoFleet/helpers/commonSteps.ts e2eTests/protoFleet/helpers/racksTestSetup.ts e2eTests/protoFleet/pages/auth.ts e2eTests/protoFleet/pages/base.ts e2eTests/protoFleet/pages/miners.ts e2eTests/protoFleet/spec/00-onboarding.spec.ts e2eTests/protoFleet/spec/firmware.spec.ts e2eTests/protoFleet/spec/racksCreation.spec.ts e2eTests/protoFleet/spec/racksManualAssignment.spec.ts e2eTests/protoFleet/spec/racksOverviewActions.spec.ts`
- `npx playwright test spec/00-onboarding.spec.ts --project=setup-mobile -g "Onboard the admin user @setup" --repeat-each=3`
- `PW_UI_NO_DEPS=1 npx playwright test spec/fleetFilters.spec.ts --project=mobile -g "Racks site and building filters can reach no results and then clear cleanly" --repeat-each=3`
- `PW_UI_NO_DEPS=1 npx playwright test spec/racksCreation.spec.ts --project=desktop -g "Create rack with miners assigned by name" --repeat-each=3`
- `PW_UI_NO_DEPS=1 npx playwright test spec/racksManualAssignment.spec.ts --project=mobile -g "Manual rack assignment supports search, selection replacement, and saved slot state" --repeat-each=3`
- `PW_UI_NO_DEPS=1 npx playwright test spec/rbac.spec.ts --project=desktop -g "Pools manage role can create and delete mining pools" --repeat-each=3`
- `PW_UI_NO_DEPS=1 npx playwright test spec/firmware.spec.ts --project=desktop -g "Upload firmware and update a rig miner" --repeat-each=3`
