### PR TITLE
Define adjacent-release HA update qualification

### DIFF
--- a/deployment-files/ha/README.md
+++ b/deployment-files/ha/README.md
@@ -262,3 +262,6 @@ A passive update rechecks the local role, active peer, and control path just
 before stopping Fleet. This crash-only profile accepts the small role-change
 window before process exit; if the peer fails in that interval, durable update
 recovery restarts the local application.
+After the baseline passes, use the
+[update qualification procedure](UPDATE_QUALIFICATION.md) for each adjacent
+release pair supported by the HA application updater.

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -34,15 +34,22 @@ customer data from committed evidence.
    swapping, restarts release `N`, serves the VIP within 45 seconds, and can
    complete a command. Restart keepalived and restore full readiness. This
    recovery bound is separate from the 15-second successful-handoff target.
-6. Retry `fleet-ha update N+1 --complete`. Measure from the first failed VIP
-   health probe until the VIP serves `N+1`.
-7. Verify the former active is now passive on `N+1`, then force an application
-   failover in each direction.
-8. Submit a command through the VIP after each failover and verify it succeeds.
-9. Reboot both database hosts, one at a time, restoring full readiness between
-   reboots. Confirm both return on `N+1`.
-10. Compare the recorded infrastructure container IDs and prove that etcd,
-   Patroni, and PostgreSQL were not replaced by the application update.
+6. Using different test devices, leave one command PENDING and one command
+   PROCESSING as described by the clean-install qualification, then retry
+   `fleet-ha update N+1 --complete`. Measure from the first failed VIP health
+   probe until the VIP serves `N+1`.
+7. Verify the PENDING command is dispatched, the interrupted PROCESSING attempt
+   reaches its documented terminal state, and a later command for that device
+   succeeds.
+8. Verify the former active is now passive on `N+1`, then force an application
+   failover in each direction. Submit a command through the VIP after each
+   failover and verify it succeeds.
+9. Compare the infrastructure container IDs recorded in step 2. Prove that the
+   application update did not replace etcd, Patroni, or PostgreSQL.
+10. Reboot both database hosts, one at a time, restoring full readiness between
+    reboots. Confirm both return on `N+1` with the same etcd membership,
+    Patroni cluster, and persisted Fleet data. Container IDs may change during
+    reboot.
 
 ## Results
 
@@ -52,11 +59,13 @@ customer data from committed evidence.
 | Mixed-version window | Authenticated reads, writes, and command completion work while peers run `N` and `N+1` | Pending | Pending | Pending |
 | Failed takeover recovery | Completion times out before swap; `N` restarts and serves commands within 45s | Pending | Pending | Pending |
 | Active completion | VIP serves `N+1` within 15s | Pending | Pending | Pending |
+| PENDING command handoff | New active dispatches the queued command | Pending | Pending | Pending |
+| PROCESSING command handoff | Interrupted attempt finishes terminally and later work resumes | Pending | Pending | Pending |
 | Failover to peer | VIP serves `N+1` within 15s | Pending | Pending | Pending |
 | Failover back | VIP serves `N+1` within 15s | Pending | Pending | Pending |
 | Command execution | Command succeeds after both failovers | N/A | Pending | Pending |
-| Reboot recovery | Both database hosts return on `N+1` | Pending | Pending | Pending |
-| Infrastructure preservation | etcd, Patroni, and PostgreSQL container IDs are unchanged | N/A | Pending | Pending |
+| Infrastructure preservation | Application update leaves etcd, Patroni, and PostgreSQL container IDs unchanged | N/A | Pending | Pending |
+| Reboot recovery | Both hosts return on `N+1` with DCS, database, and Fleet data intact | Pending | Pending | Pending |
 
 ## Verdict
 

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -106,7 +106,9 @@ sudo systemctl is-active --quiet proto-fleet-updater.service
    remain there for its full timeout, and restart release `N` automatically.
    Within 60 seconds, require the old host to serve the VIP, a persisted read,
    and a successful command, with no manual recovery command remaining. Restart
-   the `N+1` peer as passive and restore full readiness before continuing.
+   the `N+1` peer as passive and require control readiness with version mismatch
+   as the only failover-readiness degradation. Step 6 reinstalls a common
+   baseline before applying the full-readiness gate.
 6. Reinstall the clean `N` baseline and repeat steps 2 and 3 for a separate
    mixed-version failover run. Update the passive host to `N+1`, then terminate
    the active `N` Fleet process instead of running `--complete`. Require the
@@ -170,12 +172,17 @@ sudo systemctl is-active --quiet proto-fleet-updater.service
 
     Repeat a case if its required evidence clears before the fault lands.
     After each restart, require one valid deployment directory, no pending
-    recovery marker, a healthy updater socket, restored control and failover
-    readiness, and either the intact old release or fully verified target
-    release according to the recorded recovery state. When recovery retains
-    the target release, require the installed updater's `--version` to report
-    the same target version; startup repair must not leave the previous updater
-    paired with the new application.
+    recovery marker, a healthy updater socket, control readiness, and either
+    the intact old release or fully verified target release according to the
+    recorded recovery state. While hosts differ, require version mismatch to be
+    the only failover-readiness degradation. Then converge both hosts to the
+    expected retained version, by reinstalling `N` after old-release recovery
+    or running `--complete` on the remaining active `N` host after forward
+    recovery, and require full failover readiness. When recovery retains the
+    target release, require the installed updater's `--version` to report the
+    same target version;
+    startup repair must not leave the previous updater paired with the new
+    application.
 
 ## Results
 

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -42,19 +42,19 @@ certificates, device names, and customer data from committed evidence.
    three VIP probes succeed and `/api-proxy/health` reports
    `X-Proto-Fleet-Version: N+1`; require less than 15 seconds. Verify the former
    active rejoins as passive.
-6. Using a controllable test device, pause one command after its exact queue row
-   reaches PROCESSING so its successor remains PENDING, then immediately force
-   an application failover. Continuously record both rows until the old
-   `fleet-api` stops and fail if either changes before that stop. Reuse the
+6. Using a controllable test device, stall one command after its exact queue row
+   reaches PROCESSING so its successor remains PENDING. SIGSTOP the old active
+   `fleet-api`, let its lease expire, and wait for the `N+1` peer to take over
+   and recover the PROCESSING row. Queue the old plugin result while its process
+   is stopped, then SIGCONT it. Verify the old process exits, its stale database
+   transition is rejected, exactly one terminal result remains, the PENDING
+   successor dispatches, and later work for that device succeeds. Reuse the
    direct active-health and interface-address streams from step 5 through
-   convergence and fail on any active or VIP overlap. Release the test device;
-   verify the PROCESSING command reaches its expected terminal recovery state,
-   the PENDING command dispatches, and later work for that device succeeds.
-   Force a second failover in the other direction with the same ownership
-   streams. For both moves, require the former active to reject an active-only
-   request, measure usable service from the last successful pre-failover probe
-   on the same monotonic clock, require less than 15 seconds, and submit a
-   successful command.
+   convergence and fail on any active or VIP overlap. Force a second failover
+   in the other direction with the same ownership streams. For both moves,
+   require the former active to reject an active-only request, measure usable
+   service from the last successful pre-failover probe on the same monotonic
+   clock, require less than 15 seconds, and submit a successful command.
 7. Confirm the etcd and Patroni container IDs and start times, and both
    PostgreSQL postmaster start times, are unchanged from step 2. The application
    update must not replace or restart these services.
@@ -73,7 +73,7 @@ certificates, device names, and customer data from committed evidence.
 | Failed takeover recovery | No swap; `N` restores usable service and command execution | `<60s` | Pending | Pending |
 | Active completion | Active and database-backed probes serve `N+1`; former active rejoins passive | `<15s` | Pending | Pending |
 | Handoff fencing | High-frequency direct health and interface event streams never show active or VIP overlap | N/A | Pending | Pending |
-| Post-update failover command recovery | Exact rows stay PROCESSING/PENDING until stop, then PROCESSING recovers, PENDING dispatches, and later per-device work succeeds | N/A | Pending | Pending |
+| Post-update stale completion | Resumed old transition is rejected; exactly one terminal result remains; PENDING dispatches; later per-device work succeeds | N/A | Pending | Pending |
 | Failover to peer | No active or VIP overlap; old active rejects; VIP serves `N+1`; command succeeds | `<15s` | Pending | Pending |
 | Failover back | No active or VIP overlap; old active rejects; VIP serves `N+1`; command succeeds | `<15s` | Pending | Pending |
 | Infrastructure preserved | etcd and Patroni identity plus PostgreSQL start times are unchanged | N/A | Pending | Pending |

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -25,7 +25,12 @@ customer data from committed evidence.
    releases that predate this supported HA update baseline are out of scope.
 2. Record the running etcd and Patroni/PostgreSQL container IDs on all hosts.
 3. On the passive database host, run `fleet-ha update N+1` and verify that it
-   remains passive on `N+1` while the active host continues serving `N`.
+   remains passive on `N+1` while the active host continues serving `N`. Fail
+   if the operation reports `host updater refresh needs attention`. Require
+   `/usr/local/libexec/proto-fleet/proto-fleet-updater --version` to print
+   `N+1`, `proto-fleet-updater.service` to be active, and an authenticated local
+   request to `/v1/status` over `/run/proto-fleet-updater/updater.sock` to
+   succeed. Retain the redacted operation log.
 4. During the mixed-version window, use the authenticated VIP API to read
    existing database-backed configuration, submit a command, and verify its
    completion while `N` remains active.
@@ -38,7 +43,8 @@ customer data from committed evidence.
    successful-handoff target.
 6. Retry `fleet-ha update N+1 --complete` and measure from the first failed VIP
    health probe until the VIP serves `N+1`. Verify the former active is now
-   passive on `N+1`.
+   passive on `N+1`, then repeat the updater version, service, socket, warning,
+   and redacted-log checks from step 3 on this host.
 7. On one controlled test device, block a PROCESSING command and enqueue a
    second command behind it so per-device ordering keeps that row PENDING.
    Record both immutable queue row IDs and preserve a timestamped database
@@ -51,8 +57,8 @@ customer data from committed evidence.
    application update did not replace etcd, Patroni, or PostgreSQL.
 10. Reboot both database hosts, one at a time, restoring full readiness between
     reboots. Confirm both return on `N+1` with the same etcd membership,
-    Patroni cluster, and persisted Fleet data. Container IDs may change during
-    reboot.
+    Patroni cluster, and persisted Fleet data. On each host, repeat the updater
+    version, service, and socket checks. Container IDs may change during reboot.
 
 ## Results
 
@@ -68,6 +74,7 @@ customer data from committed evidence.
 | Failover back | VIP serves `N+1` within 15s | Pending | Pending | Pending |
 | Command execution | Command succeeds after both failovers | N/A | Pending | Pending |
 | Infrastructure preservation | Application update leaves etcd, Patroni, and PostgreSQL container IDs unchanged | N/A | Pending | Pending |
+| Host updater refresh | Both protected updater binaries report `N+1`; services and local status APIs survive reboot; no refresh warning remains | N/A | Pending | Pending |
 | Reboot recovery | Both hosts return on `N+1` with DCS, database, and Fleet data intact | Pending | Pending | Pending |
 
 ## Verdict

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -16,6 +16,10 @@ certificates, device names, and customer data from committed evidence.
 
 ## Procedure
 
+Set `SOURCE_RELEASE` and `TARGET_RELEASE` to the recorded canonical release tags
+and run Fleet commands as
+`sudo /opt/proto-fleet/deployment/ha/fleet-ha update "$TARGET_RELEASE"`.
+
 1. Verify the published `N` and `N+1` artifacts and their checksums. Confirm
    every `N+1` migration is expand-only and remains usable by `N`; reject
    drops, renames, narrowed types, and newly required values. Apply the
@@ -24,31 +28,36 @@ certificates, device names, and customer data from committed evidence.
    using [QUALIFICATION.md](QUALIFICATION.md).
 2. Record the container IDs and start times for etcd and Patroni on every host,
    plus `pg_postmaster_start_time()` on both PostgreSQL members.
-3. Run `fleet-ha update N+1` on the passive application host. Verify it remains
+3. Run the update command above on the passive application host. Verify it remains
    passive on `N+1` while the active host continues serving `N`. Through the
    VIP, read persisted data and submit a command to prove the temporary mixed
    `N` and `N+1` state is usable.
-4. Prevent the updated passive from advertising the VIP, then run
-   `fleet-ha update N+1 --complete` on the active host. Verify the command
+4. Prevent the updated passive from advertising the VIP, then append `--complete`
+   to the update command on the active host. Verify the command
    times out without swapping deployments, restarts `N`, and restores a usable
    VIP and successful command within 60 seconds. Restore the passive host.
-5. Retry `fleet-ha update N+1 --complete`. From one controller, continuously
-   record direct active health on both hosts with monotonic timestamps at
-   100 ms or faster. In parallel, stream interface address events from both
-   hosts and fail on any active or VIP overlap. Probe
+5. Retry the completion command. From a separate controller, use the external
+   append-only recorder, gap rejection, and uncertainty-inclusive interval rules
+   from [QUALIFICATION.md](QUALIFICATION.md). Continuously record direct active
+   health on both hosts with monotonic timestamps at 100 ms or faster. In
+   parallel, stream interface address events from both hosts and fail on any
+   active or VIP overlap. Probe
    `/api-proxy/health/active`, `/api-proxy/health`, and an authenticated
    database-backed request at least once per second. On the same monotonic
    clock, measure from the last successful pre-handoff VIP probe until all
    three VIP probes succeed and `/api-proxy/health` reports
    `X-Proto-Fleet-Version: N+1`; require less than 15 seconds. Verify the former
-   active rejoins as passive.
-6. Using a controllable test device, stall one command after its exact queue row
-   reaches PROCESSING so its successor remains PENDING. SIGSTOP the old active
-   `fleet-api`, let its lease expire, and wait for the `N+1` peer to take over
-   and recover the PROCESSING row. Queue the old plugin result while its process
-   is stopped, then SIGCONT it. Verify the old process exits, its stale database
-   transition is rejected, exactly one terminal result remains, the PENDING
-   successor dispatches, and later work for that device succeeds. Reuse the
+   active rejoins as passive. Using a client loaded from `N` before handoff,
+   perform a persisted read and a uniquely identified idempotent command against
+   the `N+1` VIP.
+6. Using a controllable test device on the current active host, stall one command
+   after its exact queue row reaches PROCESSING so its successor remains PENDING.
+   SIGSTOP that active `fleet-api`, let its lease expire, and wait for the passive
+   peer to take over. Queue the old plugin result while its process is stopped,
+   then SIGCONT it. Verify the original PROCESSING row is FAILED with the restart
+   interruption reason and is never dispatched again, the old process exits, its
+   stale database transition is rejected, exactly one terminal result remains,
+   the PENDING successor dispatches, and later work for that device succeeds. Reuse the
    direct active-health and interface-address streams from step 5 through
    convergence and fail on any active or VIP overlap. Force a second failover
    in the other direction with the same ownership streams. For both moves,
@@ -71,9 +80,9 @@ certificates, device names, and customer data from committed evidence.
 | Passive-first update | Passive runs `N+1`; active continues serving `N` | N/A | Pending | Pending |
 | Mixed-version operation | Persisted read and command succeed while hosts run `N` and `N+1` | N/A | Pending | Pending |
 | Failed takeover recovery | No swap; `N` restores usable service and command execution | `<60s` | Pending | Pending |
-| Active completion | Active and database-backed probes serve `N+1`; former active rejoins passive | `<15s` | Pending | Pending |
+| Active completion | Active and database-backed probes serve `N+1`; former active rejoins passive; cached `N` client works against `N+1` | `<15s` | Pending | Pending |
 | Handoff fencing | High-frequency direct health and interface event streams never show active or VIP overlap | N/A | Pending | Pending |
-| Post-update stale completion | Resumed old transition is rejected; exactly one terminal result remains; PENDING dispatches; later per-device work succeeds | N/A | Pending | Pending |
+| Post-update stale completion | Interrupted row is FAILED without replay; resumed old transition is rejected; PENDING successor and later work succeed | N/A | Pending | Pending |
 | Failover to peer | No active or VIP overlap; old active rejects; VIP serves `N+1`; command succeeds | `<15s` | Pending | Pending |
 | Failover back | No active or VIP overlap; old active rejects; VIP serves `N+1`; command succeeds | `<15s` | Pending | Pending |
 | Infrastructure preserved | etcd and Patroni identity plus PostgreSQL start times are unchanged | N/A | Pending | Pending |

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -31,13 +31,17 @@ customer data from committed evidence.
    completion while `N` remains active.
 5. Stop keepalived on the updated passive, then run
    `fleet-ha update N+1 --complete` on the active. Verify it times out before
-   swapping, restarts release `N`, serves the VIP within 45 seconds, and can
-   complete a command. Restart keepalived and restore full readiness. This
-   recovery bound is separate from the 15-second successful-handoff target.
-6. Using different test devices, leave one command PENDING and one command
-   PROCESSING as described by the clean-install qualification, then retry
-   `fleet-ha update N+1 --complete`. Measure from the first failed VIP health
-   probe until the VIP serves `N+1`.
+   swapping, restarts release `N`, and can complete a command. Measure
+   continuously from the first failed VIP health probe until release `N` serves
+   the VIP again; this must remain below 45 seconds. Restart keepalived and
+   restore full readiness. This recovery bound is separate from the 15-second
+   successful-handoff target.
+6. On one controlled test device, block a PROCESSING command and enqueue a
+   second command behind it so per-device ordering keeps that row PENDING.
+   Sample both database states with timestamps throughout update preflight and
+   preserve the final sample no more than one second before `fleet-api` stops.
+   Retry `fleet-ha update N+1 --complete` and measure from the first failed VIP
+   health probe until the VIP serves `N+1`.
 7. Verify the PENDING command is dispatched, the interrupted PROCESSING attempt
    reaches its documented terminal state, and a later command for that device
    succeeds.
