### PR TITLE
fix(deviceset): narrow rack-placement site:manage check to the target site

### DIFF
--- a/server/internal/domain/authz/placement.go
+++ b/server/internal/domain/authz/placement.go
@@ -1,0 +1,43 @@
+package authz
+
+import "context"
+
+// AuthorizedPlacement records the source and destination sites a rack-write
+// caller was authorized against in the handler, so the service can bind the
+// authorization to the locked write and fail closed if the sites changed
+// between the handler's unlocked resolution and the transaction.
+//
+// The handler resolves the rack's current site and the destination site with
+// unlocked reads, checks site:manage against both, then stashes the observed
+// pair via WithAuthorizedPlacement. Under the write lock the service re-reads
+// the authoritative current/target sites and rejects the write unless they
+// still match — closing the window where a concurrent building- or rack-move
+// would otherwise let a placement commit under authorization granted for a
+// different site.
+type AuthorizedPlacement struct {
+	// CurrentSiteID is the rack's site the caller was authorized to move OUT
+	// of (nil for a new or site-less rack). TargetSiteID is the site the
+	// caller was authorized to move INTO (nil for an unassign or a site-less
+	// building).
+	CurrentSiteID *int64
+	TargetSiteID  *int64
+}
+
+type authorizedPlacementCtxKey struct{}
+
+// WithAuthorizedPlacement returns a derived context carrying the sites the
+// caller was authorized against. The handler sets this after its site:manage
+// checks pass; internal/trusted callers that bypass handler authorization
+// simply never set it.
+func WithAuthorizedPlacement(ctx context.Context, ap AuthorizedPlacement) context.Context {
+	return context.WithValue(ctx, authorizedPlacementCtxKey{}, ap)
+}
+
+// AuthorizedPlacementFromContext returns the authorized placement and true
+// when one was stashed. A false second return means no handler authorization
+// is bound to this request (an internal/trusted caller), and the service
+// leaves its placement write unguarded by this check.
+func AuthorizedPlacementFromContext(ctx context.Context) (AuthorizedPlacement, bool) {
+	ap, ok := ctx.Value(authorizedPlacementCtxKey{}).(AuthorizedPlacement)
+	return ap, ok
+}

--- a/server/internal/domain/authz/placement.go
+++ b/server/internal/domain/authz/placement.go
@@ -2,41 +2,27 @@ package authz
 
 import "context"
 
-// AuthorizedPlacement records the source and destination sites a rack-write
-// caller was authorized against in the handler, so the service can bind the
-// authorization to the locked write and fail closed if the sites changed
-// between the handler's unlocked resolution and the transaction.
-//
-// The handler resolves the rack's current site and the destination site with
-// unlocked reads, checks site:manage against both, then stashes the observed
-// pair via WithAuthorizedPlacement. Under the write lock the service re-reads
-// the authoritative current/target sites and rejects the write unless they
-// still match — closing the window where a concurrent building- or rack-move
-// would otherwise let a placement commit under authorization granted for a
-// different site.
+// AuthorizedPlacement records the source and destination sites the handler
+// checked site:manage against, so the service can re-read them under the write
+// lock and fail closed if a concurrent move changed them since authorization.
 type AuthorizedPlacement struct {
-	// CurrentSiteID is the rack's site the caller was authorized to move OUT
-	// of (nil for a new or site-less rack). TargetSiteID is the site the
-	// caller was authorized to move INTO (nil for an unassign or a site-less
-	// building).
+	// CurrentSiteID: site moved OUT of (nil for a new/site-less rack).
+	// TargetSiteID: site moved INTO (nil for an unassign or site-less building).
 	CurrentSiteID *int64
 	TargetSiteID  *int64
 }
 
 type authorizedPlacementCtxKey struct{}
 
-// WithAuthorizedPlacement returns a derived context carrying the sites the
-// caller was authorized against. The handler sets this after its site:manage
-// checks pass; internal/trusted callers that bypass handler authorization
-// simply never set it.
+// WithAuthorizedPlacement stashes the authorized sites on the context. The
+// handler sets it after its site:manage checks pass; internal/trusted callers
+// never set it.
 func WithAuthorizedPlacement(ctx context.Context, ap AuthorizedPlacement) context.Context {
 	return context.WithValue(ctx, authorizedPlacementCtxKey{}, ap)
 }
 
