### PR TITLE
Add local HA operator status

### DIFF
--- a/deployment-files/client/nginx.http.conf
+++ b/deployment-files/client/nginx.http.conf
@@ -32,7 +32,7 @@ server {
     }
 
     # HA diagnostics are intentionally available only on the Fleet host.
-    location = /api-proxy/health/ha {
+    location ^~ /api-proxy/health/ha {
         return 404;
     }
 

--- a/deployment-files/client/nginx.http.conf
+++ b/deployment-files/client/nginx.http.conf
@@ -31,6 +31,11 @@ server {
         client_max_body_size 64m;
     }
 
+    # HA diagnostics are intentionally available only on the Fleet host.
+    location = /api-proxy/health/ha {
+        return 404;
+    }
+
     # For WebSocket/stream support
     location /api-proxy/ {
         proxy_pass http://localhost:4000/;

--- a/deployment-files/client/nginx.https.conf
+++ b/deployment-files/client/nginx.https.conf
@@ -52,6 +52,11 @@ server {
         client_max_body_size 64m;
     }
 
+    # HA diagnostics are intentionally available only on the Fleet host.
+    location = /api-proxy/health/ha {
+        return 404;
+    }
+
     # For WebSocket/stream support
     location /api-proxy/ {
         proxy_pass http://localhost:4000/;

--- a/deployment-files/client/nginx.https.conf
+++ b/deployment-files/client/nginx.https.conf
@@ -53,7 +53,7 @@ server {
     }
 
     # HA diagnostics are intentionally available only on the Fleet host.
-    location = /api-proxy/health/ha {
+    location ^~ /api-proxy/health/ha {
         return 404;
     }
 

--- a/deployment-files/ha/tests/test-profile.sh
+++ b/deployment-files/ha/tests/test-profile.sh
@@ -138,6 +138,11 @@ test_fleet_ha_contract() {
     assert_contains "${HA_DIR}/keepalived-systemd.conf.tmpl" "Restart=on-failure"
     assert_contains "${HA_DIR}/keepalived-systemd.conf.tmpl" 'ExecStopPost=/usr/sbin/ip address flush to ${HA_VIRTUAL_IP}/32 dev ${HA_NETWORK_INTERFACE}'
     assert_contains "${HA_DIR}/firewall.nft.tmpl" "tcp dport 40000 drop"
+
+    for nginx_config in "${HA_DIR}/../client/nginx.http.conf" "${HA_DIR}/../client/nginx.https.conf"; do
+        assert_contains "$nginx_config" "location = /api-proxy/health/ha"
+        assert_contains "$nginx_config" "return 404;"
+    done
 }
 
 test_compose_uses_one_host_identity

--- a/deployment-files/ha/tests/test-profile.sh
+++ b/deployment-files/ha/tests/test-profile.sh
@@ -140,7 +140,7 @@ test_fleet_ha_contract() {
     assert_contains "${HA_DIR}/firewall.nft.tmpl" "tcp dport 40000 drop"
 
     for nginx_config in "${HA_DIR}/../client/nginx.http.conf" "${HA_DIR}/../client/nginx.https.conf"; do
-        assert_contains "$nginx_config" "location = /api-proxy/health/ha"
+        assert_contains "$nginx_config" "location ^~ /api-proxy/health/ha"
         assert_contains "$nginx_config" "return 404;"
     done
 }

--- a/docs/rfcs/0002-active-passive-fleet-ha.md
+++ b/docs/rfcs/0002-active-passive-fleet-ha.md
@@ -180,7 +180,7 @@ Non-Fleet consumers are handled separately:
 
 - Deployment scripts that currently `docker compose exec timescaledb ...` must become Patroni-aware and run write steps only against the current primary.
 - Grafana is not on the dispatch RTO path. It can use a best-effort Postgres datasource in v1. If Grafana cannot cleanly use the same HA writer targeting, that is not a blocker for control-plane HA.
-- `ha-status.sh` and operator-protected `/health/ha` are the authoritative HA status surfaces in v1.
+- `fleet-ha status` and loopback-only `/health/ha` are the authoritative HA status surfaces in v1.
 - HA failure alerts are derived from those control-plane status surfaces, not from Grafana dashboard availability or telemetry history.
 
 PostgreSQL documents multi-host connection strings and writable-session targeting:
@@ -220,7 +220,7 @@ Both Fleet app instances run continuously.
 | Mode | Behavior |
 | ---- | -------- |
 | Active | Holds `fleet-active`; passes `/health/active`; serves product traffic; accepts Fleet Node ControlStreams; runs active-only runtime services. |
-| Passive | Does not hold `fleet-active`; fails `/health/active`; serves load-balancer-safe health and operator-protected HA status; rejects product traffic and Fleet Node ControlStreams with a machine-readable `not-active` detail. |
+| Passive | Does not hold `fleet-active`; fails `/health/active`; serves load-balancer-safe health and local HA status; rejects product traffic and Fleet Node ControlStreams with a machine-readable `not-active` detail. |
 
 Passive is deliberately dumb in v1. It does not need a carefully audited read-only API allowlist. The stable endpoint should not send normal UI/API traffic to passive.
 
@@ -239,8 +239,7 @@ Active-only work in v1 includes:
 Always-on services:
 
 - HTTP server;
-- load-balancer-safe health endpoints and operator-protected HA diagnostics;
-- auth/session plumbing needed to answer status endpoints;
+- load-balancer-safe health endpoints and loopback-only HA diagnostics;
 - components required to construct service dependencies but not start active work.
 
 Activation must trigger required control reconciliation promptly enough to meet the RTO target.
@@ -251,8 +250,7 @@ Add a single active-mode request gate for product traffic:
 
 - In active mode, requests proceed normally.
 - In passive mode, Connect/gRPC product traffic fails with `Unavailable` and a machine-readable `not-active` detail; other product transports use the equivalent retryable status.
-- Load-balancer-safe health endpoints and operator-protected HA diagnostics bypass active gating.
-- Bypassing active gating does not bypass auth; HA diagnostics still require operator access.
+- Load-balancer-safe health endpoints and loopback-only HA diagnostics bypass active gating.
 
 Fleet Node ControlStreams are explicitly gated:
 
@@ -272,13 +270,13 @@ Endpoints:
 | `/health` | Load-balancer-safe | Process liveness. Does not check DB or HA state. |
 | `/health/ready` | Load-balancer-safe | Fleet app can reach a database. Returns minimal readiness only. |
 | `/health/active` | Load-balancer-safe | Fleet app is the active controller and can safely run real-time control. Returns minimal active/passive status only. |
-| `/health/ha` | Operator-only | Admin-authenticated diagnostics: lease holder/epoch, DB primary, replication mode, quorum, degraded reasons. Redact sensitive hostnames and internal addresses where possible. |
+| `/health/ha` | Loopback-only | Redacted local runtime state: version, role, observation freshness, endpoint health, active lease expiry, and generic reason codes. |
 
 `/health/active` is intentionally narrow. It must not fail because Grafana is down, telemetry history is stale, alert history is unavailable, or dashboards cannot query.
 
-`/health/ha` is not a load-balancer health check and must not be exposed wherever unauthenticated `/health` endpoints are exposed. It bypasses active-mode gating so either Fleet app host can report diagnostics, but it still requires admin auth in every supported profile. Network allowlists can be added as defense in depth, not as the primary auth boundary.
+`/health/ha` is not a load-balancer health check. It binds to loopback and nginx explicitly returns 404 for the same path through the VIP. Local host or SSH access is the authentication boundary; v1 does not add bearer credentials for this endpoint.
 
-`ha-status.sh` provides the operator view:
+`fleet-ha status --check` provides the operator view:
 
 - Patroni cluster table;
 - etcd quorum;
@@ -288,9 +286,9 @@ Endpoints:
 - `FAILOVER READY: YES/NO`;
 - degraded reason.
 
-The v1 HA contract requires degraded readiness to be visible through `/health/ha` and `ha-status.sh`. Grafana dashboards, alert history, and notification metrics remain best-effort; they must not be the only source of HA degraded-state reporting.
+The v1 HA contract requires degraded readiness to be visible through `/health/ha` and `fleet-ha status`. Grafana dashboards, alert history, and notification metrics remain best-effort; they must not be the only source of HA degraded-state reporting.
 
-Live HA alerting is control-plane owned. The supported alert source should evaluate the same state exposed through `/health/ha` and `ha-status.sh`, including active Fleet count, lease freshness, DB primary reachability, sync standby health, etcd quorum, replication lag, and VIP/load-balancer target. Alert delivery can use the install's notification mechanism, but alert generation must not depend on Grafana, telemetry ingestion, dashboard queries, or alert-history storage being healthy. Grafana can visualize these states when available; it is not the source of truth for v1 HA failure detection.
+Future HA alerting should evaluate the same state exposed through `/health/ha` and `fleet-ha status`. Alert delivery and dashboards are outside the initial supported profile.
 
 ## Deployment model
 
@@ -371,14 +369,14 @@ Deployment and diagnostics:
 - HA management-plane ports are restricted to HA peers and approved operator diagnostics paths; cloud or untrusted network profiles add authenticated transport.
 - HA alerts fire from control-plane status for standby loss, quorum loss, active holder anomalies, replication lag, and endpoint targeting failures even when Grafana or telemetry history is unavailable.
 - Telemetry/Grafana failures do not fail `/health/active`.
-- Unauthenticated health endpoints do not expose HA topology, and `/health/ha` requires operator access.
+- Public health endpoints do not expose HA topology, and `/health/ha` is reachable only on loopback.
 
 ## Drawbacks
 
 - **More moving parts than single-host installs**. Patroni, etcd, and a witness host add operational surface area.
 - **The default durability mode is intentionally degraded after standby loss**. Auto-degrade keeps control running but exposes the site to data loss on a second failure until redundancy is restored.
 - **Passive Fleet is not a read-only replica**. This simplifies correctness but means passive hosts are not useful for normal UI/API browsing in v1.
-- **Historical views can be incomplete during incidents**. Operators may lose dashboard fidelity exactly when an incident is happening; live HA alerting, `ha-status.sh`, and operator-protected `/health/ha` become the authoritative status surfaces.
+- **Historical views can be incomplete during incidents**. Operators may lose dashboard fidelity exactly when an incident is happening; `fleet-ha status` and loopback-only `/health/ha` become the authoritative status surfaces.
 - **Local artifacts are not automatically HA**. Firmware and command artifacts need shared/replicated storage before they can be part of the v1 HA guarantee.
 - **Implementation touches startup wiring**. Moving runtime services behind an activation supervisor changes `fleetd` lifecycle code and needs careful tests.
 
@@ -409,11 +407,11 @@ Deployment and diagnostics:
 | Phase | Goal | Scope | Behavior change |
 | ----- | ---- | ----- | --------------- |
 | 1 | DB writer routing | Multi-host DSN, read-write targeting, stale pooled connection discard, failover retry classification | Fleet can reconnect to the current DB writer without HAProxy. |
-| 2 | Active lease | `fleet_runtime_lease`, sqlc queries, `ha.Coordinator`, `/health/active`, operator-protected `/health/ha` | Fleet can decide active/passive state safely. |
+| 2 | Active lease | `fleet_runtime_lease`, sqlc queries, `ha.Coordinator`, `/health/active` | Fleet can decide active/passive state safely. |
 | 3 | Runtime supervision | Move active-only services behind a supervisor; immediate reconciler tick on activation | Passive Fleet stays warm but does not dispatch or mutate control state. |
 | 4 | Passive gating and Fleet Node retry | Active-mode request gate, ControlStream `not-active`, Fleet Node fast retry and stream liveness tuning | Traffic can safely route only to active Fleet. |
-| 5 | HA substrate | Patroni image/config, etcd, keepalived/VRRP VIP templates, peer-connectivity preflight, install/join flow, `ha-status.sh` | Operators can install the on-prem HA profile. |
-| 6 | Degraded-mode observability | Alerts and status for standby loss, quorum loss, active count, replication lag, failover readiness | Operators can distinguish full HA from control-only/degraded operation. |
+| 5 | HA substrate | Patroni image/config, etcd, keepalived/VRRP VIP templates, peer-connectivity preflight, install/join flow | Operators can install the on-prem HA profile. |
+| 6 | Degraded-mode observability | Local status for standby loss, quorum loss, active count, replication lag, and failover readiness | Operators can distinguish full HA from control-only/degraded operation. |
 | 7 | Lab and cloud references | Repeated failover tests, partition tests, runbook, cloud deployment reference | The install mode can be marked supported after validation gates pass. |
 
 Each phase should preserve existing single-host installs. `FLEET_HA_ENABLED=false` remains the default outside the HA profile.

--- a/docs/rfcs/0002-active-passive-fleet-ha.md
+++ b/docs/rfcs/0002-active-passive-fleet-ha.md
@@ -276,7 +276,7 @@ Endpoints:
 
 `/health/ha` is not a load-balancer health check. It binds to loopback and nginx explicitly returns 404 for the same path through the VIP. Local host or SSH access is the authentication boundary; v1 does not add bearer credentials for this endpoint.
 
-`fleet-ha status --check` provides the operator view:
+`fleet-ha status` provides the operator view as redacted JSON and exits nonzero when failover readiness is degraded:
 
 - local runtime role, observation freshness, and endpoint health;
 - separate control and failover readiness;

--- a/docs/rfcs/0002-active-passive-fleet-ha.md
+++ b/docs/rfcs/0002-active-passive-fleet-ha.md
@@ -278,13 +278,9 @@ Endpoints:
 
 `fleet-ha status --check` provides the operator view:
 
-- Patroni cluster table;
-- etcd quorum;
-- sync standby and replication lag;
-- active Fleet holder and lease epoch;
-- VIP/load-balancer target;
-- `FAILOVER READY: YES/NO`;
-- degraded reason.
+- local runtime role, observation freshness, and endpoint health;
+- separate control and failover readiness;
+- generic reason codes for etcd quorum, writable Postgres, database redundancy, Fleet redundancy and version agreement, and VIP health.
 
 The v1 HA contract requires degraded readiness to be visible through `/health/ha` and `fleet-ha status`. Grafana dashboards, alert history, and notification metrics remain best-effort; they must not be the only source of HA degraded-state reporting.
 

--- a/server/cmd/fleet-ha/main.go
+++ b/server/cmd/fleet-ha/main.go
@@ -2,9 +2,12 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
+	"strings"
 
 	"github.com/block/proto-fleet/server/internal/ha/deployment"
 )
@@ -74,11 +77,70 @@ func run(ctx context.Context, args []string) error {
 			return errors.New("usage: fleet-ha compose COMPOSE_ARGS...")
 		}
 		return deployment.RunCompose(ctx, args[1:])
+	case "status":
+		return runStatus(ctx, args[1:], os.Stdout, deployment.Status)
 	default:
 		return usageError()
 	}
 }
 
 func usageError() error {
-	return errors.New("usage: fleet-ha <generate-secrets|preflight|bootstrap-etcd-auth|render-keepalived|compose> ...")
+	return errors.New("usage: fleet-ha <generate-secrets|preflight|bootstrap-etcd-auth|render-keepalived|compose|status> ...")
+}
+
+type statusReader func(context.Context, string, bool) (deployment.StatusReport, error)
+
+func runStatus(ctx context.Context, args []string, output io.Writer, read statusReader) error {
+	envPath := defaultNodeEnv
+	jsonOutput, check := false, false
+	positional := 0
+	for _, arg := range args {
+		switch arg {
+		case "--json":
+			jsonOutput = true
+		case "--check":
+			check = true
+		default:
+			if len(arg) > 0 && arg[0] == '-' {
+				return errors.New("usage: fleet-ha status [node.env] [--json] [--check]")
+			}
+			positional++
+			if positional > 1 {
+				return errors.New("usage: fleet-ha status [node.env] [--json] [--check]")
+			}
+			envPath = arg
+		}
+	}
+	report, err := read(ctx, envPath, check)
+	if err != nil {
+		return err
+	}
+	if jsonOutput {
+		encoder := json.NewEncoder(output)
+		encoder.SetIndent("", "  ")
+		if err := encoder.Encode(report); err != nil {
+			return fmt.Errorf("write HA status: %w", err)
+		}
+	} else {
+		lines := []string{
+			fmt.Sprintf("Fleet HA: %s (%s)", report.Runtime.Role, report.Runtime.Observation),
+			fmt.Sprintf("Endpoint: %s", report.Runtime.Endpoint),
+		}
+		if report.Control != nil {
+			lines = append(lines,
+				fmt.Sprintf("Control ready: %t", report.Control.ControlReady),
+				fmt.Sprintf("Failover ready: %t", report.Control.FailoverReady),
+			)
+		}
+		if report.Control != nil && len(report.Control.ReasonCodes) > 0 {
+			lines = append(lines, fmt.Sprintf("Reasons: %v", report.Control.ReasonCodes))
+		}
+		if _, err := fmt.Fprintln(output, strings.Join(lines, "\n")); err != nil {
+			return fmt.Errorf("write HA status: %w", err)
+		}
+	}
+	if check && (report.Control == nil || !report.Control.FailoverReady) {
+		return errors.New("HA failover readiness check failed")
+	}
+	return nil
 }

--- a/server/cmd/fleet-ha/main.go
+++ b/server/cmd/fleet-ha/main.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 
 	"github.com/block/proto-fleet/server/internal/ha/deployment"
 )