@@ -59,8 +63,8 @@ customer data from committed evidence.
 | Mixed-version window | Authenticated reads, writes, and command completion work while peers run `N` and `N+1` | Pending | Pending | Pending |
 | Failed takeover recovery | Completion times out before swap; `N` restarts and serves commands within 45s | Pending | Pending | Pending |
 | Active completion | VIP serves `N+1` within 15s | Pending | Pending | Pending |
-| PENDING command handoff | New active dispatches the queued command | Pending | Pending | Pending |
-| PROCESSING command handoff | Interrupted attempt finishes terminally and later work resumes | Pending | Pending | Pending |
+| PENDING command handoff | Timestamped pre-stop evidence shows PENDING; new active dispatches it | Pending | Pending | Pending |
+| PROCESSING command handoff | Timestamped pre-stop evidence shows PROCESSING; attempt finishes terminally and later work resumes | Pending | Pending | Pending |
 | Failover to peer | VIP serves `N+1` within 15s | Pending | Pending | Pending |
 | Failover back | VIP serves `N+1` within 15s | Pending | Pending | Pending |
 | Command execution | Command succeeds after both failovers | N/A | Pending | Pending |

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -134,7 +134,10 @@ and run Fleet commands as
     fault lands. After each restart, require one valid deployment directory,
     no pending recovery marker, a healthy updater socket, restored control and
     failover readiness, and either the intact old release or fully verified
-    target release according to the recorded recovery state.
+    target release according to the recorded recovery state. When recovery
+    retains the target release, require the installed updater's `--version` to
+    report the same target version; startup repair must not leave the previous
+    updater paired with the new application.
 
 ## Results
 

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -48,7 +48,7 @@ customer data from committed evidence.
    times out before swapping, restarts release `N`, reacquires the VIP, and can
    complete a command. Measure continuously from the first failed VIP health
    probe until release `N` serves the VIP again; this must remain below 60
-   seconds. Record the 30-second takeover wait and subsequent old-release startup
+   seconds. Record the 35-second takeover wait and subsequent old-release startup
    separately. Restart the updated peer with `fleet-ha app-start N+1 passive` and
    restore full readiness before continuing. This recovery bound is separate
    from the 15-second successful-handoff target.

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -44,14 +44,15 @@ and run Fleet commands as
    controller, poll that host's local updater status over
    `/run/proto-fleet-updater/updater.sock`. As soon as its operation phase is
    `activating`, peer validation has passed and the old active is about to stop.
-   Immediately run `sudo systemctl stop proto-fleet-ha.service` on the updated
-   peer and confirm the service stops before the 10-second Fleet lease expires.
-   This prevents the peer from acquiring ownership during the failed-takeover
-   drill. Keep recording until the command times out without swapping
-   deployments, restarts `N`, and restores a usable VIP and successful command
-   within 60 seconds. Fail on any collection gap, active overlap, or VIP overlap.
-   Start `proto-fleet-ha.service` on the peer again and restore full readiness
-   before continuing.
+   Immediately run
+   `sudo /opt/proto-fleet/deployment/ha/fleet-ha app-stop` on the updated peer
+   and confirm its Fleet containers stop before the 10-second lease expires.
+   Patroni, PostgreSQL, etcd, and keepalived must remain running. Keep recording
+   until the command times out without swapping deployments, restarts `N`, and
+   restores a usable VIP and successful command within 60 seconds. Fail on any
+   collection gap, active overlap, or VIP overlap. Restore the peer with
+   `sudo /opt/proto-fleet/deployment/ha/fleet-ha app-start "$TARGET_RELEASE" passive`
+   and wait for full readiness before continuing.
 5. Retry the completion command. From a separate controller, use the external
    append-only recorder, gap rejection, and uncertainty-inclusive interval rules
    from [QUALIFICATION.md](QUALIFICATION.md). Continuously record direct active

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -86,8 +86,9 @@ and run Fleet commands as
    identities from step 2 are unchanged.
 5. Reinstall the clean `N` baseline and repeat steps 2 and 3 for a separate
    mixed-version failover run. Update the passive host to `N+1`, then terminate
-   the active `N` Fleet process before running `--complete`. Require the `N+1`
-   peer to take over within 15 seconds with no possible active or VIP overlap,
+   the active `N` Fleet process instead of running `--complete`. Require the
+   `N+1` peer to take over within 15 seconds with no possible active or VIP
+   overlap,
    recover interrupted command state, and serve a successful command. Restart
    the `N` host as passive and update it with the ordinary passive command.
    Require both hosts to run `N+1`, full failover readiness, and unchanged

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -48,6 +48,12 @@ and run Fleet commands as
    container ID and start time on both database hosts, and
    `pg_postmaster_start_time()` on both PostgreSQL members.
 3. Before running the update command on the passive application host, start
+   the external append-only recorder, gap rejection, and uncertainty-inclusive
+   interval rules from [QUALIFICATION.md](QUALIFICATION.md). Confirm initial
+   snapshots and gap-free streams, then continuously record direct active
+   health on both hosts with monotonic timestamps at 100 ms or faster. In
+   parallel, stream interface address events from both hosts and fail on any
+   active or VIP overlap. Also start
    authenticated database-backed reads and uniquely identified idempotent
    commands through the VIP at least once per second. Give each request a
    two-second deadline, record command submission and terminal-result times,
@@ -56,13 +62,8 @@ and run Fleet commands as
    submissions are more than three seconds apart. Continue these probes through
    step 4. Verify the active host continues serving `N` throughout the migration
    and mixed-version window.
-4. From a separate controller, start the external append-only recorder, gap
-   rejection, and uncertainty-inclusive interval rules from
-   [QUALIFICATION.md](QUALIFICATION.md). Confirm initial snapshots and gap-free
-   streams before continuing. Continuously record direct active health on both
-   hosts with monotonic timestamps at 100 ms or faster. In parallel, stream
-   interface address events from both hosts and fail on any active or VIP
-   overlap. Before the handoff, hold one `N` command in PROCESSING and one
+4. Keep the recorder and probes from step 3 running. Before the handoff, hold
+   one `N` command in PROCESSING and one
    successor in PENDING. Then run the completion command. Probe
    `/api-proxy/health/active`, `/api-proxy/health`, and an authenticated
    database-backed request at least once per second. On the same monotonic
@@ -74,8 +75,17 @@ and run Fleet commands as
    `N+1`, and both accepted IDs to reach exactly one terminal result within 60
    seconds. Using a client loaded from `N` before handoff,
    perform a persisted read and a uniquely identified idempotent command against
-   the `N+1` VIP.
-5. Using a controllable test device on the current active host, stall one command
+   the `N+1` VIP. Before reinstalling for step 5, confirm the infrastructure
+   identities from step 2 are unchanged.
+5. Reinstall the clean `N` baseline and repeat steps 2 and 3 for a separate
+   mixed-version failover run. Update the passive host to `N+1`, then terminate
+   the active `N` Fleet process before running `--complete`. Require the `N+1`
+   peer to take over within 15 seconds with no possible active or VIP overlap,
+   recover interrupted command state, and serve a successful command. Restart
+   the `N` host as passive and update it with the ordinary passive command.
+   Require both hosts to run `N+1`, full failover readiness, and unchanged
+   infrastructure identities from this run's step 2.
+6. Using a controllable test device on the current active host, stall one command
    after its exact queue row reaches PROCESSING so its successor remains PENDING.
    SIGSTOP that active `fleet-api`, let its lease expire, and wait for the passive
    peer to take over. Queue the old plugin result while its process is stopped,
@@ -83,16 +93,16 @@ and run Fleet commands as
    interruption reason and is never dispatched again, the old process exits, its
    stale database transition is rejected, exactly one terminal result remains,
    the PENDING successor dispatches, and later work for that device succeeds. Reuse the
-   direct active-health and interface-address streams from step 4 through
+   direct active-health and interface-address streams from step 3 through
    convergence and fail on any active or VIP overlap. Force a second failover
    in the other direction with the same ownership streams. For both moves,
    require the former active to reject an active-only request, measure usable
    service from the last successful pre-failover probe on the same monotonic
    clock, require less than 15 seconds, and submit a successful command.
-6. Confirm the etcd and Patroni container IDs and start times, and both
+7. Confirm the etcd and Patroni container IDs and start times, and both
    PostgreSQL postmaster start times, are unchanged from step 2. The application
    update must not replace or restart these services.
-7. Confirm both updater binaries report `N+1` and their services and local
+8. Confirm both updater binaries report `N+1` and their services and local
    status sockets are healthy. Reboot the two application/database hosts one
    at a time, restoring full readiness between reboots. Repeat the updater
    checks and verify both hosts retain Fleet data and can serve a command.
@@ -107,6 +117,7 @@ and run Fleet commands as
 | Mixed-version operation | Continuous persisted reads and commands succeed throughout migration while hosts run `N` and `N+1` | N/A | Pending | Pending |
 | Active completion | Active and database-backed probes serve `N+1`; former active rejoins passive; cached `N` client works against `N+1` | `<15s` | Pending | Pending |
 | Handoff fencing | High-frequency direct health and interface event streams never show active or VIP overlap | N/A | Pending | Pending |
+| Mixed-version forced takeover | `N+1` takes over safely while its peer is `N`; the old host then completes through the ordinary passive update | `<15s` | Pending | Pending |
 | Post-update stale completion | Interrupted row is FAILED without replay; resumed old transition is rejected; PENDING successor and later work succeed | N/A | Pending | Pending |
 | Failover to peer | No active or VIP overlap; old active rejects; VIP serves `N+1`; command succeeds | `<15s` | Pending | Pending |
 | Failover back | No active or VIP overlap; old active rejects; VIP serves `N+1`; command succeeds | `<15s` | Pending | Pending |

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -1,13 +1,21 @@
 # Proto Fleet HA update qualification
 
-Use this report to qualify one adjacent released-version update, `N` to `N+1`,
-on the supported three-host HA profile. Redact addresses, credentials,
-certificates, device names, and customer data from committed evidence.
+Use this report to qualify one adjacent update, `N` to `N+1`, on the supported
+three-host HA profile. Redact addresses, credentials, certificates, device
+names, and customer data from committed evidence.
 
-This first version qualifies exact artifacts after publication because the
-production updater accepts only the fixed official release origin. Publication
-makes the pair downloadable, not supported. Do not run the update until this
-report passes; a separate prepublication artifact channel is deferred.
+Publish the final `N+1` tag and assets at the fixed official release origin as
+a GitHub prerelease. HA does not offer UI-triggered updates, so only an explicit
+local operator command can select this candidate. After every gate passes,
+promote that same release without changing its tag or assets. A failed report
+leaves the release marked prerelease and unsupported.
+
+This report does not claim hardware qualification of the automatic
+old-release restart when the peer fails to take over. That path is covered by
+the updater's focused tests, but making the hardware drill deterministic would
+require a production fault-injection hook. If completion times out during this
+initial release, follow the reported recovery command and verify local HA
+status before retrying.
 
 ## Test identity
 
@@ -25,7 +33,7 @@ Set `SOURCE_RELEASE` and `TARGET_RELEASE` to the recorded canonical release tags
 and run Fleet commands as
 `sudo /opt/proto-fleet/deployment/ha/fleet-ha update "$TARGET_RELEASE"`.
 
-1. Verify the published `N` and `N+1` artifacts and their checksums. Confirm
+1. Verify the stable `N` and prerelease `N+1` artifacts and their checksums. Confirm
    the target was built from a reviewed
    `qualified-update-from.txt` containing exactly `SOURCE_RELEASE`, and that
    its manifest-covered `ha_update_from` field matches. An empty file makes the
@@ -108,5 +116,6 @@ and run Fleet commands as
 
 ## Verdict
 
-**Pending.** Mark the adjacent update supported only when every gate passes and
-attach the redacted evidence to this report.
+**Pending.** Mark the adjacent update supported only when every gate passes,
+attach the redacted evidence to this report, and promote the unchanged `N+1`
+GitHub release from prerelease to stable.

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -23,15 +23,18 @@ and run Fleet commands as
 1. Verify the published `N` and `N+1` artifacts and their checksums. Confirm
    every `N+1` migration is expand-only and remains usable by `N`; reject
    drops, renames, narrowed types, and newly required values. Apply the
-   migrations to a disposable copy of an `N` database and run `N`'s affected
-   database and API integration tests against it. Install and qualify `N`
-   using [QUALIFICATION.md](QUALIFICATION.md).
+   migrations to a representative production-size copy of an `N` database and
+   run `N`'s affected database and API integration tests against it. Require
+   completed baseline reports from [QUALIFICATION.md](QUALIFICATION.md) for the
+   exact `N` and `N+1` artifacts, then install `N` for this procedure.
 2. Record the container IDs and start times for etcd and Patroni on every host,
    plus `pg_postmaster_start_time()` on both PostgreSQL members.
-3. Run the update command above on the passive application host. Verify it remains
-   passive on `N+1` while the active host continues serving `N`. Through the
-   VIP, read persisted data and submit a command to prove the temporary mixed
-   `N` and `N+1` state is usable.
+3. Before running the update command on the passive application host, start
+   authenticated database-backed reads and uniquely identified idempotent
+   commands through the VIP at least once per second. Continue until the host
+   is healthy and passive on `N+1`; fail on a request failure or a command that
+   does not reach terminal success. Verify the active host continues serving
+   `N` throughout this migration and mixed-version window.
 4. Prevent the updated passive from advertising the VIP, then append `--complete`
    to the update command on the active host. Verify the command
    times out without swapping deployments, restarts `N`, and restores a usable
@@ -76,9 +79,10 @@ and run Fleet commands as
 
 | Gate | Required result | Duration | Result | Evidence |
 | --- | --- | --- | --- | --- |
+| Baseline qualification | Exact `N` and `N+1` artifacts pass the clean-install HA report | N/A | Pending | Pending |
 | Migration compatibility | `N` integration tests pass against an `N` database migrated by `N+1` | N/A | Pending | Pending |
 | Passive-first update | Passive runs `N+1`; active continues serving `N` | N/A | Pending | Pending |
-| Mixed-version operation | Persisted read and command succeed while hosts run `N` and `N+1` | N/A | Pending | Pending |
+| Mixed-version operation | Continuous persisted reads and commands succeed throughout migration while hosts run `N` and `N+1` | N/A | Pending | Pending |
 | Failed takeover recovery | No swap; `N` restores usable service and command execution | `<60s` | Pending | Pending |
 | Active completion | Active and database-backed probes serve `N+1`; former active rejoins passive; cached `N` client works against `N+1` | `<15s` | Pending | Pending |
 | Handoff fencing | High-frequency direct health and interface event streams never show active or VIP overlap | N/A | Pending | Pending |

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -96,15 +96,17 @@ sudo systemctl is-active --quiet proto-fleet-updater.service
    identities from step 2 are unchanged.
 5. Reinstall the clean `N` baseline and update the passive host to `N+1`. On the
    active host, create the root-owned
-   `/var/lib/proto-fleet-updater/qualification-pause-before-ha-stop` file and
-   arrange to remove it on every exit. Start `--complete` and wait until updater
-   status enters the activating phase; the barrier now holds the old application
-   open after final preflight. Stop the updated peer's Fleet application and
-   confirm it is unavailable, then remove the barrier. Require takeover to time
-   out and the updater to restart release `N` automatically. Within 60 seconds,
-   require the old host to serve the VIP, a persisted read, and a successful
-   command, with no manual recovery command remaining. Restart the `N+1` peer as
-   passive and restore full readiness before continuing.
+   `/var/lib/proto-fleet-updater/qualification-pause-after-ha-stop` file and
+   arrange to remove it on every exit. Start `--complete`, wait until updater
+   status enters the activating phase, and prove the old Fleet containers have
+   stopped while the peer remains passive. The barrier now holds the updater
+   immediately before its takeover wait. Before the old lease can expire, stop
+   the updated peer's Fleet application and confirm it never serves the VIP,
+   then remove the barrier. Require the updater to enter the takeover wait,
+   remain there for its full timeout, and restart release `N` automatically.
+   Within 60 seconds, require the old host to serve the VIP, a persisted read,
+   and a successful command, with no manual recovery command remaining. Restart
+   the `N+1` peer as passive and restore full readiness before continuing.
 6. Reinstall the clean `N` baseline and repeat steps 2 and 3 for a separate
    mixed-version failover run. Update the passive host to `N+1`, then terminate
    the active `N` Fleet process instead of running `--complete`. Require the
@@ -136,19 +138,27 @@ sudo systemctl is-active --quiet proto-fleet-updater.service
    at a time, restoring full readiness between reboots. Repeat the updater
    checks and verify both hosts retain Fleet data and can serve a command.
 10. From a clean `N` baseline, run four separate interruption cases. First,
