### PR TITLE
fix(monitoring): narrow the heartbeat refresh window and stamp host.name on spans

### DIFF
--- a/deployment-files/README.md
+++ b/deployment-files/README.md
@@ -247,13 +247,15 @@ So the alert firing does not by itself mean ingest died. Check the raw
 samples first — this is the discriminator:
 
 ```bash
-docker exec -i <timescaledb-container> psql -U fleet -d fleet -c \
-  "SELECT organization_id, max(time) AS newest,
-          round(extract(epoch from now() - max(time))) AS staleness_seconds
-     FROM notification_metric_sample
-    WHERE metric = 'fleet_telemetry_poll_total'
-      AND time > now() - INTERVAL '15 minutes'
-    GROUP BY organization_id"
+docker exec -i <timescaledb-container> \
+  bash -c 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB"' <<'SQL'
+SELECT organization_id, max(time) AS newest,
+       round(extract(epoch from now() - max(time))) AS staleness_seconds
+  FROM notification_metric_sample
+ WHERE metric = 'fleet_telemetry_poll_total'
+   AND time > now() - INTERVAL '15 minutes'
+ GROUP BY organization_id;
+SQL
 ```
 
 If the newest raw sample is also stale, the stall is real: check fleet-api
@@ -261,16 +263,31 @@ and its metrics writer (`docker logs … | grep 'metrics:'`). If raw samples
 are landing fine, the aggregate is the problem — check its refresh policy:
 
 ```bash
-docker exec -i <timescaledb-container> psql -U fleet -d fleet -c \
-  "SELECT job_status, last_successful_finish, total_failures
-     FROM timescaledb_information.job_stats
-    WHERE job_id IN (SELECT job_id FROM timescaledb_information.jobs
-                      WHERE hypertable_name = 'fleet_telemetry_poll_heartbeat')"
+docker exec -i <timescaledb-container> \
+  bash -c 'psql -U "$POSTGRES_USER" -d "$POSTGRES_DB"' <<'SQL'
+SELECT s.job_id, s.job_status, s.last_successful_finish, s.total_failures
+  FROM timescaledb_information.job_stats s
+  JOIN timescaledb_information.jobs j ON j.job_id = s.job_id
+ WHERE j.proc_name = 'policy_refresh_continuous_aggregate'
+   AND j.hypertable_name IN (
+       SELECT ca.view_name
+         FROM timescaledb_information.continuous_aggregates ca
+        WHERE ca.view_name = 'fleet_telemetry_poll_heartbeat'
+       UNION ALL
+       SELECT ca.materialization_hypertable_name
+         FROM timescaledb_information.continuous_aggregates ca
+        WHERE ca.view_name = 'fleet_telemetry_poll_heartbeat');
+SQL
 ```
 
+The `proc_name` filter excludes the aggregate's retention policy, which is
+also registered against the same hypertable; matching the materialization
+hypertable name too covers the TimescaleDB versions that label a refresh
+policy that way rather than by view name.
+
 A `job_status` of `Paused`, or a `last_successful_finish` well in the past,