@@ -88,58 +87,27 @@ func usageError() error {
 	return errors.New("usage: fleet-ha <generate-secrets|preflight|bootstrap-etcd-auth|render-keepalived|compose|status> ...")
 }
 
-type statusReader func(context.Context, string, bool) (deployment.StatusReport, error)
+type statusReader func(context.Context, string) (deployment.StatusReport, error)
 
 func runStatus(ctx context.Context, args []string, output io.Writer, read statusReader) error {
 	envPath := defaultNodeEnv
-	jsonOutput, check := false, false
-	positional := 0
-	for _, arg := range args {
-		switch arg {
-		case "--json":
-			jsonOutput = true
-		case "--check":
-			check = true
-		default:
-			if len(arg) > 0 && arg[0] == '-' {
-				return errors.New("usage: fleet-ha status [node.env] [--json] [--check]")
-			}
-			positional++
-			if positional > 1 {
-				return errors.New("usage: fleet-ha status [node.env] [--json] [--check]")
-			}
-			envPath = arg
-		}
+	if len(args) > 1 || (len(args) == 1 && len(args[0]) > 0 && args[0][0] == '-') {
+		return errors.New("usage: fleet-ha status [node.env]")
 	}
-	report, err := read(ctx, envPath, check)
+	if len(args) == 1 {
+		envPath = args[0]
+	}
+
+	report, err := read(ctx, envPath)
 	if err != nil {
 		return err
 	}
-	if jsonOutput {
-		encoder := json.NewEncoder(output)
-		encoder.SetIndent("", "  ")
-		if err := encoder.Encode(report); err != nil {
-			return fmt.Errorf("write HA status: %w", err)
-		}
-	} else {
-		lines := []string{
-			fmt.Sprintf("Fleet HA: %s (%s)", report.Runtime.Role, report.Runtime.Observation),
-			fmt.Sprintf("Endpoint: %s", report.Runtime.Endpoint),
-		}
-		if report.Control != nil {
-			lines = append(lines,
-				fmt.Sprintf("Control ready: %t", report.Control.ControlReady),
-				fmt.Sprintf("Failover ready: %t", report.Control.FailoverReady),
-			)
-		}
-		if report.Control != nil && len(report.Control.ReasonCodes) > 0 {
-			lines = append(lines, fmt.Sprintf("Reasons: %v", report.Control.ReasonCodes))
-		}
-		if _, err := fmt.Fprintln(output, strings.Join(lines, "\n")); err != nil {
-			return fmt.Errorf("write HA status: %w", err)
-		}
+	encoder := json.NewEncoder(output)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(report); err != nil {
+		return fmt.Errorf("write HA status: %w", err)
 	}
-	if check && (report.Control == nil || !report.Control.FailoverReady) {
+	if report.Control == nil || !report.Control.FailoverReady {
 		return errors.New("HA failover readiness check failed")
 	}
 	return nil

--- a/server/cmd/fleet-ha/main_test.go
+++ b/server/cmd/fleet-ha/main_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/proto-fleet/server/internal/ha"
+	"github.com/block/proto-fleet/server/internal/ha/deployment"
+)
+
+func TestStatusCheckRequiresFailoverReadiness(t *testing.T) {
+	// Arrange
+	read := func(context.Context, string, bool) (deployment.StatusReport, error) {
+		return deployment.StatusReport{
+			Runtime: ha.Status{Role: ha.RolePassive, Observation: ha.ObservationCurrent, Endpoint: ha.EndpointNotApplicable},
+			Control: &deployment.ControlStatus{ControlReady: true},
+		}, nil
+	}
+
+	// Act
+	err := runStatus(t.Context(), []string{"custom.env", "--check"}, &bytes.Buffer{}, read)
+
+	// Assert
+	require.ErrorContains(t, err, "failover readiness")
+}
+
+func TestStatusJSONPrintsRedactedContract(t *testing.T) {
+	// Arrange
+	var output bytes.Buffer
+	read := func(_ context.Context, envPath string, check bool) (deployment.StatusReport, error) {
+		require.Equal(t, "node.env", envPath)
+		require.True(t, check)
+		return deployment.StatusReport{
+			Runtime: ha.Status{Version: "v1.2.3", Role: ha.RoleActive, Observation: ha.ObservationCurrent, Endpoint: ha.EndpointHealthy},
+			Control: &deployment.ControlStatus{ControlReady: true, FailoverReady: true},
+		}, nil
+	}
+
+	// Act
+	err := runStatus(t.Context(), []string{"--json", "--check"}, &output, read)
+
+	// Assert
+	require.NoError(t, err)
+	require.Contains(t, output.String(), `"control_ready": true`)
+	require.Contains(t, output.String(), `"failover_ready": true`)
+	require.NotContains(t, output.String(), "holder")
+	require.NotContains(t, output.String(), "token")
+}

--- a/server/cmd/fleet-ha/main_test.go
+++ b/server/cmd/fleet-ha/main_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/block/proto-fleet/server/internal/ha/deployment"
 )
 
-func TestStatusCheckRequiresFailoverReadiness(t *testing.T) {
+func TestStatusRequiresFailoverReadiness(t *testing.T) {
 	// Arrange
-	read := func(context.Context, string, bool) (deployment.StatusReport, error) {
+	read := func(context.Context, string) (deployment.StatusReport, error) {
 		return deployment.StatusReport{
 			Runtime: ha.Status{Role: ha.RolePassive, Observation: ha.ObservationCurrent, Endpoint: ha.EndpointNotApplicable},
 			Control: &deployment.ControlStatus{ControlReady: true},
@@ -21,18 +21,17 @@ func TestStatusCheckRequiresFailoverReadiness(t *testing.T) {
 	}
 
 	// Act
-	err := runStatus(t.Context(), []string{"custom.env", "--check"}, &bytes.Buffer{}, read)
+	err := runStatus(t.Context(), []string{"custom.env"}, &bytes.Buffer{}, read)
 
 	// Assert
 	require.ErrorContains(t, err, "failover readiness")
 }
 
-func TestStatusJSONPrintsRedactedContract(t *testing.T) {
+func TestStatusPrintsRedactedContract(t *testing.T) {
 	// Arrange
 	var output bytes.Buffer
-	read := func(_ context.Context, envPath string, check bool) (deployment.StatusReport, error) {
+	read := func(_ context.Context, envPath string) (deployment.StatusReport, error) {
 		require.Equal(t, "node.env", envPath)
-		require.True(t, check)
 		return deployment.StatusReport{
 			Runtime: ha.Status{Version: "v1.2.3", Role: ha.RoleActive, Observation: ha.ObservationCurrent, Endpoint: ha.EndpointHealthy},
 			Control: &deployment.ControlStatus{ControlReady: true, FailoverReady: true},
@@ -40,7 +39,7 @@ func TestStatusJSONPrintsRedactedContract(t *testing.T) {
 	}
 
 	// Act
-	err := runStatus(t.Context(), []string{"--json", "--check"}, &output, read)
+	err := runStatus(t.Context(), nil, &output, read)
 
 	// Assert
 	require.NoError(t, err)

--- a/server/cmd/fleetd/config.go
+++ b/server/cmd/fleetd/config.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/block/proto-fleet/server/internal/domain/command"
@@ -26,6 +27,16 @@ import (
 	"github.com/block/proto-fleet/server/internal/infrastructure/sysmon"
 	"github.com/block/proto-fleet/server/internal/infrastructure/timescaledb"
 )
+
+func validateHAHTTPAddress(config Config) error {
+	if !config.HA.Enabled {
+		return nil
+	}
+	if config.HTTP.Address != ha.LocalStatusAddress {
+		return fmt.Errorf("HA requires HTTP listen address %q, got %q", ha.LocalStatusAddress, config.HTTP.Address)
+	}
+	return nil
+}
 
 type HTTPConfig struct {
 	Address           string        `help:"Address to listen on" default:"127.0.0.1:8080" env:"LISTEN_ADDRESS"`

--- a/server/cmd/fleetd/main.go
+++ b/server/cmd/fleetd/main.go
@@ -182,6 +182,9 @@ func start(config *Config) (result error) {
 	if err := config.HA.Validate(); err != nil {
 		return fmt.Errorf("invalid HA configuration: %w", err)
 	}
+	if err := validateHAHTTPAddress(*config); err != nil {
+		return err
+	}
 	if config.HA.Enabled {
 		if err := config.DB.ValidateHA(); err != nil {
 			return fmt.Errorf("invalid HA database configuration: %w", err)
@@ -714,9 +717,13 @@ func start(config *Config) (result error) {
 
 	mux := http.NewServeMux()
 
-	mux.HandleFunc("/health", health.NewHandler())
+	mux.HandleFunc("/health", health.NewHandler(version))
 	mux.HandleFunc("/health/ready", health.NewReadyHandler(conn, fleetRuntime))
 	mux.HandleFunc("/health/active", health.NewActiveHandler(fleetRuntime))
+	if config.HA.Enabled {
+		mux.HandleFunc("/health/ha", health.NewHAHandler(version, fleetRuntime))
+		mux.HandleFunc("/health/passive", health.NewPassiveHandler(fleetRuntime))
+	}
 	if config.Metrics.Enabled {
 		if config.Metrics.WebhookToken == "" {
 			slog.Warn("FLEET_ALERTS_WEBHOOK_TOKEN is not set; alertmanager webhook will reject every delivery")

--- a/server/cmd/fleetd/main_test.go
+++ b/server/cmd/fleetd/main_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/alecthomas/kong"
 	kongyaml "github.com/alecthomas/kong-yaml"
+	"github.com/block/proto-fleet/server/internal/ha"
 	"github.com/stretchr/testify/require"
 )
 
@@ -278,6 +279,33 @@ encrypt:
 	require.False(t, config.SystemMonitoring.Enabled)
 	require.Equal(t, 30*time.Second, config.SystemMonitoring.Interval)
 	require.Equal(t, "/", config.SystemMonitoring.DiskPath)
+}
+
+func TestValidateHAHTTPAddressRequiresLocalStatusAddress(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		address string
+		wantErr bool
+	}{
+		{name: "loopback", address: "127.0.0.1:4000"},
+		{name: "other loopback port", address: "127.0.0.1:8080", wantErr: true},
+		{name: "network interface", address: "0.0.0.0:4000", wantErr: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			// Arrange
+			config := Config{HTTP: HTTPConfig{Address: test.address}, HA: ha.Config{Enabled: true}}
+
+			// Act
+			err := validateHAHTTPAddress(config)
+
+			// Assert
+			if test.wantErr {
+				require.ErrorContains(t, err, "HTTP listen address")
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
 }
 
 func TestHTTP2WriteByteTimeoutStopsNonReadingClient(t *testing.T) {

--- a/server/generated/sqlc/db.go
+++ b/server/generated/sqlc/db.go
@@ -132,6 +132,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.claimRigConfigReconciliationStmt, err = db.PrepareContext(ctx, claimRigConfigReconciliation); err != nil {
 		return nil, fmt.Errorf("error preparing query ClaimRigConfigReconciliation: %w", err)
 	}
+	if q.classifyFleetRuntimeLeaseAcquisitionStmt, err = db.PrepareContext(ctx, classifyFleetRuntimeLeaseAcquisition); err != nil {
+		return nil, fmt.Errorf("error preparing query ClassifyFleetRuntimeLeaseAcquisition: %w", err)
+	}
 	if q.clearCurtailmentAutomationActiveEventStmt, err = db.PrepareContext(ctx, clearCurtailmentAutomationActiveEvent); err != nil {
 		return nil, fmt.Errorf("error preparing query ClearCurtailmentAutomationActiveEvent: %w", err)
 	}
@@ -1791,6 +1794,11 @@ func (q *Queries) Close() error {
 	if q.claimRigConfigReconciliationStmt != nil {
 		if cerr := q.claimRigConfigReconciliationStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing claimRigConfigReconciliationStmt: %w", cerr)
+		}
+	}
+	if q.classifyFleetRuntimeLeaseAcquisitionStmt != nil {
+		if cerr := q.classifyFleetRuntimeLeaseAcquisitionStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing classifyFleetRuntimeLeaseAcquisitionStmt: %w", cerr)
 		}
 	}
 	if q.clearCurtailmentAutomationActiveEventStmt != nil {
@@ -4328,6 +4336,7 @@ type Queries struct {
 	claimClosedLoopFullFleetTargetsStmt                          *sql.Stmt
 	claimMessageForProcessingStmt                                *sql.Stmt
 	claimRigConfigReconciliationStmt                             *sql.Stmt
+	classifyFleetRuntimeLeaseAcquisitionStmt                     *sql.Stmt
 	clearCurtailmentAutomationActiveEventStmt                    *sql.Stmt
 	clearDeviceBuildingsByBuildingStmt                           *sql.Stmt
 	clearDeviceBuildingsBySiteStmt                               *sql.Stmt
@@ -4862,6 +4871,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		claimClosedLoopFullFleetTargetsStmt:                          q.claimClosedLoopFullFleetTargetsStmt,
 		claimMessageForProcessingStmt:                                q.claimMessageForProcessingStmt,
 		claimRigConfigReconciliationStmt:                             q.claimRigConfigReconciliationStmt,
+		classifyFleetRuntimeLeaseAcquisitionStmt:                     q.classifyFleetRuntimeLeaseAcquisitionStmt,
 		clearCurtailmentAutomationActiveEventStmt:                    q.clearCurtailmentAutomationActiveEventStmt,
 		clearDeviceBuildingsByBuildingStmt:                           q.clearDeviceBuildingsByBuildingStmt,
 		clearDeviceBuildingsBySiteStmt:                               q.clearDeviceBuildingsBySiteStmt,

--- a/server/generated/sqlc/ha.sql.go
+++ b/server/generated/sqlc/ha.sql.go
@@ -131,6 +131,57 @@ func (q *Queries) AcquireFleetRuntimeLease(ctx context.Context, arg AcquireFleet
 	return i, err
 }
 
+const classifyFleetRuntimeLeaseAcquisition = `-- name: ClassifyFleetRuntimeLeaseAcquisition :one
+WITH lease_context AS (
+    SELECT
+        clock_timestamp() AS database_time,
+        (
+            NOT connected.in_recovery
+            AND connected.server_address = $4::TEXT
+            AND connected.server_port = $5::INTEGER
+            AND connected.timeline = $6::BIGINT
+        ) AS writer_matches
+    FROM connected_postgres_identity AS connected
+)
+SELECT CASE
+    WHEN NOT lease_context.writer_matches THEN 'writer_mismatch'
+    WHEN current_lease.lease_name IS NULL THEN 'unavailable'
+    WHEN current_lease.dcs_cluster_id IS DISTINCT FROM $1 THEN 'cluster_mismatch'
+    WHEN current_lease.highest_writer_generation IS DISTINCT FROM $2 THEN 'writer_changed'
+    WHEN
+        current_lease.holder_id IS DISTINCT FROM $3
+        AND current_lease.expires_at > lease_context.database_time
+    THEN 'contended'
+    ELSE 'unavailable'
+END::TEXT AS acquisition_result
+FROM lease_context
+LEFT JOIN fleet_runtime_lease AS current_lease
+    ON current_lease.lease_name = 'fleet-active'
+`
+
+type ClassifyFleetRuntimeLeaseAcquisitionParams struct {
+	DcsClusterID     string
+	WriterGeneration int64
+	HolderID         uuid.UUID
+	ServerAddress    string
+	ServerPort       int32
+	Timeline         int64
+}
+
+func (q *Queries) ClassifyFleetRuntimeLeaseAcquisition(ctx context.Context, arg ClassifyFleetRuntimeLeaseAcquisitionParams) (string, error) {
+	row := q.queryRow(ctx, q.classifyFleetRuntimeLeaseAcquisitionStmt, classifyFleetRuntimeLeaseAcquisition,
+		arg.DcsClusterID,
+		arg.WriterGeneration,
+		arg.HolderID,
+		arg.ServerAddress,
+		arg.ServerPort,
+		arg.Timeline,
+	)
+	var acquisition_result string
+	err := row.Scan(&acquisition_result)
+	return acquisition_result, err
+}
+
 const getConnectedPostgresIdentity = `-- name: GetConnectedPostgresIdentity :one
 SELECT
     server_address,

--- a/server/generated/sqlc/querier.go
+++ b/server/generated/sqlc/querier.go
@@ -187,6 +187,7 @@ type Querier interface {
 	ClaimClosedLoopFullFleetTargets(ctx context.Context, arg ClaimClosedLoopFullFleetTargetsParams) ([]CurtailmentTarget, error)
 	ClaimMessageForProcessing(ctx context.Context, id int64) (sql.Result, error)
 	ClaimRigConfigReconciliation(ctx context.Context) (CurtailmentRigConfigReconciliation, error)
+	ClassifyFleetRuntimeLeaseAcquisition(ctx context.Context, arg ClassifyFleetRuntimeLeaseAcquisitionParams) (string, error)
 	ClearCurtailmentAutomationActiveEvent(ctx context.Context, arg ClearCurtailmentAutomationActiveEventParams) error
 	// Nulls device.building_id for every direct-FK device pointing at the
 	// given building. Used by DeleteBuilding's soft-delete cascade so a

--- a/server/generated/sqlc/retrying_querier.gen.go
+++ b/server/generated/sqlc/retrying_querier.gen.go
@@ -432,6 +432,18 @@ func (q *retryingQuerier) ClaimRigConfigReconciliation(ctx context.Context) (Cur
 	return result, err
 }
 
+func (q *retryingQuerier) ClassifyFleetRuntimeLeaseAcquisition(ctx context.Context, arg ClassifyFleetRuntimeLeaseAcquisitionParams) (string, error) {
+	var result string
+	err := q.retrier.RetryQuery(ctx, "ClassifyFleetRuntimeLeaseAcquisition", func() error {
+		callResult, callErr := q.next.ClassifyFleetRuntimeLeaseAcquisition(ctx, arg)
+		if callErr == nil {
+			result = callResult
+		}
+		return callErr
+	})
+	return result, err
+}
+
 func (q *retryingQuerier) ClearCurtailmentAutomationActiveEvent(ctx context.Context, arg ClearCurtailmentAutomationActiveEventParams) error {
 	return q.retrier.RetryQuery(ctx, "ClearCurtailmentAutomationActiveEvent", func() error {
 		return q.next.ClearCurtailmentAutomationActiveEvent(ctx, arg)

--- a/server/internal/ha/config.go
+++ b/server/internal/ha/config.go
@@ -64,7 +64,7 @@ func NewConfiguredRuntime(
 	if err != nil {
 		return nil, nil, fmt.Errorf("read HA etcd password: %w", err)
 	}
-	tlsConfig, err := loadServiceTLS(config.ServiceCAFile)
+	tlsConfig, err := LoadServiceTLS(config.ServiceCAFile)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -122,9 +122,11 @@ func NewConfiguredRuntime(
 		_ = cleanup()
 		return nil, nil, err
 	}
-	endpointHealthy := newEndpointHealth(netip.MustParseAddr(config.EndpointIP), config.EndpointInterface, EndpointHeartbeatFile, endpointHeartbeatTimeout)
+	endpointIP := netip.MustParseAddr(config.EndpointIP)
+	endpointHealthy := newEndpointHealth(endpointIP, config.EndpointInterface, EndpointHeartbeatFile, endpointHeartbeatTimeout)
 	runtime := newRuntime(coordinator, group, healthy, RuntimeConfig{
 		EndpointHealthy: endpointHealthy,
+		EndpointOwned:   newEndpointOwned(endpointIP, config.EndpointInterface),
 	})
 	return runtime, cleanup, nil
 }
@@ -177,7 +179,8 @@ func readRuntimeSecret(path string) (string, error) {
 	return secret, nil
 }
 
-func loadServiceTLS(path string) (*tls.Config, error) {
+// LoadServiceTLS loads the trust policy shared by Fleet's HA runtime and host tooling.
+func LoadServiceTLS(path string) (*tls.Config, error) {
 	contents, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("read HA service CA: %w", err)

--- a/server/internal/ha/coordinator.go
+++ b/server/internal/ha/coordinator.go
@@ -41,16 +41,17 @@ type Coordinator struct {
 	config   CoordinatorConfig
 	holderID uuid.UUID
 
-	mu           sync.RWMutex
-	ownership    Ownership
-	activeCtx    context.Context //nolint:containedctx // The coordinator owns this explicit active-lifetime context.
-	cancelActive context.CancelCauseFunc
-	leaseTimer   *time.Timer
-	leaseVersion uint64
-	stateChanged chan struct{}
-	acquireAfter time.Time
-	observed     bool
-	updatedAt    time.Time
+	mu            sync.RWMutex
+	ownership     Ownership
+	activeCtx     context.Context //nolint:containedctx // The coordinator owns this explicit active-lifetime context.
+	cancelActive  context.CancelCauseFunc
+	leaseTimer    *time.Timer
+	leaseVersion  uint64
+	stateChanged  chan struct{}
+	acquireAfter  time.Time
+	observed      bool
+	updatedAt     time.Time
+	proofDeadline time.Time
 }
 
 func NewCoordinator(
@@ -119,6 +120,9 @@ func (c *Coordinator) Snapshot() Snapshot {
 	}
 	if !c.updatedAt.IsZero() {
 		snapshot.FreshUntil = c.updatedAt.Add(c.config.LeaseDuration + c.config.RetryInterval)
+		if !c.proofDeadline.IsZero() && c.proofDeadline.Before(snapshot.FreshUntil) {
+			snapshot.FreshUntil = c.proofDeadline
+		}
 	}
 	if c.activeCtx != nil {
 		snapshot.State = StateActive
@@ -260,7 +264,7 @@ func (c *Coordinator) tryAcquire(ctx context.Context) (bool, error) {
 		return false, err
 	}
 	if contended {
-		c.deactivate(nil)
+		c.deactivateObserved(observed.DCSProofDeadline)
 		return false, ErrLeaseUnavailable
 	}
 	activationCtx, cancelActivation := context.WithDeadline(ctx, observed.DCSProofDeadline)
@@ -366,6 +370,7 @@ func (c *Coordinator) activate(
 	c.ownership = ownership
 	c.observed = true
 	c.updatedAt = time.Now()
+	c.proofDeadline = dcsProofDeadline
 	c.resetLeaseTimerLocked(deadline)
 	c.signalStateChangedLocked()
 	return nil
@@ -397,6 +402,7 @@ func (c *Coordinator) updateActive(
 	c.ownership = renewed
 	c.updatedAt = time.Now()
 	c.observed = true
+	c.proofDeadline = dcsProofDeadline
 	c.resetLeaseTimerLocked(deadline)
 	return nil
 }
@@ -453,6 +459,13 @@ func (c *Coordinator) deactivate(cause error) {
 	c.deactivateLocked(cause)
 }
 
+func (c *Coordinator) deactivateObserved(proofDeadline time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.deactivateLocked(nil)
+	c.proofDeadline = proofDeadline
+}
+
 func (c *Coordinator) abandonCandidate(leaseExpiresAt time.Time, cause error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -476,6 +489,7 @@ func (c *Coordinator) deactivateLocked(cause error) {
 	c.ownership = Ownership{}
 	c.updatedAt = time.Now()
 	c.observed = cause == nil
+	c.proofDeadline = time.Time{}
 }
 
 func (c *Coordinator) signalStateChangedLocked() {

--- a/server/internal/ha/coordinator.go
+++ b/server/internal/ha/coordinator.go
@@ -25,13 +25,14 @@ type CoordinatorConfig struct {
 
 // Snapshot is a non-authoritative view of the coordinator's current state.
 type Snapshot struct {
-	State        State
-	HolderID     uuid.UUID
-	DCSClusterID string
-	Token        Token
-	ExpiresAt    time.Time
-	LastError    string
-	UpdatedAt    time.Time
+	State                State
+	HolderID             uuid.UUID
+	DCSClusterID         string
+	Token                Token
+	ExpiresAt            time.Time
+	UpdatedAt            time.Time
+	ObservationAvailable bool
+	FreshUntil           time.Time
 }
 
 type Coordinator struct {
@@ -48,7 +49,7 @@ type Coordinator struct {
 	leaseVersion uint64
 	stateChanged chan struct{}
 	acquireAfter time.Time
-	lastError    string
+	observed     bool
 	updatedAt    time.Time
 }
 
@@ -73,14 +74,12 @@ func newCoordinatorWithHolder(
 	config CoordinatorConfig,
 	holderID uuid.UUID,
 ) *Coordinator {
-	now := time.Now()
 	return &Coordinator{
 		observer:     observer,
 		store:        store,
 		config:       config,
 		holderID:     holderID,
 		stateChanged: make(chan struct{}),
-		updatedAt:    now,
 	}
 }
 
@@ -113,10 +112,13 @@ func (c *Coordinator) Snapshot() Snapshot {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	snapshot := Snapshot{
-		State:     StatePassive,
-		HolderID:  c.holderID,
-		LastError: c.lastError,
-		UpdatedAt: c.updatedAt,
+		State:                StatePassive,
+		HolderID:             c.holderID,
+		UpdatedAt:            c.updatedAt,
+		ObservationAvailable: c.observed,
+	}
+	if !c.updatedAt.IsZero() {
+		snapshot.FreshUntil = c.updatedAt.Add(c.config.LeaseDuration + c.config.RetryInterval)
 	}
 	if c.activeCtx != nil {
 		snapshot.State = StateActive
@@ -222,6 +224,7 @@ func (c *Coordinator) tryAcquire(ctx context.Context) (bool, error) {
 	var ownership Ownership
 	var candidateExpiresAt time.Time
 	acquired := false
+	contended := false
 	observed, err := c.observer.ObserveAndRun(
 		takeoverCtx,
 		func(actionCtx context.Context, observed WriterObservation) error {
@@ -234,6 +237,10 @@ func (c *Coordinator) tryAcquire(ctx context.Context) (bool, error) {
 				c.config.LeaseDuration,
 			)
 			cancelAcquire()
+			if errors.Is(acquireErr, ErrLeaseUnavailable) {
+				contended = true
+				return nil
+			}
 			if acquireErr != nil {
 				return acquireErr
 			}
@@ -251,6 +258,10 @@ func (c *Coordinator) tryAcquire(ctx context.Context) (bool, error) {
 			c.deactivate(err)
 		}
 		return false, err
+	}
+	if contended {
+		c.deactivate(nil)
+		return false, ErrLeaseUnavailable
 	}
 	activationCtx, cancelActivation := context.WithDeadline(ctx, observed.DCSProofDeadline)
 	defer cancelActivation()
@@ -353,7 +364,7 @@ func (c *Coordinator) activate(
 	}
 	c.activeCtx, c.cancelActive = context.WithCancelCause(parent)
 	c.ownership = ownership
-	c.lastError = ""
+	c.observed = true
 	c.updatedAt = time.Now()
 	c.resetLeaseTimerLocked(deadline)
 	c.signalStateChangedLocked()
@@ -385,7 +396,7 @@ func (c *Coordinator) updateActive(
 	}
 	c.ownership = renewed
 	c.updatedAt = time.Now()
-	c.lastError = ""
+	c.observed = true
 	c.resetLeaseTimerLocked(deadline)
 	return nil
 }
@@ -464,11 +475,7 @@ func (c *Coordinator) deactivateLocked(cause error) {
 	}
 	c.ownership = Ownership{}
 	c.updatedAt = time.Now()
-	if cause != nil {
-		c.lastError = cause.Error()
-	} else {
-		c.lastError = ""
-	}
+	c.observed = cause == nil
 }
 
 func (c *Coordinator) signalStateChangedLocked() {

--- a/server/internal/ha/coordinator_test.go
+++ b/server/internal/ha/coordinator_test.go
@@ -68,6 +68,28 @@ func TestCoordinatorRenewsAfterClosingDCSProof(t *testing.T) {
 	require.Equal(t, StateActive, coordinator.Snapshot().State)
 }
 
+func TestCoordinatorMarksPassiveCurrentOnlyAfterClosingDCSProof(t *testing.T) {
+	// Arrange
+	closingProofDone := false
+	coordinator := newCoordinatorWithHolder(
+		&closingProofObserver{
+			observation: coordinatorObservation("cluster-a", 41, time.Second),
+			completed:   &closingProofDone,
+		},
+		&fakeLeaseStore{acquireErr: ErrLeaseUnavailable},
+		coordinatorTestConfig(),
+		uuid.New(),
+	)
+
+	// Act
+	err := coordinator.step(t.Context())
+
+	// Assert
+	require.ErrorIs(t, err, ErrLeaseUnavailable)
+	require.True(t, closingProofDone)
+	require.True(t, coordinator.Snapshot().ObservationAvailable)
+}
+
 func TestCoordinatorWaitForActiveUnblocksOnActivationAndOwnershipLoss(t *testing.T) {
 	coordinator := newCoordinatorWithHolder(
 		staticObserver{observation: coordinatorObservation("cluster-a", 41, time.Second)},

--- a/server/internal/ha/coordinator_test.go
+++ b/server/internal/ha/coordinator_test.go
@@ -71,9 +71,10 @@ func TestCoordinatorRenewsAfterClosingDCSProof(t *testing.T) {
 func TestCoordinatorMarksPassiveCurrentOnlyAfterClosingDCSProof(t *testing.T) {
 	// Arrange
 	closingProofDone := false
+	observed := coordinatorObservation("cluster-a", 41, 40*time.Millisecond)
 	coordinator := newCoordinatorWithHolder(
 		&closingProofObserver{
-			observation: coordinatorObservation("cluster-a", 41, time.Second),
+			observation: observed,
 			completed:   &closingProofDone,
 		},
 		&fakeLeaseStore{acquireErr: ErrLeaseUnavailable},
@@ -87,7 +88,9 @@ func TestCoordinatorMarksPassiveCurrentOnlyAfterClosingDCSProof(t *testing.T) {
 	// Assert
 	require.ErrorIs(t, err, ErrLeaseUnavailable)
 	require.True(t, closingProofDone)
-	require.True(t, coordinator.Snapshot().ObservationAvailable)
+	snapshot := coordinator.Snapshot()
+	require.True(t, snapshot.ObservationAvailable)
+	require.Equal(t, observed.DCSProofDeadline, snapshot.FreshUntil)
 }
 
 func TestCoordinatorWaitForActiveUnblocksOnActivationAndOwnershipLoss(t *testing.T) {

--- a/server/internal/ha/deployment/preflight.go
+++ b/server/internal/ha/deployment/preflight.go
@@ -287,38 +287,9 @@ func validateSecrets(config NodeConfig) error {
 }
 
 func validateFleetEnvironment(path string) error {
-	info, err := secureFileInfo(path, 0o600)
+	values, err := loadFleetEnvironment(path)
 	if err != nil {
 		return err
-	}
-	if err := requireCurrentOwner(info, fleetEnvironmentFile); err != nil {
-		return err
-	}
-
-	file, err := os.Open(path)
-	if err != nil {
-		return fmt.Errorf("open Fleet environment file: %w", err)
-	}
-	defer file.Close()
-
-	values := make(map[string]string, 3)
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		match := envLine.FindStringSubmatch(scanner.Text())
-		if match == nil {
-			return errors.New("contains a malformed entry")
-		}
-		key := match[1]
-		if key != "AUTH_CLIENT_SECRET_KEY" && key != "ENCRYPT_SERVICE_MASTER_KEY" && key != "DB_DSN" {
-			return fmt.Errorf("contains unknown key: %s", key)
-		}
-		if _, duplicate := values[key]; duplicate {
-			return fmt.Errorf("contains duplicate key: %s", key)
-		}
-		values[key] = match[2]
-	}
-	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("read Fleet environment file: %w", err)
 	}
 	if values["DB_DSN"] == "" {
 		return errors.New("DB_DSN is required")
@@ -331,6 +302,43 @@ func validateFleetEnvironment(path string) error {
 		return errors.New("ENCRYPT_SERVICE_MASTER_KEY must be a base64-encoded 32-byte key")
 	}
 	return nil
+}
+
+func loadFleetEnvironment(path string) (map[string]string, error) {
+	info, err := secureFileInfo(path, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	if err := requireCurrentOwner(info, fleetEnvironmentFile); err != nil {
+		return nil, err
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open Fleet environment file: %w", err)
+	}
+	defer file.Close()
+
+	values := make(map[string]string, 3)
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		match := envLine.FindStringSubmatch(scanner.Text())
+		if match == nil {
+			return nil, errors.New("contains a malformed entry")
+		}
+		key := match[1]
+		if key != "AUTH_CLIENT_SECRET_KEY" && key != "ENCRYPT_SERVICE_MASTER_KEY" && key != "DB_DSN" {
+			return nil, fmt.Errorf("contains unknown key: %s", key)
+		}
+		if _, duplicate := values[key]; duplicate {
+			return nil, fmt.Errorf("contains duplicate key: %s", key)
+		}
+		values[key] = match[2]
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read Fleet environment file: %w", err)
+	}
+	return values, nil
 }
 
 func verifyEndpointCertificate(path, ip string, roots *x509.CertPool, usages ...x509.ExtKeyUsage) error {

--- a/server/internal/ha/deployment/status.go
+++ b/server/internal/ha/deployment/status.go
@@ -47,14 +47,9 @@ type ControlStatus struct {
 }
 
 func Status(ctx context.Context, envPath string, check bool) (StatusReport, error) {
-	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
-	if !ok {
-		return StatusReport{}, errors.New("default HTTP transport is not configurable for HA status")
-	}
-	transport := defaultTransport.Clone()
-	transport.Proxy = nil
-	defer transport.CloseIdleConnections()
-	report, err := readLocalStatus(ctx, &http.Client{Transport: transport}, localHAStatusURL)
+	client, cleanup := newProbeHTTPClient(nil, nil)
+	defer cleanup()
+	report, err := readLocalStatus(ctx, client, localHAStatusURL)
 	if err != nil {
 		return StatusReport{}, err
 	}
@@ -127,31 +122,33 @@ func checkControlPath(ctx context.Context, envPath string, report StatusReport) 
 		vipReady           bool
 		probes             sync.WaitGroup
 	)
-	probes.Add(5)
-	go func() {
-		defer probes.Done()
+	probes.Go(func() {
 		etcdStatus = probeEtcdMembers(ctx, etcdConfig)
-	}()
-	go func() {
-		defer probes.Done()
+	})
+	probes.Go(func() {
 		primary, synchronous = patroniRoles(ctx, tlsConfig, config)
-	}()
-	go func() {
-		defer probes.Done()
-		writerReady = writerObservationReady(ctx, tlsConfig, password, endpoints, config)
-	}()
-	go func() {
-		defer probes.Done()
-		vipReady = endpointReady(ctx, tlsConfig, "https://"+config.VirtualIP+"/api-proxy/health/active")
-	}()
-	go func() {
-		defer probes.Done()
-		statuses := probeFleetHosts(ctx, tlsConfig, config)
-		_, fleetActive = summarizeFleetHosts(statuses)
+	})
+	probes.Go(func() {
+		writerReady = writerObservationReady(ctx, etcdConfig, config)
+	})
+	probes.Go(func() {
+		client, cleanup := newProbeHTTPClient(tlsConfig, nil)
+		defer cleanup()
+		vipReady = endpointReadyWithClient(ctx, client, "https://"+config.VirtualIP+"/api-proxy/health/active")
+	})
+	probes.Go(func() {
+		statuses := gather([]string{config.DatabaseAIP, config.DatabaseBIP}, func(address string) fleetHostStatus {
+			return probeFleetHost(ctx, tlsConfig, config.VirtualIP, address)
+		})
+		for _, status := range statuses {
+			if status.active {
+				fleetActive++
+			}
+		}
 		fleetRedundant = fleetRedundancyReady(statuses)
 		fleetVersionsMatch = matchingFleetVersions(statuses)
 		fleetReady = fleetRedundant && fleetVersionsMatch
-	}()
+	})
 	probes.Wait()
 
 	localRuntimeReady := report.Runtime.Observation == ha.ObservationCurrent &&
@@ -193,38 +190,28 @@ type etcdReadiness struct {
 }
 
 func probeEtcdMembers(ctx context.Context, config clientv3.Config) etcdReadiness {
-	results := make(chan etcdMemberIdentity, len(config.Endpoints))
-	for _, endpoint := range config.Endpoints {
-		go func() {
-			probeCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
-			defer cancel()
-			memberConfig := config
-			memberConfig.Endpoints = []string{endpoint}
-			if config.TLS != nil {
-				memberConfig.TLS = config.TLS.Clone()
-			}
-			client, err := clientv3.New(memberConfig)
-			if err != nil {
-				results <- etcdMemberIdentity{}
-				return
-			}
-			defer client.Close()
-			response, err := client.Status(probeCtx, endpoint)
-			if err != nil || response.Header == nil {
-				results <- etcdMemberIdentity{}
-				return
-			}
-			if _, err := client.Get(probeCtx, patroniDCSPath, clientv3.WithPrefix(), clientv3.WithLimit(1)); err != nil {
-				results <- etcdMemberIdentity{}
-				return
-			}
-			results <- etcdMemberIdentity{clusterID: response.Header.ClusterId, memberID: response.Header.MemberId}
-		}()
-	}
-	identities := make([]etcdMemberIdentity, 0, len(config.Endpoints))
-	for range config.Endpoints {
-		identities = append(identities, <-results)
-	}
+	identities := gather(config.Endpoints, func(endpoint string) etcdMemberIdentity {
+		probeCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		defer cancel()
+		memberConfig := config
+		memberConfig.Endpoints = []string{endpoint}
+		if config.TLS != nil {
+			memberConfig.TLS = config.TLS.Clone()
+		}
+		client, err := clientv3.New(memberConfig)
+		if err != nil {
+			return etcdMemberIdentity{}
+		}
+		defer client.Close()
+		response, err := client.Status(probeCtx, endpoint)
+		if err != nil || response.Header == nil {
+			return etcdMemberIdentity{}
+		}
+		if _, err := client.Get(probeCtx, patroniDCSPath, clientv3.WithPrefix(), clientv3.WithLimit(1)); err != nil {
+			return etcdMemberIdentity{}
+		}
+		return etcdMemberIdentity{clusterID: response.Header.ClusterId, memberID: response.Header.MemberId}
+	})
 	return summarizeEtcdMembers(identities, len(config.Endpoints))
 }
 
@@ -252,29 +239,21 @@ func summarizeEtcdMembers(identities []etcdMemberIdentity, expected int) etcdRea
 }
 
 func patroniRoles(ctx context.Context, tlsConfig *tls.Config, config NodeConfig) (primary, synchronous int) {
-	transport := &http.Transport{TLSClientConfig: tlsConfig.Clone(), Proxy: nil}
-	client := &http.Client{
-		Transport: transport,
-		Timeout:   2 * time.Second, CheckRedirect: transportguard.RejectRedirect,
-	}
-	defer transport.CloseIdleConnections()
+	client, cleanup := newProbeHTTPClient(tlsConfig, nil)
+	defer cleanup()
 	type roleResult struct {
 		primary     bool
 		synchronous bool
 	}
-	results := make(chan roleResult, 2)
-	for _, address := range []string{config.DatabaseAIP, config.DatabaseBIP} {
-		go func() {
-			baseURL := "https://" + address + ":8008"
-			results <- roleResult{
-				primary: endpointReadyWithClient(ctx, client, baseURL+"/primary"),
-				synchronous: endpointReadyWithClient(ctx, client, baseURL+"/synchronous") &&
-					endpointReadyWithClient(ctx, client, baseURL+"/readiness?lag=0&mode=apply"),
-			}
-		}()
-	}
-	for range 2 {
-		result := <-results
+	results := gather([]string{config.DatabaseAIP, config.DatabaseBIP}, func(address string) roleResult {
+		baseURL := "https://" + address + ":8008"
+		return roleResult{
+			primary: endpointReadyWithClient(ctx, client, baseURL+"/primary"),
+			synchronous: endpointReadyWithClient(ctx, client, baseURL+"/synchronous") &&
+				endpointReadyWithClient(ctx, client, baseURL+"/readiness?lag=0&mode=apply"),
+		}
+	})
+	for _, result := range results {
 		if result.primary {
 			primary++
 		}
@@ -292,32 +271,12 @@ type fleetHostStatus struct {
 	version   string
 }
 
-func probeFleetHosts(ctx context.Context, tlsConfig *tls.Config, config NodeConfig) []fleetHostStatus {
-	addresses := []string{config.DatabaseAIP, config.DatabaseBIP}
-	results := make(chan fleetHostStatus, len(addresses))
-	for _, address := range addresses {
-		go func() {
-			results <- probeFleetHost(ctx, tlsConfig, config.VirtualIP, address)
-		}()
-	}
-	statuses := make([]fleetHostStatus, 0, len(addresses))
-	for range addresses {
-		statuses = append(statuses, <-results)
-	}
-	return statuses
-}
-
 func probeFleetHost(ctx context.Context, tlsConfig *tls.Config, virtualIP, address string) fleetHostStatus {
 	dialer := &net.Dialer{Timeout: 2 * time.Second}
-	transport := &http.Transport{
-		TLSClientConfig: tlsConfig.Clone(),
-		Proxy:           nil,
-		DialContext: func(ctx context.Context, network, _ string) (net.Conn, error) {
-			return dialer.DialContext(ctx, network, net.JoinHostPort(address, "443"))
-		},
-	}
-	defer transport.CloseIdleConnections()
-	client := &http.Client{Transport: transport, Timeout: 2 * time.Second, CheckRedirect: transportguard.RejectRedirect}
+	client, cleanup := newProbeHTTPClient(tlsConfig, func(ctx context.Context, network, _ string) (net.Conn, error) {
+		return dialer.DialContext(ctx, network, net.JoinHostPort(address, "443"))
+	})
+	defer cleanup()
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://"+virtualIP+"/api-proxy/health", nil)
 	if err != nil {
 		return fleetHostStatus{}
@@ -336,18 +295,6 @@ func probeFleetHost(ctx context.Context, tlsConfig *tls.Config, virtualIP, addre
 		passive:   endpointReadyWithClient(ctx, client, "https://"+virtualIP+"/api-proxy/health/passive"),
 		version:   response.Header.Get("X-Proto-Fleet-Version"),
 	}
-}
-
-func summarizeFleetHosts(statuses []fleetHostStatus) (reachable, active int) {
-	for _, status := range statuses {
-		if status.reachable {
-			reachable++
-		}
-		if status.active {
-			active++
-		}
-	}
-	return reachable, active
 }
 
 func fleetRedundancyReady(statuses []fleetHostStatus) bool {
@@ -369,7 +316,7 @@ func matchingFleetVersions(statuses []fleetHostStatus) bool {
 	return len(statuses) == 2 && statuses[0].version != "" && statuses[0].version == statuses[1].version
 }
 
-func writerObservationReady(ctx context.Context, tlsConfig *tls.Config, password string, endpoints []string, config NodeConfig) bool {
+func writerObservationReady(ctx context.Context, etcdConfig clientv3.Config, config NodeConfig) bool {
 	values, err := loadFleetEnvironment(filepath.Join(config.SecretsDir, fleetEnvironmentFile))
 	if err != nil {
 		return false
@@ -395,19 +342,17 @@ func writerObservationReady(ctx context.Context, tlsConfig *tls.Config, password
 	}
 	defer pinned.Close()
 	queries := sqlc.New(pinned)
-	etcd, err := ha.NewEtcdClient(clientv3.Config{
-		Endpoints: endpoints, Username: "fleet-observer", Password: password,
-		TLS: tlsConfig.Clone(), DialTimeout: 2 * time.Second,
-	})
+	if etcdConfig.TLS != nil {
+		etcdConfig.TLS = etcdConfig.TLS.Clone()
+	}
+	etcd, err := ha.NewEtcdClient(etcdConfig)
 	if err != nil {
 		return false
 	}
 	defer etcd.Close()
-	transport := &http.Transport{TLSClientConfig: tlsConfig.Clone(), Proxy: nil}
-	defer transport.CloseIdleConnections()
-	observer, err := ha.NewObserver("/service/proto-fleet", etcd, queries, ha.NewPatroniHTTPClient(&http.Client{
-		Transport: transport, Timeout: 2 * time.Second,
-	}))
+	client, cleanup := newProbeHTTPClient(etcdConfig.TLS, nil)
+	defer cleanup()
+	observer, err := ha.NewObserver("/service/proto-fleet", etcd, queries, ha.NewPatroniHTTPClient(client))
 	if err != nil {
 		return false
 	}
@@ -427,12 +372,31 @@ func hostProbeDSN(raw, secretsDir string) (string, error) {
 	return dsn.String(), nil
 }
 
-func endpointReady(ctx context.Context, tlsConfig *tls.Config, endpoint string) bool {
-	transport := &http.Transport{TLSClientConfig: tlsConfig.Clone(), Proxy: nil}
-	defer transport.CloseIdleConnections()
-	return endpointReadyWithClient(ctx, &http.Client{
-		Transport: transport, Timeout: 2 * time.Second, CheckRedirect: transportguard.RejectRedirect,
-	}, endpoint)
+func gather[T, R any](items []T, probe func(T) R) []R {
+	results := make(chan R, len(items))
+	for _, item := range items {
+		go func(item T) {
+			results <- probe(item)
+		}(item)
+	}
+	gathered := make([]R, 0, len(items))
+	for range items {
+		gathered = append(gathered, <-results)
+	}
+	return gathered
+}
+
+func newProbeHTTPClient(tlsConfig *tls.Config, dialContext func(context.Context, string, string) (net.Conn, error)) (*http.Client, func()) {
+	transport := &http.Transport{Proxy: nil, DialContext: dialContext}
+	if tlsConfig != nil {
+		transport.TLSClientConfig = tlsConfig.Clone()
+	}
+	client := &http.Client{
+		Transport:     transport,
+		Timeout:       2 * time.Second,
+		CheckRedirect: transportguard.RejectRedirect,
+	}
+	return client, transport.CloseIdleConnections
 }
 
 func endpointReadyWithClient(ctx context.Context, client *http.Client, endpoint string) bool {

--- a/server/internal/ha/deployment/status.go
+++ b/server/internal/ha/deployment/status.go
@@ -8,12 +8,14 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 	"path/filepath"
 	"sync"
 	"time"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
 
+	"github.com/block/proto-fleet/server/generated/sqlc"
 	"github.com/block/proto-fleet/server/internal/ha"
 	"github.com/block/proto-fleet/server/internal/infrastructure/db"
 	"github.com/block/proto-fleet/server/internal/transportguard"
@@ -363,16 +365,25 @@ func writerObservationReady(ctx context.Context, tlsConfig *tls.Config, password
 	}
 	probeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
-	conn, err := db.ConnectToDatabase(&db.Config{ExplicitDSN: values["DB_DSN"]})
+	dsn, err := hostProbeDSN(values["DB_DSN"], config.SecretsDir)
+	if err != nil {
+		return false
+	}
+	conn, err := db.ConnectToDatabase(&db.Config{
+		ExplicitDSN:  dsn,
+		MaxOpenConns: 1,
+		MaxIdleConns: 1,
+	})
 	if err != nil {
 		return false
 	}
 	defer conn.Close()
-	queries, err := db.NewPreparedQuerier(probeCtx, conn)
+	pinned, err := conn.Conn(probeCtx)
 	if err != nil {
 		return false
 	}
-	defer queries.Close()
+	defer pinned.Close()
+	queries := sqlc.New(pinned)
 	etcd, err := ha.NewEtcdClient(clientv3.Config{
 		Endpoints: endpoints, Username: "fleet-observer", Password: password,
 		TLS: tlsConfig.Clone(), DialTimeout: 2 * time.Second,
@@ -391,6 +402,18 @@ func writerObservationReady(ctx context.Context, tlsConfig *tls.Config, password
 	}
 	_, err = observer.Observe(probeCtx)
 	return err == nil
+}
+
+func hostProbeDSN(raw, secretsDir string) (string, error) {
+	dsn, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("parse Fleet database DSN: %w", err)
+	}
+	query := dsn.Query()
+	query.Set("sslrootcert", filepath.Join(secretsDir, "service-ca.crt"))
+	query.Set("default_query_exec_mode", "cache_statement")
+	dsn.RawQuery = query.Encode()
+	return dsn.String(), nil
 }
 
 func endpointReady(ctx context.Context, tlsConfig *tls.Config, endpoint string) bool {

--- a/server/internal/ha/deployment/status.go
+++ b/server/internal/ha/deployment/status.go
@@ -3,7 +3,6 @@ package deployment
 import (
 	"context"
 	"crypto/tls"
-	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -15,8 +14,8 @@ import (
 
 	clientv3 "go.etcd.io/etcd/client/v3"
 
-	"github.com/block/proto-fleet/server/generated/sqlc"
 	"github.com/block/proto-fleet/server/internal/ha"
+	"github.com/block/proto-fleet/server/internal/infrastructure/db"
 	"github.com/block/proto-fleet/server/internal/transportguard"
 )
 
@@ -362,12 +361,18 @@ func writerObservationReady(ctx context.Context, tlsConfig *tls.Config, password
 	if err != nil {
 		return false
 	}
-	conn, err := sql.Open("pgx", values["DB_DSN"])
+	probeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	conn, err := db.ConnectToDatabase(&db.Config{ExplicitDSN: values["DB_DSN"]})
 	if err != nil {
 		return false
 	}
 	defer conn.Close()
-	queries := sqlc.New(conn)
+	queries, err := db.NewPreparedQuerier(probeCtx, conn)
+	if err != nil {
+		return false
+	}
+	defer queries.Close()
 	etcd, err := ha.NewEtcdClient(clientv3.Config{
 		Endpoints: endpoints, Username: "fleet-observer", Password: password,
 		TLS: tlsConfig.Clone(), DialTimeout: 2 * time.Second,
@@ -384,8 +389,6 @@ func writerObservationReady(ctx context.Context, tlsConfig *tls.Config, password
 	if err != nil {
 		return false
 	}
-	probeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
 	_, err = observer.Observe(probeCtx)
 	return err == nil
 }

--- a/server/internal/ha/deployment/status.go
+++ b/server/internal/ha/deployment/status.go
@@ -46,15 +46,12 @@ type ControlStatus struct {
 	ReasonCodes   []ControlReasonCode `json:"reason_codes"`
 }
 
-func Status(ctx context.Context, envPath string, check bool) (StatusReport, error) {
+func Status(ctx context.Context, envPath string) (StatusReport, error) {
 	client, cleanup := newProbeHTTPClient(nil, nil)
 	defer cleanup()
 	report, err := readLocalStatus(ctx, client, localHAStatusURL)
 	if err != nil {
 		return StatusReport{}, err
-	}
-	if !check {
-		return report, nil
 	}
 	return checkControlPath(ctx, envPath, report)
 }

--- a/server/internal/ha/deployment/status.go
+++ b/server/internal/ha/deployment/status.go
@@ -341,7 +341,11 @@ func writerObservationReady(ctx context.Context, etcdConfig clientv3.Config, con
 		return false
 	}
 	defer pinned.Close()
-	queries := sqlc.New(pinned)
+	queries, err := sqlc.Prepare(probeCtx, pinned)
+	if err != nil {
+		return false
+	}
+	defer queries.Close()
 	if etcdConfig.TLS != nil {
 		etcdConfig.TLS = etcdConfig.TLS.Clone()
 	}

--- a/server/internal/ha/deployment/status.go
+++ b/server/internal/ha/deployment/status.go
@@ -369,7 +369,11 @@ func hostProbeDSN(raw, secretsDir string) (string, error) {
 	query.Set("sslrootcert", filepath.Join(secretsDir, "service-ca.crt"))
 	query.Set("default_query_exec_mode", "cache_statement")
 	dsn.RawQuery = query.Encode()
-	return dsn.String(), nil
+	probeDSN := dsn.String()
+	if err := (&db.Config{ExplicitDSN: probeDSN}).ValidateHA(); err != nil {
+		return "", fmt.Errorf("validate HA database probe: %w", err)
+	}
+	return probeDSN, nil
 }
 
 func gather[T, R any](items []T, probe func(T) R) []R {

--- a/server/internal/ha/deployment/status.go
+++ b/server/internal/ha/deployment/status.go
@@ -1,0 +1,412 @@
+package deployment
+
+import (
+	"context"
+	"crypto/tls"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"path/filepath"
+	"sync"
+	"time"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+
+	"github.com/block/proto-fleet/server/generated/sqlc"
+	"github.com/block/proto-fleet/server/internal/ha"
+	"github.com/block/proto-fleet/server/internal/transportguard"
+)
+
+const localHAStatusURL = "http://" + ha.LocalStatusAddress + "/health/ha"
+
+type StatusReport struct {
+	Runtime ha.Status      `json:"runtime"`
+	Control *ControlStatus `json:"control,omitempty"`
+}
+
+type ControlReasonCode string
+
+const (
+	ReasonEtcdQuorumUnavailable      ControlReasonCode = "etcd_quorum_unavailable"
+	ReasonEtcdRedundancyDegraded     ControlReasonCode = "etcd_redundancy_degraded"
+	ReasonWriterUnavailable          ControlReasonCode = "writer_unavailable"
+	ReasonDatabaseRedundancyDegraded ControlReasonCode = "database_redundancy_degraded"
+	ReasonFleetRedundancyDegraded    ControlReasonCode = "fleet_redundancy_degraded"
+	ReasonVIPUnavailable             ControlReasonCode = "vip_unavailable"
+)
+
+type ControlStatus struct {
+	ControlReady  bool                `json:"control_ready"`
+	FailoverReady bool                `json:"failover_ready"`
+	ReasonCodes   []ControlReasonCode `json:"reason_codes"`
+}
+
+func Status(ctx context.Context, envPath string, check bool) (StatusReport, error) {
+	defaultTransport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return StatusReport{}, errors.New("default HTTP transport is not configurable for HA status")
+	}
+	transport := defaultTransport.Clone()
+	transport.Proxy = nil
+	defer transport.CloseIdleConnections()
+	report, err := readLocalStatus(ctx, &http.Client{Transport: transport}, localHAStatusURL)
+	if err != nil {
+		return StatusReport{}, err
+	}
+	if !check {
+		return report, nil
+	}
+	return checkControlPath(ctx, envPath, report)
+}
+
+func readLocalStatus(ctx context.Context, client *http.Client, endpoint string) (StatusReport, error) {
+	requestCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	request, err := http.NewRequestWithContext(requestCtx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return StatusReport{}, fmt.Errorf("create local HA status request: %w", err)
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		return StatusReport{}, fmt.Errorf("read local HA status: %w", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return StatusReport{}, fmt.Errorf("local HA status returned %s", response.Status)
+	}
+	var status ha.Status
+	if err := json.NewDecoder(response.Body).Decode(&status); err != nil {
+		return StatusReport{}, fmt.Errorf("decode local HA status: %w", err)
+	}
+	return StatusReport{Runtime: status}, nil
+}
+
+func checkControlPath(ctx context.Context, envPath string, report StatusReport) (StatusReport, error) {
+	config, err := loadNodeConfig(envPath)
+	if err != nil {
+		return StatusReport{}, err
+	}
+	if err := validateNodeConfig(config); err != nil {
+		return StatusReport{}, fmt.Errorf("validate HA node configuration: %w", err)
+	}
+	if !config.isDatabaseNode() {
+		return StatusReport{}, errors.New("HA control check must run on ha-a or ha-b")
+	}
+	tlsConfig, err := ha.LoadServiceTLS(filepath.Join(config.SecretsDir, "service-ca.crt"))
+	if err != nil {
+		return StatusReport{}, err
+	}
+	password, err := readPassword(filepath.Join(config.SecretsDir, fleetEtcdPasswordFile))
+	if err != nil {
+		return StatusReport{}, fmt.Errorf("read Fleet etcd password: %w", err)
+	}
+	endpoints := []string{
+		"https://" + config.DatabaseAIP + ":2379",
+		"https://" + config.DatabaseBIP + ":2379",
+		"https://" + config.WitnessIP + ":2379",
+	}
+	etcdConfig := clientv3.Config{
+		Endpoints: endpoints, Username: "fleet-observer", Password: password,
+		TLS: tlsConfig.Clone(), DialTimeout: 2 * time.Second,
+	}
+
+	var (
+		etcdStatus  etcdReadiness
+		primary     int
+		synchronous int
+		fleetActive int
+		fleetReady  bool
+		writerReady bool
+		vipReady    bool
+		probes      sync.WaitGroup
+	)
+	probes.Add(5)
+	go func() {
+		defer probes.Done()
+		etcdStatus = probeEtcdMembers(ctx, etcdConfig)
+	}()
+	go func() {
+		defer probes.Done()
+		primary, synchronous = patroniRoles(ctx, tlsConfig, config)
+	}()
+	go func() {
+		defer probes.Done()
+		writerReady = writerObservationReady(ctx, tlsConfig, password, endpoints, config)
+	}()
+	go func() {
+		defer probes.Done()
+		vipReady = endpointReady(ctx, tlsConfig, "https://"+config.VirtualIP+"/api-proxy/health/active")
+	}()
+	go func() {
+		defer probes.Done()
+		statuses := probeFleetHosts(ctx, tlsConfig, config)
+		_, fleetActive = summarizeFleetHosts(statuses)
+		fleetReady = fleetRedundancyReady(statuses)
+	}()
+	probes.Wait()
+
+	localRuntimeReady := report.Runtime.Observation == ha.ObservationCurrent &&
+		(report.Runtime.Role == ha.RoleActive || report.Runtime.Role == ha.RolePassive)
+	controlReady := etcdStatus.quorum && primary == 1 && writerReady && vipReady && fleetActive == 1
+	failoverReady := controlReady && etcdStatus.redundant && synchronous == 1 && fleetReady && localRuntimeReady
+	control := &ControlStatus{ControlReady: controlReady, FailoverReady: failoverReady}
+	if !etcdStatus.quorum {
+		control.ReasonCodes = append(control.ReasonCodes, ReasonEtcdQuorumUnavailable)
+	} else if !etcdStatus.redundant {
+		control.ReasonCodes = append(control.ReasonCodes, ReasonEtcdRedundancyDegraded)
+	}
+	if primary != 1 || !writerReady {
+		control.ReasonCodes = append(control.ReasonCodes, ReasonWriterUnavailable)
+	}
+	if synchronous != 1 {
+		control.ReasonCodes = append(control.ReasonCodes, ReasonDatabaseRedundancyDegraded)
+	}
+	if !fleetReady || !localRuntimeReady {
+		control.ReasonCodes = append(control.ReasonCodes, ReasonFleetRedundancyDegraded)
+	}
+	if !vipReady {
+		control.ReasonCodes = append(control.ReasonCodes, ReasonVIPUnavailable)
+	}
+	report.Control = control
+	return report, nil
+}
+
+type etcdMemberIdentity struct {
+	clusterID uint64
+	memberID  uint64
+}
+
+type etcdReadiness struct {
+	quorum    bool
+	redundant bool
+}
+
+func probeEtcdMembers(ctx context.Context, config clientv3.Config) etcdReadiness {
+	results := make(chan etcdMemberIdentity, len(config.Endpoints))
+	for _, endpoint := range config.Endpoints {
+		go func() {
+			probeCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+			defer cancel()
+			memberConfig := config
+			memberConfig.Endpoints = []string{endpoint}
+			if config.TLS != nil {
+				memberConfig.TLS = config.TLS.Clone()
+			}
+			client, err := clientv3.New(memberConfig)
+			if err != nil {
+				results <- etcdMemberIdentity{}
+				return
+			}
+			defer client.Close()
+			response, err := client.Status(probeCtx, endpoint)
+			if err != nil || response.Header == nil {
+				results <- etcdMemberIdentity{}
+				return
+			}
+			if _, err := client.Get(probeCtx, patroniDCSPath, clientv3.WithPrefix(), clientv3.WithLimit(1)); err != nil {
+				results <- etcdMemberIdentity{}
+				return
+			}
+			results <- etcdMemberIdentity{clusterID: response.Header.ClusterId, memberID: response.Header.MemberId}
+		}()
+	}
+	identities := make([]etcdMemberIdentity, 0, len(config.Endpoints))
+	for range config.Endpoints {
+		identities = append(identities, <-results)
+	}
+	return summarizeEtcdMembers(identities, len(config.Endpoints))
+}
+
+func summarizeEtcdMembers(identities []etcdMemberIdentity, expected int) etcdReadiness {
+	clusters := make(map[uint64]map[uint64]struct{})
+	for _, identity := range identities {
+		if identity.clusterID == 0 || identity.memberID == 0 {
+			continue
+		}
+		if clusters[identity.clusterID] == nil {
+			clusters[identity.clusterID] = make(map[uint64]struct{})
+		}
+		clusters[identity.clusterID][identity.memberID] = struct{}{}
+	}
+	readiness := etcdReadiness{}
+	for _, members := range clusters {
+		if len(members) >= 2 {
+			readiness.quorum = true
+		}
+		if len(clusters) == 1 && len(members) == expected {
+			readiness.redundant = true
+		}
+	}
+	return readiness
+}
+
+func patroniRoles(ctx context.Context, tlsConfig *tls.Config, config NodeConfig) (primary, synchronous int) {
+	transport := &http.Transport{TLSClientConfig: tlsConfig.Clone(), Proxy: nil}
+	client := &http.Client{
+		Transport: transport,
+		Timeout:   2 * time.Second, CheckRedirect: transportguard.RejectRedirect,
+	}
+	defer transport.CloseIdleConnections()
+	type roleResult struct {
+		primary     bool
+		synchronous bool
+	}
+	results := make(chan roleResult, 2)
+	for _, address := range []string{config.DatabaseAIP, config.DatabaseBIP} {
+		go func() {
+			baseURL := "https://" + address + ":8008"
+			results <- roleResult{
+				primary: endpointReadyWithClient(ctx, client, baseURL+"/primary"),
+				synchronous: endpointReadyWithClient(ctx, client, baseURL+"/synchronous") &&
+					endpointReadyWithClient(ctx, client, baseURL+"/readiness?lag=0&mode=apply"),
+			}
+		}()
+	}
+	for range 2 {
+		result := <-results
+		if result.primary {
+			primary++
+		}
+		if result.synchronous {
+			synchronous++
+		}
+	}
+	return primary, synchronous
+}
+
+type fleetHostStatus struct {
+	reachable bool
+	active    bool
+	passive   bool
+	version   string
+}
+
+func probeFleetHosts(ctx context.Context, tlsConfig *tls.Config, config NodeConfig) []fleetHostStatus {
+	addresses := []string{config.DatabaseAIP, config.DatabaseBIP}
+	results := make(chan fleetHostStatus, len(addresses))
+	for _, address := range addresses {
+		go func() {
+			results <- probeFleetHost(ctx, tlsConfig, config.VirtualIP, address)
+		}()
+	}
+	statuses := make([]fleetHostStatus, 0, len(addresses))
+	for range addresses {
+		statuses = append(statuses, <-results)
+	}
+	return statuses
+}
+
+func probeFleetHost(ctx context.Context, tlsConfig *tls.Config, virtualIP, address string) fleetHostStatus {
+	dialer := &net.Dialer{Timeout: 2 * time.Second}
+	transport := &http.Transport{
+		TLSClientConfig: tlsConfig.Clone(),
+		Proxy:           nil,
+		DialContext: func(ctx context.Context, network, _ string) (net.Conn, error) {
+			return dialer.DialContext(ctx, network, net.JoinHostPort(address, "443"))
+		},
+	}
+	defer transport.CloseIdleConnections()
+	client := &http.Client{Transport: transport, Timeout: 2 * time.Second, CheckRedirect: transportguard.RejectRedirect}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://"+virtualIP+"/api-proxy/health", nil)
+	if err != nil {
+		return fleetHostStatus{}
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		return fleetHostStatus{}
+	}
+	response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return fleetHostStatus{}
+	}
+	return fleetHostStatus{
+		reachable: true,
+		active:    endpointReadyWithClient(ctx, client, "https://"+virtualIP+"/api-proxy/health/active"),
+		passive:   endpointReadyWithClient(ctx, client, "https://"+virtualIP+"/api-proxy/health/passive"),
+		version:   response.Header.Get("X-Proto-Fleet-Version"),
+	}
+}
+
+func summarizeFleetHosts(statuses []fleetHostStatus) (reachable, active int) {
+	for _, status := range statuses {
+		if status.reachable {
+			reachable++
+		}
+		if status.active {
+			active++
+		}
+	}
+	return reachable, active
+}
+
+func fleetRedundancyReady(statuses []fleetHostStatus) bool {
+	active, passive := 0, 0
+	for _, status := range statuses {
+		if !status.reachable || status.active == status.passive {
+			return false
+		}
+		if status.active {
+			active++
+		} else {
+			passive++
+		}
+	}
+	return len(statuses) == 2 && active == 1 && passive == 1
+}
+
+func writerObservationReady(ctx context.Context, tlsConfig *tls.Config, password string, endpoints []string, config NodeConfig) bool {
+	values, err := loadFleetEnvironment(filepath.Join(config.SecretsDir, fleetEnvironmentFile))
+	if err != nil {
+		return false
+	}
+	conn, err := sql.Open("pgx", values["DB_DSN"])
+	if err != nil {
+		return false
+	}
+	defer conn.Close()
+	queries := sqlc.New(conn)
+	etcd, err := ha.NewEtcdClient(clientv3.Config{
+		Endpoints: endpoints, Username: "fleet-observer", Password: password,
+		TLS: tlsConfig.Clone(), DialTimeout: 2 * time.Second,
+	})
+	if err != nil {
+		return false
+	}
+	defer etcd.Close()
+	transport := &http.Transport{TLSClientConfig: tlsConfig.Clone(), Proxy: nil}
+	defer transport.CloseIdleConnections()
+	observer, err := ha.NewObserver("/service/proto-fleet", etcd, queries, ha.NewPatroniHTTPClient(&http.Client{
+		Transport: transport, Timeout: 2 * time.Second,
+	}))
+	if err != nil {
+		return false
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	_, err = observer.Observe(probeCtx)
+	return err == nil
+}
+
+func endpointReady(ctx context.Context, tlsConfig *tls.Config, endpoint string) bool {
+	transport := &http.Transport{TLSClientConfig: tlsConfig.Clone(), Proxy: nil}
+	defer transport.CloseIdleConnections()
+	return endpointReadyWithClient(ctx, &http.Client{
+		Transport: transport, Timeout: 2 * time.Second, CheckRedirect: transportguard.RejectRedirect,
+	}, endpoint)
+}
+
+func endpointReadyWithClient(ctx context.Context, client *http.Client, endpoint string) bool {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return false
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		return false
+	}
+	defer response.Body.Close()
+	return response.StatusCode == http.StatusOK
+}

--- a/server/internal/ha/deployment/status.go
+++ b/server/internal/ha/deployment/status.go
@@ -36,6 +36,7 @@ const (
 	ReasonWriterUnavailable          ControlReasonCode = "writer_unavailable"
 	ReasonDatabaseRedundancyDegraded ControlReasonCode = "database_redundancy_degraded"
 	ReasonFleetRedundancyDegraded    ControlReasonCode = "fleet_redundancy_degraded"
+	ReasonFleetVersionMismatch       ControlReasonCode = "fleet_version_mismatch"
 	ReasonVIPUnavailable             ControlReasonCode = "vip_unavailable"
 )
 
@@ -115,14 +116,16 @@ func checkControlPath(ctx context.Context, envPath string, report StatusReport) 
 	}
 
 	var (
-		etcdStatus  etcdReadiness
-		primary     int
-		synchronous int
-		fleetActive int
-		fleetReady  bool
-		writerReady bool
-		vipReady    bool
-		probes      sync.WaitGroup
+		etcdStatus         etcdReadiness
+		primary            int
+		synchronous        int
+		fleetActive        int
+		fleetRedundant     bool
+		fleetReady         bool
+		fleetVersionsMatch bool
+		writerReady        bool
+		vipReady           bool
+		probes             sync.WaitGroup
 	)
 	probes.Add(5)
 	go func() {
@@ -145,7 +148,9 @@ func checkControlPath(ctx context.Context, envPath string, report StatusReport) 
 		defer probes.Done()
 		statuses := probeFleetHosts(ctx, tlsConfig, config)
 		_, fleetActive = summarizeFleetHosts(statuses)
-		fleetReady = fleetRedundancyReady(statuses)
+		fleetRedundant = fleetRedundancyReady(statuses)
+		fleetVersionsMatch = matchingFleetVersions(statuses)
+		fleetReady = fleetRedundant && fleetVersionsMatch
 	}()
 	probes.Wait()
 
@@ -165,8 +170,10 @@ func checkControlPath(ctx context.Context, envPath string, report StatusReport) 
 	if synchronous != 1 {
 		control.ReasonCodes = append(control.ReasonCodes, ReasonDatabaseRedundancyDegraded)
 	}
-	if !fleetReady || !localRuntimeReady {
+	if !fleetRedundant || !localRuntimeReady {
 		control.ReasonCodes = append(control.ReasonCodes, ReasonFleetRedundancyDegraded)
+	} else if !fleetVersionsMatch {
+		control.ReasonCodes = append(control.ReasonCodes, ReasonFleetVersionMismatch)
 	}
 	if !vipReady {
 		control.ReasonCodes = append(control.ReasonCodes, ReasonVIPUnavailable)
@@ -356,6 +363,10 @@ func fleetRedundancyReady(statuses []fleetHostStatus) bool {
 		}
 	}
 	return len(statuses) == 2 && active == 1 && passive == 1
+}
+
+func matchingFleetVersions(statuses []fleetHostStatus) bool {
+	return len(statuses) == 2 && statuses[0].version != "" && statuses[0].version == statuses[1].version
 }
 
 func writerObservationReady(ctx context.Context, tlsConfig *tls.Config, password string, endpoints []string, config NodeConfig) bool {

--- a/server/internal/ha/deployment/status.go
+++ b/server/internal/ha/deployment/status.go
@@ -341,11 +341,7 @@ func writerObservationReady(ctx context.Context, etcdConfig clientv3.Config, con
 		return false
 	}
 	defer pinned.Close()
-	queries, err := sqlc.Prepare(probeCtx, pinned)
-	if err != nil {
-		return false
-	}
-	defer queries.Close()
+	queries := sqlc.New(pinned)
 	if etcdConfig.TLS != nil {
 		etcdConfig.TLS = etcdConfig.TLS.Clone()
 	}

--- a/server/internal/ha/deployment/status_test.go
+++ b/server/internal/ha/deployment/status_test.go
@@ -1,0 +1,49 @@
+package deployment
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFleetRedundancyRequiresOneLiveActiveAndOneLivePassive(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		statuses []fleetHostStatus
+		want     bool
+	}{
+		{name: "active and passive", statuses: []fleetHostStatus{{reachable: true, active: true}, {reachable: true, passive: true}}, want: true},
+		{name: "passive unavailable", statuses: []fleetHostStatus{{reachable: true, active: true}, {}}},
+		{name: "stale passive", statuses: []fleetHostStatus{{reachable: true, active: true}, {reachable: true}}},
+		{name: "two active processes", statuses: []fleetHostStatus{{reachable: true, active: true}, {reachable: true, active: true}}},
+		{name: "one host reports both roles", statuses: []fleetHostStatus{{reachable: true, active: true, passive: true}, {reachable: true}}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			// Act
+			ready := fleetRedundancyReady(test.statuses)
+
+			// Assert
+			require.Equal(t, test.want, ready)
+		})
+	}
+}
+
+func TestSummarizeEtcdMembersRejectsDuplicateAndSplitMembers(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		identities []etcdMemberIdentity
+		want       etcdReadiness
+	}{
+		{name: "three members", identities: []etcdMemberIdentity{{1, 11}, {1, 12}, {1, 13}}, want: etcdReadiness{quorum: true, redundant: true}},
+		{name: "duplicate member", identities: []etcdMemberIdentity{{1, 11}, {1, 12}, {1, 12}}, want: etcdReadiness{quorum: true}},
+		{name: "split witness", identities: []etcdMemberIdentity{{1, 11}, {1, 12}, {2, 13}}, want: etcdReadiness{quorum: true}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			// Act
+			ready := summarizeEtcdMembers(test.identities, 3)
+
+			// Assert
+			require.Equal(t, test.want, ready)
+		})
+	}
+}

--- a/server/internal/ha/deployment/status_test.go
+++ b/server/internal/ha/deployment/status_test.go
@@ -1,10 +1,27 @@
 package deployment
 
 import (
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestHostProbeDSNUsesHostCAAndStatementCache(t *testing.T) {
+	// Act
+	dsn, err := hostProbeDSN(
+		"postgresql://fleet:secret@10.0.0.1:5432,10.0.0.2:5432/fleet?sslmode=verify-full&sslrootcert=/run/proto-fleet-ha/service-ca.crt&target_session_attrs=read-write",
+		"/etc/proto-fleet/ha",
+	)
+
+	// Assert
+	require.NoError(t, err)
+	parsed, err := url.Parse(dsn)
+	require.NoError(t, err)
+	require.Equal(t, "/etc/proto-fleet/ha/service-ca.crt", parsed.Query().Get("sslrootcert"))
+	require.Equal(t, "cache_statement", parsed.Query().Get("default_query_exec_mode"))
+	require.Equal(t, "read-write", parsed.Query().Get("target_session_attrs"))
+}
 
 func TestFleetRedundancyRequiresOneLiveActiveAndOneLivePassive(t *testing.T) {
 	for _, test := range []struct {

--- a/server/internal/ha/deployment/status_test.go
+++ b/server/internal/ha/deployment/status_test.go
@@ -45,6 +45,26 @@ func TestFleetRedundancyRequiresOneLiveActiveAndOneLivePassive(t *testing.T) {
 	}
 }
 
+func TestMatchingFleetVersions(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		statuses []fleetHostStatus
+		want     bool
+	}{
+		{name: "same version", statuses: []fleetHostStatus{{version: "v1.2.0"}, {version: "v1.2.0"}}, want: true},
+		{name: "different versions", statuses: []fleetHostStatus{{version: "v1.2.0"}, {version: "v1.1.0"}}},
+		{name: "missing version", statuses: []fleetHostStatus{{version: "v1.2.0"}, {}}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			// Act
+			matches := matchingFleetVersions(test.statuses)
+
+			// Assert
+			require.Equal(t, test.want, matches)
+		})
+	}
+}
+
 func TestSummarizeEtcdMembersRejectsDuplicateAndSplitMembers(t *testing.T) {
 	for _, test := range []struct {
 		name       string

--- a/server/internal/ha/deployment/status_test.go
+++ b/server/internal/ha/deployment/status_test.go
@@ -2,25 +2,47 @@ package deployment
 
 import (
 	"net/url"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestHostProbeDSNUsesHostCAAndStatementCache(t *testing.T) {
+	secretsRoot := filepath.Join(t.TempDir(), "generated")
+	require.NoError(t, GenerateSecrets(secretsRoot, testHostIPs, testVirtualIP))
+	secretsDir := filepath.Join(secretsRoot, "ha-a")
+
 	// Act
 	dsn, err := hostProbeDSN(
 		"postgresql://fleet:secret@10.0.0.1:5432,10.0.0.2:5432/fleet?sslmode=verify-full&sslrootcert=/run/proto-fleet-ha/service-ca.crt&target_session_attrs=read-write",
-		"/etc/proto-fleet/ha",
+		secretsDir,
 	)
 
 	// Assert
 	require.NoError(t, err)
 	parsed, err := url.Parse(dsn)
 	require.NoError(t, err)
-	require.Equal(t, "/etc/proto-fleet/ha/service-ca.crt", parsed.Query().Get("sslrootcert"))
+	require.Equal(t, filepath.Join(secretsDir, "service-ca.crt"), parsed.Query().Get("sslrootcert"))
 	require.Equal(t, "cache_statement", parsed.Query().Get("default_query_exec_mode"))
 	require.Equal(t, "read-write", parsed.Query().Get("target_session_attrs"))
+}
+
+func TestHostProbeDSNRejectsUnsafeHAConfiguration(t *testing.T) {
+	secretsRoot := filepath.Join(t.TempDir(), "generated")
+	require.NoError(t, GenerateSecrets(secretsRoot, testHostIPs, testVirtualIP))
+	secretsDir := filepath.Join(secretsRoot, "ha-a")
+
+	for _, dsn := range []string{
+		"postgresql://fleet:secret@10.0.0.1:5432/fleet?sslmode=verify-full&target_session_attrs=read-write",
+		"postgresql://fleet:secret@10.0.0.1:5432,10.0.0.2:5432/fleet?sslmode=disable&target_session_attrs=read-write",
+	} {
+		// Act
+		_, err := hostProbeDSN(dsn, secretsDir)
+
+		// Assert
+		require.Error(t, err)
+	}
 }
 
 func TestFleetRedundancyRequiresOneLiveActiveAndOneLivePassive(t *testing.T) {

--- a/server/internal/ha/endpoint.go
+++ b/server/internal/ha/endpoint.go
@@ -10,6 +10,10 @@ import (
 // EndpointHeartbeatFile is refreshed only after keepalived's local proxy check succeeds.
 const EndpointHeartbeatFile = "/run/proto-fleet-ha/endpoint-heartbeat"
 
+func newEndpointOwned(endpointIP netip.Addr, endpointInterface string) func() bool {
+	return func() bool { return localAddressAssigned(endpointIP, endpointInterface) }
+}
+
 // Endpoint health requires both local VIP ownership and proof that keepalived
 // is still successfully probing the active client path.
 func newEndpointHealth(endpointIP netip.Addr, endpointInterface, heartbeatFile string, timeout time.Duration) func() bool {

--- a/server/internal/ha/runtime.go
+++ b/server/internal/ha/runtime.go
@@ -27,11 +27,13 @@ type RuntimeConfig struct {
 	HealthCheckInterval time.Duration
 	CleanupTimeout      time.Duration
 	EndpointHealthy     func() bool
+	EndpointOwned       func() bool
 }
 
 type runtimeOwner interface {
 	Run(ctx context.Context) error
 	WaitForActive(ctx context.Context) (context.Context, Token, error)
+	Snapshot() Snapshot
 }
 
 type runtimeGroup interface {

--- a/server/internal/ha/runtime_test.go
+++ b/server/internal/ha/runtime_test.go
@@ -50,6 +50,8 @@ func (o *runtimeTestOwner) WaitForActive(ctx context.Context) (context.Context, 
 	}
 }
 
+func (o *runtimeTestOwner) Snapshot() Snapshot { return Snapshot{} }
+
 type missedActivationOwner struct{}
 
 func (missedActivationOwner) Run(context.Context) error {
@@ -60,6 +62,8 @@ func (missedActivationOwner) WaitForActive(ctx context.Context) (context.Context
 	<-ctx.Done()
 	return nil, Token{}, fmt.Errorf("wait for missed activation: %w", ctx.Err())
 }
+
+func (missedActivationOwner) Snapshot() Snapshot { return Snapshot{} }
 
 type runtimeTestGroup struct {
 	mu sync.Mutex

--- a/server/internal/ha/status.go
+++ b/server/internal/ha/status.go
@@ -1,0 +1,106 @@
+package ha
+
+import "time"
+
+type RuntimeRole string
+type ObservationStatus string
+type EndpointStatus string
+type ReasonCode string
+
+const (
+	LocalStatusAddress = "127.0.0.1:4000"
+
+	RoleActive       RuntimeRole = "active"
+	RolePassive      RuntimeRole = "passive"
+	RoleInitializing RuntimeRole = "initializing"
+	RoleDegraded     RuntimeRole = "degraded"
+
+	ObservationCurrent     ObservationStatus = "current"
+	ObservationStale       ObservationStatus = "stale"
+	ObservationUnavailable ObservationStatus = "unavailable"
+
+	EndpointHealthy       EndpointStatus = "healthy"
+	EndpointNotApplicable EndpointStatus = "not_applicable"
+	EndpointUnhealthy     EndpointStatus = "unhealthy"
+
+	ReasonObservationPending      ReasonCode = "observation_pending"
+	ReasonControlPlaneUnavailable ReasonCode = "control_plane_unavailable"
+	ReasonObservationStale        ReasonCode = "observation_stale"
+	ReasonActivationPending       ReasonCode = "activation_pending"
+	ReasonEndpointUnhealthy       ReasonCode = "endpoint_unhealthy"
+)
+
+// Status is the intentionally redacted HA operator contract.
+type Status struct {
+	Version        string            `json:"version"`
+	Role           RuntimeRole       `json:"role"`
+	Observation    ObservationStatus `json:"observation"`
+	ObservedAt     *time.Time        `json:"observed_at,omitempty"`
+	LeaseExpiresAt *time.Time        `json:"lease_expires_at,omitempty"`
+	Endpoint       EndpointStatus    `json:"endpoint"`
+	ReasonCodes    []ReasonCode      `json:"reason_codes"`
+}
+
+// Status returns a read-only view composed from ownership, admission, and VIP health.
+func (r *Runtime) Status(now time.Time) Status {
+	status := Status{
+		Role:        RoleInitializing,
+		Observation: ObservationUnavailable,
+		Endpoint:    EndpointNotApplicable,
+		ReasonCodes: []ReasonCode{ReasonObservationPending},
+	}
+	if r.owner == nil {
+		return status
+	}
+	snapshot := r.owner.Snapshot()
+	if snapshot.UpdatedAt.IsZero() {
+		return status
+	}
+	observedAt := snapshot.UpdatedAt.UTC()
+	status.ObservedAt = &observedAt
+	status.ReasonCodes = nil
+	if !snapshot.ObservationAvailable {
+		status.Role = RoleDegraded
+		status.Observation = ObservationUnavailable
+		status.ReasonCodes = []ReasonCode{ReasonControlPlaneUnavailable}
+		return status
+	}
+	if !snapshot.FreshUntil.After(now) {
+		status.Role = RoleDegraded
+		status.Observation = ObservationStale
+		status.ReasonCodes = []ReasonCode{ReasonObservationStale}
+		return status
+	}
+	status.Observation = ObservationCurrent
+	if snapshot.State != StateActive {
+		status.Role = RolePassive
+		return status
+	}
+	if !r.Active() {
+		status.ReasonCodes = []ReasonCode{ReasonActivationPending}
+		return status
+	}
+	if r.config.EndpointHealthy != nil && !r.config.EndpointHealthy() {
+		status.Role = RoleDegraded
+		status.Endpoint = EndpointUnhealthy
+		status.ReasonCodes = []ReasonCode{ReasonEndpointUnhealthy}
+		return status
+	}
+	status.Role = RoleActive
+	status.Endpoint = EndpointHealthy
+	leaseExpiresAt := snapshot.ExpiresAt.UTC()
+	status.LeaseExpiresAt = &leaseExpiresAt
+	return status
+}
+
+// Passive is the cheap public readiness signal used by the peer health probe.
+func (r *Runtime) Passive(now time.Time) bool {
+	if r.owner == nil {
+		return false
+	}
+	snapshot := r.owner.Snapshot()
+	if snapshot.UpdatedAt.IsZero() || !snapshot.ObservationAvailable || !snapshot.FreshUntil.After(now) || snapshot.State != StatePassive {
+		return false
+	}
+	return r.config.EndpointOwned == nil || !r.config.EndpointOwned()
+}

--- a/server/internal/ha/status.go
+++ b/server/internal/ha/status.go
@@ -73,6 +73,12 @@ func (r *Runtime) Status(now time.Time) Status {
 	}
 	status.Observation = ObservationCurrent
 	if snapshot.State != StateActive {
+		if r.config.EndpointOwned != nil && r.config.EndpointOwned() {
+			status.Role = RoleDegraded
+			status.Endpoint = EndpointUnhealthy
+			status.ReasonCodes = []ReasonCode{ReasonEndpointUnhealthy}
+			return status
+		}
 		status.Role = RolePassive
 		return status
 	}

--- a/server/internal/ha/status_test.go
+++ b/server/internal/ha/status_test.go
@@ -1,0 +1,87 @@
+package ha
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRuntimeStatusReportsInitializingThenHealthyPassive(t *testing.T) {
+	// Arrange
+	now := time.Now()
+	coordinator := newCoordinatorWithHolder(staticObserver{}, &fakeLeaseStore{}, coordinatorTestConfig(), uuid.New())
+	endpointOwned := false
+	runtime := newRuntime(coordinator, newRuntimeTestGroup(), alwaysHealthy, RuntimeConfig{
+		EndpointOwned: func() bool { return endpointOwned },
+	})
+
+	// Act and assert
+	require.Equal(t, Status{
+		Role: RoleInitializing, Observation: ObservationUnavailable,
+		Endpoint: EndpointNotApplicable, ReasonCodes: []ReasonCode{ReasonObservationPending},
+	}, runtime.Status(now))
+
+	coordinator.deactivate(nil)
+	status := runtime.Status(time.Now())
+	require.Equal(t, RolePassive, status.Role)
+	require.Equal(t, ObservationCurrent, status.Observation)
+	require.Empty(t, status.ReasonCodes)
+	require.True(t, runtime.Passive(time.Now()))
+	endpointOwned = true
+	require.False(t, runtime.Passive(time.Now()))
+}
+
+func TestRuntimeStatusDegradesUnavailableAndStaleObservations(t *testing.T) {
+	// Arrange
+	coordinator := newCoordinatorWithHolder(staticObserver{}, &fakeLeaseStore{}, coordinatorTestConfig(), uuid.New())
+	runtime := newRuntime(coordinator, newRuntimeTestGroup(), alwaysHealthy, RuntimeConfig{})
+
+	// Act and assert
+	coordinator.deactivate(errors.New("secret topology details"))
+	unavailable := runtime.Status(time.Now())
+	require.Equal(t, RoleDegraded, unavailable.Role)
+	require.Equal(t, ObservationUnavailable, unavailable.Observation)
+	require.Equal(t, []ReasonCode{ReasonControlPlaneUnavailable}, unavailable.ReasonCodes)
+
+	coordinator.deactivate(nil)
+	stale := runtime.Status(time.Now().Add(2 * time.Second))
+	require.Equal(t, RoleDegraded, stale.Role)
+	require.Equal(t, ObservationStale, stale.Observation)
+	require.Equal(t, []ReasonCode{ReasonObservationStale}, stale.ReasonCodes)
+}
+
+func TestRuntimeStatusReportsActiveOnlyAfterAdmissionAndEndpointHealth(t *testing.T) {
+	// Arrange
+	coordinator := newCoordinatorWithHolder(staticObserver{}, &fakeLeaseStore{}, coordinatorTestConfig(), uuid.New())
+	coordinator.mu.Lock()
+	coordinator.activeCtx, coordinator.cancelActive = context.WithCancelCause(t.Context())
+	coordinator.ownership = Ownership{ExpiresAt: time.Now().Add(time.Second)}
+	coordinator.observed = true
+	coordinator.updatedAt = time.Now()
+	coordinator.mu.Unlock()
+	endpointHealthy := true
+	runtime := newRuntime(coordinator, newRuntimeTestGroup(), alwaysHealthy, RuntimeConfig{
+		EndpointHealthy: func() bool { return endpointHealthy },
+	})
+
+	// Act and assert
+	pending := runtime.Status(time.Now())
+	require.Equal(t, RoleInitializing, pending.Role)
+	require.Equal(t, []ReasonCode{ReasonActivationPending}, pending.ReasonCodes)
+
+	runtime.gate.activate(t.Context())
+	active := runtime.Status(time.Now())
+	require.Equal(t, RoleActive, active.Role)
+	require.Equal(t, EndpointHealthy, active.Endpoint)
+	require.NotNil(t, active.LeaseExpiresAt)
+
+	endpointHealthy = false
+	degraded := runtime.Status(time.Now())
+	require.Equal(t, RoleDegraded, degraded.Role)
+	require.Equal(t, EndpointUnhealthy, degraded.Endpoint)
+	require.Nil(t, degraded.LeaseExpiresAt)
+}

--- a/server/internal/ha/status_test.go
+++ b/server/internal/ha/status_test.go
@@ -31,7 +31,12 @@ func TestRuntimeStatusReportsInitializingThenHealthyPassive(t *testing.T) {
 	require.Equal(t, ObservationCurrent, status.Observation)
 	require.Empty(t, status.ReasonCodes)
 	require.True(t, runtime.Passive(time.Now()))
+
 	endpointOwned = true
+	status = runtime.Status(time.Now())
+	require.Equal(t, RoleDegraded, status.Role)
+	require.Equal(t, EndpointUnhealthy, status.Endpoint)
+	require.Equal(t, []ReasonCode{ReasonEndpointUnhealthy}, status.ReasonCodes)
 	require.False(t, runtime.Passive(time.Now()))
 }
 

--- a/server/internal/ha/store.go
+++ b/server/internal/ha/store.go
@@ -23,6 +23,10 @@ type leaseQuerier interface {
 		ctx context.Context,
 		arg sqlc.AcquireFleetRuntimeLeaseParams,
 	) (sqlc.AcquireFleetRuntimeLeaseRow, error)
+	ClassifyFleetRuntimeLeaseAcquisition(
+		ctx context.Context,
+		arg sqlc.ClassifyFleetRuntimeLeaseAcquisitionParams,
+	) (string, error)
 	RenewFleetRuntimeLease(
 		ctx context.Context,
 		arg sqlc.RenewFleetRuntimeLeaseParams,
@@ -64,12 +68,39 @@ func (s *LeaseStore) Acquire(
 		},
 	)
 	if errors.Is(err, sql.ErrNoRows) {
-		return Ownership{}, ErrLeaseUnavailable
+		result, classifyErr := s.queries.ClassifyFleetRuntimeLeaseAcquisition(
+			ctx,
+			sqlc.ClassifyFleetRuntimeLeaseAcquisitionParams{
+				ServerAddress:    observed.ServerAddress,
+				ServerPort:       observed.ServerPort,
+				Timeline:         observed.Timeline,
+				DcsClusterID:     observed.DCSClusterID,
+				WriterGeneration: observed.WriterGeneration,
+				HolderID:         holderID,
+			},
+		)
+		if classifyErr != nil {
+			return Ownership{}, fmt.Errorf("classify Fleet active lease acquisition: %w", classifyErr)
+		}
+		return Ownership{}, leaseAcquisitionError(result)
 	}
 	if err != nil {
 		return Ownership{}, fmt.Errorf("acquire Fleet active lease: %w", err)
 	}
 	return ownershipFromAcquire(row), nil
+}
+
+func leaseAcquisitionError(result string) error {
+	switch result {
+	case "contended":
+		return ErrLeaseUnavailable
+	case "cluster_mismatch":
+		return ErrDCSClusterIdentityMismatch
+	case "writer_mismatch", "writer_changed", "unavailable":
+		return ErrWriterChanged
+	default:
+		return fmt.Errorf("unknown Fleet active lease acquisition result %q", result)
+	}
 }
 
 // Renew extends only the exact unexpired holder/token using database time.

--- a/server/internal/ha/store_integration_test.go
+++ b/server/internal/ha/store_integration_test.go
@@ -93,7 +93,7 @@ func TestLeaseStoreRejectsClusterIdentityMismatch(t *testing.T) {
 	_, err = store.Acquire(
 		t.Context(), databaseObservation(t, reader, "cluster-b", 42), uuid.New(), time.Minute,
 	)
-	require.ErrorIs(t, err, ErrLeaseUnavailable)
+	require.ErrorIs(t, err, ErrDCSClusterIdentityMismatch)
 }
 
 func TestLeaseStoreRejectsGenerationRegression(t *testing.T) {
@@ -106,7 +106,7 @@ func TestLeaseStoreRejectsGenerationRegression(t *testing.T) {
 	_, err = store.Acquire(
 		t.Context(), databaseObservation(t, reader, "cluster-a", 41), uuid.New(), time.Minute,
 	)
-	require.ErrorIs(t, err, ErrLeaseUnavailable)
+	require.ErrorIs(t, err, ErrWriterChanged)
 }
 
 func TestLeaseStoreSameGenerationWaitsForExpiry(t *testing.T) {
@@ -203,7 +203,7 @@ func TestLeaseStoreRejectsDifferentWritableServerIdentity(t *testing.T) {
 	observed.ServerAddress = "203.0.113.1"
 
 	_, err := store.Acquire(t.Context(), observed, uuid.New(), time.Minute)
-	require.ErrorIs(t, err, ErrLeaseUnavailable)
+	require.ErrorIs(t, err, ErrWriterChanged)
 
 	active, err := store.Acquire(
 		t.Context(),

--- a/server/internal/handlers/health/handler.go
+++ b/server/internal/handlers/health/handler.go
@@ -49,22 +49,12 @@ func NewHAHandler(version string, state HAState) func(w http.ResponseWriter, r *
 
 // NewPassiveHandler reports only whether this process is ready to take over.
 func NewPassiveHandler(state PassiveState) func(w http.ResponseWriter, r *http.Request) {
-	var mu sync.Mutex
-	var lastCheck time.Time
-	var passive bool
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}
-		mu.Lock()
-		if time.Since(lastCheck) >= readyCacheInterval {
-			passive = state.Passive(time.Now())
-			lastCheck = time.Now()
-		}
-		ready := passive
-		mu.Unlock()
-		if !ready {
+		if !state.Passive(time.Now()) {
 			w.WriteHeader(http.StatusServiceUnavailable)
 			return
 		}

--- a/server/internal/handlers/health/handler.go
+++ b/server/internal/handlers/health/handler.go
@@ -2,20 +2,73 @@ package health
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 	"net/http"
 	"sync"
 	"time"
+
+	"github.com/block/proto-fleet/server/internal/ha"
 )
 
-func NewHandler() func(w http.ResponseWriter, r *http.Request) {
+func NewHandler(version string) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}
 
+		w.Header().Set("X-Proto-Fleet-Version", version)
 		writeOK(w, r, "health")
+	}
+}
+
+type HAState interface {
+	Status(now time.Time) ha.Status
+}
+
+type PassiveState interface {
+	Passive(now time.Time) bool
+}
+
+// NewHAHandler exposes the redacted local operator status document.
+func NewHAHandler(version string, state HAState) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		status := state.Status(time.Now())
+		status.Version = version
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(status); err != nil {
+			slog.Error("Failed to write HA status response", "error", err, "handler", "health-ha", "path", r.URL.Path)
+		}
+	}
+}
+
+// NewPassiveHandler reports only whether this process is ready to take over.
+func NewPassiveHandler(state PassiveState) func(w http.ResponseWriter, r *http.Request) {
+	var mu sync.Mutex
+	var lastCheck time.Time
+	var passive bool
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		mu.Lock()
+		if time.Since(lastCheck) >= readyCacheInterval {
+			passive = state.Passive(time.Now())
+			lastCheck = time.Now()
+		}
+		ready := passive
+		mu.Unlock()
+		if !ready {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		writeOK(w, r, "health-passive")
 	}
 }
 

--- a/server/internal/handlers/health/handler_test.go
+++ b/server/internal/handlers/health/handler_test.go
@@ -2,6 +2,7 @@ package health
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -10,8 +11,62 @@ import (
 	"testing"
 	"time"
 
+	"github.com/block/proto-fleet/server/internal/ha"
 	"github.com/stretchr/testify/require"
 )
+
+type fakeHAState struct {
+	status  ha.Status
+	passive bool
+}
+
+func (s fakeHAState) Status(time.Time) ha.Status { return s.status }
+func (s fakeHAState) Passive(time.Time) bool     { return s.passive }
+
+func TestHAHandlerReturnsOnlyRedactedStatus(t *testing.T) {
+	// Arrange
+	expires := time.Now().UTC().Add(time.Second)
+	recorder := httptest.NewRecorder()
+	handler := NewHAHandler("v1.2.3", fakeHAState{status: ha.Status{
+		Role: ha.RoleActive, Observation: ha.ObservationCurrent,
+		LeaseExpiresAt: &expires, Endpoint: ha.EndpointHealthy,
+	}})
+
+	// Act
+	handler(recorder, httptest.NewRequest(http.MethodGet, "/health/ha", nil))
+
+	// Assert
+	require.Equal(t, http.StatusOK, recorder.Code)
+	var status ha.Status
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &status))
+	require.Equal(t, "v1.2.3", status.Version)
+	require.Equal(t, ha.RoleActive, status.Role)
+	for _, forbidden := range []string{"holder", "token", "cluster", "address", "error"} {
+		require.NotContains(t, recorder.Body.String(), forbidden)
+	}
+}
+
+func TestPassiveHandlerRequiresCurrentPassiveObservation(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		passive    bool
+		statusCode int
+	}{
+		{name: "current passive without VIP", passive: true, statusCode: http.StatusOK},
+		{name: "not takeover ready", statusCode: http.StatusServiceUnavailable},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			// Arrange
+			recorder := httptest.NewRecorder()
+
+			// Act
+			NewPassiveHandler(fakeHAState{passive: test.passive})(recorder, httptest.NewRequest(http.MethodGet, "/health/passive", nil))
+
+			// Assert
+			require.Equal(t, test.statusCode, recorder.Code)
+		})
+	}
+}
 
 type fakePinger struct {
 	err error
@@ -34,11 +89,12 @@ func TestLivenessHandlerStaysStatic(t *testing.T) {
 	recorder := httptest.NewRecorder()
 
 	// Act
-	NewHandler()(recorder, httptest.NewRequest(http.MethodGet, "/health", nil))
+	NewHandler("v1.2.3")(recorder, httptest.NewRequest(http.MethodGet, "/health", nil))
 
 	// Assert
 	require.Equal(t, http.StatusOK, recorder.Code)
 	require.Equal(t, "ok", recorder.Body.String())
+	require.Equal(t, "v1.2.3", recorder.Header().Get("X-Proto-Fleet-Version"))
 }
 
 func TestReadyHandlerOKWhenDBReachable(t *testing.T) {

--- a/server/sqlc/queries/ha.sql
+++ b/server/sqlc/queries/ha.sql
@@ -92,6 +92,33 @@ RETURNING
     expires_at,
     (SELECT database_time FROM lease_context)::TIMESTAMPTZ AS database_time;
 
+-- name: ClassifyFleetRuntimeLeaseAcquisition :one
+WITH lease_context AS (
+    SELECT
+        clock_timestamp() AS database_time,
+        (
+            NOT connected.in_recovery
+            AND connected.server_address = sqlc.arg('server_address')::TEXT
+            AND connected.server_port = sqlc.arg('server_port')::INTEGER
+            AND connected.timeline = sqlc.arg('timeline')::BIGINT
+        ) AS writer_matches
+    FROM connected_postgres_identity AS connected
+)
+SELECT CASE
+    WHEN NOT lease_context.writer_matches THEN 'writer_mismatch'
+    WHEN current_lease.lease_name IS NULL THEN 'unavailable'
+    WHEN current_lease.dcs_cluster_id IS DISTINCT FROM sqlc.arg('dcs_cluster_id') THEN 'cluster_mismatch'
+    WHEN current_lease.highest_writer_generation IS DISTINCT FROM sqlc.arg('writer_generation') THEN 'writer_changed'
+    WHEN
+        current_lease.holder_id IS DISTINCT FROM sqlc.arg('holder_id')
+        AND current_lease.expires_at > lease_context.database_time
+    THEN 'contended'
+    ELSE 'unavailable'
+END::TEXT AS acquisition_result
+FROM lease_context
+LEFT JOIN fleet_runtime_lease AS current_lease
+    ON current_lease.lease_name = 'fleet-active';
+
 -- name: RenewFleetRuntimeLease :one
 WITH lease_context AS (
     -- Capture database time once, and fail closed unless this is the expected writer.


### PR DESCRIPTION
Reviewable diff: +795/-78 across 16 files (excludes generated, test, and story files).

## Summary

Gives operators a trustworthy answer to "is this HA cluster healthy, and would failover succeed right now?" without exposing cluster internals. Each Fleet host serves a redacted, local-only HA status document, and a new `fleet-ha status` command combines it with independent probes of etcd, Patroni, PostgreSQL, the VIP, and both Fleet hosts to produce a machine-readable readiness verdict. The public `/health` response now carries the running release version in an `X-Proto-Fleet-Version` header, which the readiness check uses to detect mixed-version peers.

**Stack:** This is PR 1 of 6, targeting `main`: **#887** -> [#888](https://github.com/block/proto-fleet/pull/888) (install on clean Linux hosts) -> [#889](https://github.com/block/proto-fleet/pull/889) (clean-install qualification) -> [#890](https://github.com/block/proto-fleet/pull/890) (passive host updates) -> [#891](https://github.com/block/proto-fleet/pull/891) (updates through bounded failover) -> [#892](https://github.com/block/proto-fleet/pull/892) (adjacent-release update qualification). This PR only establishes operator visibility; installation, qualification, and updates land in the descendants, which use `fleet-ha status` as their final readiness gate.

## How it works

**Inside fleetd.** The HA coordinator now tracks structured observation state instead of a free-text last error: whether an observation is available, and a `FreshUntil` horizon computed from the lease interval but never extending past the DCS proof deadline of the last writer observation. Losing the lease acquisition race to the peer is reclassified as a healthy outcome: a new SQL query (`ClassifyFleetRuntimeLeaseAcquisition`) distinguishes genuine contention from cluster identity or writer mismatches, and the coordinator records a contended acquisition as a valid passive observation after completing its closing DCS proof. `Runtime.Status` composes this into the redacted operator contract: a coarse role (`active`, `passive`, `initializing`, `degraded`), observation freshness, endpoint health, and machine-readable reason codes. A passive node that still owns the VIP reports `degraded`, not `passive`.

**Exposure boundaries.** The status document is served at `/health/ha` only when HA is enabled, and fleetd refuses to start in HA mode unless it listens on exactly `127.0.0.1:4000`, so the document cannot be exposed remotely by misconfiguration. The VIP nginx additionally returns 404 for `/api-proxy/health/ha`. Two signals are deliberately public through the VIP proxy: `/health` gains the `X-Proto-Fleet-Version` header, and a new `/health/passive` endpoint reports only whether the process is ready to take over (fresh observation, passive state, no VIP ownership).

**The CLI.** `fleet-ha status [node.env]` runs on ha-a or ha-b. It reads the local `/health/ha` document, then runs five parallel control-path probes, each bounded to ~2 seconds, using the host's on-disk secrets and the read-only `fleet-observer` etcd credential:

1. **etcd membership**: probes each of the three endpoints individually and cross-checks cluster/member identities, detecting split or cloned members that a single pooled client would hide.
2. **Patroni roles**: requires exactly one primary and one fully caught-up synchronous replica across the two database hosts.
3. **Writer observation**: replays the same `Observer.Observe` validation fleetd uses to acquire ownership (DCS leader, writable PostgreSQL identity, Patroni role and timeline agreement, live lease), over a fresh single pinned DB connection built from the on-disk `DB_DSN` (revalidated with `ValidateHA`).
4. **VIP**: the virtual IP must answer as the active Fleet.
5. **Per-host Fleet roles**: dials each database host directly while keeping the VIP TLS identity, requiring exactly one active and one live passive, both reporting the same release version.

The report derives `control_ready` (the cluster works now) and `failover_ready` (losing the active node would be survivable), each explained by reason codes (`etcd_quorum_unavailable`, `writer_unavailable`, `fleet_version_mismatch`, ...). Output is JSON; the command exits nonzero unless `failover_ready`, making it directly usable as a scripted gate.

```mermaid
sequenceDiagram
    participant OP as Operator
    participant CLI as fleet-ha status
    participant FD as fleetd (127.0.0.1:4000)
    participant DEP as etcd / Patroni / PostgreSQL / VIP / peer Fleet
    OP->>CLI: run on ha-a or ha-b
    CLI->>FD: GET /health/ha
    FD-->>CLI: redacted runtime status
    CLI->>DEP: 5 parallel read-only probes (~2s each)
    DEP-->>CLI: per-dependency results
    CLI-->>OP: JSON report, exit 0 only if failover_ready
```

```mermaid
flowchart TD
  RT["Coordinator snapshot: observed, FreshUntil (clamped by DCS proof deadline), state"] --> ST["Runtime.Status: role + observation + endpoint + reason codes"]
  ST --> EP["/health/ha (local only)"]
  EP --> CLI["fleet-ha status"]
  PR["etcd + Patroni + writer replay + VIP + peer Fleet probes"] --> CLI
  CLI --> CR["control_ready: quorum, one primary, writer probe, VIP, one active Fleet"]
  CR --> FR["failover_ready: control_ready plus full etcd redundancy, one sync replica, live passive, matching versions, local runtime current"]
```

## Areas of the code involved

| Area / file | What changed | Why it matters for review |
|---|---|---|
| `server/internal/ha/status.go` (new) | Redacted `Status` contract; `Runtime.Status` and `Runtime.Passive` derivation | The operator-facing contract; verify nothing sensitive leaks and role/reason mapping is right |
| `server/internal/ha/coordinator.go` | `Snapshot` drops `LastError`, gains `ObservationAvailable` + `FreshUntil`; lease contention recorded as healthy observed passive after the closing DCS proof | Core semantic change feeding all status; freshness clamped by proof deadline |
| `server/internal/ha/store.go`, `server/sqlc/queries/ha.sql` | New `ClassifyFleetRuntimeLeaseAcquisition` query maps a failed acquire to `contended` / `cluster_mismatch` / `writer_changed` / `unavailable` | Single-query classification; check the CASE ordering and `IS DISTINCT FROM` semantics |
| `server/internal/ha/runtime.go`, `endpoint.go`, `config.go` | `EndpointOwned` check wired into the runtime; `LoadServiceTLS` exported for host tooling | Detects a passive node still holding the VIP |
| `server/internal/handlers/health/handler.go` | `/health/ha` (redacted JSON), `/health/passive`, `X-Proto-Fleet-Version` on `/health` | New public surface; the version header is deliberate |
| `server/cmd/fleetd/config.go`, `main.go` | HA mode requires listen address `127.0.0.1:4000`; HA handlers registered only when HA is enabled | The locality enforcement for the status document |
| `server/internal/ha/deployment/status.go` (new, ~414 lines) | The `status` engine: five parallel probes, readiness derivation, hardened probe HTTP client, generic fan-out helper | Bulk of the PR; probe semantics and readiness formulas live here |
| `server/cmd/fleet-ha/main.go` | New `status` subcommand: JSON output, nonzero exit unless failover-ready | Operator entry point |
| `server/internal/ha/deployment/preflight.go` | `validateFleetEnvironment` split so the status probe can reuse `loadFleetEnvironment` | Refactor; validation behavior preserved |
| `deployment-files/client/nginx.http.conf`, `nginx.https.conf` | VIP nginx returns 404 for `/api-proxy/health/ha` | Keeps diagnostics off the public VIP |
| `server/generated/sqlc/**` | Regenerated for the new query | Generated, skip |
| `docs/rfcs/0002-active-passive-fleet-ha.md` | RFC updated to match the shipped status surface | Docs |

## Key technical decisions & trade-offs

- **Redacted status contract**: coarse role/observation/endpoint enums plus reason codes, instead of exposing coordinator internals. `LastError` was removed from `Snapshot` entirely so raw error strings (DSNs, hostnames) cannot reach any reportable surface.
- **Locality enforced in code, not just deployment**: fleetd hard-fails HA startup unless bound to `127.0.0.1:4000`, and the VIP nginx 404s the path as a second layer, rather than relying on either alone.
- **Lease contention classified in SQL**: one query returns the acquisition outcome, chosen over a read-then-decide sequence in Go that would race with the peer.
- **Freshness bounded by the DCS proof deadline**: a node can never claim its cluster view is fresh beyond the window its linearizable etcd proof is valid for, rather than using a wall-clock interval alone.
- **Independent verification over self-reports**: the writer probe replays the runtime's own observation logic with on-disk credentials, catching stale DCS leader records, timeline divergence, and broken rotated secrets that component health endpoints cannot see.
- **`status` is a readiness gate, not a passive viewer**: it always probes, always prints JSON, and exits nonzero unless failover-ready. There is no flag surface to keep qualified.
- **Version-mismatch detection via the public header**: `failover_ready` requires both Fleet hosts to report the same `X-Proto-Fleet-Version`, so a mid-upgrade cluster is never declared safe to fail over.
- **Hardened probe transport**: every probe client disables proxies, rejects redirects, clones TLS config, and uses ~2s timeouts; all cluster access uses the read-only `fleet-observer` role.

## Testing & validation

- Unit tests cover the status derivation table (roles, freshness, endpoint states), coordinator contention and proof-deadline clamping, the health handlers, CLI argument handling and exit behavior, and the pure probe summarizers (etcd identity dedup/split detection, fleet redundancy, version matching, probe DSN validation and rejection).
- A store integration test exercises `ClassifyFleetRuntimeLeaseAcquisition` against a real database.
- `deployment-files/ha/tests/test-profile.sh` asserts the nginx 404 for `/api-proxy/health/ha`.
- Not covered here: live three-host behavior (real etcd, Patroni, keepalived, and actual failover) is deferred to the qualification PR (#889). The network probes themselves are validated through their pure summarizers, not against live dependencies.