-    use the root-owned pre-stop barrier from step 5 and SIGKILL the updater
-    after final preflight; the old active must keep serving and the updater must
-    restart cleanly. Second, power-cycle the updating host while
-    `/var/lib/proto-fleet-updater/activation-swap.json` and
-    `/opt/proto-fleet/deployment.previous` prove a swap is in progress. Third,
-    power-cycle after that marker clears but while updater status is still
-    activating and the target application is not healthy. Require restart
-    recovery to retain `N+1`, finish startup and migrations, clear pending
-    recovery, and restore control and failover readiness. Fourth, SIGKILL the
-    updater while
-    `/usr/local/libexec/proto-fleet/proto-fleet-updater.handoff` exists during
-    self-replacement. Repeat a case if its durable marker clears before the
-    fault lands. After each restart, require one valid deployment directory,
+    create the root-owned
+    `/var/lib/proto-fleet-updater/qualification-pause-before-ha-stop` file and
+    SIGKILL the updater after final preflight; the old active must keep serving
+    and the updater must restart cleanly. Second, create the root-owned
+    `/var/lib/proto-fleet-updater/qualification-pause-between-deployment-renames`
+    file and power-cycle only after updater status is activating,
+    `/opt/proto-fleet/deployment` is absent, and
+    `/opt/proto-fleet/deployment.previous` exists. This proves the fault landed
+    between the two renames; startup must restore `N`. Third, power-cycle after
+    the activation marker clears but while updater status is still activating
+    and the target application is not healthy. Require restart recovery to
+    retain `N+1`, finish startup and migrations, clear pending recovery, and
+    restore control and failover readiness. Fourth, during self-replacement,
+    obtain the updater service's PID and require its `/proc/<pid>/cmdline` to
+    contain exactly
+    `--self-update-handoff=/usr/local/libexec/proto-fleet/proto-fleet-updater`
+    while the production updater socket is not accepting status requests, then
+    SIGKILL that process. The handoff marker alone is insufficient evidence
+    because it exists before the replacement process starts. Repeat a case if
+    its required evidence clears before the fault lands. Remove each barrier
+    after its case. After each restart, require one valid deployment directory,
     no pending recovery marker, a healthy updater socket, restored control and
     failover readiness, and either the intact old release or fully verified
     target release according to the recorded recovery state. When recovery

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -127,13 +127,17 @@ and restart the updater after the run, whether the report passes or fails.
    status sockets are healthy. Reboot the two application/database hosts one
    at a time, restoring full readiness between reboots. Repeat the updater
    checks and verify both hosts retain Fleet data and can serve a command.
-10. From a clean `N` baseline, run three separate interruption cases. First,
+10. From a clean `N` baseline, run four separate interruption cases. First,
     use the root-owned pre-stop barrier from step 5 and SIGKILL the updater
     after final preflight; the old active must keep serving and the updater must
     restart cleanly. Second, power-cycle the updating host while
     `/var/lib/proto-fleet-updater/activation-swap.json` and
     `/opt/proto-fleet/deployment.previous` prove a swap is in progress. Third,
-    SIGKILL the updater while
+    power-cycle after that marker clears but while updater status is still
+    activating and the target application is not healthy. Require restart
+    recovery to retain `N+1`, finish startup and migrations, clear pending
+    recovery, and restore control and failover readiness. Fourth, SIGKILL the
+    updater while
     `/usr/local/libexec/proto-fleet/proto-fleet-updater.handoff` exists during
     self-replacement. Repeat a case if its durable marker clears before the
     fault lands. After each restart, require one valid deployment directory,

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -21,7 +21,7 @@ and run Fleet commands as
 `sudo /opt/proto-fleet/deployment/ha/fleet-ha update "$TARGET_RELEASE"`.
 
 1. Verify the published `N` and `N+1` artifacts and their checksums. Confirm
-   the target release was published from a reviewed
+   the target was built from a reviewed
    `qualified-update-from.txt` containing exactly `SOURCE_RELEASE`, and that
    its manifest-covered `ha_update_from` field matches. An empty file makes the
    target clean-install-only. Confirm
@@ -35,10 +35,13 @@ and run Fleet commands as
    plus `pg_postmaster_start_time()` on both PostgreSQL members.
 3. Before running the update command on the passive application host, start
    authenticated database-backed reads and uniquely identified idempotent
-   commands through the VIP at least once per second. Continue until the host
-   is healthy and passive on `N+1`; fail on a request failure or a command that
-   does not reach terminal success. Verify the active host continues serving
-   `N` throughout this migration and mixed-version window.
+   commands through the VIP at least once per second. Give each request a
+   two-second deadline, record command submission and terminal-result times,
+   and require each accepted command to reach exactly one terminal result within
+   60 seconds. Before the planned handoff, fail if successful reads or command
+   submissions are more than three seconds apart. Continue these probes through
+   step 5. Verify the active host continues serving `N` throughout the migration
+   and mixed-version window.
 4. Start the external active-health and interface-address recorder from step 5,
    then append `--complete` to the update command on the active host. From the
    controller, poll that host's local updater status over
@@ -64,7 +67,11 @@ and run Fleet commands as
    clock, measure from the last successful pre-handoff VIP probe until all
    three VIP probes succeed and `/api-proxy/health` reports
    `X-Proto-Fleet-Version: N+1`; require less than 15 seconds. Verify the former
-   active rejoins as passive. Using a client loaded from `N` before handoff,
+   active rejoins as passive. Before the handoff, hold one `N` command in
+   PROCESSING and one successor in PENDING. After takeover, require the
+   PROCESSING row to fail once without replay, the PENDING row to dispatch on
+   `N+1`, and both accepted IDs to reach exactly one terminal result within 60
+   seconds. Using a client loaded from `N` before handoff,
    perform a persisted read and a uniquely identified idempotent command against
    the `N+1` VIP.
 6. Using a controllable test device on the current active host, stall one command

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -35,10 +35,15 @@ and run Fleet commands as
    is healthy and passive on `N+1`; fail on a request failure or a command that
    does not reach terminal success. Verify the active host continues serving
    `N` throughout this migration and mixed-version window.
-4. Prevent the updated passive from advertising the VIP, then append `--complete`
-   to the update command on the active host. Verify the command
-   times out without swapping deployments, restarts `N`, and restores a usable
-   VIP and successful command within 60 seconds. Restore the passive host.
+4. Start the external active-health and interface-address recorder from step 5.
+   Confirm the updated peer is healthy and passive, then stop keepalived on that
+   peer with `sudo systemctl stop keepalived`. Confirm its Fleet application
+   remains passive and its configured interface does not own the VIP. Immediately
+   append `--complete` to the update command on the active host. Keep recording
+   until the command times out without swapping deployments, restarts `N`, and
+   restores a usable VIP and successful command within 60 seconds. Fail on any
+   collection gap, active overlap, or VIP overlap. Start keepalived on the peer
+   again and restore full readiness before continuing.
 5. Retry the completion command. From a separate controller, use the external
    append-only recorder, gap rejection, and uncertainty-inclusive interval rules
    from [QUALIFICATION.md](QUALIFICATION.md). Continuously record direct active

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -21,6 +21,10 @@ and run Fleet commands as
 `sudo /opt/proto-fleet/deployment/ha/fleet-ha update "$TARGET_RELEASE"`.
 
 1. Verify the published `N` and `N+1` artifacts and their checksums. Confirm
+   the target release was published from a reviewed
+   `qualified-update-from.txt` containing exactly `SOURCE_RELEASE`, and that
+   its manifest-covered `ha_update_from` field matches. An empty file makes the
+   target clean-install-only. Confirm
    every `N+1` migration is expand-only and remains usable by `N`; reject
    drops, renames, narrowed types, and newly required values. Apply the
    migrations to a representative production-size copy of an `N` database and

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -36,18 +36,17 @@ customer data from committed evidence.
    the VIP again; this must remain below 45 seconds. Restart keepalived and
    restore full readiness. This recovery bound is separate from the 15-second
    successful-handoff target.
-6. On one controlled test device, block a PROCESSING command and enqueue a
+6. Retry `fleet-ha update N+1 --complete` and measure from the first failed VIP
+   health probe until the VIP serves `N+1`. Verify the former active is now
+   passive on `N+1`.
+7. On one controlled test device, block a PROCESSING command and enqueue a
    second command behind it so per-device ordering keeps that row PENDING.
-   Sample both database states with timestamps throughout update preflight and
-   preserve the final sample no more than one second before `fleet-api` stops.
-   Retry `fleet-ha update N+1 --complete` and measure from the first failed VIP
-   health probe until the VIP serves `N+1`.
-7. Verify the PENDING command is dispatched, the interrupted PROCESSING attempt
+   Record both immutable queue row IDs and preserve a timestamped database
+   sample no more than one second before forcing an application failover.
+8. Verify the PENDING row is dispatched, the interrupted PROCESSING attempt
    reaches its documented terminal state, and a later command for that device
-   succeeds.
-8. Verify the former active is now passive on `N+1`, then force an application
-   failover in each direction. Submit a command through the VIP after each
-   failover and verify it succeeds.
+   succeeds. Force an application failover back, submit another command through
+   the VIP, and verify it succeeds.
 9. Compare the infrastructure container IDs recorded in step 2. Prove that the
    application update did not replace etcd, Patroni, or PostgreSQL.
 10. Reboot both database hosts, one at a time, restoring full readiness between
@@ -63,8 +62,8 @@ customer data from committed evidence.
 | Mixed-version window | Authenticated reads, writes, and command completion work while peers run `N` and `N+1` | Pending | Pending | Pending |
 | Failed takeover recovery | Completion times out before swap; `N` restarts and serves commands within 45s | Pending | Pending | Pending |
 | Active completion | VIP serves `N+1` within 15s | Pending | Pending | Pending |
-| PENDING command handoff | Timestamped pre-stop evidence shows PENDING; new active dispatches it | Pending | Pending | Pending |
-| PROCESSING command handoff | Timestamped pre-stop evidence shows PROCESSING; attempt finishes terminally and later work resumes | Pending | Pending | Pending |
+| PENDING command failover | Immutable pre-stop row is PENDING; new active dispatches it | Pending | Pending | Pending |
+| PROCESSING command failover | Immutable pre-stop row is PROCESSING; attempt finishes terminally and later work resumes | Pending | Pending | Pending |
 | Failover to peer | VIP serves `N+1` within 15s | Pending | Pending | Pending |
 | Failover back | VIP serves `N+1` within 15s | Pending | Pending | Pending |
 | Command execution | Command succeeds after both failovers | N/A | Pending | Pending |

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -34,6 +34,14 @@ On both application hosts, set
 `/etc/proto-fleet/updater.env`, then restart `proto-fleet-updater.service`.
 This permits only that exact prerelease during qualification. Remove the setting
 and restart the updater after the run, whether the report passes or fails.
+Every clean reinstall recreates `updater.env`, so restore this setting and
+restart the updater before each later update attempt. Before triggering an
+update, require both the exact setting below and an active service on each host:
+
+```bash
+sudo grep -Fx "PROTO_FLEET_HA_QUALIFICATION_TARGET=$TARGET_RELEASE" /etc/proto-fleet/updater.env
+sudo systemctl is-active --quiet proto-fleet-updater.service
+```
 
 1. Verify the stable `N` and prerelease `N+1` artifacts and their checksums. Confirm
    the target was built from a reviewed

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -32,17 +32,20 @@ certificates, device names, and customer data from committed evidence.
    `fleet-ha update N+1 --complete` on the active host. Verify the command
    times out without swapping deployments, restarts `N`, and restores a usable
    VIP and successful command within 60 seconds. Restore the passive host.
-5. Create controlled PENDING and PROCESSING commands and record their immutable
-   IDs. Retry `fleet-ha update N+1 --complete`. From another host, probe
-   `/api-proxy/health/active`, `/api-proxy/health`, and an authenticated
-   database-backed request at least once per second. At the same cadence,
-   sample direct active health and VIP ownership on both hosts; fail on any
-   active or VIP overlap. Measure from the first failed probe until all three
-   VIP probes succeed and `/api-proxy/health` reports
-   `X-Proto-Fleet-Version: N+1`; require less than 15 seconds. Verify the former
-   active rejoins as passive, the PENDING command dispatches, the interrupted
-   PROCESSING command reaches the expected terminal recovery state, and later
-   work for that device succeeds.
+5. Using a controllable test device, pause one command after its exact queue row
+   reaches PROCESSING so its successor remains PENDING. Record both immutable
+   IDs, then retry `fleet-ha update N+1 --complete`. From one controller,
+   continuously record both rows and direct active health on both hosts with
+   monotonic timestamps at 100 ms or faster until the old `fleet-api` stops;
+   fail if either row changes before that stop. In parallel, stream interface
+   address events from both hosts and fail on any overlapping VIP ownership.
+   Probe `/api-proxy/health/active`, `/api-proxy/health`, and an authenticated
+   database-backed request at least once per second. Measure from the first
+   failed probe until all three VIP probes succeed and `/api-proxy/health`
+   reports `X-Proto-Fleet-Version: N+1`; require less than 15 seconds. Release
+   the test device and verify the former active rejoins as passive, the PENDING
+   command dispatches, the interrupted PROCESSING command reaches the expected
+   terminal recovery state, and later work for that device succeeds.
 6. Force an application failover in each direction. Use the same active and
    database-backed probes, require usable service within 15 seconds, and
    submit a successful command after each move.
@@ -63,8 +66,8 @@ certificates, device names, and customer data from committed evidence.
 | Mixed-version operation | Persisted read and command succeed while hosts run `N` and `N+1` | N/A | Pending | Pending |
 | Failed takeover recovery | No swap; `N` restores usable service and command execution | `<60s` | Pending | Pending |
 | Active completion | Active and database-backed probes serve `N+1`; former active rejoins passive | `<15s` | Pending | Pending |
-| Handoff fencing | Direct health and VIP samples never show active or VIP overlap | N/A | Pending | Pending |
-| Handoff command recovery | PENDING dispatches, PROCESSING recovers, and later per-device work succeeds | N/A | Pending | Pending |
+| Handoff fencing | High-frequency direct health and interface event streams never show active or VIP overlap | N/A | Pending | Pending |
+| Handoff command recovery | Exact rows stay PROCESSING/PENDING until stop, then PROCESSING recovers, PENDING dispatches, and later per-device work succeeds | N/A | Pending | Pending |
 | Failover to peer | VIP serves `N+1`; command succeeds | `<15s` | Pending | Pending |
 | Failover back | VIP serves `N+1`; command succeeds | `<15s` | Pending | Pending |
 | Infrastructure preserved | etcd and Patroni identity plus PostgreSQL start times are unchanged | N/A | Pending | Pending |

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -36,21 +36,25 @@ customer data from committed evidence.
    that the cited workflow produced the digest. This first qualification trusts
    the existing GitHub Release publishing boundary; artifact attestation is
    deferred.
-2. Record the running etcd and Patroni/PostgreSQL container IDs on all hosts.
-3. On the passive database host, run `fleet-ha update N+1` and verify that it
+2. Record the running etcd and Patroni/PostgreSQL container IDs, start times,
+   and restart counts on all hosts. Retain Docker events for those containers
+   and continuously probe etcd quorum and writable database access until both
+   application updates finish.
+3. Before starting `N+1` on a live host, review every migration between the
+   recorded commits and reject drops, renames, narrowing conversions, or newly
+   mandatory constraints that the `N` application cannot satisfy. On a
+   disposable copy of an `N` database, apply the `N+1` migrations and run the
+   `N` database and API integration tests for every affected query area.
+4. On the passive database host, run `fleet-ha update N+1` and verify that it
    remains passive on `N+1` while the active host continues serving `N`. Fail
    if the operation reports `host updater refresh needs attention`. Require
    `/usr/local/libexec/proto-fleet/proto-fleet-updater --version` to print
    `N+1`, `proto-fleet-updater.service` to be active, and an authenticated local
    request to `/v1/status` over `/run/proto-fleet-updater/updater.sock` to
-   succeed. Retain the redacted operation log.
-4. Review every migration between the recorded commits and reject drops,
-   renames, narrowing conversions, or newly mandatory constraints that the `N`
-   application cannot satisfy. On a disposable copy of an `N` database, apply
-   the `N+1` migrations and run the `N` database and API integration tests for
-   every affected query area. During the live mixed-version window, use the
-   authenticated VIP API to read existing database-backed configuration,
-   submit a command, and verify its completion while `N` remains active.
+   succeed. Retain the redacted operation log. During the live mixed-version
+   window, use the authenticated VIP API to read existing database-backed
+   configuration, submit a command, and verify its completion while `N`
+   remains active.
 5. On the updated passive, capture its running `fleet-api` and `fleet-client`
    container IDs, then stop keepalived so that host cannot advertise the VIP.
    Start a background watcher that polls the uncached
@@ -85,8 +89,11 @@ customer data from committed evidence.
    For each direction, use both 100-millisecond external probes and the
    first-failure-to-both-success interval from step 6. Submit a command through
    the VIP after each failover and verify it succeeds.
-9. Compare the infrastructure container IDs recorded in step 2. Prove that the
-   application update did not replace etcd, Patroni, or PostgreSQL.
+9. Compare the infrastructure evidence recorded in step 2. Require unchanged
+   container IDs, start times, and restart counts; no stop, die, or restart
+   events; and uninterrupted etcd quorum and writable database probes. Prove
+   that the application update neither replaced nor restarted etcd, Patroni,
+   or PostgreSQL.
 10. Reboot both database hosts, one at a time, restoring full readiness between
     reboots. Confirm both return on `N+1` with the same etcd membership,
     Patroni cluster, and persisted Fleet data. On each host, repeat the updater
