### PR TITLE
Complete HA updates through bounded failover

### DIFF
--- a/deployment-files/ha/README.md
+++ b/deployment-files/ha/README.md
@@ -180,11 +180,6 @@ only `fleet-api` and `fleet-client`; etcd, Patroni, PostgreSQL, and keepalived
 remain running. The command returns only after the target version is healthy
 and passive.
 
-The old active and new passive share the database during this rolling window.
-Every migration in the target release must be expand-only and remain compatible
-with the previous release; destructive contract migrations belong in a later
-release after both HA hosts have advanced.
-
 After the peer is confirmed on the target release, complete the update from
 the old active host:
 

--- a/deployment-files/ha/README.md
+++ b/deployment-files/ha/README.md
@@ -202,6 +202,10 @@ not complete within 35 seconds, it restarts the old local release without
 swapping. Qualification still requires a healthy takeover in less than 15
 seconds. This is a bounded interruption, not a zero-downtime update.
 
+If an update reports pending HA application recovery, retry recovery with
+`sudo systemctl restart proto-fleet-updater.service`. After the local Fleet
+application is healthy again, rerun the same `fleet-ha update` command.
+
 ## Qualification
 
 The distributions above are installer-compatible targets. The HA profile is

--- a/deployment-files/ha/README.md
+++ b/deployment-files/ha/README.md
@@ -203,8 +203,9 @@ rather than upgraded through this workflow.
 The updater stages everything first, stops the local Fleet containers, and
 waits for the updated peer to serve the VIP with the target version. Only then
 does it swap and restart the local application as passive. If takeover does
-not complete within 30 seconds, it restarts the old local release without
-swapping. This is a bounded interruption, not a zero-downtime update.
+not complete within 35 seconds, it restarts the old local release without
+swapping. Qualification still requires a healthy takeover in less than 15
+seconds. This is a bounded interruption, not a zero-downtime update.
 
 ## Qualification
 

--- a/deployment-files/ha/README.md
+++ b/deployment-files/ha/README.md
@@ -203,7 +203,7 @@ rather than upgraded through this workflow.
 The updater stages everything first, stops the local Fleet containers, and
 waits for the updated peer to serve the VIP with the target version. Only then
 does it swap and restart the local application as passive. If takeover does
-not complete within 15 seconds, it restarts the old local release without
+not complete within 30 seconds, it restarts the old local release without
 swapping. This is a bounded interruption, not a zero-downtime update.
 
 ## Qualification