-// AuthorizedPlacementFromContext returns the authorized placement and true
-// when one was stashed. A false second return means no handler authorization
-// is bound to this request (an internal/trusted caller), and the service
-// leaves its placement write unguarded by this check.
+// AuthorizedPlacementFromContext returns the stashed placement, or false when
+// none is bound (an internal/trusted caller), leaving the write unguarded.
 func AuthorizedPlacementFromContext(ctx context.Context) (AuthorizedPlacement, bool) {
 	ap, ok := ctx.Value(authorizedPlacementCtxKey{}).(AuthorizedPlacement)
 	return ap, ok

--- a/server/internal/domain/collection/service.go
+++ b/server/internal/domain/collection/service.go
@@ -197,23 +197,18 @@ func (s *Service) resolveAndLockRackPlacement(ctx context.Context, orgID int64, 
 	return siteID, buildingID, nil
 }
 
-// ResolveBuildingSite returns a building's parent site_id so the rack-write
-// handlers can narrow the site:manage escalation to a building-only placement.
-// This is an unlocked read used only for the authorization decision; it does
-// not itself close the window before the write. The handler threads the site
-// it observed here (and the rack's current site) into the write via
-// authz.WithAuthorizedPlacement, and both the create and update paths re-check
-// it under lock (see verifyAuthorizedPlacement). Returns (nil, nil) for a
-// site-less building and NotFound for a missing/soft-deleted one.
+// ResolveBuildingSite returns a building's parent site_id so the handlers can
+// narrow the site:manage check to a building-only placement. Unlocked read for
+// the authorization decision only; the observed site is bound to the write via
+// authz.WithAuthorizedPlacement and re-checked under lock (verifyAuthorizedPlacement).
+// Returns (nil, nil) for a site-less building, NotFound for a missing one.
 func (s *Service) ResolveBuildingSite(ctx context.Context, orgID, buildingID int64) (*int64, error) {
 	return s.collectionStore.GetBuildingSite(ctx, orgID, buildingID)
 }
 
-// ResolveRackSite returns a rack's current site_id (nil for a site-less rack,
-// or for a collection that is not a rack). It is an unlocked read the handlers
-// use to authorize a move against the rack's SOURCE site before the write; the
-// value is bound to the write via authz.WithAuthorizedPlacement and re-checked
-// under lock in resolveAndApplyRackPlacement.
+// ResolveRackSite returns a rack's current site_id (nil for a site-less rack or
+// a non-rack collection). Unlocked read the handlers use to authorize a move
+// against the SOURCE site; bound to the write and re-checked under lock.
 func (s *Service) ResolveRackSite(ctx context.Context, orgID, collectionID int64) (*int64, error) {
 	rackInfo, err := s.collectionStore.GetRackInfo(ctx, collectionID, orgID)
 	if err != nil {
@@ -225,14 +220,10 @@ func (s *Service) ResolveRackSite(ctx context.Context, orgID, collectionID int64
 	return rackInfo.SiteId, nil
 }
 
-// verifyAuthorizedPlacement binds a placement write to the authorization the
-// handler performed on unlocked reads. When the handler stashed an
-// authz.AuthorizedPlacement, the locked current/target sites must still match
-// the sites the caller was authorized against; otherwise a concurrent building-
-// or rack-move slipped in between the authorization and this write, and the
-// write is rejected fail-closed rather than committing under stale
-// authorization. Absent an authorized placement (an internal/trusted caller
-// that bypasses handler authorization), the check is a no-op.
+// verifyAuthorizedPlacement fails the write closed when the locked current/
+// target sites no longer match the sites the handler authorized — i.e. a
+// concurrent move slipped in between authorization and this write. A no-op when
+// no authz.AuthorizedPlacement is set (an internal/trusted caller).
 func verifyAuthorizedPlacement(ctx context.Context, lockedCurrentSite, lockedTargetSite *int64) error {
 	ap, ok := authz.AuthorizedPlacementFromContext(ctx)
 	if !ok {
@@ -403,9 +394,8 @@ func (s *Service) CreateCollection(ctx context.Context, req *pb.CreateCollection
 			if err != nil {
 				return nil, err
 			}
-			// New rack, so no current site; bind the destination to the site the
-			// handler authorized against and fail closed if the building moved
-			// sites between that unlocked check and this lock.
+			// New rack, no current site: bind the destination to what the handler
+			// authorized, failing closed if the building moved sites since.
 			if err := verifyAuthorizedPlacement(ctx, nil, siteID); err != nil {
 				return nil, err
 			}
@@ -631,9 +621,8 @@ func (s *Service) CreateRacks(ctx context.Context, params CreateRacksParams) ([]
 		if err != nil {
 			return nil, err
 		}
-		// All racks are new (no current site); the whole batch shares one
-		// placement, so a single check binds the destination to the site the
-		// handler authorized and fails closed if the building moved sites.
+		// All racks are new and share one placement, so one check binds the
+		// destination to what the handler authorized.
 		if err := verifyAuthorizedPlacement(txCtx, nil, siteID); err != nil {
 			return nil, err
 		}
@@ -2737,9 +2726,8 @@ func (s *Service) saveRackCreate(ctx context.Context, info *session.Info, req *p
 	if err != nil {
 		return nil, err
 	}
-	// New rack, so no current site; bind the destination to the site the handler
-	// authorized against and fail closed if the building moved sites between that
-	// unlocked check and this lock.
+	// New rack, no current site: bind the destination to what the handler
+	// authorized, failing closed if the building moved sites since.
 	if err := verifyAuthorizedPlacement(ctx, nil, newSiteID); err != nil {
 		return nil, err
 	}
@@ -2939,11 +2927,9 @@ func (s *Service) resolveAndApplyRackPlacement(ctx context.Context, info *sessio
 		}
 	}
 
-	// Bind the site:manage authorization to the locked reality: the handler
-	// authorized this move against the rack's current site and the destination
-	// it resolved on unlocked reads, so reject if a concurrent building- or
-	// rack-move changed either before we took these locks. Runs under the same
-	// rack lock as the write, so it can't be raced past.
+	// Bind authorization to the locked reality: reject if a concurrent move
+	// changed the current or target site since the handler authorized this move.
+	// Under the rack lock, so it can't be raced past.
 	if err := verifyAuthorizedPlacement(ctx, current.SiteID, newSiteID); err != nil {
 		return nil, err
 	}

--- a/server/internal/domain/collection/service.go
+++ b/server/internal/domain/collection/service.go
@@ -196,6 +196,15 @@ func (s *Service) resolveAndLockRackPlacement(ctx context.Context, orgID int64, 
 	return siteID, buildingID, nil
 }
 
+// ResolveBuildingSite returns a building's parent site_id so the rack-write
+// handlers can narrow the site:manage escalation to a building-only placement.
+// Unlocked read: resolveAndLockRackPlacement still re-reads under lock and
+// rejects the write if the building moved sites. Returns (nil, nil) for a
+// site-less building and NotFound for a missing/soft-deleted one.
+func (s *Service) ResolveBuildingSite(ctx context.Context, orgID, buildingID int64) (*int64, error) {
+	return s.collectionStore.GetBuildingSite(ctx, orgID, buildingID)
+}
+
 // enforceBuildingRackCapacity rejects placing a rack into buildingID when
 // the building's grid (aisles×racks_per_aisle) is already full. netNew is
 // the count of racks newly joining the building: 1 for a create or a

--- a/server/internal/domain/collection/service.go
+++ b/server/internal/domain/collection/service.go
@@ -16,6 +16,7 @@ import (
 	fm "github.com/block/proto-fleet/server/generated/grpc/fleetmanagement/v1"
 	"github.com/block/proto-fleet/server/internal/domain/activity"
 	activitymodels "github.com/block/proto-fleet/server/internal/domain/activity/models"
+	"github.com/block/proto-fleet/server/internal/domain/authz"
 	"github.com/block/proto-fleet/server/internal/domain/devicerollup"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 	minerModels "github.com/block/proto-fleet/server/internal/domain/miner/models"
@@ -198,11 +199,50 @@ func (s *Service) resolveAndLockRackPlacement(ctx context.Context, orgID int64, 
 
 // ResolveBuildingSite returns a building's parent site_id so the rack-write
 // handlers can narrow the site:manage escalation to a building-only placement.
-// Unlocked read: resolveAndLockRackPlacement still re-reads under lock and
-// rejects the write if the building moved sites. Returns (nil, nil) for a
+// This is an unlocked read used only for the authorization decision; it does
+// not itself close the window before the write. The handler threads the site
+// it observed here (and the rack's current site) into the write via
+// authz.WithAuthorizedPlacement, and both the create and update paths re-check
+// it under lock (see verifyAuthorizedPlacement). Returns (nil, nil) for a
 // site-less building and NotFound for a missing/soft-deleted one.
 func (s *Service) ResolveBuildingSite(ctx context.Context, orgID, buildingID int64) (*int64, error) {
 	return s.collectionStore.GetBuildingSite(ctx, orgID, buildingID)
+}
+
+// ResolveRackSite returns a rack's current site_id (nil for a site-less rack,
+// or for a collection that is not a rack). It is an unlocked read the handlers
+// use to authorize a move against the rack's SOURCE site before the write; the
+// value is bound to the write via authz.WithAuthorizedPlacement and re-checked
+// under lock in resolveAndApplyRackPlacement.
+func (s *Service) ResolveRackSite(ctx context.Context, orgID, collectionID int64) (*int64, error) {
+	rackInfo, err := s.collectionStore.GetRackInfo(ctx, collectionID, orgID)
+	if err != nil {
+		return nil, err
+	}
+	if rackInfo == nil {
+		return nil, nil
+	}
+	return rackInfo.SiteId, nil
+}
+
+// verifyAuthorizedPlacement binds a placement write to the authorization the
+// handler performed on unlocked reads. When the handler stashed an
+// authz.AuthorizedPlacement, the locked current/target sites must still match
+// the sites the caller was authorized against; otherwise a concurrent building-
+// or rack-move slipped in between the authorization and this write, and the
+// write is rejected fail-closed rather than committing under stale
+// authorization. Absent an authorized placement (an internal/trusted caller
+// that bypasses handler authorization), the check is a no-op.
+func verifyAuthorizedPlacement(ctx context.Context, lockedCurrentSite, lockedTargetSite *int64) error {
+	ap, ok := authz.AuthorizedPlacementFromContext(ctx)
+	if !ok {
+		return nil
+	}
+	if !int64PtrEqual(ap.CurrentSiteID, lockedCurrentSite) || !int64PtrEqual(ap.TargetSiteID, lockedTargetSite) {
+		return fleeterror.NewFailedPreconditionError(
+			"rack placement changed since authorization; refresh and retry")
+	}
+	return nil
 }
 
 // enforceBuildingRackCapacity rejects placing a rack into buildingID when
@@ -361,6 +401,12 @@ func (s *Service) CreateCollection(ctx context.Context, req *pb.CreateCollection
 			var err error
 			siteID, buildingID, err = s.resolveAndLockRackPlacement(ctx, info.OrganizationID, rackInfo)
 			if err != nil {
+				return nil, err
+			}
+			// New rack, so no current site; bind the destination to the site the
+			// handler authorized against and fail closed if the building moved
+			// sites between that unlocked check and this lock.
+			if err := verifyAuthorizedPlacement(ctx, nil, siteID); err != nil {
 				return nil, err
 			}
 		}
@@ -583,6 +629,12 @@ func (s *Service) CreateRacks(ctx context.Context, params CreateRacksParams) ([]
 
 		siteID, buildingID, err := s.resolveAndLockRackPlacement(txCtx, params.OrgID, placement)
 		if err != nil {
+			return nil, err
+		}
+		// All racks are new (no current site); the whole batch shares one
+		// placement, so a single check binds the destination to the site the
+		// handler authorized and fails closed if the building moved sites.
+		if err := verifyAuthorizedPlacement(txCtx, nil, siteID); err != nil {
 			return nil, err
 		}
 		if buildingID != nil {
@@ -2879,6 +2931,15 @@ func (s *Service) resolveAndApplyRackPlacement(ctx context.Context, info *sessio
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	// Bind the site:manage authorization to the locked reality: the handler
+	// authorized this move against the rack's current site and the destination
+	// it resolved on unlocked reads, so reject if a concurrent building- or
+	// rack-move changed either before we took these locks. Runs under the same
+	// rack lock as the write, so it can't be raced past.
+	if err := verifyAuthorizedPlacement(ctx, current.SiteID, newSiteID); err != nil {
+		return nil, err
 	}
 
 	// Re-validate under the rack lock before any write. A concurrent SaveRack

--- a/server/internal/domain/collection/service.go
+++ b/server/internal/domain/collection/service.go
@@ -2737,6 +2737,12 @@ func (s *Service) saveRackCreate(ctx context.Context, info *session.Info, req *p
 	if err != nil {
 		return nil, err
 	}
+	// New rack, so no current site; bind the destination to the site the handler
+	// authorized against and fail closed if the building moved sites between that
+	// unlocked check and this lock.
+	if err := verifyAuthorizedPlacement(ctx, nil, newSiteID); err != nil {
+		return nil, err
+	}
 
 	// A brand-new rack placed into a building is always a net-new member.
 	if newBuildingID != nil {

--- a/server/internal/domain/collection/service_test.go
+++ b/server/internal/domain/collection/service_test.go
@@ -2396,6 +2396,44 @@ func TestService_CreateCollection_RejectsPlacementDriftUnderLock(t *testing.T) {
 	_ = mockSiteStore
 }
 
+// TestService_SaveRack_CreateRejectsPlacementDriftUnderLock covers the SaveRack
+// create branch (device_set_id unset): like the other create/update paths it
+// binds the destination to the handler's authorization and aborts before any
+// write when the building moved sites between authorization and the lock.
+func TestService_SaveRack_CreateRejectsPlacementDriftUnderLock(t *testing.T) {
+	svc, mockStore, mockSiteStore := newTestServiceWithSites(t, func(_ context.Context, _ *commonpb.DeviceSelector, _ int64) ([]string, error) {
+		return nil, nil
+	})
+
+	lockedSite := int64(7)
+	building := int64(70)
+	authorizedTarget := int64(9) // what building 70 resolved to at authorization time
+	ctx := authz.WithAuthorizedPlacement(testCtx(t), authz.AuthorizedPlacement{TargetSiteID: &authorizedTarget})
+
+	mockStore.EXPECT().GetBuildingSite(gomock.Any(), testOrgID, building).Return(&lockedSite, nil).Times(2)
+	mockSiteStore.EXPECT().LockSiteForWrite(gomock.Any(), testOrgID, lockedSite).Return(nil)
+	mockSiteStore.EXPECT().LockBuildingForWrite(gomock.Any(), testOrgID, building).Return(nil)
+	// No CreateCollection / CreateRackExtension: the drift check aborts first.
+
+	_, err := svc.SaveRack(ctx, &pb.SaveRackRequest{
+		Label: "Rack",
+		RackInfo: &pb.RackInfo{
+			Rows: 4, Columns: 8,
+			OrderIndex:  pb.RackOrderIndex_RACK_ORDER_INDEX_BOTTOM_LEFT,
+			CoolingType: pb.RackCoolingType_RACK_COOLING_TYPE_AIR,
+			BuildingId:  &building,
+		},
+		DeviceSelector: &commonpb.DeviceSelector{
+			SelectionType: &commonpb.DeviceSelector_DeviceList{
+				DeviceList: &commonpb.DeviceIdentifierList{},
+			},
+		},
+	}, false)
+	require.Error(t, err)
+	assert.True(t, fleeterror.IsFailedPreconditionError(err), "expected FailedPrecondition, got %v", err)
+	_ = mockSiteStore
+}
+
 // TestService_UpdateCollection_RackSettingsRejectsShrinkBelowMembers guards the
 // #718 regression: Continue persists dimensions without touching membership, so
 // a settings save that shrinks the grid below the current member count must be

--- a/server/internal/domain/collection/service_test.go
+++ b/server/internal/domain/collection/service_test.go
@@ -11,6 +11,7 @@ import (
 	commonpb "github.com/block/proto-fleet/server/generated/grpc/common/v1"
 	"github.com/block/proto-fleet/server/internal/domain/activity"
 	activitymodels "github.com/block/proto-fleet/server/internal/domain/activity/models"
+	"github.com/block/proto-fleet/server/internal/domain/authz"
 	buildingsmodels "github.com/block/proto-fleet/server/internal/domain/buildings/models"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 	minerModels "github.com/block/proto-fleet/server/internal/domain/miner/models"
@@ -2279,6 +2280,119 @@ func TestService_UpdateCollection_RackSettingsPersistsPlacementAndCascades(t *te
 	require.NoError(t, err)
 	assert.Equal(t, "Floor 2", resp.Collection.GetRackInfo().Zone)
 	assert.Equal(t, building, *resp.Collection.GetRackInfo().BuildingId)
+	_ = mockSiteStore
+}
+
+// TestVerifyAuthorizedPlacement covers the fail-closed check that binds a
+// placement write to the sites the handler authorized on unlocked reads.
+func TestVerifyAuthorizedPlacement(t *testing.T) {
+	siteA, siteB := int64(1), int64(2)
+
+	t.Run("no authorized placement in context is a no-op (trusted caller)", func(t *testing.T) {
+		require.NoError(t, verifyAuthorizedPlacement(context.Background(), &siteA, &siteB))
+	})
+
+	t.Run("locked sites match authorized sites", func(t *testing.T) {
+		ctx := authz.WithAuthorizedPlacement(context.Background(), authz.AuthorizedPlacement{CurrentSiteID: &siteA, TargetSiteID: &siteB})
+		require.NoError(t, verifyAuthorizedPlacement(ctx, &siteA, &siteB))
+	})
+
+	t.Run("target drifted since authorization is rejected", func(t *testing.T) {
+		ctx := authz.WithAuthorizedPlacement(context.Background(), authz.AuthorizedPlacement{CurrentSiteID: &siteA, TargetSiteID: &siteB})
+		driftedTarget := int64(9)
+		err := verifyAuthorizedPlacement(ctx, &siteA, &driftedTarget)
+		require.Error(t, err)
+		assert.True(t, fleeterror.IsFailedPreconditionError(err))
+	})
+
+	t.Run("source drifted since authorization is rejected", func(t *testing.T) {
+		ctx := authz.WithAuthorizedPlacement(context.Background(), authz.AuthorizedPlacement{CurrentSiteID: &siteA, TargetSiteID: &siteB})
+		driftedSource := int64(9)
+		err := verifyAuthorizedPlacement(ctx, &driftedSource, &siteB)
+		require.Error(t, err)
+		assert.True(t, fleeterror.IsFailedPreconditionError(err))
+	})
+}
+
+// TestService_UpdateCollection_RejectsPlacementDriftUnderLock proves the wiring:
+// when the site resolved under the lock differs from the site the handler
+// authorized (a building moved sites in between), the update path rejects
+// before any write — closing the authorization TOCTOU.
+func TestService_UpdateCollection_RejectsPlacementDriftUnderLock(t *testing.T) {
+	svc, mockStore, mockSiteStore := newTestServiceWithSites(t, func(_ context.Context, _ *commonpb.DeviceSelector, _ int64) ([]string, error) {
+		return nil, nil
+	})
+
+	collectionID := int64(43)
+	lockedSite := int64(7)
+	building := int64(70)
+	// The handler authorized against site 9 (what building 70 resolved to at
+	// authorization time); under the lock building 70 now resolves to site 7.
+	authorizedTarget := int64(9)
+	ctx := authz.WithAuthorizedPlacement(testCtx(t), authz.AuthorizedPlacement{TargetSiteID: &authorizedTarget})
+
+	mockStore.EXPECT().GetCollectionType(gomock.Any(), testOrgID, collectionID).Return(pb.CollectionType_COLLECTION_TYPE_RACK, nil)
+	mockStore.EXPECT().GetBuildingSite(gomock.Any(), testOrgID, building).Return(&lockedSite, nil).Times(2)
+	mockSiteStore.EXPECT().LockSiteForWrite(gomock.Any(), testOrgID, lockedSite).Return(nil)
+	mockSiteStore.EXPECT().LockBuildingForWrite(gomock.Any(), testOrgID, building).Return(nil)
+	mockStore.EXPECT().LockRackPlacementForWrite(gomock.Any(), collectionID, testOrgID).
+		Return(interfaces.RackPlacement{}, nil)
+	// No UpdateRackInfo / UpdateRackPlacement / UpdateCollection: the drift check
+	// aborts before any write.
+
+	label := "Rack"
+	_, err := svc.UpdateCollection(ctx, &pb.UpdateCollectionRequest{
+		CollectionId: collectionID,
+		Label:        &label,
+		TypeDetails: &pb.UpdateCollectionRequest_RackInfo{
+			RackInfo: &pb.RackInfo{
+				Rows: 4, Columns: 8,
+				OrderIndex:  pb.RackOrderIndex_RACK_ORDER_INDEX_BOTTOM_LEFT,
+				CoolingType: pb.RackCoolingType_RACK_COOLING_TYPE_AIR,
+				BuildingId:  &building,
+			},
+		},
+	})
+	require.Error(t, err)
+	assert.True(t, fleeterror.IsFailedPreconditionError(err), "expected FailedPrecondition, got %v", err)
+	_ = mockSiteStore
+}
+
+// TestService_CreateCollection_RejectsPlacementDriftUnderLock proves the create
+// path binds the destination to the handler's authorization the same way the
+// update path does: when a building moves sites between the handler's unlocked
+// resolution and the locked write, the create aborts before any write.
+func TestService_CreateCollection_RejectsPlacementDriftUnderLock(t *testing.T) {
+	svc, mockStore, mockSiteStore := newTestServiceWithSites(t, func(_ context.Context, _ *commonpb.DeviceSelector, _ int64) ([]string, error) {
+		return nil, nil
+	})
+
+	lockedSite := int64(7)
+	building := int64(70)
+	// New rack (no current site); handler authorized target site 9, but under
+	// the lock building 70 now resolves to site 7.
+	authorizedTarget := int64(9)
+	ctx := authz.WithAuthorizedPlacement(testCtx(t), authz.AuthorizedPlacement{TargetSiteID: &authorizedTarget})
+
+	mockStore.EXPECT().GetBuildingSite(gomock.Any(), testOrgID, building).Return(&lockedSite, nil).Times(2)
+	mockSiteStore.EXPECT().LockSiteForWrite(gomock.Any(), testOrgID, lockedSite).Return(nil)
+	mockSiteStore.EXPECT().LockBuildingForWrite(gomock.Any(), testOrgID, building).Return(nil)
+	// No CreateCollection / CreateRackExtension: the drift check aborts first.
+
+	_, err := svc.CreateCollection(ctx, &pb.CreateCollectionRequest{
+		Type:  pb.CollectionType_COLLECTION_TYPE_RACK,
+		Label: "Rack",
+		TypeDetails: &pb.CreateCollectionRequest_RackInfo{
+			RackInfo: &pb.RackInfo{
+				Rows: 4, Columns: 8,
+				OrderIndex:  pb.RackOrderIndex_RACK_ORDER_INDEX_BOTTOM_LEFT,
+				CoolingType: pb.RackCoolingType_RACK_COOLING_TYPE_AIR,
+				BuildingId:  &building,
+			},
+		},
+	})
+	require.Error(t, err)
+	assert.True(t, fleeterror.IsFailedPreconditionError(err), "expected FailedPrecondition, got %v", err)
 	_ = mockSiteStore
 }
 

--- a/server/internal/handlers/collection/handler.go
+++ b/server/internal/handlers/collection/handler.go
@@ -26,17 +26,77 @@ func NewHandler(svc *collection.Service) *Handler {
 	}
 }
 
+// authorizeRackPlacement gates a rack placement on site:manage and returns a
+// context carrying the authorized placement for the service to bind the write
+// to (see authz.AuthorizedPlacement). It mirrors the device_set.v1 handler:
+// the check is scoped to the site the rack lands in (a building_id resolves to
+// its parent site), and a MOVE is authorized against BOTH the rack's current
+// site and the destination so a caller who manages only the destination can't
+// pull a rack out of a site they cannot manage. currentSiteID is nil for a new
+// rack; an untouched (nil) side is not checked.
+func (h *Handler) authorizeRackPlacement(ctx context.Context, orgID int64, currentSiteID, siteID, buildingID *int64) (context.Context, error) {
+	targetSiteID, err := h.resolvePlacementTargetSite(ctx, orgID, siteID, buildingID)
+	if err != nil {
+		return ctx, err
+	}
+	for _, site := range distinctSites(currentSiteID, targetSiteID) {
+		if _, err := middleware.RequirePermission(ctx, authz.PermSiteManage, authz.ResourceContext{SiteID: site}); err != nil {
+			return ctx, err
+		}
+	}
+	return authz.WithAuthorizedPlacement(ctx, authz.AuthorizedPlacement{
+		CurrentSiteID: currentSiteID,
+		TargetSiteID:  targetSiteID,
+	}), nil
+}
+
+// resolvePlacementTargetSite maps a placement request to the destination
+// site_id: a building_id resolves to its parent site, an explicit site_id is
+// used directly, and an unassign (id == 0) or a site-less building resolves to
+// no site (nil).
+func (h *Handler) resolvePlacementTargetSite(ctx context.Context, orgID int64, siteID, buildingID *int64) (*int64, error) {
+	if buildingID != nil && *buildingID > 0 {
+		return h.collectionSvc.ResolveBuildingSite(ctx, orgID, *buildingID)
+	}
+	if siteID != nil && *siteID > 0 {
+		return siteID, nil
+	}
+	return nil, nil
+}
+
+// distinctSites returns the distinct non-nil site ids among the given sites,
+// so an in-place re-assert (source == destination) is checked once and a nil
+// (untouched) side is skipped.
+func distinctSites(sites ...*int64) []*int64 {
+	var out []*int64
+	seen := make(map[int64]struct{}, len(sites))
+	for _, s := range sites {
+		if s == nil {
+			continue
+		}
+		if _, dup := seen[*s]; dup {
+			continue
+		}
+		seen[*s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}
+
 // CreateCollection creates a new collection.
 func (h *Handler) CreateCollection(ctx context.Context, r *connect.Request[pb.CreateCollectionRequest]) (*connect.Response[pb.CreateCollectionResponse], error) {
-	if _, err := middleware.RequirePermission(ctx, authz.PermRackManage, authz.ResourceContext{}); err != nil {
+	info, err := middleware.RequirePermission(ctx, authz.PermRackManage, authz.ResourceContext{})
+	if err != nil {
 		return nil, err
 	}
 	// Creating a rack under a site/building persists that placement, so mirror
 	// the Update/SaveRack gate: require site:manage when rack_info carries
-	// explicit placement (site_id/building_id). Otherwise a rack:manage-only
+	// explicit placement (site_id/building_id). The rack is new (no source
+	// site), so authorize the destination only. Otherwise a rack:manage-only
 	// caller could place a rack via the create path, bypassing the boundary.
 	if ri := r.Msg.GetRackInfo(); ri != nil && (ri.SiteId != nil || ri.BuildingId != nil) {
-		if _, err := middleware.RequirePermission(ctx, authz.PermSiteManage, authz.ResourceContext{}); err != nil {
+		ctx, err = h.authorizeRackPlacement(ctx, info.OrganizationID, nil /* currentSiteID */, ri.SiteId, ri.BuildingId)
+		if err != nil {
 			return nil, err
 		}
 	}
@@ -61,16 +121,23 @@ func (h *Handler) GetCollection(ctx context.Context, r *connect.Request[pb.GetCo
 
 // UpdateCollection updates a collection's label and/or description.
 func (h *Handler) UpdateCollection(ctx context.Context, r *connect.Request[pb.UpdateCollectionRequest]) (*connect.Response[pb.UpdateCollectionResponse], error) {
-	if _, err := middleware.RequirePermission(ctx, authz.PermRackManage, authz.ResourceContext{}); err != nil {
+	info, err := middleware.RequirePermission(ctx, authz.PermRackManage, authz.ResourceContext{})
+	if err != nil {
 		return nil, err
 	}
 	// UpdateCollection now persists a rack's placement (site/building) when
 	// rack_info carries it — the same reparent + cascade the DeviceSet handler
 	// exposes — so mirror its gate: require site:manage when placement intent is
-	// present (explicit site_id/building_id, incl. 0 to unassign). Metadata-only
-	// edits (label/zone/dims, membership) stay rack:manage.
+	// present (explicit site_id/building_id, incl. 0 to unassign). This moves an
+	// existing rack, so authorize both its current site and the destination.
+	// Metadata-only edits (label/zone/dims, membership) stay rack:manage.
 	if ri := r.Msg.GetRackInfo(); ri != nil && (ri.SiteId != nil || ri.BuildingId != nil) {
-		if _, err := middleware.RequirePermission(ctx, authz.PermSiteManage, authz.ResourceContext{}); err != nil {
+		currentSiteID, err := h.collectionSvc.ResolveRackSite(ctx, info.OrganizationID, r.Msg.CollectionId)
+		if err != nil {
+			return nil, err
+		}
+		ctx, err = h.authorizeRackPlacement(ctx, info.OrganizationID, currentSiteID, ri.SiteId, ri.BuildingId)
+		if err != nil {
 			return nil, err
 		}
 	}
@@ -203,16 +270,26 @@ func (h *Handler) ListRackZones(ctx context.Context, r *connect.Request[pb.ListR
 
 // SaveRack atomically creates or updates a rack with membership and slot assignments.
 func (h *Handler) SaveRack(ctx context.Context, r *connect.Request[pb.SaveRackRequest]) (*connect.Response[pb.SaveRackResponse], error) {
-	if _, err := middleware.RequirePermission(ctx, authz.PermRackManage, authz.ResourceContext{}); err != nil {
+	info, err := middleware.RequirePermission(ctx, authz.PermRackManage, authz.ResourceContext{})
+	if err != nil {
 		return nil, err
 	}
 	// Placement (site/building) is a site-management action, matching the
 	// dedicated AssignRacksToSite/Building RPCs. Require site:manage when the
 	// request carries placement intent; omitted placement preserves the
-	// current site/building and stays rack:manage. Mirrors the device_set.v1
-	// SaveRack handler.
+	// current site/building and stays rack:manage. SaveRack can move an existing
+	// rack, so for an update authorize its current site as well as the
+	// destination; a create has no source. Mirrors the device_set.v1 handler.
 	if ri := r.Msg.RackInfo; ri != nil && (ri.SiteId != nil || ri.BuildingId != nil) {
-		if _, err := middleware.RequirePermission(ctx, authz.PermSiteManage, authz.ResourceContext{}); err != nil {
+		var currentSiteID *int64
+		if r.Msg.CollectionId != nil {
+			currentSiteID, err = h.collectionSvc.ResolveRackSite(ctx, info.OrganizationID, *r.Msg.CollectionId)
+			if err != nil {
+				return nil, err
+			}
+		}
+		ctx, err = h.authorizeRackPlacement(ctx, info.OrganizationID, currentSiteID, ri.SiteId, ri.BuildingId)
+		if err != nil {
 			return nil, err
 		}
 	}

--- a/server/internal/handlers/collection/handler.go
+++ b/server/internal/handlers/collection/handler.go
@@ -33,13 +33,23 @@ func NewHandler(svc *collection.Service) *Handler {
 // its parent site), and a MOVE is authorized against BOTH the rack's current
 // site and the destination so a caller who manages only the destination can't
 // pull a rack out of a site they cannot manage. currentSiteID is nil for a new
-// rack; an untouched (nil) side is not checked.
+// rack (the source side is skipped when nil). Callers invoke this only when the
+// request carries placement intent, so the destination is always authorized: at
+// its resolved site, or — when the placement resolves site-less and no source
+// site is checked either — at org scope, so rack:manage alone can never place a
+// rack.
 func (h *Handler) authorizeRackPlacement(ctx context.Context, orgID int64, currentSiteID, siteID, buildingID *int64) (context.Context, error) {
 	targetSiteID, err := h.resolvePlacementTargetSite(ctx, orgID, siteID, buildingID)
 	if err != nil {
 		return ctx, err
 	}
-	for _, site := range distinctSites(currentSiteID, targetSiteID) {
+	sites := distinctSites(currentSiteID, targetSiteID)
+	if len(sites) == 0 {
+		// Placement intent present but nothing to narrow on (site-less building
+		// or explicit unassign): require site:manage at org scope.
+		sites = []*int64{nil}
+	}
+	for _, site := range sites {
 		if _, err := middleware.RequirePermission(ctx, authz.PermSiteManage, authz.ResourceContext{SiteID: site}); err != nil {
 			return ctx, err
 		}

--- a/server/internal/handlers/collection/handler.go
+++ b/server/internal/handlers/collection/handler.go
@@ -35,19 +35,22 @@ func NewHandler(svc *collection.Service) *Handler {
 // pull a rack out of a site they cannot manage. currentSiteID is nil for a new
 // rack (the source side is skipped when nil). Callers invoke this only when the
 // request carries placement intent, so the destination is always authorized: at
-// its resolved site, or — when the placement resolves site-less and no source
-// site is checked either — at org scope, so rack:manage alone can never place a
-// rack.
+// its resolved site, or — when the destination resolves to no site — at ORG
+// scope. A building_id pointing at a site-less building forces the org-scoped
+// check even on a move out of a real site, so a source-site-only manager can't
+// slip a rack into a site-less building; an unassign falls back the same way.
 func (h *Handler) authorizeRackPlacement(ctx context.Context, orgID int64, currentSiteID, siteID, buildingID *int64) (context.Context, error) {
 	targetSiteID, err := h.resolvePlacementTargetSite(ctx, orgID, siteID, buildingID)
 	if err != nil {
 		return ctx, err
 	}
 	sites := distinctSites(currentSiteID, targetSiteID)
-	if len(sites) == 0 {
-		// Placement intent present but nothing to narrow on (site-less building
-		// or explicit unassign): require site:manage at org scope.
-		sites = []*int64{nil}
+	// The destination has no site to narrow on when a building_id resolves to a
+	// site-less building, or when nothing else is being checked (unassign / new
+	// site-less rack): require site:manage at org scope in that case.
+	destSiteLessBuilding := buildingID != nil && *buildingID > 0 && targetSiteID == nil
+	if destSiteLessBuilding || len(sites) == 0 {
+		sites = append(sites, nil)
 	}
 	for _, site := range sites {
 		if _, err := middleware.RequirePermission(ctx, authz.PermSiteManage, authz.ResourceContext{SiteID: site}); err != nil {

--- a/server/internal/handlers/collection/handler.go
+++ b/server/internal/handlers/collection/handler.go
@@ -26,28 +26,19 @@ func NewHandler(svc *collection.Service) *Handler {
 	}
 }
 
-// authorizeRackPlacement gates a rack placement on site:manage and returns a
-// context carrying the authorized placement for the service to bind the write
-// to (see authz.AuthorizedPlacement). It mirrors the device_set.v1 handler:
-// the check is scoped to the site the rack lands in (a building_id resolves to
-// its parent site), and a MOVE is authorized against BOTH the rack's current
-// site and the destination so a caller who manages only the destination can't
-// pull a rack out of a site they cannot manage. currentSiteID is nil for a new
-// rack (the source side is skipped when nil). Callers invoke this only when the
-// request carries placement intent, so the destination is always authorized: at
-// its resolved site, or — when the destination resolves to no site — at ORG
-// scope. A building_id pointing at a site-less building forces the org-scoped
-// check even on a move out of a real site, so a source-site-only manager can't
-// slip a rack into a site-less building; an unassign falls back the same way.
+// authorizeRackPlacement mirrors the device_set.v1 handler: it gates a rack
+// placement on site:manage and stashes the authorized sites for the service
+// (authz.AuthorizedPlacement). A move checks both source (currentSiteID, nil
+// for a new rack) and destination; the destination narrows to the building's
+// parent site, falling back to ORG scope when it resolves to no site.
 func (h *Handler) authorizeRackPlacement(ctx context.Context, orgID int64, currentSiteID, siteID, buildingID *int64) (context.Context, error) {
 	targetSiteID, err := h.resolvePlacementTargetSite(ctx, orgID, siteID, buildingID)
 	if err != nil {
 		return ctx, err
 	}
 	sites := distinctSites(currentSiteID, targetSiteID)
-	// The destination has no site to narrow on when a building_id resolves to a
-	// site-less building, or when nothing else is being checked (unassign / new
-	// site-less rack): require site:manage at org scope in that case.
+	// Destination with no site to narrow on (site-less building, or nothing else
+	// being checked) still needs org-scoped site:manage.
 	destSiteLessBuilding := buildingID != nil && *buildingID > 0 && targetSiteID == nil
 	if destSiteLessBuilding || len(sites) == 0 {
 		sites = append(sites, nil)
@@ -102,11 +93,8 @@ func (h *Handler) CreateCollection(ctx context.Context, r *connect.Request[pb.Cr
 	if err != nil {
 		return nil, err
 	}
-	// Creating a rack under a site/building persists that placement, so mirror
-	// the Update/SaveRack gate: require site:manage when rack_info carries
-	// explicit placement (site_id/building_id). The rack is new (no source
-	// site), so authorize the destination only. Otherwise a rack:manage-only
-	// caller could place a rack via the create path, bypassing the boundary.
+	// Creating a rack under a site/building persists that placement, so gate it
+	// on site:manage. New rack, so no source site — destination only.
 	if ri := r.Msg.GetRackInfo(); ri != nil && (ri.SiteId != nil || ri.BuildingId != nil) {
 		ctx, err = h.authorizeRackPlacement(ctx, info.OrganizationID, nil /* currentSiteID */, ri.SiteId, ri.BuildingId)
 		if err != nil {
@@ -138,12 +126,9 @@ func (h *Handler) UpdateCollection(ctx context.Context, r *connect.Request[pb.Up
 	if err != nil {
 		return nil, err
 	}
-	// UpdateCollection now persists a rack's placement (site/building) when
-	// rack_info carries it — the same reparent + cascade the DeviceSet handler
-	// exposes — so mirror its gate: require site:manage when placement intent is
-	// present (explicit site_id/building_id, incl. 0 to unassign). This moves an
-	// existing rack, so authorize both its current site and the destination.
-	// Metadata-only edits (label/zone/dims, membership) stay rack:manage.
+	// Placement intent (site_id/building_id, incl. 0 to unassign) is a MOVE, so
+	// gate on site:manage against both current site and destination. Metadata-only
+	// edits (label/zone/dims, membership) stay rack:manage.
 	if ri := r.Msg.GetRackInfo(); ri != nil && (ri.SiteId != nil || ri.BuildingId != nil) {
 		currentSiteID, err := h.collectionSvc.ResolveRackSite(ctx, info.OrganizationID, r.Msg.CollectionId)
 		if err != nil {
@@ -287,12 +272,9 @@ func (h *Handler) SaveRack(ctx context.Context, r *connect.Request[pb.SaveRackRe
 	if err != nil {
 		return nil, err
 	}
-	// Placement (site/building) is a site-management action, matching the
-	// dedicated AssignRacksToSite/Building RPCs. Require site:manage when the
-	// request carries placement intent; omitted placement preserves the
-	// current site/building and stays rack:manage. SaveRack can move an existing
-	// rack, so for an update authorize its current site as well as the
-	// destination; a create has no source. Mirrors the device_set.v1 handler.
+	// Placement intent gates on site:manage. SaveRack with a collection_id is a
+	// move, so resolve and authorize the current site too; a create has none.
+	// Omitted placement preserves the current site/building and stays rack:manage.
 	if ri := r.Msg.RackInfo; ri != nil && (ri.SiteId != nil || ri.BuildingId != nil) {
 		var currentSiteID *int64
 		if r.Msg.CollectionId != nil {

--- a/server/internal/handlers/deviceset/handler.go
+++ b/server/internal/handlers/deviceset/handler.go
@@ -45,21 +45,25 @@ func NewHandler(svc *collection.Service) *Handler {
 // currentSiteID is nil for a new rack (create paths). The source side is
 // skipped when nil (a new rack has nothing to move out of). Callers invoke this
 // only when the request carries placement intent, so the destination is always
-// authorized: at its resolved site, or — when the placement resolves site-less
-// (a site-less building or an explicit unassign) and no source site is checked
-// either — at org scope, matching AssignRacksToBuilding so rack:manage alone
-// can never place a rack.
+// authorized: at its resolved site, or — when the destination resolves to no
+// site — at ORG scope, matching AssignRacksToBuilding. A building_id pointing at
+// a site-less building forces the org-scoped check even on a move out of a real
+// site, so a source-site-only manager can't slip a rack into a site-less
+// building; an unassign with no source site to check falls back the same way.
 func (h *Handler) authorizeRackPlacement(ctx context.Context, orgID int64, currentSiteID, siteID, buildingID *int64) (context.Context, error) {
 	targetSiteID, err := h.resolvePlacementTargetSite(ctx, orgID, siteID, buildingID)
 	if err != nil {
 		return ctx, err
 	}
 	sites := distinctSites(currentSiteID, targetSiteID)
-	if len(sites) == 0 {
-		// Placement intent present but nothing to narrow on: require site:manage
-		// at org scope so a site-less-building placement still fails closed for a
-		// rack:manage-only caller.
-		sites = []*int64{nil}
+	// The destination has no site to narrow on when a building_id resolves to a
+	// site-less building, or when nothing else is being checked (unassign / new
+	// site-less rack). Either way require site:manage at org scope so neither a
+	// rack:manage-only caller nor a source-site-only manager can place a rack
+	// through it.
+	destSiteLessBuilding := buildingID != nil && *buildingID > 0 && targetSiteID == nil
+	if destSiteLessBuilding || len(sites) == 0 {
+		sites = append(sites, nil)
 	}
 	for _, site := range sites {
 		if _, err := middleware.RequirePermission(ctx, authz.PermSiteManage, authz.ResourceContext{SiteID: site}); err != nil {

--- a/server/internal/handlers/deviceset/handler.go
+++ b/server/internal/handlers/deviceset/handler.go
@@ -30,16 +30,43 @@ func NewHandler(svc *collection.Service) *Handler {
 	return &Handler{svc: svc}
 }
 
+// siteManagePlacementContext builds the ResourceContext for the site:manage
+// escalation, narrowing it to the site the rack actually lands in. A
+// building_id resolves to its parent site (it dictates the site; a disagreeing
+// site_id is rejected later under lock) so a caller narrowed out of that site
+// can't bypass the check by naming a building instead. An explicit site_id is
+// used directly. A pure unassign (id == 0) or a site-less building stays
+// org-scoped — there is no destination site to narrow on.
+func (h *Handler) siteManagePlacementContext(ctx context.Context, orgID int64, siteID, buildingID *int64) (authz.ResourceContext, error) {
+	if buildingID != nil && *buildingID > 0 {
+		resolved, err := h.svc.ResolveBuildingSite(ctx, orgID, *buildingID)
+		if err != nil {
+			return authz.ResourceContext{}, err
+		}
+		return authz.ResourceContext{SiteID: resolved}, nil
+	}
+	if siteID != nil && *siteID > 0 {
+		return authz.ResourceContext{SiteID: siteID}, nil
+	}
+	return authz.ResourceContext{}, nil
+}
+
 func (h *Handler) CreateDeviceSet(ctx context.Context, r *connect.Request[dspb.CreateDeviceSetRequest]) (*connect.Response[dspb.CreateDeviceSetResponse], error) {
-	if _, err := middleware.RequirePermission(ctx, authz.PermRackManage, authz.ResourceContext{}); err != nil {
+	info, err := middleware.RequirePermission(ctx, authz.PermRackManage, authz.ResourceContext{})
+	if err != nil {
 		return nil, err
 	}
 	// Creating a rack under a site/building persists that placement (and can
 	// cascade added devices to it), so mirror the UpdateDeviceSet/SaveRack gate:
-	// require site:manage when rack_info carries explicit placement. Without
-	// this, a rack:manage-only caller could place a rack via the create path.
+	// require site:manage when rack_info carries explicit placement, narrowed
+	// to the target site. Without this, a rack:manage-only caller could place a
+	// rack via the create path.
 	if ri, ok := r.Msg.TypeDetails.(*dspb.CreateDeviceSetRequest_RackInfo); ok && ri.RackInfo != nil && (ri.RackInfo.SiteId != nil || ri.RackInfo.BuildingId != nil) {
-		if _, err := middleware.RequirePermission(ctx, authz.PermSiteManage, authz.ResourceContext{}); err != nil {
+		rc, err := h.siteManagePlacementContext(ctx, info.OrganizationID, ri.RackInfo.SiteId, ri.RackInfo.BuildingId)
+		if err != nil {
+			return nil, err
+		}
+		if _, err := middleware.RequirePermission(ctx, authz.PermSiteManage, rc); err != nil {
 			return nil, err
 		}
 	}
@@ -70,17 +97,22 @@ func (h *Handler) GetDeviceSet(ctx context.Context, r *connect.Request[dspb.GetD
 }
 
 func (h *Handler) UpdateDeviceSet(ctx context.Context, r *connect.Request[dspb.UpdateDeviceSetRequest]) (*connect.Response[dspb.UpdateDeviceSetResponse], error) {
-	if _, err := middleware.RequirePermission(ctx, authz.PermRackManage, authz.ResourceContext{}); err != nil {
+	info, err := middleware.RequirePermission(ctx, authz.PermRackManage, authz.ResourceContext{})
+	if err != nil {
 		return nil, err
 	}
 	// A rack's placement is now persisted here too (zone/dims + site/building
 	// in one settings save). Placing a rack under a site/building is a
 	// site-management action, so — mirroring SaveRack — require site:manage
 	// when the request carries explicit placement intent (site_id/building_id,
-	// including 0 to unassign). Metadata-only edits (label/zone/dims, or a
-	// membership change) stay rack:manage.
+	// including 0 to unassign), narrowed to the target site. Metadata-only edits
+	// (label/zone/dims, or a membership change) stay rack:manage.
 	if ri, ok := r.Msg.TypeDetails.(*dspb.UpdateDeviceSetRequest_RackInfo); ok && ri.RackInfo != nil && (ri.RackInfo.SiteId != nil || ri.RackInfo.BuildingId != nil) {
-		if _, err := middleware.RequirePermission(ctx, authz.PermSiteManage, authz.ResourceContext{}); err != nil {
+		rc, err := h.siteManagePlacementContext(ctx, info.OrganizationID, ri.RackInfo.SiteId, ri.RackInfo.BuildingId)
+		if err != nil {
+			return nil, err
+		}
+		if _, err := middleware.RequirePermission(ctx, authz.PermSiteManage, rc); err != nil {
 			return nil, err
 		}
 	}
@@ -367,17 +399,23 @@ func (h *Handler) ListRackTypes(ctx context.Context, r *connect.Request[dspb.Lis
 }
 
 func (h *Handler) SaveRack(ctx context.Context, r *connect.Request[dspb.SaveRackRequest]) (*connect.Response[dspb.SaveRackResponse], error) {
-	if _, err := middleware.RequirePermission(ctx, authz.PermRackManage, authz.ResourceContext{}); err != nil {
+	info, err := middleware.RequirePermission(ctx, authz.PermRackManage, authz.ResourceContext{})
+	if err != nil {
 		return nil, err
 	}
 	// Placing a rack under a site/building is a site-management action —
 	// matching the dedicated AssignRacksToSite/Building RPCs (site:manage).
 	// A rack:manage-only caller may edit rack contents but not place the rack,
 	// so require site:manage when the request carries placement intent (an
-	// explicit site_id/building_id, including 0 to unassign). Omitted placement
-	// preserves the rack's current site/building and stays rack:manage.
+	// explicit site_id/building_id, including 0 to unassign), narrowed to the
+	// target site. Omitted placement preserves the rack's current site/building
+	// and stays rack:manage.
 	if ri := r.Msg.RackInfo; ri != nil && (ri.SiteId != nil || ri.BuildingId != nil) {
-		if _, err := middleware.RequirePermission(ctx, authz.PermSiteManage, authz.ResourceContext{}); err != nil {
+		rc, err := h.siteManagePlacementContext(ctx, info.OrganizationID, ri.SiteId, ri.BuildingId)
+		if err != nil {
+			return nil, err
+		}
+		if _, err := middleware.RequirePermission(ctx, authz.PermSiteManage, rc); err != nil {
 			return nil, err
 		}
 	}
@@ -407,15 +445,13 @@ func (h *Handler) CreateRacks(ctx context.Context, r *connect.Request[dspb.Creat
 	}
 	// Placing racks into a site/building is a site-management action, so a
 	// rack:manage-only caller can create unplaced racks but not place them.
-	// Every rack here is new, so any non-nil id is placement intent.
+	// Every rack here is new, so any non-nil id is placement intent. Narrow
+	// the escalation to the target site — including the building-only path,
+	// which resolves the building's parent site.
 	if r.Msg.SiteId != nil || r.Msg.BuildingId != nil {
-		// Scope to the target site when named, so a site-scoped site:manage
-		// operator is admitted and a narrowing site assignment is honored. A
-		// building-only request stays org-scoped (resolving its parent site
-		// needs a store read this handler lacks); shared with SaveRack, see #873.
-		rc := authz.ResourceContext{}
-		if r.Msg.SiteId != nil && *r.Msg.SiteId > 0 {
-			rc.SiteID = r.Msg.SiteId
+		rc, err := h.siteManagePlacementContext(ctx, info.OrganizationID, r.Msg.SiteId, r.Msg.BuildingId)
+		if err != nil {
+			return nil, err
 		}
 		if _, err := middleware.RequirePermission(ctx, authz.PermSiteManage, rc); err != nil {
 			return nil, err

--- a/server/internal/handlers/deviceset/handler.go
+++ b/server/internal/handlers/deviceset/handler.go
@@ -30,37 +30,19 @@ func NewHandler(svc *collection.Service) *Handler {
 	return &Handler{svc: svc}
 }
 
-// authorizeRackPlacement gates a rack placement on site:manage and returns a
-// context carrying the authorized placement for the service to bind the write
-// to (see authz.AuthorizedPlacement).
-//
-// Placing a rack is a site-management action, so a rack:manage-only caller may
-// edit rack contents but not move the rack. The check is scoped to the site
-// the rack actually lands in: a building_id resolves to its parent site (it
-// dictates the site; a disagreeing site_id is rejected later under lock) so a
-// caller narrowed out of that site can't bypass the check by naming a building
-// instead. Crucially, a MOVE is authorized against BOTH the rack's current
-// site (currentSiteID) and the destination — otherwise a caller who manages
-// only the destination could pull a rack out of a site they cannot manage.
-// currentSiteID is nil for a new rack (create paths). The source side is
-// skipped when nil (a new rack has nothing to move out of). Callers invoke this
-// only when the request carries placement intent, so the destination is always
-// authorized: at its resolved site, or — when the destination resolves to no
-// site — at ORG scope, matching AssignRacksToBuilding. A building_id pointing at
-// a site-less building forces the org-scoped check even on a move out of a real
-// site, so a source-site-only manager can't slip a rack into a site-less
-// building; an unassign with no source site to check falls back the same way.
+// authorizeRackPlacement gates a placement on site:manage and stashes the
+// authorized sites for the service (authz.AuthorizedPlacement). A move checks
+// both source (currentSiteID, nil for a new rack) and destination; the
+// destination narrows to the building's parent site, falling back to ORG scope
+// when it resolves to no site.
 func (h *Handler) authorizeRackPlacement(ctx context.Context, orgID int64, currentSiteID, siteID, buildingID *int64) (context.Context, error) {
 	targetSiteID, err := h.resolvePlacementTargetSite(ctx, orgID, siteID, buildingID)
 	if err != nil {
 		return ctx, err
 	}
 	sites := distinctSites(currentSiteID, targetSiteID)
-	// The destination has no site to narrow on when a building_id resolves to a
-	// site-less building, or when nothing else is being checked (unassign / new
-	// site-less rack). Either way require site:manage at org scope so neither a
-	// rack:manage-only caller nor a source-site-only manager can place a rack
-	// through it.
+	// Destination with no site to narrow on (site-less building, or nothing else
+	// being checked) still needs org-scoped site:manage.
 	destSiteLessBuilding := buildingID != nil && *buildingID > 0 && targetSiteID == nil
 	if destSiteLessBuilding || len(sites) == 0 {
 		sites = append(sites, nil)
@@ -114,10 +96,8 @@ func (h *Handler) CreateDeviceSet(ctx context.Context, r *connect.Request[dspb.C
 	if err != nil {
 		return nil, err
 	}
-	// Creating a rack under a site/building persists that placement (and can
-	// cascade added devices to it), so mirror the UpdateDeviceSet/SaveRack gate:
-	// require site:manage when rack_info carries explicit placement. The rack is
-	// new, so there is no source site — authorize the destination only.
+	// Creating a rack under a site/building persists that placement, so gate it
+	// on site:manage. New rack, so no source site — destination only.
 	if ri, ok := r.Msg.TypeDetails.(*dspb.CreateDeviceSetRequest_RackInfo); ok && ri.RackInfo != nil && (ri.RackInfo.SiteId != nil || ri.RackInfo.BuildingId != nil) {
 		ctx, err = h.authorizeRackPlacement(ctx, info.OrganizationID, nil /* currentSiteID */, ri.RackInfo.SiteId, ri.RackInfo.BuildingId)
 		if err != nil {
@@ -155,13 +135,9 @@ func (h *Handler) UpdateDeviceSet(ctx context.Context, r *connect.Request[dspb.U
 	if err != nil {
 		return nil, err
 	}
-	// A rack's placement is now persisted here too (zone/dims + site/building
-	// in one settings save). Placing a rack under a site/building is a
-	// site-management action, so — mirroring SaveRack — require site:manage
-	// when the request carries explicit placement intent (site_id/building_id,
-	// including 0 to unassign). This is a MOVE of an existing rack, so authorize
-	// both its current site and the destination. Metadata-only edits
-	// (label/zone/dims, or a membership change) stay rack:manage.
+	// Explicit placement intent (site_id/building_id, including 0 to unassign) is
+	// a MOVE, so gate on site:manage against both current site and destination.
+	// Metadata-only edits (label/zone/dims, membership) stay rack:manage.
 	if ri, ok := r.Msg.TypeDetails.(*dspb.UpdateDeviceSetRequest_RackInfo); ok && ri.RackInfo != nil && (ri.RackInfo.SiteId != nil || ri.RackInfo.BuildingId != nil) {
 		currentSiteID, err := h.svc.ResolveRackSite(ctx, info.OrganizationID, r.Msg.DeviceSetId)
 		if err != nil {
@@ -459,14 +435,9 @@ func (h *Handler) SaveRack(ctx context.Context, r *connect.Request[dspb.SaveRack
 	if err != nil {
 		return nil, err
 	}
-	// Placing a rack under a site/building is a site-management action —
-	// matching the dedicated AssignRacksToSite/Building RPCs (site:manage).
-	// A rack:manage-only caller may edit rack contents but not place the rack,
-	// so require site:manage when the request carries placement intent (an
-	// explicit site_id/building_id, including 0 to unassign). SaveRack can move
-	// an existing rack, so for an update authorize its current site as well as
-	// the destination; a create has no source. Omitted placement preserves the
-	// rack's current site/building and stays rack:manage.
+	// Placement intent gates on site:manage. SaveRack with a device_set_id is a
+	// move, so resolve and authorize the current site too; a create has none.
+	// Omitted placement preserves the current site/building and stays rack:manage.
 	if ri := r.Msg.RackInfo; ri != nil && (ri.SiteId != nil || ri.BuildingId != nil) {
 		var currentSiteID *int64
 		if r.Msg.DeviceSetId != nil {
@@ -504,10 +475,8 @@ func (h *Handler) CreateRacks(ctx context.Context, r *connect.Request[dspb.Creat
 	if err != nil {
 		return nil, err
 	}
-	// Placing racks into a site/building is a site-management action, so a
-	// rack:manage-only caller can create unplaced racks but not place them.
-	// Every rack here is new (no source site), so authorize the destination:
-	// an explicit site_id directly, or a building_id via its parent site.
+	// Placement intent gates on site:manage. Every rack is new (no source site),
+	// so authorize the destination only.
 	if r.Msg.SiteId != nil || r.Msg.BuildingId != nil {
 		ctx, err = h.authorizeRackPlacement(ctx, info.OrganizationID, nil /* currentSiteID */, r.Msg.SiteId, r.Msg.BuildingId)
 		if err != nil {

--- a/server/internal/handlers/deviceset/handler.go
+++ b/server/internal/handlers/deviceset/handler.go
@@ -30,25 +30,67 @@ func NewHandler(svc *collection.Service) *Handler {
 	return &Handler{svc: svc}
 }
 
-// siteManagePlacementContext builds the ResourceContext for the site:manage
-// escalation, narrowing it to the site the rack actually lands in. A
-// building_id resolves to its parent site (it dictates the site; a disagreeing
-// site_id is rejected later under lock) so a caller narrowed out of that site
-// can't bypass the check by naming a building instead. An explicit site_id is
-// used directly. A pure unassign (id == 0) or a site-less building stays
-// org-scoped — there is no destination site to narrow on.
-func (h *Handler) siteManagePlacementContext(ctx context.Context, orgID int64, siteID, buildingID *int64) (authz.ResourceContext, error) {
-	if buildingID != nil && *buildingID > 0 {
-		resolved, err := h.svc.ResolveBuildingSite(ctx, orgID, *buildingID)
-		if err != nil {
-			return authz.ResourceContext{}, err
+// authorizeRackPlacement gates a rack placement on site:manage and returns a
+// context carrying the authorized placement for the service to bind the write
+// to (see authz.AuthorizedPlacement).
+//
+// Placing a rack is a site-management action, so a rack:manage-only caller may
+// edit rack contents but not move the rack. The check is scoped to the site
+// the rack actually lands in: a building_id resolves to its parent site (it
+// dictates the site; a disagreeing site_id is rejected later under lock) so a
+// caller narrowed out of that site can't bypass the check by naming a building
+// instead. Crucially, a MOVE is authorized against BOTH the rack's current
+// site (currentSiteID) and the destination — otherwise a caller who manages
+// only the destination could pull a rack out of a site they cannot manage.
+// currentSiteID is nil for a new rack (create paths). A site the placement
+// does not touch (nil source or nil destination) is not checked.
+func (h *Handler) authorizeRackPlacement(ctx context.Context, orgID int64, currentSiteID, siteID, buildingID *int64) (context.Context, error) {
+	targetSiteID, err := h.resolvePlacementTargetSite(ctx, orgID, siteID, buildingID)
+	if err != nil {
+		return ctx, err
+	}
+	for _, site := range distinctSites(currentSiteID, targetSiteID) {
+		if _, err := middleware.RequirePermission(ctx, authz.PermSiteManage, authz.ResourceContext{SiteID: site}); err != nil {
+			return ctx, err
 		}
-		return authz.ResourceContext{SiteID: resolved}, nil
+	}
+	return authz.WithAuthorizedPlacement(ctx, authz.AuthorizedPlacement{
+		CurrentSiteID: currentSiteID,
+		TargetSiteID:  targetSiteID,
+	}), nil
+}
+
+// resolvePlacementTargetSite maps a placement request to the destination
+// site_id: a building_id resolves to its parent site, an explicit site_id is
+// used directly, and an unassign (id == 0) or a site-less building resolves to
+// no site (nil).
+func (h *Handler) resolvePlacementTargetSite(ctx context.Context, orgID int64, siteID, buildingID *int64) (*int64, error) {
+	if buildingID != nil && *buildingID > 0 {
+		return h.svc.ResolveBuildingSite(ctx, orgID, *buildingID)
 	}
 	if siteID != nil && *siteID > 0 {
-		return authz.ResourceContext{SiteID: siteID}, nil
+		return siteID, nil
 	}
-	return authz.ResourceContext{}, nil
+	return nil, nil
+}
+
+// distinctSites returns the distinct non-nil site ids among the given sites,
+// so an in-place re-assert (source == destination) is checked once and a nil
+// (untouched) side is skipped.
+func distinctSites(sites ...*int64) []*int64 {
+	var out []*int64
+	seen := make(map[int64]struct{}, len(sites))
+	for _, s := range sites {
+		if s == nil {
+			continue
+		}
+		if _, dup := seen[*s]; dup {
+			continue
+		}
+		seen[*s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
 }
 
 func (h *Handler) CreateDeviceSet(ctx context.Context, r *connect.Request[dspb.CreateDeviceSetRequest]) (*connect.Response[dspb.CreateDeviceSetResponse], error) {
@@ -58,15 +100,11 @@ func (h *Handler) CreateDeviceSet(ctx context.Context, r *connect.Request[dspb.C
 	}
 	// Creating a rack under a site/building persists that placement (and can
 	// cascade added devices to it), so mirror the UpdateDeviceSet/SaveRack gate:
-	// require site:manage when rack_info carries explicit placement, narrowed
-	// to the target site. Without this, a rack:manage-only caller could place a
-	// rack via the create path.
+	// require site:manage when rack_info carries explicit placement. The rack is
+	// new, so there is no source site — authorize the destination only.
 	if ri, ok := r.Msg.TypeDetails.(*dspb.CreateDeviceSetRequest_RackInfo); ok && ri.RackInfo != nil && (ri.RackInfo.SiteId != nil || ri.RackInfo.BuildingId != nil) {
-		rc, err := h.siteManagePlacementContext(ctx, info.OrganizationID, ri.RackInfo.SiteId, ri.RackInfo.BuildingId)
+		ctx, err = h.authorizeRackPlacement(ctx, info.OrganizationID, nil /* currentSiteID */, ri.RackInfo.SiteId, ri.RackInfo.BuildingId)
 		if err != nil {
-			return nil, err
-		}
-		if _, err := middleware.RequirePermission(ctx, authz.PermSiteManage, rc); err != nil {
 			return nil, err
 		}
 	}
@@ -105,14 +143,16 @@ func (h *Handler) UpdateDeviceSet(ctx context.Context, r *connect.Request[dspb.U
 	// in one settings save). Placing a rack under a site/building is a
 	// site-management action, so — mirroring SaveRack — require site:manage
 	// when the request carries explicit placement intent (site_id/building_id,
-	// including 0 to unassign), narrowed to the target site. Metadata-only edits
+	// including 0 to unassign). This is a MOVE of an existing rack, so authorize
+	// both its current site and the destination. Metadata-only edits
 	// (label/zone/dims, or a membership change) stay rack:manage.
 	if ri, ok := r.Msg.TypeDetails.(*dspb.UpdateDeviceSetRequest_RackInfo); ok && ri.RackInfo != nil && (ri.RackInfo.SiteId != nil || ri.RackInfo.BuildingId != nil) {
-		rc, err := h.siteManagePlacementContext(ctx, info.OrganizationID, ri.RackInfo.SiteId, ri.RackInfo.BuildingId)
+		currentSiteID, err := h.svc.ResolveRackSite(ctx, info.OrganizationID, r.Msg.DeviceSetId)
 		if err != nil {
 			return nil, err
 		}
-		if _, err := middleware.RequirePermission(ctx, authz.PermSiteManage, rc); err != nil {
+		ctx, err = h.authorizeRackPlacement(ctx, info.OrganizationID, currentSiteID, ri.RackInfo.SiteId, ri.RackInfo.BuildingId)
+		if err != nil {
 			return nil, err
 		}
 	}
@@ -407,15 +447,20 @@ func (h *Handler) SaveRack(ctx context.Context, r *connect.Request[dspb.SaveRack
 	// matching the dedicated AssignRacksToSite/Building RPCs (site:manage).
 	// A rack:manage-only caller may edit rack contents but not place the rack,
 	// so require site:manage when the request carries placement intent (an
-	// explicit site_id/building_id, including 0 to unassign), narrowed to the
-	// target site. Omitted placement preserves the rack's current site/building
-	// and stays rack:manage.
+	// explicit site_id/building_id, including 0 to unassign). SaveRack can move
+	// an existing rack, so for an update authorize its current site as well as
+	// the destination; a create has no source. Omitted placement preserves the
+	// rack's current site/building and stays rack:manage.
 	if ri := r.Msg.RackInfo; ri != nil && (ri.SiteId != nil || ri.BuildingId != nil) {
-		rc, err := h.siteManagePlacementContext(ctx, info.OrganizationID, ri.SiteId, ri.BuildingId)
-		if err != nil {
-			return nil, err
+		var currentSiteID *int64
+		if r.Msg.DeviceSetId != nil {
+			currentSiteID, err = h.svc.ResolveRackSite(ctx, info.OrganizationID, *r.Msg.DeviceSetId)
+			if err != nil {
+				return nil, err
+			}
 		}
-		if _, err := middleware.RequirePermission(ctx, authz.PermSiteManage, rc); err != nil {
+		ctx, err = h.authorizeRackPlacement(ctx, info.OrganizationID, currentSiteID, ri.SiteId, ri.BuildingId)
+		if err != nil {
 			return nil, err
 		}
 	}
@@ -445,15 +490,11 @@ func (h *Handler) CreateRacks(ctx context.Context, r *connect.Request[dspb.Creat
 	}
 	// Placing racks into a site/building is a site-management action, so a
 	// rack:manage-only caller can create unplaced racks but not place them.
-	// Every rack here is new, so any non-nil id is placement intent. Narrow
-	// the escalation to the target site — including the building-only path,
-	// which resolves the building's parent site.
+	// Every rack here is new (no source site), so authorize the destination:
+	// an explicit site_id directly, or a building_id via its parent site.
 	if r.Msg.SiteId != nil || r.Msg.BuildingId != nil {
-		rc, err := h.siteManagePlacementContext(ctx, info.OrganizationID, r.Msg.SiteId, r.Msg.BuildingId)
+		ctx, err = h.authorizeRackPlacement(ctx, info.OrganizationID, nil /* currentSiteID */, r.Msg.SiteId, r.Msg.BuildingId)
 		if err != nil {
-			return nil, err
-		}
-		if _, err := middleware.RequirePermission(ctx, authz.PermSiteManage, rc); err != nil {
 			return nil, err
 		}
 	}

--- a/server/internal/handlers/deviceset/handler.go
+++ b/server/internal/handlers/deviceset/handler.go
@@ -42,14 +42,26 @@ func NewHandler(svc *collection.Service) *Handler {
 // instead. Crucially, a MOVE is authorized against BOTH the rack's current
 // site (currentSiteID) and the destination — otherwise a caller who manages
 // only the destination could pull a rack out of a site they cannot manage.
-// currentSiteID is nil for a new rack (create paths). A site the placement
-// does not touch (nil source or nil destination) is not checked.
+// currentSiteID is nil for a new rack (create paths). The source side is
+// skipped when nil (a new rack has nothing to move out of). Callers invoke this
+// only when the request carries placement intent, so the destination is always
+// authorized: at its resolved site, or — when the placement resolves site-less
+// (a site-less building or an explicit unassign) and no source site is checked
+// either — at org scope, matching AssignRacksToBuilding so rack:manage alone
+// can never place a rack.
 func (h *Handler) authorizeRackPlacement(ctx context.Context, orgID int64, currentSiteID, siteID, buildingID *int64) (context.Context, error) {
 	targetSiteID, err := h.resolvePlacementTargetSite(ctx, orgID, siteID, buildingID)
 	if err != nil {
 		return ctx, err
 	}
-	for _, site := range distinctSites(currentSiteID, targetSiteID) {
+	sites := distinctSites(currentSiteID, targetSiteID)
+	if len(sites) == 0 {
+		// Placement intent present but nothing to narrow on: require site:manage
+		// at org scope so a site-less-building placement still fails closed for a
+		// rack:manage-only caller.
+		sites = []*int64{nil}
+	}
+	for _, site := range sites {
 		if _, err := middleware.RequirePermission(ctx, authz.PermSiteManage, authz.ResourceContext{SiteID: site}); err != nil {
 			return ctx, err
 		}

--- a/server/internal/handlers/deviceset/handler_test.go
+++ b/server/internal/handlers/deviceset/handler_test.go
@@ -16,6 +16,7 @@ import (
 	dspb "github.com/block/proto-fleet/server/generated/grpc/device_set/v1"
 	"github.com/block/proto-fleet/server/internal/domain/activity"
 	"github.com/block/proto-fleet/server/internal/domain/authz"
+	buildingsmodels "github.com/block/proto-fleet/server/internal/domain/buildings/models"
 	"github.com/block/proto-fleet/server/internal/domain/collection"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 	"github.com/block/proto-fleet/server/internal/domain/session"
@@ -801,6 +802,11 @@ func TestSaveRack_PlacementRequiresSiteManage(t *testing.T) {
 
 	// Has rack:manage but NOT site:manage.
 	ctx := ctxWithPerms(authz.PermRackManage)
+	// The escalation resolves the building's parent site before the check;
+	// site:manage is absent everywhere, so the site it resolves to is
+	// immaterial to the denial.
+	buildingSite := int64(9)
+	h.collectionStore.EXPECT().GetBuildingSite(gomock.Any(), testOrgID, int64(7)).Return(&buildingSite, nil)
 	req := connect.NewRequest(&dspb.SaveRackRequest{
 		Label:          "Rack",
 		RackInfo:       &dspb.RackInfo{BuildingId: ptrInt64Local(7)},
@@ -859,6 +865,8 @@ func TestCreateDeviceSet_PlacementRequiresSiteManage(t *testing.T) {
 
 	// Has rack:manage but NOT site:manage.
 	ctx := ctxWithPerms(authz.PermRackManage)
+	buildingSite := int64(9)
+	h.collectionStore.EXPECT().GetBuildingSite(gomock.Any(), testOrgID, int64(7)).Return(&buildingSite, nil)
 	req := connect.NewRequest(&dspb.CreateDeviceSetRequest{
 		Label: "Rack",
 		TypeDetails: &dspb.CreateDeviceSetRequest_RackInfo{
@@ -1443,6 +1451,8 @@ func TestCreateRacks_RequiresRackManage(t *testing.T) {
 func TestCreateRacks_PlacementRequiresSiteManage(t *testing.T) {
 	h := newTestHandler(t)
 	ctx := ctxWithPerms(authz.PermRackManage)
+	buildingSite := int64(9)
+	h.collectionStore.EXPECT().GetBuildingSite(gomock.Any(), testOrgID, int64(7)).Return(&buildingSite, nil)
 
 	_, err := h.handler.CreateRacks(ctx, connect.NewRequest(&dspb.CreateRacksRequest{
 		BuildingId: ptrInt64Local(7),
@@ -1500,5 +1510,111 @@ func TestCreateRacks_authorizesPlacementAgainstTargetSite(t *testing.T) {
 		var fleetErr fleeterror.FleetError
 		require.ErrorAs(t, err, &fleetErr)
 		assert.Equal(t, connect.CodePermissionDenied, fleetErr.GRPCCode)
+	})
+}
+
+// TestCreateRacks_BuildingOnlyPlacementNarrowsToResolvedSite pins that a
+// building-only placement (no site_id) authorizes site:manage against the
+// building's parent site, not org scope. Vegas is site 99; Building 7 is in it.
+func TestCreateRacks_BuildingOnlyPlacementNarrowsToResolvedSite(t *testing.T) {
+	const vegas = int64(99)
+	const building7 = int64(7)
+
+	// Org-wide site:manage narrowed away at Vegas by a Vegas-only role lacking
+	// site:manage. Naming a building in Vegas must not slip past the check.
+	t.Run("org admin narrowed out of the site is denied via a building there", func(t *testing.T) {
+		h := newTestHandler(t)
+		ctx := handlerstest.CtxWithAssignments(t, testOrgID,
+			handlerstest.OrgAssignment(authz.PermRackManage, authz.PermSiteManage),
+			handlerstest.SiteAssignment(vegas, authz.PermRackRead))
+
+		// The only store call is the authz peek; denial happens before any write.
+		h.collectionStore.EXPECT().GetBuildingSite(gomock.Any(), testOrgID, building7).Return(ptrInt64Local(vegas), nil)
+
+		_, err := h.handler.CreateRacks(ctx, connect.NewRequest(&dspb.CreateRacksRequest{
+			BuildingId: ptrInt64Local(building7),
+			Racks:      []*dspb.NewRack{newRackRow("R-001")},
+		}))
+		require.Error(t, err)
+		var fe fleeterror.FleetError
+		require.ErrorAs(t, err, &fe)
+		assert.Equal(t, connect.CodePermissionDenied, fe.GRPCCode)
+	})
+
+	// Mirror case: a Vegas-only manager (site:manage at Vegas, nowhere else) is
+	// admitted once Building 7 resolves to Vegas, and the create proceeds.
+	t.Run("site-scoped manager is admitted via a building in their site", func(t *testing.T) {
+		h := newTestHandler(t)
+		ctx := handlerstest.CtxWithAssignments(t, testOrgID,
+			handlerstest.OrgAssignment(authz.PermRackManage),
+			handlerstest.SiteAssignment(vegas, authz.PermSiteManage))
+
+		// Authz peek, then the service's canonical peek + locked re-read.
+		h.collectionStore.EXPECT().GetBuildingSite(gomock.Any(), testOrgID, building7).Return(ptrInt64Local(vegas), nil).Times(3)
+		h.siteStore.EXPECT().LockSiteForWrite(gomock.Any(), testOrgID, vegas).Return(nil)
+		h.siteStore.EXPECT().LockBuildingForWrite(gomock.Any(), testOrgID, building7).Return(nil)
+		// Ungridded building (capacity 0) skips the per-building cap check.
+		h.buildingStore.EXPECT().GetBuilding(gomock.Any(), testOrgID, building7).
+			Return(&buildingsmodels.Building{ID: building7, Aisles: 0, RacksPerAisle: 0}, nil)
+		h.collectionStore.EXPECT().
+			ListTakenLabels(gomock.Any(), testOrgID, collectionpb.CollectionType_COLLECTION_TYPE_RACK, gomock.Any()).
+			Return(nil, nil)
+		h.collectionStore.EXPECT().
+			CreateCollection(gomock.Any(), testOrgID, collectionpb.CollectionType_COLLECTION_TYPE_RACK, "R-001", "").
+			Return(&collectionpb.DeviceCollection{Id: 1, Label: "R-001"}, nil)
+		h.collectionStore.EXPECT().CreateRackExtension(gomock.Any(), gomock.Any()).Return(nil)
+
+		resp, err := h.handler.CreateRacks(ctx, connect.NewRequest(&dspb.CreateRacksRequest{
+			BuildingId: ptrInt64Local(building7),
+			Racks:      []*dspb.NewRack{newRackRow("R-001")},
+		}))
+		require.NoError(t, err)
+		assert.Len(t, resp.Msg.GetRacks(), 1)
+	})
+}
+
+// TestSaveRack_PlacementNarrowsToTargetSite confirms SaveRack narrows the
+// placement escalation to the target site (not org scope): both an explicit
+// site_id and a building-only placement deny an org admin narrowed out of that
+// site.
+func TestSaveRack_PlacementNarrowsToTargetSite(t *testing.T) {
+	const vegas = int64(99)
+
+	// Narrowed out of Vegas, naming the site directly.
+	t.Run("explicit site_id is denied for a narrowed-out org admin", func(t *testing.T) {
+		h := newTestHandler(t)
+		ctx := handlerstest.CtxWithAssignments(t, testOrgID,
+			handlerstest.OrgAssignment(authz.PermRackManage, authz.PermSiteManage),
+			handlerstest.SiteAssignment(vegas, authz.PermRackRead))
+
+		_, err := h.handler.SaveRack(ctx, connect.NewRequest(&dspb.SaveRackRequest{
+			Label:          "Rack",
+			RackInfo:       &dspb.RackInfo{SiteId: ptrInt64Local(vegas)},
+			DeviceSelector: deviceListSelector(),
+		}))
+		require.Error(t, err)
+		var fe fleeterror.FleetError
+		require.ErrorAs(t, err, &fe)
+		assert.Equal(t, connect.CodePermissionDenied, fe.GRPCCode)
+	})
+
+	// Same admin, same site, but reached through a building in Vegas.
+	t.Run("building-only placement is denied for a narrowed-out org admin", func(t *testing.T) {
+		h := newTestHandler(t)
+		ctx := handlerstest.CtxWithAssignments(t, testOrgID,
+			handlerstest.OrgAssignment(authz.PermRackManage, authz.PermSiteManage),
+			handlerstest.SiteAssignment(vegas, authz.PermRackRead))
+
+		h.collectionStore.EXPECT().GetBuildingSite(gomock.Any(), testOrgID, int64(7)).Return(ptrInt64Local(vegas), nil)
+
+		_, err := h.handler.SaveRack(ctx, connect.NewRequest(&dspb.SaveRackRequest{
+			Label:          "Rack",
+			RackInfo:       &dspb.RackInfo{BuildingId: ptrInt64Local(7)},
+			DeviceSelector: deviceListSelector(),
+		}))
+		require.Error(t, err)
+		var fe fleeterror.FleetError
+		require.ErrorAs(t, err, &fe)
+		assert.Equal(t, connect.CodePermissionDenied, fe.GRPCCode)
 	})
 }

--- a/server/internal/handlers/deviceset/handler_test.go
+++ b/server/internal/handlers/deviceset/handler_test.go
@@ -1618,3 +1618,87 @@ func TestSaveRack_PlacementNarrowsToTargetSite(t *testing.T) {
 		assert.Equal(t, connect.CodePermissionDenied, fe.GRPCCode)
 	})
 }
+
+// TestUpdateDeviceSet_MoveAuthorizesSourceAndDestination is the source-site
+// regression: moving an existing rack must require site:manage at the rack's
+// CURRENT site as well as the destination, so a manager of only the
+// destination can't pull a rack out of a site they don't manage.
+func TestUpdateDeviceSet_MoveAuthorizesSourceAndDestination(t *testing.T) {
+	const rackID = int64(500)
+	const siteA = int64(11) // rack's current site
+	const siteB = int64(22) // destination
+
+	t.Run("destination-only manager cannot move a rack out of an unmanaged source", func(t *testing.T) {
+		h := newTestHandler(t)
+		ctx := handlerstest.CtxWithAssignments(t, testOrgID,
+			handlerstest.OrgAssignment(authz.PermRackManage),
+			handlerstest.SiteAssignment(siteB, authz.PermSiteManage))
+		// The rack currently lives in site A; the move targets site B. Only the
+		// source lookup runs — the source check denies before any write.
+		h.collectionStore.EXPECT().GetRackInfo(gomock.Any(), rackID, testOrgID).
+			Return(&collectionpb.RackInfo{SiteId: ptrInt64Local(siteA)}, nil)
+
+		_, err := h.handler.UpdateDeviceSet(ctx, connect.NewRequest(&dspb.UpdateDeviceSetRequest{
+			DeviceSetId: rackID,
+			TypeDetails: &dspb.UpdateDeviceSetRequest_RackInfo{RackInfo: &dspb.RackInfo{SiteId: ptrInt64Local(siteB)}},
+		}))
+		require.Error(t, err)
+		var fe fleeterror.FleetError
+		require.ErrorAs(t, err, &fe)
+		assert.Equal(t, connect.CodePermissionDenied, fe.GRPCCode)
+	})
+
+	t.Run("manager of both source and destination is admitted past authorization", func(t *testing.T) {
+		h := newTestHandler(t)
+		ctx := handlerstest.CtxWithAssignments(t, testOrgID,
+			handlerstest.OrgAssignment(authz.PermRackManage),
+			handlerstest.SiteAssignment(siteA, authz.PermSiteManage),
+			handlerstest.SiteAssignment(siteB, authz.PermSiteManage))
+		h.collectionStore.EXPECT().GetRackInfo(gomock.Any(), rackID, testOrgID).
+			Return(&collectionpb.RackInfo{SiteId: ptrInt64Local(siteA)}, nil)
+		// Authorization passes; the service is entered and stopped at its first
+		// store read with a sentinel, proving the move was admitted.
+		sentinel := fleeterror.NewInternalError("reached service")
+		h.collectionStore.EXPECT().GetCollectionType(gomock.Any(), testOrgID, rackID).Return(collectionpb.CollectionType_COLLECTION_TYPE_RACK, sentinel)
+
+		_, err := h.handler.UpdateDeviceSet(ctx, connect.NewRequest(&dspb.UpdateDeviceSetRequest{
+			DeviceSetId: rackID,
+			TypeDetails: &dspb.UpdateDeviceSetRequest_RackInfo{RackInfo: &dspb.RackInfo{
+				SiteId:      ptrInt64Local(siteB),
+				Rows:        4,
+				Columns:     8,
+				OrderIndex:  dspb.RackOrderIndex_RACK_ORDER_INDEX_BOTTOM_LEFT,
+				CoolingType: dspb.RackCoolingType_RACK_COOLING_TYPE_AIR,
+			}},
+		}))
+		require.ErrorIs(t, err, sentinel)
+	})
+}
+
+// TestSaveRack_UpdateMoveAuthorizesSourceSite mirrors the UpdateDeviceSet
+// regression on the SaveRack update path: a SaveRack that names an existing
+// rack (device_set_id set) is a move, so it must authorize the rack's current
+// site, not only the destination.
+func TestSaveRack_UpdateMoveAuthorizesSourceSite(t *testing.T) {
+	const rackID = int64(500)
+	const siteA = int64(11)
+	const siteB = int64(22)
+
+	h := newTestHandler(t)
+	ctx := handlerstest.CtxWithAssignments(t, testOrgID,
+		handlerstest.OrgAssignment(authz.PermRackManage),
+		handlerstest.SiteAssignment(siteB, authz.PermSiteManage))
+	h.collectionStore.EXPECT().GetRackInfo(gomock.Any(), rackID, testOrgID).
+		Return(&collectionpb.RackInfo{SiteId: ptrInt64Local(siteA)}, nil)
+
+	_, err := h.handler.SaveRack(ctx, connect.NewRequest(&dspb.SaveRackRequest{
+		DeviceSetId:    ptrInt64Local(rackID),
+		Label:          "Rack",
+		RackInfo:       &dspb.RackInfo{SiteId: ptrInt64Local(siteB)},
+		DeviceSelector: deviceListSelector(),
+	}))
+	require.Error(t, err)
+	var fe fleeterror.FleetError
+	require.ErrorAs(t, err, &fe)
+	assert.Equal(t, connect.CodePermissionDenied, fe.GRPCCode)
+}

--- a/server/internal/handlers/deviceset/handler_test.go
+++ b/server/internal/handlers/deviceset/handler_test.go
@@ -1726,6 +1726,59 @@ func TestUpdateDeviceSet_MoveAuthorizesSourceAndDestination(t *testing.T) {
 	})
 }
 
+// TestUpdateDeviceSet_MoveIntoSiteLessBuildingRequiresOrgSiteManage pins that a
+// move INTO a site-less building requires org-scoped site:manage even when the
+// caller manages the rack's current site, matching AssignRacksToBuilding — a
+// source-site-only manager can't slip a rack into a site-less building.
+func TestUpdateDeviceSet_MoveIntoSiteLessBuildingRequiresOrgSiteManage(t *testing.T) {
+	const rackID = int64(500)
+	const siteA = int64(11)           // rack's current site
+	const siteLessBuilding = int64(7) // destination building with no site
+
+	t.Run("source-site-only manager is denied", func(t *testing.T) {
+		h := newTestHandler(t)
+		ctx := handlerstest.CtxWithAssignments(t, testOrgID,
+			handlerstest.OrgAssignment(authz.PermRackManage),
+			handlerstest.SiteAssignment(siteA, authz.PermSiteManage))
+		h.collectionStore.EXPECT().GetRackInfo(gomock.Any(), rackID, testOrgID).
+			Return(&collectionpb.RackInfo{SiteId: ptrInt64Local(siteA)}, nil)
+		h.collectionStore.EXPECT().GetBuildingSite(gomock.Any(), testOrgID, siteLessBuilding).Return(nil, nil)
+
+		_, err := h.handler.UpdateDeviceSet(ctx, connect.NewRequest(&dspb.UpdateDeviceSetRequest{
+			DeviceSetId: rackID,
+			TypeDetails: &dspb.UpdateDeviceSetRequest_RackInfo{RackInfo: &dspb.RackInfo{BuildingId: ptrInt64Local(siteLessBuilding)}},
+		}))
+		require.Error(t, err)
+		var fe fleeterror.FleetError
+		require.ErrorAs(t, err, &fe)
+		assert.Equal(t, connect.CodePermissionDenied, fe.GRPCCode)
+	})
+
+	t.Run("org-wide site:manage manager is admitted past authorization", func(t *testing.T) {
+		h := newTestHandler(t)
+		ctx := ctxWithPerms(authz.PermRackManage, authz.PermSiteManage)
+		h.collectionStore.EXPECT().GetRackInfo(gomock.Any(), rackID, testOrgID).
+			Return(&collectionpb.RackInfo{SiteId: ptrInt64Local(siteA)}, nil)
+		h.collectionStore.EXPECT().GetBuildingSite(gomock.Any(), testOrgID, siteLessBuilding).Return(nil, nil)
+		// Authorization passes (source siteA + org-scope); the service is entered
+		// and stopped at its first store read with a sentinel.
+		sentinel := fleeterror.NewInternalError("reached service")
+		h.collectionStore.EXPECT().GetCollectionType(gomock.Any(), testOrgID, rackID).Return(collectionpb.CollectionType_COLLECTION_TYPE_RACK, sentinel)
+
+		_, err := h.handler.UpdateDeviceSet(ctx, connect.NewRequest(&dspb.UpdateDeviceSetRequest{
+			DeviceSetId: rackID,
+			TypeDetails: &dspb.UpdateDeviceSetRequest_RackInfo{RackInfo: &dspb.RackInfo{
+				BuildingId:  ptrInt64Local(siteLessBuilding),
+				Rows:        4,
+				Columns:     8,
+				OrderIndex:  dspb.RackOrderIndex_RACK_ORDER_INDEX_BOTTOM_LEFT,
+				CoolingType: dspb.RackCoolingType_RACK_COOLING_TYPE_AIR,
+			}},
+		}))
+		require.ErrorIs(t, err, sentinel)
+	})
+}
+
 // TestSaveRack_UpdateMoveAuthorizesSourceSite mirrors the UpdateDeviceSet
 // regression on the SaveRack update path: a SaveRack that names an existing
 // rack (device_set_id set) is a move, so it must authorize the rack's current

--- a/server/internal/handlers/deviceset/handler_test.go
+++ b/server/internal/handlers/deviceset/handler_test.go
@@ -881,6 +881,57 @@ func TestCreateDeviceSet_PlacementRequiresSiteManage(t *testing.T) {
 	assert.Equal(t, connect.CodePermissionDenied, fe.GRPCCode)
 }
 
+// TestCreateDeviceSet_SiteLessBuildingRequiresSiteManage pins that a placement
+// whose destination resolves to no site (a site-less building) still requires
+// site:manage: the check falls back to org scope rather than being skipped, so
+// a rack:manage-only caller cannot place a rack through a site-less building.
+func TestCreateDeviceSet_SiteLessBuildingRequiresSiteManage(t *testing.T) {
+	const siteLessBuilding = int64(7)
+	rack := func() *dspb.RackInfo {
+		return &dspb.RackInfo{
+			BuildingId:  ptrInt64Local(siteLessBuilding),
+			Rows:        4,
+			Columns:     8,
+			OrderIndex:  dspb.RackOrderIndex_RACK_ORDER_INDEX_BOTTOM_LEFT,
+			CoolingType: dspb.RackCoolingType_RACK_COOLING_TYPE_AIR,
+		}
+	}
+
+	t.Run("rack:manage-only caller is denied", func(t *testing.T) {
+		h := newTestHandler(t)
+		ctx := ctxWithPerms(authz.PermRackManage)
+		h.collectionStore.EXPECT().GetBuildingSite(gomock.Any(), testOrgID, siteLessBuilding).Return(nil, nil)
+
+		_, err := h.handler.CreateDeviceSet(ctx, connect.NewRequest(&dspb.CreateDeviceSetRequest{
+			Type:        dspb.DeviceSetType_DEVICE_SET_TYPE_RACK,
+			Label:       "Rack",
+			TypeDetails: &dspb.CreateDeviceSetRequest_RackInfo{RackInfo: rack()},
+		}))
+		require.Error(t, err)
+		var fe fleeterror.FleetError
+		require.ErrorAs(t, err, &fe)
+		assert.Equal(t, connect.CodePermissionDenied, fe.GRPCCode)
+	})
+
+	t.Run("org-wide site:manage caller is admitted past authorization", func(t *testing.T) {
+		h := newTestHandler(t)
+		ctx := ctxWithPerms(authz.PermRackManage, authz.PermSiteManage)
+		// authz resolves the building (site-less) and the org-scoped site:manage
+		// check passes; the service is then entered and stopped at the building
+		// lock with a sentinel, proving the placement was admitted.
+		h.collectionStore.EXPECT().GetBuildingSite(gomock.Any(), testOrgID, siteLessBuilding).Return(nil, nil).Times(2)
+		sentinel := fleeterror.NewInternalError("reached service")
+		h.siteStore.EXPECT().LockBuildingForWrite(gomock.Any(), testOrgID, siteLessBuilding).Return(sentinel)
+
+		_, err := h.handler.CreateDeviceSet(ctx, connect.NewRequest(&dspb.CreateDeviceSetRequest{
+			Type:        dspb.DeviceSetType_DEVICE_SET_TYPE_RACK,
+			Label:       "Rack",
+			TypeDetails: &dspb.CreateDeviceSetRequest_RackInfo{RackInfo: rack()},
+		}))
+		require.ErrorIs(t, err, sentinel)
+	})
+}
+
 // TestAssignDevicesToRack_HappyPathAssigns covers the assign branch:
 // target_rack_id set, devices flow through the lock → label-read →
 // remove → add → cascade chain, and the handler round-trips the


### PR DESCRIPTION
Reviewable diff: +65/-20 across 2 files (excludes generated, test, and story files).

## Summary

The rack-write RPCs authorized the `site:manage` placement escalation against **org scope** instead of the **site the rack actually lands in**. A caller whose org-wide `site:manage` grant was narrowed away at a specific site could bypass that narrowing by placing racks via a *building* in that site, and — the mirror case — a site-scoped-only manager was wrongly denied when naming a building. This PR scopes the escalation check to the target site across all four rack-placement RPCs, closing the bypass and the false denial. Closes #873.

## How it works

Every rack-write RPC gates in two steps: a base `rack:manage` check (you can manage racks at all), then — only when the request carries placement intent (a `site_id` or `building_id`) — a stronger `site:manage` check, because placing a rack into a site is a site-management action.

`site:manage` narrowing means an org-wide grant applies everywhere *except* sites where a narrower site-scoped role removes it. So the answer to "does this caller have `site:manage`?" depends entirely on **which site the check names**:

- Naming no site asks the org-wide question — narrowing is invisible.
- Naming a specific site asks the per-site question — narrowing is honored.

The old code always passed an empty (site-less) context to the placement check, so it asked the org-wide question every time. When a request named only a building, the handler didn't know which site that building belonged to, so it couldn't scope the check — the write later resolved the building to its real site and placed the rack there, past a check that never looked at that site.

The fix threads the real target site into the check:

1. **Base gate** runs as before and now also yields the caller's org id.
2. A shared helper decides which site the `site:manage` check should name:
   - **A `building_id`** → the service resolves the building's parent site (an unlocked point-read) and the check is scoped to that site. A building dictates its site, so this is the true write target; if a request also sends a disagreeing `site_id`, the write rejects it later under lock.
   - **An explicit `site_id`** → the check is scoped to that site directly.
   - **An unassign (`id == 0`), or a building with no parent site** → no destination site exists, so the check falls back to org scope; there is nothing to narrow on.
3. The `site:manage` check then runs against that scoped context.

Walking the reported case — an admin with org-wide `site:manage` narrowed out of "Vegas" who creates racks by naming a building that lives in Vegas: the helper resolves the building to Vegas, the check asks the Vegas-specific question, narrowing removes the grant there, and the request is **denied before any write**. The mirror case — a Vegas-only manager naming that same building — now resolves to Vegas, the per-site check passes, and the create proceeds.

The building lookup in the handler is an unlocked "peek" used only for the authorization decision. The authoritative, lock-protected resolution during the write transaction re-reads the building's site under a row lock and rejects (or retries) if it changed, so a building that moves sites between the peek and the write cannot slip past.

```mermaid
flowchart TD
    A["Rack-write RPC (CreateRacks / SaveRack / CreateDeviceSet / UpdateDeviceSet)"] --> B["Require rack:manage (base gate) → caller org id"]
    B --> C{"Placement intent? (site_id or building_id present)"}
    C -->|No| Z["Proceed to service write"]
    C -->|Yes| D["siteManagePlacementContext(orgID, siteID, buildingID)"]
    D --> E{"building_id > 0 ?"}
    E -->|Yes| F["ResolveBuildingSite → parent site"]
    E -->|No| G{"site_id > 0 ?"}
    G -->|Yes| H["Use site_id directly"]
    G -->|No| I["No target site → org scope"]
    F --> J["Require site:manage scoped to resolved/target site"]
    H --> J
    I --> J
    J -->|Denied| K["Reject before any write"]
    J -->|Allowed| Z
    Z --> L["resolveAndLockRackPlacement re-reads building→site under lock (authoritative)"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/internal/handlers/deviceset/handler.go` | New `siteManagePlacementContext` helper; `CreateRacks`, `SaveRack`, `CreateDeviceSet`, `UpdateDeviceSet` now scope the `site:manage` check to the target site and capture the base gate's org id | The security boundary. Confirm all four placement paths route through the helper and that the escalation only runs when placement intent is present |
| `server/internal/domain/collection/service.go` | New `ResolveBuildingSite` (unlocked read of a building's parent site) | The handler can't read the store directly; verify it's a peek and that the locked `resolveAndLockRackPlacement` remains the authoritative resolver for the write |
| `server/internal/handlers/deviceset/handler_test.go` | Added regression tests; updated existing deny tests for the new building→site lookup | Test-only — see Testing below |

## Key technical decisions & trade-offs

- **Building precedence over `site_id` in the check.** When both are present the helper scopes to the building's resolved site rather than the request's `site_id`, matching the write path where the building dictates the site (a disagreeing `site_id` is rejected under lock). Alternative: trust the request `site_id`, which would let a caller name a site they manage while pointing at a building elsewhere.
- **Unlocked peek for authorization, locked read for the write.** The handler reads the building's site without a lock to make the authz decision; the transactional path re-reads under lock and rejects on change. Alternative: hold a lock across the authz check, which would broaden lock scope for a marginal (concurrent building-move is itself a `site:manage` op) window.
- **Fixed all four rack-placement RPCs, not just the two named in the issue.** `CreateDeviceSet` and `UpdateDeviceSet` also persist placement and had the identical unconditional-org-scope gate; one shared helper closes all four rather than leaving two parallel holes.
- **Unassign and site-less buildings stay org-scoped.** There is no destination site to narrow on, so the check keeps its prior org-scope behavior — no change in authorization for those paths.

## Testing & validation

- `go test ./internal/handlers/deviceset/... ./internal/domain/collection/...` — pass.
- New regression tests: building-only placement denies an org admin narrowed out of the resolved site (the bypass) and admits a site-scoped manager for a building in their site (the mirror case), plus a SaveRack case proving both explicit `site_id` and building-only placements narrow to the target site.
- Existing placement deny-tests updated to expect the new building→site lookup before denial.
- `go build ./...` and `go vet` clean; files formatted with the pinned `goimports`.
- **Not covered:** no integration/E2E test drives the full RPC over the wire; coverage is at the handler + service unit level against mock stores.