@@ -105,7 +112,7 @@ customer data from committed evidence.
 | Failover to peer | VIP serves `N+1` and an authenticated database-backed request within 15s | Pending | Pending | Pending |
 | Failover back | VIP serves `N+1` and an authenticated database-backed request within 15s | Pending | Pending | Pending |
 | Command execution | Command succeeds after both failovers | N/A | Pending | Pending |
-| Infrastructure preservation | Application update leaves etcd, Patroni, and PostgreSQL container IDs unchanged | N/A | Pending | Pending |
+| Infrastructure preservation | Application update leaves etcd, Patroni, and PostgreSQL container identity and uptime unchanged, with no DCS or database probe gap | N/A | Pending | Pending |
 | Host updater refresh | Both protected updater binaries report `N+1`; services and local status APIs survive reboot; no refresh warning remains | N/A | Pending | Pending |
 | Reboot recovery | Both hosts return on `N+1` with DCS, database, and Fleet data intact | Pending | Pending | Pending |
 

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -36,8 +36,9 @@ and run Fleet commands as
    run `N`'s affected database and API integration tests against it. Require
    completed baseline reports from [QUALIFICATION.md](QUALIFICATION.md) for the
    exact `N` and `N+1` artifacts, then install `N` for this procedure.
-2. Record the container IDs and start times for etcd and Patroni on every host,
-   plus `pg_postmaster_start_time()` on both PostgreSQL members.
+2. Record the etcd container ID and start time on all three hosts, the Patroni
+   container ID and start time on both database hosts, and
+   `pg_postmaster_start_time()` on both PostgreSQL members.
 3. Before running the update command on the passive application host, start
    authenticated database-backed reads and uniquely identified idempotent
    commands through the VIP at least once per second. Give each request a
@@ -53,8 +54,10 @@ and run Fleet commands as
    `/run/proto-fleet-updater/updater.sock`. As soon as its operation phase is
    `activating`, peer validation has passed and the old active is about to stop.
    Immediately run
-   `sudo /opt/proto-fleet/deployment/ha/fleet-ha app-stop` on the updated peer
-   and confirm its Fleet containers stop before the 10-second lease expires.
+   `sudo /opt/proto-fleet/deployment/ha/fleet-ha app-stop passive` on the
+   updated peer. Require a zero exit status, then run
+   `sudo /opt/proto-fleet/deployment/ha/fleet-ha compose ps --status running fleet-api fleet-client`
+   and confirm it lists neither Fleet container before the 10-second lease expires.
    Patroni, PostgreSQL, etcd, and keepalived must remain running. Keep recording
    until the command times out without swapping deployments, restarts `N`, and
    restores a usable VIP and successful command within 60 seconds. Fail on any

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -29,6 +29,11 @@ leaves the release marked prerelease and unsupported.
 Set `SOURCE_RELEASE` and `TARGET_RELEASE` to the recorded canonical release tags
 and run Fleet commands as
 `sudo /opt/proto-fleet/deployment/ha/fleet-ha update "$TARGET_RELEASE"`.
+On both application hosts, set
+`PROTO_FLEET_HA_QUALIFICATION_TARGET=$TARGET_RELEASE` in the root-owned
+`/etc/proto-fleet/updater.env`, then restart `proto-fleet-updater.service`.
+This permits only that exact prerelease during qualification. Remove the setting
+and restart the updater after the run, whether the report passes or fails.
 
 1. Verify the stable `N` and prerelease `N+1` artifacts and their checksums. Confirm
    the target was built from a reviewed

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -32,27 +32,29 @@ certificates, device names, and customer data from committed evidence.
    `fleet-ha update N+1 --complete` on the active host. Verify the command
    times out without swapping deployments, restarts `N`, and restores a usable
    VIP and successful command within 60 seconds. Restore the passive host.
-5. Using a controllable test device, pause one command after its exact queue row
-   reaches PROCESSING so its successor remains PENDING. Record both immutable
-   IDs, then retry `fleet-ha update N+1 --complete`. From one controller,
-   continuously record both rows and direct active health on both hosts with
-   monotonic timestamps at 100 ms or faster until the old `fleet-api` stops;
-   fail if either row changes before that stop. In parallel, stream interface
-   address events from both hosts and fail on any overlapping VIP ownership.
-   Probe `/api-proxy/health/active`, `/api-proxy/health`, and an authenticated
+5. Retry `fleet-ha update N+1 --complete`. From one controller, continuously
+   record direct active health on both hosts with monotonic timestamps at
+   100 ms or faster. In parallel, stream interface address events from both
+   hosts and fail on any active or VIP overlap. Probe
+   `/api-proxy/health/active`, `/api-proxy/health`, and an authenticated
    database-backed request at least once per second. On the same monotonic
    clock, measure from the last successful pre-handoff VIP probe until all
    three VIP probes succeed and `/api-proxy/health` reports
-   `X-Proto-Fleet-Version: N+1`; require less than 15 seconds. Release the test
-   device and verify the former active rejoins as passive, the PENDING command
-   dispatches, the interrupted PROCESSING command reaches the expected
-   terminal recovery state, and later work for that device succeeds.
-6. Force an application failover in each direction. From before each trigger
-   through convergence, reuse the direct active-health and interface-address
-   streams from step 5 and fail on any active or VIP overlap. Require the
-   former active to reject an active-only request, measure usable service from
-   the last successful pre-failover probe on the same monotonic clock, require
-   less than 15 seconds, and submit a successful command after each move.
+   `X-Proto-Fleet-Version: N+1`; require less than 15 seconds. Verify the former
+   active rejoins as passive.
+6. Using a controllable test device, pause one command after its exact queue row
+   reaches PROCESSING so its successor remains PENDING, then immediately force
+   an application failover. Continuously record both rows until the old
+   `fleet-api` stops and fail if either changes before that stop. Reuse the
+   direct active-health and interface-address streams from step 5 through
+   convergence and fail on any active or VIP overlap. Release the test device;
+   verify the PROCESSING command reaches its expected terminal recovery state,
+   the PENDING command dispatches, and later work for that device succeeds.
+   Force a second failover in the other direction with the same ownership
+   streams. For both moves, require the former active to reject an active-only
+   request, measure usable service from the last successful pre-failover probe
+   on the same monotonic clock, require less than 15 seconds, and submit a
+   successful command.
 7. Confirm the etcd and Patroni container IDs and start times, and both
    PostgreSQL postmaster start times, are unchanged from step 2. The application
    update must not replace or restart these services.
@@ -71,7 +73,7 @@ certificates, device names, and customer data from committed evidence.
 | Failed takeover recovery | No swap; `N` restores usable service and command execution | `<60s` | Pending | Pending |
 | Active completion | Active and database-backed probes serve `N+1`; former active rejoins passive | `<15s` | Pending | Pending |
 | Handoff fencing | High-frequency direct health and interface event streams never show active or VIP overlap | N/A | Pending | Pending |
-| Handoff command recovery | Exact rows stay PROCESSING/PENDING until stop, then PROCESSING recovers, PENDING dispatches, and later per-device work succeeds | N/A | Pending | Pending |
+| Post-update failover command recovery | Exact rows stay PROCESSING/PENDING until stop, then PROCESSING recovers, PENDING dispatches, and later per-device work succeeds | N/A | Pending | Pending |
 | Failover to peer | No active or VIP overlap; old active rejects; VIP serves `N+1`; command succeeds | `<15s` | Pending | Pending |
 | Failover back | No active or VIP overlap; old active rejects; VIP serves `N+1`; command succeeds | `<15s` | Pending | Pending |
 | Infrastructure preserved | etcd and Patroni identity plus PostgreSQL start times are unchanged | N/A | Pending | Pending |

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -53,10 +53,21 @@ and run Fleet commands as
    controller, poll that host's local updater status over
    `/run/proto-fleet-updater/updater.sock`. As soon as its operation phase is
    `activating`, peer validation has passed and the old active is about to stop.
-   Immediately run
-   `sudo /opt/proto-fleet/deployment/ha/fleet-ha app-stop passive` on the
-   updated peer. Require a zero exit status, then run
-   `sudo /opt/proto-fleet/deployment/ha/fleet-ha compose ps --status running fleet-api fleet-client`
+   Immediately kill only the Fleet application containers on the updated peer:
+
+   ```shell
+   sudo /opt/proto-fleet/deployment/ha/fleet-ha compose \
+     --env-file /etc/proto-fleet/ha/base.env \
+     --env-file /etc/proto-fleet/ha/fleet.env \
+     --env-file /etc/proto-fleet/ha/node.env \
+     --file /opt/proto-fleet/deployment/docker-compose.yaml \
+     --file /opt/proto-fleet/deployment/ha/fleet-compose.yaml \
+     kill fleet-api fleet-client
+   ```
+
+   This fault is unconditional and therefore does not race the peer becoming
+   active. Require a zero exit status, then repeat the command with
+   `ps --status running fleet-api fleet-client` in place of the final `kill`
    and confirm it lists neither Fleet container before the 10-second lease expires.
    Patroni, PostgreSQL, etcd, and keepalived must remain running. Keep recording
    until the command times out without swapping deployments, restarts `N`, and

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -38,9 +38,10 @@ customer data from committed evidence.
    `fleet-ha update N+1 --complete` on the active. Verify it times out before
    swapping, restarts release `N`, and can complete a command. Measure
    continuously from the first failed VIP health probe until release `N` serves
-   the VIP again; this must remain below 45 seconds. Restart keepalived and
-   restore full readiness. This recovery bound is separate from the 15-second
-   successful-handoff target.
+   the VIP again; this must remain below 60 seconds. Record the 30-second
+   takeover wait and subsequent old-release startup separately. Restart
+   keepalived and restore full readiness. This recovery bound is separate from
+   the 15-second successful-handoff target.
 6. With the target artifacts and build cache warmed by step 5, block a
    PROCESSING command on one controlled test device and enqueue a second command
    behind it so per-device ordering keeps that row PENDING. Record both
@@ -68,7 +69,7 @@ customer data from committed evidence.
 | --- | --- | --- | --- | --- |
 | Passive-first update | Passive runs `N+1`; active continues serving `N` | N/A | Pending | Pending |
 | Mixed-version window | Authenticated reads, writes, and command completion work while peers run `N` and `N+1` | Pending | Pending | Pending |
-| Failed takeover recovery | Completion times out before swap; `N` restarts and serves commands within 45s | Pending | Pending | Pending |
+| Failed takeover recovery | Completion times out before swap; `N` restarts and serves commands within 60s | Pending | Pending | Pending |
 | Active completion | VIP serves `N+1` within 15s | Pending | Pending | Pending |
 | PENDING command handoff | Immutable pre-stop row crosses from `N` to `N+1` as PENDING; new active dispatches it | Pending | Pending | Pending |
 | PROCESSING command handoff | Immutable pre-stop row crosses from `N` to `N+1` as PROCESSING; attempt finishes terminally and later work resumes | Pending | Pending | Pending |
@@ -83,5 +84,5 @@ customer data from committed evidence.
 
 **Pending.** The HA application update path is qualified only when every result
 above is `PASS`, every successful handoff interruption is below 15 seconds,
-failed-takeover recovery is below 45 seconds, and the report identifies both
+failed-takeover recovery is below 60 seconds, and the report identifies both
 released artifacts and commits.

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -35,15 +35,19 @@ and run Fleet commands as
    is healthy and passive on `N+1`; fail on a request failure or a command that
    does not reach terminal success. Verify the active host continues serving
    `N` throughout this migration and mixed-version window.
-4. Start the external active-health and interface-address recorder from step 5.
-   Confirm the updated peer is healthy and passive, then stop keepalived on that
-   peer with `sudo systemctl stop keepalived`. Confirm its Fleet application
-   remains passive and its configured interface does not own the VIP. Immediately
-   append `--complete` to the update command on the active host. Keep recording
-   until the command times out without swapping deployments, restarts `N`, and
-   restores a usable VIP and successful command within 60 seconds. Fail on any
-   collection gap, active overlap, or VIP overlap. Start keepalived on the peer
-   again and restore full readiness before continuing.
+4. Start the external active-health and interface-address recorder from step 5,
+   then append `--complete` to the update command on the active host. From the
+   controller, poll that host's local updater status over
+   `/run/proto-fleet-updater/updater.sock`. As soon as its operation phase is
+   `activating`, peer validation has passed and the old active is about to stop.
+   Immediately run `sudo systemctl stop proto-fleet-ha.service` on the updated
+   peer and confirm the service stops before the 10-second Fleet lease expires.
+   This prevents the peer from acquiring ownership during the failed-takeover
+   drill. Keep recording until the command times out without swapping
+   deployments, restarts `N`, and restores a usable VIP and successful command
+   within 60 seconds. Fail on any collection gap, active overlap, or VIP overlap.
+   Start `proto-fleet-ha.service` on the peer again and restore full readiness
+   before continuing.
 5. Retry the completion command. From a separate controller, use the external
    append-only recorder, gap rejection, and uncertainty-inclusive interval rules
    from [QUALIFICATION.md](QUALIFICATION.md). Continuously record direct active

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -43,14 +43,15 @@ customer data from committed evidence.
 4. During the mixed-version window, use the authenticated VIP API to read
    existing database-backed configuration, submit a command, and verify its
    completion while `N` remains active.
-5. Stop keepalived on the updated passive, then run
-   `fleet-ha update N+1 --complete` on the active. Verify it times out before
-   swapping, restarts release `N`, and can complete a command. Measure
-   continuously from the first failed VIP health probe until release `N` serves
-   the VIP again; this must remain below 60 seconds. Record the 30-second
-   takeover wait and subsequent old-release startup separately. Restart
-   keepalived and restore full readiness. This recovery bound is separate from
-   the 15-second successful-handoff target.
+5. On the updated passive, run `fleet-ha app-stop passive N` to make takeover
+   impossible, then run `fleet-ha update N+1 --complete` on the active. Verify it
+   times out before swapping, restarts release `N`, reacquires the VIP, and can
+   complete a command. Measure continuously from the first failed VIP health
+   probe until release `N` serves the VIP again; this must remain below 60
+   seconds. Record the 30-second takeover wait and subsequent old-release startup
+   separately. Restart the updated peer with `fleet-ha app-start N+1 passive` and
+   restore full readiness before continuing. This recovery bound is separate
+   from the 15-second successful-handoff target.
 6. With the target artifacts and build cache warmed by step 5, block a
    PROCESSING command on one controlled test device and enqueue a second command
    behind it so per-device ordering keeps that row PENDING. Record both

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -43,15 +43,20 @@ customer data from committed evidence.
 4. During the mixed-version window, use the authenticated VIP API to read
    existing database-backed configuration, submit a command, and verify its
    completion while `N` remains active.
-5. On the updated passive, run `fleet-ha app-stop passive N` to make takeover
-   impossible, then run `fleet-ha update N+1 --complete` on the active. Verify it
-   times out before swapping, restarts release `N`, reacquires the VIP, and can
-   complete a command. Measure continuously from the first failed VIP health
-   probe until release `N` serves the VIP again; this must remain below 60
-   seconds. Record the 35-second takeover wait and subsequent old-release startup
-   separately. Restart the updated peer with `fleet-ha app-start N+1 passive` and
-   restore full readiness before continuing. This recovery bound is separate
-   from the 15-second successful-handoff target.
+5. On the updated passive, capture its running `fleet-api` and `fleet-client`
+   container IDs. Start a background watcher that polls
+   `http://127.0.0.1:4000/health/passive` at least every 100 milliseconds and
+   stops those exact containers as soon as the endpoint stops reporting
+   passive. Then run `fleet-ha update N+1 --complete` on the active. This keeps
+   the peer available for completion validation but stops it immediately after
+   it acquires the lease, before keepalived's one-second check can advertise the
+   VIP. Verify the operation log shows active validation and application stop,
+   followed by the 35-second takeover timeout and release `N` restart without a
+   deployment swap. Confirm `N` reacquires the VIP and can complete a command
+   within 60 seconds of the first failed VIP probe. Restart the updated peer
+   with `fleet-ha app-start N+1 passive` and restore full readiness before
+   continuing. This recovery bound is separate from the 15-second successful
+   handoff target.
 6. With the target artifacts and build cache warmed by step 5, block a
    PROCESSING command on one controlled test device and enqueue a second command
    behind it so per-device ordering keeps that row PENDING. Record both

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -32,6 +32,10 @@ customer data from committed evidence.
    release `N` using [QUALIFICATION.md](QUALIFICATION.md). Confirm `N` includes
    the `fleet-ha update` and `update --complete` protocol; releases that predate
    this supported HA update baseline are out of scope.
+   These checks establish internal archive consistency, not cryptographic proof
+   that the cited workflow produced the digest. This first qualification trusts
+   the existing GitHub Release publishing boundary; artifact attestation is
+   deferred.
 2. Record the running etcd and Patroni/PostgreSQL container IDs on all hosts.
 3. On the passive database host, run `fleet-ha update N+1` and verify that it
    remains passive on `N+1` while the active host continues serving `N`. Fail
@@ -63,14 +67,19 @@ customer data from committed evidence.
    immutable queue row IDs, retry `fleet-ha update N+1 --complete`, and sample
    both rows throughout the retry. The gate fails if either state changes before
    `fleet-api` stops; retain a final timestamped sample no more than one second
