### PR TITLE
Plan building, rack, and group targets for curtailment

### DIFF
--- a/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
+++ b/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
@@ -180,17 +180,20 @@ Bound inputs before expensive resolution:
 | IDs per topology type | 256 |
 | Total topology IDs | 1,024 |
 | Explicit device identifiers | 10,000 |
+| Deduplicated resolved miners per execution/event | 10,000 |
 | Repeated `CurtailmentScope` entries | 1,024 |
 | Curtailment RPC body | 2 MiB |
 | Active closed-loop watchers per org | 64 |
 | Active-watcher topology IDs per org | 1,024 |
 | Active-watcher explicit IDs per org | 10,000 |
 
-Enforce cardinality on raw repeated input before deduplication and again after
-domain normalization. Apply the same limits to direct requests, persisted
-profiles, automation, and reconciliation; use protobuf `max_items` where the
-wire shape permits. Enforce the active aggregate quotas transactionally before
-persisting a watcher/reservation.
+Enforce cardinality on raw repeated input before deduplication and after domain
+normalization. Page/stream topology expansion, track the deduplicated count, and
+return ResourceExhausted before fully materializing, persisting, or dispatching
+when it exceeds 10,000. Apply the limits to Preview, Start, profiles, automation,
+and reconciliation; closed-loop admission is paged and stops at the per-event
+cap. Use protobuf `max_items` where possible and enforce active aggregate quotas
+transactionally before persisting a watcher/reservation.
 
 ### 4. Resolve targets and authorization once
 
@@ -339,7 +342,8 @@ Backend coverage:
   contain only removed generic device-set wire tags.
 - Candidate membership, deduplication, cooldowns, zero-member resources,
   wrong-type/deleted/cross-org IDs, direct-site racks, rack/building mismatch,
