### PR TITLE
fix(collection): validate SetRackSlotPosition before writing

### DIFF
--- a/server/internal/domain/collection/service.go
+++ b/server/internal/domain/collection/service.go
@@ -1990,11 +1990,14 @@ func (s *Service) SetRackSlotPosition(ctx context.Context, req *pb.SetRackSlotPo
 	}
 
 	result, err := s.transactor.RunInTxWithResult(ctx, func(ctx context.Context) (any, error) {
-		coll, err := s.collectionStore.GetCollection(ctx, info.OrganizationID, req.CollectionId)
+		// Gate on type before locking. Type is immutable, so this pre-lock read
+		// can't go stale; authoritative label + site for the activity event are
+		// re-read under the lock below.
+		collType, err := s.collectionStore.GetCollectionType(ctx, info.OrganizationID, req.CollectionId)
 		if err != nil {
 			return nil, err
 		}
-		if coll.Type != pb.CollectionType_COLLECTION_TYPE_RACK {
+		if collType != pb.CollectionType_COLLECTION_TYPE_RACK {
 			return nil, fleeterror.NewInvalidArgumentError("slot positions can only be set on rack collections")
 		}
 
@@ -2007,7 +2010,10 @@ func (s *Service) SetRackSlotPosition(ctx context.Context, req *pb.SetRackSlotPo
 		}
 
 		// Reject out-of-bounds cells. A RACK always has a device_set_rack row, so
-		// nil is a broken invariant.
+		// nil is a broken invariant. Guard both bounds so a negative coordinate
+		// (which bypasses the proto interceptor on a direct call) returns
+		// InvalidArgument rather than tripping the SQL CHECK as a 500, matching
+		// the batch and SaveRack paths.
 		rackInfo, err := s.collectionStore.GetRackInfo(ctx, req.CollectionId, info.OrganizationID)
 		if err != nil {
 			return nil, err
@@ -2015,10 +2021,10 @@ func (s *Service) SetRackSlotPosition(ctx context.Context, req *pb.SetRackSlotPo
 		if rackInfo == nil {
 			return nil, fleeterror.NewInternalErrorf("rack %d has no rack extension row", req.CollectionId)
 		}
-		if req.Position.Row >= rackInfo.Rows {
+		if req.Position.Row < 0 || req.Position.Row >= rackInfo.Rows {
 			return nil, fleeterror.NewInvalidArgumentErrorf("slot row %d is out of bounds (rack has %d rows)", req.Position.Row, rackInfo.Rows)
 		}
-		if req.Position.Column >= rackInfo.Columns {
+		if req.Position.Column < 0 || req.Position.Column >= rackInfo.Columns {
 			return nil, fleeterror.NewInvalidArgumentErrorf("slot column %d is out of bounds (rack has %d columns)", req.Position.Column, rackInfo.Columns)
 		}
 
@@ -2035,6 +2041,14 @@ func (s *Service) SetRackSlotPosition(ctx context.Context, req *pb.SetRackSlotPo
 		}
 
 		if err := s.collectionStore.SetRackSlotPosition(ctx, req.CollectionId, req.DeviceIdentifier, req.Position.Row, req.Position.Column, info.OrganizationID); err != nil {
+			return nil, err
+		}
+
+		// Read the collection under the lock so the activity event's label + site
+		// reflect the state we wrote to, not a pre-lock snapshot a concurrent
+		// rename/move could have staled.
+		coll, err := s.collectionStore.GetCollection(ctx, info.OrganizationID, req.CollectionId)
+		if err != nil {
 			return nil, err
 		}
 

--- a/server/internal/domain/collection/service.go
+++ b/server/internal/domain/collection/service.go
@@ -1998,7 +1998,42 @@ func (s *Service) SetRackSlotPosition(ctx context.Context, req *pb.SetRackSlotPo
 			return nil, fleeterror.NewInvalidArgumentError("slot positions can only be set on rack collections")
 		}
 
-		// Device membership is enforced by the store query joining on device_set_membership.
+		// Lock the rack row FOR UPDATE before reading grid + membership so the
+		// checks hold for the write; without it a concurrent resize could shrink
+		// the grid out from under an in-bounds position. Same rack-first lock the
+		// batch path takes.
+		if _, err := s.collectionStore.LockRackPlacementForWrite(ctx, req.CollectionId, info.OrganizationID); err != nil {
+			return nil, err
+		}
+
+		// Reject out-of-bounds cells. A RACK always has a device_set_rack row, so
+		// nil is a broken invariant.
+		rackInfo, err := s.collectionStore.GetRackInfo(ctx, req.CollectionId, info.OrganizationID)
+		if err != nil {
+			return nil, err
+		}
+		if rackInfo == nil {
+			return nil, fleeterror.NewInternalErrorf("rack %d has no rack extension row", req.CollectionId)
+		}
+		if req.Position.Row >= rackInfo.Rows {
+			return nil, fleeterror.NewInvalidArgumentErrorf("slot row %d is out of bounds (rack has %d rows)", req.Position.Row, rackInfo.Rows)
+		}
+		if req.Position.Column >= rackInfo.Columns {
+			return nil, fleeterror.NewInvalidArgumentErrorf("slot column %d is out of bounds (rack has %d columns)", req.Position.Column, rackInfo.Columns)
+		}
+
+		// Confirm membership: the store's INSERT ... SELECT silently writes zero
+		// rows for a non-member and returns no error, so a bare call would report
+		// a placement that never landed.
+		members, err := s.collectionStore.GetDeviceSiteIDsByMembership(ctx, req.CollectionId, info.OrganizationID)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := members[req.DeviceIdentifier]; !ok {
+			return nil, fleeterror.NewInvalidArgumentErrorf(
+				"device %q is not a member of rack %d, so its slot cannot be set", req.DeviceIdentifier, req.CollectionId)
+		}
+
 		if err := s.collectionStore.SetRackSlotPosition(ctx, req.CollectionId, req.DeviceIdentifier, req.Position.Row, req.Position.Column, info.OrganizationID); err != nil {
 			return nil, err
 		}

--- a/server/internal/domain/collection/service_test.go
+++ b/server/internal/domain/collection/service_test.go
@@ -369,6 +369,92 @@ func TestService_SetRackSlotPosition_RejectsGroupCollection(t *testing.T) {
 	assert.True(t, fleeterror.IsInvalidArgumentError(err))
 }
 
+func TestService_SetRackSlotPosition_RejectsOutOfBounds(t *testing.T) {
+	svc, mockStore, _ := newTestService(t)
+	ctx := testCtx(t)
+
+	// Arrange: a 2×2 rack. Position (5, 5) is outside the grid.
+	mockStore.EXPECT().GetCollection(gomock.Any(), testOrgID, testCollectionID).
+		Return(&pb.DeviceCollection{Id: testCollectionID, Type: pb.CollectionType_COLLECTION_TYPE_RACK, Label: "R1"}, nil)
+	mockStore.EXPECT().LockRackPlacementForWrite(gomock.Any(), testCollectionID, testOrgID).
+		Return(interfaces.RackPlacement{}, nil)
+	mockStore.EXPECT().GetRackInfo(gomock.Any(), testCollectionID, testOrgID).
+		Return(&pb.RackInfo{Rows: 2, Columns: 2}, nil)
+	// No SetRackSlotPosition / GetDeviceSiteIDsByMembership: the strict mock
+	// fails if the write fires past the bounds check.
+
+	// Act
+	_, err := svc.SetRackSlotPosition(ctx, &pb.SetRackSlotPositionRequest{
+		CollectionId:     testCollectionID,
+		DeviceIdentifier: "device-1",
+		Position:         &pb.RackSlotPosition{Row: 5, Column: 5},
+	})
+
+	// Assert
+	require.Error(t, err)
+	assert.True(t, fleeterror.IsInvalidArgumentError(err))
+	assert.Contains(t, err.Error(), "out of bounds")
+}
+
+func TestService_SetRackSlotPosition_RejectsNonMember(t *testing.T) {
+	svc, mockStore, _ := newTestService(t)
+	ctx := testCtx(t)
+
+	// Arrange: in-bounds cell, but the device is not a rack member.
+	mockStore.EXPECT().GetCollection(gomock.Any(), testOrgID, testCollectionID).
+		Return(&pb.DeviceCollection{Id: testCollectionID, Type: pb.CollectionType_COLLECTION_TYPE_RACK, Label: "R1"}, nil)
+	mockStore.EXPECT().LockRackPlacementForWrite(gomock.Any(), testCollectionID, testOrgID).
+		Return(interfaces.RackPlacement{}, nil)
+	mockStore.EXPECT().GetRackInfo(gomock.Any(), testCollectionID, testOrgID).
+		Return(&pb.RackInfo{Rows: 2, Columns: 2}, nil)
+	mockStore.EXPECT().GetDeviceSiteIDsByMembership(gomock.Any(), testCollectionID, testOrgID).
+		Return(map[string]*int64{"other-device": nil}, nil)
+	// No SetRackSlotPosition: the write must not fire for a non-member.
+
+	// Act
+	_, err := svc.SetRackSlotPosition(ctx, &pb.SetRackSlotPositionRequest{
+		CollectionId:     testCollectionID,
+		DeviceIdentifier: "device-1",
+		Position:         &pb.RackSlotPosition{Row: 1, Column: 1},
+	})
+
+	// Assert
+	require.Error(t, err)
+	assert.True(t, fleeterror.IsInvalidArgumentError(err))
+	assert.Contains(t, err.Error(), "not a member")
+}
+
+func TestService_SetRackSlotPosition_InBoundsMemberSucceeds(t *testing.T) {
+	svc, mockStore, _ := newTestService(t)
+	ctx := testCtx(t)
+
+	// Arrange: in-bounds cell on a 2×2 rack for an existing member.
+	mockStore.EXPECT().GetCollection(gomock.Any(), testOrgID, testCollectionID).
+		Return(&pb.DeviceCollection{Id: testCollectionID, Type: pb.CollectionType_COLLECTION_TYPE_RACK, Label: "R1"}, nil)
+	mockStore.EXPECT().LockRackPlacementForWrite(gomock.Any(), testCollectionID, testOrgID).
+		Return(interfaces.RackPlacement{}, nil)
+	mockStore.EXPECT().GetRackInfo(gomock.Any(), testCollectionID, testOrgID).
+		Return(&pb.RackInfo{Rows: 2, Columns: 2}, nil)
+	mockStore.EXPECT().GetDeviceSiteIDsByMembership(gomock.Any(), testCollectionID, testOrgID).
+		Return(map[string]*int64{"device-1": nil}, nil)
+	mockStore.EXPECT().SetRackSlotPosition(gomock.Any(), testCollectionID, "device-1", int32(1), int32(1), testOrgID).
+		Return(nil)
+
+	// Act
+	resp, err := svc.SetRackSlotPosition(ctx, &pb.SetRackSlotPositionRequest{
+		CollectionId:     testCollectionID,
+		DeviceIdentifier: "device-1",
+		Position:         &pb.RackSlotPosition{Row: 1, Column: 1},
+	})
+
+	// Assert
+	require.NoError(t, err)
+	assert.Equal(t, testCollectionID, resp.CollectionId)
+	assert.Equal(t, "device-1", resp.Slot.DeviceIdentifier)
+	assert.Equal(t, int32(1), resp.Slot.Position.Row)
+	assert.Equal(t, int32(1), resp.Slot.Position.Column)
+}
+
 func TestService_ClearRackSlotPosition_RejectsGroupCollection(t *testing.T) {
 	svc, mockStore, _ := newTestService(t)
 	ctx := testCtx(t)

--- a/server/internal/domain/collection/service_test.go
+++ b/server/internal/domain/collection/service_test.go
@@ -354,8 +354,8 @@ func TestService_SetRackSlotPosition_RejectsGroupCollection(t *testing.T) {
 	ctx := testCtx(t)
 
 	// Arrange
-	mockStore.EXPECT().GetCollection(gomock.Any(), testOrgID, testCollectionID).
-		Return(&pb.DeviceCollection{Id: testCollectionID, Type: pb.CollectionType_COLLECTION_TYPE_GROUP, Label: "test"}, nil)
+	mockStore.EXPECT().GetCollectionType(gomock.Any(), testOrgID, testCollectionID).
+		Return(pb.CollectionType_COLLECTION_TYPE_GROUP, nil)
 
 	// Act
 	_, err := svc.SetRackSlotPosition(ctx, &pb.SetRackSlotPositionRequest{
@@ -374,8 +374,8 @@ func TestService_SetRackSlotPosition_RejectsOutOfBounds(t *testing.T) {
 	ctx := testCtx(t)
 
 	// Arrange: a 2×2 rack. Position (5, 5) is outside the grid.
-	mockStore.EXPECT().GetCollection(gomock.Any(), testOrgID, testCollectionID).
-		Return(&pb.DeviceCollection{Id: testCollectionID, Type: pb.CollectionType_COLLECTION_TYPE_RACK, Label: "R1"}, nil)
+	mockStore.EXPECT().GetCollectionType(gomock.Any(), testOrgID, testCollectionID).
+		Return(pb.CollectionType_COLLECTION_TYPE_RACK, nil)
 	mockStore.EXPECT().LockRackPlacementForWrite(gomock.Any(), testCollectionID, testOrgID).
 		Return(interfaces.RackPlacement{}, nil)
 	mockStore.EXPECT().GetRackInfo(gomock.Any(), testCollectionID, testOrgID).
@@ -396,13 +396,40 @@ func TestService_SetRackSlotPosition_RejectsOutOfBounds(t *testing.T) {
 	assert.Contains(t, err.Error(), "out of bounds")
 }
 
+func TestService_SetRackSlotPosition_RejectsNegativePosition(t *testing.T) {
+	svc, mockStore, _ := newTestService(t)
+	ctx := testCtx(t)
+
+	// Arrange: a negative coordinate bypasses the proto interceptor on a direct
+	// call and must be rejected as InvalidArgument, not tripped as a SQL CHECK.
+	mockStore.EXPECT().GetCollectionType(gomock.Any(), testOrgID, testCollectionID).
+		Return(pb.CollectionType_COLLECTION_TYPE_RACK, nil)
+	mockStore.EXPECT().LockRackPlacementForWrite(gomock.Any(), testCollectionID, testOrgID).
+		Return(interfaces.RackPlacement{}, nil)
+	mockStore.EXPECT().GetRackInfo(gomock.Any(), testCollectionID, testOrgID).
+		Return(&pb.RackInfo{Rows: 2, Columns: 2}, nil)
+	// No SetRackSlotPosition: the write must not fire for an out-of-range cell.
+
+	// Act
+	_, err := svc.SetRackSlotPosition(ctx, &pb.SetRackSlotPositionRequest{
+		CollectionId:     testCollectionID,
+		DeviceIdentifier: "device-1",
+		Position:         &pb.RackSlotPosition{Row: -1, Column: 0},
+	})
+
+	// Assert
+	require.Error(t, err)
+	assert.True(t, fleeterror.IsInvalidArgumentError(err))
+	assert.Contains(t, err.Error(), "out of bounds")
+}
+
 func TestService_SetRackSlotPosition_RejectsNonMember(t *testing.T) {
 	svc, mockStore, _ := newTestService(t)
 	ctx := testCtx(t)
 
 	// Arrange: in-bounds cell, but the device is not a rack member.
-	mockStore.EXPECT().GetCollection(gomock.Any(), testOrgID, testCollectionID).
-		Return(&pb.DeviceCollection{Id: testCollectionID, Type: pb.CollectionType_COLLECTION_TYPE_RACK, Label: "R1"}, nil)
+	mockStore.EXPECT().GetCollectionType(gomock.Any(), testOrgID, testCollectionID).
+		Return(pb.CollectionType_COLLECTION_TYPE_RACK, nil)
 	mockStore.EXPECT().LockRackPlacementForWrite(gomock.Any(), testCollectionID, testOrgID).
 		Return(interfaces.RackPlacement{}, nil)
 	mockStore.EXPECT().GetRackInfo(gomock.Any(), testCollectionID, testOrgID).
@@ -428,9 +455,10 @@ func TestService_SetRackSlotPosition_InBoundsMemberSucceeds(t *testing.T) {
 	svc, mockStore, _ := newTestService(t)
 	ctx := testCtx(t)
 
-	// Arrange: in-bounds cell on a 2×2 rack for an existing member.
-	mockStore.EXPECT().GetCollection(gomock.Any(), testOrgID, testCollectionID).
-		Return(&pb.DeviceCollection{Id: testCollectionID, Type: pb.CollectionType_COLLECTION_TYPE_RACK, Label: "R1"}, nil)
+	// Arrange: in-bounds cell on a 2×2 rack for an existing member. The
+	// collection label + site are read under the lock, after the write.
+	mockStore.EXPECT().GetCollectionType(gomock.Any(), testOrgID, testCollectionID).
+		Return(pb.CollectionType_COLLECTION_TYPE_RACK, nil)
 	mockStore.EXPECT().LockRackPlacementForWrite(gomock.Any(), testCollectionID, testOrgID).
 		Return(interfaces.RackPlacement{}, nil)
 	mockStore.EXPECT().GetRackInfo(gomock.Any(), testCollectionID, testOrgID).
@@ -439,6 +467,8 @@ func TestService_SetRackSlotPosition_InBoundsMemberSucceeds(t *testing.T) {
 		Return(map[string]*int64{"device-1": nil}, nil)
 	mockStore.EXPECT().SetRackSlotPosition(gomock.Any(), testCollectionID, "device-1", int32(1), int32(1), testOrgID).
 		Return(nil)
+	mockStore.EXPECT().GetCollection(gomock.Any(), testOrgID, testCollectionID).
+		Return(&pb.DeviceCollection{Id: testCollectionID, Type: pb.CollectionType_COLLECTION_TYPE_RACK, Label: "R1"}, nil)
 
 	// Act
 	resp, err := svc.SetRackSlotPosition(ctx, &pb.SetRackSlotPositionRequest{

--- a/server/internal/domain/collection/service_test.go
+++ b/server/internal/domain/collection/service_test.go
@@ -452,11 +452,12 @@ func TestService_SetRackSlotPosition_RejectsNonMember(t *testing.T) {
 }
 
 func TestService_SetRackSlotPosition_InBoundsMemberSucceeds(t *testing.T) {
-	svc, mockStore, _ := newTestService(t)
+	svc, mockStore, mockActivityStore := newTestServiceWithActivityAssertions(t)
 	ctx := testCtx(t)
 
-	// Arrange: in-bounds cell on a 2×2 rack for an existing member. The
-	// collection label + site are read under the lock, after the write.
+	const siteID int64 = 77
+
+	// Arrange: in-bounds cell on a 2×2 rack for an existing member.
 	mockStore.EXPECT().GetCollectionType(gomock.Any(), testOrgID, testCollectionID).
 		Return(pb.CollectionType_COLLECTION_TYPE_RACK, nil)
 	mockStore.EXPECT().LockRackPlacementForWrite(gomock.Any(), testCollectionID, testOrgID).
@@ -465,10 +466,31 @@ func TestService_SetRackSlotPosition_InBoundsMemberSucceeds(t *testing.T) {
 		Return(&pb.RackInfo{Rows: 2, Columns: 2}, nil)
 	mockStore.EXPECT().GetDeviceSiteIDsByMembership(gomock.Any(), testCollectionID, testOrgID).
 		Return(map[string]*int64{"device-1": nil}, nil)
-	mockStore.EXPECT().SetRackSlotPosition(gomock.Any(), testCollectionID, "device-1", int32(1), int32(1), testOrgID).
-		Return(nil)
-	mockStore.EXPECT().GetCollection(gomock.Any(), testOrgID, testCollectionID).
-		Return(&pb.DeviceCollection{Id: testCollectionID, Type: pb.CollectionType_COLLECTION_TYPE_RACK, Label: "R1"}, nil)
+	// Pin the authoritative read AFTER the write: the activity event's label +
+	// site must come from the post-write, under-lock snapshot, so this test
+	// fails if the GetCollection read is moved ahead of the slot write.
+	gomock.InOrder(
+		mockStore.EXPECT().SetRackSlotPosition(gomock.Any(), testCollectionID, "device-1", int32(1), int32(1), testOrgID).
+			Return(nil),
+		mockStore.EXPECT().GetCollection(gomock.Any(), testOrgID, testCollectionID).
+			Return(&pb.DeviceCollection{
+				Id:        testCollectionID,
+				Type:      pb.CollectionType_COLLECTION_TYPE_RACK,
+				Label:     "R1",
+				Placement: &commonpb.PlacementRefs{Site: &commonpb.ResourceRef{Id: siteID}},
+			}, nil),
+	)
+
+	// The event carries the rack's label + site read under the lock.
+	mockActivityStore.EXPECT().Insert(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, event *activitymodels.Event) error {
+			assert.Equal(t, "set_rack_slot", event.Type)
+			require.NotNil(t, event.ScopeLabel)
+			assert.Equal(t, "R1", *event.ScopeLabel)
+			require.NotNil(t, event.SiteID)
+			assert.Equal(t, siteID, *event.SiteID)
+			return nil
+		})
 
 	// Act
 	resp, err := svc.SetRackSlotPosition(ctx, &pb.SetRackSlotPositionRequest{

--- a/server/internal/domain/stores/sqlstores/collection.go
+++ b/server/internal/domain/stores/sqlstores/collection.go
@@ -107,7 +107,7 @@ func (s *SQLCollectionStore) GetCollection(ctx context.Context, orgID int64, col
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, fleeterror.NewNotFoundErrorf("collection not found: %d", collectionID)
 		}
-		return nil, fleeterror.NewInternalErrorf("failed to get collection: %v", err)
+		return nil, fleeterror.NewInternalErrorf("failed to get collection: %w", err)
 	}
 
 	collection := newDeviceCollection(row.ID, row.Type, row.Label, row.Description, row.DeviceCount, row.CreatedAt, row.UpdatedAt)
@@ -124,7 +124,7 @@ func (s *SQLCollectionStore) GetRackInfo(ctx context.Context, collectionID int64
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil
 		}
-		return nil, fleeterror.NewInternalErrorf("failed to get rack info: %v", err)
+		return nil, fleeterror.NewInternalErrorf("failed to get rack info: %w", err)
 	}
 
 	rackInfo := &pb.RackInfo{
@@ -235,7 +235,7 @@ func (s *SQLCollectionStore) LockRackPlacementForWrite(ctx context.Context, coll
 		if errors.Is(err, sql.ErrNoRows) {
 			return interfaces.RackPlacement{}, fleeterror.NewNotFoundErrorf("rack %d not found", collectionID)
 		}
-		return interfaces.RackPlacement{}, fleeterror.NewInternalErrorf("failed to lock rack placement: %v", err)
+		return interfaces.RackPlacement{}, fleeterror.NewInternalErrorf("failed to lock rack placement: %w", err)
 	}
 	placement := interfaces.RackPlacement{
 		SiteID:     nullInt64ToPtr(row.SiteID),
@@ -388,7 +388,7 @@ func (s *SQLCollectionStore) GetDeviceSiteIDsByMembership(ctx context.Context, c
 		OrgID:       orgID,
 	})
 	if err != nil {
-		return nil, fleeterror.NewInternalErrorf("failed to load device sites for rack members: %v", err)
+		return nil, fleeterror.NewInternalErrorf("failed to load device sites for rack members: %w", err)
 	}
 	out := make(map[string]*int64, len(rows))
 	for _, row := range rows {
@@ -590,7 +590,7 @@ func (s *SQLCollectionStore) GetCollectionType(ctx context.Context, orgID int64,
 		if errors.Is(err, sql.ErrNoRows) {
 			return pb.CollectionType_COLLECTION_TYPE_UNSPECIFIED, fleeterror.NewNotFoundErrorf("collection not found: %d", collectionID)
 		}
-		return pb.CollectionType_COLLECTION_TYPE_UNSPECIFIED, fleeterror.NewInternalErrorf("failed to get collection type: %v", err)
+		return pb.CollectionType_COLLECTION_TYPE_UNSPECIFIED, fleeterror.NewInternalErrorf("failed to get collection type: %w", err)
 	}
 	return sqlDeviceSetTypeToProto(sqlType), nil
 }
@@ -942,7 +942,7 @@ func (s *SQLCollectionStore) SetRackSlotPosition(ctx context.Context, collection
 		if errors.As(err, &pgErr) && pgErr.ConstraintName == "uk_rack_slot_position" {
 			return fleeterror.NewInvalidArgumentErrorf("slot (%d, %d) is already occupied", row, column)
 		}
-		return fleeterror.NewInternalErrorf("failed to set rack slot position: %v", err)
+		return fleeterror.NewInternalErrorf("failed to set rack slot position: %w", err)
 	}
 	return nil
 }

--- a/server/internal/domain/stores/sqlstores/collection_retry_wrap_test.go
+++ b/server/internal/domain/stores/sqlstores/collection_retry_wrap_test.go
@@ -1,0 +1,45 @@
+package sqlstores
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/proto-fleet/server/generated/sqlc"
+	"github.com/block/proto-fleet/server/internal/infrastructure/db"
+)
+
+// stubQuerier embeds sqlc.Querier so only the methods a test exercises need
+// implementing; any other call nil-panics, which never happens here.
+type stubQuerier struct {
+	sqlc.Querier
+	lockErr error
+}
+
+func (s stubQuerier) LockRackPlacementForWrite(context.Context, sqlc.LockRackPlacementForWriteParams) (sqlc.LockRackPlacementForWriteRow, error) {
+	return sqlc.LockRackPlacementForWriteRow{}, s.lockErr
+}
+
+// TestLockRackPlacementForWrite_PreservesRetryablePgError pins the transaction
+// retry contract for the lock the slot-write path acquires: a serialization
+// failure raised by the lock query must stay reachable through the store's
+// error wrapping (%w, not %v) so db.IsRetryablePostgresError — and therefore
+// WithTransaction — still fires. A %v wrap flattens the *pgconn.PgError out of
+// the chain and the tx would surface a dead 500 instead of retrying.
+func TestLockRackPlacementForWrite_PreservesRetryablePgError(t *testing.T) {
+	store := NewSQLCollectionStore(nil)
+	// GetQueries returns the ctx-bound querier when present, so the stub stands
+	// in for the tx queries without a real DB connection.
+	ctx := db.WithTxQueries(context.Background(), stubQuerier{
+		lockErr: &pgconn.PgError{Code: db.PGSerializationFailure, Message: "could not serialize access"},
+	})
+
+	_, err := store.LockRackPlacementForWrite(ctx, 1, 1)
+
+	require.Error(t, err)
+	assert.True(t, db.IsRetryablePostgresError(err),
+		"serialization failure must survive the store's error wrapping so the tx can retry")
+}


### PR DESCRIPTION
Reviewable diff: +36/-1 across 1 files (excludes generated, test, and story files).

## Summary

`SetRackSlotPosition` — the single-slot placement RPC behind both the collection and deviceset handlers — accepted a slot write without checking the rack's grid dimensions, taking a rack lock, or confirming the device was a rack member. It would persist a position outside the grid and return success for a non-member, leaving a miner recorded in a cell the UI can never render and cannot be dragged off. This PR brings the single-slot path up to the same write contract the batch assignment path (`AssignDevicesToRack`) already enforces.

## How it works

The change adds three guards inside the RPC's existing transaction, after the collection is confirmed to be a rack and before the slot is written:

1. **Lock the rack row** (`LockRackPlacementForWrite`) up front, so the reads that follow and the eventual write all hold under the same lock. This is the same rack-first lock the resize and batch paths take, so a concurrent resize can no longer shrink the grid out from under a position that just passed its bounds check.
2. **Bounds check** — read the rack's real dimensions and reject any row/column that falls outside the grid with `InvalidArgument`, using the same wording as the batch path. A rack with no dimension row is treated as a broken invariant and fails loudly rather than writing blind.
3. **Membership check** — confirm the device is actually a member before writing. The underlying store statement is an `INSERT … SELECT` over the membership table that silently writes zero rows for a non-member, so without this the RPC returned `200 OK` for a placement that never happened.

Only when all three pass does the slot write proceed. Both handler surfaces call this one service method, so the fix covers them without duplication.

```mermaid
flowchart TD
    A["SetRackSlotPosition RPC"] --> B["Begin transaction"]
    B --> C{"Collection is a rack?"}
    C -->|"no"| E1["Reject: InvalidArgument"]
    C -->|"yes"| D["Lock rack row FOR UPDATE"]
    D --> F["Read rack dimensions"]
    F --> G{"Position within grid?"}
    G -->|"no"| E2["Reject: out of bounds"]
    G -->|"yes"| H{"Device is a member?"}
    H -->|"no"| E3["Reject: not a member"]
    H -->|"yes"| I["Write slot position"]
    I --> J["Commit + log activity"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
|---|---|---|
| `server/internal/domain/collection/service.go` | Added lock, bounds, and membership guards inside `SetRackSlotPosition`'s transaction | The behavioral change — verify the guards run under the lock and before the write |
| `server/internal/domain/collection/service_test.go` | Added unit tests: out-of-bounds rejected, non-member rejected, in-bounds member succeeds | Confirms each guard fires and the happy path still writes |

## Key technical decisions & trade-offs

- **Lock the rack row rather than rely on a bounds check alone** — a check without a lock is still racy against a concurrent resize; the lock matches the ordering the batch and resize paths already use.
- **Reject a missing dimension row as `Internal`** — a rack always has a dimension row, so `nil` signals data corruption and is failed loudly instead of silently skipping the bounds check.
- **Fix in the shared service method, not the two handlers** — both handlers delegate here, so a single change covers both surfaces with no duplicated validation.

## Testing & validation

Added unit tests covering out-of-bounds rejection, non-member rejection, and the in-bounds member happy path; full collection package tests pass, `gofmt` and `go vet` clean. `ClearRackSlotPosition` is intentionally out of scope: it only deletes, so it has no bounds risk and clearing a non-member is a harmless no-op.