-confirms it. Resume the job and backfill enough buckets to clear the alert
-(the `CALL` must not run inside a transaction):
+confirms it. Resume the job with the `job_id` from above and backfill enough
+buckets to clear the alert (the `CALL` must not run inside a transaction):
 
 ```sql
 SELECT alter_job(<job_id>, scheduled => true);

--- a/deployment-files/README.md
+++ b/deployment-files/README.md
@@ -235,6 +235,50 @@ The configs live under `server/monitoring/grafana/`:
 - `provisioning/alerting/notification-policies.yaml` — root routing
   tree (grouping + repeat interval).
 
+### When "Metric Ingest Stalled" fires
+
+The rule reads the `fleet_telemetry_poll_heartbeat` continuous aggregate,
+not the raw samples. That aggregate is `materialized_only` and carries its
+own retention policy, so if its refresh policy job stops, retention keeps
+deleting buckets until the aggregate is empty and the rule fires for every
+pollable organization while ingest is perfectly healthy.
+
+So the alert firing does not by itself mean ingest died. Check the raw
+samples first — this is the discriminator:
+
+```bash
+docker exec -i <timescaledb-container> psql -U fleet -d fleet -c \
+  "SELECT organization_id, max(time) AS newest,
+          round(extract(epoch from now() - max(time))) AS staleness_seconds
+     FROM notification_metric_sample
+    WHERE metric = 'fleet_telemetry_poll_total'
+      AND time > now() - INTERVAL '15 minutes'
+    GROUP BY organization_id"
+```
+
+If the newest raw sample is also stale, the stall is real: check fleet-api
+and its metrics writer (`docker logs … | grep 'metrics:'`). If raw samples
+are landing fine, the aggregate is the problem — check its refresh policy:
+
+```bash
+docker exec -i <timescaledb-container> psql -U fleet -d fleet -c \
+  "SELECT job_status, last_successful_finish, total_failures
+     FROM timescaledb_information.job_stats
+    WHERE job_id IN (SELECT job_id FROM timescaledb_information.jobs
+                      WHERE hypertable_name = 'fleet_telemetry_poll_heartbeat')"
+```
+
+A `job_status` of `Paused`, or a `last_successful_finish` well in the past,
+confirms it. Resume the job and backfill enough buckets to clear the alert
+(the `CALL` must not run inside a transaction):
+
+```sql
+SELECT alter_job(<job_id>, scheduled => true);
+CALL refresh_continuous_aggregate('fleet_telemetry_poll_heartbeat',
+                                  now() - INTERVAL '2 hours',
+                                  now() - INTERVAL '1 minute');
+```
+
 ### Enabling system monitoring
 
 Host system monitoring is **off by default** and requires the alerts
@@ -314,7 +358,7 @@ DD_CLIENT_TOKEN=your-datadog-rum-client-token
 # Optional
 DD_SITE=datadoghq.com          # your Datadog site (default: datadoghq.com)
 DD_SERVICE=proto-fleet-client  # service name (default: proto-fleet-client)
-DD_ENV=production              # environment tag (default: build env)
+DD_ENV=prod-site1              # environment tag; use prod-<site> so per-site data stays separable (default: build env)
 DD_RUM_SAMPLE_RATE=100         # RUM session sample rate (default: 100)
 DD_SESSION_REPLAY_SAMPLE_RATE=0  # Session Replay sample rate (default: 0, off)
 DD_TRACE_SAMPLE_RATE=100       # trace sample rate for API calls (default: 100)
@@ -348,10 +392,23 @@ DD_API_KEY=your-datadog-api-key
 
 # Optional
 DD_SITE=datadoghq.com            # your Datadog site (default: datadoghq.com)
-DD_ENV=production                # APM env tag (default: production)
+DD_ENV=prod-site1                # APM environment tag; use prod-<site> to match the RUM config (default: production)
+DD_HOSTNAME=fleet-host-1         # host tag on spans (default: this machine's hostname)
 FLEET_TELEMETRY_SAMPLE_RATE=1.0  # server-side trace sample cap (default: 1.0)
 FLEET_TELEMETRY_TRUST_INCOMING_TRACES=true  # parent spans to RUM trace context (default: true)
 ```
+
+`DD_HOSTNAME` is stamped onto spans as `host.name`. Without it the Datadog
+exporter infers a hostname from inside the collector container, so traces
+hang off a host that nothing else reports. `run-fleet.sh` defaults it to the
+output of `hostname` and writes that value to `.env`; if you also run a
+Datadog Agent on this machine for host metrics or logs, set `DD_HOSTNAME` to
+the hostname that agent reports (its `DD_HOSTNAME`, or `datadog-agent
+hostname`) so APM traces and infra data resolve to the same host. Matching
+`DD_ENV` across the agent, this overlay, and the RUM config is what joins
+infra, APM, and RUM. The overlay itself treats `DD_HOSTNAME` as required, so
+driving `docker compose` with `docker-compose.tracing.yaml` by hand needs it
+set in `.env` or the shell.
 
 Unlike the RUM client token, `DD_API_KEY` is a secret Datadog API key;
 it stays in `.env` (mode 0600) and the collector container's

--- a/deployment-files/README.md
+++ b/deployment-files/README.md
@@ -287,14 +287,21 @@ policy that way rather than by view name.
 
 A `job_status` of `Paused`, or a `last_successful_finish` well in the past,
 confirms it. Resume the job with the `job_id` from above and backfill enough
-buckets to clear the alert (the `CALL` must not run inside a transaction):
+buckets to clear the alert:
 
-```sql
+```bash
+docker exec -i <timescaledb-container> \
+  bash -c 'psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB"' <<'SQL'
 SELECT alter_job(<job_id>, scheduled => true);
 CALL refresh_continuous_aggregate('fleet_telemetry_poll_heartbeat',
                                   now() - INTERVAL '2 hours',
                                   now() - INTERVAL '1 minute');