-   before that stop. Measure until the VIP serves `N+1`.
+   before that stop. From another host, probe the authenticated VIP at least
+   every 100 milliseconds. Measure from the first failed request through the
+   first successful response whose version header reports `N+1`, and retain the
+   timestamped probe output.
 7. Verify those exact rows on `N+1`: the PENDING row is dispatched, the
    interrupted PROCESSING attempt reaches its documented terminal state, and a
    later command for that device succeeds. Verify the former active is passive
    on `N+1`, then repeat the updater version, service, socket, warning, and
    redacted-log checks from step 3 on this host.
 8. Force an application failover to the former active and back to its peer.
-   Submit a command through the VIP after each failover and verify it succeeds.
+   For each direction, use the same 100-millisecond external VIP probe and
+   first-failure-to-first-versioned-success interval from step 6. Submit a
+   command through the VIP after each failover and verify it succeeds.
 9. Compare the infrastructure container IDs recorded in step 2. Prove that the
    application update did not replace etcd, Patroni, or PostgreSQL.
 10. Reboot both database hosts, one at a time, restoring full readiness between

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -44,17 +44,17 @@ customer data from committed evidence.
    existing database-backed configuration, submit a command, and verify its
    completion while `N` remains active.
 5. On the updated passive, capture its running `fleet-api` and `fleet-client`
-   container IDs. Start a background watcher that polls
-   `http://127.0.0.1:4000/health/passive` at least every 100 milliseconds and
-   stops those exact containers as soon as the endpoint stops reporting
-   passive. Then run `fleet-ha update N+1 --complete` on the active. This keeps
-   the peer available for completion validation but stops it immediately after
-   it acquires the lease, before keepalived's one-second check can advertise the
-   VIP. Verify the operation log shows active validation and application stop,
-   followed by the 35-second takeover timeout and release `N` restart without a
-   deployment swap. Confirm `N` reacquires the VIP and can complete a command
-   within 60 seconds of the first failed VIP probe. Restart the updated peer
-   with `fleet-ha app-start N+1 passive` and restore full readiness before
+   container IDs, then stop keepalived so that host cannot advertise the VIP.
+   Start a background watcher that polls the uncached
+   `http://127.0.0.1:4000/health/active` endpoint at least every 100 milliseconds
+   and stops those exact containers as soon as it reports active. Continuously
+   probe the VIP from another host and run `fleet-ha update N+1 --complete` on
+   the active. Verify the updated peer never serves the VIP and the operation
+   log shows active validation and application stop, followed by the 35-second
+   takeover timeout and release `N` restart without a deployment swap. Confirm
+   `N` reacquires the VIP and can complete a command within 60 seconds of the
+   first failed VIP probe. Start keepalived, restart the updated peer with
+   `fleet-ha app-start N+1 passive`, and restore full readiness before
    continuing. This recovery bound is separate from the 15-second successful
    handoff target.
 6. With the target artifacts and build cache warmed by step 5, block a

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -143,4 +143,6 @@ and run Fleet commands as
 
 **Pending.** Mark the adjacent update supported only when every gate passes,
 attach the redacted evidence to this report, and promote the unchanged `N+1`
-GitHub release from prerelease to stable.
+GitHub release with
+`gh release edit "$TARGET_RELEASE" --prerelease=false --latest`. Do not rebuild,
+retag, or replace its assets.

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -4,6 +4,11 @@ Use this report to qualify one adjacent released-version update, `N` to `N+1`,
 on the supported three-host HA profile. Redact addresses, credentials,
 certificates, device names, and customer data from committed evidence.
 
+This first version qualifies exact artifacts after publication because the
+production updater accepts only the fixed official release origin. Publication
+makes the pair downloadable, not supported. Do not run the update until this
+report passes; a separate prepublication artifact channel is deferred.
+
 ## Test identity
 
 | Field | Value |

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -41,18 +41,20 @@ customer data from committed evidence.
    the VIP again; this must remain below 45 seconds. Restart keepalived and
    restore full readiness. This recovery bound is separate from the 15-second
    successful-handoff target.
-6. Retry `fleet-ha update N+1 --complete` and measure from the first failed VIP
-   health probe until the VIP serves `N+1`. Verify the former active is now
-   passive on `N+1`, then repeat the updater version, service, socket, warning,
-   and redacted-log checks from step 3 on this host.
-7. On one controlled test device, block a PROCESSING command and enqueue a
-   second command behind it so per-device ordering keeps that row PENDING.
-   Record both immutable queue row IDs and preserve a timestamped database
-   sample no more than one second before forcing an application failover.
-8. Verify the PENDING row is dispatched, the interrupted PROCESSING attempt
-   reaches its documented terminal state, and a later command for that device
-   succeeds. Force an application failover back, submit another command through
-   the VIP, and verify it succeeds.
+6. With the target artifacts and build cache warmed by step 5, block a
+   PROCESSING command on one controlled test device and enqueue a second command
+   behind it so per-device ordering keeps that row PENDING. Record both
+   immutable queue row IDs, retry `fleet-ha update N+1 --complete`, and sample
+   both rows throughout the retry. The gate fails if either state changes before
+   `fleet-api` stops; retain a final timestamped sample no more than one second
+   before that stop. Measure until the VIP serves `N+1`.
+7. Verify those exact rows on `N+1`: the PENDING row is dispatched, the
+   interrupted PROCESSING attempt reaches its documented terminal state, and a
+   later command for that device succeeds. Verify the former active is passive
+   on `N+1`, then repeat the updater version, service, socket, warning, and
+   redacted-log checks from step 3 on this host.
+8. Force an application failover to the former active and back to its peer.
+   Submit a command through the VIP after each failover and verify it succeeds.
 9. Compare the infrastructure container IDs recorded in step 2. Prove that the
    application update did not replace etcd, Patroni, or PostgreSQL.
 10. Reboot both database hosts, one at a time, restoring full readiness between
@@ -68,8 +70,8 @@ customer data from committed evidence.
 | Mixed-version window | Authenticated reads, writes, and command completion work while peers run `N` and `N+1` | Pending | Pending | Pending |
 | Failed takeover recovery | Completion times out before swap; `N` restarts and serves commands within 45s | Pending | Pending | Pending |
 | Active completion | VIP serves `N+1` within 15s | Pending | Pending | Pending |
-| PENDING command failover | Immutable pre-stop row is PENDING; new active dispatches it | Pending | Pending | Pending |
-| PROCESSING command failover | Immutable pre-stop row is PROCESSING; attempt finishes terminally and later work resumes | Pending | Pending | Pending |
+| PENDING command handoff | Immutable pre-stop row crosses from `N` to `N+1` as PENDING; new active dispatches it | Pending | Pending | Pending |
+| PROCESSING command handoff | Immutable pre-stop row crosses from `N` to `N+1` as PROCESSING; attempt finishes terminally and later work resumes | Pending | Pending | Pending |
 | Failover to peer | VIP serves `N+1` within 15s | Pending | Pending | Pending |
 | Failover back | VIP serves `N+1` within 15s | Pending | Pending | Pending |
 | Command execution | Command succeeds after both failovers | N/A | Pending | Pending |

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -43,7 +43,11 @@ and run Fleet commands as
    migrations to a representative production-size copy of an `N` database and
    run `N`'s affected database and API integration tests against it. Require
    completed baseline reports from [QUALIFICATION.md](QUALIFICATION.md) for the
-   exact `N` and `N+1` artifacts, then install `N` for this procedure.
+   exact `N` and `N+1` artifacts, then install `N` for this procedure and load
+   a sanitized production-scale `N` dataset. Record table sizes and row counts.
+   The passive-first update below must run its actual migrations against this
+   dataset while the sustained reads, writes, and commands in step 3 continue;
+   fail on a migration lock or probe gap beyond the stated bounds.
 2. Record the etcd container ID and start time on all three hosts, the Patroni
    container ID and start time on both database hosts, and
    `pg_postmaster_start_time()` on both PostgreSQL members.
@@ -57,8 +61,11 @@ and run Fleet commands as
    authenticated database-backed reads and uniquely identified idempotent
    commands through the VIP at least once per second. Give each request a
    two-second deadline, record command submission and terminal-result times,
-   and require each accepted command to reach exactly one terminal result within
-   60 seconds. Before the planned handoff, fail if successful reads or command
+   and require each background command to reach SUCCESS exactly once within 60
+   seconds. FAILED is permitted only for the deliberately interrupted
+   PROCESSING commands in steps 4 and 6, with the expected restart interruption
+   reason.
+   Before the planned handoff, fail if successful reads or command
    submissions are more than three seconds apart. Continue these probes through
    step 4. Verify the active host continues serving `N` throughout the migration
    and mixed-version window.
@@ -113,6 +120,7 @@ and run Fleet commands as
 | --- | --- | --- | --- | --- |
 | Baseline qualification | Exact `N` and `N+1` artifacts pass the clean-install HA report | N/A | Pending | Pending |
 | Migration compatibility | `N` integration tests pass against an `N` database migrated by `N+1` | N/A | Pending | Pending |
+| Live production-scale migration | The real passive updater migrates the recorded sanitized dataset without exceeding traffic or lock bounds | N/A | Pending | Pending |
 | Passive-first update | Passive runs `N+1`; active continues serving `N` | N/A | Pending | Pending |
 | Mixed-version operation | Continuous persisted reads and commands succeed throughout migration while hosts run `N` and `N+1` | N/A | Pending | Pending |
 | Active completion | Active and database-backed probes serve `N+1`; former active rejoins passive; cached `N` client works against `N+1` | `<15s` | Pending | Pending |

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -10,13 +10,6 @@ local operator command can select this candidate. After every gate passes,
 promote that same release without changing its tag or assets. A failed report
 leaves the release marked prerelease and unsupported.
 
-This report does not claim hardware qualification of the automatic
-old-release restart when the peer fails to take over. That path is covered by
-the updater's focused tests, but making the hardware drill deterministic would
-require a production fault-injection hook. If completion times out during this
-initial release, follow the reported recovery command and verify local HA
-status before retrying.
-
 ## Test identity
 
 | Field | Value |
@@ -63,7 +56,7 @@ and run Fleet commands as
    two-second deadline, record command submission and terminal-result times,
    and require each background command to reach SUCCESS exactly once within 60
    seconds. FAILED is permitted only for the deliberately interrupted
-   PROCESSING commands in steps 4 and 6, with the expected restart interruption
+   PROCESSING commands in steps 4 and 7, with the expected restart interruption
    reason.
    Before the planned handoff, fail if successful reads or command
    submissions are more than three seconds apart. Continue these probes through
@@ -84,7 +77,16 @@ and run Fleet commands as
    perform a persisted read and a uniquely identified idempotent command against
    the `N+1` VIP. Before reinstalling for step 5, confirm the infrastructure
    identities from step 2 are unchanged.
-5. Reinstall the clean `N` baseline and repeat steps 2 and 3 for a separate
+5. Reinstall the clean `N` baseline, update the passive host to `N+1`, and keep
+   a persistent controller connection to both hosts. Start `--complete` on the
+   active `N` host while the controller polls its local updater status. As soon
+   as the operation enters the activating phase, stop the updated peer's Fleet
+   application before the old host stops. Require takeover to time out and the
+   updater to restart release `N` automatically. Within 60 seconds, require the
+   old host to serve the VIP, a persisted read, and a successful command, with
+   no manual recovery command remaining. Restart the `N+1` peer as passive and
+   restore full readiness before continuing.
+6. Reinstall the clean `N` baseline and repeat steps 2 and 3 for a separate
    mixed-version failover run. Update the passive host to `N+1`, then terminate
    the active `N` Fleet process instead of running `--complete`. Require the
    `N+1` peer to take over within 15 seconds with no possible active or VIP
@@ -93,7 +95,7 @@ and run Fleet commands as
    the `N` host as passive and update it with the ordinary passive command.
    Require both hosts to run `N+1`, full failover readiness, and unchanged
    infrastructure identities from this run's step 2.
-6. Using a controllable test device on the current active host, stall one command
+7. Using a controllable test device on the current active host, stall one command
    after its exact queue row reaches PROCESSING so its successor remains PENDING.
    SIGSTOP that active `fleet-api`, let its lease expire, and wait for the passive
    peer to take over. Queue the old plugin result while its process is stopped,
@@ -107,10 +109,10 @@ and run Fleet commands as
    require the former active to reject an active-only request, measure usable
    service from the last successful pre-failover probe on the same monotonic
    clock, require less than 15 seconds, and submit a successful command.
-7. Confirm the etcd and Patroni container IDs and start times, and both
+8. Confirm the etcd and Patroni container IDs and start times, and both
    PostgreSQL postmaster start times, are unchanged from step 2. The application
    update must not replace or restart these services.
-8. Confirm both updater binaries report `N+1` and their services and local
+9. Confirm both updater binaries report `N+1` and their services and local
    status sockets are healthy. Reboot the two application/database hosts one
    at a time, restoring full readiness between reboots. Repeat the updater
    checks and verify both hosts retain Fleet data and can serve a command.
@@ -125,6 +127,7 @@ and run Fleet commands as
 | Passive-first update | Passive runs `N+1`; active continues serving `N` | N/A | Pending | Pending |
 | Mixed-version operation | Continuous persisted reads and commands succeed throughout migration while hosts run `N` and `N+1` | N/A | Pending | Pending |
 | Active completion | Active and database-backed probes serve `N+1`; former active rejoins passive; cached `N` client works against `N+1` | `<15s` | Pending | Pending |
+| Takeover timeout recovery | Updated peer is unavailable; old `N` restarts automatically and serves reads and commands | `<60s` | Pending | Pending |
 | Handoff fencing | High-frequency direct health and interface event streams never show active or VIP overlap | N/A | Pending | Pending |
 | Mixed-version forced takeover | `N+1` takes over safely while its peer is `N`; the old host then completes through the ordinary passive update | `<15s` | Pending | Pending |
 | Post-update stale completion | Interrupted row is FAILED without replay; resumed old transition is rejected; PENDING successor and later work succeed | N/A | Pending | Pending |

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -46,36 +46,9 @@ and run Fleet commands as
    and require each accepted command to reach exactly one terminal result within
    60 seconds. Before the planned handoff, fail if successful reads or command
    submissions are more than three seconds apart. Continue these probes through
-   step 5. Verify the active host continues serving `N` throughout the migration
+   step 4. Verify the active host continues serving `N` throughout the migration
    and mixed-version window.
-4. Start the external active-health and interface-address recorder from step 5,
-   then append `--complete` to the update command on the active host. From the
-   controller, poll that host's local updater status over
-   `/run/proto-fleet-updater/updater.sock`. As soon as its operation phase is
-   `activating`, peer validation has passed and the old active is about to stop.
-   Immediately kill only the Fleet application containers on the updated peer:
-
-   ```shell
-   sudo /opt/proto-fleet/deployment/ha/fleet-ha compose \
-     --env-file /etc/proto-fleet/ha/base.env \
-     --env-file /etc/proto-fleet/ha/fleet.env \
-     --env-file /etc/proto-fleet/ha/node.env \
-     --file /opt/proto-fleet/deployment/docker-compose.yaml \
-     --file /opt/proto-fleet/deployment/ha/fleet-compose.yaml \
-     kill fleet-api fleet-client
-   ```
-
-   This fault is unconditional and therefore does not race the peer becoming
-   active. Require a zero exit status, then repeat the command with
-   `ps --status running fleet-api fleet-client` in place of the final `kill`
-   and confirm it lists neither Fleet container before the 10-second lease expires.
-   Patroni, PostgreSQL, etcd, and keepalived must remain running. Keep recording
-   until the command times out without swapping deployments, restarts `N`, and
-   restores a usable VIP and successful command within 60 seconds. Fail on any
-   collection gap, active overlap, or VIP overlap. Restore the peer with
-   `sudo /opt/proto-fleet/deployment/ha/fleet-ha app-start "$TARGET_RELEASE" passive`
-   and wait for full readiness before continuing.
-5. Retry the completion command. From a separate controller, use the external
+4. Run the completion command. From a separate controller, use the external
    append-only recorder, gap rejection, and uncertainty-inclusive interval rules
    from [QUALIFICATION.md](QUALIFICATION.md). Continuously record direct active
    health on both hosts with monotonic timestamps at 100 ms or faster. In
@@ -93,7 +66,7 @@ and run Fleet commands as
    seconds. Using a client loaded from `N` before handoff,
    perform a persisted read and a uniquely identified idempotent command against
    the `N+1` VIP.
-6. Using a controllable test device on the current active host, stall one command
+5. Using a controllable test device on the current active host, stall one command
    after its exact queue row reaches PROCESSING so its successor remains PENDING.
    SIGSTOP that active `fleet-api`, let its lease expire, and wait for the passive
    peer to take over. Queue the old plugin result while its process is stopped,
@@ -101,16 +74,16 @@ and run Fleet commands as
    interruption reason and is never dispatched again, the old process exits, its
    stale database transition is rejected, exactly one terminal result remains,
    the PENDING successor dispatches, and later work for that device succeeds. Reuse the
-   direct active-health and interface-address streams from step 5 through
+   direct active-health and interface-address streams from step 4 through
    convergence and fail on any active or VIP overlap. Force a second failover
    in the other direction with the same ownership streams. For both moves,
    require the former active to reject an active-only request, measure usable
    service from the last successful pre-failover probe on the same monotonic
    clock, require less than 15 seconds, and submit a successful command.
-7. Confirm the etcd and Patroni container IDs and start times, and both
+6. Confirm the etcd and Patroni container IDs and start times, and both
    PostgreSQL postmaster start times, are unchanged from step 2. The application
    update must not replace or restart these services.
