### PR TITLE
fix(sitemap): make safeInt32 clamp provable to static analyzers

### DIFF
--- a/server/internal/domain/sitemap/service.go
+++ b/server/internal/domain/sitemap/service.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"sort"
 	"strconv"
 	"strings"
@@ -3349,14 +3350,13 @@ func rackIdentitySet(rows []map[string]string, racks []rackSnapshot) map[string]
 }
 
 func safeInt32(value int) int32 {
-	const maxInt32 = int64(1<<31 - 1)
 	if value < 0 {
 		return 0
 	}
-	if int64(value) > maxInt32 {
-		return int32(maxInt32)
+	if value > math.MaxInt32 {
+		return math.MaxInt32
 	}
-	return int32(value) // #nosec G115 -- value is bounded above to MaxInt32.
+	return int32(value)
 }
 
 func rowMap(headers, values []string) map[string]string {


### PR DESCRIPTION
Reviewable diff: +4/-4 across 1 file (excludes generated, test, and story files).

## Summary

Closes the remaining open CodeQL alert (`go/incorrect-integer-conversion`) on the sitemap service's `safeInt32` helper by restructuring the clamp so static analyzers can prove the bound, and drops the `#nosec G115` suppression that papered over it for gosec. Runtime behavior is unchanged. Follow-up to #894 in the security-alert remediation series; remaining items are alert triage/dismissals in the Security tab and a react-router upgrade.

## How it works

`safeInt32` clamps an `int` (CSV import row numbers) into `int32` range before it goes into the `ImportValidationError` proto. The old code compared `int64(value)` against a locally defined `int64` constant before converting — correct, but opaque to CodeQL's and gosec's guard recognition, so the conversion on the return line stayed flagged. The new code compares `value > math.MaxInt32` directly on the `int`; both analyzers recognize that dominating comparison as proof the subsequent `int32(value)` cannot overflow. Negative values still clamp to 0, oversized values to `math.MaxInt32`.

## Diagrams

```mermaid
flowchart LR
    A["int value (import row)"] --> B{"value < 0?"}
    B -- yes --> C["return 0"]
    B -- no --> D{"value > math.MaxInt32?"}
    D -- yes --> E["return math.MaxInt32"]
    D -- no --> F["return int32(value) — provably in range"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/internal/domain/sitemap/service.go` | `safeInt32` bound check rewritten to compare directly against `math.MaxInt32`; `#nosec G115` removed; `math` import added | Only change; verify clamp semantics are identical |

## Key technical decisions & trade-offs

- Compare the `int` directly against `math.MaxInt32` instead of round-tripping through `int64`: chosen because both CodeQL and gosec recognize this guard shape, over dismissing the alert as a false positive (a code shape both tools can verify is better than a suppression comment).
- Removed `#nosec G115` rather than keeping it defensively — golangci-lint (gosec included) passes clean without it, so keeping it would hide future regressions of the guard.

## Testing & validation

- `go build ./...` and `golangci-lint run internal/domain/sitemap/` — clean, 0 issues without the `#nosec`.
- `go test ./internal/domain/sitemap/...` — passes.
- Pre-push hooks (typecheck, golangci-lint) passed.
- Not covered: CodeQL's own verdict lands when the analysis workflow runs on this PR; the alert should auto-close on merge.