+SQL
 ```
+
+Keep this on psql's default autocommit — `refresh_continuous_aggregate()`
+cannot run inside a transaction block, so adding `--single-transaction` (or
+wrapping the statements in `BEGIN`) fails with that error.
 
 ### Enabling system monitoring
 

--- a/deployment-files/docker-compose.tracing.yaml
+++ b/deployment-files/docker-compose.tracing.yaml
@@ -1,6 +1,6 @@
 # Tracing overlay (run-fleet.sh --enable-tracing): fleet-api request spans →
-# OTel collector → Datadog APM. Requires DD_API_KEY in the operator .env;
-# run-fleet.sh enforces that before layering this file.
+# OTel collector → Datadog APM. Requires DD_API_KEY and DD_HOSTNAME; run-fleet.sh
+# enforces the key and defaults the hostname into .env before layering this file.
 services:
   fleet-api:
     environment:
@@ -27,6 +27,8 @@ services:
       DD_API_KEY: "${DD_API_KEY:?DD_API_KEY is required for the tracing overlay (set it in .env)}"
       DD_SITE: "${DD_SITE:-datadoghq.com}"
       DD_ENV: "${DD_ENV:-production}"
+      # Stamped onto spans as host.name so APM traces join the Datadog Agent's host metrics.
+      DD_HOSTNAME: "${DD_HOSTNAME:?DD_HOSTNAME is required for the tracing overlay (run-fleet.sh defaults it to the host hostname)}"
     volumes:
       - ./server/otel-collector-config.datadog.yaml:/etc/otelcol-contrib/config.yaml:ro
     ports:

--- a/deployment-files/run-fleet.sh
+++ b/deployment-files/run-fleet.sh
@@ -49,6 +49,7 @@ PROTO_FLEET_IMAGE_REPOSITORIES=(
 )
 PREVIOUS_RELEASE_IMAGE_TAGS=()
 RELEASE_IMAGE_CLEANUP_SAFE=true
+DD_HOSTNAME_DEFAULTED=false
 
 # How long the post-start steps wait for fleet-api to finish its migrations.
 # 300 x 2s = 10 minutes: a first boot on SD-card-class hardware (Raspberry Pi)
@@ -284,6 +285,37 @@ resolve_release_image_tag() {
     printf '%s' "$tag"
 }
 
+# A hand-edited .env may lack a trailing newline; a bare append would glue the key onto the last line.
+append_env_line() {
+    if [ -s "$ENV_FILE" ] && [ -n "$(tail -c1 "$ENV_FILE")" ]; then
+        echo >> "$ENV_FILE"
+    fi
+    echo "$1" >> "$ENV_FILE"
+}
+
+# An exported-but-empty value still wins over --env-file in compose interpolation, so it would trip ${VAR:?} despite a good .env value.
+unset_if_empty_env() {
+    if [ -z "${!1:-}" ]; then
+        unset -v "$1"
+    fi
+}
+
+# Satisfies the tracing overlay's ${DD_HOSTNAME:?}; compose gives the shell precedence over --env-file, so only default when neither sets it.
+ensure_dd_hostname() {
+    unset_if_empty_env DD_HOSTNAME
+    if [ -n "${DD_HOSTNAME:-}" ] || env_has_nonempty_value DD_HOSTNAME; then
+        return 0
+    fi
+    local detected
+    detected=$(hostname 2>/dev/null || true)
+    if [ -z "$detected" ]; then
+        echo "Error: could not read this host's hostname; set DD_HOSTNAME in $ENV_FILE and re-run with --enable-tracing." >&2
+        exit 1
+    fi
+    export DD_HOSTNAME="$detected"
+    DD_HOSTNAME_DEFAULTED=true
+}
+
 usage() {
     cat <<'EOF'
 Usage: run-fleet.sh [options]
@@ -418,16 +450,19 @@ fi
 # Validate tracing prerequisites before the overlay is layered: its ${DD_API_KEY:?}
 # interpolation would otherwise abort every compose command, even `compose down`.
 if [ "$ENABLE_TRACING" = "true" ]; then
-    validate_runner_env_value_syntax DD_API_KEY || exit 1
+    validate_runner_env_value_syntax DD_API_KEY DD_HOSTNAME || exit 1
     if [ ! -f "$COMPOSE_TRACING_FILE" ]; then
         echo "Error: --enable-tracing was passed but $COMPOSE_TRACING_FILE is missing." >&2
         exit 1
     fi
     # Compose interpolation reads the shell environment and the .env file; accept either.
+    unset_if_empty_env DD_API_KEY
     if [ -z "${DD_API_KEY:-}" ] && ! env_has_nonempty_value DD_API_KEY; then
         echo "Error: --enable-tracing requires DD_API_KEY (a Datadog API key) in $ENV_FILE." >&2
         exit 1
     fi
+    # Before layering too: the overlay's ${DD_HOSTNAME:?} would abort the `compose down` the volume-reinit prompt runs.
+    ensure_dd_hostname
 fi
 
 if [ "$PREFLIGHT_ONLY" = "true" ]; then
@@ -1643,12 +1678,7 @@ prompt_fleet_profile() {
         3|max) choice="max" ;;
         *) choice="standard" ;;
     esac
-    # A hand-edited .env may lack a trailing newline; a bare append would
-    # glue FLEET_PROFILE onto the last line and corrupt that key
-    if [ -s "$ENV_FILE" ] && [ -n "$(tail -c1 "$ENV_FILE")" ]; then
-        echo >> "$ENV_FILE"
-    fi
-    echo "FLEET_PROFILE=$choice" >> "$ENV_FILE"
+    append_env_line "FLEET_PROFILE=$choice"
     echo "Host profile '$choice' saved to $ENV_FILE (edit FLEET_PROFILE there to change it)."
 }
 
@@ -1897,6 +1927,12 @@ if [ "$ENABLE_TRACING" = "true" ]; then
         exit 1
     fi
     echo "Tracing: enabled (fleet-api request spans forwarded to Datadog APM)"
+    # Re-run in case .env was regenerated above, then persist so later manual compose commands satisfy ${DD_HOSTNAME:?} too.
+    ensure_dd_hostname
+    if [ "$DD_HOSTNAME_DEFAULTED" = "true" ] && ! env_has_nonempty_value DD_HOSTNAME; then
+        append_env_line "DD_HOSTNAME=$DD_HOSTNAME"
+        echo "         trace host.name defaults to '$DD_HOSTNAME' (saved to $ENV_FILE); change it there if the Datadog Agent reports a different hostname"
+    fi
 else
     echo "Tracing: disabled (pass --enable-tracing with DD_API_KEY in .env to forward request spans to Datadog)"
 fi

--- a/deployment-files/run-fleet.sh
+++ b/deployment-files/run-fleet.sh
@@ -196,6 +196,13 @@ env_has_nonempty_value() {
     [ -n "$value" ]
 }
 
+# .env-scoped counterpart: whether a key still needs persisting, ignoring any process-level override.
+dotenv_has_nonempty_value() {
+    local value
+    value=$(compose_env_last_value "$1") || return 1
+    [ -n "$value" ]
+}
+
 env_boolean_is_true() {
     local key="$1" value read_status
     value=$(env_last_value "$key")
@@ -293,17 +300,9 @@ append_env_line() {
     echo "$1" >> "$ENV_FILE"
 }
 
-# An exported-but-empty value still wins over --env-file in compose interpolation, so it would trip ${VAR:?} despite a good .env value.
-unset_if_empty_env() {
-    if [ -z "${!1:-}" ]; then
-        unset -v "$1"
-    fi
-}
-
-# Satisfies the tracing overlay's ${DD_HOSTNAME:?}; compose gives the shell precedence over --env-file, so only default when neither sets it.
+# Satisfies the tracing overlay's ${DD_HOSTNAME:?}; env_has_nonempty_value already reads the effective Compose value, so only default when that is empty.
 ensure_dd_hostname() {
-    unset_if_empty_env DD_HOSTNAME
-    if [ -n "${DD_HOSTNAME:-}" ] || env_has_nonempty_value DD_HOSTNAME; then
+    if env_has_nonempty_value DD_HOSTNAME; then
         return 0
     fi
     local detected
@@ -455,9 +454,7 @@ if [ "$ENABLE_TRACING" = "true" ]; then
         echo "Error: --enable-tracing was passed but $COMPOSE_TRACING_FILE is missing." >&2
         exit 1
     fi
-    # Compose interpolation reads the shell environment and the .env file; accept either.
-    unset_if_empty_env DD_API_KEY
-    if [ -z "${DD_API_KEY:-}" ] && ! env_has_nonempty_value DD_API_KEY; then
+    if ! env_has_nonempty_value DD_API_KEY; then
         echo "Error: --enable-tracing requires DD_API_KEY (a Datadog API key) in $ENV_FILE." >&2
         exit 1
     fi
@@ -1922,14 +1919,14 @@ fi
 
 if [ "$ENABLE_TRACING" = "true" ]; then
     # Re-check after env setup: regenerating .env above drops keys the pre-layering check accepted.
-    if [ -z "${DD_API_KEY:-}" ] && ! env_has_nonempty_value DD_API_KEY; then
+    if ! env_has_nonempty_value DD_API_KEY; then
         echo "Error: $ENV_FILE was regenerated without DD_API_KEY; add it and re-run with --enable-tracing." >&2
         exit 1
     fi
     echo "Tracing: enabled (fleet-api request spans forwarded to Datadog APM)"
     # Re-run in case .env was regenerated above, then persist so later manual compose commands satisfy ${DD_HOSTNAME:?} too.
     ensure_dd_hostname
-    if [ "$DD_HOSTNAME_DEFAULTED" = "true" ] && ! env_has_nonempty_value DD_HOSTNAME; then
+    if [ "$DD_HOSTNAME_DEFAULTED" = "true" ] && ! dotenv_has_nonempty_value DD_HOSTNAME; then
         append_env_line "DD_HOSTNAME=$DD_HOSTNAME"
         echo "         trace host.name defaults to '$DD_HOSTNAME' (saved to $ENV_FILE); change it there if the Datadog Agent reports a different hostname"
     fi

--- a/deployment-files/server/otel-collector-config.datadog.yaml
+++ b/deployment-files/server/otel-collector-config.datadog.yaml
@@ -22,6 +22,10 @@ processors:
       - key: deployment.environment
         value: ${env:DD_ENV}
         action: upsert
+      # Must match the Datadog Agent's DD_HOSTNAME; unset, the exporter infers the container's hostname.
+      - key: host.name
+        value: ${env:DD_HOSTNAME}
+        action: upsert
 
 connectors:
   # Computes APM stats (hit/error/latency metrics); the exporter stopped doing this in contrib 0.95.
@@ -32,6 +36,8 @@ exporters:
     api:
       key: ${env:DD_API_KEY}
       site: ${env:DD_SITE}
+    # Fallback for the resource attribute above, which a whole-value env reference types as int for an all-numeric hostname.
+    hostname: "${env:DD_HOSTNAME}"
 
 extensions:
   health_check:

--- a/server/internal/infrastructure/timescaledb/ingest_stalled_rule_test.go
+++ b/server/internal/infrastructure/timescaledb/ingest_stalled_rule_test.go
@@ -172,3 +172,39 @@ func TestMetricIngestStalledRule_NoPollableMiners(t *testing.T) {
 	got := runRule(t, db, rawSQL)
 	require.Equal(t, map[string]float64{"": 0}, got, "expected only the healthy global sentinel")
 }
+
+// TestHeartbeatRefreshPolicyWindowIsNarrow guards migration 000133. The rule
+// above reads a materialized_only aggregate, so its refresh policy has to keep
+// succeeding or the aggregate empties and the rule fires on healthy ingest.
+// 000082's 1-day start_offset re-scanned roughly a day of notification_metric_sample
+// every 30s, most of it compressed once 000121 cut chunks to 1 hour and compression
+// to 4 hours. Keep the window inside that uncompressed region: the rule only ever
+// reads max(bucket), so a wider backfill buys nothing and costs a refresh that can
+// outrun its own schedule.
+func TestHeartbeatRefreshPolicyWindowIsNarrow(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test in short mode")
+	}
+	db := testutil.GetTestDB(t)
+
+	var startOffset time.Duration
+	require.NoError(t, db.QueryRowContext(t.Context(), `
+		SELECT extract(epoch from (j.config->>'start_offset')::interval)::bigint * 1000000000
+		FROM timescaledb_information.jobs j
+		WHERE j.proc_name = 'policy_refresh_continuous_aggregate'
+		  AND j.hypertable_name IN (
+		      SELECT ca.view_name
+		      FROM timescaledb_information.continuous_aggregates ca
+		      WHERE ca.view_name = 'fleet_telemetry_poll_heartbeat'
+		      UNION ALL
+		      SELECT ca.materialization_hypertable_name
+		      FROM timescaledb_information.continuous_aggregates ca
+		      WHERE ca.view_name = 'fleet_telemetry_poll_heartbeat'
+		  )`).Scan(&startOffset),
+		"no refresh policy found on fleet_telemetry_poll_heartbeat")
+
+	require.LessOrEqual(t, startOffset, 4*time.Hour,
+		"refresh window must stay inside the 4h uncompressed region (see migration 000121)")
+	require.Greater(t, startOffset, 5*time.Minute,
+		"window must still comfortably exceed the rule's 5m staleness threshold")
+}

--- a/server/migrations/000133_narrow_heartbeat_refresh_window.down.sql
+++ b/server/migrations/000133_narrow_heartbeat_refresh_window.down.sql
@@ -1,0 +1,27 @@
+-- Restores 000082's 1-day start_offset.
+DO $$
+DECLARE
+    refresh_job_id integer;
+BEGIN
+    FOR refresh_job_id IN
+        SELECT j.job_id
+        FROM timescaledb_information.jobs j
+        WHERE j.proc_name = 'policy_refresh_continuous_aggregate'
+          AND j.hypertable_name IN (
+              SELECT ca.view_name
+              FROM timescaledb_information.continuous_aggregates ca
+              WHERE ca.view_name = 'fleet_telemetry_poll_heartbeat'
+              UNION ALL
+              SELECT ca.materialization_hypertable_name
+              FROM timescaledb_information.continuous_aggregates ca
+              WHERE ca.view_name = 'fleet_telemetry_poll_heartbeat'
+          )
+    LOOP
+        PERFORM public.delete_job(refresh_job_id);
+    END LOOP;
+END $$;
+
+SELECT add_continuous_aggregate_policy('fleet_telemetry_poll_heartbeat',
+    start_offset => INTERVAL '1 day',
+    end_offset => INTERVAL '1 minute',
+    schedule_interval => INTERVAL '30 seconds');

--- a/server/migrations/000133_narrow_heartbeat_refresh_window.up.sql
+++ b/server/migrations/000133_narrow_heartbeat_refresh_window.up.sql
@@ -1,0 +1,30 @@
+-- 000082 set start_offset to 1 day, so every 30s refresh re-scanned roughly a day of notification_metric_sample; since 000121 cut chunks to 1 hour and compresses after 4 hours, most of that window is compressed chunks. Narrowed to 30 minutes so a refresh stays inside the uncompressed region. Only protofleet-ingest-stalled reads this aggregate and it reads max(bucket), so no consumer needs the wider backfill.
+-- Replacing the job also clears a paused job_status: add_continuous_aggregate_policy creates the new job scheduled.
+
+-- delete_job over a lookup rather than remove_continuous_aggregate_policy: the spelling of that function's if-exists argument differs across TimescaleDB versions. Matching both the view name and the materialization hypertable name covers either way timescaledb_information.jobs labels a refresh policy.
+DO $$
+DECLARE
+    refresh_job_id integer;
+BEGIN
+    FOR refresh_job_id IN
+        SELECT j.job_id
+        FROM timescaledb_information.jobs j
+        WHERE j.proc_name = 'policy_refresh_continuous_aggregate'
+          AND j.hypertable_name IN (
+              SELECT ca.view_name
+              FROM timescaledb_information.continuous_aggregates ca
+              WHERE ca.view_name = 'fleet_telemetry_poll_heartbeat'
+              UNION ALL
+              SELECT ca.materialization_hypertable_name
+              FROM timescaledb_information.continuous_aggregates ca
+              WHERE ca.view_name = 'fleet_telemetry_poll_heartbeat'
+          )
+    LOOP
+        PERFORM public.delete_job(refresh_job_id);
+    END LOOP;
+END $$;
+
+SELECT add_continuous_aggregate_policy('fleet_telemetry_poll_heartbeat',
+    start_offset => INTERVAL '30 minutes',
+    end_offset => INTERVAL '1 minute',
+    schedule_interval => INTERVAL '30 seconds');

--- a/server/monitoring/grafana/provisioning/alerting/proto-fleet-rules.yaml
+++ b/server/monitoring/grafana/provisioning/alerting/proto-fleet-rules.yaml
@@ -469,4 +469,9 @@ groups:
             {{ $labels.organization_id }} in the last five minutes, even
             though it has pollable miners. Either fleet-api is down or the
             in-process metrics writer is wedged. Alerts cannot fire until
-            ingest resumes.
+            ingest resumes. This reads the fleet_telemetry_poll_heartbeat
+            aggregate, not the raw samples, so a stalled refresh policy on
+            that aggregate presents identically. Compare the newest
+            notification_metric_sample row against the aggregate's newest
+            bucket to tell them apart; see the alerts section of the
+            deployment README.


### PR DESCRIPTION
Reviewable diff: +199/-15 across 7 files (excludes generated, test, and story files).

## Summary

Two operator-facing monitoring fixes.

The **Metric Ingest Stalled** alert could fire for every pollable organization while ingest was perfectly healthy. The rule reads the `fleet_telemetry_poll_heartbeat` continuous aggregate, which is `materialized_only` and carries its own retention policy — so when its refresh policy falls behind, retention keeps deleting buckets until the aggregate is empty and the rule reads "no ingest." Migration `000133` narrows the refresh window from 1 day to 30 minutes so a refresh stays cheap enough to keep up, and the alert annotation plus the deployment README now tell an operator how to distinguish a real stall from a stalled aggregate.

Separately, **Datadog APM traces landed on a host nothing else reported**. The tracing overlay now requires `DD_HOSTNAME` and stamps it onto spans as `host.name`, so APM traces, host metrics, and RUM resolve to the same host. `run-fleet.sh` defaults it to the machine's `hostname` and persists it to `.env`.

## How it works

### Why the refresh window mattered

`fleet_telemetry_poll_heartbeat` rolls `notification_metric_sample` into per-org buckets. Migration `000082` gave its refresh policy `start_offset => INTERVAL '1 day'` with a 30-second `schedule_interval`, so each run re-scanned roughly a day of samples. Migration `000121` later cut `notification_metric_sample` chunks to 1 hour and set compression at 4 hours — which means most of that 1-day window became *compressed* chunks. A refresh that takes longer than its own 30-second schedule falls behind; the aggregate stops advancing while its retention policy keeps trimming from the back, and it empties out.

The only consumer of this aggregate is the ingest-stalled rule, and it reads `max(bucket)`. A wider backfill window buys nothing, so `000133` narrows `start_offset` to 30 minutes — inside the uncompressed region, and still comfortably wider than the rule's 5-minute staleness threshold.

`000133` replaces the policy rather than altering it: `add_continuous_aggregate_policy` creates the new job in a `scheduled` state, so the migration also un-pauses a job that TimescaleDB had already given up on. It removes the old job via `delete_job` over a catalog lookup instead of `remove_continuous_aggregate_policy`, because that function's if-exists argument is spelled differently across TimescaleDB versions. The lookup matches both the view name and the materialization hypertable name, since `timescaledb_information.jobs` labels refresh policies either way depending on version.

```mermaid
flowchart TD
    A["notification_metric_sample<br/>(1h chunks, compressed at 4h — 000121)"] --> B["refresh policy<br/>every 30s"]
    B --> C["fleet_telemetry_poll_heartbeat<br/>materialized_only + retention"]
    C --> D["Grafana rule:<br/>Metric Ingest Stalled"]
    B -. "1-day start_offset re-scans<br/>compressed chunks (000082)" .-> E["refresh outruns its schedule"]
    E --> F["aggregate stops advancing"]
    F --> G["retention empties it"]
    G --> H["rule fires on healthy ingest"]