-8. Confirm both updater binaries report `N+1` and their services and local
+7. Confirm both updater binaries report `N+1` and their services and local
    status sockets are healthy. Reboot the two application/database hosts one
    at a time, restoring full readiness between reboots. Repeat the updater
    checks and verify both hosts retain Fleet data and can serve a command.
@@ -123,7 +96,6 @@ and run Fleet commands as
 | Migration compatibility | `N` integration tests pass against an `N` database migrated by `N+1` | N/A | Pending | Pending |
 | Passive-first update | Passive runs `N+1`; active continues serving `N` | N/A | Pending | Pending |
 | Mixed-version operation | Continuous persisted reads and commands succeed throughout migration while hosts run `N` and `N+1` | N/A | Pending | Pending |
-| Failed takeover recovery | No swap; `N` restores usable service and command execution | `<60s` | Pending | Pending |
 | Active completion | Active and database-backed probes serve `N+1`; former active rejoins passive; cached `N` client works against `N+1` | `<15s` | Pending | Pending |
 | Handoff fencing | High-frequency direct health and interface event streams never show active or VIP overlap | N/A | Pending | Pending |
 | Post-update stale completion | Interrupted row is FAILED without replay; resumed old transition is rejected; PENDING successor and later work succeed | N/A | Pending | Pending |

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -16,7 +16,9 @@ certificates, device names, and customer data from committed evidence.
 
 ## Procedure
 
-1. Verify the published `N` and `N+1` artifacts and their checksums. Install and
+1. Verify the published `N` and `N+1` artifacts and their checksums. Confirm
+   every `N+1` migration is expand-only and remains usable by `N`; reject
+   drops, renames, narrowed types, and newly required values. Install and
    qualify `N` using [QUALIFICATION.md](QUALIFICATION.md).
 2. Record the container IDs and start times for etcd, Patroni, and PostgreSQL on
    every host.
@@ -24,17 +26,25 @@ certificates, device names, and customer data from committed evidence.
    passive on `N+1` while the active host continues serving `N`. Through the
    VIP, read persisted data and submit a command to prove the temporary mixed
    `N` and `N+1` state is usable.
-4. Run `fleet-ha update N+1 --complete` on the active host. Probe the VIP from
-   another host and measure from its first failed response until it returns a
-   successful `/health` response reporting `N+1`. Require less than 15 seconds.
-   Verify the former active rejoins as passive on `N+1`.
-5. Force an application failover in each direction. After each failover,
-   require the VIP to serve `N+1` within 15 seconds and submit a successful
-   command.
-6. Confirm the etcd, Patroni, and PostgreSQL container IDs and start times from
+4. Prevent the updated passive from advertising the VIP, then run
+   `fleet-ha update N+1 --complete` on the active host. Verify the command
+   times out without swapping deployments, restarts `N`, and restores a usable
+   VIP and successful command within 60 seconds. Restore the passive host.
+5. Retry `fleet-ha update N+1 --complete`. From another host, probe
+   `/health/active` and an authenticated database-backed request at least once
+   per second. Measure from the first failed probe until both succeed and the
+   public health header reports `N+1`; require less than 15 seconds. Verify the
+   former active rejoins as passive on `N+1`.
+6. Force an application failover in each direction. Use the same active and
+   database-backed probes, require usable service within 15 seconds, and
+   submit a successful command after each move.
+7. Confirm the etcd, Patroni, and PostgreSQL container IDs and start times from
    step 2 are unchanged. The application update must not replace or restart
    these services.
-7. Reboot the two application/database hosts one at a time, restoring full
+8. Confirm both updater binaries report `N+1` and their services and local
+   status sockets are healthy. Reboot the two application/database hosts one
+   at a time, restoring full readiness between reboots. Repeat the updater
+   checks and verify both hosts retain Fleet data and can serve a command.
    readiness between reboots. Verify both return on `N+1`, retain persisted
    Fleet data, and can serve a command after failover.
 
@@ -42,12 +52,15 @@ certificates, device names, and customer data from committed evidence.
 
 | Gate | Required result | Duration | Result | Evidence |
 | --- | --- | --- | --- | --- |
+| Migration compatibility | `N+1` migrations are expand-only and usable by `N` | N/A | Pending | Pending |
 | Passive-first update | Passive runs `N+1`; active continues serving `N` | N/A | Pending | Pending |
 | Mixed-version operation | Persisted read and command succeed while hosts run `N` and `N+1` | N/A | Pending | Pending |
-| Active completion | VIP serves `N+1`; former active rejoins passive | `<15s` | Pending | Pending |
+| Failed takeover recovery | No swap; `N` restores usable service and command execution | `<60s` | Pending | Pending |
+| Active completion | Active and database-backed probes serve `N+1`; former active rejoins passive | `<15s` | Pending | Pending |
 | Failover to peer | VIP serves `N+1`; command succeeds | `<15s` | Pending | Pending |
 | Failover back | VIP serves `N+1`; command succeeds | `<15s` | Pending | Pending |
 | Infrastructure preserved | etcd, Patroni, and PostgreSQL are not replaced or restarted | N/A | Pending | Pending |
+| Updater refresh | Both updater binaries, services, and local status sockets run `N+1` | N/A | Pending | Pending |
 | Reboot recovery | Both hosts return on `N+1` with persisted data and working failover | Pending | Pending | Pending |
 
 ## Verdict

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -4,6 +4,10 @@ Use this report to qualify one adjacent update, `N` to `N+1`, on the supported
 three-host HA profile. Redact addresses, credentials, certificates, device
 names, and customer data from committed evidence.
 
+Run the full procedure and keep a separate result table for every architecture
+enabled by the release. The initial profile requires both amd64 and arm64 to
+pass before promotion.
+
 Publish the final `N+1` tag and assets at the fixed official release origin as
 a GitHub prerelease. HA does not offer UI-triggered updates, so only an explicit
 local operator command can select this candidate. After every gate passes,
@@ -118,6 +122,19 @@ and run Fleet commands as
    status sockets are healthy. Reboot the two application/database hosts one
    at a time, restoring full readiness between reboots. Repeat the updater
    checks and verify both hosts retain Fleet data and can serve a command.
+10. From a clean `N` baseline, run three separate interruption cases. First,
+    use the root-owned pre-stop barrier from step 5 and SIGKILL the updater
+    after final preflight; the old active must keep serving and the updater must
+    restart cleanly. Second, power-cycle the updating host while
+    `/var/lib/proto-fleet-updater/activation-swap.json` and
+    `/opt/proto-fleet/deployment.previous` prove a swap is in progress. Third,
+    SIGKILL the updater while
+    `/usr/local/libexec/proto-fleet/proto-fleet-updater.handoff` exists during
+    self-replacement. Repeat a case if its durable marker clears before the
+    fault lands. After each restart, require one valid deployment directory,
+    no pending recovery marker, a healthy updater socket, restored control and
+    failover readiness, and either the intact old release or fully verified
+    target release according to the recorded recovery state.
 
 ## Results
 
@@ -137,12 +154,13 @@ and run Fleet commands as
 | Failover back | No active or VIP overlap; old active rejects; VIP serves `N+1`; command succeeds | `<15s` | Pending | Pending |
 | Infrastructure preserved | etcd and Patroni identity plus PostgreSQL start times are unchanged | N/A | Pending | Pending |
 | Updater refresh | Both updater binaries, services, and local status sockets run `N+1` | N/A | Pending | Pending |
+| Updater interruption recovery | Pre-activation, post-swap, and self-update faults recover automatically | N/A | Pending | Pending |
 | Reboot recovery | Both hosts return on `N+1` with persisted data and working failover | Pending | Pending | Pending |
 
 ## Verdict
 
-**Pending.** Mark the adjacent update supported only when every gate passes,
-attach the redacted evidence to this report, and promote the unchanged `N+1`
-GitHub release with
+**Pending.** Mark the adjacent update supported only when every gate passes on
+both amd64 and arm64, attach the redacted evidence to each report, and promote
+the unchanged `N+1` GitHub release with
 `gh release edit "$TARGET_RELEASE" --prerelease=false --latest`. Do not rebuild,
 retag, or replace its assets.

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -40,15 +40,19 @@ certificates, device names, and customer data from committed evidence.
    fail if either row changes before that stop. In parallel, stream interface
    address events from both hosts and fail on any overlapping VIP ownership.
    Probe `/api-proxy/health/active`, `/api-proxy/health`, and an authenticated
-   database-backed request at least once per second. Measure from the first
-   failed probe until all three VIP probes succeed and `/api-proxy/health`
-   reports `X-Proto-Fleet-Version: N+1`; require less than 15 seconds. Release
-   the test device and verify the former active rejoins as passive, the PENDING
-   command dispatches, the interrupted PROCESSING command reaches the expected
+   database-backed request at least once per second. On the same monotonic
+   clock, measure from the last successful pre-handoff VIP probe until all
+   three VIP probes succeed and `/api-proxy/health` reports
+   `X-Proto-Fleet-Version: N+1`; require less than 15 seconds. Release the test
+   device and verify the former active rejoins as passive, the PENDING command
+   dispatches, the interrupted PROCESSING command reaches the expected
    terminal recovery state, and later work for that device succeeds.
-6. Force an application failover in each direction. Use the same active and
-   database-backed probes, require usable service within 15 seconds, and
-   submit a successful command after each move.
+6. Force an application failover in each direction. From before each trigger
+   through convergence, reuse the direct active-health and interface-address
+   streams from step 5 and fail on any active or VIP overlap. Require the
+   former active to reject an active-only request, measure usable service from
+   the last successful pre-failover probe on the same monotonic clock, require
+   less than 15 seconds, and submit a successful command after each move.
 7. Confirm the etcd and Patroni container IDs and start times, and both
    PostgreSQL postmaster start times, are unchanged from step 2. The application
    update must not replace or restart these services.
@@ -68,8 +72,8 @@ certificates, device names, and customer data from committed evidence.
 | Active completion | Active and database-backed probes serve `N+1`; former active rejoins passive | `<15s` | Pending | Pending |
 | Handoff fencing | High-frequency direct health and interface event streams never show active or VIP overlap | N/A | Pending | Pending |
 | Handoff command recovery | Exact rows stay PROCESSING/PENDING until stop, then PROCESSING recovers, PENDING dispatches, and later per-device work succeeds | N/A | Pending | Pending |
-| Failover to peer | VIP serves `N+1`; command succeeds | `<15s` | Pending | Pending |
-| Failover back | VIP serves `N+1`; command succeeds | `<15s` | Pending | Pending |
+| Failover to peer | No active or VIP overlap; old active rejects; VIP serves `N+1`; command succeeds | `<15s` | Pending | Pending |
+| Failover back | No active or VIP overlap; old active rejects; VIP serves `N+1`; command succeeds | `<15s` | Pending | Pending |
 | Infrastructure preserved | etcd and Patroni identity plus PostgreSQL start times are unchanged | N/A | Pending | Pending |
 | Updater refresh | Both updater binaries, services, and local status sockets run `N+1` | N/A | Pending | Pending |
 | Reboot recovery | Both hosts return on `N+1` with persisted data and working failover | Pending | Pending | Pending |

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -77,15 +77,17 @@ and run Fleet commands as
    perform a persisted read and a uniquely identified idempotent command against
    the `N+1` VIP. Before reinstalling for step 5, confirm the infrastructure
    identities from step 2 are unchanged.
-5. Reinstall the clean `N` baseline, update the passive host to `N+1`, and keep
-   a persistent controller connection to both hosts. Start `--complete` on the
-   active `N` host while the controller polls its local updater status. As soon
-   as the operation enters the activating phase, stop the updated peer's Fleet
-   application before the old host stops. Require takeover to time out and the
-   updater to restart release `N` automatically. Within 60 seconds, require the
-   old host to serve the VIP, a persisted read, and a successful command, with
-   no manual recovery command remaining. Restart the `N+1` peer as passive and
-   restore full readiness before continuing.
+5. Reinstall the clean `N` baseline and update the passive host to `N+1`. On the
+   active host, create the root-owned
+   `/var/lib/proto-fleet-updater/qualification-pause-before-ha-stop` file and
+   arrange to remove it on every exit. Start `--complete` and wait until updater
+   status enters the activating phase; the barrier now holds the old application
+   open after final preflight. Stop the updated peer's Fleet application and
+   confirm it is unavailable, then remove the barrier. Require takeover to time
+   out and the updater to restart release `N` automatically. Within 60 seconds,
+   require the old host to serve the VIP, a persisted read, and a successful
+   command, with no manual recovery command remaining. Restart the `N+1` peer as
+   passive and restore full readiness before continuing.
 6. Reinstall the clean `N` baseline and repeat steps 2 and 3 for a separate
    mixed-version failover run. Update the passive host to `N+1`, then terminate
    the active `N` Fleet process instead of running `--complete`. Require the

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -18,8 +18,10 @@ certificates, device names, and customer data from committed evidence.
 
 1. Verify the published `N` and `N+1` artifacts and their checksums. Confirm
    every `N+1` migration is expand-only and remains usable by `N`; reject
-   drops, renames, narrowed types, and newly required values. Install and
-   qualify `N` using [QUALIFICATION.md](QUALIFICATION.md).
+   drops, renames, narrowed types, and newly required values. Apply the
+   migrations to a disposable copy of an `N` database and run `N`'s affected
+   database and API integration tests against it. Install and qualify `N`
+   using [QUALIFICATION.md](QUALIFICATION.md).
 2. Record the container IDs and start times for etcd and Patroni on every host,
    plus `pg_postmaster_start_time()` on both PostgreSQL members.
 3. Run `fleet-ha update N+1` on the passive application host. Verify it remains
@@ -30,12 +32,17 @@ certificates, device names, and customer data from committed evidence.
    `fleet-ha update N+1 --complete` on the active host. Verify the command
    times out without swapping deployments, restarts `N`, and restores a usable
    VIP and successful command within 60 seconds. Restore the passive host.
-5. Retry `fleet-ha update N+1 --complete`. From another host, probe
+5. Create controlled PENDING and PROCESSING commands and record their immutable
+   IDs. Retry `fleet-ha update N+1 --complete`. From another host, probe
    `/api-proxy/health/active`, `/api-proxy/health`, and an authenticated
-   database-backed request at least once per second. Measure from the first
-   failed probe until all three succeed and `/api-proxy/health` reports
+   database-backed request at least once per second. At the same cadence,
+   sample direct active health and VIP ownership on both hosts; fail on any
+   active or VIP overlap. Measure from the first failed probe until all three
+   VIP probes succeed and `/api-proxy/health` reports
    `X-Proto-Fleet-Version: N+1`; require less than 15 seconds. Verify the former
-   active rejoins as passive on `N+1`.
+   active rejoins as passive, the PENDING command dispatches, the interrupted
+   PROCESSING command reaches the expected terminal recovery state, and later
+   work for that device succeeds.
 6. Force an application failover in each direction. Use the same active and
    database-backed probes, require usable service within 15 seconds, and
    submit a successful command after each move.
@@ -46,18 +53,18 @@ certificates, device names, and customer data from committed evidence.
    status sockets are healthy. Reboot the two application/database hosts one
    at a time, restoring full readiness between reboots. Repeat the updater
    checks and verify both hosts retain Fleet data and can serve a command.
-   readiness between reboots. Verify both return on `N+1`, retain persisted
-   Fleet data, and can serve a command after failover.
 
 ## Results
 
 | Gate | Required result | Duration | Result | Evidence |
 | --- | --- | --- | --- | --- |
-| Migration compatibility | `N+1` migrations are expand-only and usable by `N` | N/A | Pending | Pending |
+| Migration compatibility | `N` integration tests pass against an `N` database migrated by `N+1` | N/A | Pending | Pending |
 | Passive-first update | Passive runs `N+1`; active continues serving `N` | N/A | Pending | Pending |
 | Mixed-version operation | Persisted read and command succeed while hosts run `N` and `N+1` | N/A | Pending | Pending |
 | Failed takeover recovery | No swap; `N` restores usable service and command execution | `<60s` | Pending | Pending |
 | Active completion | Active and database-backed probes serve `N+1`; former active rejoins passive | `<15s` | Pending | Pending |
+| Handoff fencing | Direct health and VIP samples never show active or VIP overlap | N/A | Pending | Pending |
+| Handoff command recovery | PENDING dispatches, PROCESSING recovers, and later per-device work succeeds | N/A | Pending | Pending |
 | Failover to peer | VIP serves `N+1`; command succeeds | `<15s` | Pending | Pending |
 | Failover back | VIP serves `N+1`; command succeeds | `<15s` | Pending | Pending |
 | Infrastructure preserved | etcd and Patroni identity plus PostgreSQL start times are unchanged | N/A | Pending | Pending |

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -1,125 +1,56 @@
 # Proto Fleet HA update qualification
 
-Use this report for one adjacent released-version update, `N` to `N+1`, on the
-qualified three-host profile. Do not use development builds or skip a released
-version. Redact addresses, credentials, certificates, device names, and
-customer data from committed evidence.
+Use this report to qualify one adjacent released-version update, `N` to `N+1`,
+on the supported three-host HA profile. Redact addresses, credentials,
+certificates, device names, and customer data from committed evidence.
 
 ## Test identity
 
 | Field | Value |
 | --- | --- |
