### PR TITLE
fix(sites): plain centered empty state for site buildings pane

### DIFF
--- a/client/src/protoFleet/features/sites/components/ManageSiteModal/ManageSiteModal.tsx
+++ b/client/src/protoFleet/features/sites/components/ManageSiteModal/ManageSiteModal.tsx
@@ -415,7 +415,7 @@ const ManageSiteModal = ({
                 {sortedEntries === undefined ? (
                   <PlaceholderBlock label="Loading buildings…" className="h-20 w-[120px]" />
                 ) : sortedEntries.length === 0 ? (
-                  <PlaceholderBlock label="No buildings in this site" className="h-20 w-[120px]" />
+                  <p className="text-200 whitespace-nowrap text-text-primary-50">No buildings in this site</p>
                 ) : (
                   sortedEntries.map((b) => (
                     <PlaceholderBlock key={b.buildingId.toString()} label={b.label} className="h-20 w-[120px]" />


### PR DESCRIPTION
## What & why

The Manage Site modal's right pane renders each building as a fixed-size gray FPO tile (`PlaceholderBlock`). When a site had **no** buildings, the empty state reused that same tile treatment — producing a bordered white box that read as a building and forced "No buildings in this site" to wrap inside the 120px width.

This swaps that one branch for plain text centered on both axes in the existing flex container, with `whitespace-nowrap` to stop the wrap. The empty state now reads as an empty state rather than a stray building card.

## Scope

The loading and populated states still use `PlaceholderBlock` — those remain FPO pending the real `BuildingCard` component (#263). **Non-goal / deferred:** no change to the tile design itself or the broader FPO-to-real-component migration; this is a targeted empty-state cleanup only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)