-  empty/cross-site groups, and unassigned resources.
+  empty/cross-site groups, unassigned resources, oversized single selectors,
+  and overlapping unions whose deduplicated expansion exceeds 10,000.
 - Frozen versus topology-following FULL_FLEET behavior, empty watchers,
   explicit-miner snapshot behavior, flagged explicit-miner policy,
   reservation conflicts, pairing transitions, fan-on admission (including

--- a/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
+++ b/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
@@ -304,9 +304,10 @@ admin requirement, topology, and quotas before claiming targets.
 1. Ship server parsing, schema versions, profile revisions, automation bindings,
    rejection of unknown nonempty scope keys, and a durable topology-scope
    feature gate without emitting topology scopes.
-2. Require every replica at that minimum version. Do not backfill or support
-   unversioned profiles, rules, or events; new records missing a required scope,
-   envelope, revision, or binding fail closed.
+2. Require every replica at that minimum version and verify there are zero
+   pre-contract profile, rule, or event rows. Any unexpected row blocks rollout;
+   do not backfill or support it. New records missing a required scope, envelope,
+   revision, or binding fail closed.
 3. Deploy the frontend that always sends the new version and explicit whole-org
    scope, raise the minimum accepted schema version, then open the feature gate.
    Rollback below the minimum server version requires disabling automation and

--- a/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
+++ b/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
@@ -69,9 +69,11 @@ Resolve topology membership on the backend, not in the browser:
 - A non-FULL_FLEET Start resolves current membership once, then freezes
   concrete miner targets in `curtailment_target`, matching existing open-loop
   behavior.
-- FULL_FLEET without `Target all paired miners` preserves the existing
-  closed-loop watcher: it may start with zero eligible miners, re-resolves the
-  logical union, and claims newly eligible in-scope miners at dispatch time.
+- FULL_FLEET without `Target all paired miners` preserves existing scope
+  behavior: whole-org/site selectors remain closed-loop and buildings/racks/
+  groups join that topology-following watcher, while explicit-miner selectors
+  remain snapshot-only. A mixed union watches its topology portion and includes
+  explicit miners only when they are eligible in the Start snapshot.
 - A response profile stores logical IDs, so each later manual or automation
   execution resolves the then-current members.
 - For FULL_FLEET with `Target all paired miners`, extend the durable closed-loop
@@ -300,23 +302,28 @@ with the proto source.
 - For cooldown lookup, use the already-resolved candidate identifiers (or add
   equivalent topology predicates) so a building/rack/group request cannot
   accidentally apply org-wide cooldown exclusions.
-- Keep non-FULL_FLEET event targets frozen. For every FULL_FLEET event, persist
-  the logical selector union and extend the existing closed-loop candidate
-  translation beyond whole-org/sites to buildings, racks, groups, and explicit
-  identifiers.
+- Keep non-FULL_FLEET event targets frozen. Persist the logical selector union
+  for closed-loop FULL_FLEET events and extend the existing watcher beyond
+  whole-org/sites to buildings, racks, and groups. Do not turn an unflagged
+  explicit-miner-only FULL_FLEET request into a watcher.
 - Preserve this lifecycle matrix:
   - Non-FULL_FLEET: resolve/freeze once; zero resolved miners fails as
     insufficient load.
   - FULL_FLEET without `force_include_all_paired_miners`: maintain the existing
-    eligible-miner watcher and admit newly eligible in-scope miners.
+    eligible-miner watcher for whole-org/site/building/rack/group selectors and
+    admit newly eligible members of those selectors. Explicit identifiers are
+    snapshot-only; an explicit-only empty selection completes as the existing
+    no-op rather than leaving a watcher.
   - FULL_FLEET with `force_include_all_paired_miners`: maintain the durable
-    paired-miner policy, including unavailable ownership and the
-    restore-before-release rules below.
-  Both FULL_FLEET variants may create a targetless watcher for a valid,
-  authorized logical selector. A targetless watcher sends no facility-fan
-  command until at least one miner is admitted and confirmed through the
-  normal sequencing gates; this never permits infrastructure-only or
-  missing-scope submissions.
+    paired-miner policy across the full union, deliberately including explicit
+    identifiers. This is new admin-only behavior: an explicitly selected
+    unpaired miner is logically reserved and admitted after pairing. Preserve
+    unavailable ownership and the restore-before-release rules below.
+  A topology-following FULL_FLEET scope, or a flagged explicit-miner policy,
+  may create a targetless watcher. A targetless watcher sends no facility-fan
+  command until at least one miner is admitted and confirmed through the normal
+  sequencing gates; this never permits infrastructure-only or missing-scope
+  submissions.
 - On every all-paired reconciliation pass, resolve the current union and:
   - admit miners that newly enter the selected topology or become paired,
   - retain paired-like unavailable miners under policy ownership,
@@ -330,9 +337,10 @@ with the proto source.
 - Apply the same topology scope to cooldown/admission queries and preserve the
   existing event/device exclusivity guarantees while targets are added,
   reopened, restored, or released.
-- Treat every active FULL_FLEET logical scope as a reservation, including
-  devices that currently match but are unpaired, unavailable, or not yet
-  represented by `curtailment_target`. Extend
+- Treat every active closed-loop FULL_FLEET logical scope as a reservation,
+  including devices that currently match but are unpaired, unavailable, or not
+  yet represented by `curtailment_target`. A flagged explicit-miner policy
+  participates in the same reservation path. Extend
   `CountCurtailmentScopeConflicts`, `ListActiveCurtailedDevicesByOrg`,
   `hierarchicalScopeSiteIDs`, and every direct `scope_jsonb` consumer to use one
   canonical typed-scope resolver rather than whole-org/site-only logic.
@@ -472,6 +480,10 @@ Backend unit/store/integration coverage:
   reconciliation ticks, explicit-miner reservations, unpair/re-pair gaps,
   deterministic older-event precedence, and a pre-owned miner moving into a
   watched topology with a surfaced/retried conflict.
+- FULL_FLEET lifecycle tests proving unflagged explicit-miner-only scope stays
+  snapshot-only and completes as a no-op when empty; mixed unflagged scope
+  watches only its topology portion; and the flagged admin policy deliberately
+  reserves/re-admits explicit identifiers after pairing.
 - Response-profile CRUD/list filtering and automation execution with each new
   scope, including a deleted or moved target that remains visible and
   deletable under its persisted authorization envelope but fails execution and
@@ -567,8 +579,11 @@ developer approval.
   targeting or reaches facility-fan dispatch; legacy persisted whole-org
   profiles are backfilled to the explicit representation during rollout.
 - Valid zero-member building/rack/group selectors fail non-FULL_FLEET Start,
-  but both FULL_FLEET variants may persist a targetless watcher and admit
-  future eligible members without commanding fans before a miner is confirmed.
+  but FULL_FLEET topology watchers may persist targetless and admit future
+  eligible members without commanding fans before a miner is confirmed.
+- Unflagged explicit-miner FULL_FLEET remains snapshot-only. The admin-only
+  all-paired flag deliberately makes explicit identifiers durable members of
+  the union, including admission after an explicitly selected miner pairs.
 - Active FULL_FLEET logical scopes reserve matching devices between
   reconciliation ticks; competing events cannot silently take newly eligible
   or newly assigned members.

--- a/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
+++ b/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
@@ -277,6 +277,12 @@ with the proto source.
 - Validate every submitted topology ID even when it currently contains zero
   miners. Return NotFound for deleted, wrong-type, or cross-org IDs rather than
   converting them into an empty/insufficient-load preview.
+- Resolve authorization coverage from both the selected topology resources and
+  their current members. A building contributes its owning site even when
+  empty; a rack contributes the site of its assigned building even when it has
+  no members; an unassigned building/rack requires org-wide authorization. A
+  group contributes every current member site, and an empty group requires
+  org-wide authorization because its future site coverage is unbounded.
 - Deduplicate candidates across overlapping selectors before classification.
 - For cooldown lookup, use the already-resolved candidate identifiers (or add
   equivalent topology predicates) so a building/rack/group request cannot
@@ -285,6 +291,13 @@ with the proto source.
   `force_include_all_paired_miners=true`, persist the logical selector union on
   the event and extend the reconciler's candidate-parameter translation beyond
   whole-org/sites to buildings, racks, groups, and explicit identifiers.
+- A normal non-policy Start with zero resolved miners fails as insufficient
+  load. A FULL_FLEET Start with `force_include_all_paired_miners=true` may
+  create a targetless policy watcher for a valid, authorized logical selector
+  so miners assigned or paired later can be admitted. The watcher owns no
+  concrete target and sends no facility-fan command until at least one miner is
+  admitted and confirmed through the normal sequencing gates; this exception
+  does not permit infrastructure-only or missing-scope submissions.
 - On every all-paired reconciliation pass, resolve the current union and:
   - admit miners that newly enter the selected topology or become paired,
   - retain paired-like unavailable miners under policy ownership,
@@ -303,8 +316,10 @@ with the proto source.
 
 - Add a single server-side scope-resolution result that reports:
   - validated selector IDs and types,
-  - the miner-covered site IDs,
-  - whether any selected resource/member is unassigned,
+  - site IDs contributed by selected building/rack resources,
+  - site IDs contributed by current miner members,
+  - whether any selected resource/member is unassigned or has unbounded future
+    coverage,
   - the resolved current device identifiers,
   - separately resolved facility-fan site IDs and unassigned status.
 - Reuse strict current-topology resolution for Preview, Start,
@@ -322,11 +337,12 @@ with the proto source.
   moved device; it must never admit a device outside the caller's or event's
   authorization envelope.
 - On response-profile Create/Update, persist the resolved authorization
-  envelope in the existing `scope_json`: exact miner-covered site IDs, exact
-  facility-fan site IDs, and separate org-wide authorization flags for either
-  dimension when site coverage is incomplete or unassigned. Preserve the
-  current `site:read` plus `curtailment:manage` checks for every fan site rather
-  than treating miner-scope authorization as permission to control fans.
+  envelope in the existing `scope_json`: the union of selected-resource and
+  current-member site coverage for miner selectors, exact facility-fan site
+  IDs, and separate org-wide authorization flags for either dimension when
+  coverage is incomplete, unassigned, or unbounded. Preserve the current
+  `site:read` plus `curtailment:manage` checks for every fan site rather than
+  treating miner-scope authorization as permission to control fans.
 - Backfill existing API-created profiles only where the original authorization
   envelope is provable from persisted scope: whole-org scope becomes
   org-wide miner authorization, and site-only scope with no facility fans
@@ -434,8 +450,15 @@ Backend unit/store/integration coverage:
 - Empty/unknown-scope tests proving Preview, Start, profile save/execution, and
   automation never infer whole organization and reject infrastructure-only or
   unknown-scope-plus-fan requests before any event, profile, target ownership,
-  or fan command is created. Cover explicit selectors that currently resolve
-  zero miners and assert execution fails without commanding fans.
+  or fan command is created. Prove a normal non-policy execution with a valid
+  zero-member selector fails without commanding fans, while an all-paired
+  FULL_FLEET execution persists a targetless watcher, sends no fan command,
+  later admits an assigned/paired miner, and only then follows normal fan
+  sequencing.
+- Authorization tests for empty buildings/racks using the resource's owning
+  site, unassigned buildings/racks requiring org-wide access, empty groups
+  requiring org-wide access, and cross-site groups requiring every current
+  member site while remaining bounded by their persisted envelope.
 - Rollout tests proving legacy persisted whole-org profiles backfill to the
   explicit representation and the updated frontend emits explicit whole-org
   scope before the server begins rejecting omitted submissions.
@@ -499,6 +522,9 @@ developer approval.
   unsupported, and infrastructure-only miner scope never widens to whole-org
   targeting or reaches facility-fan dispatch; legacy persisted whole-org
   profiles are backfilled to the explicit representation during rollout.
+- Valid zero-member building/rack/group selectors fail ordinary Start, but an
+  authorized all-paired FULL_FLEET policy may persist a targetless watcher and
+  admit future members without commanding fans before a miner is confirmed.
 - Whole-org/site all-paired behavior, explicit-miner targeting, facility-fan
   sequencing, and active/history displays keep working. Deprecated generic
   device-set wire input fails closed and is never persisted, executed as, or

--- a/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
+++ b/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
@@ -110,7 +110,7 @@ When an owned miner leaves scope or becomes unpaired:
   `useCurtailmentResponseProfiles.ts`, `CurtailmentSettingsPage.tsx`,
   `CurtailmentManagementPanel.tsx`, and `curtailmentMappers.ts`.
 - Treat scalar `scopeType`, `scopeId`, `siteId`, `siteSelection`, and
-  `minerSelectionMode` as derived UI/legacy fields, not independent targeting
+  `minerSelectionMode` as derived UI fields, not independent targeting
   inputs.
 - Ensure the typed IDs round-trip through Preview, Start, profile create/list/
   reload/edit, profile selection, Test curtailment, automation, event history,
@@ -159,12 +159,10 @@ When an owned miner leaves scope or becomes unpaired:
   every new Preview, Start, profile Create/Update, test, and automation path.
   Missing, unknown, unsupported, or infrastructure-only scope never widens to
   whole organization or reaches fan dispatch.
-- Backfill persisted empty-scope/absent-site whole-org profiles to explicit
-  `{"whole_org":true}` before omitted scopes are rejected.
 - Add a required scope-schema version to new submissions. Deploy server support
-  and the updated frontend, complete the backfill, then raise the minimum
-  accepted version before topology scopes are emitted. This rejects stale
-  browser tabs without retaining an old-client compatibility path.
+  before the updated frontend, then raise the minimum accepted version before
+  topology scopes are emitted. This rejects stale browser tabs rather than
+  supporting two request shapes.
 - Maintain an opaque profile revision that changes on every execution-affecting
   update: miner/fan scope, mode, power target, maintenance inclusion, all-paired
   or other admin controls, batching, and sequencing. Require it on profile
@@ -277,9 +275,8 @@ Create/Update/enable/execution. Use persisted envelopes for recovery operations:
 | Record state/operation | Behavior |
 | --- | --- |
 | Valid profile Get/List/Delete | Authorize against persisted miner/fan envelope; hydrate stale typed IDs without live topology. |
-| Profile with missing/unproven envelope | Org-wide `curtailment:manage`, plus org-wide `site:read` when fans exist; no current-location fallback. |
 | Stale profile resave/execution | Reject until stale IDs are explicitly removed/replaced. |
-| Automation Get/List/Delete/disable | Authorize against the bound envelope; if missing/unproven, require the same org-wide fallback as profiles. Remain available when profile topology or revision is stale. |
+| Automation Get/List/Delete/disable | Authorize against the bound envelope; remain available when profile topology or revision is stale. |
 | Automation Create/Update/enable/OFF start | Require strict topology, exact executable-profile revision/envelope, current principal permissions, and current Admin/SuperAdmin role for admin-only controls. |
 | Automation ON/stop with an active event | Restore from the event's durable targets and fan settings without requiring the current profile revision/topology/admin grant; never admit or recurtail targets. |
 
@@ -304,28 +301,16 @@ admin requirement, topology, and quotas before claiming targets.
 
 ### 7. Roll out fail-closed behavior safely
 
-1. Ship a compatibility-floor server that rejects unknown nonempty scope keys,
-   plus proto parsing, schema versions, profile revisions, automation bindings,
-   and a durable topology-scope feature gate, without emitting topology scopes.
-   Require every replica at this floor before opening the gate; rollback below
-   it requires disabling affected automation and draining topology events first.
-2. Deploy the frontend that always sends the new version and explicit
-   whole-org scope.
-3. Inventory and remediate persisted data:
-   - Backfill provable whole-org/site profile envelopes.
-   - Mark ambiguous profiles `reauthorization_required`.
-   - Inventory rules missing a proven revision, envelope, principal, or admin
-     marker; rebind/backfill or disable them while retaining org-wide-authorized
-     CRUD through the announced cutoff.
-   - Mark oversized profiles `scope_limit_remediation_required`; keep Get/List/
-     Delete and shrink-to-valid Update available.
-   - Backfill active event envelopes only when scope and principal prove the
-     boundary.
-4. Put ambiguous or oversized active events into no-admission drain mode:
-   continue confirmation, fan sequencing, restoration, release, and
-   terminalization from durable target rows without re-resolving logical scope.
-5. Gate enforcement on remediation/cutoff completion, raise the minimum schema
-   version, then enable topology-scope creation and emission.
+1. Ship server parsing, schema versions, profile revisions, automation bindings,
+   rejection of unknown nonempty scope keys, and a durable topology-scope
+   feature gate without emitting topology scopes.
+2. Require every replica at that minimum version. Do not backfill or support
+   unversioned profiles, rules, or events; new records missing a required scope,
+   envelope, revision, or binding fail closed.
+3. Deploy the frontend that always sends the new version and explicit whole-org
+   scope, raise the minimum accepted schema version, then open the feature gate.
+   Rollback below the minimum server version requires disabling automation and
+   draining topology-scoped events first.
 
 ## Verification
 
@@ -346,17 +331,17 @@ Backend coverage:
   wrong-type/deleted/cross-org IDs, direct-site racks, rack/building mismatch,
   empty/cross-site groups, and unassigned resources.
 - Frozen versus topology-following FULL_FLEET behavior, empty watchers,
-  explicit-miner snapshot compatibility, flagged explicit-miner policy,
+  explicit-miner snapshot behavior, flagged explicit-miner policy,
   reservation conflicts, pairing transitions, fan-on admission (including
   crash/concurrency recovery), and restore obligations.
 - Authorization races for empty watchers and moved fans, separate fan coverage,
-  stale CRUD recovery, missing envelopes, current permission revocation,
+  stale CRUD recovery, current permission revocation,
   Admin/SuperAdmin demotion, and current topology exceeding an envelope.
 - Full executable-profile revision coverage, automation binding races,
   `rebind_required`, stale rule management, ON/stop recovery after profile or
-  permission changes, and rollout remediation.
+  permission changes, and fail-closed rollout sequencing.
 - Raw/normalized and active-watcher quotas, paginated/time-budgeted overload
-  behavior with restore priority, oversized remediation, and safe event draining.
+  behavior with restore priority and admission backpressure.
 
 Run:
 
@@ -394,9 +379,8 @@ snapshots without explicit approval.
   but resave, enable, and execution fail closed until corrected or rebound.
 - Schema versions and opaque revisions prevent stale clients or profile races
   from broadening or silently retargeting a scope.
-- Rollout remediates ambiguous/oversized records and drains unsafe active events
-  without new admissions or stranded miners; the durable compatibility floor
-  prevents mixed-version execution or unsafe rollback of topology scopes.
+- The deployment gate prevents mixed-version execution; missing versioned scope,
+  envelope, revision, or binding data is rejected rather than preserved.
 - Response profiles reuse existing scope JSON; automation bindings use a new
   immutable up/down migration. Proto and generated output are committed
   together.

--- a/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
+++ b/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
@@ -282,11 +282,11 @@ with the proto source.
   - the covered site IDs,
   - whether any selected resource/member is unassigned,
   - the resolved current device identifiers.
-- Reuse it for Preview, Start, response-profile Create/Update/Get/List/Delete,
-  and automation-rule profile checks. Require `curtailment:manage` at every
-  covered site; require org-wide permission when scope coverage is incomplete
-  or includes unassigned resources. Picker filtering is usability only, never
-  authorization.
+- Reuse strict current-topology resolution for Preview, Start,
+  response-profile Create/Update, profile execution, and automation-rule
+  profile checks. Require `curtailment:manage` at every covered site; require
+  org-wide permission when scope coverage is incomplete or includes unassigned
+  resources. Picker filtering is usability only, never authorization.
 - Treat Preview as a point-in-time estimate, but make Start and every all-paired
   reconciliation admission atomic with authorization-envelope enforcement.
   Selector validation, membership expansion, current site coverage, and target
@@ -315,8 +315,13 @@ with the proto source.
   rule, and the event surfaces an actionable authorization-change reason. An
   org-wide-authorized event may continue following the selected topology across
   sites.
-- Apply the same resolution to profile list/get filtering so users never see or
-  mutate topology-scoped profiles outside their current grant.
+- Do not require current topology resolution for response-profile Get/List or
+  Delete. Authorize those operations against the profile's persisted
+  authorization envelope and hydrate its stored typed IDs even when a target
+  was deleted or moved. Surface unresolved targets as unavailable/stale so an
+  authorized operator can inspect, edit, or delete the profile; Create/Update
+  and every execution path still perform strict current-topology validation,
+  so a stale ID must be removed or replaced before resave and can never execute.
 
 ### 6. Cover manual and automated execution
 
@@ -367,7 +372,9 @@ Backend unit/store/integration coverage:
   response-profile create/update, automation execution, and forged oversized
   persisted scopes.
 - Response-profile CRUD/list filtering and automation execution with each new
-  scope.
+  scope, including a deleted or moved target that remains visible and
+  deletable under its persisted authorization envelope but fails execution and
+  resave until corrected.
 - Regression coverage for whole-org, multi-site, explicit-miner, and
   facility-fan behavior; assert no generic device-set scope state remains in
   frontend/domain/storage models.
@@ -414,6 +421,9 @@ developer approval.
   with actionable errors and never broaden to whole-org scope. Unassigned
   in-org targets are admitted only when the caller has org-wide
   `curtailment:manage`; otherwise they are treated as uncovered and rejected.
+- A saved profile with a later-deleted or moved target remains visible and
+  deletable to operators authorized for its persisted envelope, renders the
+  unresolved target as stale, and fails strict resave or execution until fixed.
 - Whole-org/site all-paired behavior, explicit-miner targeting, facility-fan
   sequencing, and active/history displays keep working. Deprecated generic
   device-set wire input fails closed and is never persisted, executed as, or

--- a/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
+++ b/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
@@ -136,8 +136,10 @@ When an owned miner leaves scope or becomes unpaired:
 - Preserve existing off-site selections when editing under a narrower topbar
   filter or when the operator cannot open a picker.
 - Add resource-aware picker permissions instead of plain `useHasPermission`:
-  evaluate the selected site grants and use site-filtered building/rack/group
-  catalog handlers that authenticate/derive the org before scoped authorization.
+  authenticate/derive the org, evaluate selected-site grants, and filter each
+  catalog by full authorization coverage. For groups, evaluate every current
+  member site—not an any-member site match—and hide or disable groups with
+  unauthorized or unbounded coverage.
   Hide a control only when no authorized resource remains; hide rack/group miner
   facets when the scoped role lacks `rack:read`, matching Schedules.
 - Allow **Target all paired miners** for FULL_FLEET with any site/building/rack/

--- a/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
+++ b/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
@@ -264,10 +264,24 @@ with the proto source.
 - Preserve existing persisted response profiles whose empty legacy
   `scope_json` plus absent `site_id` means whole organization, but backfill them
   to explicit `{"whole_org":true}` before enabling the new submission rules.
-  Because there are no old clients, deploy the frontend change that always
-  emits explicit Whole organization first, complete the data backfill, then
-  make server Create/Update/Preview/Start reject omitted scopes. This is a
-  coordinated contract cleanup, not a capability-negotiation path.
+  There are no supported old clients, but a browser tab opened before the
+  frontend deployment can still submit the old shape. Add a required scope-
+  schema version to every Create/Update/Preview/Start request, including test
+  curtailments and profile-derived starts. Deploy server support and the
+  frontend that always emits the new version and explicit Whole organization,
+  complete the data backfill, then raise the server's minimum accepted version
+  before any building/rack/group scope can be created or returned. Reject a
+  missing, old, or unknown version rather than interpreting its recognized
+  subset. This is a bounded cutover guard, not a retained old-client runtime
+  compatibility path.
+- Give each response profile an opaque scope revision derived from its canonical
+  persisted miner/fan scope. Return it from Get/List and require an exact match
+  on Update and every profile-derived execution. The server must load and use
+  the matching stored logical scope instead of trusting a client-expanded copy;
+  stale or missing revisions fail with a refresh-required error. Together with
+  the minimum schema version, this prevents a stale tab that ignores unknown
+  topology cases from overwriting or running a narrow profile as explicit
+  Whole organization.
 - Add `max_items` validation to every repeated scope/identifier field and
   domain validation for raw pre-deduplication totals and normalized per-type/
   aggregate selector limits. Enforce the transport byte cap before decoding and
@@ -305,10 +319,14 @@ with the proto source.
   converting them into an empty/insufficient-load preview.
 - Resolve authorization coverage from both the selected topology resources and
   their current members. A building contributes its owning site even when
-  empty; a rack contributes the site of its assigned building even when it has
-  no members; an unassigned building/rack requires org-wide authorization. A
-  group contributes every current member site, and an empty group requires
-  org-wide authorization because its future site coverage is unbounded.
+  empty. A rack contributes `device_set_rack.site_id` even when it has no
+  building or members; if that field is NULL, the rack requires org-wide
+  authorization. When a rack also has a building, validate that the building's
+  site agrees with the rack's site and reject inconsistent topology rather than
+  silently selecting either value. An unassigned building also requires
+  org-wide authorization. A group contributes every current member site, and
+  an empty group requires org-wide authorization because its future site
+  coverage is unbounded.
 - Deduplicate candidates across overlapping selectors before classification.
 - For cooldown lookup, use the already-resolved candidate identifiers (or add
   equivalent topology predicates) so a building/rack/group request cannot
@@ -407,6 +425,13 @@ with the proto source.
   missing or unproven envelope; it must never derive authority from a miner's
   or fan's current site at execution time. Surface this state in profile
   Get/List so it can be fixed or deleted.
+- Before enforcing profile envelopes, inventory every enabled automation rule
+  that references a profile marked `reauthorization_required`, expose the
+  affected rules and profiles to operators, and reauthorize or disable them.
+  Gate enforcement on that inventory reaching zero, unless owners explicitly
+  approve an announced cutoff for the remaining rules. After the gate, keep
+  execution fail closed; do not temporarily infer an envelope to preserve an
+  unremediated automation.
 - Bind every automation rule execution to an explicit user or service-account
   principal; the stored envelope is a maximum boundary, not a durable
   capability. At every trigger, reload that principal's current effective
@@ -429,6 +454,15 @@ with the proto source.
   remain degraded until safe restoration completes. An org-wide envelope may
   follow topology across sites only while the principal still has the required
   live org-wide permissions.
+- Before requiring envelopes on reconciliation, inventory active closed-loop
+  events created by the old schema. Backfill an envelope only when the event's
+  persisted whole-org/site scope and original authorizing principal prove the
+  exact boundary. If either is absent or ambiguous, place the event in explicit
+  drain mode: admit no new targets and do not re-resolve its logical scope, but
+  continue confirmation, fan sequencing, safe restoration, ownership release,
+  and terminalization from durable target rows. Run this migration before the
+  reconciler begins rejecting missing envelopes so an upgrade cannot either
+  widen authority or strand already-curtailed miners.
 - Do not require current topology resolution for response-profile Get/List or
   Delete. Authorize those operations against the profile's persisted
   miner and facility-fan envelope dimensions, including `site:read` on fan
@@ -531,13 +565,25 @@ Backend unit/store/integration coverage:
   FULL_FLEET execution persists a targetless watcher, sends no fan command,
   later admits an assigned/paired miner, and only then follows normal fan
   sequencing.
-- Authorization tests for empty buildings/racks using the resource's owning
-  site, unassigned buildings/racks requiring org-wide access, empty groups
-  requiring org-wide access, and cross-site groups requiring every current
-  member site while remaining bounded by their persisted envelope.
+- Authorization tests for empty buildings using the resource's owning site,
+  building-less racks using `device_set_rack.site_id`, rack/building site
+  mismatches failing closed, NULL-site racks and unassigned buildings requiring
+  org-wide access, empty groups requiring org-wide access, and cross-site groups
+  requiring every current member site while remaining bounded by their
+  persisted envelope.
 - Rollout tests proving legacy persisted whole-org profiles backfill to the
   explicit representation and the updated frontend emits explicit whole-org
-  scope before the server begins rejecting omitted submissions.
+  scope before the server begins rejecting omitted submissions. Cover a stale
+  browser missing the minimum scope-schema version, an unknown topology case,
+  profile update/execution with a missing or stale scope revision, and a valid
+  refreshed profile-derived execution that uses the server-stored scope.
+- Authorization-envelope rollout tests for active closed-loop events: provable
+  whole-org/site boundaries retain reconciliation, while an event with an
+  ambiguous scope or principal enters no-admission drain mode and completes
+  safe restoration from durable targets.
+- Automation rollout tests inventory enabled rules bound to profiles requiring
+  reauthorization, prevent enforcement before remediation or an explicit
+  cutoff, and fail closed after cutover without silently widening scope.
 - Selector-limit rollout tests covering inventory of legacy API-created
   oversized profiles/events, readable and deletable remediation state,
   shrink-only updates, automation cutoff, and an active oversized event that
@@ -601,6 +647,10 @@ developer approval.
   or are marked as requiring operator reauthorization. Automation cannot run a
   profile with a missing or unproven envelope, and only an operator with the
   required org-wide permissions can view, delete, or reauthorize it.
+- Scope-schema version enforcement rejects stale browser submissions before
+  topology scopes are exposed, and profile updates/executions require a matching
+  opaque scope revision and use the server-stored canonical scope. An unknown
+  topology case can never round-trip as intentional Whole organization.
 - Response-profile envelopes independently cover miner and facility-fan sites;
   profile CRUD and execution preserve both `site:read` and
   `curtailment:manage` requirements for every selected fan site.
@@ -608,6 +658,10 @@ developer approval.
   principal. Automation triggers and reconciliation require that principal's
   current effective permissions; revocation blocks admission and safely
   restores owned targets instead of leaving the envelope as a perpetual grant.
+- Legacy active closed-loop events receive a provable envelope and principal or
+  enter no-admission drain mode before envelope enforcement begins. Enabled
+  automations referencing ambiguous profiles are inventoried and remediated or
+  explicitly cut off before enforcement, then remain fail closed.
 - Whole organization is explicit for every new submission. Empty, unknown,
   unsupported, and infrastructure-only miner scope never widens to whole-org
   targeting or reaches facility-fan dispatch; legacy persisted whole-org

--- a/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
+++ b/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
@@ -747,5 +747,8 @@ developer approval.
   sequencing, and active/history displays keep working. Deprecated generic
   device-set wire input fails closed and is never persisted, executed as, or
   widened to a new topology scope.
-- Proto source and generated output are committed together; no schema migration
-  is added unless implementation proves JSON persistence is insufficient.
+- Proto source and generated output are committed together. Response-profile
+  topology and envelope persistence reuse the existing scope JSON unless
+  implementation proves that insufficient; the durable automation binding
+  fields explicitly require a new immutable up/down schema migration committed
+  with their sqlc source and generated output.

--- a/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
+++ b/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
@@ -175,11 +175,12 @@ Persist the same envelope and authorizing-principal reference on every
 closed-loop FULL_FLEET event, with or without the all-paired flag; frozen
 non-FULL_FLEET and unflagged explicit-miner events continue to rely on
 authorization at Preview/Start plus their concrete target rows.
-Add an automation-rule migration for a bound profile scope revision and bound
-miner/fan authorization envelope. These fields preserve the exact profile
-scope an operator authorized when the rule was created, updated, or enabled;
-they are also the stable authorization source for managing a rule after its
-profile topology becomes stale.
+Add an automation-rule migration for a bound profile scope revision, bound
+miner/fan authorization envelope, and required-admin-controls marker. These
+fields preserve the exact profile scope and privilege class an operator
+authorized when the rule was created, updated, or enabled; they are also the
+stable authorization source for managing a rule after its profile topology
+becomes stale.
 
 Generated protobuf output must be regenerated with `just gen` and committed
 with the proto source.
@@ -438,8 +439,8 @@ with the proto source.
 - Before enforcing profile envelopes or bound-revision checks, inventory every
   enabled automation rule that references a profile marked
   `reauthorization_required` or lacks a proven bound revision, envelope, or
-  execution principal. Expose the affected rules and profiles to operators and
-  reauthorize/rebind or disable them. Gate enforcement on that inventory
+  execution principal/admin-control requirement. Expose the affected rules and
+  profiles to operators and reauthorize/rebind or disable them. Gate enforcement on that inventory
   reaching zero, unless owners explicitly approve an announced cutoff for the
   remaining rules. After the gate, keep execution fail closed; do not
   temporarily infer binding state to preserve an unremediated automation.
@@ -450,9 +451,17 @@ with the proto source.
   both the live permissions and stored envelope to authorize the operation. A
   deactivated principal or revoked grant blocks execution. Do not fall back to
   the profile creator or an ambient system principal.
+- Record whether an automation binding or event uses admin-only controls,
+  including `force_include_all_paired_miners`. Every manual/profile execution,
+  automation trigger, and closed-loop reconciliation pass must separately
+  revalidate that the current principal is still Admin or SuperAdmin; site/org
+  `curtailment:manage` alone is insufficient. Demotion blocks new events and
+  admissions. An active event then stops expansion and retains already-owned
+  targets through the same fan-aware safe restore-before-release lifecycle.
 - Stamp the applicable authorization envelope and authorizing principal onto
-  every closed-loop FULL_FLEET event, not only all-paired events. Each
-  reconciliation pass must reload the principal's current effective
+  every closed-loop FULL_FLEET event, not only all-paired events, together with
+  its required-admin-controls marker. Each reconciliation pass must reload the
+  principal's current effective
   permissions and compare current topology/fan coverage with both those
   permissions and the envelope before admitting targets. A rack or building
   moved to another site, a group gaining an out-of-envelope member, a fan
@@ -506,14 +515,16 @@ with the proto source.
   and enable requests. In the same database transaction that saves or enables
   the rule, lock and reload the profile, compare its canonical scope revision
   and authorization envelope with the values authorized by the handler, and
-  persist that revision, envelope, and execution principal as the rule's bound
-  profile state. Extend the existing store-side facility-fan race check rather
-  than leaving scope validation only in the handler. Any mismatch returns
+  persist that revision, envelope, execution principal, and whether the profile
+  requires admin-only controls as the rule's bound profile state. Extend the
+  existing store-side facility-fan race check rather than leaving scope or
+  privilege validation only in the handler. Any mismatch returns
   FailedPrecondition and saves nothing.
 - At every trigger, require the current profile revision to equal the rule's
   bound revision before resolving or starting an event, then enforce the bound
-  envelope and the execution principal's current permissions. A profile scope
-  change never silently retargets an enabled rule: the revision mismatch makes
+  envelope, the execution principal's current permissions, and any bound Admin/
+  SuperAdmin requirement. A profile scope change never silently retargets an
+  enabled rule: the revision mismatch makes
   linked bindings report `rebind_required`, blocks event and fan creation, and
   requires an authorized operator to review the current profile and re-enable/
   rebind the rule.
@@ -595,7 +606,8 @@ Backend unit/store/integration coverage:
 - Automation binding race tests that change a profile's scope or envelope
   between handler authorization and the store transaction. Create, Update, and
   enable must fail atomically on an expected-revision/envelope mismatch; a
-  successful bind persists the exact revision, envelope, and principal.
+  successful bind persists the exact revision, envelope, principal, and admin-
+  control requirement.
 - Automation trigger tests proving a later profile-scope revision puts the rule
   in `rebind_required`, creates no event or fan command, and resumes only after
   an authorized rebind. Disabling and deleting the mismatched rule must not
@@ -607,8 +619,9 @@ Backend unit/store/integration coverage:
   failing closed before reauthorization.
 - Current-permission tests for automation owner deactivation, site-grant and
   org-wide-grant revocation, facility-fan `site:read` revocation, service-account
-  principals, and mid-event revocation that blocks admission and safely
-  restores existing ownership for both ordinary and all-paired FULL_FLEET.
+  principals, Admin/SuperAdmin demotion for admin-only profiles/events, and
+  mid-event revocation or demotion that blocks admission and safely restores
+  existing ownership for both ordinary and all-paired FULL_FLEET.
 - Facility-fan authorization tests for a fan outside the miner scope, fan site
   movement, unassigned/stale fans, `site:read` without `curtailment:manage` and
   vice versa, CRUD/list filtering against persisted fan-site coverage, and
@@ -638,7 +651,8 @@ Backend unit/store/integration coverage:
   ambiguous scope or principal enters no-admission drain mode and completes
   safe restoration from durable targets.
 - Automation rollout tests inventory enabled rules bound to profiles requiring
-  reauthorization or missing a proven bound revision, envelope, or principal;
+  reauthorization or missing a proven bound revision, envelope, principal, or
+  admin-control requirement;
   prevent enforcement before rebind/disable remediation or an explicit cutoff;
   preserve authorized read/disable/delete recovery; and fail closed after
   cutover without silently widening scope.
@@ -710,9 +724,9 @@ developer approval.
   opaque scope revision and use the server-stored canonical scope. An unknown
   topology case can never round-trip as intentional Whole organization.
 - Automation rules bind atomically to an exact profile scope revision, miner/
-  fan envelope, and execution principal. A profile-scope change blocks triggers
-  as `rebind_required` until an authorized rebind; it never silently retargets
-  an enabled rule.
+  fan envelope, execution principal, and required admin-control state. A
+  profile-scope change blocks triggers as `rebind_required` until an authorized
+  rebind; it never silently retargets an enabled rule.
 - Stale or revision-mismatched automation rules remain visible, disableable, and
   deletable under their bound envelope without current-topology resolution.
   Create, Update, enable, and execution still fail closed on stale topology,
@@ -724,6 +738,10 @@ developer approval.
   principal. Automation triggers and reconciliation require that principal's
   current effective permissions; revocation blocks admission and safely
   restores owned targets instead of leaving the envelope as a perpetual grant.
+- Admin-only profiles, rules, and events persist that privilege requirement and
+  recheck the principal's current Admin/SuperAdmin role at execution and every
+  reconciliation pass. Demotion blocks new work and safely restores active
+  ownership even when `curtailment:manage` remains granted.
 - Legacy active closed-loop events receive a provable envelope and principal or
   enter no-admission drain mode before envelope enforcement begins. Enabled
   automations referencing ambiguous profiles or lacking proven binding state

--- a/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
+++ b/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
@@ -74,11 +74,16 @@ Resolve topology membership on the backend, not in the browser:
 - For FULL_FLEET with `Target all paired miners`, extend the durable closed-loop
   policy to every composable miner selector: sites, buildings, racks, groups,
   and explicit miners. The reconciler re-resolves the union while the event is
-  active, admits newly paired/in-scope miners, and releases miners that become
-  unpaired or leave the selected topology. A truly UNPAIRED miner cannot
-  receive commands and remains outside ownership until it becomes paired;
-  paired-like but temporarily unavailable miners retain the existing
-  `UNAVAILABLE` behavior.
+  active and admits newly paired/in-scope miners. A newly considered UNPAIRED
+  miner cannot receive commands and remains outside ownership until it becomes
+  paired; paired-like but temporarily unavailable miners retain the existing
+  `UNAVAILABLE` behavior. When an owned target becomes unpaired or leaves the
+  selected topology, release it immediately only if no Curtail command could
+  have been dispatched. A dispatched or confirmed target becomes a durable
+  restore obligation: retain ownership and use the normal safe restore
+  lifecycle before release. If it is unreachable or unpaired, retry after it
+  becomes commandable; if facility fans are off, defer miner restoration until
+  the existing fan-before-miner restore sequence makes restoration safe.
 
 Use explicit proto cases for buildings, racks, and groups rather than encoding
 racks and groups into the legacy `device_set_ids` case. This preserves target
@@ -125,6 +130,15 @@ feature satisfies the repository's Buf `FILE` compatibility policy; do not add
 new runtime/storage support or reinterpret those numbers as buildings, racks,
 or groups. Remove the deprecated declarations in a separate intentional API
 cleanup if the repository's breaking-change policy is relaxed for them.
+
+Bound selector cardinality using named shared constants: at most 256 IDs for
+each topology type (sites, buildings, racks, and groups), at most 1,024 topology
+IDs across the normalized union, at most 10,000 explicit device identifiers,
+and at most 1,024 repeated `CurtailmentScope` entries. Apply protobuf
+`max_items` validation where the wire shape permits and enforce the normalized
+per-type/aggregate limits again in the domain for direct requests, response
+profiles, automation execution, and persisted all-paired reconciliation. The
+frontend mirrors these limits for usability; the server remains authoritative.
 
 Extend the Go domain `Scope` and JSON codec with `building_ids`, `rack_ids`, and
 `group_ids`, and remove generic `DeviceSetIDs`/`device_set_ids` domain and JSON
@@ -210,6 +224,9 @@ with the proto source.
   `MarshalScopeJSON`, and `ScopeFromJSON`.
 - Ensure a whole-org entry still dominates narrower selectors and mixed
   entries are normalized/deduplicated deterministically.
+- Add `max_items` validation to every repeated scope/identifier field and
+  domain validation for the normalized per-type and aggregate selector limits.
+  Reject oversized persisted profile/event scopes before resolving them.
 - Remove generic device-set translation, domain/JSON decode/render paths,
   frontend `deviceSetIds` scope state, and the special unsupported-device-set
   preview branch. Keep only deprecated protobuf declarations/field numbers as
@@ -247,11 +264,16 @@ with the proto source.
 - On every all-paired reconciliation pass, resolve the current union and:
   - admit miners that newly enter the selected topology or become paired,
   - retain paired-like unavailable miners under policy ownership,
-  - release miners that leave every selected selector or become UNPAIRED,
+  - immediately release miners that leave every selector or become UNPAIRED
+    only when no Curtail command could have been dispatched,
+  - move dispatched or confirmed miners that leave scope into the existing safe
+    restore lifecycle and retain ownership until restore confirmation,
+  - persist and retry restore obligations for unreachable/unpaired miners, and
+    respect facility-fan sequencing before issuing their restore command,
   - deduplicate miners that match multiple selector categories.
 - Apply the same topology scope to cooldown/admission queries and preserve the
   existing event/device exclusivity guarantees while targets are added,
-  reopened, or released.
+  reopened, restored, or released.
 
 ### 5. Make authorization fail closed
 
@@ -265,6 +287,15 @@ with the proto source.
   covered site; require org-wide permission when scope coverage is incomplete
   or includes unassigned resources. Picker filtering is usability only, never
   authorization.
+- Treat Preview as a point-in-time estimate, but make Start and every all-paired
+  reconciliation admission atomic with authorization-envelope enforcement.
+  Selector validation, membership expansion, current site coverage, and target
+  claim/insertion must use one transaction/locked snapshot, or every
+  materialized device and current site must be revalidated inside the target
+  claim transaction. Dispatch starts only after that transaction commits.
+  A concurrent topology move must make the claim fail/retry or exclude the
+  moved device; it must never admit a device outside the caller's or event's
+  authorization envelope.
 - On response-profile Create/Update, persist the resolved authorization
   envelope in the existing `scope_json`: exact covered site IDs for narrowed
   authorization, or `org_wide_authorized=true` when org-wide permission was
@@ -280,9 +311,10 @@ with the proto source.
   authorization envelope onto the event. Each reconciliation pass must compare
   current topology coverage with that envelope before admitting targets.
   Out-of-envelope miners are not admitted, already-owned miners that move
-  outside the envelope are released, and the event surfaces an actionable
-  authorization-change reason. An org-wide-authorized event may continue
-  following the selected topology across sites.
+  outside the envelope follow the same dispatch-aware restore-before-release
+  rule, and the event surfaces an actionable authorization-change reason. An
+  org-wide-authorized event may continue following the selected topology across
+  sites.
 - Apply the same resolution to profile list/get filtering so users never see or
   mutate topology-scoped profiles outside their current grant.
 
@@ -325,10 +357,15 @@ Backend unit/store/integration coverage:
 - Cooldown, active-event exclusion, fixed-kW, and full-fleet selection over
   each topology scope.
 - All-paired reconciliation for building/rack/group membership additions,
-  removals, cross-selector overlap, unpair/re-pair transitions, and paired-like
-  unavailable miners.
+  removals before dispatch, removals after confirmed curtailment, cross-selector
+  overlap, unpair/re-pair restore retries, facility-fan sequencing, and
+  paired-like unavailable miners.
 - Authorization for one-site, multi-site, cross-site group, unassigned,
-  narrowed-role, and topology-change-after-profile-save cases.
+  narrowed-role, and topology-change-after-profile-save cases, including race
+  tests that move topology across sites between resolution and target claim.
+- Per-type and aggregate selector-limit tests for direct Preview/Start,
+  response-profile create/update, automation execution, and forged oversized
+  persisted scopes.
 - Response-profile CRUD/list filtering and automation execution with each new
   scope.
 - Regression coverage for whole-org, multi-site, explicit-miner, and
@@ -365,8 +402,14 @@ developer approval.
   affect future profile executions, not the in-flight event.
 - FULL_FLEET events with `Target all paired miners` continuously re-resolve the
   selected site/building/rack/group/miner union: newly paired or newly assigned
-  miners are admitted, while unpaired or no-longer-in-scope miners are
-  released.
+  miners are admitted. Unpaired or no-longer-in-scope miners are released
+  immediately only when undispatched; any miner that may already be curtailed
+  remains owned until it completes the safe restore lifecycle.
+- Start and each reconciliation pass atomically bind topology membership,
+  authorization-envelope validation, and target claim before dispatch, so a
+  concurrent cross-site move cannot admit an unauthorized miner.
+- Per-type and aggregate selector limits bound direct and persisted scope
+  resolution and are enforced server-side after normalization.
 - Deleted, wrong-type, cross-org, unassigned, or unauthorized topology targets
   fail closed with actionable errors and never broaden to whole-org scope.
 - Whole-org/site all-paired behavior, explicit-miner targeting, facility-fan

--- a/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
+++ b/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
@@ -218,10 +218,10 @@ membership, logical reservation, and facility fan—not only concrete miners.
 Lock relevant topology rows or compare topology revisions; dispatch only after
 commit.
 
-Replace Preview/Start's org-scoped `RequirePermission(..., ResourceContext{})`
-entry gates with authentication/org derivation followed by the resolver's
-scoped requirement check; otherwise site-scoped grants can never reach this
-authorization path.
+Replace the org-scoped `RequirePermission(..., ResourceContext{})` entry gates
+across Preview/Start and response-profile/automation RPCs with authentication/
+org derivation followed by their scoped resolver or persisted-envelope checks;
+otherwise site-scoped grants cannot reach those authorization paths.
 
 On profile Create/Update, persist the union of selected-resource and current-
 member site coverage plus the independent fan-site coverage in `scope_json`,

--- a/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
+++ b/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
@@ -154,10 +154,11 @@ When an owned miner leaves scope or becomes unpaired:
   and the updated frontend, complete the backfill, then raise the minimum
   accepted version before topology scopes are emitted. This rejects stale
   browser tabs without retaining an old-client compatibility path.
-- Derive and return an opaque revision from each profile's canonical miner/fan
-  scope. Require it on profile Update, profile-derived execution, and
-  automation Create/Update/enable; the server reloads the matching stored scope
-  instead of trusting a client-expanded copy.
+- Maintain an opaque profile revision that changes on every execution-affecting
+  update: miner/fan scope, mode, power target, maintenance inclusion, all-paired
+  or other admin controls, batching, and sequencing. Require it on profile
+  Update, profile-derived execution, and automation Create/Update/enable; reload
+  the matching stored profile and recompute its required-admin marker.
 
 Bound inputs before expensive resolution:
 
@@ -206,9 +207,11 @@ Authorization coverage follows these rules:
 
 Require `curtailment:manage` for every miner site and org-wide permission for
 unassigned/unbounded coverage. Bind selector validation, membership expansion,
-site coverage, envelope validation, and target claim in one locked transaction
-or revalidate each materialized target inside the claim transaction. Dispatch
-only after commit.
+site coverage, envelope validation, and target claim in one transaction. Within
+it, re-resolve and reauthorize every original selector, selected resource,
+membership, logical reservation, and facility fan—not only concrete miners.
+Lock relevant topology rows or compare topology revisions; dispatch only after
+commit.
 
 On profile Create/Update, persist the union of selected-resource and current-
 member site coverage plus the independent fan-site coverage in `scope_json`,
@@ -250,10 +253,11 @@ Create/Update/enable/execution. Use persisted envelopes for recovery operations:
 | Profile with missing/unproven envelope | Org-wide `curtailment:manage`, plus org-wide `site:read` when fans exist; no current-location fallback. |
 | Stale profile resave/execution | Reject until stale IDs are explicitly removed/replaced. |
 | Automation Get/List/Delete/disable | Authorize against the rule's bound envelope; remain available when profile topology or revision is stale. |
-| Automation Create/Update/enable/trigger | Require strict topology, exact profile revision/envelope, current principal permissions, and current Admin/SuperAdmin role for admin-only controls. |
+| Automation Create/Update/enable/OFF start | Require strict topology, exact executable-profile revision/envelope, current principal permissions, and current Admin/SuperAdmin role for admin-only controls. |
+| Automation ON/stop with an active event | Restore from the event's durable targets and fan settings without requiring the current profile revision/topology/admin grant; never admit or recurtail targets. |
 
-Add immutable up/down migrations for automation-rule binding fields: profile
-scope revision, miner/fan envelope, execution principal, and required-admin
+Add immutable up/down migrations for automation-rule binding fields: executable-
+profile revision, miner/fan envelope, execution principal, and required-admin
 marker. In the same transaction that saves/enables a rule, lock the profile,
 compare the handler-authorized revision/envelope, and persist that exact
 binding. Extend the existing store-side fan-settings race check; mismatch
@@ -262,10 +266,11 @@ returns FailedPrecondition without saving.
 Reload the bound user or service-account permissions at every trigger; never
 fall back to the profile creator or an ambient system principal.
 
-At each trigger, compare the current profile revision with the bound revision
-before creating an event or fan action. A mismatch reports `rebind_required`
-until an authorized operator reviews and re-enables the rule. Disable/Delete do
-not require a current revision or strict topology.
+Before an OFF/start or recurtail action, compare the current profile revision
+with the bound revision; mismatch reports `rebind_required`. An authenticated
+ON/stop for an already-owned event must always follow its durable restore path,
+even after profile change/deletion, permission loss, or admin demotion.
+Disable/Delete likewise do not require a current revision or strict topology.
 
 ### 7. Roll out fail-closed behavior safely
 
@@ -308,11 +313,12 @@ Backend coverage:
 - Frozen versus topology-following FULL_FLEET behavior, empty watchers,
   explicit-miner snapshot compatibility, flagged explicit-miner policy,
   reservation conflicts, pairing transitions, and restore obligations.
-- Authorization races, separate fan coverage, stale CRUD recovery, missing
-  envelopes, current permission revocation, Admin/SuperAdmin demotion, and
-  current topology exceeding an envelope.
-- Automation binding races, `rebind_required`, stale rule management, and
-  rollout remediation.
+- Authorization races for empty watchers and moved fans, separate fan coverage,
+  stale CRUD recovery, missing envelopes, current permission revocation,
+  Admin/SuperAdmin demotion, and current topology exceeding an envelope.
+- Full executable-profile revision coverage, automation binding races,
+  `rebind_required`, stale rule management, ON/stop recovery after profile or
+  permission changes, and rollout remediation.
 - Raw/normalized limits, oversized-record remediation, and safe active-event
   draining.
 

--- a/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
+++ b/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
@@ -205,6 +205,11 @@ with the proto source.
 - Reuse/extract the Schedule building, rack, and group selection modals,
   including select-all, empty/error states, stale selection preservation, and
   site filters.
+- Do not reuse the Schedule pickers' current behavior of pruning IDs absent
+  from the live inventory. Add an explicit curtailment/profile mode that keeps
+  stored missing IDs selected, renders them from hydrated profile metadata (or
+  their ID) as unavailable/stale, and removes them only through an operator's
+  explicit action. Preserve the existing pruning behavior for Schedule callers.
 - Pass the topbar-derived `SiteFilterFields` from both parent flows. Pass the
   same scope to the miner selector and hide rack/group miner facets when the
   current role lacks `rack:read`, following `ScheduleModal`.
@@ -337,6 +342,11 @@ with the proto source.
   authorized operator can inspect, edit, or delete the profile; Create/Update
   and every execution path still perform strict current-topology validation,
   so a stale ID must be removed or replaced before resave and can never execute.
+- When a profile has a missing or unproven authorization envelope, require
+  org-wide `curtailment:manage` for Get/List/Delete and reauthorization. Do not
+  fall back to current topology or current miner locations to grant access.
+  Site-scoped operators do not see the profile until an org-wide operator
+  establishes a proven envelope or deletes it.
 
 ### 6. Cover manual and automated execution
 
@@ -358,6 +368,9 @@ Frontend unit/component coverage:
 - Shared modal tests in both variants for buttons, selection counts, clear/
   select-all, active-site filtering, stale selection preservation, and
   permission-gated pickers.
+- Picker tests proving the curtailment/profile mode retains and labels missing
+  rack/group IDs until explicit removal while Schedule mode keeps its existing
+  pruning behavior.
 - Response-profile API tests proving create/update payloads and list/reload
   hydration retain each target type without relying on the in-memory session
   cache.
@@ -392,8 +405,9 @@ Backend unit/store/integration coverage:
   resave until corrected.
 - Authorization-envelope rollout tests for provable whole-org/site backfills,
   explicit-miner and mixed profiles requiring reauthorization, a miner moving
-  sites before reauthorization, and automation failing closed while the
-  envelope is missing or unproven.
+  sites before reauthorization, org-wide-only Get/List/Delete access while the
+  envelope is missing or unproven, site-scoped filtering, and automation
+  failing closed before reauthorization.
 - Empty/unknown-scope tests proving Preview, Start, profile save/execution, and
   automation never infer whole organization; cover an intentional
   infrastructure-only plan separately.
@@ -448,7 +462,8 @@ developer approval.
   unresolved target as stale, and fails strict resave or execution until fixed.
 - Existing profiles receive a provable whole-org/site authorization envelope
   or are marked as requiring operator reauthorization. Automation cannot run a
-  profile with a missing or unproven envelope.
+  profile with a missing or unproven envelope, and only an org-wide manager can
+  view, delete, or reauthorize it.
 - Whole organization is always explicit. Empty, unknown, or unsupported miner
   scope never widens to whole-org targeting.
 - Whole-org/site all-paired behavior, explicit-miner targeting, facility-fan

--- a/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
+++ b/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
@@ -169,10 +169,11 @@ with the proto source.
     `deviceIdentifiers`.
   Keep target names/labels and Infrastructure fields outside this semantic
   scope object.
-- Require Whole organization to be an explicit selection. An empty or
-  unrecognized miner scope must never default to whole organization; it
-  represents zero miners and is valid only when explicit Infrastructure
-  targets make the overall plan valid.
+- Require every new Preview, Start, and response-profile Create/Update request
+  to contain a recognized, explicit miner selector: Whole organization or at
+  least one site, building, rack, group, or miner. Infrastructure does not make
+  an empty or unrecognized miner scope valid, and those requests must fail
+  before an event, profile, or facility-fan action is created.
 - Create a pure curtailment-scope module used by:
   - `CurtailmentStartModal.tsx`
   - `curtailmentRequestBuilders.ts`
@@ -235,9 +236,18 @@ with the proto source.
   `MarshalScopeJSON`, and `ScopeFromJSON`.
 - Ensure a whole-org entry still dominates narrower selectors and mixed
   entries are normalized/deduplicated deterministically.
-- Reject an empty or unrecognized miner scope at boundaries that require miner
-  targets. Never synthesize whole-org scope from missing, unknown, or
-  unsupported cases.
+- Reject an empty or unrecognized miner scope at every new submission boundary,
+  including when facility fans are present. Never synthesize whole-org scope
+  from missing, unknown, or unsupported cases, and never dispatch a fan unless
+  the execution has at least one admitted miner target and the existing
+  confirmation/sequencing preconditions are satisfied.
+- Preserve existing persisted response profiles whose empty legacy
+  `scope_json` plus absent `site_id` means whole organization, but backfill them
+  to explicit `{"whole_org":true}` before enabling the new submission rules.
+  Because there are no old clients, deploy the frontend change that always
+  emits explicit Whole organization first, complete the data backfill, then
+  make server Create/Update/Preview/Start reject omitted scopes. This is a
+  coordinated contract cleanup, not a capability-negotiation path.
 - Add `max_items` validation to every repeated scope/identifier field and
   domain validation for the normalized per-type and aggregate selector limits.
   Reject oversized persisted profile/event scopes before resolving them.
@@ -422,8 +432,13 @@ Backend unit/store/integration coverage:
   vice versa, CRUD/list filtering against persisted fan-site coverage, and
   automation failing when current fan coverage exceeds its envelope.
 - Empty/unknown-scope tests proving Preview, Start, profile save/execution, and
-  automation never infer whole organization; cover an intentional
-  infrastructure-only plan separately.
+  automation never infer whole organization and reject infrastructure-only or
+  unknown-scope-plus-fan requests before any event, profile, target ownership,
+  or fan command is created. Cover explicit selectors that currently resolve
+  zero miners and assert execution fails without commanding fans.
+- Rollout tests proving legacy persisted whole-org profiles backfill to the
+  explicit representation and the updated frontend emits explicit whole-org
+  scope before the server begins rejecting omitted submissions.
 - Regression coverage for whole-org, multi-site, explicit-miner, and
   facility-fan behavior; assert no generic device-set scope state remains in
   frontend/domain/storage models.
@@ -480,8 +495,10 @@ developer approval.
 - Response-profile envelopes independently cover miner and facility-fan sites;
   profile CRUD and execution preserve both `site:read` and
   `curtailment:manage` requirements for every selected fan site.
-- Whole organization is always explicit. Empty, unknown, or unsupported miner
-  scope never widens to whole-org targeting.
+- Whole organization is explicit for every new submission. Empty, unknown,
+  unsupported, and infrastructure-only miner scope never widens to whole-org
+  targeting or reaches facility-fan dispatch; legacy persisted whole-org
+  profiles are backfilled to the explicit representation during rollout.
 - Whole-org/site all-paired behavior, explicit-miner targeting, facility-fan
   sequencing, and active/history displays keep working. Deprecated generic
   device-set wire input fails closed and is never persisted, executed as, or

--- a/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
+++ b/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
@@ -410,8 +410,10 @@ developer approval.
   concurrent cross-site move cannot admit an unauthorized miner.
 - Per-type and aggregate selector limits bound direct and persisted scope
   resolution and are enforced server-side after normalization.
-- Deleted, wrong-type, cross-org, unassigned, or unauthorized topology targets
-  fail closed with actionable errors and never broaden to whole-org scope.
+- Deleted, wrong-type, cross-org, or unauthorized topology targets fail closed
+  with actionable errors and never broaden to whole-org scope. Unassigned
+  in-org targets are admitted only when the caller has org-wide
+  `curtailment:manage`; otherwise they are treated as uncovered and rejected.
 - Whole-org/site all-paired behavior, explicit-miner targeting, facility-fan
   sequencing, and active/history displays keep working. Deprecated generic
   device-set wire input fails closed and is never persisted, executed as, or

--- a/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
+++ b/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
@@ -164,8 +164,9 @@ Extend the Go domain `Scope` and JSON codec with `building_ids`, `rack_ids`, and
 handling. Preserve existing decoding and proto rendering for whole-org, site,
 device-list, and mixed records. New topology-only or composite records can
 continue to persist with the existing `mixed` scope type plus the richer JSON
-object, avoiding a migration and new database scope-type values. For response
-profiles, the same JSON object should also carry an authorization envelope
+object, avoiding a response-profile schema migration and new database scope-
+type values. For response profiles, the same JSON object should also carry an
+authorization envelope
 with separate miner-scope and facility-fan site coverage captured when the
 profile is created or updated. The fan dimension must preserve the existing
 requirement for both `site:read` and `curtailment:manage`; miner coverage
@@ -174,6 +175,11 @@ Persist the same envelope and authorizing-principal reference on every
 closed-loop FULL_FLEET event, with or without the all-paired flag; frozen
 non-FULL_FLEET and unflagged explicit-miner events continue to rely on
 authorization at Preview/Start plus their concrete target rows.
+Add an automation-rule migration for a bound profile scope revision and bound
+miner/fan authorization envelope. These fields preserve the exact profile
+scope an operator authorized when the rule was created, updated, or enabled;
+they are also the stable authorization source for managing a rule after its
+profile topology becomes stale.
 
 Generated protobuf output must be regenerated with `just gen` and committed
 with the proto source.
@@ -276,12 +282,14 @@ with the proto source.
   compatibility path.
 - Give each response profile an opaque scope revision derived from its canonical
   persisted miner/fan scope. Return it from Get/List and require an exact match
-  on Update and every profile-derived execution. The server must load and use
-  the matching stored logical scope instead of trusting a client-expanded copy;
-  stale or missing revisions fail with a refresh-required error. Together with
-  the minimum schema version, this prevents a stale tab that ignores unknown
-  topology cases from overwriting or running a narrow profile as explicit
-  Whole organization.
+  on Update, every profile-derived execution, and automation-rule Create,
+  Update, or enable. The server must load and use the matching stored logical
+  scope instead of trusting a client-expanded copy; stale or missing revisions
+  fail with a refresh-required error. Disabling or deleting an automation rule
+  does not require a current revision. Together with the minimum schema version,
+  this prevents a stale tab that ignores unknown topology cases from
+  overwriting, running, or binding a narrow profile as explicit Whole
+  organization.
 - Add `max_items` validation to every repeated scope/identifier field and
   domain validation for raw pre-deduplication totals and normalized per-type/
   aggregate selector limits. Enforce the transport byte cap before decoding and
@@ -394,9 +402,11 @@ with the proto source.
   - the resolved current device identifiers,
   - separately resolved facility-fan site IDs and unassigned status.
 - Reuse strict current-topology resolution for Preview, Start,
-  response-profile Create/Update, profile execution, and automation-rule
-  profile checks. Require `curtailment:manage` at every covered site; require
-  org-wide permission when scope coverage is incomplete or includes unassigned
+  response-profile Create/Update, profile execution, automation-rule Create/
+  Update/enable, and automation execution. Do not use strict live topology for
+  response-profile or automation-rule read/delete paths, or for disabling a
+  rule. Require `curtailment:manage` at every covered site; require org-wide
+  permission when scope coverage is incomplete or includes unassigned
   resources. Picker filtering is usability only, never authorization.
 - Treat Preview as a point-in-time estimate, but make Start and every
   closed-loop reconciliation admission atomic with authorization-envelope
@@ -425,13 +435,14 @@ with the proto source.
   missing or unproven envelope; it must never derive authority from a miner's
   or fan's current site at execution time. Surface this state in profile
   Get/List so it can be fixed or deleted.
-- Before enforcing profile envelopes, inventory every enabled automation rule
-  that references a profile marked `reauthorization_required`, expose the
-  affected rules and profiles to operators, and reauthorize or disable them.
-  Gate enforcement on that inventory reaching zero, unless owners explicitly
-  approve an announced cutoff for the remaining rules. After the gate, keep
-  execution fail closed; do not temporarily infer an envelope to preserve an
-  unremediated automation.
+- Before enforcing profile envelopes or bound-revision checks, inventory every
+  enabled automation rule that references a profile marked
+  `reauthorization_required` or lacks a proven bound revision, envelope, or
+  execution principal. Expose the affected rules and profiles to operators and
+  reauthorize/rebind or disable them. Gate enforcement on that inventory
+  reaching zero, unless owners explicitly approve an announced cutoff for the
+  remaining rules. After the gate, keep execution fail closed; do not
+  temporarily infer binding state to preserve an unremediated automation.
 - Bind every automation rule execution to an explicit user or service-account
   principal; the stored envelope is a maximum boundary, not a durable
   capability. At every trigger, reload that principal's current effective
@@ -477,11 +488,40 @@ with the proto source.
   current topology, miner locations, or fan locations to grant access.
   Site-scoped operators do not see the profile until an org-wide operator with
   the required permissions establishes a proven envelope or deletes it.
+- Apply the same recovery boundary to automation-rule management. Get/List,
+  Delete, and disable must authorize against the rule's persisted bound miner/
+  fan envelope and hydrate the stored profile reference without resolving its
+  current topology. A deleted or moved topology target therefore marks the rule
+  stale or `rebind_required` but cannot make it unlistable or prevent an
+  authorized operator from disabling or deleting it. A legacy rule with a
+  missing or unproven bound envelope uses the same org-wide recovery rule as an
+  unproven profile. Create, Update, enable, and execution remain strict and
+  cannot use this recovery path.
 
 ### 6. Cover manual and automated execution
 
 - Ensure `startRequestFromAutomationProfile` carries the new scope arrays and
   exercises the same selector pipeline as direct Start.
+- Add the profile's expected scope revision to automation-rule Create, Update,
+  and enable requests. In the same database transaction that saves or enables
+  the rule, lock and reload the profile, compare its canonical scope revision
+  and authorization envelope with the values authorized by the handler, and
+  persist that revision, envelope, and execution principal as the rule's bound
+  profile state. Extend the existing store-side facility-fan race check rather
+  than leaving scope validation only in the handler. Any mismatch returns
+  FailedPrecondition and saves nothing.
+- At every trigger, require the current profile revision to equal the rule's
+  bound revision before resolving or starting an event, then enforce the bound
+  envelope and the execution principal's current permissions. A profile scope
+  change never silently retargets an enabled rule: the revision mismatch makes
+  linked bindings report `rebind_required`, blocks event and fan creation, and
+  requires an authorized operator to review the current profile and re-enable/
+  rebind the rule.
+- Keep recovery operations independent of live topology and revision matching.
+  Get/List render the stale/rebind state, while disable and Delete authorize
+  from the bound envelope and remain available even when the profile target is
+  stale or its revision changed. Disabling must not call the strict enable path
+  or require a client-supplied profile revision.
 - Ensure selecting a saved response profile in New curtailment restores its
   building/rack/group selections and that subsequent manual edits switch the
   dropdown to Custom plan, matching current site/miner behavior.
@@ -504,6 +544,9 @@ Frontend unit/component coverage:
 - Response-profile API tests proving create/update payloads and list/reload
   hydration retain each target type without relying on the in-memory session
   cache.
+- Automation API tests proving Create/Update/enable carry the selected profile's
+  scope revision, stale revisions surface a refresh-required state, and disable/
+  Delete remain available without a current revision.
 - Cross-boundary contract tests proving the same canonical selection emits the
   same normalized scopes for Preview, Start, and response-profile
   create/update, and hydrates back without losing a category.
@@ -544,6 +587,19 @@ Backend unit/store/integration coverage:
   scope, including a deleted or moved target that remains visible and
   deletable under its persisted authorization envelope but fails execution and
   resave until corrected.
+- Automation-rule authorization tests proving Get/List/Delete/disable use the
+  persisted bound miner/fan envelope and remain available when a referenced
+  topology target is stale, while Create/Update/enable/execution require strict
+  current topology. Cover the org-wide recovery rule for legacy bindings with
+  missing or unproven envelopes.
+- Automation binding race tests that change a profile's scope or envelope
+  between handler authorization and the store transaction. Create, Update, and
+  enable must fail atomically on an expected-revision/envelope mismatch; a
+  successful bind persists the exact revision, envelope, and principal.
+- Automation trigger tests proving a later profile-scope revision puts the rule
+  in `rebind_required`, creates no event or fan command, and resumes only after
+  an authorized rebind. Disabling and deleting the mismatched rule must not
+  require live topology or revision equality.
 - Authorization-envelope rollout tests for provable whole-org/site backfills,
   explicit-miner and mixed profiles requiring reauthorization, a miner moving
   sites before reauthorization, org-wide-only Get/List/Delete access while the
@@ -582,8 +638,10 @@ Backend unit/store/integration coverage:
   ambiguous scope or principal enters no-admission drain mode and completes
   safe restoration from durable targets.
 - Automation rollout tests inventory enabled rules bound to profiles requiring
-  reauthorization, prevent enforcement before remediation or an explicit
-  cutoff, and fail closed after cutover without silently widening scope.
+  reauthorization or missing a proven bound revision, envelope, or principal;
+  prevent enforcement before rebind/disable remediation or an explicit cutoff;
+  preserve authorized read/disable/delete recovery; and fail closed after
+  cutover without silently widening scope.
 - Selector-limit rollout tests covering inventory of legacy API-created
   oversized profiles/events, readable and deletable remediation state,
   shrink-only updates, automation cutoff, and an active oversized event that
@@ -651,6 +709,14 @@ developer approval.
   topology scopes are exposed, and profile updates/executions require a matching
   opaque scope revision and use the server-stored canonical scope. An unknown
   topology case can never round-trip as intentional Whole organization.
+- Automation rules bind atomically to an exact profile scope revision, miner/
+  fan envelope, and execution principal. A profile-scope change blocks triggers
+  as `rebind_required` until an authorized rebind; it never silently retargets
+  an enabled rule.
+- Stale or revision-mismatched automation rules remain visible, disableable, and
+  deletable under their bound envelope without current-topology resolution.
+  Create, Update, enable, and execution still fail closed on stale topology,
+  revision, envelope, or current permissions.
 - Response-profile envelopes independently cover miner and facility-fan sites;
   profile CRUD and execution preserve both `site:read` and
   `curtailment:manage` requirements for every selected fan site.
@@ -660,8 +726,10 @@ developer approval.
   restores owned targets instead of leaving the envelope as a perpetual grant.
 - Legacy active closed-loop events receive a provable envelope and principal or
   enter no-admission drain mode before envelope enforcement begins. Enabled
-  automations referencing ambiguous profiles are inventoried and remediated or
-  explicitly cut off before enforcement, then remain fail closed.
+  automations referencing ambiguous profiles or lacking proven binding state
+  are inventoried and rebound, disabled, or explicitly cut off before
+  enforcement, then remain fail closed while recovery operations stay
+  available.
 - Whole organization is explicit for every new submission. Empty, unknown,
   unsupported, and infrastructure-only miner scope never widens to whole-org
   targeting or reaches facility-fan dispatch; legacy persisted whole-org

--- a/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
+++ b/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
@@ -279,7 +279,7 @@ Create/Update/enable/execution. Use persisted envelopes for recovery operations:
 | Valid profile Get/List/Delete | Authorize against persisted miner/fan envelope; hydrate stale typed IDs without live topology. |
 | Profile with missing/unproven envelope | Org-wide `curtailment:manage`, plus org-wide `site:read` when fans exist; no current-location fallback. |
 | Stale profile resave/execution | Reject until stale IDs are explicitly removed/replaced. |
-| Automation Get/List/Delete/disable | Authorize against the rule's bound envelope; remain available when profile topology or revision is stale. |
+| Automation Get/List/Delete/disable | Authorize against the bound envelope; if missing/unproven, require the same org-wide fallback as profiles. Remain available when profile topology or revision is stale. |
 | Automation Create/Update/enable/OFF start | Require strict topology, exact executable-profile revision/envelope, current principal permissions, and current Admin/SuperAdmin role for admin-only controls. |
 | Automation ON/stop with an active event | Restore from the event's durable targets and fan settings without requiring the current profile revision/topology/admin grant; never admit or recurtail targets. |
 
@@ -314,8 +314,9 @@ admin requirement, topology, and quotas before claiming targets.
 3. Inventory and remediate persisted data:
    - Backfill provable whole-org/site profile envelopes.
    - Mark ambiguous profiles `reauthorization_required`.
-   - Inventory enabled rules missing a proven revision, envelope, principal, or
-     admin marker; rebind, disable, or approve an announced cutoff.
+   - Inventory rules missing a proven revision, envelope, principal, or admin
+     marker; rebind/backfill or disable them while retaining org-wide-authorized
+     CRUD through the announced cutoff.
    - Mark oversized profiles `scope_limit_remediation_required`; keep Get/List/
      Delete and shrink-to-valid Update available.
    - Backfill active event envelopes only when scope and principal prove the

--- a/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
+++ b/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
@@ -271,7 +271,12 @@ with the proto source.
 - Add `max_items` validation to every repeated scope/identifier field and
   domain validation for raw pre-deduplication totals and normalized per-type/
   aggregate selector limits. Enforce the transport byte cap before decoding and
-  reject oversized persisted profile/event scopes before resolving them.
+  reject oversized persisted profiles before execution. For an already-active
+  oversized legacy event, do not resolve its logical scope for new admissions;
+  mark it degraded and continue confirmation, facility-fan sequencing,
+  restoration, ownership release, and terminalization from its durable target
+  rows. This active-event drain exception must run before general persisted-
+  scope rejection so enforcement cannot strand curtailed miners.
 - Remove generic device-set translation, domain/JSON decode/render paths,
   frontend `deviceSetIds` scope state, and the special unsupported-device-set
   preview branch. Keep only deprecated protobuf declarations/field numbers as
@@ -535,8 +540,9 @@ Backend unit/store/integration coverage:
   scope before the server begins rejecting omitted submissions.
 - Selector-limit rollout tests covering inventory of legacy API-created
   oversized profiles/events, readable and deletable remediation state,
-  shrink-only updates, automation cutoff, and active-event grandfathering
-  through safe restoration.
+  shrink-only updates, automation cutoff, and an active oversized event that
+  blocks new admissions but completes confirmation, fan sequencing, safe
+  restoration, ownership release, and terminalization after upgrade.
 - Regression coverage for whole-org, multi-site, explicit-miner, and
   facility-fan behavior; assert no generic device-set scope state remains in
   frontend/domain/storage models.
@@ -582,7 +588,8 @@ developer approval.
   resolution and are enforced on raw input before deduplication and server-side
   after normalization, with a transport byte limit. Existing oversized records
   are inventoried and remediated before enforcement; profiles remain readable/
-  deletable and active events complete safely.
+  deletable, while active events stop new admissions and drain safely from
+  durable targets.
 - Deleted, wrong-type, cross-org, or unauthorized topology targets fail closed
   with actionable errors and never broaden to whole-org scope. Unassigned
   in-org targets are admitted only when the caller has org-wide

--- a/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
+++ b/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
@@ -127,10 +127,11 @@ When an owned miner leaves scope or becomes unpaired:
   existing prune-missing behavior.
 - Preserve existing off-site selections when editing under a narrower topbar
   filter or when the operator cannot open a picker.
-- Gate list controls by their required permissions: Buildings use `site:read`,
-  Racks/Groups use `rack:read`, and Miners use `miner:read`. Picker filtering
-  is usability only; the server remains authoritative. Hide rack/group miner
-  facets when the role lacks `rack:read`, matching Schedules.
+- Add resource-aware picker permissions instead of plain `useHasPermission`:
+  evaluate the selected site grants and use site-filtered building/rack/group
+  catalog handlers that authenticate/derive the org before scoped authorization.
+  Hide a control only when no authorized resource remains; hide rack/group miner
+  facets when the scoped role lacks `rack:read`, matching Schedules.
 - Allow **Target all paired miners** for FULL_FLEET with any site/building/rack/
   group/miner union, and clear it when switching away from FULL_FLEET.
 
@@ -169,11 +170,15 @@ Bound inputs before expensive resolution:
 | Explicit device identifiers | 10,000 |
 | Repeated `CurtailmentScope` entries | 1,024 |
 | Curtailment RPC body | 2 MiB |
+| Active closed-loop watchers per org | 64 |
+| Active-watcher topology IDs per org | 1,024 |
+| Active-watcher explicit IDs per org | 10,000 |
 
 Enforce cardinality on raw repeated input before deduplication and again after
 domain normalization. Apply the same limits to direct requests, persisted
 profiles, automation, and reconciliation; use protobuf `max_items` where the
-wire shape permits.
+wire shape permits. Enforce the active aggregate quotas transactionally before
+persisting a watcher/reservation.
 
 ### 4. Resolve targets and authorization once
 
@@ -213,6 +218,11 @@ membership, logical reservation, and facility fan—not only concrete miners.
 Lock relevant topology rows or compare topology revisions; dispatch only after
 commit.
 
+Replace Preview/Start's org-scoped `RequirePermission(..., ResourceContext{})`
+entry gates with authentication/org derivation followed by the resolver's
+scoped requirement check; otherwise site-scoped grants can never reach this
+authorization path.
+
 On profile Create/Update, persist the union of selected-resource and current-
 member site coverage plus the independent fan-site coverage in `scope_json`,
 with separate org-wide flags for incomplete or unbounded dimensions.
@@ -241,6 +251,9 @@ with separate org-wide flags for incomplete or unbounded dimensions.
 - Permission revocation, role demotion, or out-of-envelope topology stops new
   admissions and moves owned targets through safe restoration; it never
   releases a possibly curtailed miner directly.
+- Reconcile watchers/targets in pages under a per-tick time budget. Prioritize
+  stop/restore work; overload backpressure pauses new admissions before it can
+  delay safety-critical restoration.
 
 ### 6. Make profiles and automation strict but recoverable
 
@@ -271,6 +284,9 @@ with the bound revision; mismatch reports `rebind_required`. An authenticated
 ON/stop for an already-owned event must always follow its durable restore path,
 even after profile change/deletion, permission loss, or admin demotion.
 Disable/Delete likewise do not require a current revision or strict topology.
+The event-create/recurtail transaction must lock the rule and profile, then
+recheck enabled state, binding, revision, envelope, principal authorization,
+admin requirement, topology, and quotas before claiming targets.
 
 ### 7. Roll out fail-closed behavior safely
 
@@ -319,8 +335,8 @@ Backend coverage:
 - Full executable-profile revision coverage, automation binding races,
   `rebind_required`, stale rule management, ON/stop recovery after profile or
   permission changes, and rollout remediation.
-- Raw/normalized limits, oversized-record remediation, and safe active-event
-  draining.
+- Raw/normalized and active-watcher quotas, paginated/time-budgeted overload
+  behavior with restore priority, oversized remediation, and safe event draining.
 
 Run:
 

--- a/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
+++ b/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
@@ -231,13 +231,15 @@ Lock relevant topology rows or compare topology revisions; dispatch only after
 commit.
 
 Replace the org-scoped `RequirePermission(..., ResourceContext{})` entry gates
-across Preview/Start and response-profile/automation RPCs with authentication/
-org derivation followed by their scoped resolver or persisted-envelope checks;
-otherwise site-scoped grants cannot reach those authorization paths.
+across Preview/Start, response-profile/automation, and event Get/List/Update/Stop
+RPCs with authentication/org derivation followed by scoped resolution or
+persisted-envelope checks. Event Get/Update/Stop authorize against that event's
+envelope; List returns only events whose envelopes the caller can access.
 
-On profile Create/Update, persist the union of selected-resource and current-
-member site coverage plus the independent fan-site coverage in `scope_json`,
-with separate org-wide flags for incomplete or unbounded dimensions.
+Keep `scope_json` executable-selector-only. On profile Create/Update, persist
+selected-resource/current-member site coverage, independent fan-site coverage,
+and separate unbounded flags in a dedicated authorization-envelope column that
+target resolution never interprets as selectors.
 
 ### 5. Preserve closed-loop ownership and exclusivity
 
@@ -261,7 +263,7 @@ with separate org-wide flags for incomplete or unbounded dimensions.
   it moves into a watched scope retains its owner; mark the watcher degraded
   and retry after release.
 - Persist the authorization envelope, authorizing principal, and whether
-  admin-only controls are required on every closed-loop event. Each admission
+  admin-only controls are required on every event. Each closed-loop admission
   reloads current permissions, current Admin/SuperAdmin role when required, and
   current topology before claiming a target.
 - Permission revocation, role demotion, or out-of-envelope topology stops new
@@ -284,12 +286,13 @@ Create/Update/enable/execution. Use persisted envelopes for recovery operations:
 | Automation Create/Update/enable/OFF start | Require strict topology, exact executable-profile revision/envelope, current principal permissions, and current Admin/SuperAdmin role for admin-only controls. |
 | Automation ON/stop with an active event | Restore from the event's durable targets and fan settings without requiring the current profile revision/topology/admin grant; never admit or recurtail targets. |
 
-Add immutable up/down migrations for automation-rule binding fields: executable-
-profile revision, miner/fan envelope, execution principal, and required-admin
-marker. In the same transaction that saves/enables a rule, lock the profile,
-compare the handler-authorized revision/envelope, and persist that exact
-binding. Extend the existing store-side fan-settings race check; mismatch
-returns FailedPrecondition without saving.
+Add immutable up/down migrations for separate profile/event authorization-
+envelope columns and automation-rule binding fields: executable-profile
+revision, miner/fan envelope, execution principal, and required-admin marker.
+In the same transaction that saves/enables a rule, lock the profile, compare the
+handler-authorized revision/envelope, and persist that exact binding. Extend the
+existing store-side fan-settings race check; mismatch returns FailedPrecondition
+without saving.
 
 Reload the bound user or service-account permissions at every trigger; never
 fall back to the profile creator or an ambient system principal.
@@ -314,8 +317,9 @@ admin requirement, topology, and quotas before claiming targets.
    revision, or binding fail closed.
 3. Deploy the frontend that always sends the new version and explicit whole-org
    scope, raise the minimum accepted schema version, then open the feature gate.
-   Rollback below the minimum server version requires disabling automation and
-   draining topology-scoped events first.
+   Rollback below the minimum requires closing the gate, blocking profile Test/
+   Start/Create/Update, disabling dependent automation, draining topology events,
+   and deleting topology-scoped profiles before an older server starts.
 
 ## Verification
 
@@ -343,6 +347,8 @@ Backend coverage:
 - Authorization races for empty watchers and moved fans, separate fan coverage,
   stale CRUD recovery, current permission revocation,
   Admin/SuperAdmin demotion, and current topology exceeding an envelope.
+- Site-scoped Start followed by event List/Get/Update/Stop, denial outside the
+  persisted envelope, and proof that selector resolution ignores envelope data.
 - Full executable-profile revision coverage, automation binding races,
   `rebind_required`, stale rule management, ON/stop recovery after profile or
   permission changes, and fail-closed rollout sequencing.
@@ -376,6 +382,8 @@ snapshots without explicit approval.
   empty, unknown, and infrastructure-only scope never widens to whole org.
 - Authorization includes selected resources, members, and independent fan
   coverage; unassigned/unbounded targets require org-wide permission.
+- Selector JSON and authorization envelopes are stored separately; envelope
+  coverage can never become an executable site selector.
 - Target claims are atomic with topology and authorization checks, and active
   logical reservations prevent competing events from stealing future members.
 - Dispatched targets remain owned through fan-aware safe restoration when they
@@ -387,6 +395,6 @@ snapshots without explicit approval.
   from broadening or silently retargeting a scope.
 - The deployment gate prevents mixed-version execution; missing versioned scope,
   envelope, revision, or binding data is rejected rather than preserved.
-- Response profiles reuse existing scope JSON; automation bindings use a new
-  immutable up/down migration. Proto and generated output are committed
-  together.
+- Response profiles keep executable selectors in existing scope JSON; immutable
+  up/down migrations add separate profile/event envelopes and automation
+  bindings. Proto and generated output are committed together.

--- a/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
+++ b/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
@@ -140,10 +140,14 @@ Bound selector cardinality using named shared constants: at most 256 IDs for
 each topology type (sites, buildings, racks, and groups), at most 1,024 topology
 IDs across the normalized union, at most 10,000 explicit device identifiers,
 and at most 1,024 repeated `CurtailmentScope` entries. Apply protobuf
-`max_items` validation where the wire shape permits and enforce the normalized
-per-type/aggregate limits again in the domain for direct requests, response
-profiles, automation execution, and persisted all-paired reconciliation. The
-frontend mirrors these limits for usability; the server remains authoritative.
+`max_items` validation where the wire shape permits. Before deduplication,
+enforce the same 256-per-type, 1,024-total-topology, and 10,000-total-explicit
+limits across all repeated scope entries, then enforce them again after
+normalization in the domain for direct requests, response profiles, automation
+execution, and persisted closed-loop reconciliation. Configure a 2 MiB request
+body limit for curtailment RPCs so oversized protobuf payloads are rejected
+before decoding/normalization. The frontend mirrors these limits for usability;
+the server remains authoritative.
 
 Before enabling limit enforcement, inventory every persisted profile and
 active event using the normalized counters. Gate rollout on remediating all
@@ -166,9 +170,10 @@ with separate miner-scope and facility-fan site coverage captured when the
 profile is created or updated. The fan dimension must preserve the existing
 requirement for both `site:read` and `curtailment:manage`; miner coverage
 continues to require `curtailment:manage`.
-Persist the same envelope on an event when all-paired topology reconciliation
-is enabled; normal frozen-target events continue to rely on authorization at
-Preview/Start plus their concrete target rows.
+Persist the same envelope and authorizing-principal reference on every
+closed-loop FULL_FLEET event, with or without the all-paired flag; frozen
+non-FULL_FLEET and unflagged explicit-miner events continue to rely on
+authorization at Preview/Start plus their concrete target rows.
 
 Generated protobuf output must be regenerated with `just gen` and committed
 with the proto source.
@@ -264,8 +269,9 @@ with the proto source.
   make server Create/Update/Preview/Start reject omitted scopes. This is a
   coordinated contract cleanup, not a capability-negotiation path.
 - Add `max_items` validation to every repeated scope/identifier field and
-  domain validation for the normalized per-type and aggregate selector limits.
-  Reject oversized persisted profile/event scopes before resolving them.
+  domain validation for raw pre-deduplication totals and normalized per-type/
+  aggregate selector limits. Enforce the transport byte cap before decoding and
+  reject oversized persisted profile/event scopes before resolving them.
 - Remove generic device-set translation, domain/JSON decode/render paths,
   frontend `deviceSetIds` scope state, and the special unsupported-device-set
   preview branch. Keep only deprecated protobuf declarations/field numbers as
@@ -369,8 +375,9 @@ with the proto source.
   profile checks. Require `curtailment:manage` at every covered site; require
   org-wide permission when scope coverage is incomplete or includes unassigned
   resources. Picker filtering is usability only, never authorization.
-- Treat Preview as a point-in-time estimate, but make Start and every all-paired
-  reconciliation admission atomic with authorization-envelope enforcement.
+- Treat Preview as a point-in-time estimate, but make Start and every
+  closed-loop reconciliation admission atomic with authorization-envelope
+  enforcement.
   Selector validation, membership expansion, current site coverage, and target
   claim/insertion must use one transaction/locked snapshot, or every
   materialized device and current site must be revalidated inside the target
@@ -395,21 +402,28 @@ with the proto source.
   missing or unproven envelope; it must never derive authority from a miner's
   or fan's current site at execution time. Surface this state in profile
   Get/List so it can be fixed or deleted.
-- Before automation execution, resolve current topology coverage again and
-  resolve current facility-fan sites, and require both dimensions to remain
-  inside the stored authorization envelope. A rack or building moved to
-  another site, a group gaining an out-of-envelope member, a fan moving sites,
-  or newly unassigned membership must fail with a clear FailedPrecondition
-  instead of silently broadening the operation. A dimension with proven
-  org-wide authorization may follow current membership across sites.
-- When Start enables all-paired topology reconciliation, stamp the applicable
-  authorization envelope onto the event. Each reconciliation pass must compare
-  current topology coverage with that envelope before admitting targets.
+- Bind every automation rule execution to an explicit user or service-account
+  principal; the stored envelope is a maximum boundary, not a durable
+  capability. At every trigger, reload that principal's current effective
+  permissions, resolve current topology and facility-fan sites, and require
+  both the live permissions and stored envelope to authorize the operation. A
+  deactivated principal or revoked grant blocks execution. Do not fall back to
+  the profile creator or an ambient system principal.
+- Stamp the applicable authorization envelope and authorizing principal onto
+  every closed-loop FULL_FLEET event, not only all-paired events. Each
+  reconciliation pass must reload the principal's current effective
+  permissions and compare current topology/fan coverage with both those
+  permissions and the envelope before admitting targets. A rack or building
+  moved to another site, a group gaining an out-of-envelope member, a fan
+  moving sites, newly unassigned membership, or permission revocation blocks
+  new admission with a clear reason.
   Out-of-envelope miners are not admitted, already-owned miners that move
-  outside the envelope follow the same dispatch-aware restore-before-release
-  rule, and the event surfaces an actionable authorization-change reason. An
-  org-wide-authorized event may continue following the selected topology across
-  sites.
+  outside the envelope—or lose current principal authorization—follow the same
+  dispatch-aware restore-before-release rule. Restore facility fans first when
+  required, surface an actionable authorization-change reason, and terminate or
+  remain degraded until safe restoration completes. An org-wide envelope may
+  follow topology across sites only while the principal still has the required
+  live org-wide permissions.
 - Do not require current topology resolution for response-profile Get/List or
   Delete. Authorize those operations against the profile's persisted
   miner and facility-fan envelope dimensions, including `site:read` on fan
@@ -476,6 +490,9 @@ Backend unit/store/integration coverage:
 - Per-type and aggregate selector-limit tests for direct Preview/Start,
   response-profile create/update, automation execution, and forged oversized
   persisted scopes.
+- Raw-limit tests with duplicate-heavy identifiers split across many scope
+  entries, per-type and cross-type raw totals, and payloads above the 2 MiB
+  transport limit, proving rejection occurs before normalization work.
 - Scope-reservation tests for concurrent starts, membership changes between
   reconciliation ticks, explicit-miner reservations, unpair/re-pair gaps,
   deterministic older-event precedence, and a pre-owned miner moving into a
@@ -493,6 +510,10 @@ Backend unit/store/integration coverage:
   sites before reauthorization, org-wide-only Get/List/Delete access while the
   envelope is missing or unproven, site-scoped filtering, and automation
   failing closed before reauthorization.
+- Current-permission tests for automation owner deactivation, site-grant and
+  org-wide-grant revocation, facility-fan `site:read` revocation, service-account
+  principals, and mid-event revocation that blocks admission and safely
+  restores existing ownership for both ordinary and all-paired FULL_FLEET.
 - Facility-fan authorization tests for a fan outside the miner scope, fan site
   movement, unassigned/stale fans, `site:read` without `curtailment:manage` and
   vice versa, CRUD/list filtering against persisted fan-site coverage, and
@@ -546,8 +567,9 @@ developer approval.
   fleet.
 - Preview and Start resolve the same miners for the same scope, subject only to
   normal time-varying telemetry/eligibility.
-- Normal started events freeze concrete miner targets; later topology changes
-  affect future profile executions, not the in-flight event.
+- Non-FULL_FLEET and unflagged explicit-miner events freeze concrete miner
+  targets; closed-loop FULL_FLEET topology watchers follow their logical scope
+  within their persisted authorization boundary.
 - FULL_FLEET events with `Target all paired miners` continuously re-resolve the
   selected site/building/rack/group/miner union: newly paired or newly assigned
   miners are admitted. Unpaired or no-longer-in-scope miners are released
@@ -557,9 +579,10 @@ developer approval.
   authorization-envelope validation, and target claim before dispatch, so a
   concurrent cross-site move cannot admit an unauthorized miner.
 - Per-type and aggregate selector limits bound direct and persisted scope
-  resolution and are enforced server-side after normalization. Existing
-  oversized records are inventoried and remediated before enforcement;
-  profiles remain readable/deletable and active events complete safely.
+  resolution and are enforced on raw input before deduplication and server-side
+  after normalization, with a transport byte limit. Existing oversized records
+  are inventoried and remediated before enforcement; profiles remain readable/
+  deletable and active events complete safely.
 - Deleted, wrong-type, cross-org, or unauthorized topology targets fail closed
   with actionable errors and never broaden to whole-org scope. Unassigned
   in-org targets are admitted only when the caller has org-wide
@@ -574,6 +597,10 @@ developer approval.
 - Response-profile envelopes independently cover miner and facility-fan sites;
   profile CRUD and execution preserve both `site:read` and
   `curtailment:manage` requirements for every selected fan site.
+- Every closed-loop FULL_FLEET event persists its envelope and authorizing
+  principal. Automation triggers and reconciliation require that principal's
+  current effective permissions; revocation blocks admission and safely
+  restores owned targets instead of leaving the envelope as a perpetual grant.
 - Whole organization is explicit for every new submission. Empty, unknown,
   unsupported, and infrastructure-only miner scope never widens to whole-org
   targeting or reaches facility-fan dispatch; legacy persisted whole-org

--- a/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
+++ b/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
@@ -66,9 +66,12 @@ Resolve topology membership on the backend, not in the browser:
 
 - Preview resolves current membership and reports the current eligible target
   set.
-- A normal Start resolves current membership once, then freezes concrete miner
-  targets in `curtailment_target`, matching existing open-loop explicit-miner
+- A non-FULL_FLEET Start resolves current membership once, then freezes
+  concrete miner targets in `curtailment_target`, matching existing open-loop
   behavior.
+- FULL_FLEET without `Target all paired miners` preserves the existing
+  closed-loop watcher: it may start with zero eligible miners, re-resolves the
+  logical union, and claims newly eligible in-scope miners at dispatch time.
 - A response profile stores logical IDs, so each later manual or automation
   execution resolves the then-current members.
 - For FULL_FLEET with `Target all paired miners`, extend the durable closed-loop
@@ -139,6 +142,16 @@ and at most 1,024 repeated `CurtailmentScope` entries. Apply protobuf
 per-type/aggregate limits again in the domain for direct requests, response
 profiles, automation execution, and persisted all-paired reconciliation. The
 frontend mirrors these limits for usability; the server remains authoritative.
+
+Before enabling limit enforcement, inventory every persisted profile and
+active event using the normalized counters. Gate rollout on remediating all
+oversized profiles or marking them `scope_limit_remediation_required`; keep
+Get/List/Delete available and allow only shrink-to-valid updates for marked
+profiles. Do not bind or execute their automation after the announced
+remediation cutoff. Grandfather already-active oversized events through safe
+completion so an upgrade cannot strand curtailed miners, but reject new events
+at the limits. Since records are API-created rather than manually inserted,
+this audit/backfill is the authoritative migration path.
 
 Extend the Go domain `Scope` and JSON codec with `building_ids`, `rack_ids`, and
 `group_ids`, and remove generic `DeviceSetIDs`/`device_set_ids` domain and JSON
@@ -287,17 +300,23 @@ with the proto source.
 - For cooldown lookup, use the already-resolved candidate identifiers (or add
   equivalent topology predicates) so a building/rack/group request cannot
   accidentally apply org-wide cooldown exclusions.
-- Keep normal event Start behavior frozen. When
-  `force_include_all_paired_miners=true`, persist the logical selector union on
-  the event and extend the reconciler's candidate-parameter translation beyond
-  whole-org/sites to buildings, racks, groups, and explicit identifiers.
-- A normal non-policy Start with zero resolved miners fails as insufficient
-  load. A FULL_FLEET Start with `force_include_all_paired_miners=true` may
-  create a targetless policy watcher for a valid, authorized logical selector
-  so miners assigned or paired later can be admitted. The watcher owns no
-  concrete target and sends no facility-fan command until at least one miner is
-  admitted and confirmed through the normal sequencing gates; this exception
-  does not permit infrastructure-only or missing-scope submissions.
+- Keep non-FULL_FLEET event targets frozen. For every FULL_FLEET event, persist
+  the logical selector union and extend the existing closed-loop candidate
+  translation beyond whole-org/sites to buildings, racks, groups, and explicit
+  identifiers.
+- Preserve this lifecycle matrix:
+  - Non-FULL_FLEET: resolve/freeze once; zero resolved miners fails as
+    insufficient load.
+  - FULL_FLEET without `force_include_all_paired_miners`: maintain the existing
+    eligible-miner watcher and admit newly eligible in-scope miners.
+  - FULL_FLEET with `force_include_all_paired_miners`: maintain the durable
+    paired-miner policy, including unavailable ownership and the
+    restore-before-release rules below.
+  Both FULL_FLEET variants may create a targetless watcher for a valid,
+  authorized logical selector. A targetless watcher sends no facility-fan
+  command until at least one miner is admitted and confirmed through the
+  normal sequencing gates; this never permits infrastructure-only or
+  missing-scope submissions.
 - On every all-paired reconciliation pass, resolve the current union and:
   - admit miners that newly enter the selected topology or become paired,
   - retain paired-like unavailable miners under policy ownership,
@@ -311,6 +330,21 @@ with the proto source.
 - Apply the same topology scope to cooldown/admission queries and preserve the
   existing event/device exclusivity guarantees while targets are added,
   reopened, restored, or released.
+- Treat every active FULL_FLEET logical scope as a reservation, including
+  devices that currently match but are unpaired, unavailable, or not yet
+  represented by `curtailment_target`. Extend
+  `CountCurtailmentScopeConflicts`, `ListActiveCurtailedDevicesByOrg`,
+  `hierarchicalScopeSiteIDs`, and every direct `scope_jsonb` consumer to use one
+  canonical typed-scope resolver rather than whole-org/site-only logic.
+- Serialize Start, closed-loop admission/release, and scope-conflict checks with
+  an organization-scoped transaction/advisory lock. Before any event claims a
+  device, resolve it against older active logical reservations inside that
+  critical section; the older reservation wins and the competing Start fails
+  or excludes the conflict explicitly. Membership/assignment and pairing
+  transitions must trigger immediate reservation reconciliation under the same
+  ordering. If a device was already owned before moving into a reserved scope,
+  retain its current owner but mark the watcher degraded with an actionable
+  conflict and retry after release—never silently treat the policy as fulfilled.
 
 ### 5. Make authorization fail closed
 
@@ -434,6 +468,10 @@ Backend unit/store/integration coverage:
 - Per-type and aggregate selector-limit tests for direct Preview/Start,
   response-profile create/update, automation execution, and forged oversized
   persisted scopes.
+- Scope-reservation tests for concurrent starts, membership changes between
+  reconciliation ticks, explicit-miner reservations, unpair/re-pair gaps,
+  deterministic older-event precedence, and a pre-owned miner moving into a
+  watched topology with a surfaced/retried conflict.
 - Response-profile CRUD/list filtering and automation execution with each new
   scope, including a deleted or moved target that remains visible and
   deletable under its persisted authorization envelope but fails execution and
@@ -462,6 +500,10 @@ Backend unit/store/integration coverage:
 - Rollout tests proving legacy persisted whole-org profiles backfill to the
   explicit representation and the updated frontend emits explicit whole-org
   scope before the server begins rejecting omitted submissions.
+- Selector-limit rollout tests covering inventory of legacy API-created
+  oversized profiles/events, readable and deletable remediation state,
+  shrink-only updates, automation cutoff, and active-event grandfathering
+  through safe restoration.
 - Regression coverage for whole-org, multi-site, explicit-miner, and
   facility-fan behavior; assert no generic device-set scope state remains in
   frontend/domain/storage models.
@@ -503,7 +545,9 @@ developer approval.
   authorization-envelope validation, and target claim before dispatch, so a
   concurrent cross-site move cannot admit an unauthorized miner.
 - Per-type and aggregate selector limits bound direct and persisted scope
-  resolution and are enforced server-side after normalization.
+  resolution and are enforced server-side after normalization. Existing
+  oversized records are inventoried and remediated before enforcement;
+  profiles remain readable/deletable and active events complete safely.
 - Deleted, wrong-type, cross-org, or unauthorized topology targets fail closed
   with actionable errors and never broaden to whole-org scope. Unassigned
   in-org targets are admitted only when the caller has org-wide
@@ -522,9 +566,12 @@ developer approval.
   unsupported, and infrastructure-only miner scope never widens to whole-org
   targeting or reaches facility-fan dispatch; legacy persisted whole-org
   profiles are backfilled to the explicit representation during rollout.
-- Valid zero-member building/rack/group selectors fail ordinary Start, but an
-  authorized all-paired FULL_FLEET policy may persist a targetless watcher and
-  admit future members without commanding fans before a miner is confirmed.
+- Valid zero-member building/rack/group selectors fail non-FULL_FLEET Start,
+  but both FULL_FLEET variants may persist a targetless watcher and admit
+  future eligible members without commanding fans before a miner is confirmed.
+- Active FULL_FLEET logical scopes reserve matching devices between
+  reconciliation ticks; competing events cannot silently take newly eligible
+  or newly assigned members.
 - Whole-org/site all-paired behavior, explicit-miner targeting, facility-fan
   sequencing, and active/history displays keep working. Deprecated generic
   device-set wire input fails closed and is never persisted, executed as, or

--- a/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
+++ b/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
@@ -45,8 +45,10 @@ authorization, and closed-loop lifecycle.
 The published generic `ScopeDeviceSets` case is not a compatibility route:
 curtailment has always returned Unimplemented for it, response-profile creation
 rejects it, and there are no old clients or manually inserted records requiring
-runtime/storage support. Keep its protobuf numbers reserved and deprecated for
-Buf compatibility, but remove generic device-set handling from this feature.
+support. Remove the message and its oneof fields rather than deprecating them.
+Reserve each removed field's name and tag in its enclosing message: tag 2 for
+`CurtailmentScope`, Preview, and Start; tag 8 for events; and tag 11 for the
+signal-ingestion override.
 
 ## Approach
 
@@ -149,9 +151,11 @@ When an owned miner leaves scope or becomes unpaired:
 
 - Add validated building/rack/group messages and oneof cases to
   `proto/curtailment/v1/curtailment.proto`; use new field numbers.
-- Deprecate and reserve the unused generic `device_set_ids` and
-  `device_set_ids_override` fields. Reject them at transport boundaries and
-  remove frontend/domain/JSON runtime paths.
+- Remove the unused generic `device_set_ids` and `device_set_ids_override`
+  fields and `ScopeDeviceSets`; reserve the field names/tags listed above and
+  remove frontend/domain/JSON runtime paths. Do not retain deprecated typed
+  accessors: after decode, a payload containing only removed tags fails the
+  required recognized-scope validation.
 - Extend the Go `Scope`, proto translators, `MarshalScopeJSON`, and
   `ScopeFromJSON` with typed ID arrays. Continue using the existing `mixed`
   scope type and scope JSON columns.
@@ -327,7 +331,8 @@ Frontend coverage:
 
 Backend coverage:
 
-- Proto/domain/JSON round trips and rejection of generic device-set input.
+- Proto/domain/JSON round trips and required-scope rejection for payloads that
+  contain only removed generic device-set wire tags.
 - Candidate membership, deduplication, cooldowns, zero-member resources,
   wrong-type/deleted/cross-org IDs, direct-site racks, rack/building mismatch,
   empty/cross-site groups, and unassigned resources.

--- a/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
+++ b/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
@@ -10,93 +10,54 @@ tracker: https://github.com/block/proto-fleet/issues/909
 
 ## Context
 
-Both operator flows use the same form component:
+Both affected flows render the shared
+`client/src/protoFleet/features/energy/CurtailmentStartModal.tsx`:
 
-- Energy's **New curtailment** flow renders
-  `client/src/protoFleet/features/energy/CurtailmentStartModal.tsx` through
-  `CurtailmentManagementPanel.tsx`.
-- Settings' **Create/Edit response profile** flow renders the same component
-  with `variant="responseProfile"` through
-  `CurtailmentSettingsPage.tsx`.
+- Energy > **New curtailment**, through `CurtailmentManagementPanel.tsx`.
+- Settings > **Create/Edit response profile**, through
+  `CurtailmentSettingsPage.tsx` with `variant="responseProfile"`.
 
-The shared **Apply to** section currently exposes Sites, Miners, and
-Infrastructure. Sites and miners are composable miner selectors; Infrastructure
-is an independent list of facility fans plus sequencing delays. Start and
-Preview already share `buildCurtailmentScopes`, but the surrounding scope
-semantics are still distributed across modal normalization, preview labels,
-response-profile proto hydration/construction, settings and energy-page form
-adapters, and event mappers. Those paths independently reconstruct parts of the
-same rules (whole-org dominance, site/miner unions, legacy scalar fallbacks,
-deduplication, and display labels), so adding another target category in only
-one path can silently lose it in another.
+Their **Apply to** section currently exposes Sites, Miners, and Infrastructure.
+Sites and miners compose as a miner-target union. Infrastructure is a separate
+facility-fan selection with sequencing delays and never contributes miners.
 
-The API already supports repeated `CurtailmentScope` entries and unions them on
-the server. It can persist composite scopes in `curtailment_event.scope_jsonb`
-and `curtailment_response_profile.scope_json`, so adding topology target fields
-does not require a new database column. There is a published generic
-`ScopeDeviceSets` selector, but the curtailment domain has deliberately
-returned Unimplemented for it since the initial backend implementation, and
-response-profile creation rejects it too. There are no old clients or manually
-inserted records that require its runtime or storage representation to remain
-readable. Treat it as dead contract surface, not as a compatibility path or an
-implementation shortcut for racks and groups.
+Start and Preview already share `buildCurtailmentScopes`, but form
+normalization, request construction, proto hydration, profile adapters, event
+mappers, and display labels each reconstruct parts of the site/miner rules.
+Adding a category to only one copy can therefore lose it on preview, save,
+reload, test, automation, or live Start. This work should establish one client
+scope representation and one server resolver rather than extending those
+copies independently.
 
-The closest implemented precedent is Settings > Schedules:
+Settings > Schedules is the closest UI/domain precedent:
 
-- `ScheduleModal.tsx` presents Sites → Buildings → Racks → Groups → Miners.
-- `BuildingSelectionModal.tsx`, `RackSelectionModal.tsx`, and
-  `GroupSelectionModal.tsx` already provide multi-select, loading, empty, and
-  error states.
-- `server/internal/domain/schedule/targets/expand.go` resolves logical targets
-  at execution time and deduplicates their miner union.
+- `ScheduleModal.tsx` orders Sites → Buildings → Racks → Groups → Miners.
+- Its building/rack/group modals already provide multi-select, loading, empty,
+  error, and site-filter behavior.
+- `server/internal/domain/schedule/targets/expand.go` expands logical targets
+  and deduplicates their miner union.
 
-Curtailment needs the same logical targeting vocabulary, but it must retain its
-own eligibility, cooldown, active-event exclusion, preview, authorization, and
-event-snapshot semantics.
+Curtailment needs that targeting vocabulary while preserving its own
+eligibility, cooldown, event exclusivity, facility-fan sequencing,
+authorization, and closed-loop lifecycle.
+
+The published generic `ScopeDeviceSets` case is not a compatibility route:
+curtailment has always returned Unimplemented for it, response-profile creation
+rejects it, and there are no old clients or manually inserted records requiring
+runtime/storage support. Keep its protobuf numbers reserved and deprecated for
+Buf compatibility, but remove generic device-set handling from this feature.
 
 ## Approach
 
-Add Buildings, Racks, and Groups as first-class, persisted curtailment scope
-selectors. Keep target selections as a union: a miner is in scope when it is in
-any selected site, building, rack, group, or explicit-miner list; deduplicate
-before selection and dispatch. Infrastructure remains independent and does not
-contribute miners to the union.
+Add Buildings, Racks, and Groups as explicit, persisted
+`CurtailmentScope` cases. A miner is in scope when it matches any selected
+site, building, rack, group, or explicit identifier; the backend validates,
+unions, and deduplicates that selection. Whole organization dominates and
+clears narrower miner selectors. Infrastructure remains independent, and a
+request without a recognized miner selector is invalid even if fans are
+selected.
 
-Resolve topology membership on the backend, not in the browser:
-
-- Preview resolves current membership and reports the current eligible target
-  set.
-- A non-FULL_FLEET Start resolves current membership once, then freezes
-  concrete miner targets in `curtailment_target`, matching existing open-loop
-  behavior.
-- FULL_FLEET without `Target all paired miners` preserves existing scope
-  behavior: whole-org/site selectors remain closed-loop and buildings/racks/
-  groups join that topology-following watcher, while explicit-miner selectors
-  remain snapshot-only. A mixed union watches its topology portion and includes
-  explicit miners only when they are eligible in the Start snapshot.
-- A response profile stores logical IDs, so each later manual or automation
-  execution resolves the then-current members.
-- For FULL_FLEET with `Target all paired miners`, extend the durable closed-loop
-  policy to every composable miner selector: sites, buildings, racks, groups,
-  and explicit miners. The reconciler re-resolves the union while the event is
-  active and admits newly paired/in-scope miners. A newly considered UNPAIRED
-  miner cannot receive commands and remains outside ownership until it becomes
-  paired; paired-like but temporarily unavailable miners retain the existing
-  `UNAVAILABLE` behavior. When an owned target becomes unpaired or leaves the
-  selected topology, release it immediately only if no Curtail command could
-  have been dispatched. A dispatched or confirmed target becomes a durable
-  restore obligation: retain ownership and use the normal safe restore
-  lifecycle before release. If it is unreachable or unpaired, retry after it
-  becomes commandable; if facility fans are off, defer miner restoration until
-  the existing fan-before-miner restore sequence makes restoration safe.
-
-Use explicit proto cases for buildings, racks, and groups rather than encoding
-racks and groups into the legacy `device_set_ids` case. This preserves target
-type fidelity after reload, makes stale-target errors intelligible, and avoids
-requiring the frontend to refetch and infer whether each generic set ID was a
-rack or a group.
-
-The Apply-to order in both flows should be:
+Both modal variants use this order:
 
 1. Sites
 2. Buildings
@@ -105,567 +66,257 @@ The Apply-to order in both flows should be:
 5. Miners
 6. Infrastructure
 
-Reuse the Schedule selection modals by moving them to a neutral shared
-ProtoFleet target-picker location, or make their current module explicitly
-shared without importing curtailment into Schedules. Preserve the current soft
-site default: a selected topbar site filters building/rack/miner inventory;
-all-sites shows org-wide inventory; groups stay org-wide/cross-site. Existing
-off-site selections must remain visible/preserved when editing a profile under
-a narrower topbar filter.
+Resolve topology membership on the backend. Persist logical selectors for
+response profiles and closed-loop events; persist concrete targets for frozen
+events and for every dispatched miner that may require restoration.
 
-## Scope model and compatibility
+### Execution semantics
 
-Extend the client form models with separate arrays:
+| Start mode | Membership behavior | Zero current miners |
+| --- | --- | --- |
+| Non-FULL_FLEET | Resolve once and freeze `curtailment_target` rows. | Fail as insufficient load. |
+| FULL_FLEET without `force_include_all_paired_miners` | Whole-org/site/building/rack/group selectors remain topology-following; explicit identifiers are Start-time snapshots. A mixed union watches only its topology portion. | A topology selector may remain as a targetless watcher; explicit-only completes as the existing no-op. |
+| FULL_FLEET with `force_include_all_paired_miners` | Admin-only durable policy over the complete union, including explicit identifiers. Newly assigned or newly paired miners can be admitted later. | Persist the watcher without commanding fans until a miner is admitted and confirmed. |
 
-- `buildingTargetIds: string[]`
-- `rackTargetIds: string[]`
-- `groupTargetIds: string[]`
+An unpaired miner can belong to a site, building, rack, or group. It remains
+logically covered by an all-paired policy but cannot receive a command or own a
+target until paired. Paired-like unavailable miners retain existing ownership
+semantics.
 
-Retain `siteIds`, `deviceIdentifiers`, and facility-fan fields. Treat the
-existing scalar `scopeType` as a derived compatibility/display field rather
-than the source of truth for composite selections. Selecting Whole fleet / All
-miners clears every narrower miner selector. Clearing one selector category
-does not clear the others.
+When an owned miner leaves scope or becomes unpaired:
 
-Add three selectors to `CurtailmentScope` in
-`proto/curtailment/v1/curtailment.proto`, each with validated, unique positive
-IDs and new protobuf field numbers. Mark the unused generic `device_set_ids`
-fields deprecated and leave their field numbers allocated so this additive
-feature satisfies the repository's Buf `FILE` compatibility policy; do not add
-new runtime/storage support or reinterpret those numbers as buildings, racks,
-or groups. Remove the deprecated declarations in a separate intentional API
-cleanup if the repository's breaking-change policy is relaxed for them.
-
-Bound selector cardinality using named shared constants: at most 256 IDs for
-each topology type (sites, buildings, racks, and groups), at most 1,024 topology
-IDs across the normalized union, at most 10,000 explicit device identifiers,
-and at most 1,024 repeated `CurtailmentScope` entries. Apply protobuf
-`max_items` validation where the wire shape permits. Before deduplication,
-enforce the same 256-per-type, 1,024-total-topology, and 10,000-total-explicit
-limits across all repeated scope entries, then enforce them again after
-normalization in the domain for direct requests, response profiles, automation
-execution, and persisted closed-loop reconciliation. Configure a 2 MiB request
-body limit for curtailment RPCs so oversized protobuf payloads are rejected
-before decoding/normalization. The frontend mirrors these limits for usability;
-the server remains authoritative.
-
-Before enabling limit enforcement, inventory every persisted profile and
-active event using the normalized counters. Gate rollout on remediating all
-oversized profiles or marking them `scope_limit_remediation_required`; keep
-Get/List/Delete available and allow only shrink-to-valid updates for marked
-profiles. Do not bind or execute their automation after the announced
-remediation cutoff. Grandfather already-active oversized events through safe
-completion so an upgrade cannot strand curtailed miners, but reject new events
-at the limits. Since records are API-created rather than manually inserted,
-this audit/backfill is the authoritative migration path.
-
-Extend the Go domain `Scope` and JSON codec with `building_ids`, `rack_ids`, and
-`group_ids`, and remove generic `DeviceSetIDs`/`device_set_ids` domain and JSON
-handling. Preserve existing decoding and proto rendering for whole-org, site,
-device-list, and mixed records. New topology-only or composite records can
-continue to persist with the existing `mixed` scope type plus the richer JSON
-object, avoiding a response-profile schema migration and new database scope-
-type values. For response profiles, the same JSON object should also carry an
-authorization envelope
-with separate miner-scope and facility-fan site coverage captured when the
-profile is created or updated. The fan dimension must preserve the existing
-requirement for both `site:read` and `curtailment:manage`; miner coverage
-continues to require `curtailment:manage`.
-Persist the same envelope and authorizing-principal reference on every
-closed-loop FULL_FLEET event, with or without the all-paired flag; frozen
-non-FULL_FLEET and unflagged explicit-miner events continue to rely on
-authorization at Preview/Start plus their concrete target rows.
-Add an automation-rule migration for a bound profile scope revision, bound
-miner/fan authorization envelope, and required-admin-controls marker. These
-fields preserve the exact profile scope and privilege class an operator
-authorized when the rule was created, updated, or enabled; they are also the
-stable authorization source for managing a rule after its profile topology
-becomes stale.
-
-Generated protobuf output must be regenerated with `just gen` and committed
-with the proto source.
+- Release it immediately only if no Curtail command could have been dispatched.
+- Otherwise retain ownership as a durable restore obligation until restoration
+  is confirmed.
+- Retry unreachable/unpaired obligations when commandable and preserve the
+  existing fan-before-miner restore sequence.
 
 ## Steps
 
-### 1. Centralize client scope conversion
+### 1. Centralize the client scope model
 
-- Define one canonical miner-target selection independent of presentation
-  metadata:
-  - either whole organization, or
-  - a union of `siteIds`, `buildingIds`, `rackIds`, `groupIds`, and explicit
-    `deviceIdentifiers`.
-  Keep target names/labels and Infrastructure fields outside this semantic
-  scope object.
-- Require every new Preview, Start, and response-profile Create/Update request
-  to contain a recognized, explicit miner selector: Whole organization or at
-  least one site, building, rack, group, or miner. Infrastructure does not make
-  an empty or unrecognized miner scope valid, and those requests must fail
-  before an event, profile, or facility-fan action is created.
-- Create a pure curtailment-scope module used by:
-  - `CurtailmentStartModal.tsx`
-  - `curtailmentRequestBuilders.ts`
-  - `useCurtailmentPlanPreview.ts`
-  - `useCurtailmentResponseProfiles.ts`
-  - `CurtailmentSettingsPage.tsx`
-  - `CurtailmentManagementPanel.tsx`
-  - `curtailmentMappers.ts`
-- Put normalization, whole-org dominance/clearing, deterministic deduplication,
-  proto scope construction, proto scope hydration, target counts,
-  all-paired eligibility, and human-readable summaries in that module. Start,
-  Preview, and response-profile create/update must call the same proto scope
-  constructor; event and response-profile hydration must call the same proto
-  scope decoder.
-- Keep boundary-specific adapters only for genuinely different concerns such
-  as string-to-`bigint` validation, preview debounce/request keys, site-name
-  lookup, and non-scope response-profile fields. Treat `scopeType`, `scopeId`,
-  scalar `siteId`, `siteSelection`, and `minerSelectionMode` as derived legacy/UI
-  compatibility fields rather than independent sources of targeting truth.
-- Update `ResponseProfileFormValues`, `CurtailmentFormValues`, session-cache
-  normalization, and settings-page form adapters so building/rack/group IDs
-  round-trip through API-backed create, list/reload, edit, profile selection,
-  test-curtailment, and live Start.
-- Update event/profile display helpers to render counts by their real type
-  (for example, `2 buildings + 1 group`) instead of `device sets` or `Unknown
-  scope`.
+- Add `buildingTargetIds`, `rackTargetIds`, and `groupTargetIds` beside
+  `siteIds` and `deviceIdentifiers`. Keep fan fields outside the miner scope.
+- Create one pure curtailment-scope module for normalization, whole-org
+  dominance, deterministic deduplication, proto construction/hydration,
+  all-paired eligibility, counts, and summaries.
+- Use it from `CurtailmentStartModal.tsx`,
+  `curtailmentRequestBuilders.ts`, `useCurtailmentPlanPreview.ts`,
+  `useCurtailmentResponseProfiles.ts`, `CurtailmentSettingsPage.tsx`,
+  `CurtailmentManagementPanel.tsx`, and `curtailmentMappers.ts`.
+- Treat scalar `scopeType`, `scopeId`, `siteId`, `siteSelection`, and
+  `minerSelectionMode` as derived UI/legacy fields, not independent targeting
+  inputs.
+- Ensure the typed IDs round-trip through Preview, Start, profile create/list/
+  reload/edit, profile selection, Test curtailment, automation, event history,
+  and session-cache normalization.
+- Selecting a profile rehydrates its logical union; subsequent edits switch to
+  Custom plan. Settings Test saves and starts that same union without a
+  whole-org fallback. `startRequestFromAutomationProfile` uses the same path.
+- Render summaries by real type, such as `2 buildings + 1 group`.
 
-### 2. Add the shared Apply-to controls
+### 2. Add shared Apply-to controls
 
-- Add Buildings, Racks, and Groups `TargetSelectButton`s to the shared modal in
-  broad-to-narrow order.
-- Reuse/extract the Schedule building, rack, and group selection modals,
-  including select-all, empty/error states, stale selection preservation, and
-  site filters.
-- Do not reuse the Schedule pickers' current behavior of pruning IDs absent
-  from the live inventory. Add an explicit curtailment/profile mode that keeps
-  stored missing IDs selected, renders them from hydrated profile metadata (or
-  their ID) as unavailable/stale, and removes them only through an operator's
-  explicit action. Preserve the existing pruning behavior for Schedule callers.
-- Pass the topbar-derived `SiteFilterFields` from both parent flows. Pass the
-  same scope to the miner selector and hide rack/group miner facets when the
-  current role lacks `rack:read`, following `ScheduleModal`.
-- Gate target buttons on the list permissions their picker needs:
-  Buildings require `site:read`; Racks/Groups require `rack:read`; Miners
-  require `miner:read`. Keep submitted existing selections intact when a
-  picker is unavailable so editing does not erase data the user cannot list.
-- Update Apply-to helper text, confirmation copy, profile-card summaries, and
-  preview scope labels for the additional categories.
-- Allow `Target all paired miners` for FULL_FLEET across any union of site,
-  building, rack, group, and explicit-miner selectors. Continue clearing it
-  when switching away from FULL_FLEET. Confirmation copy must describe the
-  selected union rather than implying the entire organization.
+- Reuse/extract the Schedule building/rack/group pickers into a neutral
+  ProtoFleet location without creating imports between feature areas.
+- Preserve the topbar site as a soft inventory filter: it filters buildings,
+  racks, and miners; groups remain org-wide/cross-site.
+- Add a curtailment/profile picker mode that retains missing stored IDs,
+  labels them stale/unavailable from hydrated metadata or their ID, and removes
+  them only through explicit operator action. Schedule callers retain their
+  existing prune-missing behavior.
+- Preserve existing off-site selections when editing under a narrower topbar
+  filter or when the operator cannot open a picker.
+- Gate list controls by their required permissions: Buildings use `site:read`,
+  Racks/Groups use `rack:read`, and Miners use `miner:read`. Picker filtering
+  is usability only; the server remains authoritative. Hide rack/group miner
+  facets when the role lacks `rack:read`, matching Schedules.
+- Allow **Target all paired miners** for FULL_FLEET with any site/building/rack/
+  group/miner union, and clear it when switching away from FULL_FLEET.
 
-### 3. Extend proto translation and JSON round trips
+### 3. Extend contracts and persistence
 
-- Add explicit building/rack/group scope messages and cases to
-  `CurtailmentScope`.
-- Extend `toCompositeScope`, legacy/request translators,
-  `protoScopesFromDomainScope`, event rendering, response-profile rendering,
-  `MarshalScopeJSON`, and `ScopeFromJSON`.
-- Ensure a whole-org entry still dominates narrower selectors and mixed
-  entries are normalized/deduplicated deterministically.
-- Reject an empty or unrecognized miner scope at every new submission boundary,
-  including when facility fans are present. Never synthesize whole-org scope
-  from missing, unknown, or unsupported cases, and never dispatch a fan unless
-  the execution has at least one admitted miner target and the existing
-  confirmation/sequencing preconditions are satisfied.
-- Preserve existing persisted response profiles whose empty legacy
-  `scope_json` plus absent `site_id` means whole organization, but backfill them
-  to explicit `{"whole_org":true}` before enabling the new submission rules.
-  There are no supported old clients, but a browser tab opened before the
-  frontend deployment can still submit the old shape. Add a required scope-
-  schema version to every Create/Update/Preview/Start request, including test
-  curtailments and profile-derived starts. Deploy server support and the
-  frontend that always emits the new version and explicit Whole organization,
-  complete the data backfill, then raise the server's minimum accepted version
-  before any building/rack/group scope can be created or returned. Reject a
-  missing, old, or unknown version rather than interpreting its recognized
-  subset. This is a bounded cutover guard, not a retained old-client runtime
-  compatibility path.
-- Give each response profile an opaque scope revision derived from its canonical
-  persisted miner/fan scope. Return it from Get/List and require an exact match
-  on Update, every profile-derived execution, and automation-rule Create,
-  Update, or enable. The server must load and use the matching stored logical
-  scope instead of trusting a client-expanded copy; stale or missing revisions
-  fail with a refresh-required error. Disabling or deleting an automation rule
-  does not require a current revision. Together with the minimum schema version,
-  this prevents a stale tab that ignores unknown topology cases from
-  overwriting, running, or binding a narrow profile as explicit Whole
-  organization.
-- Add `max_items` validation to every repeated scope/identifier field and
-  domain validation for raw pre-deduplication totals and normalized per-type/
-  aggregate selector limits. Enforce the transport byte cap before decoding and
-  reject oversized persisted profiles before execution. For an already-active
-  oversized legacy event, do not resolve its logical scope for new admissions;
-  mark it degraded and continue confirmation, facility-fan sequencing,
-  restoration, ownership release, and terminalization from its durable target
-  rows. This active-event drain exception must run before general persisted-
-  scope rejection so enforcement cannot strand curtailed miners.
-- Remove generic device-set translation, domain/JSON decode/render paths,
-  frontend `deviceSetIds` scope state, and the special unsupported-device-set
-  preview branch. Keep only deprecated protobuf declarations/field numbers as
-  inert schema surface; reject them at the transport boundary if they are ever
-  submitted. New explicit topology cases must preview normally.
-- Apply the same deprecation to the unused
-  `IngestCurtailmentSignalRequest.device_set_ids_override` field; the ingest RPC
-  itself is currently Unimplemented, so it must not remain as a hidden generic
-  device-set route when that RPC is implemented later.
+- Add validated building/rack/group messages and oneof cases to
+  `proto/curtailment/v1/curtailment.proto`; use new field numbers.
+- Deprecate and reserve the unused generic `device_set_ids` and
+  `device_set_ids_override` fields. Reject them at transport boundaries and
+  remove frontend/domain/JSON runtime paths.
+- Extend the Go `Scope`, proto translators, `MarshalScopeJSON`, and
+  `ScopeFromJSON` with typed ID arrays. Continue using the existing `mixed`
+  scope type and scope JSON columns.
+- Require explicit Whole organization or at least one typed miner selector for
+  every new Preview, Start, profile Create/Update, test, and automation path.
+  Missing, unknown, unsupported, or infrastructure-only scope never widens to
+  whole organization or reaches fan dispatch.
+- Backfill persisted empty-scope/absent-site whole-org profiles to explicit
+  `{"whole_org":true}` before omitted scopes are rejected.
+- Add a required scope-schema version to new submissions. Deploy server support
+  and the updated frontend, complete the backfill, then raise the minimum
+  accepted version before topology scopes are emitted. This rejects stale
+  browser tabs without retaining an old-client compatibility path.
+- Derive and return an opaque revision from each profile's canonical miner/fan
+  scope. Require it on profile Update, profile-derived execution, and
+  automation Create/Update/enable; the server reloads the matching stored scope
+  instead of trusting a client-expanded copy.
 
-### 4. Resolve and validate topology scopes in the curtailment backend
+Bound inputs before expensive resolution:
 
-- Extend `interfaces.ListCandidatesParams`, the SQL store adapter, and
-  `ListCurtailmentCandidatesByOrg` with building/rack/group filters whose
-  predicates are unioned with sites and explicit miners.
-- Match existing fleet semantics:
-  - Building: direct `device.building_id` or membership in a rack assigned to
-    the building.
-  - Rack: live rack `device_set` membership only.
-  - Group: live group `device_set` membership only, including cross-site
-    members.
-  - Always constrain resources, sets, memberships, and devices to the caller's
-    organization and exclude deleted rows.
-- Validate every submitted topology ID even when it currently contains zero
-  miners. Return NotFound for deleted, wrong-type, or cross-org IDs rather than
-  converting them into an empty/insufficient-load preview.
-- Resolve authorization coverage from both the selected topology resources and
-  their current members. A building contributes its owning site even when
-  empty. A rack contributes `device_set_rack.site_id` even when it has no
-  building or members; if that field is NULL, the rack requires org-wide
-  authorization. When a rack also has a building, validate that the building's
-  site agrees with the rack's site and reject inconsistent topology rather than
-  silently selecting either value. An unassigned building also requires
-  org-wide authorization. A group contributes every current member site, and
-  an empty group requires org-wide authorization because its future site
-  coverage is unbounded.
-- Deduplicate candidates across overlapping selectors before classification.
-- For cooldown lookup, use the already-resolved candidate identifiers (or add
-  equivalent topology predicates) so a building/rack/group request cannot
-  accidentally apply org-wide cooldown exclusions.
-- Keep non-FULL_FLEET event targets frozen. Persist the logical selector union
-  for closed-loop FULL_FLEET events and extend the existing watcher beyond
-  whole-org/sites to buildings, racks, and groups. Do not turn an unflagged
-  explicit-miner-only FULL_FLEET request into a watcher.
-- Preserve this lifecycle matrix:
-  - Non-FULL_FLEET: resolve/freeze once; zero resolved miners fails as
-    insufficient load.
-  - FULL_FLEET without `force_include_all_paired_miners`: maintain the existing
-    eligible-miner watcher for whole-org/site/building/rack/group selectors and
-    admit newly eligible members of those selectors. Explicit identifiers are
-    snapshot-only; an explicit-only empty selection completes as the existing
-    no-op rather than leaving a watcher.
-  - FULL_FLEET with `force_include_all_paired_miners`: maintain the durable
-    paired-miner policy across the full union, deliberately including explicit
-    identifiers. This is new admin-only behavior: an explicitly selected
-    unpaired miner is logically reserved and admitted after pairing. Preserve
-    unavailable ownership and the restore-before-release rules below.
-  A topology-following FULL_FLEET scope, or a flagged explicit-miner policy,
-  may create a targetless watcher. A targetless watcher sends no facility-fan
-  command until at least one miner is admitted and confirmed through the normal
-  sequencing gates; this never permits infrastructure-only or missing-scope
-  submissions.
-- On every all-paired reconciliation pass, resolve the current union and:
-  - admit miners that newly enter the selected topology or become paired,
-  - retain paired-like unavailable miners under policy ownership,
-  - immediately release miners that leave every selector or become UNPAIRED
-    only when no Curtail command could have been dispatched,
-  - move dispatched or confirmed miners that leave scope into the existing safe
-    restore lifecycle and retain ownership until restore confirmation,
-  - persist and retry restore obligations for unreachable/unpaired miners, and
-    respect facility-fan sequencing before issuing their restore command,
-  - deduplicate miners that match multiple selector categories.
-- Apply the same topology scope to cooldown/admission queries and preserve the
-  existing event/device exclusivity guarantees while targets are added,
-  reopened, restored, or released.
-- Treat every active closed-loop FULL_FLEET logical scope as a reservation,
-  including devices that currently match but are unpaired, unavailable, or not
-  yet represented by `curtailment_target`. A flagged explicit-miner policy
-  participates in the same reservation path. Extend
-  `CountCurtailmentScopeConflicts`, `ListActiveCurtailedDevicesByOrg`,
-  `hierarchicalScopeSiteIDs`, and every direct `scope_jsonb` consumer to use one
-  canonical typed-scope resolver rather than whole-org/site-only logic.
-- Serialize Start, closed-loop admission/release, and scope-conflict checks with
-  an organization-scoped transaction/advisory lock. Before any event claims a
-  device, resolve it against older active logical reservations inside that
-  critical section; the older reservation wins and the competing Start fails
-  or excludes the conflict explicitly. Membership/assignment and pairing
-  transitions must trigger immediate reservation reconciliation under the same
-  ordering. If a device was already owned before moving into a reserved scope,
-  retain its current owner but mark the watcher degraded with an actionable
-  conflict and retry after release—never silently treat the policy as fulfilled.
+| Limit | Bound |
+| --- | ---: |
+| IDs per topology type | 256 |
+| Total topology IDs | 1,024 |
+| Explicit device identifiers | 10,000 |
+| Repeated `CurtailmentScope` entries | 1,024 |
+| Curtailment RPC body | 2 MiB |
 
-### 5. Make authorization fail closed
+Enforce cardinality on raw repeated input before deduplication and again after
+domain normalization. Apply the same limits to direct requests, persisted
+profiles, automation, and reconciliation; use protobuf `max_items` where the
+wire shape permits.
 
-- Add a single server-side scope-resolution result that reports:
-  - validated selector IDs and types,
-  - site IDs contributed by selected building/rack resources,
-  - site IDs contributed by current miner members,
-  - whether any selected resource/member is unassigned or has unbounded future
-    coverage,
-  - the resolved current device identifiers,
-  - separately resolved facility-fan site IDs and unassigned status.
-- Reuse strict current-topology resolution for Preview, Start,
-  response-profile Create/Update, profile execution, automation-rule Create/
-  Update/enable, and automation execution. Do not use strict live topology for
-  response-profile or automation-rule read/delete paths, or for disabling a
-  rule. Require `curtailment:manage` at every covered site; require org-wide
-  permission when scope coverage is incomplete or includes unassigned
-  resources. Picker filtering is usability only, never authorization.
-- Treat Preview as a point-in-time estimate, but make Start and every
-  closed-loop reconciliation admission atomic with authorization-envelope
-  enforcement.
-  Selector validation, membership expansion, current site coverage, and target
-  claim/insertion must use one transaction/locked snapshot, or every
-  materialized device and current site must be revalidated inside the target
-  claim transaction. Dispatch starts only after that transaction commits.
-  A concurrent topology move must make the claim fail/retry or exclude the
-  moved device; it must never admit a device outside the caller's or event's
-  authorization envelope.
-- On response-profile Create/Update, persist the resolved authorization
-  envelope in the existing `scope_json`: the union of selected-resource and
-  current-member site coverage for miner selectors, exact facility-fan site
-  IDs, and separate org-wide authorization flags for either dimension when
-  coverage is incomplete, unassigned, or unbounded. Preserve the current
-  `site:read` plus `curtailment:manage` checks for every fan site rather than
-  treating miner-scope authorization as permission to control fans.
-- Backfill existing API-created profiles only where the original authorization
-  envelope is provable from persisted scope: whole-org scope becomes
-  org-wide miner authorization, and site-only scope with no facility fans
-  retains its exact miner site IDs. Profiles containing explicit miners,
-  facility fans without persisted site coverage, or any otherwise ambiguous
-  coverage are marked `reauthorization_required` until an operator with current
-  authority reviews and resaves them. Automation must reject a profile with a
-  missing or unproven envelope; it must never derive authority from a miner's
-  or fan's current site at execution time. Surface this state in profile
-  Get/List so it can be fixed or deleted.
-- Before enforcing profile envelopes or bound-revision checks, inventory every
-  enabled automation rule that references a profile marked
-  `reauthorization_required` or lacks a proven bound revision, envelope, or
-  execution principal/admin-control requirement. Expose the affected rules and
-  profiles to operators and reauthorize/rebind or disable them. Gate enforcement on that inventory
-  reaching zero, unless owners explicitly approve an announced cutoff for the
-  remaining rules. After the gate, keep execution fail closed; do not
-  temporarily infer binding state to preserve an unremediated automation.
-- Bind every automation rule execution to an explicit user or service-account
-  principal; the stored envelope is a maximum boundary, not a durable
-  capability. At every trigger, reload that principal's current effective
-  permissions, resolve current topology and facility-fan sites, and require
-  both the live permissions and stored envelope to authorize the operation. A
-  deactivated principal or revoked grant blocks execution. Do not fall back to
-  the profile creator or an ambient system principal.
-- Record whether an automation binding or event uses admin-only controls,
-  including `force_include_all_paired_miners`. Every manual/profile execution,
-  automation trigger, and closed-loop reconciliation pass must separately
-  revalidate that the current principal is still Admin or SuperAdmin; site/org
-  `curtailment:manage` alone is insufficient. Demotion blocks new events and
-  admissions. An active event then stops expansion and retains already-owned
-  targets through the same fan-aware safe restore-before-release lifecycle.
-- Stamp the applicable authorization envelope and authorizing principal onto
-  every closed-loop FULL_FLEET event, not only all-paired events, together with
-  its required-admin-controls marker. Each reconciliation pass must reload the
-  principal's current effective
-  permissions and compare current topology/fan coverage with both those
-  permissions and the envelope before admitting targets. A rack or building
-  moved to another site, a group gaining an out-of-envelope member, a fan
-  moving sites, newly unassigned membership, or permission revocation blocks
-  new admission with a clear reason.
-  Out-of-envelope miners are not admitted, already-owned miners that move
-  outside the envelope—or lose current principal authorization—follow the same
-  dispatch-aware restore-before-release rule. Restore facility fans first when
-  required, surface an actionable authorization-change reason, and terminate or
-  remain degraded until safe restoration completes. An org-wide envelope may
-  follow topology across sites only while the principal still has the required
-  live org-wide permissions.
-- Before requiring envelopes on reconciliation, inventory active closed-loop
-  events created by the old schema. Backfill an envelope only when the event's
-  persisted whole-org/site scope and original authorizing principal prove the
-  exact boundary. If either is absent or ambiguous, place the event in explicit
-  drain mode: admit no new targets and do not re-resolve its logical scope, but
-  continue confirmation, fan sequencing, safe restoration, ownership release,
-  and terminalization from durable target rows. Run this migration before the
-  reconciler begins rejecting missing envelopes so an upgrade cannot either
-  widen authority or strand already-curtailed miners.
-- Do not require current topology resolution for response-profile Get/List or
-  Delete. Authorize those operations against the profile's persisted
-  miner and facility-fan envelope dimensions, including `site:read` on fan
-  sites, and hydrate stored typed IDs even when a target was deleted or moved.
-  Surface unresolved targets as unavailable/stale so an authorized operator
-  can inspect, edit, or delete the profile; Create/Update and every execution
-  path still perform strict current-topology and current-fan-site validation,
-  so a stale ID must be removed or replaced before resave and can never execute.
-- When a profile has a missing or unproven authorization envelope, require
-  org-wide `curtailment:manage` for Get/List/Delete and reauthorization, plus
-  org-wide `site:read` when it contains facility fans. Do not fall back to
-  current topology, miner locations, or fan locations to grant access.
-  Site-scoped operators do not see the profile until an org-wide operator with
-  the required permissions establishes a proven envelope or deletes it.
-- Apply the same recovery boundary to automation-rule management. Get/List,
-  Delete, and disable must authorize against the rule's persisted bound miner/
-  fan envelope and hydrate the stored profile reference without resolving its
-  current topology. A deleted or moved topology target therefore marks the rule
-  stale or `rebind_required` but cannot make it unlistable or prevent an
-  authorized operator from disabling or deleting it. A legacy rule with a
-  missing or unproven bound envelope uses the same org-wide recovery rule as an
-  unproven profile. Create, Update, enable, and execution remain strict and
-  cannot use this recovery path.
+### 4. Resolve targets and authorization once
 
-### 6. Cover manual and automated execution
+- Extend `ListCandidatesParams`, the SQL adapter, and
+  `ListCurtailmentCandidatesByOrg` with unioned building/rack/group predicates.
+- Match fleet semantics:
+  - Building: direct `device.building_id` or rack assigned to the building.
+  - Rack: live rack device-set membership.
+  - Group: live group membership, including cross-site members.
+  - Always constrain resources, memberships, and devices to the organization
+    and exclude deleted rows.
+- Validate every topology ID even when it has zero members. Deleted,
+  wrong-type, and cross-org IDs return NotFound rather than looking like empty
+  load.
+- Resolve cooldowns from the already-resolved candidate identifiers so a
+  topology request cannot accidentally apply org-wide exclusions.
+- Return one resolution result containing typed IDs, selected-resource sites,
+  current-member sites, uncovered/unbounded state, concrete identifiers, and
+  separate facility-fan sites/unassigned state.
 
-- Ensure `startRequestFromAutomationProfile` carries the new scope arrays and
-  exercises the same selector pipeline as direct Start.
-- Add the profile's expected scope revision to automation-rule Create, Update,
-  and enable requests. In the same database transaction that saves or enables
-  the rule, lock and reload the profile, compare its canonical scope revision
-  and authorization envelope with the values authorized by the handler, and
-  persist that revision, envelope, execution principal, and whether the profile
-  requires admin-only controls as the rule's bound profile state. Extend the
-  existing store-side facility-fan race check rather than leaving scope or
-  privilege validation only in the handler. Any mismatch returns
-  FailedPrecondition and saves nothing.
-- At every trigger, require the current profile revision to equal the rule's
-  bound revision before resolving or starting an event, then enforce the bound
-  envelope, the execution principal's current permissions, and any bound Admin/
-  SuperAdmin requirement. A profile scope change never silently retargets an
-  enabled rule: the revision mismatch makes
-  linked bindings report `rebind_required`, blocks event and fan creation, and
-  requires an authorized operator to review the current profile and re-enable/
-  rebind the rule.
-- Keep recovery operations independent of live topology and revision matching.
-  Get/List render the stale/rebind state, while disable and Delete authorize
-  from the bound envelope and remain available even when the profile target is
-  stale or its revision changed. Disabling must not call the strict enable path
-  or require a client-supplied profile revision.
-- Ensure selecting a saved response profile in New curtailment restores its
-  building/rack/group selections and that subsequent manual edits switch the
-  dropdown to Custom plan, matching current site/miner behavior.
-- Ensure Settings' Test curtailment path saves the logical profile scope first,
-  then starts with the same logical scope; it must not fall back to whole fleet
-  if a topology mapper omits fields.
+Authorization coverage follows these rules:
 
-### 7. Verification
+| Selector/resource | Required coverage |
+| --- | --- |
+| Site | That site. |
+| Building | Its owning site even when empty; org-wide when unassigned. |
+| Rack | `device_set_rack.site_id` even without a building or members; org-wide when NULL. If a building exists, reject a rack/building site mismatch. |
+| Group | Every current member site; org-wide when empty or when future coverage is otherwise unbounded. |
+| Explicit miner | Its current site; org-wide when unassigned. |
+| Facility fan | Separate exact-site envelope requiring both `site:read` and `curtailment:manage`; org-wide recovery for unproven coverage. |
 
-Frontend unit/component coverage:
+Require `curtailment:manage` for every miner site and org-wide permission for
+unassigned/unbounded coverage. Bind selector validation, membership expansion,
+site coverage, envelope validation, and target claim in one locked transaction
+or revalidate each materialized target inside the claim transaction. Dispatch
+only after commit.
 
-- Request-building tests for building-only, rack-only, group-only, and mixed
-  site/building/rack/group/miner unions.
-- Shared modal tests in both variants for buttons, selection counts, clear/
-  select-all, active-site filtering, stale selection preservation, and
-  permission-gated pickers.
-- Picker tests proving the curtailment/profile mode retains and labels missing
-  rack/group IDs until explicit removal while Schedule mode keeps its existing
-  pruning behavior.
-- Response-profile API tests proving create/update payloads and list/reload
-  hydration retain each target type without relying on the in-memory session
-  cache.
-- Automation API tests proving Create/Update/enable carry the selected profile's
-  scope revision, stale revisions surface a refresh-required state, and disable/
-  Delete remain available without a current revision.
-- Cross-boundary contract tests proving the same canonical selection emits the
-  same normalized scopes for Preview, Start, and response-profile
-  create/update, and hydrates back without losing a category.
-- Display tests for preview, confirmation, response-profile cards, active
-  events, and history.
+On profile Create/Update, persist the union of selected-resource and current-
+member site coverage plus the independent fan-site coverage in `scope_json`,
+with separate org-wide flags for incomplete or unbounded dimensions.
 
-Backend unit/store/integration coverage:
+### 5. Preserve closed-loop ownership and exclusivity
 
-- Proto ↔ domain ↔ JSON round trips for the supported scope cases, plus a
-  transport test that deprecated generic device-set input fails closed.
-- Candidate resolution for direct-building and rack-in-building devices, rack
-  membership, cross-site group membership, mixed overlap deduplication, empty
-  valid resources, wrong-type IDs, deleted IDs, and cross-org IDs.
-- Cooldown, active-event exclusion, fixed-kW, and full-fleet selection over
-  each topology scope.
-- All-paired reconciliation for building/rack/group membership additions,
-  removals before dispatch, removals after confirmed curtailment, cross-selector
-  overlap, unpair/re-pair restore retries, facility-fan sequencing, and
-  paired-like unavailable miners.
-- Authorization for one-site, multi-site, cross-site group, unassigned,
-  narrowed-role, and topology-change-after-profile-save cases, including race
-  tests that move topology across sites between resolution and target claim.
-- Per-type and aggregate selector-limit tests for direct Preview/Start,
-  response-profile create/update, automation execution, and forged oversized
-  persisted scopes.
-- Raw-limit tests with duplicate-heavy identifiers split across many scope
-  entries, per-type and cross-type raw totals, and payloads above the 2 MiB
-  transport limit, proving rejection occurs before normalization work.
-- Scope-reservation tests for concurrent starts, membership changes between
-  reconciliation ticks, explicit-miner reservations, unpair/re-pair gaps,
-  deterministic older-event precedence, and a pre-owned miner moving into a
-  watched topology with a surfaced/retried conflict.
-- FULL_FLEET lifecycle tests proving unflagged explicit-miner-only scope stays
-  snapshot-only and completes as a no-op when empty; mixed unflagged scope
-  watches only its topology portion; and the flagged admin policy deliberately
-  reserves/re-admits explicit identifiers after pairing.
-- Response-profile CRUD/list filtering and automation execution with each new
-  scope, including a deleted or moved target that remains visible and
-  deletable under its persisted authorization envelope but fails execution and
-  resave until corrected.
-- Automation-rule authorization tests proving Get/List/Delete/disable use the
-  persisted bound miner/fan envelope and remain available when a referenced
-  topology target is stale, while Create/Update/enable/execution require strict
-  current topology. Cover the org-wide recovery rule for legacy bindings with
-  missing or unproven envelopes.
-- Automation binding race tests that change a profile's scope or envelope
-  between handler authorization and the store transaction. Create, Update, and
-  enable must fail atomically on an expected-revision/envelope mismatch; a
-  successful bind persists the exact revision, envelope, principal, and admin-
-  control requirement.
-- Automation trigger tests proving a later profile-scope revision puts the rule
-  in `rebind_required`, creates no event or fan command, and resumes only after
-  an authorized rebind. Disabling and deleting the mismatched rule must not
-  require live topology or revision equality.
-- Authorization-envelope rollout tests for provable whole-org/site backfills,
-  explicit-miner and mixed profiles requiring reauthorization, a miner moving
-  sites before reauthorization, org-wide-only Get/List/Delete access while the
-  envelope is missing or unproven, site-scoped filtering, and automation
-  failing closed before reauthorization.
-- Current-permission tests for automation owner deactivation, site-grant and
-  org-wide-grant revocation, facility-fan `site:read` revocation, service-account
-  principals, Admin/SuperAdmin demotion for admin-only profiles/events, and
-  mid-event revocation or demotion that blocks admission and safely restores
-  existing ownership for both ordinary and all-paired FULL_FLEET.
-- Facility-fan authorization tests for a fan outside the miner scope, fan site
-  movement, unassigned/stale fans, `site:read` without `curtailment:manage` and
-  vice versa, CRUD/list filtering against persisted fan-site coverage, and
-  automation failing when current fan coverage exceeds its envelope.
-- Empty/unknown-scope tests proving Preview, Start, profile save/execution, and
-  automation never infer whole organization and reject infrastructure-only or
-  unknown-scope-plus-fan requests before any event, profile, target ownership,
-  or fan command is created. Prove a normal non-policy execution with a valid
-  zero-member selector fails without commanding fans, while an all-paired
-  FULL_FLEET execution persists a targetless watcher, sends no fan command,
-  later admits an assigned/paired miner, and only then follows normal fan
-  sequencing.
-- Authorization tests for empty buildings using the resource's owning site,
-  building-less racks using `device_set_rack.site_id`, rack/building site
-  mismatches failing closed, NULL-site racks and unassigned buildings requiring
-  org-wide access, empty groups requiring org-wide access, and cross-site groups
-  requiring every current member site while remaining bounded by their
-  persisted envelope.
-- Rollout tests proving legacy persisted whole-org profiles backfill to the
-  explicit representation and the updated frontend emits explicit whole-org
-  scope before the server begins rejecting omitted submissions. Cover a stale
-  browser missing the minimum scope-schema version, an unknown topology case,
-  profile update/execution with a missing or stale scope revision, and a valid
-  refreshed profile-derived execution that uses the server-stored scope.
-- Authorization-envelope rollout tests for active closed-loop events: provable
-  whole-org/site boundaries retain reconciliation, while an event with an
-  ambiguous scope or principal enters no-admission drain mode and completes
-  safe restoration from durable targets.
-- Automation rollout tests inventory enabled rules bound to profiles requiring
-  reauthorization or missing a proven bound revision, envelope, principal, or
-  admin-control requirement;
-  prevent enforcement before rebind/disable remediation or an explicit cutoff;
-  preserve authorized read/disable/delete recovery; and fail closed after
-  cutover without silently widening scope.
-- Selector-limit rollout tests covering inventory of legacy API-created
-  oversized profiles/events, readable and deletable remediation state,
-  shrink-only updates, automation cutoff, and an active oversized event that
-  blocks new admissions but completes confirmation, fan sequencing, safe
-  restoration, ownership release, and terminalization after upgrade.
-- Regression coverage for whole-org, multi-site, explicit-miner, and
-  facility-fan behavior; assert no generic device-set scope state remains in
-  frontend/domain/storage models.
+- Persist the logical union for topology-following FULL_FLEET events; keep
+  non-FULL_FLEET and unflagged explicit-miner targets frozen.
+- On reconciliation, admit newly eligible/paired members, deduplicate overlap,
+  retain unavailable ownership, and apply the restore-before-release rules
+  above to targets leaving the union.
+- Treat every active closed-loop logical scope as a reservation, including
+  matching miners not yet represented by target rows. Flagged explicit-miner
+  policies use the same reservation path.
+- Update `CountCurtailmentScopeConflicts`,
+  `ListActiveCurtailedDevicesByOrg`, `hierarchicalScopeSiteIDs`, and direct
+  `scope_jsonb` consumers to use the canonical typed resolver.
+- Serialize Start, reconciliation, and conflict checks with an org-scoped
+  lock. Older reservations win deterministically. A device already owned when
+  it moves into a watched scope retains its owner; mark the watcher degraded
+  and retry after release.
+- Persist the authorization envelope, authorizing principal, and whether
+  admin-only controls are required on every closed-loop event. Each admission
+  reloads current permissions, current Admin/SuperAdmin role when required, and
+  current topology before claiming a target.
+- Permission revocation, role demotion, or out-of-envelope topology stops new
+  admissions and moves owned targets through safe restoration; it never
+  releases a possibly curtailed miner directly.
 
-Run the smallest relevant suites first, then the canonical checks:
+### 6. Make profiles and automation strict but recoverable
+
+Use strict current topology for profile Create/Update/execution and automation
+Create/Update/enable/execution. Use persisted envelopes for recovery operations:
+
+| Record state/operation | Behavior |
+| --- | --- |
+| Valid profile Get/List/Delete | Authorize against persisted miner/fan envelope; hydrate stale typed IDs without live topology. |
+| Profile with missing/unproven envelope | Org-wide `curtailment:manage`, plus org-wide `site:read` when fans exist; no current-location fallback. |
+| Stale profile resave/execution | Reject until stale IDs are explicitly removed/replaced. |
+| Automation Get/List/Delete/disable | Authorize against the rule's bound envelope; remain available when profile topology or revision is stale. |
+| Automation Create/Update/enable/trigger | Require strict topology, exact profile revision/envelope, current principal permissions, and current Admin/SuperAdmin role for admin-only controls. |
+
+Add immutable up/down migrations for automation-rule binding fields: profile
+scope revision, miner/fan envelope, execution principal, and required-admin
+marker. In the same transaction that saves/enables a rule, lock the profile,
+compare the handler-authorized revision/envelope, and persist that exact
+binding. Extend the existing store-side fan-settings race check; mismatch
+returns FailedPrecondition without saving.
+
+Reload the bound user or service-account permissions at every trigger; never
+fall back to the profile creator or an ambient system principal.
+
+At each trigger, compare the current profile revision with the bound revision
+before creating an event or fan action. A mismatch reports `rebind_required`
+until an authorized operator reviews and re-enables the rule. Disable/Delete do
+not require a current revision or strict topology.
+
+### 7. Roll out fail-closed behavior safely
+
+1. Ship proto/server parsing, schema-version support, profile revisions, and
+   automation binding storage without emitting topology scopes.
+2. Deploy the frontend that always sends the new version and explicit
+   whole-org scope.
+3. Inventory and remediate persisted data:
+   - Backfill provable whole-org/site profile envelopes.
+   - Mark ambiguous profiles `reauthorization_required`.
+   - Inventory enabled rules missing a proven revision, envelope, principal, or
+     admin marker; rebind, disable, or approve an announced cutoff.
+   - Mark oversized profiles `scope_limit_remediation_required`; keep Get/List/
+     Delete and shrink-to-valid Update available.
+   - Backfill active event envelopes only when scope and principal prove the
+     boundary.
+4. Put ambiguous or oversized active events into no-admission drain mode:
+   continue confirmation, fan sequencing, restoration, release, and
+   terminalization from durable target rows without re-resolving logical scope.
+5. Gate enforcement on remediation/cutoff completion, raise the minimum schema
+   version, then enable topology-scope creation and emission.
+
+## Verification
+
+Frontend coverage:
+
+- Both modal variants: ordering, counts, select-all/clear, site filters,
+  permissions, stale-ID preservation, and all-paired behavior.
+- Canonical request/hydration tests for each target type and mixed unions across
+  Preview, Start, profile create/reload/edit/test, automation, and display.
+- Stale-browser schema rejection and profile/automation revision handling;
+  disable/delete remain available without a current revision.
+
+Backend coverage:
+
+- Proto/domain/JSON round trips and rejection of generic device-set input.
+- Candidate membership, deduplication, cooldowns, zero-member resources,
+  wrong-type/deleted/cross-org IDs, direct-site racks, rack/building mismatch,
+  empty/cross-site groups, and unassigned resources.
+- Frozen versus topology-following FULL_FLEET behavior, empty watchers,
+  explicit-miner snapshot compatibility, flagged explicit-miner policy,
+  reservation conflicts, pairing transitions, and restore obligations.
+- Authorization races, separate fan coverage, stale CRUD recovery, missing
+  envelopes, current permission revocation, Admin/SuperAdmin demotion, and
+  current topology exceeding an envelope.
+- Automation binding races, `rebind_required`, stale rule management, and
+  rollout remediation.
+- Raw/normalized limits, oversized-record remediation, and safe active-event
+  draining.
+
+Run:
 
 ```sh
 bin/just gen
@@ -674,99 +325,33 @@ bin/just gen
 bin/just lint
 ```
 
-Add ProtoFleet Playwright coverage for both entry points: create a topology-
-scoped response profile, reload/edit it, and run a new curtailment scoped to a
-building/rack/group. Do not refresh visual snapshot baselines without explicit
-developer approval.
+Add ProtoFleet Playwright coverage for creating, reloading/editing, testing, and
+running topology-scoped profiles from both entry points. Do not refresh visual
+snapshots without explicit approval.
 
 ## Acceptance
 
-- New curtailment and Create/Edit response profile show Sites, Buildings,
-  Racks, Groups, Miners, and Infrastructure in the same order and with
-  consistent selection behavior.
-- Operators can combine any narrower miner target categories; the backend
-  unions and deduplicates current membership for Preview and Start.
-- Building/rack/group IDs survive profile save, page reload, edit, manual run,
-  and automation execution without becoming explicit-miner snapshots or whole
-  fleet.
-- Preview and Start resolve the same miners for the same scope, subject only to
-  normal time-varying telemetry/eligibility.
-- Non-FULL_FLEET and unflagged explicit-miner events freeze concrete miner
-  targets; closed-loop FULL_FLEET topology watchers follow their logical scope
-  within their persisted authorization boundary.
-- FULL_FLEET events with `Target all paired miners` continuously re-resolve the
-  selected site/building/rack/group/miner union: newly paired or newly assigned
-  miners are admitted. Unpaired or no-longer-in-scope miners are released
-  immediately only when undispatched; any miner that may already be curtailed
-  remains owned until it completes the safe restore lifecycle.
-- Start and each reconciliation pass atomically bind topology membership,
-  authorization-envelope validation, and target claim before dispatch, so a
-  concurrent cross-site move cannot admit an unauthorized miner.
-- Per-type and aggregate selector limits bound direct and persisted scope
-  resolution and are enforced on raw input before deduplication and server-side
-  after normalization, with a transport byte limit. Existing oversized records
-  are inventoried and remediated before enforcement; profiles remain readable/
-  deletable, while active events stop new admissions and drain safely from
-  durable targets.
-- Deleted, wrong-type, cross-org, or unauthorized topology targets fail closed
-  with actionable errors and never broaden to whole-org scope. Unassigned
-  in-org targets are admitted only when the caller has org-wide
-  `curtailment:manage`; otherwise they are treated as uncovered and rejected.
-- A saved profile with a later-deleted or moved target remains visible and
-  deletable to operators authorized for its persisted envelope, renders the
-  unresolved target as stale, and fails strict resave or execution until fixed.
-- Existing profiles receive a provable whole-org/site authorization envelope
-  or are marked as requiring operator reauthorization. Automation cannot run a
-  profile with a missing or unproven envelope, and only an operator with the
-  required org-wide permissions can view, delete, or reauthorize it.
-- Scope-schema version enforcement rejects stale browser submissions before
-  topology scopes are exposed, and profile updates/executions require a matching
-  opaque scope revision and use the server-stored canonical scope. An unknown
-  topology case can never round-trip as intentional Whole organization.
-- Automation rules bind atomically to an exact profile scope revision, miner/
-  fan envelope, execution principal, and required admin-control state. A
-  profile-scope change blocks triggers as `rebind_required` until an authorized
-  rebind; it never silently retargets an enabled rule.
-- Stale or revision-mismatched automation rules remain visible, disableable, and
-  deletable under their bound envelope without current-topology resolution.
-  Create, Update, enable, and execution still fail closed on stale topology,
-  revision, envelope, or current permissions.
-- Response-profile envelopes independently cover miner and facility-fan sites;
-  profile CRUD and execution preserve both `site:read` and
-  `curtailment:manage` requirements for every selected fan site.
-- Every closed-loop FULL_FLEET event persists its envelope and authorizing
-  principal. Automation triggers and reconciliation require that principal's
-  current effective permissions; revocation blocks admission and safely
-  restores owned targets instead of leaving the envelope as a perpetual grant.
-- Admin-only profiles, rules, and events persist that privilege requirement and
-  recheck the principal's current Admin/SuperAdmin role at execution and every
-  reconciliation pass. Demotion blocks new work and safely restores active
-  ownership even when `curtailment:manage` remains granted.
-- Legacy active closed-loop events receive a provable envelope and principal or
-  enter no-admission drain mode before envelope enforcement begins. Enabled
-  automations referencing ambiguous profiles or lacking proven binding state
-  are inventoried and rebound, disabled, or explicitly cut off before
-  enforcement, then remain fail closed while recovery operations stay
-  available.
-- Whole organization is explicit for every new submission. Empty, unknown,
-  unsupported, and infrastructure-only miner scope never widens to whole-org
-  targeting or reaches facility-fan dispatch; legacy persisted whole-org
-  profiles are backfilled to the explicit representation during rollout.
-- Valid zero-member building/rack/group selectors fail non-FULL_FLEET Start,
-  but FULL_FLEET topology watchers may persist targetless and admit future
-  eligible members without commanding fans before a miner is confirmed.
-- Unflagged explicit-miner FULL_FLEET remains snapshot-only. The admin-only
-  all-paired flag deliberately makes explicit identifiers durable members of
-  the union, including admission after an explicitly selected miner pairs.
-- Active FULL_FLEET logical scopes reserve matching devices between
-  reconciliation ticks; competing events cannot silently take newly eligible
-  or newly assigned members.
-- Whole-org/site all-paired behavior, explicit-miner targeting, facility-fan
-  sequencing, and active/history displays keep working. Deprecated generic
-  device-set wire input fails closed and is never persisted, executed as, or
-  widened to a new topology scope.
-- Proto source and generated output are committed together. Response-profile
-  topology and envelope persistence reuse the existing scope JSON unless
-  implementation proves that insufficient; the durable automation binding
-  fields explicitly require a new immutable up/down schema migration committed
-  with their sqlc source and generated output.
+- Both Apply-to flows expose Sites, Buildings, Racks, Groups, Miners, and
+  Infrastructure with consistent union semantics and typed round trips.
+- Preview, Start, profiles, automation, active events, and history use the same
+  canonical scope conversion/resolution.
+- Normal and unflagged explicit-miner events remain snapshots; closed-loop
+  topology and flagged all-paired policies follow their documented unions.
+- Empty topology watchers never command fans before a miner is confirmed;
+  empty, unknown, and infrastructure-only scope never widens to whole org.
+- Authorization includes selected resources, members, and independent fan
+  coverage; unassigned/unbounded targets require org-wide permission.
+- Target claims are atomic with topology and authorization checks, and active
+  logical reservations prevent competing events from stealing future members.
+- Dispatched targets remain owned through fan-aware safe restoration when they
+  leave scope, lose authorization, become unpaired, or their principal is
+  demoted.
+- Stale profiles/rules remain visible and removable under persisted envelopes,
+  but resave, enable, and execution fail closed until corrected or rebound.
+- Schema versions and opaque revisions prevent stale clients or profile races
+  from broadening or silently retargeting a scope.
+- Rollout remediates ambiguous/oversized records and drains unsafe active events
+  without new admissions or stranded miners.
+- Response profiles reuse existing scope JSON; automation bindings use a new
+  immutable up/down migration. Proto and generated output are committed
+  together.

--- a/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
+++ b/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
@@ -32,8 +32,9 @@ copies independently.
 Settings > Schedules is the closest UI/domain precedent:
 
 - `ScheduleModal.tsx` orders Sites → Buildings → Racks → Groups → Miners.
-- Its building/rack/group modals already provide multi-select, loading, empty,
-  error, and site-filter behavior.
+- Its target pickers provide reusable loading, empty, error, multi-select, and
+  filtering behavior, but their independent flat selections should move to the
+  same drill-down experience as curtailment.
 - `server/internal/domain/schedule/targets/expand.go` expands logical targets
   and deduplicates their miner union.
 
@@ -57,14 +58,16 @@ clears narrower miner selectors. Infrastructure remains independent, and a
 request without a recognized miner selector is invalid even if fans are
 selected.
 
-Both modal variants use this order:
+Both modal variants use a repeatable hierarchical target builder. Ancestor
+selection constrains child catalogs (for example, Site A exposes only its
+buildings and their racks). Each completed target contributes one typed terminal
+selector; targets compose as a union, navigation ancestors are not additional
+selectors, and duplicate labels include ancestor context.
 
-1. Sites
-2. Buildings
-3. Racks
-4. Groups
-5. Miners
-6. Infrastructure
+The builder supports Sites, Buildings, Racks, Groups, and Miners, while
+Infrastructure remains an explicit independent selection. Exact interactions
+and presentation follow the pending design without changing these semantics.
+Schedules adopts the same shared behavior.
 
 Resolve topology membership on the backend. Persist logical selectors for
 response profiles and closed-loop events; persist concrete targets for frozen
@@ -97,6 +100,8 @@ When an owned miner leaves scope or becomes unpaired:
 
 - Add `buildingTargetIds`, `rackTargetIds`, and `groupTargetIds` beside
   `siteIds` and `deviceIdentifiers`. Keep fan fields outside the miner scope.
+- Treat target rows as a view model and normalize their terminal selectors into
+  those canonical collections before validation, persistence, Preview, or Start.
 - Create one pure curtailment-scope module for normalization, whole-org
   dominance, deterministic deduplication, proto construction/hydration,
   all-paired eligibility, counts, and summaries.
@@ -114,13 +119,16 @@ When an owned miner leaves scope or becomes unpaired:
   Custom plan. Settings Test saves and starts that same union without a
   whole-org fallback. `startRequestFromAutomationProfile` uses the same path.
 - Render summaries by real type, such as `2 buildings + 1 group`.
+- This UI-neutral model plus contracts, persistence, and backend resolution can
+  land before the final target-builder visuals are ready.
 
-### 2. Add shared Apply-to controls
+### 2. Add the shared drill-down target builder
 
-- Reuse/extract the Schedule building/rack/group pickers into a neutral
-  ProtoFleet location without creating imports between feature areas.
-- Preserve the topbar site as a soft inventory filter: it filters buildings,
-  racks, and miners; groups remain org-wide/cross-site.
+- Build the hierarchy in a neutral ProtoFleet location for both curtailment
+  variants and Schedules, without cross-feature imports. Filter child catalogs
+  by each target's ancestors and disambiguate duplicate labels; the topbar site
+  remains a soft initial filter rather than a hidden selector, and groups retain
+  cross-site semantics.
 - Add a curtailment/profile picker mode that retains missing stored IDs,
   labels them stale/unavailable from hydrated metadata or their ID, and removes
   them only through explicit operator action. Schedule callers retain their
@@ -320,8 +328,9 @@ admin requirement, topology, and quotas before claiming targets.
 
 Frontend coverage:
 
-- Both modal variants: ordering, counts, select-all/clear, site filters,
-  permissions, stale-ID preservation, and all-paired behavior.
+- Both modal variants and Schedules: ancestor-filtered drill-down, duplicate
+  labels, multiple-target unions, counts, permissions, stale-ID preservation,
+  and all-paired behavior where applicable.
 - Canonical request/hydration tests for each target type and mixed unions across
   Preview, Start, profile create/reload/edit/test, automation, and display.
 - Stale-browser schema rejection and profile/automation revision handling;
@@ -361,8 +370,10 @@ snapshots without explicit approval.
 
 ## Acceptance
 
-- Both Apply-to flows expose Sites, Buildings, Racks, Groups, Miners, and
-  Infrastructure with consistent union semantics and typed round trips.
+- Both Apply-to flows and Schedules use the same hierarchical builder: child
+  options follow selected ancestors, each completed target contributes one
+  typed terminal selector, and multiple targets resolve as a deduplicated union.
+- Infrastructure remains an explicit independent selection.
 - Preview, Start, profiles, automation, active events, and history use the same
   canonical scope conversion/resolution.
 - Normal and unflagged explicit-miner events remain snapshots; closed-loop

--- a/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
+++ b/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
@@ -167,6 +167,10 @@ with the proto source.
     `deviceIdentifiers`.
   Keep target names/labels and Infrastructure fields outside this semantic
   scope object.
+- Require Whole organization to be an explicit selection. An empty or
+  unrecognized miner scope must never default to whole organization; it
+  represents zero miners and is valid only when explicit Infrastructure
+  targets make the overall plan valid.
 - Create a pure curtailment-scope module used by:
   - `CurtailmentStartModal.tsx`
   - `curtailmentRequestBuilders.ts`
@@ -224,6 +228,9 @@ with the proto source.
   `MarshalScopeJSON`, and `ScopeFromJSON`.
 - Ensure a whole-org entry still dominates narrower selectors and mixed
   entries are normalized/deduplicated deterministically.
+- Reject an empty or unrecognized miner scope at boundaries that require miner
+  targets. Never synthesize whole-org scope from missing, unknown, or
+  unsupported cases.
 - Add `max_items` validation to every repeated scope/identifier field and
   domain validation for the normalized per-type and aggregate selector limits.
   Reject oversized persisted profile/event scopes before resolving them.
@@ -299,8 +306,16 @@ with the proto source.
 - On response-profile Create/Update, persist the resolved authorization
   envelope in the existing `scope_json`: exact covered site IDs for narrowed
   authorization, or `org_wide_authorized=true` when org-wide permission was
-  required and granted. Legacy profiles without topology selectors do not need
-  a backfill.
+  required and granted.
+- Backfill existing API-created profiles only where the original authorization
+  envelope is provable from persisted scope: whole-org scope becomes
+  `org_wide_authorized=true`, and site-only scope retains its exact site IDs.
+  Profiles containing explicit miners or any otherwise ambiguous coverage are
+  marked `reauthorization_required` until an operator with current authority
+  reviews and resaves them. Automation must reject a profile with a missing or
+  unproven envelope; it must never derive authority from a miner's current site
+  at execution time. Surface this state in profile Get/List so it can be fixed
+  or deleted.
 - Before automation execution, resolve current topology coverage again and
   require it to remain inside the stored authorization envelope. A rack or
   building moved to another site, a group gaining an out-of-envelope member,
@@ -375,6 +390,13 @@ Backend unit/store/integration coverage:
   scope, including a deleted or moved target that remains visible and
   deletable under its persisted authorization envelope but fails execution and
   resave until corrected.
+- Authorization-envelope rollout tests for provable whole-org/site backfills,
+  explicit-miner and mixed profiles requiring reauthorization, a miner moving
+  sites before reauthorization, and automation failing closed while the
+  envelope is missing or unproven.
+- Empty/unknown-scope tests proving Preview, Start, profile save/execution, and
+  automation never infer whole organization; cover an intentional
+  infrastructure-only plan separately.
 - Regression coverage for whole-org, multi-site, explicit-miner, and
   facility-fan behavior; assert no generic device-set scope state remains in
   frontend/domain/storage models.
@@ -424,6 +446,11 @@ developer approval.
 - A saved profile with a later-deleted or moved target remains visible and
   deletable to operators authorized for its persisted envelope, renders the
   unresolved target as stale, and fails strict resave or execution until fixed.
+- Existing profiles receive a provable whole-org/site authorization envelope
+  or are marked as requiring operator reauthorization. Automation cannot run a
+  profile with a missing or unproven envelope.
+- Whole organization is always explicit. Empty, unknown, or unsupported miner
+  scope never widens to whole-org targeting.
 - Whole-org/site all-paired behavior, explicit-miner targeting, facility-fan
   sequencing, and active/history displays keep working. Deprecated generic
   device-set wire input fails closed and is never persisted, executed as, or

--- a/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
+++ b/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
@@ -1,0 +1,377 @@
+---
+title: "Curtailment building, rack, and group targets"
+date: 2026-08-11
+status: draft
+type: plan
+tracker: https://github.com/block/proto-fleet/issues/909
+---
+
+# Curtailment building, rack, and group targets
+
+## Context
+
+Both operator flows use the same form component:
+
+- Energy's **New curtailment** flow renders
+  `client/src/protoFleet/features/energy/CurtailmentStartModal.tsx` through
+  `CurtailmentManagementPanel.tsx`.
+- Settings' **Create/Edit response profile** flow renders the same component
+  with `variant="responseProfile"` through
+  `CurtailmentSettingsPage.tsx`.
+
+The shared **Apply to** section currently exposes Sites, Miners, and
+Infrastructure. Sites and miners are composable miner selectors; Infrastructure
+is an independent list of facility fans plus sequencing delays. Start and
+Preview already share `buildCurtailmentScopes`, but the surrounding scope
+semantics are still distributed across modal normalization, preview labels,
+response-profile proto hydration/construction, settings and energy-page form
+adapters, and event mappers. Those paths independently reconstruct parts of the
+same rules (whole-org dominance, site/miner unions, legacy scalar fallbacks,
+deduplication, and display labels), so adding another target category in only
+one path can silently lose it in another.
+
+The API already supports repeated `CurtailmentScope` entries and unions them on
+the server. It can persist composite scopes in `curtailment_event.scope_jsonb`
+and `curtailment_response_profile.scope_json`, so adding topology target fields
+does not require a new database column. There is a published generic
+`ScopeDeviceSets` selector, but the curtailment domain has deliberately
+returned Unimplemented for it since the initial backend implementation, and
+response-profile creation rejects it too. There are no old clients or manually
+inserted records that require its runtime or storage representation to remain
+readable. Treat it as dead contract surface, not as a compatibility path or an
+implementation shortcut for racks and groups.
+
+The closest implemented precedent is Settings > Schedules:
+
+- `ScheduleModal.tsx` presents Sites → Buildings → Racks → Groups → Miners.
+- `BuildingSelectionModal.tsx`, `RackSelectionModal.tsx`, and
+  `GroupSelectionModal.tsx` already provide multi-select, loading, empty, and
+  error states.
+- `server/internal/domain/schedule/targets/expand.go` resolves logical targets
+  at execution time and deduplicates their miner union.
+
+Curtailment needs the same logical targeting vocabulary, but it must retain its
+own eligibility, cooldown, active-event exclusion, preview, authorization, and
+event-snapshot semantics.
+
+## Approach
+
+Add Buildings, Racks, and Groups as first-class, persisted curtailment scope
+selectors. Keep target selections as a union: a miner is in scope when it is in
+any selected site, building, rack, group, or explicit-miner list; deduplicate
+before selection and dispatch. Infrastructure remains independent and does not
+contribute miners to the union.
+
+Resolve topology membership on the backend, not in the browser:
+
+- Preview resolves current membership and reports the current eligible target
+  set.
+- A normal Start resolves current membership once, then freezes concrete miner
+  targets in `curtailment_target`, matching existing open-loop explicit-miner
+  behavior.
+- A response profile stores logical IDs, so each later manual or automation
+  execution resolves the then-current members.
+- For FULL_FLEET with `Target all paired miners`, extend the durable closed-loop
+  policy to every composable miner selector: sites, buildings, racks, groups,
+  and explicit miners. The reconciler re-resolves the union while the event is
+  active, admits newly paired/in-scope miners, and releases miners that become
+  unpaired or leave the selected topology. A truly UNPAIRED miner cannot
+  receive commands and remains outside ownership until it becomes paired;
+  paired-like but temporarily unavailable miners retain the existing
+  `UNAVAILABLE` behavior.
+
+Use explicit proto cases for buildings, racks, and groups rather than encoding
+racks and groups into the legacy `device_set_ids` case. This preserves target
+type fidelity after reload, makes stale-target errors intelligible, and avoids
+requiring the frontend to refetch and infer whether each generic set ID was a
+rack or a group.
+
+The Apply-to order in both flows should be:
+
+1. Sites
+2. Buildings
+3. Racks
+4. Groups
+5. Miners
+6. Infrastructure
+
+Reuse the Schedule selection modals by moving them to a neutral shared
+ProtoFleet target-picker location, or make their current module explicitly
+shared without importing curtailment into Schedules. Preserve the current soft
+site default: a selected topbar site filters building/rack/miner inventory;
+all-sites shows org-wide inventory; groups stay org-wide/cross-site. Existing
+off-site selections must remain visible/preserved when editing a profile under
+a narrower topbar filter.
+
+## Scope model and compatibility
+
+Extend the client form models with separate arrays:
+
+- `buildingTargetIds: string[]`
+- `rackTargetIds: string[]`
+- `groupTargetIds: string[]`
+
+Retain `siteIds`, `deviceIdentifiers`, and facility-fan fields. Treat the
+existing scalar `scopeType` as a derived compatibility/display field rather
+than the source of truth for composite selections. Selecting Whole fleet / All
+miners clears every narrower miner selector. Clearing one selector category
+does not clear the others.
+
+Add three selectors to `CurtailmentScope` in
+`proto/curtailment/v1/curtailment.proto`, each with validated, unique positive
+IDs and new protobuf field numbers. Mark the unused generic `device_set_ids`
+fields deprecated and leave their field numbers allocated so this additive
+feature satisfies the repository's Buf `FILE` compatibility policy; do not add
+new runtime/storage support or reinterpret those numbers as buildings, racks,
+or groups. Remove the deprecated declarations in a separate intentional API
+cleanup if the repository's breaking-change policy is relaxed for them.
+
+Extend the Go domain `Scope` and JSON codec with `building_ids`, `rack_ids`, and
+`group_ids`, and remove generic `DeviceSetIDs`/`device_set_ids` domain and JSON
+handling. Preserve existing decoding and proto rendering for whole-org, site,
+device-list, and mixed records. New topology-only or composite records can
+continue to persist with the existing `mixed` scope type plus the richer JSON
+object, avoiding a migration and new database scope-type values. For response
+profiles, the same JSON object should also carry an authorization envelope
+(`authorized_site_ids` plus an `org_wide_authorized` flag) captured when the
+profile is created or updated.
+Persist the same envelope on an event when all-paired topology reconciliation
+is enabled; normal frozen-target events continue to rely on authorization at
+Preview/Start plus their concrete target rows.
+
+Generated protobuf output must be regenerated with `just gen` and committed
+with the proto source.
+
+## Steps
+
+### 1. Centralize client scope conversion
+
+- Define one canonical miner-target selection independent of presentation
+  metadata:
+  - either whole organization, or
+  - a union of `siteIds`, `buildingIds`, `rackIds`, `groupIds`, and explicit
+    `deviceIdentifiers`.
+  Keep target names/labels and Infrastructure fields outside this semantic
+  scope object.
+- Create a pure curtailment-scope module used by:
+  - `CurtailmentStartModal.tsx`
+  - `curtailmentRequestBuilders.ts`
+  - `useCurtailmentPlanPreview.ts`
+  - `useCurtailmentResponseProfiles.ts`
+  - `CurtailmentSettingsPage.tsx`
+  - `CurtailmentManagementPanel.tsx`
+  - `curtailmentMappers.ts`
+- Put normalization, whole-org dominance/clearing, deterministic deduplication,
+  proto scope construction, proto scope hydration, target counts,
+  all-paired eligibility, and human-readable summaries in that module. Start,
+  Preview, and response-profile create/update must call the same proto scope
+  constructor; event and response-profile hydration must call the same proto
+  scope decoder.
+- Keep boundary-specific adapters only for genuinely different concerns such
+  as string-to-`bigint` validation, preview debounce/request keys, site-name
+  lookup, and non-scope response-profile fields. Treat `scopeType`, `scopeId`,
+  scalar `siteId`, `siteSelection`, and `minerSelectionMode` as derived legacy/UI
+  compatibility fields rather than independent sources of targeting truth.
+- Update `ResponseProfileFormValues`, `CurtailmentFormValues`, session-cache
+  normalization, and settings-page form adapters so building/rack/group IDs
+  round-trip through API-backed create, list/reload, edit, profile selection,
+  test-curtailment, and live Start.
+- Update event/profile display helpers to render counts by their real type
+  (for example, `2 buildings + 1 group`) instead of `device sets` or `Unknown
+  scope`.
+
+### 2. Add the shared Apply-to controls
+
+- Add Buildings, Racks, and Groups `TargetSelectButton`s to the shared modal in
+  broad-to-narrow order.
+- Reuse/extract the Schedule building, rack, and group selection modals,
+  including select-all, empty/error states, stale selection preservation, and
+  site filters.
+- Pass the topbar-derived `SiteFilterFields` from both parent flows. Pass the
+  same scope to the miner selector and hide rack/group miner facets when the
+  current role lacks `rack:read`, following `ScheduleModal`.
+- Gate target buttons on the list permissions their picker needs:
+  Buildings require `site:read`; Racks/Groups require `rack:read`; Miners
+  require `miner:read`. Keep submitted existing selections intact when a
+  picker is unavailable so editing does not erase data the user cannot list.
+- Update Apply-to helper text, confirmation copy, profile-card summaries, and
+  preview scope labels for the additional categories.
+- Allow `Target all paired miners` for FULL_FLEET across any union of site,
+  building, rack, group, and explicit-miner selectors. Continue clearing it
+  when switching away from FULL_FLEET. Confirmation copy must describe the
+  selected union rather than implying the entire organization.
+
+### 3. Extend proto translation and JSON round trips
+
+- Add explicit building/rack/group scope messages and cases to
+  `CurtailmentScope`.
+- Extend `toCompositeScope`, legacy/request translators,
+  `protoScopesFromDomainScope`, event rendering, response-profile rendering,
+  `MarshalScopeJSON`, and `ScopeFromJSON`.
+- Ensure a whole-org entry still dominates narrower selectors and mixed
+  entries are normalized/deduplicated deterministically.
+- Remove generic device-set translation, domain/JSON decode/render paths,
+  frontend `deviceSetIds` scope state, and the special unsupported-device-set
+  preview branch. Keep only deprecated protobuf declarations/field numbers as
+  inert schema surface; reject them at the transport boundary if they are ever
+  submitted. New explicit topology cases must preview normally.
+- Apply the same deprecation to the unused
+  `IngestCurtailmentSignalRequest.device_set_ids_override` field; the ingest RPC
+  itself is currently Unimplemented, so it must not remain as a hidden generic
+  device-set route when that RPC is implemented later.
+
+### 4. Resolve and validate topology scopes in the curtailment backend
+
+- Extend `interfaces.ListCandidatesParams`, the SQL store adapter, and
+  `ListCurtailmentCandidatesByOrg` with building/rack/group filters whose
+  predicates are unioned with sites and explicit miners.
+- Match existing fleet semantics:
+  - Building: direct `device.building_id` or membership in a rack assigned to
+    the building.
+  - Rack: live rack `device_set` membership only.
+  - Group: live group `device_set` membership only, including cross-site
+    members.
+  - Always constrain resources, sets, memberships, and devices to the caller's
+    organization and exclude deleted rows.
+- Validate every submitted topology ID even when it currently contains zero
+  miners. Return NotFound for deleted, wrong-type, or cross-org IDs rather than
+  converting them into an empty/insufficient-load preview.
+- Deduplicate candidates across overlapping selectors before classification.
+- For cooldown lookup, use the already-resolved candidate identifiers (or add
+  equivalent topology predicates) so a building/rack/group request cannot
+  accidentally apply org-wide cooldown exclusions.
+- Keep normal event Start behavior frozen. When
+  `force_include_all_paired_miners=true`, persist the logical selector union on
+  the event and extend the reconciler's candidate-parameter translation beyond
+  whole-org/sites to buildings, racks, groups, and explicit identifiers.
+- On every all-paired reconciliation pass, resolve the current union and:
+  - admit miners that newly enter the selected topology or become paired,
+  - retain paired-like unavailable miners under policy ownership,
+  - release miners that leave every selected selector or become UNPAIRED,
+  - deduplicate miners that match multiple selector categories.
+- Apply the same topology scope to cooldown/admission queries and preserve the
+  existing event/device exclusivity guarantees while targets are added,
+  reopened, or released.
+
+### 5. Make authorization fail closed
+
+- Add a single server-side scope-resolution result that reports:
+  - validated selector IDs and types,
+  - the covered site IDs,
+  - whether any selected resource/member is unassigned,
+  - the resolved current device identifiers.
+- Reuse it for Preview, Start, response-profile Create/Update/Get/List/Delete,
+  and automation-rule profile checks. Require `curtailment:manage` at every
+  covered site; require org-wide permission when scope coverage is incomplete
+  or includes unassigned resources. Picker filtering is usability only, never
+  authorization.
+- On response-profile Create/Update, persist the resolved authorization
+  envelope in the existing `scope_json`: exact covered site IDs for narrowed
+  authorization, or `org_wide_authorized=true` when org-wide permission was
+  required and granted. Legacy profiles without topology selectors do not need
+  a backfill.
+- Before automation execution, resolve current topology coverage again and
+  require it to remain inside the stored authorization envelope. A rack or
+  building moved to another site, a group gaining an out-of-envelope member,
+  or newly unassigned membership must fail with a clear FailedPrecondition
+  instead of silently broadening the operation. Org-wide-authorized profiles
+  may follow current membership across sites.
+- When Start enables all-paired topology reconciliation, stamp the applicable
+  authorization envelope onto the event. Each reconciliation pass must compare
+  current topology coverage with that envelope before admitting targets.
+  Out-of-envelope miners are not admitted, already-owned miners that move
+  outside the envelope are released, and the event surfaces an actionable
+  authorization-change reason. An org-wide-authorized event may continue
+  following the selected topology across sites.
+- Apply the same resolution to profile list/get filtering so users never see or
+  mutate topology-scoped profiles outside their current grant.
+
+### 6. Cover manual and automated execution
+
+- Ensure `startRequestFromAutomationProfile` carries the new scope arrays and
+  exercises the same selector pipeline as direct Start.
+- Ensure selecting a saved response profile in New curtailment restores its
+  building/rack/group selections and that subsequent manual edits switch the
+  dropdown to Custom plan, matching current site/miner behavior.
+- Ensure Settings' Test curtailment path saves the logical profile scope first,
+  then starts with the same logical scope; it must not fall back to whole fleet
+  if a topology mapper omits fields.
+
+### 7. Verification
+
+Frontend unit/component coverage:
+
+- Request-building tests for building-only, rack-only, group-only, and mixed
+  site/building/rack/group/miner unions.
+- Shared modal tests in both variants for buttons, selection counts, clear/
+  select-all, active-site filtering, stale selection preservation, and
+  permission-gated pickers.
+- Response-profile API tests proving create/update payloads and list/reload
+  hydration retain each target type without relying on the in-memory session
+  cache.
+- Cross-boundary contract tests proving the same canonical selection emits the
+  same normalized scopes for Preview, Start, and response-profile
+  create/update, and hydrates back without losing a category.
+- Display tests for preview, confirmation, response-profile cards, active
+  events, and history.
+
+Backend unit/store/integration coverage:
+
+- Proto ↔ domain ↔ JSON round trips for the supported scope cases, plus a
+  transport test that deprecated generic device-set input fails closed.
+- Candidate resolution for direct-building and rack-in-building devices, rack
+  membership, cross-site group membership, mixed overlap deduplication, empty
+  valid resources, wrong-type IDs, deleted IDs, and cross-org IDs.
+- Cooldown, active-event exclusion, fixed-kW, and full-fleet selection over
+  each topology scope.
+- All-paired reconciliation for building/rack/group membership additions,
+  removals, cross-selector overlap, unpair/re-pair transitions, and paired-like
+  unavailable miners.
+- Authorization for one-site, multi-site, cross-site group, unassigned,
+  narrowed-role, and topology-change-after-profile-save cases.
+- Response-profile CRUD/list filtering and automation execution with each new
+  scope.
+- Regression coverage for whole-org, multi-site, explicit-miner, and
+  facility-fan behavior; assert no generic device-set scope state remains in
+  frontend/domain/storage models.
+
+Run the smallest relevant suites first, then the canonical checks:
+
+```sh
+bin/just gen
+(cd server && ../bin/go test ./internal/domain/curtailment/... ./internal/handlers/curtailment ./internal/domain/stores/sqlstores)
+(cd client && ../bin/npx vitest run src/protoFleet/features/energy/CurtailmentStartModal.test.tsx src/protoFleet/features/energy/curtailmentRequestBuilders.test.ts src/protoFleet/features/energy/useCurtailmentPlanPreview.test.ts src/protoFleet/api/useCurtailmentResponseProfiles.test.tsx src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.test.tsx)
+bin/just lint
+```
+
+Add ProtoFleet Playwright coverage for both entry points: create a topology-
+scoped response profile, reload/edit it, and run a new curtailment scoped to a
+building/rack/group. Do not refresh visual snapshot baselines without explicit
+developer approval.
+
+## Acceptance
+
+- New curtailment and Create/Edit response profile show Sites, Buildings,
+  Racks, Groups, Miners, and Infrastructure in the same order and with
+  consistent selection behavior.
+- Operators can combine any narrower miner target categories; the backend
+  unions and deduplicates current membership for Preview and Start.
+- Building/rack/group IDs survive profile save, page reload, edit, manual run,
+  and automation execution without becoming explicit-miner snapshots or whole
+  fleet.
+- Preview and Start resolve the same miners for the same scope, subject only to
+  normal time-varying telemetry/eligibility.
+- Normal started events freeze concrete miner targets; later topology changes
+  affect future profile executions, not the in-flight event.
+- FULL_FLEET events with `Target all paired miners` continuously re-resolve the
+  selected site/building/rack/group/miner union: newly paired or newly assigned
+  miners are admitted, while unpaired or no-longer-in-scope miners are
+  released.
+- Deleted, wrong-type, cross-org, unassigned, or unauthorized topology targets
+  fail closed with actionable errors and never broaden to whole-org scope.
+- Whole-org/site all-paired behavior, explicit-miner targeting, facility-fan
+  sequencing, and active/history displays keep working. Deprecated generic
+  device-set wire input fails closed and is never persisted, executed as, or
+  widened to a new topology scope.
+- Proto source and generated output are committed together; no schema migration
+  is added unless implementation proves JSON persistence is insufficient.

--- a/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
+++ b/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
@@ -231,7 +231,11 @@ site coverage, envelope validation, and target claim in one transaction. Within
 it, re-resolve and reauthorize every original selector, selected resource,
 membership, logical reservation, and facility fan—not only concrete miners.
 Lock relevant topology rows or compare topology revisions; dispatch only after
-commit.
+commit. Immediately before each physical Curtail send, the dispatcher must
+reload the claimed miner's current topology and the event's persisted envelope,
+then reauthorize the principal with no intervening asynchronous work. A failed
+check sends no command, marks the watcher degraded, and safely restores any
+previously dispatched ownership; the claim alone is never authority to send.
 
 Replace the org-scoped `RequirePermission(..., ResourceContext{})` entry gates
 across Preview/Start, response-profile/automation, and event Get/List/Update/Stop
@@ -351,6 +355,8 @@ Backend coverage:
 - Authorization races for empty watchers and moved fans, separate fan coverage,
   stale CRUD recovery, current permission revocation,
   Admin/SuperAdmin demotion, and current topology exceeding an envelope.
+- A miner moving outside the envelope after claim/commit but before dispatch is
+  rejected by the final send-time check and receives no Curtail command.
 - Site-scoped Start followed by event List/Get/Update/Stop, denial outside the
   persisted envelope, and proof that selector resolution ignores envelope data.
 - Full executable-profile revision coverage, automation binding races,
@@ -388,8 +394,9 @@ snapshots without explicit approval.
   coverage; unassigned/unbounded targets require org-wide permission.
 - Selector JSON and authorization envelopes are stored separately; envelope
   coverage can never become an executable site selector.
-- Target claims are atomic with topology and authorization checks, and active
-  logical reservations prevent competing events from stealing future members.
+- Target claims are atomic with topology and authorization checks; a final
+  current-envelope check gates each physical send, and active logical
+  reservations prevent competing events from stealing future members.
 - Dispatched targets remain owned through fan-aware safe restoration when they
   leave scope, lose authorization, become unpaired, or their principal is
   demoted.

--- a/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
+++ b/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
@@ -234,6 +234,10 @@ with separate org-wide flags for incomplete or unbounded dimensions.
 - On reconciliation, admit newly eligible/paired members, deduplicate overlap,
   retain unavailable ownership, and apply the restore-before-release rules
   above to targets leaving the union.
+- If admission finds the event's facility fans off, persist a fans-on
+  transition, wait the airflow delay, then re-resolve/re-authorize before
+  claiming and curtailing the miner. Turn fans off again only after every owned
+  target is confirmed curtailed; recovery resumes this sequence after crashes.
 - Treat every active closed-loop logical scope as a reservation, including
   matching miners not yet represented by target rows. Flagged explicit-miner
   policies use the same reservation path.
@@ -290,8 +294,11 @@ admin requirement, topology, and quotas before claiming targets.
 
 ### 7. Roll out fail-closed behavior safely
 
-1. Ship proto/server parsing, schema-version support, profile revisions, and
-   automation binding storage without emitting topology scopes.
+1. Ship a compatibility-floor server that rejects unknown nonempty scope keys,
+   plus proto parsing, schema versions, profile revisions, automation bindings,
+   and a durable topology-scope feature gate, without emitting topology scopes.
+   Require every replica at this floor before opening the gate; rollback below
+   it requires disabling affected automation and draining topology events first.
 2. Deploy the frontend that always sends the new version and explicit
    whole-org scope.
 3. Inventory and remediate persisted data:
@@ -328,7 +335,8 @@ Backend coverage:
   empty/cross-site groups, and unassigned resources.
 - Frozen versus topology-following FULL_FLEET behavior, empty watchers,
   explicit-miner snapshot compatibility, flagged explicit-miner policy,
-  reservation conflicts, pairing transitions, and restore obligations.
+  reservation conflicts, pairing transitions, fan-on admission (including
+  crash/concurrency recovery), and restore obligations.
 - Authorization races for empty watchers and moved fans, separate fan coverage,
   stale CRUD recovery, missing envelopes, current permission revocation,
   Admin/SuperAdmin demotion, and current topology exceeding an envelope.
@@ -373,7 +381,8 @@ snapshots without explicit approval.
 - Schema versions and opaque revisions prevent stale clients or profile races
   from broadening or silently retargeting a scope.
 - Rollout remediates ambiguous/oversized records and drains unsafe active events
-  without new admissions or stranded miners.
+  without new admissions or stranded miners; the durable compatibility floor
+  prevents mixed-version execution or unsafe rollback of topology scopes.
 - Response profiles reuse existing scope JSON; automation bindings use a new
   immutable up/down migration. Proto and generated output are committed
   together.

--- a/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
+++ b/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
@@ -147,8 +147,10 @@ device-list, and mixed records. New topology-only or composite records can
 continue to persist with the existing `mixed` scope type plus the richer JSON
 object, avoiding a migration and new database scope-type values. For response
 profiles, the same JSON object should also carry an authorization envelope
-(`authorized_site_ids` plus an `org_wide_authorized` flag) captured when the
-profile is created or updated.
+with separate miner-scope and facility-fan site coverage captured when the
+profile is created or updated. The fan dimension must preserve the existing
+requirement for both `site:read` and `curtailment:manage`; miner coverage
+continues to require `curtailment:manage`.
 Persist the same envelope on an event when all-paired topology reconciliation
 is enabled; normal frozen-target events continue to rely on authorization at
 Preview/Start plus their concrete target rows.
@@ -291,9 +293,10 @@ with the proto source.
 
 - Add a single server-side scope-resolution result that reports:
   - validated selector IDs and types,
-  - the covered site IDs,
+  - the miner-covered site IDs,
   - whether any selected resource/member is unassigned,
-  - the resolved current device identifiers.
+  - the resolved current device identifiers,
+  - separately resolved facility-fan site IDs and unassigned status.
 - Reuse strict current-topology resolution for Preview, Start,
   response-profile Create/Update, profile execution, and automation-rule
   profile checks. Require `curtailment:manage` at every covered site; require
@@ -309,24 +312,28 @@ with the proto source.
   moved device; it must never admit a device outside the caller's or event's
   authorization envelope.
 - On response-profile Create/Update, persist the resolved authorization
-  envelope in the existing `scope_json`: exact covered site IDs for narrowed
-  authorization, or `org_wide_authorized=true` when org-wide permission was
-  required and granted.
+  envelope in the existing `scope_json`: exact miner-covered site IDs, exact
+  facility-fan site IDs, and separate org-wide authorization flags for either
+  dimension when site coverage is incomplete or unassigned. Preserve the
+  current `site:read` plus `curtailment:manage` checks for every fan site rather
+  than treating miner-scope authorization as permission to control fans.
 - Backfill existing API-created profiles only where the original authorization
   envelope is provable from persisted scope: whole-org scope becomes
-  `org_wide_authorized=true`, and site-only scope retains its exact site IDs.
-  Profiles containing explicit miners or any otherwise ambiguous coverage are
-  marked `reauthorization_required` until an operator with current authority
-  reviews and resaves them. Automation must reject a profile with a missing or
-  unproven envelope; it must never derive authority from a miner's current site
-  at execution time. Surface this state in profile Get/List so it can be fixed
-  or deleted.
+  org-wide miner authorization, and site-only scope with no facility fans
+  retains its exact miner site IDs. Profiles containing explicit miners,
+  facility fans without persisted site coverage, or any otherwise ambiguous
+  coverage are marked `reauthorization_required` until an operator with current
+  authority reviews and resaves them. Automation must reject a profile with a
+  missing or unproven envelope; it must never derive authority from a miner's
+  or fan's current site at execution time. Surface this state in profile
+  Get/List so it can be fixed or deleted.
 - Before automation execution, resolve current topology coverage again and
-  require it to remain inside the stored authorization envelope. A rack or
-  building moved to another site, a group gaining an out-of-envelope member,
+  resolve current facility-fan sites, and require both dimensions to remain
+  inside the stored authorization envelope. A rack or building moved to
+  another site, a group gaining an out-of-envelope member, a fan moving sites,
   or newly unassigned membership must fail with a clear FailedPrecondition
-  instead of silently broadening the operation. Org-wide-authorized profiles
-  may follow current membership across sites.
+  instead of silently broadening the operation. A dimension with proven
+  org-wide authorization may follow current membership across sites.
 - When Start enables all-paired topology reconciliation, stamp the applicable
   authorization envelope onto the event. Each reconciliation pass must compare
   current topology coverage with that envelope before admitting targets.
@@ -337,16 +344,18 @@ with the proto source.
   sites.
 - Do not require current topology resolution for response-profile Get/List or
   Delete. Authorize those operations against the profile's persisted
-  authorization envelope and hydrate its stored typed IDs even when a target
-  was deleted or moved. Surface unresolved targets as unavailable/stale so an
-  authorized operator can inspect, edit, or delete the profile; Create/Update
-  and every execution path still perform strict current-topology validation,
+  miner and facility-fan envelope dimensions, including `site:read` on fan
+  sites, and hydrate stored typed IDs even when a target was deleted or moved.
+  Surface unresolved targets as unavailable/stale so an authorized operator
+  can inspect, edit, or delete the profile; Create/Update and every execution
+  path still perform strict current-topology and current-fan-site validation,
   so a stale ID must be removed or replaced before resave and can never execute.
 - When a profile has a missing or unproven authorization envelope, require
-  org-wide `curtailment:manage` for Get/List/Delete and reauthorization. Do not
-  fall back to current topology or current miner locations to grant access.
-  Site-scoped operators do not see the profile until an org-wide operator
-  establishes a proven envelope or deletes it.
+  org-wide `curtailment:manage` for Get/List/Delete and reauthorization, plus
+  org-wide `site:read` when it contains facility fans. Do not fall back to
+  current topology, miner locations, or fan locations to grant access.
+  Site-scoped operators do not see the profile until an org-wide operator with
+  the required permissions establishes a proven envelope or deletes it.
 
 ### 6. Cover manual and automated execution
 
@@ -408,6 +417,10 @@ Backend unit/store/integration coverage:
   sites before reauthorization, org-wide-only Get/List/Delete access while the
   envelope is missing or unproven, site-scoped filtering, and automation
   failing closed before reauthorization.
+- Facility-fan authorization tests for a fan outside the miner scope, fan site
+  movement, unassigned/stale fans, `site:read` without `curtailment:manage` and
+  vice versa, CRUD/list filtering against persisted fan-site coverage, and
+  automation failing when current fan coverage exceeds its envelope.
 - Empty/unknown-scope tests proving Preview, Start, profile save/execution, and
   automation never infer whole organization; cover an intentional
   infrastructure-only plan separately.
@@ -462,8 +475,11 @@ developer approval.
   unresolved target as stale, and fails strict resave or execution until fixed.
 - Existing profiles receive a provable whole-org/site authorization envelope
   or are marked as requiring operator reauthorization. Automation cannot run a
-  profile with a missing or unproven envelope, and only an org-wide manager can
-  view, delete, or reauthorize it.
+  profile with a missing or unproven envelope, and only an operator with the
+  required org-wide permissions can view, delete, or reauthorize it.
+- Response-profile envelopes independently cover miner and facility-fan sites;
+  profile CRUD and execution preserve both `site:read` and
+  `curtailment:manage` requirements for every selected fan site.
 - Whole organization is always explicit. Empty, unknown, or unsupported miner
   scope never widens to whole-org targeting.
 - Whole-org/site all-paired behavior, explicit-miner targeting, facility-fan


### PR DESCRIPTION
Reviewable diff: +411/-0 across 1 files (excludes generated, test, and story files).

## Summary

This PR proposes the implementation plan for adding Buildings, Racks, and Groups to the curtailment target controls shared by New curtailment and Create/Edit response profile. It defines shared hierarchical targeting for Curtailment and Schedules while leaving exact interactions to the pending UI design, allowing scope unification and backend work to start independently. The plan also covers API and persistence changes, backend union resolution, authorization boundaries, all-paired reconciliation, rollout, and verification. This PR contains planning documentation only; implementation remains tracked by #909.

## How it works

The plan establishes one canonical frontend target union for sites, buildings, racks, groups, and explicit miners. A repeatable drill-down builder constrains child options by selected ancestors and normalizes each completed target to one typed terminal selector; multiple targets form the union carried through Preview, Start, response-profile persistence, automation, and event rendering. The backend validates every selector, resolves and deduplicates current miner membership, and persists executable selector JSON separately from authorization envelopes. Normal events freeze resolved targets, while closed-loop full-fleet events reconcile the topology portion of the selected union. Admission atomically revalidates topology and current principal authorization during target claim, then checks them again immediately before each physical Curtail send; a previously dispatched miner that leaves scope remains owned until it completes the safe restore lifecycle.

The rollout rejects stale browser submissions with a minimum scope-schema version, requires a matching opaque revision for profile-derived execution, and opens topology targeting only after every server replica supports the new contract and a zero-pre-contract-record precondition is verified. It does not preserve or backfill an older record shape; an unexpected row blocks rollout, while missing required scope, envelope, revision, or binding data fails closed. After this plan is approved and merged, implementation will proceed as follow-up PRs under #909. No frontend, API, database, or runtime behavior changes in this PR.

## Diagrams

```mermaid
flowchart TD
  A["New curtailment or response profile"] --> B["Canonical target union"]
  B --> C["Preview, Start, and profile APIs"]
  C --> D["Validate scope and authorization"]
  D --> E["Resolve and deduplicate miners"]
  D --> F["Persist logical scope"]
  E --> G["Normal event freezes concrete targets"]
  F --> H["Closed-loop event reconciles topology"]
  F --> I["Future profile execution resolves current members"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md` | Adds the proposed cross-frontend/backend implementation plan, acceptance criteria, and validation matrix. | This is the approval artifact that defines scope and safety boundaries for the subsequent implementation PRs. |

## Key technical decisions & trade-offs

- Model buildings, racks, and groups as explicit typed selectors instead of generic device-set IDs so saved scopes retain target identity and can be validated precisely.
- Resolve logical topology on the backend instead of expanding miner snapshots in the browser so Preview, Start, profiles, and automation share one authoritative membership calculation.
- Freeze normal event targets but continuously reconcile topology-scoped full-fleet events so standard runs remain deterministic while closed-loop policies follow eligibility and topology transitions.
- Persist authorization envelopes in dedicated profile/event columns, separate from executable selector JSON, so coverage metadata cannot broaden targeting.
- Bind topology expansion, authorization-envelope validation, and target claim atomically, then recheck current topology and authority immediately before each physical Curtail send so a post-claim move cannot create an unauthorized dispatch window.
- Release an out-of-scope target directly only when undispatched; retain dispatched targets as restore obligations through confirmation and facility-fan sequencing.
- Bound raw and normalized selectors, transport size, active watcher totals, and deduplicated expansion to 10,000 miners per execution/event; page resolution and admission so over-limit scopes fail before full materialization or dispatch.
- Require a scope-schema version and profile scope revision so stale browser sessions cannot reinterpret unknown topology scope as Whole organization.
- Keep logical selectors in the existing JSON scope columns and mixed scope type; add separate envelope columns and automation-binding fields through immutable migrations.
- Remove the unused generic device-set message and oneof fields, reserve their names and tag numbers, and rely on required-scope validation for payloads containing only removed wire tags; no deprecated accessor or compatibility handler remains.

## Testing & validation

- Verified the plan filename and frontmatter follow `docs/plans` conventions and link to tracking issue #909.
- Ran Git whitespace validation for the committed Markdown file.
- Incorporated review findings covering hierarchical targeting, full-member group authorization, event lifecycle authorization, selector/envelope separation, rollback safety, restore obligations, authorization/topology races, selector and expanded-target limits, facility fans, FULL_FLEET reconciliation, logical-scope reservations, live-principal and Admin/SuperAdmin revalidation, stale-browser cutover safety, and versioned automation bindings.
- No code generation, builds, or tests were run because this PR changes documentation only; the plan specifies the required frontend, backend, integration, and E2E coverage for implementation PRs.

Refs #909
