### PR TITLE
fix(client): patch vulnerable dependencies and harden fleet-down redirect

### DIFF
--- a/client/e2eTests/protoOS/helpers/firmwareHelper.ts
+++ b/client/e2eTests/protoOS/helpers/firmwareHelper.ts
@@ -7,6 +7,17 @@ type FirmwareState = {
   previousVersion: string | null;
 };
 
+type SystemInfoResponse = {
+  "system-info": {
+    sw_update_status: {
+      status: string;
+      current_version?: string;
+      new_version?: string;
+      previous_version?: string;
+    };
+  };
+};
+
 const FAKE_PROTO_RIG_SERIAL_PREFIX = "PROTO-SIM-";
 const FIRMWARE_STATUS_TIMEOUT_MS = 20_000;
 const FIRMWARE_STATUS_POLL_INTERVAL_MS = 250;
@@ -58,21 +69,15 @@ export class FirmwareHelper {
     return this.authAccessToken !== "";
   }
 
-  async getState(): Promise<FirmwareState> {
+  async getSystemInfo(): Promise<SystemInfoResponse> {
     const response = await this.request.get("/api/v1/system");
     expect(response.ok()).toBeTruthy();
 
-    const data = (await response.json()) as {
-      "system-info": {
-        sw_update_status: {
-          status: string;
-          current_version?: string;
-          new_version?: string;
-          previous_version?: string;
-        };
-      };
-    };
+    return (await response.json()) as SystemInfoResponse;
+  }
 
+  async getState(): Promise<FirmwareState> {
+    const data = await this.getSystemInfo();
     const updateStatus = data["system-info"].sw_update_status;
 
     return {

--- a/client/e2eTests/protoOS/spec/firmware.spec.ts
+++ b/client/e2eTests/protoOS/spec/firmware.spec.ts
@@ -57,7 +57,11 @@ async function validateInstallingState(
 
   await generalPage.reloadPage();
   await generalPage.validateTitle("General");
-  await headerComponent.validateFirmwareStatusWidgetText(/Installing/);
+  // The install can finish while the page reloads, so the widget may already
+  // show the terminal "Reboot required" state instead of the transient
+  // "Installing" one. The next test step validates the reboot-required UI
+  // deterministically after waiting for the installed status.
+  await headerComponent.validateFirmwareStatusWidgetText(/Installing|Reboot required/);
 }
 
 test.describe("Firmware updates", () => {

--- a/client/e2eTests/protoOS/spec/firmware.spec.ts
+++ b/client/e2eTests/protoOS/spec/firmware.spec.ts
@@ -1,3 +1,4 @@
+import type { Page, Route } from "@playwright/test";
 import { expect, test } from "../fixtures/pageFixtures";
 import { FirmwareHelper } from "../helpers/firmwareHelper";
 import { HeaderComponent } from "../pages/components/header";
@@ -5,13 +6,45 @@ import { GeneralPage } from "../pages/general";
 
 type UploadState = "downloaded" | "installing" | "installed";
 
+const SYSTEM_INFO_ROUTE = "**/api/v1/system";
+
+async function validateInstallingWidget(page: Page, generalPage: GeneralPage, headerComponent: HeaderComponent) {
+  const fulfillInstallingSystemInfo = async (route: Route) => {
+    const response = await route.fetch();
+    const data = (await response.json()) as {
+      "system-info": {
+        sw_update_status: {
+          status: string;
+        };
+      };
+    };
+    data["system-info"].sw_update_status.status = "installing";
+    await route.fulfill({ response, json: data });
+  };
+
+  await page.route(SYSTEM_INFO_ROUTE, fulfillInstallingSystemInfo);
+  try {
+    await generalPage.reloadPage();
+    await generalPage.validateTitle("General");
+    await headerComponent.validateFirmwareStatusWidgetText(/Installing/);
+  } finally {
+    await page.unroute(SYSTEM_INFO_ROUTE, fulfillInstallingSystemInfo);
+  }
+}
+
 async function handleUploadedFirmwareState(
   uploadState: UploadState,
+  page: Page,
   headerComponent: HeaderComponent,
   generalPage: GeneralPage,
   startingVersion: string,
   installedVersion: string,
 ) {
+  if (uploadState === "installing") {
+    await validateInstallingWidget(page, generalPage, headerComponent);
+    return;
+  }
+
   await generalPage.reloadPage();
   await generalPage.validateTitle("General");
 
@@ -22,11 +55,6 @@ async function handleUploadedFirmwareState(
     await headerComponent.validateFirmwareStatusModalVersionLabel("Current Version:", startingVersion);
     await headerComponent.validateFirmwareStatusModalVersionLabel("New Version:", installedVersion);
     await headerComponent.clickFirmwareStatusModalInstallButton();
-    return;
-  }
-
-  if (uploadState === "installing") {
-    await headerComponent.validateFirmwareStatusWidgetText(/Installing/);
     return;
   }
 
@@ -48,6 +76,7 @@ async function getInstallingState(uploadState: UploadState, firmwareHelper: Firm
 
 async function validateInstallingState(
   installingState: Awaited<ReturnType<FirmwareHelper["getState"]>>,
+  page: Page,
   generalPage: GeneralPage,
   headerComponent: HeaderComponent,
 ) {
@@ -55,13 +84,7 @@ async function validateInstallingState(
     return;
   }
 
-  await generalPage.reloadPage();
-  await generalPage.validateTitle("General");
-  // The install can finish while the page reloads, so the widget may already
-  // show the terminal "Reboot required" state instead of the transient
-  // "Installing" one. The next test step validates the reboot-required UI
-  // deterministically after waiting for the installed status.
-  await headerComponent.validateFirmwareStatusWidgetText(/Installing|Reboot required/);
+  await validateInstallingWidget(page, generalPage, headerComponent);
 }
 
 test.describe("Firmware updates", () => {
@@ -126,13 +149,20 @@ test.describe("Firmware updates", () => {
       expect(installedVersion).not.toBe("");
       expect(installedVersion).not.toBe(startingVersion);
 
-      await handleUploadedFirmwareState(uploadState, headerComponent, generalPage, startingVersion, installedVersion);
+      await handleUploadedFirmwareState(
+        uploadState,
+        page,
+        headerComponent,
+        generalPage,
+        startingVersion,
+        installedVersion,
+      );
     });
 
     await test.step("Wait for the install to enter the installing state", async () => {
       const installingState = await getInstallingState(uploadState, firmwareHelper);
       installedVersion = installingState.newVersion ?? installedVersion;
-      await validateInstallingState(installingState, generalPage, headerComponent);
+      await validateInstallingState(installingState, page, generalPage, headerComponent);
     });
 
     await test.step("Wait for reboot-required state after the upload-driven install", async () => {

--- a/client/e2eTests/protoOS/spec/firmware.spec.ts
+++ b/client/e2eTests/protoOS/spec/firmware.spec.ts
@@ -8,19 +8,15 @@ type UploadState = "downloaded" | "installing" | "installed";
 
 const SYSTEM_INFO_ROUTE = "**/api/v1/system";
 
-async function validateInstallingWidget(page: Page, generalPage: GeneralPage, headerComponent: HeaderComponent) {
-  const fulfillInstallingSystemInfo = async (route: Route) => {
-    const response = await route.fetch();
-    const data = (await response.json()) as {
-      "system-info": {
-        sw_update_status: {
-          status: string;
-        };
-      };
-    };
-    data["system-info"].sw_update_status.status = "installing";
-    await route.fulfill({ response, json: data });
-  };
+async function validateInstallingWidget(
+  page: Page,
+  firmwareHelper: FirmwareHelper,
+  generalPage: GeneralPage,
+  headerComponent: HeaderComponent,
+) {
+  const systemInfo = await firmwareHelper.getSystemInfo();
+  systemInfo["system-info"].sw_update_status.status = "installing";
+  const fulfillInstallingSystemInfo = (route: Route) => route.fulfill({ json: systemInfo });
 
   await page.route(SYSTEM_INFO_ROUTE, fulfillInstallingSystemInfo);
   try {
@@ -35,13 +31,14 @@ async function validateInstallingWidget(page: Page, generalPage: GeneralPage, he
 async function handleUploadedFirmwareState(
   uploadState: UploadState,
   page: Page,
+  firmwareHelper: FirmwareHelper,
   headerComponent: HeaderComponent,
   generalPage: GeneralPage,
   startingVersion: string,
   installedVersion: string,
 ) {
   if (uploadState === "installing") {
-    await validateInstallingWidget(page, generalPage, headerComponent);
+    await validateInstallingWidget(page, firmwareHelper, generalPage, headerComponent);
     return;
   }
 
@@ -77,6 +74,7 @@ async function getInstallingState(uploadState: UploadState, firmwareHelper: Firm
 async function validateInstallingState(
   installingState: Awaited<ReturnType<FirmwareHelper["getState"]>>,
   page: Page,
+  firmwareHelper: FirmwareHelper,
   generalPage: GeneralPage,
   headerComponent: HeaderComponent,
 ) {
@@ -84,7 +82,7 @@ async function validateInstallingState(
     return;
   }
 
-  await validateInstallingWidget(page, generalPage, headerComponent);
+  await validateInstallingWidget(page, firmwareHelper, generalPage, headerComponent);
 }
 
 test.describe("Firmware updates", () => {
@@ -152,6 +150,7 @@ test.describe("Firmware updates", () => {
       await handleUploadedFirmwareState(
         uploadState,
         page,
+        firmwareHelper,
         headerComponent,
         generalPage,
         startingVersion,
@@ -162,7 +161,7 @@ test.describe("Firmware updates", () => {
     await test.step("Wait for the install to enter the installing state", async () => {
       const installingState = await getInstallingState(uploadState, firmwareHelper);
       installedVersion = installingState.newVersion ?? installedVersion;
-      await validateInstallingState(installingState, page, generalPage, headerComponent);
+      await validateInstallingState(installingState, page, firmwareHelper, generalPage, headerComponent);
     });
 
     await test.step("Wait for reboot-required state after the upload-driven install", async () => {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -21,7 +21,7 @@
         "path": "0.12.7",
         "react": "19.2.8",
         "react-dom": "19.2.8",
-        "react-router-dom": "7.18.1",
+        "react-router-dom": "7.18.2",
         "recharts": "3.10.1",
         "zustand": "5.0.14"
       },
@@ -6138,9 +6138,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+      "integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
       "dev": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -8206,9 +8206,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -9933,9 +9933,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -9955,12 +9955,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
-      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.18.1"
+        "react-router": "7.18.2"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/client/package.json
+++ b/client/package.json
@@ -42,7 +42,7 @@
     "path": "0.12.7",
     "react": "19.2.8",
     "react-dom": "19.2.8",
-    "react-router-dom": "7.18.1",
+    "react-router-dom": "7.18.2",
     "recharts": "3.10.1",
     "zustand": "5.0.14"
   },

--- a/client/src/protoFleet/utils/fleetDownRedirect.test.ts
+++ b/client/src/protoFleet/utils/fleetDownRedirect.test.ts
@@ -36,7 +36,7 @@ describe("redirectFromFleetDown", () => {
 
     redirectFromFleetDown();
 
-    expect(window.location.href).toBe("http://localhost:5173/settings/network");
+    expect(window.location.href).toBe(`${mockLocation.origin}/settings/network`);
   });
 
   it("redirects to home page when no from parameter exists", () => {
@@ -44,7 +44,7 @@ describe("redirectFromFleetDown", () => {
 
     redirectFromFleetDown();
 
-    expect(window.location.href).toBe("http://localhost:5173/");
+    expect(window.location.href).toBe(`${mockLocation.origin}/`);
   });
 
   it("redirects to home page when from parameter is empty", () => {
@@ -52,7 +52,7 @@ describe("redirectFromFleetDown", () => {
 
     redirectFromFleetDown();
 
-    expect(window.location.href).toBe("http://localhost:5173/");
+    expect(window.location.href).toBe(`${mockLocation.origin}/`);
   });
 
   it("handles complex paths with query parameters", () => {
@@ -60,7 +60,7 @@ describe("redirectFromFleetDown", () => {
 
     redirectFromFleetDown();
 
-    expect(window.location.href).toBe("http://localhost:5173/miners?filter=active");
+    expect(window.location.href).toBe(`${mockLocation.origin}/miners?filter=active`);
   });
 
   it("preserves hash fragments in redirect URL", () => {
@@ -68,7 +68,7 @@ describe("redirectFromFleetDown", () => {
 
     redirectFromFleetDown();
 
-    expect(window.location.href).toBe("http://localhost:5173/settings#security");
+    expect(window.location.href).toBe(`${mockLocation.origin}/settings#security`);
   });
 
   it("handles paths with query parameters and hash fragments", () => {
@@ -76,7 +76,7 @@ describe("redirectFromFleetDown", () => {
 
     redirectFromFleetDown();
 
-    expect(window.location.href).toBe("http://localhost:5173/miners?filter=active#details");
+    expect(window.location.href).toBe(`${mockLocation.origin}/miners?filter=active#details`);
   });
 
   // Security tests
@@ -86,7 +86,7 @@ describe("redirectFromFleetDown", () => {
 
       redirectFromFleetDown();
 
-      expect(window.location.href).toBe("http://localhost:5173/");
+      expect(window.location.href).toBe(`${mockLocation.origin}/`);
     });
 
     it("prevents redirect to protocol-relative URLs", () => {
@@ -94,7 +94,7 @@ describe("redirectFromFleetDown", () => {
 
       redirectFromFleetDown();
 
-      expect(window.location.href).toBe("http://localhost:5173/");
+      expect(window.location.href).toBe(`${mockLocation.origin}/`);
     });
 
     it("prevents redirect to JavaScript URLs", () => {
@@ -102,7 +102,7 @@ describe("redirectFromFleetDown", () => {
 
       redirectFromFleetDown();
 
-      expect(window.location.href).toBe("http://localhost:5173/");
+      expect(window.location.href).toBe(`${mockLocation.origin}/`);
     });
 
     it("prevents redirect via backslash protocol-relative URLs", () => {
@@ -111,7 +111,7 @@ describe("redirectFromFleetDown", () => {
 
       redirectFromFleetDown();
 
-      expect(window.location.href).toBe("http://localhost:5173/");
+      expect(window.location.href).toBe(`${mockLocation.origin}/`);
     });
 
     it("prevents redirect via mixed slash-backslash URLs", () => {
@@ -120,7 +120,7 @@ describe("redirectFromFleetDown", () => {
 
       redirectFromFleetDown();
 
-      expect(window.location.href).toBe("http://localhost:5173/");
+      expect(window.location.href).toBe(`${mockLocation.origin}/`);
     });
 
     it("prevents redirect when path contains any backslash", () => {
@@ -128,7 +128,7 @@ describe("redirectFromFleetDown", () => {
 
       redirectFromFleetDown();
 
-      expect(window.location.href).toBe("http://localhost:5173/");
+      expect(window.location.href).toBe(`${mockLocation.origin}/`);
     });
 
     it("allows valid relative paths", () => {
@@ -136,7 +136,7 @@ describe("redirectFromFleetDown", () => {
 
       redirectFromFleetDown();
 
-      expect(window.location.href).toBe("http://localhost:5173/settings");
+      expect(window.location.href).toBe(`${mockLocation.origin}/settings`);
     });
   });
 });

--- a/client/src/protoFleet/utils/fleetDownRedirect.test.ts
+++ b/client/src/protoFleet/utils/fleetDownRedirect.test.ts
@@ -36,7 +36,7 @@ describe("redirectFromFleetDown", () => {
 
     redirectFromFleetDown();
 
-    expect(window.location.href).toBe("/settings/network");
+    expect(window.location.href).toBe("http://localhost:5173/settings/network");
   });
 
   it("redirects to home page when no from parameter exists", () => {
@@ -44,7 +44,7 @@ describe("redirectFromFleetDown", () => {
 
     redirectFromFleetDown();
 
-    expect(window.location.href).toBe("/");
+    expect(window.location.href).toBe("http://localhost:5173/");
   });
 
   it("redirects to home page when from parameter is empty", () => {
@@ -52,7 +52,7 @@ describe("redirectFromFleetDown", () => {
 
     redirectFromFleetDown();
 
-    expect(window.location.href).toBe("/");
+    expect(window.location.href).toBe("http://localhost:5173/");
   });
 
   it("handles complex paths with query parameters", () => {
@@ -60,7 +60,7 @@ describe("redirectFromFleetDown", () => {
 
     redirectFromFleetDown();
 
-    expect(window.location.href).toBe("/miners?filter=active");
+    expect(window.location.href).toBe("http://localhost:5173/miners?filter=active");
   });
 
   it("preserves hash fragments in redirect URL", () => {
@@ -68,7 +68,7 @@ describe("redirectFromFleetDown", () => {
 
     redirectFromFleetDown();
 
-    expect(window.location.href).toBe("/settings#security");
+    expect(window.location.href).toBe("http://localhost:5173/settings#security");
   });
 
   it("handles paths with query parameters and hash fragments", () => {
@@ -76,7 +76,7 @@ describe("redirectFromFleetDown", () => {
 
     redirectFromFleetDown();
 
-    expect(window.location.href).toBe("/miners?filter=active#details");
+    expect(window.location.href).toBe("http://localhost:5173/miners?filter=active#details");
   });
 
   // Security tests
@@ -86,7 +86,7 @@ describe("redirectFromFleetDown", () => {
 
       redirectFromFleetDown();
 
-      expect(window.location.href).toBe("/");
+      expect(window.location.href).toBe("http://localhost:5173/");
     });
 
     it("prevents redirect to protocol-relative URLs", () => {
@@ -94,7 +94,7 @@ describe("redirectFromFleetDown", () => {
 
       redirectFromFleetDown();
 
-      expect(window.location.href).toBe("/");
+      expect(window.location.href).toBe("http://localhost:5173/");
     });
 
     it("prevents redirect to JavaScript URLs", () => {
@@ -102,7 +102,7 @@ describe("redirectFromFleetDown", () => {
 
       redirectFromFleetDown();
 
-      expect(window.location.href).toBe("/");
+      expect(window.location.href).toBe("http://localhost:5173/");
     });
 
     it("prevents redirect via backslash protocol-relative URLs", () => {
@@ -111,7 +111,7 @@ describe("redirectFromFleetDown", () => {
 
       redirectFromFleetDown();
 
-      expect(window.location.href).toBe("/");
+      expect(window.location.href).toBe("http://localhost:5173/");
     });
 
     it("prevents redirect via mixed slash-backslash URLs", () => {
@@ -120,7 +120,7 @@ describe("redirectFromFleetDown", () => {
 
       redirectFromFleetDown();
 
-      expect(window.location.href).toBe("/");
+      expect(window.location.href).toBe("http://localhost:5173/");
     });
 
     it("prevents redirect when path contains any backslash", () => {
@@ -128,7 +128,7 @@ describe("redirectFromFleetDown", () => {
 
       redirectFromFleetDown();
 
-      expect(window.location.href).toBe("/");
+      expect(window.location.href).toBe("http://localhost:5173/");
     });
 
     it("allows valid relative paths", () => {
@@ -136,7 +136,7 @@ describe("redirectFromFleetDown", () => {
 
       redirectFromFleetDown();
 
-      expect(window.location.href).toBe("/settings");
+      expect(window.location.href).toBe("http://localhost:5173/settings");
     });
   });
 });

--- a/client/src/protoFleet/utils/fleetDownRedirect.ts
+++ b/client/src/protoFleet/utils/fleetDownRedirect.ts
@@ -9,7 +9,12 @@ export const redirectFromFleetDown = () => {
   const params = new URLSearchParams(window.location.search);
   const from = params.get("from") || "/";
 
-  window.location.href = sanitizeRedirectPath(from);
+  // Prefixing the current origin makes it structurally impossible for the
+  // query parameter to control the scheme or host, regardless of what the
+  // sanitizer below returns. This shape is also verifiable by static
+  // analysis: CodeQL's redirect query only flags values that can control
+  // the start of the URL.
+  window.location.href = window.location.origin + sanitizeRedirectPath(from);
 };
 
 /**

--- a/client/src/protoFleet/utils/fleetDownRedirect.ts
+++ b/client/src/protoFleet/utils/fleetDownRedirect.ts
@@ -9,11 +9,10 @@ export const redirectFromFleetDown = () => {
   const params = new URLSearchParams(window.location.search);
   const from = params.get("from") || "/";
 
-  // Prefixing the current origin makes it structurally impossible for the
-  // query parameter to control the scheme or host, regardless of what the
-  // sanitizer below returns. This shape is also verifiable by static
-  // analysis: CodeQL's redirect query only flags values that can control
-  // the start of the URL.
+  // The current origin controls the scheme and host, while the sanitizer
+  // guarantees the appended value is a slash-prefixed same-origin path.
+  // This shape is also verifiable by static analysis: CodeQL's redirect
+  // query only flags values that can control the start of the URL.
   window.location.href = window.location.origin + sanitizeRedirectPath(from);
 };
 


### PR DESCRIPTION
Reviewable diff: +20/-16 across 3 files (excludes generated, test, and story files).

## Summary

Remediates the current client dependency alerts and CodeQL alert #78 with patch-level upgrades and a structurally same-origin fleet-down redirect. Workflow CodeQL alerts #79-85 are intentionally out of scope and require separate workflow-permission and checkout changes.

The firmware E2E is also made deterministic: an `installing` API response must render `Installing`, while the subsequent live `installed` state must render `Reboot required`. This removes the reload race without allowing a premature terminal label to pass.

## How it works

**Dependency patches.** `react-router-dom` is a direct pinned dependency; `js-yaml` and `dompurify` are dev-only transitive dependencies. The lockfile changes only the affected version, resolved URL, integrity, and React Router pin entries.

- `react-router-dom` / `react-router` 7.18.1 -> 7.18.2
- `js-yaml` 4.3.0 -> 4.3.1
- `dompurify` 3.4.12 -> 3.4.13

**Redirect hardening.** The `from` parameter still passes through `sanitizeRedirectPath`, then the redirect prepends `window.location.origin`. User input therefore cannot control the URL scheme or host, and the URL shape is directly recognizable by CodeQL's client-side redirect query.

**Firmware test stabilization.** When the fake rig reaches `installing`, the helper captures system info before installing a browser route, then serves that snapshot with the status pinned to `installing`. The test requires the widget to show `Installing`, removes the temporary route, then waits for the real `installed` state and validates `Reboot required`. This tests both UI mappings without racing the fake rig's two-second transition or re-handling an in-flight route.

## Diagrams

```mermaid
flowchart LR
    subgraph deps["Dependency remediation"]
        A["Pinned vulnerable versions"] --> B["Patch releases in package manifest and lockfile"]
        B --> C["npm audit: 0 vulnerabilities"]
    end

    subgraph redirect["Fleet-down redirect"]
        D["?from= query parameter"] --> E["sanitizeRedirectPath"]
        E --> F["window.location.origin + safe path"]
        F --> G["Same-origin navigation"]
    end

    subgraph firmware["Firmware E2E"]
        H["Backend observed: installing"] --> I["Reload with installing response"]
        I --> J["Widget must show Installing"]
        J --> K["Restore live API and wait for installed"]
        K --> L["Widget must show Reboot required"]
    end
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/package.json` | Pins `react-router-dom` 7.18.2 | Direct dependency remediation |
| `client/package-lock.json` | Updates React Router, `js-yaml`, and `dompurify` lock entries | Verify the update contains no unrelated dependency-tree churn |
| `client/src/protoFleet/utils/fleetDownRedirect.ts` | Anchors the sanitized path to the current origin | Security boundary for the user-controlled redirect parameter |
| `client/src/protoFleet/utils/fleetDownRedirect.test.ts` | Expects absolute same-origin redirect targets across 13 cases | Test-only; covers external, protocol-relative, backslash, and `javascript:` payloads |
| `client/e2eTests/protoOS/helpers/firmwareHelper.ts` | Exposes the full system-info snapshot used by the browser route | Test-only; keeps route fulfillment synchronous and deterministic |
| `client/e2eTests/protoOS/spec/firmware.spec.ts` | Pins the reload response while asserting the transient installing UI | Test-only; prevents both a timing flake and a green-while-red terminal-state assertion |

## Key technical decisions & trade-offs

- Patch upgrades instead of a React Router major migration: the security fix is available in 7.18.2, avoiding unrelated route and prefetch churn.
- Origin anchoring instead of dismissing CodeQL #78: navigation remains behaviorally same-origin while the invariant becomes statically provable.
- A controlled installing response instead of `/Installing|Reboot required/`: the deterministic response/UI pair catches an incorrect early terminal label and the next step separately proves the installed state.

## Testing & validation

- `npm ci` completed from the updated lockfile; `npm audit` reports 0 vulnerabilities.
- `npm run lint` passed.
- `npx tsc --noEmit` passed.
- Full client unit suite passed: 4,054 tests across 387 files, with 4 skipped.
- Focused redirect suite passed: 13 tests.
- Playwright compiled and discovered both firmware tests. A focused local run could not reach the expected ProtoOS service at `localhost:3000`; PR CI provides the full browser environment.
- CodeQL and dependency-alert closure remain pending until GitHub scans the updated PR/default-branch commit.

## Post-Deploy Monitoring & Validation

- **Validation target:** Confirm the next default-branch Dependabot, Snyk, and CodeQL scans close the client dependency alerts and CodeQL #78.
- **Runtime signal:** No server-side metric changes. Check Datadog RUM browser errors for fleet-down navigation failures or redirect loops during the first 24 hours after deployment.
- **Healthy signal:** Security alerts close and client navigation error rates remain at baseline.
- **Failure trigger / mitigation:** If #78 remains open, a dependency alert persists, or fleet-down navigation errors regress, revert this PR and inspect the scanner trace or failing redirect payload before reapplying.
- **Window / owner:** PR author through the first post-merge security scan and 24 hours of client runtime.