--- a/deployment-files/ha/README.md
+++ b/deployment-files/ha/README.md
@@ -165,6 +165,47 @@ The Docker repository setup follows the official instructions for
 [Ubuntu](https://docs.docker.com/engine/install/ubuntu/), and
 [64-bit Raspberry Pi OS](https://docs.docker.com/engine/install/raspberry-pi-os/).
 
+## Update a passive Fleet host
+
+HA disables application-triggered updates. On the passive database host, run:
+
+```bash
+sudo /opt/proto-fleet/deployment/ha/fleet-ha update v0.2.11
+```
+
+The local updater downloads the release from the fixed Proto Fleet GitHub
+release origin, verifies its SHA256 checksum, builds and persists the staged
+Fleet images, then rechecks that this host is passive. It stops and replaces
+only `fleet-api` and `fleet-client`; etcd, Patroni, PostgreSQL, and keepalived
+remain running. The command returns only after the target version is healthy
+and passive.
+
+The old active and new passive share the database during this rolling window.
+Every migration in the target release must be expand-only and remain compatible
+with the previous release; destructive contract migrations belong in a later
+release after both HA hosts have advanced.
+
+After the peer is confirmed on the target release, complete the update from
+the old active host:
+
+```bash
+sudo /opt/proto-fleet/deployment/ha/fleet-ha update v0.2.11 --complete
+```
+
+If the updated host has already become active, the old host is now passive.
+Run the ordinary `fleet-ha update v0.2.11` command on that passive host instead.
+
+The source release must already contain this HA update protocol. HA is being
+introduced for new deployments, so an older experimental HA installation that
+predates `update --complete` must be reinstalled at the supported baseline
+rather than upgraded through this workflow.
+
+The updater stages everything first, stops the local Fleet containers, and
+waits for the updated peer to serve the VIP with the target version. Only then
+does it swap and restart the local application as passive. If takeover does
+not complete within 15 seconds, it restarts the old local release without
+swapping. This is a bounded interruption, not a zero-downtime update.
+
 ## Qualification
 
 The distributions above are installer-compatible targets. The HA profile is

--- a/deployment-files/ha/README.md
+++ b/deployment-files/ha/README.md
@@ -203,8 +203,11 @@ swapping. Qualification still requires a healthy takeover in less than 15
 seconds. This is a bounded interruption, not a zero-downtime update.
 
 If an update reports pending HA application recovery, retry recovery with
-`sudo systemctl restart proto-fleet-updater.service`. After the local Fleet
-application is healthy again, rerun the same `fleet-ha update` command.
+`sudo systemctl restart proto-fleet-updater.service`, then run
+`sudo /opt/proto-fleet/deployment/ha/fleet-ha status /etc/proto-fleet/ha/node.env`.
+If the target version is already installed and healthy, do not rerun the
+update. Retry only if the old version remains: use the ordinary update while
+passive, or `--complete` while active after the peer reaches the target.
 
 ## Qualification
 

--- a/server/cmd/fleet-ha/main.go
+++ b/server/cmd/fleet-ha/main.go
@@ -179,7 +179,7 @@ func (c *appStopCmd) Run(ctx context.Context) error {
 
 type appStartCmd struct {
 	Version string `arg:"" help:"application version to start"`
-	Mode    string `arg:"" enum:"passive,any" help:"required HA role after startup"`
+	Mode    string `arg:"" optional:"" default:"passive" enum:"passive,any" help:"required HA role after startup"`
 }
 
 func (c *appStartCmd) Run(ctx context.Context) error {

--- a/server/cmd/fleet-ha/main.go
+++ b/server/cmd/fleet-ha/main.go
@@ -14,7 +14,6 @@ import (
 	"github.com/alecthomas/kong"
 	"github.com/google/uuid"
 
-	"github.com/block/proto-fleet/server/internal/ha"
 	"github.com/block/proto-fleet/server/internal/ha/deployment"
 	"github.com/block/proto-fleet/server/internal/updaterapi"
 )

--- a/server/cmd/fleet-ha/main.go
+++ b/server/cmd/fleet-ha/main.go
@@ -181,7 +181,7 @@ func (c *appStopCmd) Run(ctx context.Context) error {
 
 type appStartCmd struct {
 	Version string `arg:"" help:"application version to start"`
-	Mode    string `arg:"" optional:"" default:"passive" enum:"passive,any" help:"required HA role after startup"`
+	Mode    string `arg:"" optional:"" default:"passive" enum:"passive,complete,any" help:"required HA readiness after startup"`
 }
 
 func (c *appStartCmd) Run(ctx context.Context) error {
@@ -189,7 +189,7 @@ func (c *appStartCmd) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	return deployment.StartApplication(ctx, root, c.Version, c.Mode == "passive")
+	return deployment.StartApplication(ctx, root, c.Version, c.Mode != "any", c.Mode == "complete")
 }
 
 type waitTakeoverCmd struct {

--- a/server/cmd/fleet-ha/main.go
+++ b/server/cmd/fleet-ha/main.go
@@ -275,7 +275,7 @@ func runPassiveUpdate(
 	if report.Control != nil && report.Control.FailoverReady {
 		return nil
 	}
-	if deployment.ExpectedRollingVersionMismatch(report.Control) {
+	if !complete && deployment.ExpectedRollingVersionMismatch(report.Control) {
 		_, err = fmt.Fprintln(output, "Update succeeded; failover readiness will recover after the peer is updated.")
 		if err != nil {
 			return fmt.Errorf("write update outcome: %w", err)

--- a/server/cmd/fleet-ha/main.go
+++ b/server/cmd/fleet-ha/main.go
@@ -41,7 +41,6 @@ type cli struct {
 	UpdatePreflight   updatePreflightCmd   `cmd:"" help:"prepare the current release for an application update"`
 	AppStop           appStopCmd           `cmd:"" help:"stop the Fleet application services"`
 	AppStart          appStartCmd          `cmd:"" help:"start the Fleet application services"`
-	AppRecover        appRecoverCmd        `cmd:"" help:"recover an interrupted Fleet application update"`
 	WaitTakeover      waitTakeoverCmd      `cmd:"" help:"wait for the VIP to serve an application version"`
 }
 
@@ -189,18 +188,6 @@ func (c *appStartCmd) Run(ctx context.Context) error {
 		return err
 	}
 	return deployment.StartApplication(ctx, root, c.Version, c.Mode == "passive")
-}
-
-type appRecoverCmd struct {
-	Version string `arg:"" help:"application version to recover"`
-}
-
-func (c *appRecoverCmd) Run(ctx context.Context) error {
-	root, err := deployment.ReleaseRoot()
-	if err != nil {
-		return err
-	}
-	return deployment.RecoverApplication(ctx, root, c.Version)
 }
 
 type waitTakeoverCmd struct {

--- a/server/cmd/fleet-ha/main.go
+++ b/server/cmd/fleet-ha/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/alecthomas/kong"
 	"github.com/google/uuid"
 
+	"github.com/block/proto-fleet/server/internal/ha"
 	"github.com/block/proto-fleet/server/internal/ha/deployment"
 	"github.com/block/proto-fleet/server/internal/updaterapi"
 )
@@ -148,10 +149,12 @@ func (c *requirePassiveCmd) Run(ctx context.Context) error {
 
 type requireActiveCmd struct {
 	NodeEnv string `arg:"" type:"path" help:"node environment file"`
+	Version string `arg:"" help:"target application version"`
 }
 
 func (c *requireActiveCmd) Run(ctx context.Context) error {
-	return deployment.RequireActive(ctx, c.NodeEnv)
+	_, err := deployment.ValidateActiveUpdate(ctx, c.NodeEnv, c.Version)
+	return err
 }
 
 type updatePreflightCmd struct{}

--- a/server/cmd/fleet-ha/main.go
+++ b/server/cmd/fleet-ha/main.go
@@ -153,8 +153,7 @@ type requireActiveCmd struct {
 }
 
 func (c *requireActiveCmd) Run(ctx context.Context) error {
-	_, err := deployment.ValidateActiveUpdate(ctx, c.NodeEnv, c.Version)
-	return err
+	return deployment.ValidateActiveUpdate(ctx, c.NodeEnv, c.Version)
 }
 
 type updatePreflightCmd struct{}
@@ -250,8 +249,7 @@ type updatePreflight func(context.Context, string, string, bool) error
 
 func validateHAUpdate(ctx context.Context, envPath, targetVersion string, complete bool) error {
 	if complete {
-		_, err := deployment.ValidateActiveUpdate(ctx, envPath, targetVersion)
-		return err
+		return deployment.ValidateActiveUpdate(ctx, envPath, targetVersion)
 	}
 	return deployment.ValidatePassiveUpdate(ctx, envPath, targetVersion)
 }

--- a/server/cmd/fleet-ha/main.go
+++ b/server/cmd/fleet-ha/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/alecthomas/kong"
 	"github.com/google/uuid"
 
+	"github.com/block/proto-fleet/server/internal/ha"
 	"github.com/block/proto-fleet/server/internal/ha/deployment"
 	"github.com/block/proto-fleet/server/internal/updaterapi"
 )
@@ -36,9 +37,11 @@ type cli struct {
 	Start             startCmd             `cmd:"" help:"start installed HA services"`
 	Stop              stopCmd              `cmd:"" help:"stop installed HA services"`
 	RequirePassive    requirePassiveCmd    `cmd:"" help:"verify that the local Fleet instance is passive"`
+	RequireActive     requireActiveCmd     `cmd:"" help:"verify that the local Fleet instance is active"`
 	UpdatePreflight   updatePreflightCmd   `cmd:"" help:"prepare the current release for an application update"`
 	AppStop           appStopCmd           `cmd:"" help:"stop the Fleet application services"`
 	AppStart          appStartCmd          `cmd:"" help:"start the Fleet application services"`
+	WaitTakeover      waitTakeoverCmd      `cmd:"" help:"wait for the VIP to serve an application version"`
 }
 
 type preflightCmd struct {
@@ -110,11 +113,12 @@ func (c *installCmd) Run(ctx context.Context) error {
 }
 
 type updateCmd struct {
-	Version string `arg:"" help:"target application version"`
+	Version  string `arg:"" help:"target application version"`
+	Complete bool   `help:"complete the update through failover from the active host"`
 }
 
 func (c *updateCmd) Run(ctx context.Context) error {
-	return runPassiveUpdate(ctx, c.Version, os.Stdout, deployment.ValidatePassiveUpdate, updaterapi.NewClient(defaultUpdaterSocket), deployment.Status)
+	return runPassiveUpdate(ctx, c.Version, c.Complete, os.Stdout, validateHAUpdate, updaterapi.NewClient(defaultUpdaterSocket), deployment.Status)
 }
 
 type startCmd struct {
@@ -143,6 +147,14 @@ func (c *requirePassiveCmd) Run(ctx context.Context) error {
 	return deployment.ValidatePassiveUpdate(ctx, c.NodeEnv, c.Version)
 }
 
+type requireActiveCmd struct {
+	NodeEnv string `arg:"" type:"path" help:"node environment file"`
+}
+
+func (c *requireActiveCmd) Run(ctx context.Context) error {
+	return deployment.RequireActive(ctx, c.NodeEnv)
+}
+
 type updatePreflightCmd struct{}
 
 func (*updatePreflightCmd) Run(ctx context.Context) error {
@@ -153,19 +165,21 @@ func (*updatePreflightCmd) Run(ctx context.Context) error {
 	return deployment.PrepareApplicationUpdate(ctx, root)
 }
 
-type appStopCmd struct{}
+type appStopCmd struct {
+	Role ha.RuntimeRole `arg:"" enum:"passive,active" help:"expected local HA role"`
+}
 
-func (*appStopCmd) Run(ctx context.Context) error {
+func (c *appStopCmd) Run(ctx context.Context) error {
 	root, err := deployment.ReleaseRoot()
 	if err != nil {
 		return err
 	}
-	return deployment.StopApplication(ctx, root)
+	return deployment.StopApplication(ctx, root, c.Role)
 }
 
 type appStartCmd struct {
 	Version string `arg:"" help:"application version to start"`
-	Mode    string `arg:"" optional:"" default:"passive" enum:"passive,any" help:"required HA role after startup"`
+	Mode    string `arg:"" enum:"passive,any" help:"required HA role after startup"`
 }
 
 func (c *appStartCmd) Run(ctx context.Context) error {
@@ -174,6 +188,14 @@ func (c *appStartCmd) Run(ctx context.Context) error {
 		return err
 	}
 	return deployment.StartApplication(ctx, root, c.Version, c.Mode == "passive")
+}
+
+type waitTakeoverCmd struct {
+	Version string `arg:"" help:"application version expected on the VIP"`
+}
+
+func (c *waitTakeoverCmd) Run(ctx context.Context) error {
+	return deployment.WaitForVIPVersion(ctx, installedNodeEnv, c.Version)
 }
 
 func main() {
@@ -214,6 +236,7 @@ func runStatus(ctx context.Context, envPath string, output io.Writer, read statu
 type updaterClient interface {
 	Status(ctx context.Context) (updaterapi.StatusResponse, error)
 	Trigger(ctx context.Context, operationID, targetVersion string) (updaterapi.Operation, error)
+	TriggerComplete(ctx context.Context, operationID, targetVersion string) (updaterapi.Operation, error)
 }
 
 const (
@@ -221,17 +244,26 @@ const (
 	updateCommunicationTimeout = 30 * time.Second
 )
 
-type updatePreflight func(context.Context, string, string) error
+type updatePreflight func(context.Context, string, string, bool) error
+
+func validateHAUpdate(ctx context.Context, envPath, targetVersion string, complete bool) error {
+	if complete {
+		_, err := deployment.ValidateActiveUpdate(ctx, envPath, targetVersion)
+		return err
+	}
+	return deployment.ValidatePassiveUpdate(ctx, envPath, targetVersion)
+}
 
 func runPassiveUpdate(
 	ctx context.Context,
 	targetVersion string,
+	complete bool,
 	output io.Writer,
 	preflight updatePreflight,
 	client updaterClient,
 	read statusReader,
 ) error {
-	if err := runUpdate(ctx, targetVersion, output, preflight, client); err != nil {
+	if err := runUpdate(ctx, targetVersion, complete, output, preflight, client); err != nil {
 		return err
 	}
 	report, err := read(ctx, installedNodeEnv)
@@ -257,15 +289,20 @@ func runPassiveUpdate(
 func runUpdate(
 	ctx context.Context,
 	targetVersion string,
+	complete bool,
 	output io.Writer,
 	preflight updatePreflight,
 	client updaterClient,
 ) error {
-	if err := preflight(ctx, installedNodeEnv, targetVersion); err != nil {
+	if err := preflight(ctx, installedNodeEnv, targetVersion, complete); err != nil {
 		return err
 	}
 	operationID := uuid.NewString()
-	operation, err := triggerUpdate(ctx, operationID, targetVersion, client.Trigger)
+	trigger := client.Trigger
+	if complete {
+		trigger = client.TriggerComplete
+	}
+	operation, err := triggerUpdate(ctx, operationID, targetVersion, trigger)
 	if err != nil {
 		return err
 	}

--- a/server/cmd/fleet-ha/main.go
+++ b/server/cmd/fleet-ha/main.go
@@ -41,6 +41,7 @@ type cli struct {
 	UpdatePreflight   updatePreflightCmd   `cmd:"" help:"prepare the current release for an application update"`
 	AppStop           appStopCmd           `cmd:"" help:"stop the Fleet application services"`
 	AppStart          appStartCmd          `cmd:"" help:"start the Fleet application services"`
+	AppRecover        appRecoverCmd        `cmd:"" help:"recover an interrupted Fleet application update"`
 	WaitTakeover      waitTakeoverCmd      `cmd:"" help:"wait for the VIP to serve an application version"`
 }
 
@@ -188,6 +189,18 @@ func (c *appStartCmd) Run(ctx context.Context) error {
 		return err
 	}
 	return deployment.StartApplication(ctx, root, c.Version, c.Mode == "passive")
+}
+
+type appRecoverCmd struct {
+	Version string `arg:"" help:"application version to recover"`
+}
+
+func (c *appRecoverCmd) Run(ctx context.Context) error {
+	root, err := deployment.ReleaseRoot()
+	if err != nil {
+		return err
+	}
+	return deployment.RecoverApplication(ctx, root, c.Version)
 }
 
 type waitTakeoverCmd struct {

--- a/server/cmd/fleet-ha/main_test.go
+++ b/server/cmd/fleet-ha/main_test.go
@@ -157,7 +157,7 @@ func TestPassiveUpdateAllowsExpectedVersionMismatch(t *testing.T) {
 func TestCompleteUpdateRejectsExpectedVersionMismatch(t *testing.T) {
 	// Arrange
 	client := &fakeUpdaterClient{}
-	read := func(context.Context, string, bool) (deployment.StatusReport, error) {
+	read := func(context.Context, string) (deployment.StatusReport, error) {
 		return deployment.StatusReport{Control: &deployment.ControlStatus{
 			ControlReady: true,
 			ReasonCodes:  []deployment.ControlReasonCode{deployment.ReasonFleetVersionMismatch},

--- a/server/cmd/fleet-ha/main_test.go
+++ b/server/cmd/fleet-ha/main_test.go
@@ -154,6 +154,23 @@ func TestPassiveUpdateAllowsExpectedVersionMismatch(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestCompleteUpdateRejectsExpectedVersionMismatch(t *testing.T) {
+	// Arrange
+	client := &fakeUpdaterClient{}
+	read := func(context.Context, string, bool) (deployment.StatusReport, error) {
+		return deployment.StatusReport{Control: &deployment.ControlStatus{
+			ControlReady: true,
+			ReasonCodes:  []deployment.ControlReasonCode{deployment.ReasonFleetVersionMismatch},
+		}}, nil
+	}
+
+	// Act
+	err := runPassiveUpdate(t.Context(), []string{"v1.2.3", "--complete"}, &bytes.Buffer{}, func(context.Context, string, string, bool) error { return nil }, client, read)
+
+	// Assert
+	require.ErrorContains(t, err, "failover readiness is degraded")
+}
+
 func TestUpdateReturnsWhenUpdaterIsUnavailable(t *testing.T) {
 	// Arrange
 	client := &fakeUpdaterClient{triggerErr: updaterapi.ErrUnavailable}

--- a/server/cmd/fleet-ha/main_test.go
+++ b/server/cmd/fleet-ha/main_test.go
@@ -165,7 +165,7 @@ func TestCompleteUpdateRejectsExpectedVersionMismatch(t *testing.T) {
 	}
 
 	// Act
-	err := runPassiveUpdate(t.Context(), []string{"v1.2.3", "--complete"}, &bytes.Buffer{}, func(context.Context, string, string, bool) error { return nil }, client, read)
+	err := runPassiveUpdate(t.Context(), "v1.2.3", true, &bytes.Buffer{}, func(context.Context, string, string, bool) error { return nil }, client, read)
 
 	// Assert
 	require.ErrorContains(t, err, "failover readiness is degraded")

--- a/server/cmd/fleet-ha/main_test.go
+++ b/server/cmd/fleet-ha/main_test.go
@@ -15,8 +15,18 @@ import (
 
 type fakeUpdaterClient struct {
 	triggered  bool
+	complete   bool
 	triggerErr error
 	operation  updaterapi.Operation
+}
+
+func (f *fakeUpdaterClient) TriggerComplete(_ context.Context, operationID, targetVersion string) (updaterapi.Operation, error) {
+	f.triggered = true
+	f.complete = true
+	if f.triggerErr != nil {
+		return updaterapi.Operation{}, f.triggerErr
+	}
+	return updaterapi.Operation{ID: operationID, TargetVersion: targetVersion, Phase: updaterapi.PhaseSucceeded}, nil
 }
 
 func (f *fakeUpdaterClient) Status(context.Context) (updaterapi.StatusResponse, error) {
@@ -79,7 +89,7 @@ func TestUpdateRequiresPassiveBeforeTriggering(t *testing.T) {
 	client := &fakeUpdaterClient{}
 
 	// Act
-	err := runUpdate(t.Context(), "v1.2.3", &bytes.Buffer{}, func(context.Context, string, string) error {
+	err := runUpdate(t.Context(), "v1.2.3", false, &bytes.Buffer{}, func(context.Context, string, string, bool) error {
 		return errors.New("local Fleet is active")
 	}, client)
 
@@ -98,7 +108,7 @@ func TestUpdateReportsTerminalSuccess(t *testing.T) {
 	var output bytes.Buffer
 
 	// Act
-	err := runUpdate(t.Context(), "v1.2.3", &output, func(context.Context, string, string) error { return nil }, client)
+	err := runUpdate(t.Context(), "v1.2.3", false, &output, func(context.Context, string, string, bool) error { return nil }, client)
 
 	// Assert
 	require.NoError(t, err)
@@ -120,7 +130,7 @@ func TestPassiveUpdateReportsDegradedFailoverReadiness(t *testing.T) {
 	}
 
 	// Act
-	err := runPassiveUpdate(t.Context(), "v1.2.3", &output, func(context.Context, string, string) error { return nil }, client, read)
+	err := runPassiveUpdate(t.Context(), "v1.2.3", false, &output, func(context.Context, string, string, bool) error { return nil }, client, read)
 
 	// Assert
 	require.ErrorContains(t, err, "failover readiness is degraded")
@@ -138,7 +148,7 @@ func TestPassiveUpdateAllowsExpectedVersionMismatch(t *testing.T) {
 	}
 
 	// Act
-	err := runPassiveUpdate(t.Context(), "v1.2.3", &bytes.Buffer{}, func(context.Context, string, string) error { return nil }, client, read)
+	err := runPassiveUpdate(t.Context(), "v1.2.3", false, &bytes.Buffer{}, func(context.Context, string, string, bool) error { return nil }, client, read)
 
 	// Assert
 	require.NoError(t, err)
@@ -149,7 +159,7 @@ func TestUpdateReturnsWhenUpdaterIsUnavailable(t *testing.T) {
 	client := &fakeUpdaterClient{triggerErr: updaterapi.ErrUnavailable}
 
 	// Act
-	err := runUpdate(t.Context(), "v1.2.3", &bytes.Buffer{}, func(context.Context, string, string) error { return nil }, client)
+	err := runUpdate(t.Context(), "v1.2.3", false, &bytes.Buffer{}, func(context.Context, string, string, bool) error { return nil }, client)
 
 	// Assert
 	require.ErrorIs(t, err, updaterapi.ErrUnavailable)
@@ -186,10 +196,31 @@ func TestUpdateFailureIncludesRecoveryDetails(t *testing.T) {
 	var output bytes.Buffer
 
 	// Act
-	err := runUpdate(t.Context(), "v1.2.3", &output, func(context.Context, string, string) error { return nil }, client)
+	err := runUpdate(t.Context(), "v1.2.3", false, &output, func(context.Context, string, string, bool) error { return nil }, client)
 
 	// Assert
 	require.ErrorContains(t, err, "Recovery: fleet-ha app-start v1.2.3")
 	require.ErrorContains(t, err, "Log: /var/log/proto-fleet-updater/update.log")
 	require.Contains(t, output.String(), "Update operation")
+}
+
+func TestCompleteUpdateRequiresActiveAndUsesCompletionRequest(t *testing.T) {
+	// Arrange
+	client := &fakeUpdaterClient{}
+	activeChecked := false
+
+	// Act
+	err := runUpdate(
+		t.Context(), "v1.2.3", true, &bytes.Buffer{},
+		func(_ context.Context, _, _ string, complete bool) error {
+			activeChecked = complete
+			return nil
+		},
+		client,
+	)
+
+	// Assert
+	require.NoError(t, err)
+	require.True(t, activeChecked)
+	require.True(t, client.complete)
 }

--- a/server/cmd/fleetd/main.go
+++ b/server/cmd/fleetd/main.go
@@ -721,7 +721,7 @@ func start(config *Config) (result error) {
 
 	mux.HandleFunc("/health", health.NewHandler(version))
 	mux.HandleFunc("/health/ready", health.NewReadyHandler(conn, fleetRuntime))
-	mux.HandleFunc("/health/active", health.NewActiveHandler(fleetRuntime))
+	mux.HandleFunc("/health/active", health.NewActiveHandler(version, fleetRuntime))
 	if config.HA.Enabled {
 		mux.HandleFunc("/health/ha", health.NewHAHandler(version, fleetRuntime))
 		mux.HandleFunc("/health/passive", health.NewPassiveHandler(fleetRuntime))

--- a/server/internal/domain/updates/executor_test.go
+++ b/server/internal/domain/updates/executor_test.go
@@ -143,7 +143,7 @@ func TestUnixExecutorClientTriggerComplete(t *testing.T) {
 		observed <- executorRequestObservation{trigger: request, decodeErr: decodeErr}
 		w.WriteHeader(http.StatusAccepted)
 		_ = json.NewEncoder(w).Encode(updaterapi.TriggerResponse{Operation: updaterapi.Operation{
-			ID: operationID, TargetVersion: "v1.2.3", Phase: updaterapi.PhaseQueued,
+			ID: operationID, TargetVersion: "v1.2.3", Complete: true, Phase: updaterapi.PhaseQueued,
 		}})
 	}))
 
@@ -229,6 +229,24 @@ func TestUnixExecutorClientRejectsMismatchedTriggerIdentity(t *testing.T) {
 	}))
 
 	_, err := client.Trigger(t.Context(), "11111111-1111-4111-8111-111111111111", "v1.2.3")
+	require.Error(t, err)
+	var protocolErr *updaterapi.ProtocolError
+	assert.ErrorAs(t, err, &protocolErr)
+}
+
+func TestUnixExecutorClientRejectsMismatchedCompletionMode(t *testing.T) {
+	// Arrange
+	client := startExecutorTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+		_ = json.NewEncoder(w).Encode(updaterapi.TriggerResponse{Operation: updaterapi.Operation{
+			ID: "11111111-1111-4111-8111-111111111111", TargetVersion: "v1.2.3",
+		}})
+	}))
+
+	// Act
+	_, err := client.TriggerComplete(t.Context(), "11111111-1111-4111-8111-111111111111", "v1.2.3")
+
+	// Assert
 	require.Error(t, err)
 	var protocolErr *updaterapi.ProtocolError
 	assert.ErrorAs(t, err, &protocolErr)

--- a/server/internal/domain/updates/executor_test.go
+++ b/server/internal/domain/updates/executor_test.go
@@ -133,6 +133,31 @@ func TestUnixExecutorClientTrigger(t *testing.T) {
 	assert.NoError(t, observation.decodeErr)
 }
 
+func TestUnixExecutorClientTriggerComplete(t *testing.T) {
+	// Arrange
+	operationID := "11111111-1111-4111-8111-111111111111"
+	observed := make(chan executorRequestObservation, 1)
+	client := startExecutorTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request updaterapi.TriggerRequest
+		decodeErr := json.NewDecoder(r.Body).Decode(&request)
+		observed <- executorRequestObservation{trigger: request, decodeErr: decodeErr}
+		w.WriteHeader(http.StatusAccepted)
+		_ = json.NewEncoder(w).Encode(updaterapi.TriggerResponse{Operation: updaterapi.Operation{
+			ID: operationID, TargetVersion: "v1.2.3", Phase: updaterapi.PhaseQueued,
+		}})
+	}))
+
+	// Act
+	operation, err := client.TriggerComplete(t.Context(), operationID, "v1.2.3")
+
+	// Assert
+	require.NoError(t, err)
+	require.Equal(t, operationID, operation.ID)
+	observation := <-observed
+	require.NoError(t, observation.decodeErr)
+	require.True(t, observation.trigger.Complete)
+}
+
 func TestUnixExecutorClientHTTPFailures(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/ha/deployment/update.go
+++ b/server/internal/ha/deployment/update.go
@@ -154,9 +154,9 @@ func StopApplication(ctx context.Context, root string, expectedRole ha.RuntimeRo
 	}
 	// The crash-only design intentionally has no maintenance lease. If the role
 	// changes after this final proof, normal update recovery restarts Fleet.
-	// Leave two seconds inside the updater's five-second active-stop deadline
-	// for Compose and Docker to confirm both containers stopped.
-	if err := RunCompose(ctx, fleetComposeArgsAt(root, "stop", "--timeout", "3", "fleet-api", "fleet-client")); err != nil {
+	// The HA workload is crash-only. Avoid per-service graceful-stop timers so
+	// the updater's five-second deadline remains a hard total shutdown bound.
+	if err := RunCompose(ctx, fleetComposeArgsAt(root, "kill", "fleet-api", "fleet-client")); err != nil {
 		return fmt.Errorf("stop HA application: %w", err)
 	}
 	return nil

--- a/server/internal/ha/deployment/update.go
+++ b/server/internal/ha/deployment/update.go
@@ -13,7 +13,7 @@ import (
 	"github.com/block/proto-fleet/server/internal/transportguard"
 )
 
-const vipTakeoverTimeout = 15 * time.Second
+const vipTakeoverTimeout = 30 * time.Second
 
 func requirePassiveStatus(ctx context.Context, envPath string) (StatusReport, error) {
 	report, err := Status(ctx, envPath)
@@ -66,7 +66,12 @@ func requireActiveStatus(ctx context.Context, envPath string) (StatusReport, err
 		return StatusReport{}, err
 	}
 	if report.Runtime.Observation != ha.ObservationCurrent || report.Runtime.Role != ha.RoleActive || report.Runtime.Endpoint != ha.EndpointHealthy {
-		return StatusReport{}, fmt.Errorf("HA completion update requires a healthy active node; local role is %s", report.Runtime.Role)
+		return StatusReport{}, fmt.Errorf(
+			"HA completion update requires a healthy active node; local role is %s, observation is %s, and endpoint is %s",
+			report.Runtime.Role,
+			report.Runtime.Observation,
+			report.Runtime.Endpoint,
+		)
 	}
 	if !rollingUpdateControlReady(report.Control) {
 		return StatusReport{}, errors.New("HA completion update requires rolling-update readiness")
@@ -303,7 +308,7 @@ func WaitForVIPVersion(ctx context.Context, envPath, targetVersion string) error
 		}
 		select {
 		case <-deadline.Done():
-			return errors.New("updated peer did not serve the VIP within 15 seconds")
+			return fmt.Errorf("updated peer did not serve the VIP within %s", vipTakeoverTimeout)
 		case <-time.After(500 * time.Millisecond):
 		}
 	}

--- a/server/internal/ha/deployment/update.go
+++ b/server/internal/ha/deployment/update.go
@@ -13,7 +13,9 @@ import (
 	"github.com/block/proto-fleet/server/internal/transportguard"
 )
 
-const vipTakeoverTimeout = 30 * time.Second
+// Covers one 10s lease lifetime, the coordinator's two-lease acquire budget,
+// and a small keepalived scheduling margin.
+const vipTakeoverTimeout = 35 * time.Second
 
 func requirePassiveStatus(ctx context.Context, envPath string) (StatusReport, error) {
 	report, err := Status(ctx, envPath)

--- a/server/internal/ha/deployment/update.go
+++ b/server/internal/ha/deployment/update.go
@@ -4,12 +4,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"path/filepath"
 	"syscall"
 	"time"
 
 	"github.com/block/proto-fleet/server/internal/ha"
+	"github.com/block/proto-fleet/server/internal/transportguard"
 )
+
+const vipTakeoverTimeout = 15 * time.Second
 
 func requirePassiveStatus(ctx context.Context, envPath string) (StatusReport, error) {
 	report, err := Status(ctx, envPath)
@@ -51,6 +55,56 @@ func ValidatePassiveUpdate(ctx context.Context, envPath, targetVersion string) e
 	return nil
 }
 
+func RequireActive(ctx context.Context, envPath string) error {
+	_, err := requireActiveStatus(ctx, envPath)
+	return err
+}
+
+func requireActiveStatus(ctx context.Context, envPath string) (StatusReport, error) {
+	report, err := Status(ctx, envPath)
+	if err != nil {
+		return StatusReport{}, err
+	}
+	if report.Runtime.Observation != ha.ObservationCurrent || report.Runtime.Role != ha.RoleActive || report.Runtime.Endpoint != ha.EndpointHealthy {
+		return StatusReport{}, fmt.Errorf("HA completion update requires a healthy active node; local role is %s", report.Runtime.Role)
+	}
+	if !rollingUpdateControlReady(report.Control) {
+		return StatusReport{}, errors.New("HA completion update requires rolling-update readiness")
+	}
+	return report, nil
+}
+
+func RequireUpdatedPeer(ctx context.Context, envPath, targetVersion string) error {
+	config, err := loadNodeConfig(envPath)
+	if err != nil {
+		return err
+	}
+	peerAddress := config.DatabaseAIP
+	if config.NodeIP == config.DatabaseAIP {
+		peerAddress = config.DatabaseBIP
+	}
+	tlsConfig, err := ha.LoadServiceTLS(filepath.Join(config.SecretsDir, "service-ca.crt"))
+	if err != nil {
+		return err
+	}
+	status := probeFleetHost(ctx, tlsConfig, config.VirtualIP, peerAddress)
+	if !updatedPassivePeerReady(status, targetVersion) {
+		return fmt.Errorf("HA completion update requires the passive peer to run %s", targetVersion)
+	}
+	return nil
+}
+
+func ValidateActiveUpdate(ctx context.Context, envPath, targetVersion string) (string, error) {
+	report, err := requireActiveStatus(ctx, envPath)
+	if err != nil {
+		return "", err
+	}
+	if err := RequireUpdatedPeer(ctx, envPath, targetVersion); err != nil {
+		return "", err
+	}
+	return report.Runtime.Version, nil
+}
+
 // PrepareApplicationUpdate loads only the Fleet API and client from a verified release.
 func PrepareApplicationUpdate(ctx context.Context, root string) error {
 	return prepareApplicationUpdate(ctx, root, defaultInstallDependencies(), RunCompose)
@@ -78,10 +132,19 @@ func prepareApplicationUpdate(ctx context.Context, root string, deps installDepe
 	return nil
 }
 
-// StopApplication stops only Fleet containers; the HA substrate keeps running.
-func StopApplication(ctx context.Context, root string) error {
-	if _, err := requirePassiveStatus(ctx, filepath.Join(configRoot, "node.env")); err != nil {
-		return fmt.Errorf("refuse to stop HA application after passive role changed: %w", err)
+// StopApplication rechecks the expected role, then stops only Fleet containers.
+func StopApplication(ctx context.Context, root string, expectedRole ha.RuntimeRole) error {
+	var err error
+	switch expectedRole {
+	case ha.RolePassive:
+		_, err = requirePassiveStatus(ctx, filepath.Join(configRoot, "node.env"))
+	case ha.RoleActive:
+		_, err = requireActiveStatus(ctx, filepath.Join(configRoot, "node.env"))
+	case ha.RoleInitializing, ha.RoleDegraded:
+		return fmt.Errorf("unsupported HA role %q", expectedRole)
+	}
+	if err != nil {
+		return fmt.Errorf("refuse to stop HA application after %s role changed: %w", expectedRole, err)
 	}
 	// The crash-only design intentionally has no maintenance lease. If the role
 	// changes after this final proof, normal update recovery restarts Fleet.
@@ -89,6 +152,10 @@ func StopApplication(ctx context.Context, root string) error {
 		return fmt.Errorf("stop HA application: %w", err)
 	}
 	return nil
+}
+
+func updatedPassivePeerReady(status fleetHostStatus, targetVersion string) bool {
+	return status.reachable && status.passive && status.version == targetVersion
 }
 
 // StartApplication starts the target release and proves it serves its observed HA role.
@@ -170,16 +237,6 @@ func rollingUpdateApplicationReady(report StatusReport, public fleetHostStatus, 
 		rollingUpdateControlReady(report.Control), nil
 }
 
-func updatedApplicationReady(report StatusReport, publicStatus fleetHostStatus, targetVersion string, requirePassive bool) (bool, error) {
-	if requirePassive {
-		return rollingUpdateApplicationReady(report, publicStatus, targetVersion)
-	}
-	if report.Control == nil || !report.Control.ControlReady {
-		return false, nil
-	}
-	return applicationReady(report.Runtime, publicStatus, targetVersion), nil
-}
-
 func rollingUpdateControlReady(control *ControlStatus) bool {
 	if control == nil || !control.ControlReady {
 		return false
@@ -193,6 +250,16 @@ func ExpectedRollingVersionMismatch(control *ControlStatus) bool {
 		len(control.ReasonCodes) == 1 && control.ReasonCodes[0] == ReasonFleetVersionMismatch
 }
 
+func updatedApplicationReady(report StatusReport, publicStatus fleetHostStatus, targetVersion string, requirePassive bool) (bool, error) {
+	if requirePassive {
+		return rollingUpdateApplicationReady(report, publicStatus, targetVersion)
+	}
+	if report.Control == nil || !report.Control.ControlReady {
+		return false, nil
+	}
+	return applicationReady(report.Runtime, publicStatus, targetVersion), nil
+}
+
 func applicationReady(runtime ha.Status, public fleetHostStatus, targetVersion string) bool {
 	publicRoleReady := runtime.Role == ha.RoleActive && public.active || runtime.Role == ha.RolePassive && public.passive
 	return runtime.Version == targetVersion &&
@@ -200,4 +267,57 @@ func applicationReady(runtime ha.Status, public fleetHostStatus, targetVersion s
 		publicRoleReady &&
 		public.reachable &&
 		public.version == targetVersion
+}
+
+func WaitForVIPVersion(ctx context.Context, envPath, targetVersion string) error {
+	config, err := loadNodeConfig(envPath)
+	if err != nil {
+		return err
+	}
+	tlsConfig, err := ha.LoadServiceTLS(filepath.Join(config.SecretsDir, "service-ca.crt"))
+	if err != nil {
+		return err
+	}
+	transport := &http.Transport{TLSClientConfig: tlsConfig, Proxy: nil}
+	client := &http.Client{Transport: transport, Timeout: 2 * time.Second, CheckRedirect: transportguard.RejectRedirect}
+	defer transport.CloseIdleConnections()
+	deadline, cancel := context.WithTimeout(ctx, vipTakeoverTimeout)
+	defer cancel()
+	endpoint := "https://" + config.VirtualIP + "/api-proxy/health"
+	for {
+		request, requestErr := http.NewRequestWithContext(deadline, http.MethodGet, endpoint, nil)
+		if requestErr != nil {
+			return fmt.Errorf("create VIP takeover probe: %w", requestErr)
+		}
+		response, requestErr := client.Do(request)
+		if requestErr == nil {
+			response.Body.Close()
+			version := response.Header.Get("X-Proto-Fleet-Version")
+			ready, versionErr := acceptVIPVersion(response.StatusCode, version, targetVersion)
+			if versionErr != nil {
+				return versionErr
+			}
+			if ready {
+				return nil
+			}
+		}
+		select {
+		case <-deadline.Done():
+			return errors.New("updated peer did not serve the VIP within 15 seconds")
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+}
+
+func acceptVIPVersion(status int, version, targetVersion string) (bool, error) {
+	if status != http.StatusOK {
+		return false, nil
+	}
+	if version == targetVersion {
+		return true, nil
+	}
+	if version != "" {
+		return false, fmt.Errorf("VIP is served by %s, expected %s", version, targetVersion)
+	}
+	return false, nil
 }

--- a/server/internal/ha/deployment/update.go
+++ b/server/internal/ha/deployment/update.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"path/filepath"
 	"syscall"
@@ -309,14 +310,17 @@ func WaitForVIPVersion(ctx context.Context, envPath, targetVersion string) error
 		}
 		response, requestErr := client.Do(request)
 		if requestErr == nil {
-			response.Body.Close()
+			_, drainErr := io.Copy(io.Discard, response.Body)
+			_ = response.Body.Close()
 			version := response.Header.Get("X-Proto-Fleet-Version")
-			ready, versionErr := acceptVIPVersion(response.StatusCode, version, targetVersion)
-			if versionErr != nil {
-				return versionErr
-			}
-			if ready {
-				return nil
+			if drainErr == nil {
+				ready, versionErr := acceptVIPVersion(response.StatusCode, version, targetVersion)
+				if versionErr != nil {
+					return versionErr
+				}
+				if ready {
+					return nil
+				}
 			}
 		}
 		select {

--- a/server/internal/ha/deployment/update.go
+++ b/server/internal/ha/deployment/update.go
@@ -154,7 +154,9 @@ func StopApplication(ctx context.Context, root string, expectedRole ha.RuntimeRo
 	}
 	// The crash-only design intentionally has no maintenance lease. If the role
 	// changes after this final proof, normal update recovery restarts Fleet.
-	if err := RunCompose(ctx, fleetComposeArgsAt(root, "stop", "fleet-api", "fleet-client")); err != nil {
+	// Leave two seconds inside the updater's five-second active-stop deadline
+	// for Compose and Docker to confirm both containers stopped.
+	if err := RunCompose(ctx, fleetComposeArgsAt(root, "stop", "--timeout", "3", "fleet-api", "fleet-client")); err != nil {
 		return fmt.Errorf("stop HA application: %w", err)
 	}
 	return nil
@@ -201,8 +203,16 @@ func startApplication(ctx context.Context, root, targetVersion string, requirePa
 		return fmt.Errorf("verify local HA application is stopped: %w", statusErr)
 	}
 	args := fleetComposeArgsAt(root, "up", "-d", "--no-deps", "--no-build", "--pull", "never", "fleet-api", "fleet-client")
-	if err := RunCompose(ctx, args); err != nil {
-		return fmt.Errorf("start HA application: %w", err)
+	for {
+		err := RunCompose(ctx, args)
+		if err == nil {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("start HA application after Compose failure %v: %w", err, ctx.Err())
+		case <-time.After(2 * time.Second):
+		}
 	}
 	for {
 		report, err := Status(ctx, filepath.Join(configRoot, "node.env"))

--- a/server/internal/ha/deployment/update.go
+++ b/server/internal/ha/deployment/update.go
@@ -167,6 +167,15 @@ func updatedPassivePeerReady(status fleetHostStatus, targetVersion string) bool 
 
 // StartApplication starts the target release and proves it serves its observed HA role.
 func StartApplication(ctx context.Context, root, targetVersion string, requirePassive bool) error {
+	return startApplication(ctx, root, targetVersion, requirePassive, false)
+}
+
+// RecoverApplication resumes interrupted activation without recreating running containers.
+func RecoverApplication(ctx context.Context, root, targetVersion string) error {
+	return startApplication(ctx, root, targetVersion, false, true)
+}
+
+func startApplication(ctx context.Context, root, targetVersion string, requirePassive, recovering bool) error {
 	config, err := loadNodeConfig(filepath.Join(configRoot, "node.env"))
 	if err != nil {
 		return err

--- a/server/internal/ha/deployment/update.go
+++ b/server/internal/ha/deployment/update.go
@@ -152,9 +152,11 @@ func StopApplication(ctx context.Context, root string, expectedRole ha.RuntimeRo
 	}
 	// The crash-only design intentionally has no maintenance lease. If the role
 	// changes after this final proof, normal update recovery restarts Fleet.
-	// The HA workload is crash-only. Avoid per-service graceful-stop timers so
-	// the updater's five-second deadline remains a hard total shutdown bound.
-	if err := RunCompose(ctx, fleetComposeArgsAt(root, "kill", "fleet-api", "fleet-client")); err != nil {
+	// Role validation runs while Fleet still serves. Bound only the crash-only
+	// kill so slow control probes cannot consume the interruption budget.
+	stopCtx, cancel := context.WithTimeout(ctx, ha.UpdateActiveStopTimeout)
+	defer cancel()
+	if err := RunCompose(stopCtx, fleetComposeArgsAt(root, "kill", "fleet-api", "fleet-client")); err != nil {
 		return fmt.Errorf("stop HA application: %w", err)
 	}
 	return nil

--- a/server/internal/ha/deployment/update.go
+++ b/server/internal/ha/deployment/update.go
@@ -294,7 +294,7 @@ func WaitForVIPVersion(ctx context.Context, envPath, targetVersion string) error
 	defer transport.CloseIdleConnections()
 	deadline, cancel := context.WithTimeout(ctx, ha.UpdateTakeoverTimeout)
 	defer cancel()
-	endpoint := "https://" + config.VirtualIP + "/api-proxy/health"
+	endpoint := "https://" + config.VirtualIP + "/api-proxy/health/active"
 	for {
 		request, requestErr := http.NewRequestWithContext(deadline, http.MethodGet, endpoint, nil)
 		if requestErr != nil {

--- a/server/internal/ha/deployment/update.go
+++ b/server/internal/ha/deployment/update.go
@@ -54,11 +54,6 @@ func ValidatePassiveUpdate(ctx context.Context, envPath, targetVersion string) e
 	return nil
 }
 
-func RequireActive(ctx context.Context, envPath string) error {
-	_, err := requireActiveStatus(ctx, envPath)
-	return err
-}
-
 func requireActiveStatus(ctx context.Context, envPath string) (StatusReport, error) {
 	report, err := Status(ctx, envPath)
 	if err != nil {
@@ -78,7 +73,7 @@ func requireActiveStatus(ctx context.Context, envPath string) (StatusReport, err
 	return report, nil
 }
 
-func RequireUpdatedPeer(ctx context.Context, envPath, targetVersion string) error {
+func requireUpdatedPeer(ctx context.Context, envPath, targetVersion string) error {
 	config, err := loadNodeConfig(envPath)
 	if err != nil {
 		return err
@@ -98,15 +93,12 @@ func RequireUpdatedPeer(ctx context.Context, envPath, targetVersion string) erro
 	return nil
 }
 
-func ValidateActiveUpdate(ctx context.Context, envPath, targetVersion string) (string, error) {
-	report, err := requireActiveStatus(ctx, envPath)
+func ValidateActiveUpdate(ctx context.Context, envPath, targetVersion string) error {
+	_, err := requireActiveStatus(ctx, envPath)
 	if err != nil {
-		return "", err
+		return err
 	}
-	if err := RequireUpdatedPeer(ctx, envPath, targetVersion); err != nil {
-		return "", err
-	}
-	return report.Runtime.Version, nil
+	return requireUpdatedPeer(ctx, envPath, targetVersion)
 }
 
 // PrepareApplicationUpdate loads only the Fleet API and client from a verified release.
@@ -152,11 +144,17 @@ func StopApplication(ctx context.Context, root string, expectedRole ha.RuntimeRo
 	}
 	// The crash-only design intentionally has no maintenance lease. If the role
 	// changes after this final proof, normal update recovery restarts Fleet.
-	// Role validation runs while Fleet still serves. Give Compose one second to
-	// stop cleanly, then let the outer deadline bound forced termination.
-	stopCtx, cancel := context.WithTimeout(ctx, ha.UpdateActiveStopTimeout)
-	defer cancel()
-	if err := RunCompose(stopCtx, fleetComposeArgsAt(root, "stop", "--timeout", "1", "fleet-api", "fleet-client")); err != nil {
+	composeCtx := ctx
+	args := fleetComposeArgsAt(root, "stop", "fleet-api", "fleet-client")
+	if expectedRole == ha.RoleActive {
+		// Bound only the serving node's interruption. A passive stop is not on the
+		// availability path and can use Compose's normal shutdown behavior.
+		stopCtx, cancel := context.WithTimeout(ctx, ha.UpdateActiveStopTimeout)
+		defer cancel()
+		composeCtx = stopCtx
+		args = fleetComposeArgsAt(root, "stop", "--timeout", "1", "fleet-api", "fleet-client")
+	}
+	if err := RunCompose(composeCtx, args); err != nil {
 		return fmt.Errorf("stop HA application: %w", err)
 	}
 	return nil
@@ -200,16 +198,8 @@ func StartApplication(ctx context.Context, root, targetVersion string, requirePa
 		return fmt.Errorf("verify local HA application is stopped: %w", statusErr)
 	}
 	args := fleetComposeArgsAt(root, "up", "-d", "--no-deps", "--no-build", "--pull", "never", "fleet-api", "fleet-client")
-	for {
-		err := RunCompose(ctx, args)
-		if err == nil {
-			break
-		}
-		select {
-		case <-ctx.Done():
-			return fmt.Errorf("start HA application after Compose failure %v: %w", err, ctx.Err())
-		case <-time.After(2 * time.Second):
-		}
+	if err := RunCompose(ctx, args); err != nil {
+		return fmt.Errorf("start HA application: %w", err)
 	}
 	for {
 		report, err := Status(ctx, filepath.Join(configRoot, "node.env"))

--- a/server/internal/ha/deployment/update.go
+++ b/server/internal/ha/deployment/update.go
@@ -13,9 +13,8 @@ import (
 	"github.com/block/proto-fleet/server/internal/transportguard"
 )
 
-// Covers one 10s lease lifetime, the coordinator's two-lease acquire budget,
-// and a small keepalived scheduling margin.
-const vipTakeoverTimeout = 35 * time.Second
+// Bounds the planned interruption promised by the HA update flow.
+const vipTakeoverTimeout = 15 * time.Second
 
 func requirePassiveStatus(ctx context.Context, envPath string) (StatusReport, error) {
 	report, err := Status(ctx, envPath)
@@ -168,11 +167,6 @@ func updatedPassivePeerReady(status fleetHostStatus, targetVersion string) bool 
 // StartApplication starts the target release and proves it serves its observed HA role.
 func StartApplication(ctx context.Context, root, targetVersion string, requirePassive bool) error {
 	return startApplication(ctx, root, targetVersion, requirePassive)
-}
-
-// RecoverApplication converges both Fleet services after interrupted activation.
-func RecoverApplication(ctx context.Context, root, targetVersion string) error {
-	return startApplication(ctx, root, targetVersion, false)
 }
 
 func startApplication(ctx context.Context, root, targetVersion string, requirePassive bool) error {

--- a/server/internal/ha/deployment/update.go
+++ b/server/internal/ha/deployment/update.go
@@ -291,7 +291,7 @@ func WaitForVIPVersion(ctx context.Context, envPath, targetVersion string) error
 	transport := &http.Transport{TLSClientConfig: tlsConfig, Proxy: nil}
 	client := &http.Client{Transport: transport, Timeout: 2 * time.Second, CheckRedirect: transportguard.RejectRedirect}
 	defer transport.CloseIdleConnections()
-	deadline, cancel := context.WithTimeout(ctx, vipTakeoverTimeout)
+	deadline, cancel := context.WithTimeout(ctx, ha.UpdateTakeoverTimeout)
 	defer cancel()
 	endpoint := "https://" + config.VirtualIP + "/api-proxy/health"
 	for {
@@ -313,7 +313,7 @@ func WaitForVIPVersion(ctx context.Context, envPath, targetVersion string) error
 		}
 		select {
 		case <-deadline.Done():
-			return fmt.Errorf("updated peer did not serve the VIP within %s", vipTakeoverTimeout)
+			return fmt.Errorf("updated peer did not serve the VIP within %s", ha.UpdateTakeoverTimeout)
 		case <-time.After(500 * time.Millisecond):
 		}
 	}

--- a/server/internal/ha/deployment/update.go
+++ b/server/internal/ha/deployment/update.go
@@ -13,9 +13,6 @@ import (
 	"github.com/block/proto-fleet/server/internal/transportguard"
 )
 
-// Leaves room for lease expiry and acquisition before falling back to the old release.
-const vipTakeoverTimeout = 35 * time.Second
-
 func requirePassiveStatus(ctx context.Context, envPath string) (StatusReport, error) {
 	report, err := Status(ctx, envPath)
 	if err != nil {
@@ -168,10 +165,6 @@ func updatedPassivePeerReady(status fleetHostStatus, targetVersion string) bool 
 
 // StartApplication starts the target release and proves it serves its observed HA role.
 func StartApplication(ctx context.Context, root, targetVersion string, requirePassive bool) error {
-	return startApplication(ctx, root, targetVersion, requirePassive)
-}
-
-func startApplication(ctx context.Context, root, targetVersion string, requirePassive bool) error {
 	config, err := loadNodeConfig(filepath.Join(configRoot, "node.env"))
 	if err != nil {
 		return err

--- a/server/internal/ha/deployment/update.go
+++ b/server/internal/ha/deployment/update.go
@@ -167,15 +167,15 @@ func updatedPassivePeerReady(status fleetHostStatus, targetVersion string) bool 
 
 // StartApplication starts the target release and proves it serves its observed HA role.
 func StartApplication(ctx context.Context, root, targetVersion string, requirePassive bool) error {
-	return startApplication(ctx, root, targetVersion, requirePassive, false)
+	return startApplication(ctx, root, targetVersion, requirePassive)
 }
 
-// RecoverApplication resumes interrupted activation without recreating running containers.
+// RecoverApplication converges both Fleet services after interrupted activation.
 func RecoverApplication(ctx context.Context, root, targetVersion string) error {
-	return startApplication(ctx, root, targetVersion, false, true)
+	return startApplication(ctx, root, targetVersion, false)
 }
 
-func startApplication(ctx context.Context, root, targetVersion string, requirePassive, recovering bool) error {
+func startApplication(ctx context.Context, root, targetVersion string, requirePassive bool) error {
 	config, err := loadNodeConfig(filepath.Join(configRoot, "node.env"))
 	if err != nil {
 		return err

--- a/server/internal/ha/deployment/update.go
+++ b/server/internal/ha/deployment/update.go
@@ -164,7 +164,7 @@ func updatedPassivePeerReady(status fleetHostStatus, targetVersion string) bool 
 }
 
 // StartApplication starts the target release and proves it serves its observed HA role.
-func StartApplication(ctx context.Context, root, targetVersion string, requirePassive bool) error {
+func StartApplication(ctx context.Context, root, targetVersion string, requirePassive, requireFailoverReady bool) error {
 	config, err := loadNodeConfig(filepath.Join(configRoot, "node.env"))
 	if err != nil {
 		return err
@@ -180,6 +180,7 @@ func StartApplication(ctx context.Context, root, targetVersion string, requirePa
 			probeFleetHost(ctx, tlsConfig, config.VirtualIP, config.NodeIP),
 			targetVersion,
 			requirePassive,
+			requireFailoverReady,
 		)
 		if readinessErr != nil {
 			return readinessErr
@@ -211,7 +212,7 @@ func StartApplication(ctx context.Context, root, targetVersion string, requirePa
 		report, err := Status(ctx, filepath.Join(configRoot, "node.env"))
 		if err == nil {
 			publicStatus := probeFleetHost(ctx, tlsConfig, config.VirtualIP, config.NodeIP)
-			ready, readinessErr := updatedApplicationReady(report, publicStatus, targetVersion, requirePassive)
+			ready, readinessErr := updatedApplicationReady(report, publicStatus, targetVersion, requirePassive, requireFailoverReady)
 			if readinessErr != nil {
 				return readinessErr
 			}
@@ -241,13 +242,17 @@ func applicationMayConverge(runtime ha.Status, targetVersion string, requirePass
 	return runtime.Role == ha.RoleActive || runtime.Role == ha.RolePassive
 }
 
-func rollingUpdateApplicationReady(report StatusReport, public fleetHostStatus, targetVersion string) (bool, error) {
+func rollingUpdateApplicationReady(report StatusReport, public fleetHostStatus, targetVersion string, requireFailoverReady bool) (bool, error) {
 	if report.Runtime.Observation == ha.ObservationCurrent && report.Runtime.Role == ha.RoleActive {
 		return false, errors.New("updated node became active; inspect the peer before retrying")
 	}
+	controlReady := rollingUpdateControlReady(report.Control)
+	if requireFailoverReady {
+		controlReady = report.Control != nil && report.Control.FailoverReady
+	}
 	return report.Runtime.Role == ha.RolePassive &&
 		applicationReady(report.Runtime, public, targetVersion) &&
-		rollingUpdateControlReady(report.Control), nil
+		controlReady, nil
 }
 
 func rollingUpdateControlReady(control *ControlStatus) bool {
@@ -263,9 +268,9 @@ func ExpectedRollingVersionMismatch(control *ControlStatus) bool {
 		len(control.ReasonCodes) == 1 && control.ReasonCodes[0] == ReasonFleetVersionMismatch
 }
 
-func updatedApplicationReady(report StatusReport, publicStatus fleetHostStatus, targetVersion string, requirePassive bool) (bool, error) {
+func updatedApplicationReady(report StatusReport, publicStatus fleetHostStatus, targetVersion string, requirePassive, requireFailoverReady bool) (bool, error) {
 	if requirePassive {
-		return rollingUpdateApplicationReady(report, publicStatus, targetVersion)
+		return rollingUpdateApplicationReady(report, publicStatus, targetVersion, requireFailoverReady)
 	}
 	if report.Control == nil || !report.Control.ControlReady {
 		return false, nil

--- a/server/internal/ha/deployment/update.go
+++ b/server/internal/ha/deployment/update.go
@@ -152,11 +152,11 @@ func StopApplication(ctx context.Context, root string, expectedRole ha.RuntimeRo
 	}
 	// The crash-only design intentionally has no maintenance lease. If the role
 	// changes after this final proof, normal update recovery restarts Fleet.
-	// Role validation runs while Fleet still serves. Bound only the crash-only
-	// kill so slow control probes cannot consume the interruption budget.
+	// Role validation runs while Fleet still serves. Give Compose one second to
+	// stop cleanly, then let the outer deadline bound forced termination.
 	stopCtx, cancel := context.WithTimeout(ctx, ha.UpdateActiveStopTimeout)
 	defer cancel()
-	if err := RunCompose(stopCtx, fleetComposeArgsAt(root, "kill", "fleet-api", "fleet-client")); err != nil {
+	if err := RunCompose(stopCtx, fleetComposeArgsAt(root, "stop", "--timeout", "1", "fleet-api", "fleet-client")); err != nil {
 		return fmt.Errorf("stop HA application: %w", err)
 	}
 	return nil

--- a/server/internal/ha/deployment/update.go
+++ b/server/internal/ha/deployment/update.go
@@ -13,8 +13,8 @@ import (
 	"github.com/block/proto-fleet/server/internal/transportguard"
 )
 
-// Bounds the planned interruption promised by the HA update flow.
-const vipTakeoverTimeout = 15 * time.Second
+// Leaves room for lease expiry and acquisition before falling back to the old release.
+const vipTakeoverTimeout = 35 * time.Second
 
 func requirePassiveStatus(ctx context.Context, envPath string) (StatusReport, error) {
 	report, err := Status(ctx, envPath)

--- a/server/internal/ha/deployment/update_test.go
+++ b/server/internal/ha/deployment/update_test.go
@@ -189,6 +189,15 @@ func TestAcceptVIPVersionRejectsWrongPeerRelease(t *testing.T) {
 	require.ErrorContains(t, err, "v1.0.0")
 }
 
+func TestAcceptVIPVersionWaitsForActivePeer(t *testing.T) {
+	// Act
+	ready, err := acceptVIPVersion(http.StatusServiceUnavailable, "v1.1.0", "v1.1.0")
+
+	// Assert
+	require.NoError(t, err)
+	require.False(t, ready)
+}
+
 func TestUpdatedPassivePeerReady(t *testing.T) {
 	// Act and assert
 	require.True(t, updatedPassivePeerReady(fleetHostStatus{reachable: true, passive: true, version: "v1.1.0"}, "v1.1.0"))

--- a/server/internal/ha/deployment/update_test.go
+++ b/server/internal/ha/deployment/update_test.go
@@ -123,6 +123,27 @@ func TestRecoveryAcceptsHealthyActiveApplication(t *testing.T) {
 	require.True(t, ready)
 }
 
+func TestApplicationConvergenceRequiresExpectedVersionAndRole(t *testing.T) {
+	for _, test := range []struct {
+		name           string
+		runtime        ha.Status
+		requirePassive bool
+		want           bool
+	}{
+		{name: "active recovery", runtime: ha.Status{Version: "v1.1.0", Role: ha.RoleActive, Observation: ha.ObservationCurrent}, want: true},
+		{name: "active passive-update", runtime: ha.Status{Version: "v1.1.0", Role: ha.RoleActive, Observation: ha.ObservationCurrent}, requirePassive: true},
+		{name: "wrong version", runtime: ha.Status{Version: "v1.0.0", Role: ha.RolePassive, Observation: ha.ObservationCurrent}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			// Act
+			got := applicationMayConverge(test.runtime, "v1.1.0", test.requirePassive)
+
+			// Assert
+			require.Equal(t, test.want, got)
+		})
+	}
+}
+
 func TestCompletedUpdateRequiresFullFailoverReadiness(t *testing.T) {
 	// Arrange
 	report := StatusReport{

--- a/server/internal/ha/deployment/update_test.go
+++ b/server/internal/ha/deployment/update_test.go
@@ -44,7 +44,7 @@ func TestRollingUpdateApplicationRejectsActiveTakeover(t *testing.T) {
 	public := fleetHostStatus{reachable: true, active: true, version: "v1.1.0"}
 
 	// Act
-	ready, err := rollingUpdateApplicationReady(report, public, "v1.1.0")
+	ready, err := rollingUpdateApplicationReady(report, public, "v1.1.0", false)
 
 	// Assert
 	require.False(t, ready)
@@ -116,11 +116,27 @@ func TestRecoveryAcceptsHealthyActiveApplication(t *testing.T) {
 	public := fleetHostStatus{reachable: true, active: true, version: "v1.1.0"}
 
 	// Act
-	ready, err := updatedApplicationReady(report, public, "v1.1.0", false)
+	ready, err := updatedApplicationReady(report, public, "v1.1.0", false, false)
 
 	// Assert
 	require.NoError(t, err)
 	require.True(t, ready)
+}
+
+func TestCompletedUpdateRequiresFullFailoverReadiness(t *testing.T) {
+	// Arrange
+	report := StatusReport{
+		Runtime: ha.Status{Version: "v1.1.0", Role: ha.RolePassive, Observation: ha.ObservationCurrent},
+		Control: &ControlStatus{ControlReady: true, ReasonCodes: []ControlReasonCode{ReasonFleetVersionMismatch}},
+	}
+	public := fleetHostStatus{reachable: true, passive: true, version: "v1.1.0"}
+
+	// Act
+	ready, err := rollingUpdateApplicationReady(report, public, "v1.1.0", true)
+
+	// Assert
+	require.NoError(t, err)
+	require.False(t, ready)
 }
 
 func TestRollingUpdateControlAllowsOnlyExpectedVersionMismatch(t *testing.T) {

--- a/server/internal/ha/deployment/update_test.go
+++ b/server/internal/ha/deployment/update_test.go
@@ -3,6 +3,7 @@ package deployment
 import (
 	"context"
 	"errors"
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -106,6 +107,22 @@ func TestPrepareApplicationUpdateStopsBeforeImageLoadWhenComposeValidationFails(
 	require.Empty(t, commands)
 }
 
+func TestRecoveryAcceptsHealthyActiveApplication(t *testing.T) {
+	// Arrange
+	report := StatusReport{
+		Runtime: ha.Status{Version: "v1.1.0", Role: ha.RoleActive, Observation: ha.ObservationCurrent},
+		Control: &ControlStatus{ControlReady: true},
+	}
+	public := fleetHostStatus{reachable: true, active: true, version: "v1.1.0"}
+
+	// Act
+	ready, err := updatedApplicationReady(report, public, "v1.1.0", false)
+
+	// Assert
+	require.NoError(t, err)
+	require.True(t, ready)
+}
+
 func TestRollingUpdateControlAllowsOnlyExpectedVersionMismatch(t *testing.T) {
 	for _, test := range []struct {
 		name    string
@@ -124,4 +141,21 @@ func TestRollingUpdateControlAllowsOnlyExpectedVersionMismatch(t *testing.T) {
 			require.Equal(t, test.want, ready)
 		})
 	}
+}
+
+func TestAcceptVIPVersionRejectsWrongPeerRelease(t *testing.T) {
+	// Act
+	ready, err := acceptVIPVersion(http.StatusOK, "v1.0.0", "v1.1.0")
+
+	// Assert
+	require.False(t, ready)
+	require.ErrorContains(t, err, "v1.0.0")
+}
+
+func TestUpdatedPassivePeerReady(t *testing.T) {
+	// Act and assert
+	require.True(t, updatedPassivePeerReady(fleetHostStatus{reachable: true, passive: true, version: "v1.1.0"}, "v1.1.0"))
+	require.False(t, updatedPassivePeerReady(fleetHostStatus{reachable: true, version: "v1.1.0"}, "v1.1.0"))
+	require.False(t, updatedPassivePeerReady(fleetHostStatus{reachable: true, active: true, version: "v1.1.0"}, "v1.1.0"))
+	require.False(t, updatedPassivePeerReady(fleetHostStatus{reachable: true, passive: true, version: "v1.0.0"}, "v1.1.0"))
 }

--- a/server/internal/ha/update_timing.go
+++ b/server/internal/ha/update_timing.go
@@ -1,0 +1,8 @@
+package ha
+
+import "time"
+
+const (
+	UpdateActiveStopTimeout = 5 * time.Second
+	UpdateTakeoverTimeout   = 35 * time.Second
+)

--- a/server/internal/handlers/health/handler.go
+++ b/server/internal/handlers/health/handler.go
@@ -128,12 +128,13 @@ type ActiveState interface {
 
 // NewActiveHandler reports whether this process currently owns a healthy
 // active runtime. It does not grant ownership.
-func NewActiveHandler(state ActiveState) func(w http.ResponseWriter, r *http.Request) {
+func NewActiveHandler(version string, state ActiveState) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}
+		w.Header().Set("X-Proto-Fleet-Version", version)
 		if !state.Active() {
 			w.Header().Set("Content-Type", "text/plain")
 			w.WriteHeader(http.StatusServiceUnavailable)

--- a/server/internal/handlers/health/handler_test.go
+++ b/server/internal/handlers/health/handler_test.go
@@ -238,12 +238,13 @@ func TestActiveHandlerReflectsStrictActiveState(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			recorder := httptest.NewRecorder()
 
-			NewActiveHandler(fakeActiveState(test.active))(
+			NewActiveHandler("v1.2.3", fakeActiveState(test.active))(
 				recorder,
 				httptest.NewRequest(http.MethodGet, "/health/active", nil),
 			)
 
 			require.Equal(t, test.statusCode, recorder.Code)
+			require.Equal(t, "v1.2.3", recorder.Header().Get("X-Proto-Fleet-Version"))
 		})
 	}
 }

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -996,7 +996,7 @@ func (m *Manager) trigger(targetVersion, operationID string, idempotent, complet
 		m.mu.RUnlock()
 		return updaterapi.Operation{}, newTriggerError(
 			errTriggerBusy,
-			fmt.Sprintf("HA application recovery for operation %s is pending", recoveryOperationID),
+			fmt.Sprintf("HA application recovery for operation %s is pending; restart proto-fleet-updater.service to retry recovery", recoveryOperationID),
 		)
 	}
 	m.mu.RUnlock()
@@ -1031,7 +1031,7 @@ func (m *Manager) trigger(targetVersion, operationID string, idempotent, complet
 	if m.operation != nil && m.operation.RecoveryPending {
 		return updaterapi.Operation{}, newTriggerError(
 			errTriggerBusy,
-			fmt.Sprintf("HA application recovery for operation %s is pending", m.operation.ID),
+			fmt.Sprintf("HA application recovery for operation %s is pending; restart proto-fleet-updater.service to retry recovery", m.operation.ID),
 		)
 	}
 	if m.closing {

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -1914,7 +1914,7 @@ func (m *Manager) fail(id string, err error, recovery string) {
 	m.operation.Message = "Upgrade failed"
 	m.operation.Error = err.Error()
 	m.operation.RecoveryCommand = recovery
-	m.operation.RecoveryPending = m.cfg.DeploymentMode == DeploymentModeHA && recovery != ""
+	m.operation.RecoveryPending = false
 	m.operation.UpdatedAt = now
 	m.operation.CompletedAt = &now
 	if persistErr := m.persistLocked(); persistErr != nil {

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -1339,11 +1339,7 @@ func (m *Manager) run(ctx context.Context, operationID, targetVersion string, co
 				return
 			}
 		}
-		stopTimeout := m.cfg.ActivationTimeout
-		if complete {
-			stopTimeout = ha.UpdateActiveStopTimeout
-		}
-		if err := m.runHACommand(activationCtx, stopTimeout, currentDeployment, commandOutput, "app-stop", requiredRole); err != nil {
+		if err := m.runHACommand(activationCtx, m.cfg.ActivationTimeout, currentDeployment, commandOutput, "app-stop", requiredRole); err != nil {
 			if complete {
 				restartErr := m.restartHAApplication(ctx, currentDeployment, previousVersion, commandOutput)
 				if restartErr == nil {

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -670,11 +670,6 @@ func NewManager(cfg Config) (*Manager, error) {
 		_ = logRoot.Close()
 		return nil, err
 	}
-	if err := m.recoverHAApplication(); err != nil {
-		_ = processLock.Close()
-		_ = logRoot.Close()
-		return nil, err
-	}
 	if err := m.cleanupStaleArtifacts(); err != nil {
 		_ = processLock.Close()
 		_ = logRoot.Close()

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -568,6 +568,9 @@ func NewManager(cfg Config) (*Manager, error) {
 
 // RepairStartup restores a crash-interrupted deployment layout without starting Fleet.
 func RepairStartup(cfg Config) error {
+	if _, err := PrepareSelfUpdateStartup(cfg.SelfUpdatePath, ""); err != nil {
+		return err
+	}
 	manager, err := newManager(cfg, false)
 	if err != nil {
 		return err

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -565,10 +565,10 @@ func wrapIfError(message string, err error) error {
 }
 
 func NewManager(cfg Config) (*Manager, error) {
-	return newManager(cfg, true)
+	return newManager(cfg)
 }
 
-// RepairStartup restores a crash-interrupted deployment layout without starting Fleet.
+// RepairStartup restores crash-interrupted updater and deployment state before HA starts.
 func RepairStartup(cfg Config) error {
 	canonicalStateDir, err := ensureUpdaterStateDirectory(cfg.StateDir)
 	if err != nil {
@@ -578,21 +578,25 @@ func RepairStartup(cfg Config) error {
 	if err != nil {
 		return err
 	}
-	if _, err := PrepareSelfUpdateStartup(cfg.SelfUpdatePath, ""); err != nil {
-		return errors.Join(err, processLock.Close())
+	_, prepareErr := PrepareSelfUpdateStartup(cfg.SelfUpdatePath, "")
+	if prepareErr != nil && !errors.Is(prepareErr, ErrInterruptedSelfUpdateRestored) {
+		return errors.Join(prepareErr, processLock.Close())
 	}
 	if err := processLock.Close(); err != nil {
 		return fmt.Errorf("release updater repair lock: %w", err)
 	}
 	cfg.StateDir = canonicalStateDir
-	manager, err := newManager(cfg, false)
+	manager, err := newManager(cfg)
 	if err != nil {
 		return err
 	}
-	return manager.Close()
+	if prepareErr != nil {
+		err = manager.restoreUpdaterFromInstalledDeployment()
+	}
+	return errors.Join(err, manager.Close())
 }
 
-func newManager(cfg Config, recoverApplication bool) (*Manager, error) {
+func newManager(cfg Config) (*Manager, error) {
 	if !filepath.IsAbs(cfg.InstallRoot) {
 		return nil, fmt.Errorf("install root must be absolute")
 	}
@@ -704,13 +708,6 @@ func newManager(cfg Config, recoverApplication bool) (*Manager, error) {
 		_ = processLock.Close()
 		_ = logRoot.Close()
 		return nil, err
-	}
-	if recoverApplication {
-		if err := m.recoverHAApplication(); err != nil {
-			_ = processLock.Close()
-			_ = logRoot.Close()
-			return nil, err
-		}
 	}
 	protectedLogName := ""
 	if m.operation != nil {

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -578,9 +578,9 @@ func RepairStartup(cfg Config) error {
 	if err != nil {
 		return err
 	}
-	_, prepareErr := PrepareSelfUpdateStartup(cfg.SelfUpdatePath, "")
-	restoreUpdater := errors.Is(prepareErr, ErrInterruptedSelfUpdateRestored)
-	if prepareErr != nil && !restoreUpdater && !errors.Is(prepareErr, errRetriedSelfUpdateRestored) {
+	prepareErr := prepareSelfUpdateRepair(cfg.SelfUpdatePath)
+	interruptedSelfUpdate := errors.Is(prepareErr, ErrInterruptedSelfUpdateRestored)
+	if prepareErr != nil && !interruptedSelfUpdate && !errors.Is(prepareErr, errRetriedSelfUpdateRestored) {
 		return errors.Join(prepareErr, processLock.Close())
 	}
 	if err := processLock.Close(); err != nil {
@@ -591,8 +591,14 @@ func RepairStartup(cfg Config) error {
 	if err != nil {
 		return err
 	}
-	if restoreUpdater {
-		err = manager.restoreUpdaterFromInstalledDeployment()
+	convergeUpdater := interruptedSelfUpdate || (prepareErr == nil && manager.cfg.DeploymentMode == DeploymentModeHA)
+	if manager.cfg.SelfUpdatePath != "" && convergeUpdater {
+		matches, matchErr := manager.updaterMatchesInstalledDeployment()
+		if matchErr != nil {
+			err = matchErr
+		} else if !matches {
+			err = manager.restoreUpdaterFromInstalledDeployment()
+		}
 	}
 	return errors.Join(err, manager.Close())
 }
@@ -720,29 +726,6 @@ func newManager(cfg Config) (*Manager, error) {
 		return nil, fmt.Errorf("prune updater operation logs: %w", err)
 	}
 	return m, nil
-}
-
-// RepairStartup restores crash-interrupted updater and deployment state before HA starts.
-func RepairStartup(cfg Config) error {
-	prepareErr := prepareSelfUpdateRepair(cfg.SelfUpdatePath)
-	interruptedSelfUpdate := errors.Is(prepareErr, ErrInterruptedSelfUpdateRestored)
-	if prepareErr != nil && !interruptedSelfUpdate && !errors.Is(prepareErr, errRetriedSelfUpdateRestored) {
-		return prepareErr
-	}
-	manager, err := NewManager(cfg)
-	if err != nil {
-		return err
-	}
-	convergeUpdater := interruptedSelfUpdate || (prepareErr == nil && manager.cfg.DeploymentMode == DeploymentModeHA)
-	if manager.cfg.SelfUpdatePath != "" && convergeUpdater {
-		matches, matchErr := manager.updaterMatchesInstalledDeployment()
-		if matchErr != nil {
-			err = matchErr
-		} else if !matches {
-			err = manager.restoreUpdaterFromInstalledDeployment()
-		}
-	}
-	return errors.Join(err, manager.Close())
 }
 
 func (m *Manager) updaterMatchesInstalledDeployment() (bool, error) {

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -760,7 +760,7 @@ func (m *Manager) RecoverApplication() error {
 	if err != nil {
 		return fmt.Errorf("read interrupted HA deployment version: %w", err)
 	}
-	if err := m.runHACommand(context.Background(), m.cfg.ActivationTimeout, deployment, io.Discard, "app-start", version, "any"); err != nil {
+	if err := m.runHACommand(context.Background(), m.cfg.ActivationTimeout, deployment, io.Discard, "app-recover", version); err != nil {
 		recoveryErr := fmt.Errorf("restart interrupted HA application: %w", err)
 		m.operation.Phase = updaterapi.PhaseFailed
 		m.operation.Message = "HA application recovery failed"

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -987,10 +987,10 @@ func (m *Manager) trigger(targetVersion, operationID string, idempotent, complet
 	if idempotent && m.operation != nil && m.operation.ID == operationID {
 		existing := *m.operation
 		m.mu.RUnlock()
-		if existing.TargetVersion != targetVersion {
+		if existing.TargetVersion != targetVersion || existing.Complete != complete {
 			return updaterapi.Operation{}, newTriggerError(
 				errTriggerInvalid,
-				"operation id is already associated with another target",
+				"operation id is already associated with another update",
 			)
 		}
 		return existing, nil
@@ -1024,10 +1024,10 @@ func (m *Manager) trigger(targetVersion, operationID string, idempotent, complet
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if idempotent && m.operation != nil && m.operation.ID == operationID {
-		if m.operation.TargetVersion != targetVersion {
+		if m.operation.TargetVersion != targetVersion || m.operation.Complete != complete {
 			return updaterapi.Operation{}, newTriggerError(
 				errTriggerInvalid,
-				"operation id is already associated with another target",
+				"operation id is already associated with another update",
 			)
 		}
 		return *m.operation, nil
@@ -1086,6 +1086,7 @@ func (m *Manager) trigger(targetVersion, operationID string, idempotent, complet
 	op := &updaterapi.Operation{
 		ID:            operationID,
 		TargetVersion: targetVersion,
+		Complete:      complete,
 		Phase:         updaterapi.PhaseQueued,
 		Message:       "Upgrade queued",
 		StartedAt:     now,

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -579,7 +579,8 @@ func RepairStartup(cfg Config) error {
 		return err
 	}
 	_, prepareErr := PrepareSelfUpdateStartup(cfg.SelfUpdatePath, "")
-	if prepareErr != nil && !errors.Is(prepareErr, ErrInterruptedSelfUpdateRestored) {
+	restoreUpdater := errors.Is(prepareErr, ErrInterruptedSelfUpdateRestored)
+	if prepareErr != nil && !restoreUpdater && !errors.Is(prepareErr, errRetriedSelfUpdateRestored) {
 		return errors.Join(prepareErr, processLock.Close())
 	}
 	if err := processLock.Close(); err != nil {
@@ -590,7 +591,7 @@ func RepairStartup(cfg Config) error {
 	if err != nil {
 		return err
 	}
-	if prepareErr != nil {
+	if restoreUpdater {
 		err = manager.restoreUpdaterFromInstalledDeployment()
 	}
 	return errors.Join(err, manager.Close())

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -563,6 +563,19 @@ func wrapIfError(message string, err error) error {
 }
 
 func NewManager(cfg Config) (*Manager, error) {
+	return newManager(cfg, true)
+}
+
+// RepairStartup restores a crash-interrupted deployment layout without starting Fleet.
+func RepairStartup(cfg Config) error {
+	manager, err := newManager(cfg, false)
+	if err != nil {
+		return err
+	}
+	return manager.Close()
+}
+
+func newManager(cfg Config, recoverApplication bool) (*Manager, error) {
 	if !filepath.IsAbs(cfg.InstallRoot) {
 		return nil, fmt.Errorf("install root must be absolute")
 	}
@@ -674,6 +687,13 @@ func NewManager(cfg Config) (*Manager, error) {
 		_ = processLock.Close()
 		_ = logRoot.Close()
 		return nil, err
+	}
+	if recoverApplication {
+		if err := m.recoverHAApplication(); err != nil {
+			_ = processLock.Close()
+			_ = logRoot.Close()
+			return nil, err
+		}
 	}
 	protectedLogName := ""
 	if m.operation != nil {

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -1337,6 +1337,18 @@ func (m *Manager) run(ctx context.Context, operationID, targetVersion string, co
 			stopTimeout = ha.UpdateActiveStopTimeout
 		}
 		if err := m.runHACommand(activationCtx, stopTimeout, currentDeployment, commandOutput, "app-stop", requiredRole); err != nil {
+			if complete {
+				restartErr := m.restartHAApplication(ctx, currentDeployment, previousVersion, commandOutput)
+				if restartErr == nil {
+					m.fail(operationID, fmt.Errorf("stop HA application failed; previous release restarted: %w", err), "")
+					return
+				}
+				m.fail(operationID, errors.Join(
+					fmt.Errorf("stop HA application: %w", err),
+					fmt.Errorf("restart previous release: %w", restartErr),
+				), recovery)
+				return
+			}
 			m.failActivation(operationID, targetVersion, fmt.Errorf("stop HA application: %w", err), logFile, true)
 			return
 		}

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -60,6 +60,7 @@ const (
 	processLockFilename      = "updater.lock"
 	activationMarkerFilename = "activation-swap.json"
 	activationMarkerTempName = ".activation-swap.json.tmp"
+	qualificationBarrierName = "qualification-pause-before-ha-stop"
 	preflightProofFilename   = ".update-preflight-complete"
 	operationArtifactPrefix  = ".proto-fleet-upgrade-"
 	selfUpdateBackupSuffix   = ".previous"
@@ -1332,6 +1333,12 @@ func (m *Manager) run(ctx context.Context, operationID, targetVersion string, co
 			m.failActivation(operationID, targetVersion, fmt.Errorf("persist passive application recovery: %w", err), logFile, false)
 			return
 		}
+		if complete {
+			if err := m.waitForQualificationBarrier(activationCtx); err != nil {
+				m.fail(operationID, errors.Join(err, m.clearActivationMarker()), "")
+				return
+			}
+		}
 		stopTimeout := m.cfg.ActivationTimeout
 		if complete {
 			stopTimeout = ha.UpdateActiveStopTimeout
@@ -1447,6 +1454,27 @@ func (m *Manager) restartHAApplication(
 		return err
 	}
 	return m.clearActivationMarker()
+}
+
+// A root-created barrier lets exact release qualification stop the peer after
+// final preflight without racing the old application's stop. Normal hosts never
+// create this file and take the fast path.
+func (m *Manager) waitForQualificationBarrier(ctx context.Context) error {
+	path := filepath.Join(m.cfg.StateDir, qualificationBarrierName)
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if _, err := os.Lstat(path); errors.Is(err, os.ErrNotExist) {
+			return nil
+		} else if err != nil {
+			return fmt.Errorf("inspect HA update qualification barrier: %w", err)
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("wait for HA update qualification barrier: %w", ctx.Err())
+		case <-ticker.C:
+		}
+	}
 }
 
 func (m *Manager) runPreflight(ctx context.Context, deployment string, output io.Writer) error {

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -49,23 +49,25 @@ const (
 	// Activation includes migrations and multiple readiness windows after the
 	// old stack is stopped. Timing out requires forward manual recovery, making
 	// this a minimum liveness bound rather than spare retry time.
-	defaultActivationTimeout = 45 * time.Minute
-	defaultCleanupTimeout    = 2 * time.Minute
-	defaultCandidateTimeout  = 10 * time.Second
-	maxCommandLogBytes       = int64(64 << 20)
-	maxCandidateVersionBytes = int64(4096)
-	maxRetainedOperationLogs = 8
-	maxRetainedLogBytes      = int64(256 << 20)
-	canonicalDownloadBaseURL = "https://github.com/block/proto-fleet/releases/download"
-	processLockFilename      = "updater.lock"
-	activationMarkerFilename = "activation-swap.json"
-	activationMarkerTempName = ".activation-swap.json.tmp"
-	qualificationBarrierName = "qualification-pause-before-ha-stop"
-	preflightProofFilename   = ".update-preflight-complete"
-	operationArtifactPrefix  = ".proto-fleet-upgrade-"
-	selfUpdateBackupSuffix   = ".previous"
-	stateTempPrefix          = ".state-"
-	haNodeEnvPath            = "/etc/proto-fleet/ha/node.env"
+	defaultActivationTimeout               = 45 * time.Minute
+	defaultCleanupTimeout                  = 2 * time.Minute
+	defaultCandidateTimeout                = 10 * time.Second
+	maxCommandLogBytes                     = int64(64 << 20)
+	maxCandidateVersionBytes               = int64(4096)
+	maxRetainedOperationLogs               = 8
+	maxRetainedLogBytes                    = int64(256 << 20)
+	canonicalDownloadBaseURL               = "https://github.com/block/proto-fleet/releases/download"
+	processLockFilename                    = "updater.lock"
+	activationMarkerFilename               = "activation-swap.json"
+	activationMarkerTempName               = ".activation-swap.json.tmp"
+	qualificationBeforeStopBarrierName     = "qualification-pause-before-ha-stop"
+	qualificationAfterStopBarrierName      = "qualification-pause-after-ha-stop"
+	qualificationBetweenRenamesBarrierName = "qualification-pause-between-deployment-renames"
+	preflightProofFilename                 = ".update-preflight-complete"
+	operationArtifactPrefix                = ".proto-fleet-upgrade-"
+	selfUpdateBackupSuffix                 = ".previous"
+	stateTempPrefix                        = ".state-"
+	haNodeEnvPath                          = "/etc/proto-fleet/ha/node.env"
 )
 
 var (
@@ -1315,7 +1317,7 @@ func (m *Manager) run(ctx context.Context, operationID, targetVersion string, co
 			return
 		}
 		if complete {
-			if err := m.waitForQualificationBarrier(activationCtx); err != nil {
+			if err := m.waitForQualificationBarrier(activationCtx, qualificationBeforeStopBarrierName); err != nil {
 				m.fail(operationID, errors.Join(err, m.clearActivationMarker()), "")
 				return
 			}
@@ -1337,6 +1339,15 @@ func (m *Manager) run(ctx context.Context, operationID, targetVersion string, co
 			return
 		}
 		if complete {
+			if err := m.waitForQualificationBarrier(activationCtx, qualificationAfterStopBarrierName); err != nil {
+				restartErr := m.restartHAApplication(ctx, currentDeployment, previousVersion, commandOutput)
+				if restartErr == nil {
+					m.fail(operationID, fmt.Errorf("post-stop qualification pause failed; previous release restarted: %w", err), "")
+					return
+				}
+				m.failPendingRecovery(operationID, errors.Join(err, restartErr), recovery)
+				return
+			}
 			takeoverCtx, cancelTakeover := context.WithTimeout(activationCtx, ha.UpdateTakeoverTimeout)
 			err := m.runHACommand(takeoverCtx, ha.UpdateTakeoverTimeout, currentDeployment, commandOutput, "wait-takeover", targetVersion)
 			cancelTakeover()
@@ -1351,7 +1362,13 @@ func (m *Manager) run(ctx context.Context, operationID, targetVersion string, co
 			}
 		}
 	}
-	if err := activateDeployment(stageDeployment, currentDeployment, backupDeployment); err != nil {
+	betweenRenames := func() error { return nil }
+	if m.cfg.DeploymentMode == DeploymentModeHA {
+		betweenRenames = func() error {
+			return m.waitForQualificationBarrier(activationCtx, qualificationBetweenRenamesBarrierName)
+		}
+	}
+	if err := activateDeployment(stageDeployment, currentDeployment, backupDeployment, betweenRenames); err != nil {
 		m.failActivation(operationID, targetVersion, err, logFile, m.cfg.DeploymentMode == DeploymentModeHA)
 		return
 	}
@@ -1433,11 +1450,10 @@ func (m *Manager) restartHAApplication(
 	return m.clearActivationMarker()
 }
 
-// A root-created barrier lets exact release qualification stop the peer after
-// final preflight without racing the old application's stop. Normal hosts never
-// create this file and take the fast path.
-func (m *Manager) waitForQualificationBarrier(ctx context.Context) error {
-	path := filepath.Join(m.cfg.StateDir, qualificationBarrierName)
+// Root-created barriers let exact release qualification pause at otherwise
+// unobservable crash windows. Normal hosts never create them and take the fast path.
+func (m *Manager) waitForQualificationBarrier(ctx context.Context, name string) error {
+	path := filepath.Join(m.cfg.StateDir, name)
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 	for {
@@ -1631,7 +1647,7 @@ func (m *Manager) failActivation(
 // portable filesystem operation, so every completed metadata step is fsynced
 // and every pre-command failure attempts a checked restoration. Startup
 // reconciliation covers a process or power loss between the renames.
-func activateDeployment(staged, current, previous string) error {
+func activateDeployment(staged, current, previous string, betweenRenames func() error) error {
 	installRoot := filepath.Dir(current)
 	stageRoot := filepath.Dir(staged)
 	if err := os.RemoveAll(previous); err != nil {
@@ -1647,6 +1663,13 @@ func activateDeployment(staged, current, previous string) error {
 		restoreErr := restorePreviousDeployment(current, previous, installRoot)
 		return errors.Join(
 			fmt.Errorf("persist current deployment backup: %w", err),
+			restoreErr,
+		)
+	}
+	if err := betweenRenames(); err != nil {
+		restoreErr := restorePreviousDeployment(current, previous, installRoot)
+		return errors.Join(
+			fmt.Errorf("pause between deployment renames: %w", err),
 			restoreErr,
 		)
 	}

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -760,7 +760,7 @@ func (m *Manager) RecoverApplication() error {
 	if err != nil {
 		return fmt.Errorf("read interrupted HA deployment version: %w", err)
 	}
-	if err := m.runHACommand(context.Background(), m.cfg.ActivationTimeout, deployment, io.Discard, "app-recover", version); err != nil {
+	if err := m.runHACommand(context.Background(), m.cfg.ActivationTimeout, deployment, io.Discard, "app-start", version, "any"); err != nil {
 		recoveryErr := fmt.Errorf("restart interrupted HA application: %w", err)
 		m.operation.Phase = updaterapi.PhaseFailed
 		m.operation.Message = "HA application recovery failed"

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -1904,6 +1904,7 @@ func (m *Manager) fail(id string, err error, recovery string) {
 	m.operation.Message = "Upgrade failed"
 	m.operation.Error = err.Error()
 	m.operation.RecoveryCommand = recovery
+	m.operation.RecoveryPending = m.cfg.DeploymentMode == DeploymentModeHA && recovery != ""
 	m.operation.UpdatedAt = now
 	m.operation.CompletedAt = &now
 	if persistErr := m.persistLocked(); persistErr != nil {

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -1320,20 +1320,19 @@ func (m *Manager) run(ctx context.Context, operationID, targetVersion string, co
 			m.failActivation(operationID, targetVersion, fmt.Errorf("persist passive application recovery: %w", err), logFile, false)
 			return
 		}
-		haActivationCtx := activationCtx
 		stopTimeout := m.cfg.ActivationTimeout
-		cancelOutage := func() {}
 		if complete {
-			haActivationCtx, cancelOutage = context.WithTimeout(activationCtx, ha.UpdateTakeoverTimeout)
 			stopTimeout = ha.UpdateActiveStopTimeout
 		}
-		defer cancelOutage()
-		if err := m.runHACommand(haActivationCtx, stopTimeout, currentDeployment, commandOutput, "app-stop", requiredRole); err != nil {
+		if err := m.runHACommand(activationCtx, stopTimeout, currentDeployment, commandOutput, "app-stop", requiredRole); err != nil {
 			m.failActivation(operationID, targetVersion, fmt.Errorf("stop HA application: %w", err), logFile, true)
 			return
 		}
 		if complete {
-			if err := m.runHACommand(haActivationCtx, ha.UpdateTakeoverTimeout, currentDeployment, commandOutput, "wait-takeover", targetVersion); err != nil {
+			takeoverCtx, cancelTakeover := context.WithTimeout(activationCtx, ha.UpdateTakeoverTimeout)
+			err := m.runHACommand(takeoverCtx, ha.UpdateTakeoverTimeout, currentDeployment, commandOutput, "wait-takeover", targetVersion)
+			cancelTakeover()
+			if err != nil {
 				restartErr := m.restartHAApplication(ctx, currentDeployment, previousVersion, commandOutput)
 				if restartErr == nil {
 					m.fail(operationID, fmt.Errorf("updated peer did not take over; previous release restarted: %w", err), "")

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -569,9 +569,21 @@ func NewManager(cfg Config) (*Manager, error) {
 
 // RepairStartup restores a crash-interrupted deployment layout without starting Fleet.
 func RepairStartup(cfg Config) error {
-	if _, err := PrepareSelfUpdateStartup(cfg.SelfUpdatePath, ""); err != nil {
+	canonicalStateDir, err := ensureUpdaterStateDirectory(cfg.StateDir)
+	if err != nil {
 		return err
 	}
+	processLock, err := acquireProcessLock(canonicalStateDir)
+	if err != nil {
+		return err
+	}
+	if _, err := PrepareSelfUpdateStartup(cfg.SelfUpdatePath, ""); err != nil {
+		return errors.Join(err, processLock.Close())
+	}
+	if err := processLock.Close(); err != nil {
+		return fmt.Errorf("release updater repair lock: %w", err)
+	}
+	cfg.StateDir = canonicalStateDir
 	manager, err := newManager(cfg, false)
 	if err != nil {
 		return err

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -2058,11 +2058,6 @@ func (m *Manager) loadState() error {
 		}
 		return err
 	}
-	if marker != nil {
-		if err := m.clearActivationMarker(); err != nil {
-			return err
-		}
-	}
 	if !wasTerminal {
 		op.RecoveryPending = m.cfg.DeploymentMode == DeploymentModeHA && op.RecoveryCommand != ""
 		now := m.cfg.Now().UTC()
@@ -2097,7 +2092,13 @@ func (m *Manager) loadState() error {
 		op.RecoveryPending = true
 	}
 	m.operation = &op
-	return m.persistReconciledState()
+	if err := m.persistReconciledState(); err != nil {
+		return err
+	}
+	if marker != nil {
+		return m.clearActivationMarker()
+	}
+	return nil
 }
 
 // persistReconciledState normally preserves the ordering of reconciliation,

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -670,6 +670,11 @@ func NewManager(cfg Config) (*Manager, error) {
 		_ = logRoot.Close()
 		return nil, err
 	}
+	if err := m.recoverHAApplication(); err != nil {
+		_ = processLock.Close()
+		_ = logRoot.Close()
+		return nil, err
+	}
 	if err := m.cleanupStaleArtifacts(); err != nil {
 		_ = processLock.Close()
 		_ = logRoot.Close()
@@ -910,7 +915,7 @@ func (m *Manager) Trigger(targetVersion string) (updaterapi.Operation, error) {
 	if m.cfg.NewID == nil {
 		return updaterapi.Operation{}, fmt.Errorf("generate updater operation id: generator is not configured")
 	}
-	return m.trigger(targetVersion, m.cfg.NewID(), false)
+	return m.trigger(targetVersion, m.cfg.NewID(), false, false)
 }
 
 // TriggerWithID accepts a caller-generated UUID so a client that loses the
@@ -918,14 +923,22 @@ func (m *Manager) Trigger(targetVersion string) (updaterapi.Operation, error) {
 // guessing by target or time. Reusing the ID for the same target is
 // idempotent; reusing it for another target is rejected.
 func (m *Manager) TriggerWithID(targetVersion, operationID string) (updaterapi.Operation, error) {
+	return m.triggerWithID(targetVersion, operationID, false)
+}
+
+func (m *Manager) TriggerCompleteWithID(targetVersion, operationID string) (updaterapi.Operation, error) {
+	return m.triggerWithID(targetVersion, operationID, true)
+}
+
+func (m *Manager) triggerWithID(targetVersion, operationID string, complete bool) (updaterapi.Operation, error) {
 	parsedID, err := uuid.Parse(operationID)
 	if err != nil || parsedID.String() != operationID {
 		return updaterapi.Operation{}, newTriggerError(errTriggerInvalid, "operation id must be a canonical UUID")
 	}
-	return m.trigger(targetVersion, operationID, true)
+	return m.trigger(targetVersion, operationID, true, complete)
 }
 
-func (m *Manager) trigger(targetVersion, operationID string, idempotent bool) (updaterapi.Operation, error) {
+func (m *Manager) trigger(targetVersion, operationID string, idempotent, complete bool) (updaterapi.Operation, error) {
 	if operationID == "" {
 		return updaterapi.Operation{}, fmt.Errorf("generate updater operation id: empty value")
 	}
@@ -934,6 +947,9 @@ func (m *Manager) trigger(targetVersion, operationID string, idempotent bool) (u
 			errTriggerInvalid,
 			"target version must be a stable or RC release tag",
 		)
+	}
+	if complete && m.cfg.DeploymentMode != DeploymentModeHA {
+		return updaterapi.Operation{}, newTriggerError(errTriggerPrecondition, "completion updates require HA deployment mode")
 	}
 	// Check before host-state validation so a retry can recover the original
 	// response even after that operation has completed and changed the
@@ -1047,7 +1063,7 @@ func (m *Manager) trigger(targetVersion, operationID string, idempotent bool) (u
 	go func() {
 		defer m.operationWG.Done()
 		defer m.finishOperation()
-		m.run(operationCtx, operationCopy.ID, targetVersion)
+		m.run(operationCtx, operationCopy.ID, targetVersion, complete)
 	}()
 	return operationCopy, nil
 }
@@ -1059,7 +1075,7 @@ func (m *Manager) finishOperation() {
 	m.cancelOperation = nil
 }
 
-func (m *Manager) run(ctx context.Context, operationID, targetVersion string) {
+func (m *Manager) run(ctx context.Context, operationID, targetVersion string, complete bool) {
 	logName := operationLogFilename(operationID)
 	logPath := filepath.Join(m.cfg.StateDir, "logs", logName)
 	logFile, err := m.logRoot.OpenFile(logName, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
@@ -1236,9 +1252,15 @@ func (m *Manager) run(ctx context.Context, operationID, targetVersion string) {
 		return
 	}
 
+	requiredRole := "passive"
 	if m.cfg.DeploymentMode == DeploymentModeHA {
-		if err := m.runHACommand(ctx, m.cfg.ActivationTimeout, currentDeployment, commandOutput, "require-passive", haNodeEnvPath, targetVersion); err != nil {
-			m.fail(operationID, fmt.Errorf("local Fleet is not passive immediately before activation: %w", err), recovery)
+		requireArgs := []string{"require-passive", haNodeEnvPath, targetVersion}
+		if complete {
+			requiredRole = "active"
+			requireArgs = []string{"require-active", haNodeEnvPath}
+		}
+		if err := m.runHACommand(ctx, m.cfg.ActivationTimeout, currentDeployment, commandOutput, requireArgs...); err != nil {
+			m.fail(operationID, fmt.Errorf("local Fleet is not %s immediately before activation: %w", requiredRole, err), recovery)
 			return
 		}
 	}
@@ -1255,9 +1277,21 @@ func (m *Manager) run(ctx context.Context, operationID, targetVersion string) {
 			m.failActivation(operationID, targetVersion, fmt.Errorf("persist passive application recovery: %w", err), logFile, false)
 			return
 		}
-		if err := m.runHACommand(activationCtx, m.cfg.ActivationTimeout, currentDeployment, commandOutput, "app-stop"); err != nil {
-			m.failActivation(operationID, targetVersion, fmt.Errorf("stop passive HA application: %w", err), logFile, true)
+		if err := m.runHACommand(activationCtx, m.cfg.ActivationTimeout, currentDeployment, commandOutput, "app-stop", requiredRole); err != nil {
+			m.failActivation(operationID, targetVersion, fmt.Errorf("stop HA application: %w", err), logFile, true)
 			return
+		}
+		if complete {
+			if err := m.runHACommand(activationCtx, m.cfg.ActivationTimeout, currentDeployment, commandOutput, "wait-takeover", targetVersion); err != nil {
+				restartErr := m.runHACommand(activationCtx, m.cfg.ActivationTimeout, currentDeployment, commandOutput, "app-start", previousVersion, "any")
+				clearErr := m.clearActivationMarker()
+				if restartErr == nil && clearErr == nil {
+					m.fail(operationID, fmt.Errorf("updated peer did not take over; previous release restarted: %w", err), "")
+					return
+				}
+				m.fail(operationID, errors.Join(err, restartErr, clearErr), m.activationRecoveryCommand(currentDeployment, previousVersion))
+				return
+			}
 		}
 	}
 	if err := activateDeployment(stageDeployment, currentDeployment, backupDeployment); err != nil {
@@ -1337,7 +1371,7 @@ func (m *Manager) runPreflight(ctx context.Context, deployment string, output io
 
 func (m *Manager) runActivation(ctx context.Context, deployment, targetVersion string, output io.Writer) error {
 	if m.cfg.DeploymentMode == DeploymentModeHA {
-		return m.runHACommand(ctx, m.cfg.ActivationTimeout, deployment, output, "app-start", targetVersion)
+		return m.runHACommand(ctx, m.cfg.ActivationTimeout, deployment, output, "app-start", targetVersion, "passive")
 	}
 	return m.runCommand(ctx, m.cfg.ActivationTimeout, deployment, output, "/bin/bash", "./run-fleet.sh", "--non-interactive", "--skip-build")
 }
@@ -1925,7 +1959,7 @@ func (m *Manager) loadState() error {
 		op.Phase = updaterapi.PhaseFailed
 		if restoredPrevious {
 			op.Message = "Upgrade interrupted; previous deployment restored"
-			op.Error = "The updater restarted during the activation swap before Fleet was stopped. The previous deployment was restored safely."
+			op.Error = "The updater restarted during the activation swap. The previous deployment was restored."
 		} else {
 			op.Message = "Upgrade interrupted"
 			op.Error = "The updater restarted before the operation completed; inspect the host log and recovery details before retrying."
@@ -1940,6 +1974,9 @@ func (m *Manager) loadState() error {
 			op.Error = "The active deployment was missing; the updater restored the validated previous deployment."
 		} else {
 			op.Error += " The active deployment was missing during startup; the updater restored the validated previous deployment."
+		}
+		if m.cfg.DeploymentMode != DeploymentModeHA {
+			op.RecoveryCommand = ""
 		}
 		op.UpdatedAt = now
 		if op.CompletedAt == nil {

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -1591,6 +1591,7 @@ func (m *Manager) failActivation(
 	logOutput io.Writer,
 	restartHA bool,
 ) {
+	recoveryPending := false
 	layout := &updaterapi.Operation{
 		TargetVersion: targetVersion,
 		Phase:         updaterapi.PhaseActivating,
@@ -1615,9 +1616,14 @@ func (m *Manager) failActivation(
 		}
 		if err != nil {
 			activationErr = errors.Join(activationErr, fmt.Errorf("restart HA application after failed activation: %w", err))
+			recoveryPending = layout.RecoveryCommand != ""
 		} else {
 			layout.RecoveryCommand = ""
 		}
+	}
+	if recoveryPending {
+		m.failPendingRecovery(operationID, activationErr, layout.RecoveryCommand)
+		return
 	}
 	m.fail(operationID, activationErr, layout.RecoveryCommand)
 }

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -752,7 +752,7 @@ func (m *Manager) restoreUpdaterFromInstalledDeployment() error {
 
 // RecoverApplication restarts an application left stopped by an interrupted HA update.
 func (m *Manager) RecoverApplication() error {
-	if m.cfg.DeploymentMode != DeploymentModeHA || m.operation == nil || m.operation.RecoveryCommand == "" {
+	if m.operation == nil || !m.operation.RecoveryPending || m.operation.RecoveryCommand == "" {
 		return nil
 	}
 	deployment := filepath.Join(m.cfg.InstallRoot, "deployment")
@@ -764,6 +764,7 @@ func (m *Manager) RecoverApplication() error {
 		return fmt.Errorf("restart interrupted HA application: %w", err)
 	}
 	m.operation.RecoveryCommand = ""
+	m.operation.RecoveryPending = false
 	m.operation.Message += "; HA application restarted"
 	m.operation.UpdatedAt = m.cfg.Now().UTC()
 	return m.persistLocked()
@@ -1950,6 +1951,7 @@ func (m *Manager) loadState() error {
 		}
 	}
 	if !wasTerminal {
+		op.RecoveryPending = m.cfg.DeploymentMode == DeploymentModeHA && op.RecoveryCommand != ""
 		now := m.cfg.Now().UTC()
 		op.Phase = updaterapi.PhaseFailed
 		if restoredPrevious {

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -1284,13 +1284,12 @@ func (m *Manager) run(ctx context.Context, operationID, targetVersion string, co
 		}
 		if complete {
 			if err := m.runHACommand(activationCtx, m.cfg.ActivationTimeout, currentDeployment, commandOutput, "wait-takeover", targetVersion); err != nil {
-				restartErr := m.runHACommand(activationCtx, m.cfg.ActivationTimeout, currentDeployment, commandOutput, "app-start", previousVersion, "any")
-				clearErr := m.clearActivationMarker()
-				if restartErr == nil && clearErr == nil {
+				restartErr := m.restartHAApplication(ctx, currentDeployment, previousVersion, commandOutput)
+				if restartErr == nil {
 					m.fail(operationID, fmt.Errorf("updated peer did not take over; previous release restarted: %w", err), "")
 					return
 				}
-				m.fail(operationID, errors.Join(err, restartErr, clearErr), m.activationRecoveryCommand(currentDeployment, previousVersion))
+				m.fail(operationID, errors.Join(err, restartErr), m.activationRecoveryCommand(currentDeployment, previousVersion))
 				return
 			}
 		}
@@ -1361,6 +1360,20 @@ func (m *Manager) run(ctx context.Context, operationID, targetVersion string, co
 		}
 	}
 	_, _ = fmt.Fprintf(logFile, "[%s] upgrade completed\n", m.cfg.Now().UTC().Format(time.RFC3339))
+}
+
+func (m *Manager) restartHAApplication(
+	parent context.Context,
+	deployment string,
+	version string,
+	output io.Writer,
+) error {
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(parent), m.cfg.ActivationTimeout)
+	defer cancel()
+	if err := m.runHACommand(ctx, m.cfg.ActivationTimeout, deployment, output, "app-start", version, "any"); err != nil {
+		return err
+	}
+	return m.clearActivationMarker()
 }
 
 func (m *Manager) runPreflight(ctx context.Context, deployment string, output io.Writer) error {

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -1327,7 +1327,7 @@ func (m *Manager) run(ctx context.Context, operationID, targetVersion string, co
 					m.fail(operationID, fmt.Errorf("stop HA application failed; previous release restarted: %w", err), "")
 					return
 				}
-				m.fail(operationID, errors.Join(
+				m.failPendingRecovery(operationID, errors.Join(
 					fmt.Errorf("stop HA application: %w", err),
 					fmt.Errorf("restart previous release: %w", restartErr),
 				), recovery)
@@ -1346,7 +1346,7 @@ func (m *Manager) run(ctx context.Context, operationID, targetVersion string, co
 					m.fail(operationID, fmt.Errorf("updated peer did not take over; previous release restarted: %w", err), "")
 					return
 				}
-				m.fail(operationID, errors.Join(err, restartErr), m.activationRecoveryCommand(currentDeployment, previousVersion))
+				m.failPendingRecovery(operationID, errors.Join(err, restartErr), m.activationRecoveryCommand(currentDeployment, previousVersion))
 				return
 			}
 		}
@@ -1935,6 +1935,14 @@ func (m *Manager) setRecoveryCommand(id, recovery string) error {
 }
 
 func (m *Manager) fail(id string, err error, recovery string) {
+	m.finishFailure(id, err, recovery, false)
+}
+
+func (m *Manager) failPendingRecovery(id string, err error, recovery string) {
+	m.finishFailure(id, err, recovery, true)
+}
+
+func (m *Manager) finishFailure(id string, err error, recovery string, recoveryPending bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.operation == nil || m.operation.ID != id {
@@ -1946,7 +1954,7 @@ func (m *Manager) fail(id string, err error, recovery string) {
 	m.operation.Message = "Upgrade failed"
 	m.operation.Error = err.Error()
 	m.operation.RecoveryCommand = recovery
-	m.operation.RecoveryPending = false
+	m.operation.RecoveryPending = recoveryPending
 	m.operation.UpdatedAt = now
 	m.operation.CompletedAt = &now
 	if persistErr := m.persistLocked(); persistErr != nil {

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -1591,7 +1591,6 @@ func (m *Manager) failActivation(
 	logOutput io.Writer,
 	restartHA bool,
 ) {
-	recoveryPending := false
 	layout := &updaterapi.Operation{
 		TargetVersion: targetVersion,
 		Phase:         updaterapi.PhaseActivating,
@@ -1616,12 +1615,11 @@ func (m *Manager) failActivation(
 		}
 		if err != nil {
 			activationErr = errors.Join(activationErr, fmt.Errorf("restart HA application after failed activation: %w", err))
-			recoveryPending = layout.RecoveryCommand != ""
 		} else {
 			layout.RecoveryCommand = ""
 		}
 	}
-	if recoveryPending {
+	if restartHA && layout.RecoveryCommand != "" {
 		m.failPendingRecovery(operationID, activationErr, layout.RecoveryCommand)
 		return
 	}
@@ -2094,6 +2092,9 @@ func (m *Manager) loadState() error {
 		if op.CompletedAt == nil {
 			op.CompletedAt = &now
 		}
+	}
+	if marker != nil && m.cfg.DeploymentMode == DeploymentModeHA && op.RecoveryCommand != "" {
+		op.RecoveryPending = true
 	}
 	m.operation = &op
 	return m.persistReconciledState()

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -1363,7 +1363,7 @@ func (m *Manager) run(ctx context.Context, operationID, targetVersion string, co
 		return
 	}
 
-	if err := m.runActivation(activationCtx, currentDeployment, targetVersion, commandOutput); err != nil {
+	if err := m.runActivation(activationCtx, currentDeployment, targetVersion, complete, commandOutput); err != nil {
 		activationErr := fmt.Errorf("new stack failed to start: %w", err)
 		// Migrations may already have run, so keep the new deployment active for
 		// forward recovery instead of starting an older binary against its schema.
@@ -1433,9 +1433,13 @@ func (m *Manager) runPreflight(ctx context.Context, deployment string, output io
 	return m.runCommand(ctx, m.cfg.PreflightTimeout, deployment, output, "/bin/bash", "./run-fleet.sh", "--non-interactive", "--preflight-only")
 }
 
-func (m *Manager) runActivation(ctx context.Context, deployment, targetVersion string, output io.Writer) error {
+func (m *Manager) runActivation(ctx context.Context, deployment, targetVersion string, complete bool, output io.Writer) error {
 	if m.cfg.DeploymentMode == DeploymentModeHA {
-		return m.runHACommand(ctx, m.cfg.ActivationTimeout, deployment, output, "app-start", targetVersion, "passive")
+		mode := "passive"
+		if complete {
+			mode = "complete"
+		}
+		return m.runHACommand(ctx, m.cfg.ActivationTimeout, deployment, output, "app-start", targetVersion, mode)
 	}
 	return m.runCommand(ctx, m.cfg.ActivationTimeout, deployment, output, "/bin/bash", "./run-fleet.sh", "--non-interactive", "--skip-build")
 }

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -766,7 +766,10 @@ func (m *Manager) RecoverApplication() error {
 		m.operation.Message = "HA application recovery failed"
 		m.operation.Error = recoveryErr.Error()
 		m.operation.UpdatedAt = m.cfg.Now().UTC()
-		return m.persistLocked()
+		if persistErr := m.persistLocked(); persistErr != nil {
+			return errors.Join(recoveryErr, fmt.Errorf("persist HA application recovery failure: %w", persistErr))
+		}
+		return recoveryErr
 	}
 	m.operation.RecoveryCommand = ""
 	m.operation.RecoveryPending = false
@@ -968,6 +971,14 @@ func (m *Manager) trigger(targetVersion, operationID string, idempotent, complet
 		}
 		return existing, nil
 	}
+	if m.operation != nil && m.operation.RecoveryPending {
+		recoveryOperationID := m.operation.ID
+		m.mu.RUnlock()
+		return updaterapi.Operation{}, newTriggerError(
+			errTriggerBusy,
+			fmt.Sprintf("HA application recovery for operation %s is pending", recoveryOperationID),
+		)
+	}
 	m.mu.RUnlock()
 	marker, err := m.readActivationMarker()
 	if err != nil {
@@ -996,6 +1007,12 @@ func (m *Manager) trigger(targetVersion, operationID string, idempotent, complet
 			)
 		}
 		return *m.operation, nil
+	}
+	if m.operation != nil && m.operation.RecoveryPending {
+		return updaterapi.Operation{}, newTriggerError(
+			errTriggerBusy,
+			fmt.Sprintf("HA application recovery for operation %s is pending", m.operation.ID),
+		)
 	}
 	if m.closing {
 		return updaterapi.Operation{}, errTriggerClosing

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -1298,7 +1298,7 @@ func (m *Manager) run(ctx context.Context, operationID, targetVersion string, co
 		requireArgs := []string{"require-passive", haNodeEnvPath, targetVersion}
 		if complete {
 			requiredRole = "active"
-			requireArgs = []string{"require-active", haNodeEnvPath}
+			requireArgs = []string{"require-active", haNodeEnvPath, targetVersion}
 		}
 		if err := m.runHACommand(ctx, m.cfg.ActivationTimeout, currentDeployment, commandOutput, requireArgs...); err != nil {
 			m.fail(operationID, fmt.Errorf("local Fleet is not %s immediately before activation: %w", requiredRole, err), recovery)

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -29,6 +29,7 @@ import (
 	"github.com/google/uuid"
 	"golang.org/x/mod/semver"
 
+	"github.com/block/proto-fleet/server/internal/ha"
 	"github.com/block/proto-fleet/server/internal/updaterapi"
 )
 
@@ -1318,12 +1319,20 @@ func (m *Manager) run(ctx context.Context, operationID, targetVersion string, co
 			m.failActivation(operationID, targetVersion, fmt.Errorf("persist passive application recovery: %w", err), logFile, false)
 			return
 		}
-		if err := m.runHACommand(activationCtx, m.cfg.ActivationTimeout, currentDeployment, commandOutput, "app-stop", requiredRole); err != nil {
+		haActivationCtx := activationCtx
+		stopTimeout := m.cfg.ActivationTimeout
+		cancelOutage := func() {}
+		if complete {
+			haActivationCtx, cancelOutage = context.WithTimeout(activationCtx, ha.UpdateTakeoverTimeout)
+			stopTimeout = ha.UpdateActiveStopTimeout
+		}
+		defer cancelOutage()
+		if err := m.runHACommand(haActivationCtx, stopTimeout, currentDeployment, commandOutput, "app-stop", requiredRole); err != nil {
 			m.failActivation(operationID, targetVersion, fmt.Errorf("stop HA application: %w", err), logFile, true)
 			return
 		}
 		if complete {
-			if err := m.runHACommand(activationCtx, m.cfg.ActivationTimeout, currentDeployment, commandOutput, "wait-takeover", targetVersion); err != nil {
+			if err := m.runHACommand(haActivationCtx, ha.UpdateTakeoverTimeout, currentDeployment, commandOutput, "wait-takeover", targetVersion); err != nil {
 				restartErr := m.restartHAApplication(ctx, currentDeployment, previousVersion, commandOutput)
 				if restartErr == nil {
 					m.fail(operationID, fmt.Errorf("updated peer did not take over; previous release restarted: %w", err), "")

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -761,7 +761,12 @@ func (m *Manager) RecoverApplication() error {
 		return fmt.Errorf("read interrupted HA deployment version: %w", err)
 	}
 	if err := m.runHACommand(context.Background(), m.cfg.ActivationTimeout, deployment, io.Discard, "app-start", version, "any"); err != nil {
-		return fmt.Errorf("restart interrupted HA application: %w", err)
+		recoveryErr := fmt.Errorf("restart interrupted HA application: %w", err)
+		m.operation.Phase = updaterapi.PhaseFailed
+		m.operation.Message = "HA application recovery failed"
+		m.operation.Error = recoveryErr.Error()
+		m.operation.UpdatedAt = m.cfg.Now().UTC()
+		return m.persistLocked()
 	}
 	m.operation.RecoveryCommand = ""
 	m.operation.RecoveryPending = false

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -1260,13 +1260,13 @@ func TestManagerActivationFailurePersistsProofAwareForwardRecovery(t *testing.T)
 	}
 }
 
-func TestManagerHAFailedActivationRestartsRestoredDeployment(t *testing.T) {
+func TestManagerHAFailedActivationRetriesRestartAfterDaemonRecovery(t *testing.T) {
 	t.Parallel()
 
 	installRoot := t.TempDir()
 	writeCurrentDeployment(t, installRoot, "v1.0.0")
 	stateDir := filepath.Join(t.TempDir(), "state")
-	runner := &haRecordingRunner{fail: make(map[string]error)}
+	runner := &haRecordingRunner{fail: map[string]error{"app-start": errors.New("restart failed")}}
 	manager, err := NewManager(Config{
 		InstallRoot:    installRoot,
 		StateDir:       stateDir,
@@ -1303,16 +1303,28 @@ func TestManagerHAFailedActivationRestartsRestoredDeployment(t *testing.T) {
 	require.NotNil(t, operation)
 	assert.Equal(t, updaterapi.PhaseFailed, operation.Phase)
 	assert.Contains(t, operation.Error, assert.AnError.Error())
-	assert.Empty(t, operation.RecoveryCommand)
+	assert.Contains(t, operation.Error, "restart failed")
+	assert.True(t, operation.RecoveryPending)
+	assert.NotEmpty(t, operation.RecoveryCommand)
 	assert.Equal(t, "v1.0.0", mustReadVersion(t, filepath.Join(installRoot, "deployment", "version.txt")))
 	assert.NoDirExists(t, filepath.Join(installRoot, "deployment.previous"))
 	var persisted updaterapi.Operation
 	require.NoError(t, json.Unmarshal([]byte(mustReadFile(t, filepath.Join(stateDir, stateFilename))), &persisted))
 	assert.Equal(t, updaterapi.PhaseFailed, persisted.Phase)
-	assert.Empty(t, persisted.RecoveryCommand)
+	assert.True(t, persisted.RecoveryPending)
+	require.NoError(t, manager.Close())
+	restarted, err := NewManager(manager.cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, restarted.Close()) })
+	require.NoError(t, restarted.RecoverApplication())
+	recovered := restarted.Status().Operation
+	require.NotNil(t, recovered)
+	assert.False(t, recovered.RecoveryPending)
+	assert.Empty(t, recovered.RecoveryCommand)
 	commands := runner.Commands()
-	require.Len(t, commands, 1)
+	require.Len(t, commands, 2)
 	assert.Equal(t, []string{"app-start", "v1.0.0", "any"}, commands[0].Args)
+	assert.Equal(t, []string{"app-start", "v1.0.0", "any"}, commands[1].Args)
 }
 
 func TestActivationMarkerWriteIsAtomicAndExclusive(t *testing.T) {

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -413,7 +413,7 @@ func TestManagerHACompletionWaitsForUpdatedPeerBeforeSwap(t *testing.T) {
 	commands := runner.Commands()
 	require.Len(t, commands, 5)
 	assert.Equal(t, []string{"update-preflight"}, commands[0].Args)
-	assert.Equal(t, []string{"require-active", "/etc/proto-fleet/ha/node.env"}, commands[1].Args)
+	assert.Equal(t, []string{"require-active", "/etc/proto-fleet/ha/node.env", "v1.1.0"}, commands[1].Args)
 	assert.Equal(t, []string{"app-stop", "active"}, commands[2].Args)
 	assert.Equal(t, []string{"wait-takeover", "v1.1.0"}, commands[3].Args)
 	assert.Equal(t, []string{"app-start", "v1.1.0", "passive"}, commands[4].Args)

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -2048,7 +2048,7 @@ func TestManagerDoesNotReplayTerminalHARecovery(t *testing.T) {
 	assert.Empty(t, runner.Commands())
 }
 
-func TestManagerReconcilesTerminalFailedActivationBeforeCleaningArtifacts(t *testing.T) {
+func TestManagerPersistsTerminalHARecoveryBeforeClearingActivationMarker(t *testing.T) {
 	t.Parallel()
 
 	installRoot := t.TempDir()
@@ -2087,13 +2087,28 @@ func TestManagerReconcilesTerminalFailedActivationBeforeCleaningArtifacts(t *tes
 	require.NoError(t, os.WriteFile(filepath.Join(stateDir, activationMarkerFilename), marker, 0o600))
 
 	runner := &haRecordingRunner{}
-	manager, err := NewManager(Config{
+	failPersist := true
+	config := Config{
 		InstallRoot:    installRoot,
 		StateDir:       stateDir,
 		GOARCH:         "amd64",
 		Runner:         runner,
 		DeploymentMode: DeploymentModeHA,
-	})
+		beforePersistState: func(operation updaterapi.Operation) error {
+			if operation.RecoveryPending && failPersist {
+				failPersist = false
+				return assert.AnError
+			}
+			return nil
+		},
+	}
+	manager, err := NewManager(config)
+	require.ErrorContains(t, err, assert.AnError.Error())
+	require.Nil(t, manager)
+	assert.FileExists(t, filepath.Join(stateDir, activationMarkerFilename))
+
+	config.beforePersistState = nil
+	manager, err = NewManager(config)
 	require.NoError(t, err)
 	t.Cleanup(func() { assert.NoError(t, manager.Close()) })
 
@@ -2101,13 +2116,12 @@ func TestManagerReconcilesTerminalFailedActivationBeforeCleaningArtifacts(t *tes
 	require.NotNil(t, operation)
 	assert.Equal(t, updaterapi.PhaseFailed, operation.Phase)
 	assert.Contains(t, operation.Error, "input/output error")
-	assert.Contains(t, operation.Error, "restored the validated previous deployment")
-	assert.Contains(t, operation.Message, "Previous deployment restored")
 	assert.Equal(t, completed, *operation.CompletedAt)
 	assert.Contains(t, operation.RecoveryCommand, "app-start")
 	assert.True(t, operation.RecoveryPending)
 	assert.Equal(t, "v1.0.0", mustReadVersion(t, filepath.Join(installRoot, "deployment", "version.txt")))
 	assert.NoDirExists(t, filepath.Join(installRoot, "deployment.previous"))
+	assert.NoFileExists(t, filepath.Join(stateDir, activationMarkerFilename))
 	assert.NoDirExists(t, stageRoot)
 	require.NoError(t, manager.RecoverApplication())
 	recovered := manager.Status().Operation

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -443,6 +443,30 @@ func TestManagerHACompletionRestartsOldReleaseWhenTakeoverFails(t *testing.T) {
 	assert.Equal(t, []string{"app-start", "v1.0.0", "any"}, commands[len(commands)-1].Args)
 }
 
+func TestManagerHACompletionRestartsOldReleaseWhenStopFails(t *testing.T) {
+	// Arrange
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	bundle := releaseBundle(t, "v1.1.0")
+	server := releaseServer(t, "v1.1.0", "amd64", bundle, "")
+	runner := &haRecordingRunner{fail: map[string]error{"app-stop": assert.AnError}}
+	manager := newTestManagerWithConfig(t, installRoot, server, runner, func(cfg *Config) {
+		cfg.DeploymentMode = DeploymentModeHA
+	})
+
+	// Act
+	_, err := manager.TriggerCompleteWithID("v1.1.0", "11111111-1111-4111-8111-111111111111")
+	require.NoError(t, err)
+	completed := waitForTerminal(t, manager)
+
+	// Assert
+	require.Equal(t, updaterapi.PhaseFailed, completed.Phase)
+	assert.Contains(t, completed.Error, "previous release restarted")
+	assert.Empty(t, completed.RecoveryCommand)
+	commands := runner.Commands()
+	assert.Equal(t, []string{"app-start", "v1.0.0", "any"}, commands[len(commands)-1].Args)
+}
+
 func TestManagerHACompletionInterruptedAfterSwapStartsTargetRelease(t *testing.T) {
 	// Arrange
 	installRoot := t.TempDir()

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -1276,31 +1276,28 @@ func TestManagerRejectsAnotherUpgradeWhileActivationRecoveryIsPending(t *testing
 	now := time.Date(2026, 8, 5, 8, 0, 0, 0, time.UTC)
 	manager.mu.Lock()
 	manager.operation = &updaterapi.Operation{
-		ID:            "pending-recovery",
-		TargetVersion: "v1.1.0",
-		Phase:         updaterapi.PhaseFailed,
-		Message:       "Activation layout requires manual recovery",
-		StartedAt:     now,
-		UpdatedAt:     now,
-		CompletedAt:   &now,
+		ID:              "pending-recovery",
+		TargetVersion:   "v1.1.0",
+		Phase:           updaterapi.PhaseFailed,
+		Message:         "Activation layout requires manual recovery",
+		RecoveryCommand: "app-recover",
+		RecoveryPending: true,
+		StartedAt:       now,
+		UpdatedAt:       now,
+		CompletedAt:     &now,
 	}
 	require.NoError(t, manager.persistLocked())
 	manager.mu.Unlock()
-	require.NoError(t, manager.writeActivationMarker(activationMarker{
-		OperationID:   "pending-recovery",
-		TargetVersion: "v1.1.0",
-	}))
 	stateBefore := mustReadFile(t, filepath.Join(stateDir, stateFilename))
 
 	_, err = manager.Trigger("v1.2.0")
-	require.ErrorContains(t, err, "activation recovery for operation pending-recovery is pending")
+	require.ErrorContains(t, err, "HA application recovery for operation pending-recovery is pending")
 	require.ErrorIs(t, err, errTriggerBusy)
 	operation := manager.Status().Operation
 	require.NotNil(t, operation)
 	assert.Equal(t, "pending-recovery", operation.ID)
 	assert.Equal(t, updaterapi.PhaseFailed, operation.Phase)
 	assert.Equal(t, stateBefore, mustReadFile(t, filepath.Join(stateDir, stateFilename)))
-	assert.FileExists(t, filepath.Join(stateDir, activationMarkerFilename))
 }
 
 func TestManagerProcessLockPreventsASecondDaemonFromMutatingState(t *testing.T) {
@@ -1881,7 +1878,7 @@ func TestManagerRestartsHAApplicationAfterInterruptedSwap(t *testing.T) {
 	assert.False(t, manager.Status().Operation.RecoveryPending)
 }
 
-func TestManagerServesRecoveryStateAfterRestartFailure(t *testing.T) {
+func TestManagerFailsStartupWhenHARecoveryFails(t *testing.T) {
 	// Arrange
 	installRoot := t.TempDir()
 	writeCurrentDeployment(t, installRoot, "v1.0.0")
@@ -1898,12 +1895,12 @@ func TestManagerServesRecoveryStateAfterRestartFailure(t *testing.T) {
 		DeploymentMode: DeploymentModeHA,
 		Runner:         &haRecordingRunner{fail: map[string]error{"app-recover": errors.New("restart failed")}},
 	})
-	require.NoError(t, err)
-	t.Cleanup(func() { assert.NoError(t, manager.Close()) })
+	require.ErrorContains(t, err, "restart interrupted HA application")
+	require.Nil(t, manager)
 
 	// Assert
-	operation := manager.Status().Operation
-	require.NotNil(t, operation)
+	var operation updaterapi.Operation
+	require.NoError(t, json.Unmarshal([]byte(mustReadFile(t, filepath.Join(stateDir, stateFilename))), &operation))
 	assert.True(t, operation.RecoveryPending)
 	assert.NotEmpty(t, operation.RecoveryCommand)
 	assert.Contains(t, operation.Error, "restart failed")

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -1878,6 +1878,36 @@ func TestManagerRestartsHAApplicationAfterInterruptedSwap(t *testing.T) {
 	assert.False(t, manager.Status().Operation.RecoveryPending)
 }
 
+func TestRepairStartupRestoresLayoutWithoutStartingHAApplication(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	require.NoError(t, os.Rename(
+		filepath.Join(installRoot, "deployment"),
+		filepath.Join(installRoot, "deployment.previous"),
+	))
+	stateDir := filepath.Join(t.TempDir(), "state")
+	writeInterruptedOperationState(t, stateDir, "v1.1.0")
+	runner := &haRecordingRunner{}
+
+	// Act
+	err := RepairStartup(Config{
+		InstallRoot: installRoot, StateDir: stateDir, GOARCH: "amd64",
+		DeploymentMode: DeploymentModeHA, Runner: runner,
+	})
+
+	// Assert
+	require.NoError(t, err)
+	assert.Empty(t, runner.Commands())
+	assert.Equal(t, "v1.0.0", mustReadVersion(t, filepath.Join(installRoot, "deployment", "version.txt")))
+	assert.NoDirExists(t, filepath.Join(installRoot, "deployment.previous"))
+	var operation updaterapi.Operation
+	require.NoError(t, json.Unmarshal([]byte(mustReadFile(t, filepath.Join(stateDir, stateFilename))), &operation))
+	assert.True(t, operation.RecoveryPending)
+}
+
 func TestManagerFailsStartupWhenHARecoveryFails(t *testing.T) {
 	// Arrange
 	installRoot := t.TempDir()

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -1957,7 +1957,25 @@ func TestRepairStartupRestoresInterruptedSelfUpdateBeforeState(t *testing.T) {
 	// Assert
 	require.ErrorIs(t, err, ErrInterruptedSelfUpdateRestored)
 	assert.Equal(t, "old updater", mustReadFile(t, destination))
-	assert.NoDirExists(t, stateDir)
+	assert.DirExists(t, stateDir)
+}
+
+func TestRepairStartupDoesNotTouchSelfUpdateWhileManagerRuns(t *testing.T) {
+	// Arrange
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	destination := installSelfUpdateForHandoffTest(t)
+	stateDir := filepath.Join(t.TempDir(), "state")
+	manager, err := NewManager(Config{InstallRoot: installRoot, StateDir: stateDir})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, manager.Close()) })
+
+	// Act
+	err = RepairStartup(Config{InstallRoot: installRoot, StateDir: stateDir, SelfUpdatePath: destination})
+
+	// Assert
+	require.ErrorContains(t, err, "another updater process is already running")
+	assert.Equal(t, "new updater", mustReadFile(t, destination))
 }
 
 func TestManagerFailsStartupWhenHARecoveryFails(t *testing.T) {

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -388,7 +388,7 @@ func TestManagerHAInterruptedAfterStopRestartsCurrentApplication(t *testing.T) {
 	assert.Contains(t, operation.Message, "HA application restarted")
 	commands := runner.Commands()
 	require.Len(t, commands, 1)
-	assert.Equal(t, []string{"app-recover", "v1.0.0"}, commands[0].Args)
+	assert.Equal(t, []string{"app-start", "v1.0.0", "any"}, commands[0].Args)
 }
 
 func TestManagerHACompletionWaitsForUpdatedPeerBeforeSwap(t *testing.T) {
@@ -492,7 +492,7 @@ func TestManagerHACompletionInterruptedAfterSwapStartsTargetRelease(t *testing.T
 	require.Empty(t, operation.RecoveryCommand)
 	commands := runner.Commands()
 	require.Len(t, commands, 1)
-	assert.Equal(t, []string{"app-recover", "v1.1.0"}, commands[0].Args)
+	assert.Equal(t, []string{"app-start", "v1.1.0", "any"}, commands[0].Args)
 }
 
 func TestManagerTriggerWithIDDeduplicatesConcurrentAdmission(t *testing.T) {
@@ -1280,7 +1280,7 @@ func TestManagerRejectsAnotherUpgradeWhileActivationRecoveryIsPending(t *testing
 		TargetVersion:   "v1.1.0",
 		Phase:           updaterapi.PhaseFailed,
 		Message:         "Activation layout requires manual recovery",
-		RecoveryCommand: "app-recover",
+		RecoveryCommand: "app-start",
 		RecoveryPending: true,
 		StartedAt:       now,
 		UpdatedAt:       now,
@@ -1873,7 +1873,7 @@ func TestManagerRestartsHAApplicationAfterInterruptedSwap(t *testing.T) {
 	// Assert
 	commands := runner.Commands()
 	require.Len(t, commands, 1)
-	assert.Equal(t, []string{"app-recover", "v1.0.0"}, commands[0].Args)
+	assert.Equal(t, []string{"app-start", "v1.0.0", "any"}, commands[0].Args)
 	assert.Empty(t, manager.Status().Operation.RecoveryCommand)
 	assert.False(t, manager.Status().Operation.RecoveryPending)
 }
@@ -1893,7 +1893,7 @@ func TestManagerFailsStartupWhenHARecoveryFails(t *testing.T) {
 	manager, err := NewManager(Config{
 		InstallRoot: installRoot, StateDir: stateDir, GOARCH: "amd64",
 		DeploymentMode: DeploymentModeHA,
-		Runner:         &haRecordingRunner{fail: map[string]error{"app-recover": errors.New("restart failed")}},
+		Runner:         &haRecordingRunner{fail: map[string]error{"app-start": errors.New("restart failed")}},
 	})
 	require.ErrorContains(t, err, "restart interrupted HA application")
 	require.Nil(t, manager)

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -484,6 +484,44 @@ func TestManagerHACompletionRestartsOldReleaseWhenStopFails(t *testing.T) {
 	assert.Equal(t, []string{"app-start", "v1.0.0", "any"}, commands[len(commands)-1].Args)
 }
 
+func TestManagerHACompletionRetriesFailedRollbackAfterRestart(t *testing.T) {
+	for _, failedCommand := range []string{"app-stop", "wait-takeover"} {
+		t.Run(failedCommand, func(t *testing.T) {
+			// Arrange
+			installRoot := t.TempDir()
+			writeCurrentDeployment(t, installRoot, "v1.0.0")
+			bundle := releaseBundle(t, "v1.1.0")
+			server := releaseServer(t, "v1.1.0", "amd64", bundle, "")
+			runner := &haRecordingRunner{fail: map[string]error{
+				failedCommand: assert.AnError,
+				"app-start":   errors.New("restart failed"),
+			}}
+			manager := newTestManagerWithConfig(t, installRoot, server, runner, func(cfg *Config) {
+				cfg.DeploymentMode = DeploymentModeHA
+			})
+
+			// Act
+			_, err := manager.TriggerCompleteWithID("v1.1.0", "11111111-1111-4111-8111-111111111111")
+			require.NoError(t, err)
+			failed := waitForTerminal(t, manager)
+			require.NoError(t, manager.Close())
+			restarted, err := NewManager(manager.cfg)
+			require.NoError(t, err)
+			t.Cleanup(func() { assert.NoError(t, restarted.Close()) })
+			err = restarted.RecoverApplication()
+
+			// Assert
+			require.NoError(t, err)
+			assert.True(t, failed.RecoveryPending)
+			assert.NotEmpty(t, failed.RecoveryCommand)
+			recovered := restarted.Status().Operation
+			require.NotNil(t, recovered)
+			assert.False(t, recovered.RecoveryPending)
+			assert.Empty(t, recovered.RecoveryCommand)
+		})
+	}
+}
+
 func TestManagerHACompletionRestartsOldReleaseWhenStopBlocks(t *testing.T) {
 	// Arrange
 	installRoot := t.TempDir()

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -503,6 +503,32 @@ func TestManagerHACompletionRestartsOldReleaseWhenStopBlocks(t *testing.T) {
 	assert.Equal(t, []string{"app-start", "v1.0.0", "any"}, commands[len(commands)-1].Args)
 }
 
+func TestHAQualificationBarrierPausesBeforeStop(t *testing.T) {
+	// Arrange
+	stateDir := t.TempDir()
+	barrier := filepath.Join(stateDir, qualificationBarrierName)
+	require.NoError(t, os.WriteFile(barrier, nil, 0o600))
+	manager := &Manager{cfg: Config{StateDir: stateDir}}
+	done := make(chan error, 1)
+	go func() { done <- manager.waitForQualificationBarrier(t.Context()) }()
+
+	// Act
+	select {
+	case err := <-done:
+		t.Fatalf("barrier returned before release: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	require.NoError(t, os.Remove(barrier))
+
+	// Assert
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("barrier did not release")
+	}
+}
+
 func TestManagerHACompletionInterruptedAfterSwapStartsTargetRelease(t *testing.T) {
 	// Arrange
 	installRoot := t.TempDir()

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -424,7 +424,7 @@ func TestManagerHACompletionWaitsForUpdatedPeerBeforeSwap(t *testing.T) {
 	assert.Equal(t, []string{"require-active", "/etc/proto-fleet/ha/node.env", "v1.1.0"}, commands[1].Args)
 	assert.Equal(t, []string{"app-stop", "active"}, commands[2].Args)
 	assert.Equal(t, []string{"wait-takeover", "v1.1.0"}, commands[3].Args)
-	assert.Equal(t, []string{"app-start", "v1.1.0", "passive"}, commands[4].Args)
+	assert.Equal(t, []string{"app-start", "v1.1.0", "complete"}, commands[4].Args)
 
 	_, err = manager.TriggerWithID("v1.1.0", "11111111-1111-4111-8111-111111111111")
 	require.ErrorContains(t, err, "operation id is already associated with another update")

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -274,6 +274,7 @@ func TestManagerHAUpdateKeepsForwardRecoveryWhenStartupFails(t *testing.T) {
 	assert.Contains(t, completed.RecoveryCommand, "app-start")
 	assert.Contains(t, completed.RecoveryCommand, "v1.1.0")
 	assert.True(t, strings.HasSuffix(completed.RecoveryCommand, " any"))
+	assert.True(t, completed.RecoveryPending)
 	assert.Contains(t, completed.Error, "new stack failed to start")
 	assert.Equal(t, "v1.1.0", mustReadVersion(t, filepath.Join(installRoot, "deployment", "version.txt")))
 	commands := runner.Commands()

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -379,12 +379,18 @@ func TestManagerHAInterruptedAfterStopRestartsCurrentApplication(t *testing.T) {
 	writeCurrentDeployment(t, installRoot, "v1.0.0")
 	require.NoError(t, os.Rename(filepath.Join(installRoot, "deployment"), filepath.Join(installRoot, "deployment.previous")))
 	writeInterruptedOperationState(t, stateDir, "v1.1.0")
+	runner := &haRecordingRunner{fail: make(map[string]error)}
+	cfg := Config{
+		InstallRoot: installRoot, StateDir: stateDir, GOARCH: "amd64", DeploymentMode: DeploymentModeHA, Runner: runner,
+	}
 
 	// Act
-	runner := &haRecordingRunner{fail: make(map[string]error)}
-	err := RepairStartup(Config{
-		InstallRoot: installRoot, StateDir: stateDir, GOARCH: "amd64", DeploymentMode: DeploymentModeHA, Runner: runner,
-	})
+	err := RepairStartup(cfg)
+	require.NoError(t, err)
+	manager, err := NewManager(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, manager.Close()) })
+	err = manager.RecoverApplication()
 	require.NoError(t, err)
 
 	// Assert
@@ -538,11 +544,17 @@ func TestManagerHACompletionInterruptedAfterSwapStartsTargetRelease(t *testing.T
 	require.NoError(t, os.WriteFile(previousVersionPath, []byte("version: v1.0.0\n"), 0o600))
 	writeInterruptedOperationState(t, stateDir, "v1.1.0")
 	runner := &haRecordingRunner{fail: make(map[string]error)}
+	cfg := Config{
+		InstallRoot: installRoot, StateDir: stateDir, GOARCH: "amd64", DeploymentMode: DeploymentModeHA, Runner: runner,
+	}
 
 	// Act
-	err := RepairStartup(Config{
-		InstallRoot: installRoot, StateDir: stateDir, GOARCH: "amd64", DeploymentMode: DeploymentModeHA, Runner: runner,
-	})
+	err := RepairStartup(cfg)
+	require.NoError(t, err)
+	manager, err := NewManager(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, manager.Close()) })
+	err = manager.RecoverApplication()
 	require.NoError(t, err)
 
 	// Assert
@@ -1926,7 +1938,7 @@ func TestRepairStartupDoesNotTouchSelfUpdateWhileManagerRuns(t *testing.T) {
 	assert.Equal(t, "new updater", mustReadFile(t, destination))
 }
 
-func TestRepairStartupFailsWhenHARecoveryFails(t *testing.T) {
+func TestRecoverApplicationKeepsPendingRecoveryAfterFailure(t *testing.T) {
 	// Arrange
 	installRoot := t.TempDir()
 	writeCurrentDeployment(t, installRoot, "v1.0.0")
@@ -1936,13 +1948,19 @@ func TestRepairStartupFailsWhenHARecoveryFails(t *testing.T) {
 	))
 	stateDir := filepath.Join(t.TempDir(), "state")
 	writeInterruptedOperationState(t, stateDir, "v1.1.0")
-
-	// Act
-	err := RepairStartup(Config{
+	cfg := Config{
 		InstallRoot: installRoot, StateDir: stateDir, GOARCH: "amd64",
 		DeploymentMode: DeploymentModeHA,
 		Runner:         &haRecordingRunner{fail: map[string]error{"app-start": errors.New("restart failed")}},
-	})
+	}
+
+	// Act
+	err := RepairStartup(cfg)
+	require.NoError(t, err)
+	manager, err := NewManager(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, manager.Close()) })
+	err = manager.RecoverApplication()
 	require.ErrorContains(t, err, "restart interrupted HA application")
 
 	// Assert

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -417,6 +417,7 @@ func TestManagerHACompletionWaitsForUpdatedPeerBeforeSwap(t *testing.T) {
 
 	// Assert
 	require.Equal(t, updaterapi.PhaseSucceeded, completed.Phase, completed.Error)
+	require.True(t, completed.Complete)
 	commands := runner.Commands()
 	require.Len(t, commands, 5)
 	assert.Equal(t, []string{"update-preflight"}, commands[0].Args)
@@ -424,6 +425,9 @@ func TestManagerHACompletionWaitsForUpdatedPeerBeforeSwap(t *testing.T) {
 	assert.Equal(t, []string{"app-stop", "active"}, commands[2].Args)
 	assert.Equal(t, []string{"wait-takeover", "v1.1.0"}, commands[3].Args)
 	assert.Equal(t, []string{"app-start", "v1.1.0", "passive"}, commands[4].Args)
+
+	_, err = manager.TriggerWithID("v1.1.0", "11111111-1111-4111-8111-111111111111")
+	require.ErrorContains(t, err, "operation id is already associated with another update")
 }
 
 func TestManagerHACompletionRestartsOldReleaseWhenTakeoverFails(t *testing.T) {

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -1970,22 +1970,6 @@ func TestRepairStartupRestoresLayoutWithoutStartingHAApplication(t *testing.T) {
 	assert.True(t, operation.RecoveryPending)
 }
 
-func TestRepairStartupRestoresInterruptedSelfUpdateBeforeState(t *testing.T) {
-	// Arrange
-	destination := installSelfUpdateForHandoffTest(t)
-	stateDir := filepath.Join(t.TempDir(), "state")
-
-	// Act
-	err := RepairStartup(Config{
-		InstallRoot: t.TempDir(), StateDir: stateDir, SelfUpdatePath: destination,
-	})
-
-	// Assert
-	require.ErrorIs(t, err, ErrInterruptedSelfUpdateRestored)
-	assert.Equal(t, "old updater", mustReadFile(t, destination))
-	assert.DirExists(t, stateDir)
-}
-
 func TestRepairStartupDoesNotTouchSelfUpdateWhileManagerRuns(t *testing.T) {
 	// Arrange
 	installRoot := t.TempDir()

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -281,7 +281,7 @@ func TestManagerHAUpdateKeepsForwardRecoveryWhenStartupFails(t *testing.T) {
 	assert.Contains(t, completed.RecoveryCommand, "app-start")
 	assert.Contains(t, completed.RecoveryCommand, "v1.1.0")
 	assert.True(t, strings.HasSuffix(completed.RecoveryCommand, " any"))
-	assert.True(t, completed.RecoveryPending)
+	assert.False(t, completed.RecoveryPending)
 	assert.Contains(t, completed.Error, "new stack failed to start")
 	assert.Equal(t, "v1.1.0", mustReadVersion(t, filepath.Join(installRoot, "deployment", "version.txt")))
 	commands := runner.Commands()

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -546,14 +546,14 @@ func TestManagerHACompletionRestartsOldReleaseWhenStopBlocks(t *testing.T) {
 	assert.Equal(t, []string{"app-start", "v1.0.0", "any"}, commands[len(commands)-1].Args)
 }
 
-func TestHAQualificationBarrierPausesBeforeStop(t *testing.T) {
+func TestHAQualificationBarrierPausesUntilRemoved(t *testing.T) {
 	// Arrange
 	stateDir := t.TempDir()
-	barrier := filepath.Join(stateDir, qualificationBarrierName)
+	barrier := filepath.Join(stateDir, qualificationAfterStopBarrierName)
 	require.NoError(t, os.WriteFile(barrier, nil, 0o600))
 	manager := &Manager{cfg: Config{StateDir: stateDir}}
 	done := make(chan error, 1)
-	go func() { done <- manager.waitForQualificationBarrier(t.Context()) }()
+	go func() { done <- manager.waitForQualificationBarrier(t.Context(), qualificationAfterStopBarrierName) }()
 
 	// Act
 	select {
@@ -570,6 +570,27 @@ func TestHAQualificationBarrierPausesBeforeStop(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("barrier did not release")
 	}
+}
+
+func TestActivateDeploymentRestoresCurrentWhenQualificationPauseFails(t *testing.T) {
+	// Arrange
+	installRoot := t.TempDir()
+	current := filepath.Join(installRoot, "deployment")
+	staged := filepath.Join(installRoot, "staging", "deployment")
+	previous := filepath.Join(installRoot, "deployment.previous")
+	require.NoError(t, os.MkdirAll(current, 0o750))
+	require.NoError(t, os.MkdirAll(staged, 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(current, "version.txt"), []byte("v1"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(staged, "version.txt"), []byte("v2"), 0o600))
+
+	// Act
+	err := activateDeployment(staged, current, previous, func() error { return assert.AnError })
+
+	// Assert
+	require.ErrorIs(t, err, assert.AnError)
+	version, readErr := os.ReadFile(filepath.Join(current, "version.txt"))
+	require.NoError(t, readErr)
+	assert.Equal(t, "v1", string(version))
 }
 
 func TestManagerHACompletionInterruptedAfterSwapStartsTargetRelease(t *testing.T) {

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -242,8 +242,8 @@ func TestManagerHAUpdateTouchesOnlyThePassiveApplication(t *testing.T) {
 	require.Len(t, commands, 5)
 	assert.Equal(t, []string{"update-preflight"}, commands[0].Args)
 	assert.Equal(t, []string{"require-passive", "/etc/proto-fleet/ha/node.env", "v1.1.0"}, commands[1].Args)
-	assert.Equal(t, []string{"app-stop"}, commands[2].Args)
-	assert.Equal(t, []string{"app-start", "v1.1.0"}, commands[3].Args)
+	assert.Equal(t, []string{"app-stop", "passive"}, commands[2].Args)
+	assert.Equal(t, []string{"app-start", "v1.1.0", "passive"}, commands[3].Args)
 	for _, command := range commands[:4] {
 		assert.Contains(t, command.Name, filepath.Join("ha", "fleet-ha"))
 		assert.NotContains(t, strings.Join(command.Args, " "), "etcd")
@@ -276,7 +276,7 @@ func TestManagerHAUpdateKeepsForwardRecoveryWhenStartupFails(t *testing.T) {
 	assert.Contains(t, completed.Error, "new stack failed to start")
 	assert.Equal(t, "v1.1.0", mustReadVersion(t, filepath.Join(installRoot, "deployment", "version.txt")))
 	commands := runner.Commands()
-	assert.Equal(t, []string{"app-start", "v1.1.0"}, commands[len(commands)-1].Args)
+	assert.Equal(t, []string{"app-start", "v1.1.0", "passive"}, commands[len(commands)-1].Args)
 }
 
 func TestManagerHAPreflightFailureLeavesCurrentApplicationUntouched(t *testing.T) {
@@ -363,7 +363,7 @@ func TestManagerHARejectsDowngrade(t *testing.T) {
 	assert.Equal(t, "v1.4.0", mustReadVersion(t, filepath.Join(installRoot, "deployment", "version.txt")))
 }
 
-func TestManagerHAInterruptedAfterStopRetainsRestartCommand(t *testing.T) {
+func TestManagerHAInterruptedAfterStopRestartsCurrentApplication(t *testing.T) {
 	// Arrange
 	installRoot := t.TempDir()
 	stateDir := filepath.Join(t.TempDir(), "state")
@@ -372,8 +372,9 @@ func TestManagerHAInterruptedAfterStopRetainsRestartCommand(t *testing.T) {
 	writeInterruptedOperationState(t, stateDir, "v1.1.0")
 
 	// Act
+	runner := &haRecordingRunner{fail: make(map[string]error)}
 	manager, err := NewManager(Config{
-		InstallRoot: installRoot, StateDir: stateDir, GOARCH: "amd64", DeploymentMode: DeploymentModeHA,
+		InstallRoot: installRoot, StateDir: stateDir, GOARCH: "amd64", DeploymentMode: DeploymentModeHA, Runner: runner,
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, manager.Close()) })
@@ -382,9 +383,91 @@ func TestManagerHAInterruptedAfterStopRetainsRestartCommand(t *testing.T) {
 	operation := manager.Status().Operation
 	require.NotNil(t, operation)
 	require.Equal(t, updaterapi.PhaseFailed, operation.Phase)
-	assert.Contains(t, operation.RecoveryCommand, "app-start")
-	assert.Contains(t, operation.RecoveryCommand, "v1.0.0")
-	assert.True(t, strings.HasSuffix(operation.RecoveryCommand, " any"))
+	assert.Empty(t, operation.RecoveryCommand)
+	assert.Contains(t, operation.Message, "HA application restarted")
+	commands := runner.Commands()
+	require.Len(t, commands, 1)
+	assert.Equal(t, []string{"app-start", "v1.0.0", "any"}, commands[0].Args)
+}
+
+func TestManagerHACompletionWaitsForUpdatedPeerBeforeSwap(t *testing.T) {
+	// Arrange
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	bundle := releaseBundle(t, "v1.1.0")
+	server := releaseServer(t, "v1.1.0", "amd64", bundle, "")
+	runner := &haRecordingRunner{fail: make(map[string]error)}
+	manager := newTestManagerWithConfig(t, installRoot, server, runner, func(cfg *Config) {
+		cfg.DeploymentMode = DeploymentModeHA
+	})
+
+	// Act
+	_, err := manager.TriggerCompleteWithID("v1.1.0", "11111111-1111-4111-8111-111111111111")
+	require.NoError(t, err)
+	completed := waitForTerminal(t, manager)
+
+	// Assert
+	require.Equal(t, updaterapi.PhaseSucceeded, completed.Phase, completed.Error)
+	commands := runner.Commands()
+	require.Len(t, commands, 5)
+	assert.Equal(t, []string{"update-preflight"}, commands[0].Args)
+	assert.Equal(t, []string{"require-active", "/etc/proto-fleet/ha/node.env"}, commands[1].Args)
+	assert.Equal(t, []string{"app-stop", "active"}, commands[2].Args)
+	assert.Equal(t, []string{"wait-takeover", "v1.1.0"}, commands[3].Args)
+	assert.Equal(t, []string{"app-start", "v1.1.0", "passive"}, commands[4].Args)
+}
+
+func TestManagerHACompletionRestartsOldReleaseWhenTakeoverFails(t *testing.T) {
+	// Arrange
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	bundle := releaseBundle(t, "v1.1.0")
+	server := releaseServer(t, "v1.1.0", "amd64", bundle, "")
+	runner := &haRecordingRunner{fail: map[string]error{"wait-takeover": assert.AnError}}
+	manager := newTestManagerWithConfig(t, installRoot, server, runner, func(cfg *Config) {
+		cfg.DeploymentMode = DeploymentModeHA
+	})
+
+	// Act
+	_, err := manager.TriggerCompleteWithID("v1.1.0", "11111111-1111-4111-8111-111111111111")
+	require.NoError(t, err)
+	completed := waitForTerminal(t, manager)
+
+	// Assert
+	require.Equal(t, updaterapi.PhaseFailed, completed.Phase)
+	assert.Contains(t, completed.Error, "previous release restarted")
+	assert.Empty(t, completed.RecoveryCommand)
+	assert.Equal(t, "v1.0.0", mustReadVersion(t, filepath.Join(installRoot, "deployment", "version.txt")))
+	commands := runner.Commands()
+	assert.Equal(t, []string{"app-start", "v1.0.0", "any"}, commands[len(commands)-1].Args)
+}
+
+func TestManagerHACompletionInterruptedAfterSwapStartsTargetRelease(t *testing.T) {
+	// Arrange
+	installRoot := t.TempDir()
+	stateDir := filepath.Join(t.TempDir(), "state")
+	writeCurrentDeployment(t, installRoot, "v1.1.0")
+	previousVersionPath := filepath.Join(installRoot, "deployment.previous", "version.txt")
+	require.NoError(t, os.MkdirAll(filepath.Dir(previousVersionPath), 0o750))
+	require.NoError(t, os.WriteFile(previousVersionPath, []byte("version: v1.0.0\n"), 0o600))
+	writeInterruptedOperationState(t, stateDir, "v1.1.0")
+	runner := &haRecordingRunner{fail: make(map[string]error)}
+
+	// Act
+	manager, err := NewManager(Config{
+		InstallRoot: installRoot, StateDir: stateDir, GOARCH: "amd64", DeploymentMode: DeploymentModeHA, Runner: runner,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, manager.Close()) })
+
+	// Assert
+	operation := manager.Status().Operation
+	require.NotNil(t, operation)
+	require.Equal(t, updaterapi.PhaseFailed, operation.Phase)
+	require.Empty(t, operation.RecoveryCommand)
+	commands := runner.Commands()
+	require.Len(t, commands, 1)
+	assert.Equal(t, []string{"app-start", "v1.1.0", "any"}, commands[0].Args)
 }
 
 func TestManagerTriggerWithIDDeduplicatesConcurrentAdmission(t *testing.T) {
@@ -1741,6 +1824,35 @@ func TestRepairStartupKeepsPreviousUpdaterAfterReplacementRetryFails(t *testing.
 	require.NoError(t, err)
 	assert.Equal(t, "old updater", mustReadFile(t, installedUpdater))
 	assert.NoFileExists(t, installedUpdater+selfUpdateHandoffSuffix)
+}
+
+func TestManagerRestartsHAApplicationAfterInterruptedSwap(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	require.NoError(t, os.Rename(
+		filepath.Join(installRoot, "deployment"),
+		filepath.Join(installRoot, "deployment.previous"),
+	))
+	stateDir := filepath.Join(t.TempDir(), "state")
+	writeInterruptedOperationState(t, stateDir, "v1.1.0")
+	runner := &haRecordingRunner{}
+
+	// Act
+	manager, err := NewManager(Config{
+		InstallRoot: installRoot, StateDir: stateDir, GOARCH: "amd64",
+		DeploymentMode: DeploymentModeHA, Runner: runner,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, manager.Close()) })
+
+	// Assert
+	commands := runner.Commands()
+	require.Len(t, commands, 1)
+	assert.Equal(t, []string{"app-start", "v1.0.0", "any"}, commands[0].Args)
+	assert.Empty(t, manager.Status().Operation.RecoveryCommand)
 }
 
 func TestManagerReconcilesTerminalFailedActivationBeforeCleaningArtifacts(t *testing.T) {

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -1855,6 +1855,34 @@ func TestManagerRestartsHAApplicationAfterInterruptedSwap(t *testing.T) {
 	assert.Empty(t, manager.Status().Operation.RecoveryCommand)
 }
 
+func TestManagerDoesNotReplayTerminalHARecovery(t *testing.T) {
+	// Arrange
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	stateDir := filepath.Join(t.TempDir(), "state")
+	require.NoError(t, os.MkdirAll(stateDir, 0o700))
+	now := time.Date(2026, 8, 5, 8, 0, 0, 0, time.UTC)
+	operation := updaterapi.Operation{
+		ID: "failed", TargetVersion: "v1.1.0", Phase: updaterapi.PhaseFailed,
+		RecoveryCommand: "stale", StartedAt: now, UpdatedAt: now, CompletedAt: &now,
+	}
+	data, err := json.Marshal(operation)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(stateDir, stateFilename), data, 0o600))
+	runner := &haRecordingRunner{}
+
+	// Act
+	manager, err := NewManager(Config{
+		InstallRoot: installRoot, StateDir: stateDir, GOARCH: "amd64",
+		DeploymentMode: DeploymentModeHA, Runner: runner,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, manager.Close()) })
+
+	// Assert
+	assert.Empty(t, runner.Commands())
+}
+
 func TestManagerReconcilesTerminalFailedActivationBeforeCleaningArtifacts(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -1908,6 +1908,22 @@ func TestRepairStartupRestoresLayoutWithoutStartingHAApplication(t *testing.T) {
 	assert.True(t, operation.RecoveryPending)
 }
 
+func TestRepairStartupRestoresInterruptedSelfUpdateBeforeState(t *testing.T) {
+	// Arrange
+	destination := installSelfUpdateForHandoffTest(t)
+	stateDir := filepath.Join(t.TempDir(), "state")
+
+	// Act
+	err := RepairStartup(Config{
+		InstallRoot: t.TempDir(), StateDir: stateDir, SelfUpdatePath: destination,
+	})
+
+	// Assert
+	require.ErrorIs(t, err, ErrInterruptedSelfUpdateRestored)
+	assert.Equal(t, "old updater", mustReadFile(t, destination))
+	assert.NoDirExists(t, stateDir)
+}
+
 func TestManagerFailsStartupWhenHARecoveryFails(t *testing.T) {
 	// Arrange
 	installRoot := t.TempDir()

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -388,7 +388,7 @@ func TestManagerHAInterruptedAfterStopRestartsCurrentApplication(t *testing.T) {
 	assert.Contains(t, operation.Message, "HA application restarted")
 	commands := runner.Commands()
 	require.Len(t, commands, 1)
-	assert.Equal(t, []string{"app-start", "v1.0.0", "any"}, commands[0].Args)
+	assert.Equal(t, []string{"app-recover", "v1.0.0"}, commands[0].Args)
 }
 
 func TestManagerHACompletionWaitsForUpdatedPeerBeforeSwap(t *testing.T) {
@@ -468,7 +468,7 @@ func TestManagerHACompletionInterruptedAfterSwapStartsTargetRelease(t *testing.T
 	require.Empty(t, operation.RecoveryCommand)
 	commands := runner.Commands()
 	require.Len(t, commands, 1)
-	assert.Equal(t, []string{"app-start", "v1.1.0", "any"}, commands[0].Args)
+	assert.Equal(t, []string{"app-recover", "v1.1.0"}, commands[0].Args)
 }
 
 func TestManagerTriggerWithIDDeduplicatesConcurrentAdmission(t *testing.T) {
@@ -1852,7 +1852,7 @@ func TestManagerRestartsHAApplicationAfterInterruptedSwap(t *testing.T) {
 	// Assert
 	commands := runner.Commands()
 	require.Len(t, commands, 1)
-	assert.Equal(t, []string{"app-start", "v1.0.0", "any"}, commands[0].Args)
+	assert.Equal(t, []string{"app-recover", "v1.0.0"}, commands[0].Args)
 	assert.Empty(t, manager.Status().Operation.RecoveryCommand)
 	assert.False(t, manager.Status().Operation.RecoveryPending)
 }
@@ -1872,7 +1872,7 @@ func TestManagerServesRecoveryStateAfterRestartFailure(t *testing.T) {
 	manager, err := NewManager(Config{
 		InstallRoot: installRoot, StateDir: stateDir, GOARCH: "amd64",
 		DeploymentMode: DeploymentModeHA,
-		Runner:         &haRecordingRunner{fail: map[string]error{"app-start": errors.New("restart failed")}},
+		Runner:         &haRecordingRunner{fail: map[string]error{"app-recover": errors.New("restart failed")}},
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() { assert.NoError(t, manager.Close()) })

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -2057,13 +2057,18 @@ func TestManagerDoesNotReplayTerminalHARecovery(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(filepath.Join(stateDir, stateFilename), data, 0o600))
 	runner := &haRecordingRunner{}
-
-	// Act
-	err = RepairStartup(Config{
+	cfg := Config{
 		InstallRoot: installRoot, StateDir: stateDir, GOARCH: "amd64",
 		DeploymentMode: DeploymentModeHA, Runner: runner,
-	})
+	}
+
+	// Act
+	err = RepairStartup(cfg)
 	require.NoError(t, err)
+	manager, err := NewManager(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, manager.Close()) })
+	require.NoError(t, manager.RecoverApplication())
 
 	// Assert
 	assert.Empty(t, runner.Commands())

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -1853,6 +1854,39 @@ func TestManagerRestartsHAApplicationAfterInterruptedSwap(t *testing.T) {
 	require.Len(t, commands, 1)
 	assert.Equal(t, []string{"app-start", "v1.0.0", "any"}, commands[0].Args)
 	assert.Empty(t, manager.Status().Operation.RecoveryCommand)
+	assert.False(t, manager.Status().Operation.RecoveryPending)
+}
+
+func TestManagerRetriesInterruptedHARecoveryAfterRestartFailure(t *testing.T) {
+	// Arrange
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	require.NoError(t, os.Rename(
+		filepath.Join(installRoot, "deployment"),
+		filepath.Join(installRoot, "deployment.previous"),
+	))
+	stateDir := filepath.Join(t.TempDir(), "state")
+	writeInterruptedOperationState(t, stateDir, "v1.1.0")
+
+	// Act
+	_, err := NewManager(Config{
+		InstallRoot: installRoot, StateDir: stateDir, GOARCH: "amd64",
+		DeploymentMode: DeploymentModeHA,
+		Runner:         &haRecordingRunner{fail: map[string]error{"app-start": errors.New("restart failed")}},
+	})
+	require.ErrorContains(t, err, "restart failed")
+	manager, err := NewManager(Config{
+		InstallRoot: installRoot, StateDir: stateDir, GOARCH: "amd64",
+		DeploymentMode: DeploymentModeHA, Runner: &haRecordingRunner{},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, manager.Close()) })
+
+	// Assert
+	operation := manager.Status().Operation
+	require.NotNil(t, operation)
+	assert.False(t, operation.RecoveryPending)
+	assert.Empty(t, operation.RecoveryCommand)
 }
 
 func TestManagerDoesNotReplayTerminalHARecovery(t *testing.T) {

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -2086,10 +2086,12 @@ func TestManagerReconcilesTerminalFailedActivationBeforeCleaningArtifacts(t *tes
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(filepath.Join(stateDir, activationMarkerFilename), marker, 0o600))
 
+	runner := &haRecordingRunner{}
 	manager, err := NewManager(Config{
 		InstallRoot:    installRoot,
 		StateDir:       stateDir,
 		GOARCH:         "amd64",
+		Runner:         runner,
 		DeploymentMode: DeploymentModeHA,
 	})
 	require.NoError(t, err)
@@ -2103,9 +2105,18 @@ func TestManagerReconcilesTerminalFailedActivationBeforeCleaningArtifacts(t *tes
 	assert.Contains(t, operation.Message, "Previous deployment restored")
 	assert.Equal(t, completed, *operation.CompletedAt)
 	assert.Contains(t, operation.RecoveryCommand, "app-start")
+	assert.True(t, operation.RecoveryPending)
 	assert.Equal(t, "v1.0.0", mustReadVersion(t, filepath.Join(installRoot, "deployment", "version.txt")))
 	assert.NoDirExists(t, filepath.Join(installRoot, "deployment.previous"))
 	assert.NoDirExists(t, stageRoot)
+	require.NoError(t, manager.RecoverApplication())
+	recovered := manager.Status().Operation
+	require.NotNil(t, recovered)
+	assert.Empty(t, recovered.RecoveryCommand)
+	assert.False(t, recovered.RecoveryPending)
+	commands := runner.Commands()
+	require.Len(t, commands, 1)
+	assert.Equal(t, []string{"app-start", "v1.0.0", "any"}, commands[0].Args)
 }
 
 func TestManagerDoesNotRestorePreviousWithoutAPendingSwapMarker(t *testing.T) {

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -1857,7 +1857,7 @@ func TestManagerRestartsHAApplicationAfterInterruptedSwap(t *testing.T) {
 	assert.False(t, manager.Status().Operation.RecoveryPending)
 }
 
-func TestManagerRetriesInterruptedHARecoveryAfterRestartFailure(t *testing.T) {
+func TestManagerServesRecoveryStateAfterRestartFailure(t *testing.T) {
 	// Arrange
 	installRoot := t.TempDir()
 	writeCurrentDeployment(t, installRoot, "v1.0.0")
@@ -1869,15 +1869,10 @@ func TestManagerRetriesInterruptedHARecoveryAfterRestartFailure(t *testing.T) {
 	writeInterruptedOperationState(t, stateDir, "v1.1.0")
 
 	// Act
-	_, err := NewManager(Config{
+	manager, err := NewManager(Config{
 		InstallRoot: installRoot, StateDir: stateDir, GOARCH: "amd64",
 		DeploymentMode: DeploymentModeHA,
 		Runner:         &haRecordingRunner{fail: map[string]error{"app-start": errors.New("restart failed")}},
-	})
-	require.ErrorContains(t, err, "restart failed")
-	manager, err := NewManager(Config{
-		InstallRoot: installRoot, StateDir: stateDir, GOARCH: "amd64",
-		DeploymentMode: DeploymentModeHA, Runner: &haRecordingRunner{},
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() { assert.NoError(t, manager.Close()) })
@@ -1885,8 +1880,9 @@ func TestManagerRetriesInterruptedHARecoveryAfterRestartFailure(t *testing.T) {
 	// Assert
 	operation := manager.Status().Operation
 	require.NotNil(t, operation)
-	assert.False(t, operation.RecoveryPending)
-	assert.Empty(t, operation.RecoveryCommand)
+	assert.True(t, operation.RecoveryPending)
+	assert.NotEmpty(t, operation.RecoveryCommand)
+	assert.Contains(t, operation.Error, "restart failed")
 }
 
 func TestManagerDoesNotReplayTerminalHARecovery(t *testing.T) {

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -52,27 +52,34 @@ type recordingRunner struct {
 }
 
 type haRecordingRunner struct {
-	mu       sync.Mutex
-	commands []recordedCommand
-	fail     map[string]error
+	mu        sync.Mutex
+	commands  []recordedCommand
+	fail      map[string]error
+	blockStop bool
 }
 
-func (r *haRecordingRunner) Run(_ context.Context, dir string, output io.Writer, name string, args ...string) error {
+func (r *haRecordingRunner) Run(ctx context.Context, dir string, output io.Writer, name string, args ...string) error {
 	r.mu.Lock()
-	defer r.mu.Unlock()
 	r.commands = append(r.commands, recordedCommand{Dir: dir, Name: name, Args: append([]string(nil), args...)})
+	blockStop := r.blockStop && len(args) > 0 && args[0] == "app-stop"
 	if len(args) == 1 && args[0] == "--version" {
+		r.mu.Unlock()
 		if _, err := fmt.Fprintln(output, "v1.1.0"); err != nil {
 			return fmt.Errorf("write candidate version: %w", err)
 		}
 		return nil
 	}
+	var err error
 	if len(args) > 0 {
-		err := r.fail[args[0]]
+		err = r.fail[args[0]]
 		delete(r.fail, args[0])
-		return err
 	}
-	return nil
+	r.mu.Unlock()
+	if blockStop {
+		<-ctx.Done()
+		return fmt.Errorf("blocked application stop: %w", ctx.Err())
+	}
+	return err
 }
 
 func (r *haRecordingRunner) Commands() []recordedCommand {
@@ -464,6 +471,30 @@ func TestManagerHACompletionRestartsOldReleaseWhenStopFails(t *testing.T) {
 	require.Equal(t, updaterapi.PhaseFailed, completed.Phase)
 	assert.Contains(t, completed.Error, "previous release restarted")
 	assert.Empty(t, completed.RecoveryCommand)
+	commands := runner.Commands()
+	assert.Equal(t, []string{"app-start", "v1.0.0", "any"}, commands[len(commands)-1].Args)
+}
+
+func TestManagerHACompletionRestartsOldReleaseWhenStopBlocks(t *testing.T) {
+	// Arrange
+	installRoot := t.TempDir()
+	writeCurrentDeployment(t, installRoot, "v1.0.0")
+	bundle := releaseBundle(t, "v1.1.0")
+	server := releaseServer(t, "v1.1.0", "amd64", bundle, "")
+	runner := &haRecordingRunner{fail: make(map[string]error), blockStop: true}
+	manager := newTestManagerWithConfig(t, installRoot, server, runner, func(cfg *Config) {
+		cfg.DeploymentMode = DeploymentModeHA
+		cfg.ActivationTimeout = 250 * time.Millisecond
+	})
+
+	// Act
+	_, err := manager.TriggerCompleteWithID("v1.1.0", "11111111-1111-4111-8111-111111111111")
+	require.NoError(t, err)
+	completed := waitForTerminal(t, manager)
+
+	// Assert
+	require.Equal(t, updaterapi.PhaseFailed, completed.Phase)
+	assert.Contains(t, completed.Error, "previous release restarted")
 	commands := runner.Commands()
 	assert.Equal(t, []string{"app-start", "v1.0.0", "any"}, commands[len(commands)-1].Args)
 }

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -382,15 +382,14 @@ func TestManagerHAInterruptedAfterStopRestartsCurrentApplication(t *testing.T) {
 
 	// Act
 	runner := &haRecordingRunner{fail: make(map[string]error)}
-	manager, err := NewManager(Config{
+	err := RepairStartup(Config{
 		InstallRoot: installRoot, StateDir: stateDir, GOARCH: "amd64", DeploymentMode: DeploymentModeHA, Runner: runner,
 	})
 	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, manager.Close()) })
 
 	// Assert
-	operation := manager.Status().Operation
-	require.NotNil(t, operation)
+	var operation updaterapi.Operation
+	require.NoError(t, json.Unmarshal([]byte(mustReadFile(t, filepath.Join(stateDir, stateFilename))), &operation))
 	require.Equal(t, updaterapi.PhaseFailed, operation.Phase)
 	assert.Empty(t, operation.RecoveryCommand)
 	assert.Contains(t, operation.Message, "HA application restarted")
@@ -541,15 +540,14 @@ func TestManagerHACompletionInterruptedAfterSwapStartsTargetRelease(t *testing.T
 	runner := &haRecordingRunner{fail: make(map[string]error)}
 
 	// Act
-	manager, err := NewManager(Config{
+	err := RepairStartup(Config{
 		InstallRoot: installRoot, StateDir: stateDir, GOARCH: "amd64", DeploymentMode: DeploymentModeHA, Runner: runner,
 	})
 	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, manager.Close()) })
 
 	// Assert
-	operation := manager.Status().Operation
-	require.NotNil(t, operation)
+	var operation updaterapi.Operation
+	require.NoError(t, json.Unmarshal([]byte(mustReadFile(t, filepath.Join(stateDir, stateFilename))), &operation))
 	require.Equal(t, updaterapi.PhaseFailed, operation.Phase)
 	require.Empty(t, operation.RecoveryCommand)
 	commands := runner.Commands()
@@ -1910,66 +1908,6 @@ func TestRepairStartupKeepsPreviousUpdaterAfterReplacementRetryFails(t *testing.
 	assert.NoFileExists(t, installedUpdater+selfUpdateHandoffSuffix)
 }
 
-func TestManagerRestartsHAApplicationAfterInterruptedSwap(t *testing.T) {
-	t.Parallel()
-
-	// Arrange
-	installRoot := t.TempDir()
-	writeCurrentDeployment(t, installRoot, "v1.0.0")
-	require.NoError(t, os.Rename(
-		filepath.Join(installRoot, "deployment"),
-		filepath.Join(installRoot, "deployment.previous"),
-	))
-	stateDir := filepath.Join(t.TempDir(), "state")
-	writeInterruptedOperationState(t, stateDir, "v1.1.0")
-	runner := &haRecordingRunner{}
-
-	// Act
-	manager, err := NewManager(Config{
-		InstallRoot: installRoot, StateDir: stateDir, GOARCH: "amd64",
-		DeploymentMode: DeploymentModeHA, Runner: runner,
-	})
-	require.NoError(t, err)
-	t.Cleanup(func() { assert.NoError(t, manager.Close()) })
-
-	// Assert
-	commands := runner.Commands()
-	require.Len(t, commands, 1)
-	assert.Equal(t, []string{"app-start", "v1.0.0", "any"}, commands[0].Args)
-	assert.Empty(t, manager.Status().Operation.RecoveryCommand)
-	assert.False(t, manager.Status().Operation.RecoveryPending)
-}
-
-func TestRepairStartupRestoresLayoutWithoutStartingHAApplication(t *testing.T) {
-	t.Parallel()
-
-	// Arrange
-	installRoot := t.TempDir()
-	writeCurrentDeployment(t, installRoot, "v1.0.0")
-	require.NoError(t, os.Rename(
-		filepath.Join(installRoot, "deployment"),
-		filepath.Join(installRoot, "deployment.previous"),
-	))
-	stateDir := filepath.Join(t.TempDir(), "state")
-	writeInterruptedOperationState(t, stateDir, "v1.1.0")
-	runner := &haRecordingRunner{}
-
-	// Act
-	err := RepairStartup(Config{
-		InstallRoot: installRoot, StateDir: stateDir, GOARCH: "amd64",
-		DeploymentMode: DeploymentModeHA, Runner: runner,
-	})
-
-	// Assert
-	require.NoError(t, err)
-	assert.Empty(t, runner.Commands())
-	assert.Equal(t, "v1.0.0", mustReadVersion(t, filepath.Join(installRoot, "deployment", "version.txt")))
-	assert.NoDirExists(t, filepath.Join(installRoot, "deployment.previous"))
-	var operation updaterapi.Operation
-	require.NoError(t, json.Unmarshal([]byte(mustReadFile(t, filepath.Join(stateDir, stateFilename))), &operation))
-	assert.True(t, operation.RecoveryPending)
-}
-
 func TestRepairStartupDoesNotTouchSelfUpdateWhileManagerRuns(t *testing.T) {
 	// Arrange
 	installRoot := t.TempDir()
@@ -1988,7 +1926,7 @@ func TestRepairStartupDoesNotTouchSelfUpdateWhileManagerRuns(t *testing.T) {
 	assert.Equal(t, "new updater", mustReadFile(t, destination))
 }
 
-func TestManagerFailsStartupWhenHARecoveryFails(t *testing.T) {
+func TestRepairStartupFailsWhenHARecoveryFails(t *testing.T) {
 	// Arrange
 	installRoot := t.TempDir()
 	writeCurrentDeployment(t, installRoot, "v1.0.0")
@@ -2000,13 +1938,12 @@ func TestManagerFailsStartupWhenHARecoveryFails(t *testing.T) {
 	writeInterruptedOperationState(t, stateDir, "v1.1.0")
 
 	// Act
-	manager, err := NewManager(Config{
+	err := RepairStartup(Config{
 		InstallRoot: installRoot, StateDir: stateDir, GOARCH: "amd64",
 		DeploymentMode: DeploymentModeHA,
 		Runner:         &haRecordingRunner{fail: map[string]error{"app-start": errors.New("restart failed")}},
 	})
 	require.ErrorContains(t, err, "restart interrupted HA application")
-	require.Nil(t, manager)
 
 	// Assert
 	var operation updaterapi.Operation
@@ -2033,12 +1970,11 @@ func TestManagerDoesNotReplayTerminalHARecovery(t *testing.T) {
 	runner := &haRecordingRunner{}
 
 	// Act
-	manager, err := NewManager(Config{
+	err = RepairStartup(Config{
 		InstallRoot: installRoot, StateDir: stateDir, GOARCH: "amd64",
 		DeploymentMode: DeploymentModeHA, Runner: runner,
 	})
 	require.NoError(t, err)
-	t.Cleanup(func() { assert.NoError(t, manager.Close()) })
 
 	// Assert
 	assert.Empty(t, runner.Commands())

--- a/server/internal/updater/server.go
+++ b/server/internal/updater/server.go
@@ -250,7 +250,12 @@ func (s *Server) handleUpgrade(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, updaterapi.ErrorResponse{Error: "invalid request body"})
 		return
 	}
-	operation, err := s.manager.TriggerWithID(request.TargetVersion, request.OperationID)
+	var operation updaterapi.Operation
+	if request.Complete {
+		operation, err = s.manager.TriggerCompleteWithID(request.TargetVersion, request.OperationID)
+	} else {
+		operation, err = s.manager.TriggerWithID(request.TargetVersion, request.OperationID)
+	}
 	if err != nil {
 		status := triggerErrorHTTPStatus(err)
 		message := err.Error()

--- a/server/internal/updaterapi/client.go
+++ b/server/internal/updaterapi/client.go
@@ -72,7 +72,15 @@ func (c *Client) Status(ctx context.Context) (StatusResponse, error) {
 }
 
 func (c *Client) Trigger(ctx context.Context, operationID, targetVersion string) (Operation, error) {
-	request := TriggerRequest{OperationID: operationID, TargetVersion: targetVersion}
+	return c.trigger(ctx, operationID, targetVersion, false)
+}
+
+func (c *Client) TriggerComplete(ctx context.Context, operationID, targetVersion string) (Operation, error) {
+	return c.trigger(ctx, operationID, targetVersion, true)
+}
+
+func (c *Client) trigger(ctx context.Context, operationID, targetVersion string, complete bool) (Operation, error) {
+	request := TriggerRequest{OperationID: operationID, TargetVersion: targetVersion, Complete: complete}
 	var response TriggerResponse
 	if err := c.do(ctx, http.MethodPost, "/v1/upgrade", request, &response); err != nil {
 		return Operation{}, err

--- a/server/internal/updaterapi/client.go
+++ b/server/internal/updaterapi/client.go
@@ -85,11 +85,12 @@ func (c *Client) trigger(ctx context.Context, operationID, targetVersion string,
 	if err := c.do(ctx, http.MethodPost, "/v1/upgrade", request, &response); err != nil {
 		return Operation{}, err
 	}
-	if response.Operation.ID != operationID || response.Operation.TargetVersion != targetVersion {
+	if response.Operation.ID != operationID || response.Operation.TargetVersion != targetVersion || response.Operation.Complete != complete {
 		return Operation{}, &ProtocolError{Cause: fmt.Errorf(
-			"operation identity mismatch: got id %q target %q",
+			"operation identity mismatch: got id %q target %q complete %t",
 			response.Operation.ID,
 			response.Operation.TargetVersion,
+			response.Operation.Complete,
 		)}
 	}
 	return response.Operation, nil

--- a/server/internal/updaterapi/types.go
+++ b/server/internal/updaterapi/types.go
@@ -24,6 +24,7 @@ func (p Phase) Terminal() bool {
 type Operation struct {
 	ID              string     `json:"id"`
 	TargetVersion   string     `json:"target_version"`
+	Complete        bool       `json:"complete,omitempty"`
 	Phase           Phase      `json:"phase"`
 	Message         string     `json:"message,omitempty"`
 	StartedAt       time.Time  `json:"started_at"`

--- a/server/internal/updaterapi/types.go
+++ b/server/internal/updaterapi/types.go
@@ -31,6 +31,7 @@ type Operation struct {
 	CompletedAt     *time.Time `json:"completed_at,omitempty"`
 	Error           string     `json:"error,omitempty"`
 	RecoveryCommand string     `json:"recovery_command,omitempty"`
+	RecoveryPending bool       `json:"recovery_pending,omitempty"`
 	LogPath         string     `json:"log_path,omitempty"`
 }
 

--- a/server/internal/updaterapi/types.go
+++ b/server/internal/updaterapi/types.go
@@ -41,6 +41,7 @@ type StatusResponse struct {
 type TriggerRequest struct {
 	OperationID   string `json:"operation_id"`
 	TargetVersion string `json:"target_version"`
+	Complete      bool   `json:"complete,omitempty"`
 }
 
 type TriggerResponse struct {


### PR DESCRIPTION
Reviewable diff: +516/-98 across 8 files (excludes generated, test, and story files).

## Summary

Completes a passive-first HA application update by moving the VIP to the already-updated peer before replacing the old active host. It accepts one bounded lease-expiry and VIP-takeover interruption instead of adding graceful handoff. The operator chooses the target release under #890's compatibility policy; this PR proves only that the peer is already serving that exact version before the old active swaps.

**Stack:** [#888](https://github.com/block/proto-fleet/pull/888) -> [#914](https://github.com/block/proto-fleet/pull/914) -> [#890](https://github.com/block/proto-fleet/pull/890) -> **#891**. This diff is relative to #890, which provides operator-selected passive application updates and restart recovery. #914 supplies the promotion-observation invariant used during takeover. This PR adds active completion and its crash-recovery states.

## How it works

`fleet-ha update VERSION --complete` first proves that the local node is active and that the peer is healthy, passive, and already running the target. It stages and preflights the target without stopping service, then rechecks both roles before persisting recovery intent.

Stopping the local Fleet application causes normal lease expiry and VIP withdrawal. The updated peer must acquire ownership and serve the VIP at the requested version within the takeover deadline. If stop or takeover fails before the deployment swap, the updater restarts the unchanged old deployment.

Only after the target serves the VIP does the old active atomically swap its local deployment, start the target, and verify that it is healthy and passive. Startup repair reconciles interrupted swaps and updater handoffs. Durable pending recovery prevents another update until the selected application is healthy again.

```mermaid
sequenceDiagram
  participant A as Old active
  participant P as Updated passive
  participant V as VIP
  A->>A: Stage and preflight target
  A->>A: Recheck roles and persist recovery intent
  A->>A: Stop local Fleet application
  A-->>P: Lease expires
  P->>V: Acquire ownership and advertise VIP
  A->>V: Require target version before deadline
  A->>A: Swap, start target, and verify passive
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/cmd/fleet-ha/` | Add `update VERSION --complete` | Check command selection and argument enforcement |
| `server/internal/ha/deployment/update.go` and `update_timing.go` | Add active validation, peer proof, Fleet stop/start, and takeover deadlines | Check takeover and fallback ordering |
| `server/internal/updater/` and `server/internal/updaterapi/` | Persist completion mode, operation identity, recovery intent, and interrupted activation state | Check idempotent retries and crash recovery |
| `deployment-files/ha/README.md` | Document the bounded interruption and completion flow | Check operator expectations |

## Key technical decisions & trade-offs

- Normal lease expiry and VIP takeover replace a graceful ownership-handoff protocol.
- The local deployment swaps only after the target serves the VIP, so failed takeover can restart the unchanged release.
- The target is operator-selected. Completion verifies exact peer/local version agreement but does not infer release compatibility.
- Packaged Compose files use literal application image tags, so fallback selects the retained old images.
- Active shutdown is bounded at 5 seconds and takeover fallback at 35 seconds. Hardware qualification must still demonstrate the expected interruption target.
- Recovery uses the existing role-aware application start command instead of adding another lifecycle protocol.
- Root-owned fault-injection barriers exist only for deterministic crash-window qualification and are absent in normal operation.

## Testing & validation

- Tests cover successful completion, wrong peer version, takeover timeout, bounded active shutdown, old-release restart, cross-mode idempotency rejection, interrupted swaps, durable recovery, and updater-lock exclusion.
- Targeted updater, HA deployment, CLI, updater API, and domain tests pass after restacking on #890.
- Hermit lint, the static HA profile check, and `git diff --check` pass.
- Hardware outage timing remains qualification work.

## Post-Deploy Monitoring & Validation

- Owner: the operator completing the update.
- Window: from local Fleet stop until the old active returns healthy as the passive host.
- Healthy signals: the updated peer serves the VIP at the requested version, the old active restarts passive at that version, and failover readiness returns.
- Failure signals: VIP takeover exceeds the deadline, the old release cannot restart, or the updater reports pending recovery.
- Mitigation: stop further update attempts, inspect both hosts with `fleet-ha status`, and use the persisted recovery command before retrying completion.