-| Source release (`N`) | Pending |
-| Source commit SHA | Pending |
-| Source archive filename and SHA-256 | Pending |
-| Source release workflow run | Pending |
-| Target release (`N+1`) | Pending |
-| Target commit SHA | Pending |
-| Target archive filename and SHA-256 | Pending |
-| Target release workflow run | Pending |
-| Architecture | arm64 |
-| Operating system | Debian 13 |
-| Started | Pending |
-| Completed | Pending |
+| Source release and commit (`N`) | Pending |
+| Target release and commit (`N+1`) | Pending |
+| Release artifacts and SHA-256 digests | Pending |
+| Architecture and operating system | Pending |
+| Started and completed | Pending |
 
 ## Procedure
 
-1. Download each arm64 archive and its `.sha256` sidecar from the published
-   release, verify the sidecar, and record the exact filename and digest above.
-   For both extracted archives, verify `deployment-manifest.sha256`, confirm
-   that `version.txt` names the recorded release and commit, and link the
-   release workflow run whose head SHA matches that commit. Install and qualify
-   release `N` using [QUALIFICATION.md](QUALIFICATION.md). Confirm `N` includes
-   the `fleet-ha update` and `update --complete` protocol; releases that predate
-   this supported HA update baseline are out of scope.
-   These checks establish internal archive consistency, not cryptographic proof
-   that the cited workflow produced the digest. This first qualification trusts
-   the existing GitHub Release publishing boundary; artifact attestation is
-   deferred.
-2. Record the running etcd and Patroni/PostgreSQL container IDs, start times,
-   and restart counts on all hosts. Retain Docker events for those containers
-   and continuously probe etcd quorum and writable database access until both
-   application updates finish.
-3. Before starting `N+1` on a live host, review every migration between the
-   recorded commits and reject drops, renames, narrowing conversions, or newly
-   mandatory constraints that the `N` application cannot satisfy. On a
-   disposable copy of an `N` database, apply the `N+1` migrations and run the
-   `N` database and API integration tests for every affected query area.
-4. On the passive database host, run `fleet-ha update N+1` and verify that it
-   remains passive on `N+1` while the active host continues serving `N`. Fail
-   if the operation reports `host updater refresh needs attention`. Require
-   `/usr/local/libexec/proto-fleet/proto-fleet-updater --version` to print
-   `N+1`, `proto-fleet-updater.service` to be active, and an authenticated local
-   request to `/v1/status` over `/run/proto-fleet-updater/updater.sock` to
-   succeed. Retain the redacted operation log. During the live mixed-version
-   window, use the authenticated VIP API to read existing database-backed
-   configuration, submit a command, and verify its completion while `N`
-   remains active.
-5. On the updated passive, capture its running `fleet-api` and `fleet-client`
-   container IDs, then stop keepalived so that host cannot advertise the VIP.
-   Start a background watcher that polls the uncached
-   `http://127.0.0.1:4000/health/active` endpoint at least every 100 milliseconds
-   and stops those exact containers as soon as it reports active. Continuously
-   probe the VIP from another host and run `fleet-ha update N+1 --complete` on
-   the active. Verify the updated peer never serves the VIP and the operation
-   log shows active validation and application stop, followed by the 35-second
-   takeover timeout and release `N` restart without a deployment swap. Confirm
-   `N` reacquires the VIP and can complete a command within 60 seconds of the
-   first failed VIP probe. Start keepalived, restart the updated peer with
-   `fleet-ha app-start N+1 passive`, and restore full readiness before
-   continuing. This recovery bound is separate from the 15-second successful
-   handoff target.
-6. With the target artifacts and build cache warmed by step 5, block a
-   PROCESSING command on one controlled test device and enqueue a second command
-   behind it so per-device ordering keeps that row PENDING. Record both
-   immutable queue row IDs, retry `fleet-ha update N+1 --complete`, and sample
-   both rows throughout the retry. The gate fails if either state changes before
-   `fleet-api` stops; retain a final timestamped sample no more than one second
-   before that stop. From another host, probe the versioned health endpoint and
-   an authenticated database-backed API at least every 100 milliseconds.
-   Measure from the first failure of either probe through the first interval in
-   which health reports `N+1` and the authenticated request succeeds. Retain
-   both timestamped probe streams.
-7. Verify those exact rows on `N+1`: the PENDING row is dispatched, the
-   interrupted PROCESSING attempt reaches its documented terminal state, and a
-   later command for that device succeeds. Verify the former active is passive
-   on `N+1`, then repeat the updater version, service, socket, warning, and
-   redacted-log checks from step 3 on this host.
-8. Force an application failover to the former active and back to its peer.
-   For each direction, use both 100-millisecond external probes and the
-   first-failure-to-both-success interval from step 6. Submit a command through
-   the VIP after each failover and verify it succeeds.
-9. Compare the infrastructure evidence recorded in step 2. Require unchanged
-   container IDs, start times, and restart counts; no stop, die, or restart
-   events; and uninterrupted etcd quorum and writable database probes. Prove
-   that the application update neither replaced nor restarted etcd, Patroni,
-   or PostgreSQL.
-10. Reboot both database hosts, one at a time, restoring full readiness between
-    reboots. Confirm both return on `N+1` with the same etcd membership,
-    Patroni cluster, and persisted Fleet data. On each host, repeat the updater
-    version, service, and socket checks. Container IDs may change during reboot.
+1. Verify the published `N` and `N+1` artifacts and their checksums. Install and
+   qualify `N` using [QUALIFICATION.md](QUALIFICATION.md).
+2. Record the container IDs and start times for etcd, Patroni, and PostgreSQL on
+   every host.
+3. Run `fleet-ha update N+1` on the passive application host. Verify it remains
+   passive on `N+1` while the active host continues serving `N`. Through the
+   VIP, read persisted data and submit a command to prove the temporary mixed
+   `N` and `N+1` state is usable.
+4. Run `fleet-ha update N+1 --complete` on the active host. Probe the VIP from
+   another host and measure from its first failed response until it returns a
+   successful `/health` response reporting `N+1`. Require less than 15 seconds.
+   Verify the former active rejoins as passive on `N+1`.
+5. Force an application failover in each direction. After each failover,
+   require the VIP to serve `N+1` within 15 seconds and submit a successful
+   command.
+6. Confirm the etcd, Patroni, and PostgreSQL container IDs and start times from
+   step 2 are unchanged. The application update must not replace or restart
+   these services.
+7. Reboot the two application/database hosts one at a time, restoring full
+   readiness between reboots. Verify both return on `N+1`, retain persisted
+   Fleet data, and can serve a command after failover.
 
 ## Results
 
 | Gate | Required result | Duration | Result | Evidence |
 | --- | --- | --- | --- | --- |
 | Passive-first update | Passive runs `N+1`; active continues serving `N` | N/A | Pending | Pending |
-| Mixed-version window | Authenticated reads, writes, and command completion work while peers run `N` and `N+1` | Pending | Pending | Pending |
-| Failed takeover recovery | Completion times out before swap; `N` restarts and serves commands within 60s | Pending | Pending | Pending |
-| Active completion | VIP serves `N+1` and an authenticated database-backed request within 15s | Pending | Pending | Pending |
-| PENDING command handoff | Immutable pre-stop row crosses from `N` to `N+1` as PENDING; new active dispatches it | Pending | Pending | Pending |
-| PROCESSING command handoff | Immutable pre-stop row crosses from `N` to `N+1` as PROCESSING; attempt finishes terminally and later work resumes | Pending | Pending | Pending |
-| Failover to peer | VIP serves `N+1` and an authenticated database-backed request within 15s | Pending | Pending | Pending |
-| Failover back | VIP serves `N+1` and an authenticated database-backed request within 15s | Pending | Pending | Pending |
-| Command execution | Command succeeds after both failovers | N/A | Pending | Pending |
-| Infrastructure preservation | Application update leaves etcd, Patroni, and PostgreSQL container identity and uptime unchanged, with no DCS or database probe gap | N/A | Pending | Pending |
-| Host updater refresh | Both protected updater binaries report `N+1`; services and local status APIs survive reboot; no refresh warning remains | N/A | Pending | Pending |
-| Reboot recovery | Both hosts return on `N+1` with DCS, database, and Fleet data intact | Pending | Pending | Pending |
+| Mixed-version operation | Persisted read and command succeed while hosts run `N` and `N+1` | N/A | Pending | Pending |
+| Active completion | VIP serves `N+1`; former active rejoins passive | `<15s` | Pending | Pending |
+| Failover to peer | VIP serves `N+1`; command succeeds | `<15s` | Pending | Pending |
+| Failover back | VIP serves `N+1`; command succeeds | `<15s` | Pending | Pending |
+| Infrastructure preserved | etcd, Patroni, and PostgreSQL are not replaced or restarted | N/A | Pending | Pending |
+| Reboot recovery | Both hosts return on `N+1` with persisted data and working failover | Pending | Pending | Pending |
 
 ## Verdict
 
-**Pending.** The HA application update path is qualified only when every result
-above is `PASS`, every successful handoff interruption is below 15 seconds,
-failed-takeover recovery is below 60 seconds, and the report binds both exact
-archives to their published digests, packaged commits, and release workflow
-runs.
+**Pending.** Mark the adjacent update supported only when every gate passes and
+attach the redacted evidence to this report.

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -20,7 +20,7 @@ leaves the release marked prerelease and unsupported.
 | --- | --- |
 | Source release and commit (`N`) | Pending |
 | Target release and commit (`N+1`) | Pending |
-| Release artifacts and SHA-256 digests | Pending |
+| Source and target artifacts and SHA-256 digests | Pending |
 | Architecture and operating system | Pending |
 | Started and completed | Pending |
 
@@ -159,16 +159,16 @@ and run Fleet commands as
 | Updater refresh | Both updater binaries, services, and local status sockets run `N+1` | N/A | Pending | Pending |
 | Updater interruption recovery | Pre-activation, post-swap, and self-update faults recover automatically | N/A | Pending | Pending |
 | Reboot recovery | Both hosts return on `N+1` with persisted data and working failover | Pending | Pending | Pending |
-| Promotion drift guard | Source is still latest stable; target tag, commit, and asset digests still match this report | N/A | Pending | Pending |
+| Promotion drift guard | Source is still latest stable; both tags, commits, and complete asset digests still match this report | N/A | Pending | Pending |
 
 ## Verdict
 
 **Pending.** Mark the adjacent update supported only when every gate passes on
 both amd64 and arm64 and attach the redacted evidence to each report.
 Immediately before promotion, re-fetch both releases and re-download every
-target asset into a clean directory. Abort unless `SOURCE_RELEASE` is still the
-latest stable release, the target is still a prerelease, its tag resolves to
-the recorded commit, and its asset names and SHA-256 digests exactly match the
-report. Then promote it with
+source and target asset into separate clean directories. Abort unless
+`SOURCE_RELEASE` is still the latest stable release, the target is still a
+prerelease, both tags resolve to their recorded commits, and both complete
+asset name and SHA-256 digest sets exactly match the report. Then promote it with
 `gh release edit "$TARGET_RELEASE" --prerelease=false --latest`. Do not rebuild,
 retag, replace assets, or promote after any drift.

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -11,8 +11,12 @@ customer data from committed evidence.
 | --- | --- |
 | Source release (`N`) | Pending |
 | Source commit SHA | Pending |
+| Source archive filename and SHA-256 | Pending |
+| Source release workflow run | Pending |
 | Target release (`N+1`) | Pending |
 | Target commit SHA | Pending |
+| Target archive filename and SHA-256 | Pending |
+| Target release workflow run | Pending |
 | Architecture | arm64 |
 | Operating system | Debian 13 |
 | Started | Pending |
@@ -20,9 +24,14 @@ customer data from committed evidence.
 
 ## Procedure
 
-1. Install and qualify release `N` using [QUALIFICATION.md](QUALIFICATION.md).
-   Confirm `N` includes the `fleet-ha update` and `update --complete` protocol;
-   releases that predate this supported HA update baseline are out of scope.
+1. Download each arm64 archive and its `.sha256` sidecar from the published
+   release, verify the sidecar, and record the exact filename and digest above.
+   For both extracted archives, verify `deployment-manifest.sha256`, confirm
+   that `version.txt` names the recorded release and commit, and link the
+   release workflow run whose head SHA matches that commit. Install and qualify
+   release `N` using [QUALIFICATION.md](QUALIFICATION.md). Confirm `N` includes
+   the `fleet-ha update` and `update --complete` protocol; releases that predate
+   this supported HA update baseline are out of scope.
 2. Record the running etcd and Patroni/PostgreSQL container IDs on all hosts.
 3. On the passive database host, run `fleet-ha update N+1` and verify that it
    remains passive on `N+1` while the active host continues serving `N`. Fail
@@ -84,5 +93,6 @@ customer data from committed evidence.
 
 **Pending.** The HA application update path is qualified only when every result
 above is `PASS`, every successful handoff interruption is below 15 seconds,
-failed-takeover recovery is below 60 seconds, and the report identifies both
-released artifacts and commits.
+failed-takeover recovery is below 60 seconds, and the report binds both exact
+archives to their published digests, packaged commits, and release workflow
+runs.

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -137,34 +137,45 @@ sudo systemctl is-active --quiet proto-fleet-updater.service
    status sockets are healthy. Reboot the two application/database hosts one
    at a time, restoring full readiness between reboots. Repeat the updater
    checks and verify both hosts retain Fleet data and can serve a command.
-10. From a clean `N` baseline, run four separate interruption cases. First,
-    create the root-owned
-    `/var/lib/proto-fleet-updater/qualification-pause-before-ha-stop` file and
-    SIGKILL the updater after final preflight; the old active must keep serving
-    and the updater must restart cleanly. Second, create the root-owned
-    `/var/lib/proto-fleet-updater/qualification-pause-between-deployment-renames`
-    file and power-cycle only after updater status is activating,
-    `/opt/proto-fleet/deployment` is absent, and
-    `/opt/proto-fleet/deployment.previous` exists. This proves the fault landed
-    between the two renames; startup must restore `N`. Third, power-cycle after
-    the activation marker clears but while updater status is still activating
-    and the target application is not healthy. Require restart recovery to
-    retain `N+1`, finish startup and migrations, clear pending recovery, and
-    restore control and failover readiness. Fourth, during self-replacement,
-    obtain the updater service's PID and require its `/proc/<pid>/cmdline` to
-    contain exactly
-    `--self-update-handoff=/usr/local/libexec/proto-fleet/proto-fleet-updater`
-    while the production updater socket is not accepting status requests, then
-    SIGKILL that process. The handoff marker alone is insufficient evidence
-    because it exists before the replacement process starts. Repeat a case if
-    its required evidence clears before the fault lands. Remove each barrier
-    after its case. After each restart, require one valid deployment directory,
-    no pending recovery marker, a healthy updater socket, restored control and
-    failover readiness, and either the intact old release or fully verified
-    target release according to the recorded recovery state. When recovery
-    retains the target release, require the installed updater's `--version` to
-    report the same target version; startup repair must not leave the previous
-    updater paired with the new application.
+10. Run these four cases separately, reinstalling the clean `N` baseline and
+    restoring control and failover readiness before each one:
+
+    - For the pre-stop case, first run the ordinary passive update on the peer
+      and require it healthy and passive on `N+1`. On the active `N` host,
+      create the root-owned
+      `/var/lib/proto-fleet-updater/qualification-pause-before-ha-stop` file,
+      run `fleet-ha update "$TARGET_RELEASE" --complete`, and wait for the
+      activating phase while `N` still serves the VIP. SIGKILL the updater,
+      remove the barrier, and require the old active to keep serving while the
+      updater restarts cleanly.
+    - For the two-rename case, create the root-owned
+      `/var/lib/proto-fleet-updater/qualification-pause-between-deployment-renames`
+      file on the passive `N` host and run the ordinary passive update.
+      Power-cycle only after updater status is activating,
+      `/opt/proto-fleet/deployment` is absent, and
+      `/opt/proto-fleet/deployment.previous` exists. Remove the barrier after
+      reboot and require startup to restore `N`.
+    - For the forward-activation case, run the ordinary passive update on the
+      passive `N` host. Power-cycle after the activation marker clears but
+      while updater status is still activating and the target application is
+      not healthy. Require restart recovery to retain `N+1`, finish startup and
+      migrations, and clear pending recovery.
+    - For the self-update case, run the ordinary passive update on the passive
+      `N` host. During self-replacement, obtain the updater service's PID and
+      require its `/proc/<pid>/cmdline` to contain exactly
+      `--self-update-handoff=/usr/local/libexec/proto-fleet/proto-fleet-updater`
+      while the production updater socket is not accepting status requests,
+      then SIGKILL that process. The handoff marker alone is insufficient
+      evidence because it exists before the replacement process starts.
+
+    Repeat a case if its required evidence clears before the fault lands.
+    After each restart, require one valid deployment directory, no pending
+    recovery marker, a healthy updater socket, restored control and failover
+    readiness, and either the intact old release or fully verified target
+    release according to the recorded recovery state. When recovery retains
+    the target release, require the installed updater's `--version` to report
+    the same target version; startup repair must not leave the previous updater
+    paired with the new application.
 
 ## Results
 

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -44,9 +44,13 @@ customer data from committed evidence.
    `N+1`, `proto-fleet-updater.service` to be active, and an authenticated local
    request to `/v1/status` over `/run/proto-fleet-updater/updater.sock` to
    succeed. Retain the redacted operation log.
