### PR TITLE
Stabilize Proto Fleet E2E toast handling

### DIFF
--- a/client/e2eTests/protoFleet/pages/base.ts
+++ b/client/e2eTests/protoFleet/pages/base.ts
@@ -465,16 +465,33 @@ export class BasePage {
     await expect
       .poll(
         async () => {
+          const normalize = (value: string | null | undefined) => (value ?? "").replace(/\s+/g, " ").trim();
+
+          const groupedHeader = this.page.getByTestId("grouped-toaster-header");
+          if (await groupedHeader.isVisible().catch(() => false)) {
+            const headerText = normalize(await groupedHeader.textContent().catch(() => ""));
+            if (headerText.includes(text)) {
+              return true;
+            }
+          }
+
+          const toastContainer = this.page.getByTestId("toaster-container");
+          if (await toastContainer.isVisible().catch(() => false)) {
+            const containerText = normalize(await toastContainer.textContent().catch(() => ""));
+            if (containerText.includes(text)) {
+              return true;
+            }
+          }
+
           const toasts = this.page.getByTestId("toast");
           const count = await toasts.count();
-
           for (let i = count - 1; i >= 0; i -= 1) {
-            const toast = toasts.nth(i);
-            if (!(await toast.isVisible().catch(() => false))) {
-              continue;
-            }
-
-            const toastText = ((await toast.textContent().catch(() => "")) ?? "").replace(/\s+/g, " ").trim();
+            const toastText = normalize(
+              await toasts
+                .nth(i)
+                .textContent()
+                .catch(() => ""),
+            );
             if (toastText.includes(text)) {
               return true;
             }

--- a/client/e2eTests/protoFleet/pages/base.ts
+++ b/client/e2eTests/protoFleet/pages/base.ts
@@ -486,12 +486,12 @@ export class BasePage {
           const toasts = this.page.getByTestId("toast");
           const count = await toasts.count();
           for (let i = count - 1; i >= 0; i -= 1) {
-            const toastText = normalize(
-              await toasts
-                .nth(i)
-                .textContent()
-                .catch(() => ""),
-            );
+            const toast = toasts.nth(i);
+            if (!(await toast.isVisible().catch(() => false))) {
+              continue;
+            }
+
+            const toastText = normalize(await toast.textContent().catch(() => ""));
             if (toastText.includes(text)) {
               return true;
             }

--- a/client/e2eTests/protoFleet/pages/home.ts
+++ b/client/e2eTests/protoFleet/pages/home.ts
@@ -47,6 +47,16 @@ export class HomePage extends BasePage {
     await this.clickButton("Authenticate");
   }
 
+  async dismissCompleteSetupIfVisible() {
+    const dismissButton = this.page.getByRole("button", { name: "Dismiss complete setup", exact: true });
+    if (!(await dismissButton.isVisible().catch(() => false))) {
+      return;
+    }
+
+    await dismissButton.click();
+    await expect(dismissButton).toBeHidden();
+  }
+
   async validateAuthenticateMinersModalTitle() {
     await this.validateTitleInModal("Authenticate miners");
   }

--- a/client/e2eTests/protoFleet/pages/racks.ts
+++ b/client/e2eTests/protoFleet/pages/racks.ts
@@ -584,6 +584,8 @@ export class RacksPage extends BasePage {
     await this.clickEditRack();
     await this.clickDeleteRack();
     await this.clickDeleteConfirm();
+    await expect(this.page).toHaveURL(/\/racks(?:\?.*)?$/, { timeout });
+    await this.waitForRackListToLoad({ timeout });
     await this.tryAction(() => this.validateRackNotVisible(label), timeout);
   }
 
@@ -663,7 +665,11 @@ export class RacksPage extends BasePage {
     for (let i = 0; i < optionByTestIdCount; i++) {
       const option = optionByTestId.nth(i);
       if (await option.isVisible().catch(() => false)) {
-        await option.click();
+        await option.click().catch(async () => {
+          await option.evaluate((element) => {
+            (element as HTMLElement).click();
+          });
+        });
         return;
       }
     }
@@ -674,7 +680,11 @@ export class RacksPage extends BasePage {
       const option = optionRows.nth(i);
       const label = ((await option.textContent()) ?? "").replace(/\s+/g, " ").trim();
       if (label === optionName && (await option.isVisible().catch(() => false))) {
-        await option.click();
+        await option.click().catch(async () => {
+          await option.evaluate((element) => {
+            (element as HTMLElement).click();
+          });
+        });
         return;
       }
     }

--- a/client/e2eTests/protoFleet/pages/racks.ts
+++ b/client/e2eTests/protoFleet/pages/racks.ts
@@ -584,7 +584,7 @@ export class RacksPage extends BasePage {
     await this.clickEditRack();
     await this.clickDeleteRack();
     await this.clickDeleteConfirm();
-    await this.tryAction(() => this.validateRackDeletedToast(timeout), timeout);
+    await this.tryAction(() => this.validateRackNotVisible(label), timeout);
   }
 
   async clickEditRack() {

--- a/client/e2eTests/protoFleet/pages/racks.ts
+++ b/client/e2eTests/protoFleet/pages/racks.ts
@@ -665,11 +665,7 @@ export class RacksPage extends BasePage {
     for (let i = 0; i < optionByTestIdCount; i++) {
       const option = optionByTestId.nth(i);
       if (await option.isVisible().catch(() => false)) {
-        await option.click().catch(async () => {
-          await option.evaluate((element) => {
-            (element as HTMLElement).click();
-          });
-        });
+        await option.click();
         return;
       }
     }
@@ -680,11 +676,7 @@ export class RacksPage extends BasePage {
       const option = optionRows.nth(i);
       const label = ((await option.textContent()) ?? "").replace(/\s+/g, " ").trim();
       if (label === optionName && (await option.isVisible().catch(() => false))) {
-        await option.click().catch(async () => {
-          await option.evaluate((element) => {
-            (element as HTMLElement).click();
-          });
-        });
+        await option.click();
         return;
       }
     }

--- a/client/e2eTests/protoFleet/spec/racksManagement.spec.ts
+++ b/client/e2eTests/protoFleet/spec/racksManagement.spec.ts
@@ -17,7 +17,7 @@ import { type RackSelectorMiner } from "../pages/racks";
 test.describe("Racks - management", () => {
   useRacksHooks();
 
-  test("Multiple racks support zone filtering and miner sorting", async ({ racksPage }) => {
+  test("Multiple racks support zone filtering and miner sorting", async ({ homePage, racksPage }) => {
     const zoneA = createZoneName("A");
     const zoneB = createZoneName("B");
     const createdRackLabels: string[] = [];
@@ -103,6 +103,7 @@ test.describe("Racks - management", () => {
     });
 
     await test.step("Validate default grid order and miners sort order", async () => {
+      await homePage.dismissCompleteSetupIfVisible();
       await expectGridRackLabels(racksPage, ["A-01", "A-02", "B-01"]);
       await racksPage.selectGridSort("Miners");
       await expectGridRackLabels(racksPage, ["B-01", "A-02", "A-01"]);

--- a/client/e2eTests/protoFleet/spec/racksManagement.spec.ts
+++ b/client/e2eTests/protoFleet/spec/racksManagement.spec.ts
@@ -31,9 +31,11 @@ test.describe("Racks - management", () => {
       await racksPage.inputRows(RACK_ROWS);
       await racksPage.clickCreateRackFromSettings();
       await racksPage.validateRackToast("A-01");
+      await racksPage.clearToasts();
       await addSelectableMinersToSlots(racksPage, 3, [1, 2, 3]);
       await racksPage.clickSaveMinerPositions();
       await racksPage.validateMinerPositionsToast("A-01");
+      await racksPage.clearToasts();
       await racksPage.clickViewGrid();
       await racksPage.validateRackCardVisible("A-01", zoneA);
       createdRackLabels.push("A-01");
@@ -45,9 +47,11 @@ test.describe("Racks - management", () => {
       await racksPage.inputRackLabel("A-02");
       await racksPage.clickCreateRackFromSettings();
       await racksPage.validateRackToast("A-02");
+      await racksPage.clearToasts();
       await addSelectableMinersToSlots(racksPage, 2, [1, 2]);
       await racksPage.clickSaveMinerPositions();
       await racksPage.validateMinerPositionsToast("A-02");
+      await racksPage.clearToasts();
       await racksPage.clickViewGrid();
       await racksPage.validateRackCardVisible("A-02", zoneA);
       createdRackLabels.push("A-02");
@@ -59,9 +63,11 @@ test.describe("Racks - management", () => {
       await racksPage.inputRackLabel("B-01");
       await racksPage.clickCreateRackFromSettings();
       await racksPage.validateRackToast("B-01");
+      await racksPage.clearToasts();
       await addSelectableMinersToSlots(racksPage, 1, [1]);
       await racksPage.clickSaveMinerPositions();
       await racksPage.validateMinerPositionsToast("B-01");
+      await racksPage.clearToasts();
       await racksPage.clickViewGrid();
       await racksPage.validateRackCardVisible("B-01", zoneB);
       createdRackLabels.push("B-01");


### PR DESCRIPTION
Reviewable diff: +25/-8 across 2 files (excludes generated, test, and story files).

## Summary
This updates the shared Proto Fleet E2E toast assertions so they handle both the standard toast stack and the grouped toaster UI that newer flows render. It also removes a brittle rack-cleanup dependency on the transient `Rack deleted` toast and instead waits for the rack row itself to disappear.

## How it works
The shared `validateTextInToast()` helper now normalizes text and checks the grouped toaster header, grouped toaster container, and the standard toast stack before failing. Rack deletion cleanup no longer treats a toast as the source of truth; after clicking delete, it validates that the rack is no longer present in the list.

## Diagrams
```mermaid
flowchart TD
  A["Test action"] --> B["Toast or state change"]
  B --> C["Shared toast matcher checks grouped + standard toasts"]
  B --> D["Rack cleanup waits for row disappearance"]
  C --> E["Assertion passes when user-visible message is present"]
  D --> F["Cleanup passes when durable UI state is updated"]
```

## Areas of the code involved
| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/e2eTests/protoFleet/pages/base.ts` | Broadened the shared toast matcher to understand grouped toaster markup. | This affects many existing E2E assertions that rely on toast content. |
| `client/e2eTests/protoFleet/pages/racks.ts` | Rack cleanup now waits for the deleted rack to disappear instead of waiting for a toast. | This removes the flaky dependency that was breaking teardown paths. |

## Key technical decisions & trade-offs
- Prefer durable state for cleanup validation over transient toast text, instead of increasing timeouts around the existing toast assertion.
- Keep the shared toast assertion flexible enough for both toaster variants, instead of forking separate helpers per page.

## Testing & validation
- `./node_modules/.bin/eslint e2eTests/protoFleet/pages/base.ts e2eTests/protoFleet/pages/racks.ts`
- `npx playwright test spec/racksCreation.spec.ts --project=desktop --no-deps -g "Create rack with miners assigned by name"`
- `npx playwright test spec/buildingDetail.spec.ts --project=mobile --no-deps`