### PR TITLE
fix(client): close open-redirect bypass, insecure randomness, and fast-uri alerts

### DIFF
--- a/client/e2eTests/protoFleet/helpers/testDataHelper.ts
+++ b/client/e2eTests/protoFleet/helpers/testDataHelper.ts
@@ -1,5 +1,9 @@
+import { randomUUID } from "crypto";
+
 export function generateRandomText(prefix: string): string {
-  const randomCode = Math.random().toString(36).substring(2, 9);
+  // Same 7-char suffix length as the previous Math.random() implementation,
+  // but from a CSPRNG since these names feed real account creation in RBAC specs.
+  const randomCode = randomUUID().replaceAll("-", "").substring(0, 7);
   return `${prefix}_${randomCode}`;
 }
 

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -7115,9 +7115,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {

--- a/client/src/protoFleet/utils/fleetDownRedirect.test.ts
+++ b/client/src/protoFleet/utils/fleetDownRedirect.test.ts
@@ -105,6 +105,32 @@ describe("redirectFromFleetDown", () => {
       expect(window.location.href).toBe("/");
     });
 
+    it("prevents redirect via backslash protocol-relative URLs", () => {
+      // Browsers normalize "\" to "/", so "/\evil.com" navigates to "//evil.com"
+      window.location.search = "?from=%2F%5Cevil.com";
+
+      redirectFromFleetDown();
+
+      expect(window.location.href).toBe("/");
+    });
+
+    it("prevents redirect via mixed slash-backslash URLs", () => {
+      // "/\/evil.com" also normalizes to a protocol-relative external URL
+      window.location.search = "?from=%2F%5C%2Fevil.com";
+
+      redirectFromFleetDown();
+
+      expect(window.location.href).toBe("/");
+    });
+
+    it("prevents redirect when path contains any backslash", () => {
+      window.location.search = "?from=%2Fminers%5Cpath";
+
+      redirectFromFleetDown();
+
+      expect(window.location.href).toBe("/");
+    });
+
     it("allows valid relative paths", () => {
       window.location.search = "?from=%2Fsettings";
 

--- a/client/src/protoFleet/utils/fleetDownRedirect.ts
+++ b/client/src/protoFleet/utils/fleetDownRedirect.ts
@@ -2,18 +2,37 @@
  * Redirects to the original page stored in the "from" query parameter,
  * or to the home page if no parameter exists.
  *
- * Security: Only allows relative paths starting with "/" to prevent open redirect vulnerabilities.
+ * Security: only same-origin paths are allowed, to prevent open redirect
+ * vulnerabilities.
  */
 export const redirectFromFleetDown = () => {
   const params = new URLSearchParams(window.location.search);
   const from = params.get("from") || "/";
 
-  // Security: Validate that the redirect URL is a relative path
-  // Prevent external URLs, protocol-relative URLs, and JavaScript URLs
-  if (!from.startsWith("/") || from.startsWith("//")) {
-    window.location.href = "/";
-    return;
+  window.location.href = sanitizeRedirectPath(from);
+};
+
+/**
+ * Returns `from` unchanged when it resolves to a same-origin path, "/" otherwise.
+ *
+ * Validation goes through the URL parser rather than string prefix checks:
+ * browsers normalize "\" to "/" when parsing URLs, so a payload like
+ * "/\evil.com" passes a startsWith("//") rejection yet still navigates to
+ * the external protocol-relative URL "//evil.com".
+ */
+const sanitizeRedirectPath = (from: string): string => {
+  if (!from.startsWith("/") || from.includes("\\")) {
+    return "/";
   }
 
-  window.location.href = from;
+  try {
+    const resolved = new URL(from, window.location.origin);
+    if (resolved.origin !== window.location.origin) {
+      return "/";
+    }
+  } catch {
+    return "/";
+  }
+
+  return from;
 };


### PR DESCRIPTION
Reviewable diff: +34/-11 across 3 files (excludes generated, test, and story files).

## Summary

Closes three open security-scanning findings in the client: an open-redirect bypass on the fleet-down page, insecure randomness feeding account creation in the RBAC E2E suite, and the vulnerable transitive `fast-uri` dependency (GHSA-7p8r-x3mc-p8w7). Before this change, `?from=/\evil.com` on the fleet-down page redirected users to the external site `//evil.com` despite the existing prefix validation; it now falls back to `/`.

Remaining alert remediation is intentionally out of scope here and lands separately: the `react-router` major upgrade (RSC-mode CSRF advisory, patched only in 8.3.0) and triage/dismissal of the CodeQL findings that are false positives or documented accepted risks.

## How it works

When the client recovers from a fleet-down state, it navigates back to the page stored in the `from` query parameter. Validation of that parameter now goes through the URL parser instead of string prefix checks: the value must start with `/`, contain no backslash, and — once resolved against `window.location.origin` via `new URL()` — stay on the current origin. Anything else falls back to `/`. This matters because browsers normalize `\` to `/` when parsing URLs, so the previous `startsWith("//")` rejection missed `/\evil.com`, which the browser treats as the protocol-relative external URL `//evil.com`.

The E2E helper change swaps `Math.random()` for `crypto.randomUUID()` when generating role/user names; the 7-character suffix length is unchanged so prefix-based cleanup helpers and name-length constraints are unaffected. The `fast-uri` change is a lockfile-only patch bump of a transitive dev dependency.

## Diagrams

```mermaid
flowchart TB
    A["/fleet-down loads with ?from=path"] --> B["redirectFromFleetDown()"]
    B --> C{"starts with / and contains no backslash?"}
    C -- "no" --> F["navigate to /"]
    C -- "yes" --> D["resolve with new URL(from, window.location.origin)"]
    D --> E{"resolved origin == current origin?"}
    E -- "no" --> F
    E -- "yes" --> G["navigate to from"]
```

## Areas of the code involved

| Area / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/src/protoFleet/utils/fleetDownRedirect.ts` | Prefix-check validation replaced with URL-parser origin validation plus backslash rejection | Security boundary — the main review focus |
| `client/src/protoFleet/utils/fleetDownRedirect.test.ts` | 3 new tests covering backslash bypass vectors | Test — verifies the fix |
| `client/e2eTests/protoFleet/helpers/testDataHelper.ts` | `generateRandomText` now derives its suffix from `crypto.randomUUID()` | Test tooling — feeds real account creation in RBAC specs |
| `client/package-lock.json` | `fast-uri` 3.1.4 → 3.1.5 | Lockfile-only; integrity hash verified against upstream npmjs |

## Key technical decisions & trade-offs

- Validate through the URL parser rather than extending the string-prefix blacklist: the parser applies the same normalization the browser does at navigation time, so validation and navigation cannot disagree; blacklists have to enumerate every bypass vector.
- Invalid values fall back to `/` silently (existing behavior) rather than surfacing an error — the parameter is attacker-controllable, so there is no legitimate failure to report.
- Kept the 7-character random suffix (truncated UUID) instead of a full UUID so E2E name-length constraints and prefix-based cleanup matching hold.
- Surgical lockfile edit instead of `npm update`: avoids unrelated lockfile churn from npm-version drift and keeps the diff reviewable at 3 lines.

## Testing & validation

- New unit tests for `/\evil.com`, `/\/evil.com`, and embedded-backslash paths; all 13 tests in the file pass.
- Full client unit suite: 3,989 passed / 4 skipped, 0 failed (Node 24.15.0 via Hermit).
- `eslint --max-warnings 0` and `tsc --noEmit` (covers `e2eTests/` via the root tsconfig) both clean; lefthook pre-commit and pre-push hooks passed.
- `npm ci` validates the edited lockfile entry's integrity hash, which was also cross-checked against the upstream npmjs metadata for `fast-uri@3.1.5`.
- Not covered: no full RBAC E2E run (the generated name shape is unchanged).

## New concepts

**Backslash URL normalization (open-redirect bypass vector)**

The WHATWG URL parser — the one browsers use for navigation — treats `\` as `/` in http(s) URLs. Any redirect validator built on string prefix checks (`startsWith("/")` + `!startsWith("//")`) can therefore be bypassed with `/\evil.com`: as a string it passes both checks, but the browser navigates to the protocol-relative external URL `//evil.com`.

The robust pattern, used in this PR, is to validate with the same parser the browser uses: resolve the candidate against the current origin (`new URL(from, window.location.origin)`) and require the resolved origin to equal the current origin. Validation and navigation then share one normalization model and cannot disagree.

When not to use it: this shape allow-lists same-origin paths only. If a flow legitimately needs cross-origin redirects, compare against an explicit allow-list of full origins instead of loosening the parser check.

## Related

- https://github.com/block/proto-fleet/security/code-scanning/61
- https://github.com/block/proto-fleet/security/code-scanning/62
- https://github.com/block/proto-fleet/security/code-scanning/63
- https://github.com/block/proto-fleet/security/code-scanning/64
- https://github.com/block/proto-fleet/security/dependabot/62

(Alerts auto-close when scanning re-runs on `main` after merge.)