-4. During the mixed-version window, use the authenticated VIP API to read
-   existing database-backed configuration, submit a command, and verify its
-   completion while `N` remains active.
+4. Review every migration between the recorded commits and reject drops,
+   renames, narrowing conversions, or newly mandatory constraints that the `N`
+   application cannot satisfy. On a disposable copy of an `N` database, apply
+   the `N+1` migrations and run the `N` database and API integration tests for
+   every affected query area. During the live mixed-version window, use the
+   authenticated VIP API to read existing database-backed configuration,
+   submit a command, and verify its completion while `N` remains active.
 5. On the updated passive, capture its running `fleet-api` and `fleet-client`
    container IDs, then stop keepalived so that host cannot advertise the VIP.
    Start a background watcher that polls the uncached
@@ -67,19 +71,20 @@ customer data from committed evidence.
    immutable queue row IDs, retry `fleet-ha update N+1 --complete`, and sample
    both rows throughout the retry. The gate fails if either state changes before
    `fleet-api` stops; retain a final timestamped sample no more than one second
-   before that stop. From another host, probe the authenticated VIP at least
-   every 100 milliseconds. Measure from the first failed request through the
-   first successful response whose version header reports `N+1`, and retain the
-   timestamped probe output.
+   before that stop. From another host, probe the versioned health endpoint and
+   an authenticated database-backed API at least every 100 milliseconds.
+   Measure from the first failure of either probe through the first interval in
+   which health reports `N+1` and the authenticated request succeeds. Retain
+   both timestamped probe streams.
 7. Verify those exact rows on `N+1`: the PENDING row is dispatched, the
    interrupted PROCESSING attempt reaches its documented terminal state, and a
    later command for that device succeeds. Verify the former active is passive
    on `N+1`, then repeat the updater version, service, socket, warning, and
    redacted-log checks from step 3 on this host.
 8. Force an application failover to the former active and back to its peer.
-   For each direction, use the same 100-millisecond external VIP probe and
-   first-failure-to-first-versioned-success interval from step 6. Submit a
-   command through the VIP after each failover and verify it succeeds.
+   For each direction, use both 100-millisecond external probes and the
+   first-failure-to-both-success interval from step 6. Submit a command through
+   the VIP after each failover and verify it succeeds.
 9. Compare the infrastructure container IDs recorded in step 2. Prove that the
    application update did not replace etcd, Patroni, or PostgreSQL.
 10. Reboot both database hosts, one at a time, restoring full readiness between
@@ -94,11 +99,11 @@ customer data from committed evidence.
 | Passive-first update | Passive runs `N+1`; active continues serving `N` | N/A | Pending | Pending |
 | Mixed-version window | Authenticated reads, writes, and command completion work while peers run `N` and `N+1` | Pending | Pending | Pending |
 | Failed takeover recovery | Completion times out before swap; `N` restarts and serves commands within 60s | Pending | Pending | Pending |
-| Active completion | VIP serves `N+1` within 15s | Pending | Pending | Pending |
+| Active completion | VIP serves `N+1` and an authenticated database-backed request within 15s | Pending | Pending | Pending |
 | PENDING command handoff | Immutable pre-stop row crosses from `N` to `N+1` as PENDING; new active dispatches it | Pending | Pending | Pending |
 | PROCESSING command handoff | Immutable pre-stop row crosses from `N` to `N+1` as PROCESSING; attempt finishes terminally and later work resumes | Pending | Pending | Pending |
-| Failover to peer | VIP serves `N+1` within 15s | Pending | Pending | Pending |
-| Failover back | VIP serves `N+1` within 15s | Pending | Pending | Pending |
+| Failover to peer | VIP serves `N+1` and an authenticated database-backed request within 15s | Pending | Pending | Pending |
+| Failover back | VIP serves `N+1` and an authenticated database-backed request within 15s | Pending | Pending | Pending |
 | Command execution | Command succeeds after both failovers | N/A | Pending | Pending |
 | Infrastructure preservation | Application update leaves etcd, Patroni, and PostgreSQL container IDs unchanged | N/A | Pending | Pending |
 | Host updater refresh | Both protected updater binaries report `N+1`; services and local status APIs survive reboot; no refresh warning remains | N/A | Pending | Pending |

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -1,0 +1,66 @@
+# Proto Fleet HA update qualification
+
+Use this report for one adjacent released-version update, `N` to `N+1`, on the
+qualified three-host profile. Do not use development builds or skip a released
+version. Redact addresses, credentials, certificates, device names, and
+customer data from committed evidence.
+
+## Test identity
+
+| Field | Value |
+| --- | --- |
+| Source release (`N`) | Pending |
+| Source commit SHA | Pending |
+| Target release (`N+1`) | Pending |
+| Target commit SHA | Pending |
+| Architecture | arm64 |
+| Operating system | Debian 13 |
+| Started | Pending |
+| Completed | Pending |
+
+## Procedure
+
+1. Install and qualify release `N` using [QUALIFICATION.md](QUALIFICATION.md).
+   Confirm `N` includes the `fleet-ha update` and `update --complete` protocol;
+   releases that predate this supported HA update baseline are out of scope.
+2. Record the running etcd and Patroni/PostgreSQL container IDs on all hosts.
+3. On the passive database host, run `fleet-ha update N+1` and verify that it
+   remains passive on `N+1` while the active host continues serving `N`.
+4. During the mixed-version window, use the authenticated VIP API to read
+   existing database-backed configuration, submit a command, and verify its
+   completion while `N` remains active.
+5. Stop keepalived on the updated passive, then run
+   `fleet-ha update N+1 --complete` on the active. Verify it times out before
+   swapping, restarts release `N`, serves the VIP within 45 seconds, and can
+   complete a command. Restart keepalived and restore full readiness. This
+   recovery bound is separate from the 15-second successful-handoff target.
+6. Retry `fleet-ha update N+1 --complete`. Measure from the first failed VIP
+   health probe until the VIP serves `N+1`.
+7. Verify the former active is now passive on `N+1`, then force an application
+   failover in each direction.
+8. Submit a command through the VIP after each failover and verify it succeeds.
+9. Reboot both database hosts, one at a time, restoring full readiness between
+   reboots. Confirm both return on `N+1`.
+10. Compare the recorded infrastructure container IDs and prove that etcd,
+   Patroni, and PostgreSQL were not replaced by the application update.
+
+## Results
+
+| Gate | Required result | Duration | Result | Evidence |
+| --- | --- | --- | --- | --- |
+| Passive-first update | Passive runs `N+1`; active continues serving `N` | N/A | Pending | Pending |
+| Mixed-version window | Authenticated reads, writes, and command completion work while peers run `N` and `N+1` | Pending | Pending | Pending |
+| Failed takeover recovery | Completion times out before swap; `N` restarts and serves commands within 45s | Pending | Pending | Pending |
+| Active completion | VIP serves `N+1` within 15s | Pending | Pending | Pending |
+| Failover to peer | VIP serves `N+1` within 15s | Pending | Pending | Pending |
+| Failover back | VIP serves `N+1` within 15s | Pending | Pending | Pending |
+| Command execution | Command succeeds after both failovers | N/A | Pending | Pending |
+| Reboot recovery | Both database hosts return on `N+1` | Pending | Pending | Pending |
+| Infrastructure preservation | etcd, Patroni, and PostgreSQL container IDs are unchanged | N/A | Pending | Pending |
+
+## Verdict
+
+**Pending.** The HA application update path is qualified only when every result
+above is `PASS`, every successful handoff interruption is below 15 seconds,
+failed-takeover recovery is below 45 seconds, and the report identifies both
+released artifacts and commits.

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -48,20 +48,21 @@ and run Fleet commands as
    submissions are more than three seconds apart. Continue these probes through
    step 4. Verify the active host continues serving `N` throughout the migration
    and mixed-version window.
-4. Run the completion command. From a separate controller, use the external
-   append-only recorder, gap rejection, and uncertainty-inclusive interval rules
-   from [QUALIFICATION.md](QUALIFICATION.md). Continuously record direct active
-   health on both hosts with monotonic timestamps at 100 ms or faster. In
-   parallel, stream interface address events from both hosts and fail on any
-   active or VIP overlap. Probe
+4. From a separate controller, start the external append-only recorder, gap
+   rejection, and uncertainty-inclusive interval rules from
+   [QUALIFICATION.md](QUALIFICATION.md). Confirm initial snapshots and gap-free
+   streams before continuing. Continuously record direct active health on both
+   hosts with monotonic timestamps at 100 ms or faster. In parallel, stream
+   interface address events from both hosts and fail on any active or VIP
+   overlap. Before the handoff, hold one `N` command in PROCESSING and one
+   successor in PENDING. Then run the completion command. Probe
    `/api-proxy/health/active`, `/api-proxy/health`, and an authenticated
    database-backed request at least once per second. On the same monotonic
    clock, measure from the last successful pre-handoff VIP probe until all
    three VIP probes succeed and `/api-proxy/health` reports
    `X-Proto-Fleet-Version: N+1`; require less than 15 seconds. Verify the former
-   active rejoins as passive. Before the handoff, hold one `N` command in
-   PROCESSING and one successor in PENDING. After takeover, require the
-   PROCESSING row to fail once without replay, the PENDING row to dispatch on
+   active rejoins as passive. After takeover, require the PROCESSING row to
+   fail once without replay, the PENDING row to dispatch on
    `N+1`, and both accepted IDs to reach exactly one terminal result within 60
    seconds. Using a client loaded from `N` before handoff,
    perform a persisted read and a uniquely identified idempotent command against

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -159,11 +159,16 @@ and run Fleet commands as
 | Updater refresh | Both updater binaries, services, and local status sockets run `N+1` | N/A | Pending | Pending |
 | Updater interruption recovery | Pre-activation, post-swap, and self-update faults recover automatically | N/A | Pending | Pending |
 | Reboot recovery | Both hosts return on `N+1` with persisted data and working failover | Pending | Pending | Pending |
+| Promotion drift guard | Source is still latest stable; target tag, commit, and asset digests still match this report | N/A | Pending | Pending |
 
 ## Verdict
 
 **Pending.** Mark the adjacent update supported only when every gate passes on
-both amd64 and arm64, attach the redacted evidence to each report, and promote
-the unchanged `N+1` GitHub release with
+both amd64 and arm64 and attach the redacted evidence to each report.
+Immediately before promotion, re-fetch both releases and re-download every
+target asset into a clean directory. Abort unless `SOURCE_RELEASE` is still the
+latest stable release, the target is still a prerelease, its tag resolves to
+the recorded commit, and its asset names and SHA-256 digests exactly match the
+report. Then promote it with
 `gh release edit "$TARGET_RELEASE" --prerelease=false --latest`. Do not rebuild,
-retag, or replace its assets.
+retag, replace assets, or promote after any drift.

--- a/deployment-files/ha/UPDATE_QUALIFICATION.md
+++ b/deployment-files/ha/UPDATE_QUALIFICATION.md
@@ -20,8 +20,8 @@ certificates, device names, and customer data from committed evidence.
    every `N+1` migration is expand-only and remains usable by `N`; reject
    drops, renames, narrowed types, and newly required values. Install and
    qualify `N` using [QUALIFICATION.md](QUALIFICATION.md).
-2. Record the container IDs and start times for etcd, Patroni, and PostgreSQL on
-   every host.
+2. Record the container IDs and start times for etcd and Patroni on every host,
+   plus `pg_postmaster_start_time()` on both PostgreSQL members.
 3. Run `fleet-ha update N+1` on the passive application host. Verify it remains
    passive on `N+1` while the active host continues serving `N`. Through the
    VIP, read persisted data and submit a command to prove the temporary mixed
@@ -31,16 +31,17 @@ certificates, device names, and customer data from committed evidence.
    times out without swapping deployments, restarts `N`, and restores a usable
    VIP and successful command within 60 seconds. Restore the passive host.
 5. Retry `fleet-ha update N+1 --complete`. From another host, probe
-   `/health/active` and an authenticated database-backed request at least once
-   per second. Measure from the first failed probe until both succeed and the
-   public health header reports `N+1`; require less than 15 seconds. Verify the
-   former active rejoins as passive on `N+1`.
+   `/api-proxy/health/active`, `/api-proxy/health`, and an authenticated
+   database-backed request at least once per second. Measure from the first
+   failed probe until all three succeed and `/api-proxy/health` reports
+   `X-Proto-Fleet-Version: N+1`; require less than 15 seconds. Verify the former
+   active rejoins as passive on `N+1`.
 6. Force an application failover in each direction. Use the same active and
    database-backed probes, require usable service within 15 seconds, and
    submit a successful command after each move.
-7. Confirm the etcd, Patroni, and PostgreSQL container IDs and start times from
-   step 2 are unchanged. The application update must not replace or restart
-   these services.
+7. Confirm the etcd and Patroni container IDs and start times, and both
+   PostgreSQL postmaster start times, are unchanged from step 2. The application
+   update must not replace or restart these services.
 8. Confirm both updater binaries report `N+1` and their services and local
    status sockets are healthy. Reboot the two application/database hosts one
    at a time, restoring full readiness between reboots. Repeat the updater
@@ -59,7 +60,7 @@ certificates, device names, and customer data from committed evidence.
 | Active completion | Active and database-backed probes serve `N+1`; former active rejoins passive | `<15s` | Pending | Pending |
 | Failover to peer | VIP serves `N+1`; command succeeds | `<15s` | Pending | Pending |
 | Failover back | VIP serves `N+1`; command succeeds | `<15s` | Pending | Pending |
-| Infrastructure preserved | etcd, Patroni, and PostgreSQL are not replaced or restarted | N/A | Pending | Pending |
+| Infrastructure preserved | etcd and Patroni identity plus PostgreSQL start times are unchanged | N/A | Pending | Pending |
 | Updater refresh | Both updater binaries, services, and local status sockets run `N+1` | N/A | Pending | Pending |
 | Reboot recovery | Both hosts return on `N+1` with persisted data and working failover | Pending | Pending | Pending |
 


### PR DESCRIPTION
Reviewable diff: +222/-0 across 2 files (excludes generated, test, and story files).

## Summary

Defines the evidence required to support an adjacent-version HA application update from stable `N` to prerelease `N+1`. The same target tag and assets become stable only after migration compatibility, passive-first update, mixed-version forced takeover, bounded completion and timeout recovery, bidirectional failover, command recovery, infrastructure preservation, deployment-swap, forward-activation, updater interruption, and reboot gates pass on both amd64 and arm64.

**Stack:** [#887](https://github.com/block/proto-fleet/pull/887) -> [#888](https://github.com/block/proto-fleet/pull/888) -> [#890](https://github.com/block/proto-fleet/pull/890) -> [#891](https://github.com/block/proto-fleet/pull/891) -> **#892**. This documentation-only diff is relative to completion PR #891.

## How it works

Operators publish the final `N+1` tag and assets at the fixed official origin as a GitHub prerelease. HA does not offer UI-triggered updates, so qualification configures the root-owned updater environment to authorize only that exact target and then uses the explicit local operator command. The authorization is restored after every clean reinstall, verified before each update attempt, and removed after the run. The report requires clean-install qualification for the exact source and target artifacts and verifies that the target's reviewed qualification file and manifest metadata name the exact source. It first runs compatibility tests, then loads a sanitized production-scale `N` dataset into the HA cluster so the real passive updater runs migrations under sustained traffic. Gap-free active-health and VIP ownership recording starts before the passive update. Authenticated reads and uniquely identified commands continue through passive-first update and completion, with bounded success gaps; every background command must reach SUCCESS, except the deliberately interrupted PROCESSING rows. The live handoff carries one `N` PROCESSING row and PENDING successor into `N+1`, proving the interrupted row fails without replay and the successor dispatches. A separate exact-artifact run pauses after the old application stops, makes the updated peer unavailable, proves the updater enters its takeover wait, and requires automatic `N` recovery within 60 seconds. Rename-window and self-update faults require direct process and filesystem evidence before injection rather than inferring the window from an ambiguous durable marker. A client loaded from `N` must still work against the `N+1` VIP. Another clean `N` baseline forces the updated `N+1` passive to take over before completion, then updates the old `N` host through the ordinary passive command. Public and database-backed probes measure normal interruption below 15 seconds; container identity, PostgreSQL start times, updater checks, and one-at-a-time reboots finish the evidence. Forward-activation interruption must resume target startup and migrations; self-update interruption passes only when the updater converges to the same version as the retained application deployment. Only after every gate passes does a final drift guard re-resolve both commits, re-download the complete source and target asset sets, compare their recorded digests, and promote the unchanged prerelease to stable.

```mermaid
flowchart LR
  A["Verify N and N+1 artifacts"] --> P["Update passive"]
  P --> M["Exercise mixed versions"]
  M --> X["Force mixed-version takeover"]
  X --> C["Complete active within 15s"]
  C --> F["Fail over both directions"]
  F --> R["Reboot and verify"]
  R --> V{"Every gate passes?"}
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `deployment-files/ha/UPDATE_QUALIFICATION.md` | Adds the adjacent-release procedure and result table | Check every support claim has direct, executable evidence |
| `deployment-files/ha/README.md` | Links the report | Check operator discoverability |

## Key technical decisions & trade-offs

- Only consecutive released artifacts are qualified; skipped versions remain unsupported.
- Qualification authorizes one exact GitHub prerelease through the local root-owned updater environment, then promotes the unchanged tag and assets only after every gate passes.
- The runbook reuses the baseline external recorder and the root-only qualification barriers from #891; it adds no deployment controller or remote diagnostics.
- Interrupted PROCESSING work must fail without replay; its existing PENDING successor continues.
- The availability target is a bounded interruption below 15 seconds, not zero downtime.

## Testing & validation

- The static HA profile check and diff check pass.
- Migration review, hardware recovery, timing, updater, and reboot evidence are pending; therefore this PR remains draft.