```

### Telling a real stall from a stalled aggregate

Both failure modes present identically to the rule, so the alert annotation now names the ambiguity and the README adds a runbook section with the discriminator: query the newest `notification_metric_sample` row directly. If the raw samples are also stale, the stall is real — look at fleet-api and its metrics writer. If raw samples are landing fine, check the aggregate's job in `timescaledb_information.job_stats`; a `Paused` status or a stale `last_successful_finish` confirms it, and the section gives the `alter_job` + `refresh_continuous_aggregate` calls to resume and backfill.

### DD_HOSTNAME plumbing

Without an explicit hostname the Datadog exporter infers one from inside the collector container, so traces hang off a host that no agent reports and APM can't be joined to infra data. The collector config now upserts `host.name` as a resource attribute and also sets the exporter's own `hostname` field as a quoted fallback — a whole-value env reference gets typed as an int for an all-numeric hostname, which the resource attribute path wouldn't survive.

`run-fleet.sh` resolves the value before compose ever runs. `ensure_dd_hostname` is called early, ahead of the volume-reinit prompt, because that prompt runs `docker compose down` with the overlay layered in and the overlay's `${DD_HOSTNAME:?}` would abort it. It is called a second time after the point where `.env` may have been regenerated, and the detected value is appended to `.env` so later manual `docker compose` invocations satisfy the guard too.

Precedence is not handled here at all: `env_has_nonempty_value` (via #835's `env_last_value`) already resolves the effective Compose value — a process-level override wins, and an exported-but-empty value reads as empty — so both `DD_API_KEY` and `DD_HOSTNAME` just ask it.

Deciding whether to *persist* is a different question, and asking it of the effective value gets it wrong twice: `ensure_dd_hostname` exports the value it just detected, so an effective-value guard reads its own export and skips the write; and an exported-empty override shadowing a real `.env` value would append a duplicate key. So the persist guard uses a `.env`-scoped `dotenv_has_nonempty_value` instead.

`append_env_line` is the trailing-newline-safe append that `prompt_fleet_profile` already had inline; it's now a shared helper both callers use.

```mermaid
sequenceDiagram
    participant Op as Operator
    participant RF as run-fleet.sh
    participant Env as .env
    participant DC as docker compose
    participant OC as otel-collector
    Op->>RF: --enable-tracing
    RF->>Env: env_has_nonempty_value DD_API_KEY, DD_HOSTNAME
    alt effective DD_HOSTNAME is empty
        RF->>RF: detect via hostname(1)
        opt .env itself lacks the key
            RF->>Env: append DD_HOSTNAME=<detected>
        end
    end
    RF->>DC: up with docker-compose.tracing.yaml
    DC->>OC: DD_HOSTNAME (guarded by ${DD_HOSTNAME:?})
    OC->>OC: upsert host.name on spans
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/migrations/000133_*.{up,down}.sql` | Replaces the heartbeat refresh policy: `start_offset` 1 day → 30 minutes | The load-bearing change. Check the job-lookup predicate and that down restores `000082`'s policy exactly. |
| `server/monitoring/grafana/provisioning/alerting/proto-fleet-rules.yaml` | Extends the Metric Ingest Stalled annotation with the aggregate-vs-raw ambiguity | Operator-facing text on a live alert; no query change. |
| `deployment-files/README.md` | New "When Metric Ingest Stalled fires" runbook section; `DD_HOSTNAME` documented; `DD_ENV` examples now `prod-<site>` | Verify the psql/SQL snippets are correct and safe to paste. |
| `deployment-files/run-fleet.sh` | `ensure_dd_hostname`, `dotenv_has_nonempty_value`, `append_env_line`; two call sites in the tracing path, plus `DD_HOSTNAME` added to the dotenv-syntax validation | Ordering is the subtle part: early call must precede the volume-reinit prompt, late call must precede `.env` persistence. |
| `deployment-files/docker-compose.tracing.yaml` | `DD_HOSTNAME` passed to the collector with a `${VAR:?}` guard | Makes the variable hard-required for anyone driving compose by hand. |
| `deployment-files/server/otel-collector-config.datadog.yaml` | `host.name` resource attribute + exporter `hostname` fallback | Two mechanisms for one value — see the int-typing note above. |
| `server/internal/infrastructure/timescaledb/ingest_stalled_rule_test.go` | Adds `TestHeartbeatRefreshPolicyWindowIsNarrow` | Guards the migration against a future widening. |

## Key technical decisions & trade-offs

- **Narrow the window rather than drop `materialized_only`.** Keeps reads cheap; the alternative (real-time aggregate) would make the rule scan raw samples on every evaluation.
- **Replace the policy instead of `alter_job`.** Replacing also resets a job TimescaleDB had paused, which `alter_job` on the config alone would not.
- **`delete_job` over a catalog lookup, not `remove_continuous_aggregate_policy`.** That function's if-exists argument name varies across TimescaleDB versions; the lookup is version-agnostic and matches both the view and materialization hypertable naming.
- **`DD_HOSTNAME` hard-required in the overlay (`${VAR:?}`) rather than defaulted there.** A compose-level default would silently reintroduce the container-inferred hostname; failing loudly forces `run-fleet.sh` (or the operator) to supply a real value.
- **Both a resource attribute and an exporter `hostname`.** Redundant on paper, but the resource-attribute path mistypes an all-numeric hostname as an int.
- **Assert the refresh window in a test.** The failure mode is a healthy-system false alarm that's easy to reintroduce and slow to notice.
- **Defer precedence to `env_last_value` rather than re-deriving it per key.** Fewer places encode "shell beats `.env`"; the cost is that an exported-empty `DD_API_KEY` now fails closed with an error instead of falling back to `.env`, matching #835's stated model.
- **Persist guard is `.env`-scoped, not effective-value-scoped.** `ensure_dd_hostname` exports what it detects, so an effective-value check would read its own export and skip the write.
- **`DD_HOSTNAME` goes through `validate_runner_env_value_syntax` alongside `DD_API_KEY`.** It is now a runner-consumed Compose value, so it needs the same dotenv-syntax gate #835 added; without it a malformed `.env` value reads as absent and gets shadowed by an appended default.

### Rebase note

Rebased onto `main` after #853, which landed its own `000132`. This migration is renumbered to `000133`, folded into the commit that introduces it so no commit on the branch carries a duplicate version. #835 also rewrote `run-fleet.sh` substantially; `env_has_nonempty_value` now delegates to a new `env_last_value` that treats the process environment as authoritative. This PR defers to that model rather than working around it: the earlier `unset_if_empty_env` helper and the `[ -z "${DD_*:-}" ]` prefixes are gone, and both keys go through `env_has_nonempty_value`.

## Testing & validation

- `TestHeartbeatRefreshPolicyWindowIsNarrow` reads the live policy from `timescaledb_information.jobs` on a freshly migrated DB and asserts `5m < start_offset <= 4h` (inside `000121`'s uncompressed region, outside the rule's staleness threshold).
- Ran `go test ./internal/infrastructure/timescaledb/ -run 'Heartbeat|MetricIngestStalled' -p 1` — all pass, migrations reach version 133.
- Exercised `000133` up → down → up against a scratch database: `30 min` → `1 day` → `30 min`, exactly one refresh policy at each step, with #853's `000132` applied ahead of it.
- Ran the three suites the Deployment Config Checks workflow gates on, all green: `tests/test-profiles.sh`, `ha/tests/test-profile.sh`, and `tests/test-run-fleet-upgrade.sh` (369 assertions, several covering the `ENABLE_TRACING` / `DD_API_KEY` paths this PR touches).
- Confirmed the overlay's guard fires: `docker compose config` without `DD_HOSTNAME` errors with the intended message.
- Exercised `ensure_dd_hostname` plus the persist guard against #835's real env helpers across six precedence cases (unset / `.env`-only / exported / exported-empty × `.env` present-absent-empty, plus a `.env` with no trailing newline), asserting the resulting `DD_HOSTNAME` line count each time.
- Ran each README runbook block verbatim against a live TimescaleDB container, including the `alter_job` + `refresh_continuous_aggregate` recovery block.
- `golangci-lint` clean on the changed package; `bash -n` clean on `run-fleet.sh`.
- **Not covered:** no automated test asserts the collector actually emits `host.name` — that needs a live Datadog org. The README runbook commands were reasoned through against the schema but not run against a genuinely stalled aggregate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
