### PR TITLE
fix(ci): support stacked PR review policy evaluation

### DIFF
--- a/.github/review-policy.json
+++ b/.github/review-policy.json
@@ -20,6 +20,7 @@
   "low_risk": {
     "max_changed_files": 10,
     "max_file_changes": 80,
+    "max_test_file_changes": 120,
     "max_total_changes": 200,
     "minimum_ai_confidence": 0.85,
     "trusted_actor_workflow": {
@@ -143,6 +144,10 @@
       "**/pyproject.toml",
       "**/requirements*.txt",
       "**/uv.lock"
+    ],
+    "deny_path_exceptions": [
+      "deployment-files/*.md",
+      "deployment-files/**/*.md"
     ]
   }
 }

--- a/.github/scripts/evaluate_review_policy.py
+++ b/.github/scripts/evaluate_review_policy.py
@@ -1116,6 +1116,14 @@ def write_preflight(preflight: dict[str, Any], path: str | None) -> None:
         handle.write("\n")
 
 
+def effective_enforcement(config_enforce: bool, base_ref: str | None, default_branch: str | None) -> bool:
+    if not config_enforce:
+        return False
+    if base_ref and default_branch and base_ref != default_branch:
+        return False
+    return True
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("--config", required=True)
@@ -1127,6 +1135,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--pr-number", required=True, type=int)
     parser.add_argument("--author", required=True)
     parser.add_argument("--base-sha")
+    parser.add_argument("--base-ref")
+    parser.add_argument("--default-branch")
     parser.add_argument("--head-sha", required=True)
     return parser.parse_args()
 
@@ -1159,7 +1169,7 @@ def main() -> int:
             print(f"- {blocker}")
         return 0
 
-    enforced = bool(config.get("enforce", True))
+    enforced = effective_enforcement(bool(config.get("enforce", True)), args.base_ref, args.default_branch)
     if not args.base_sha:
         raise PolicyError("--base-sha is required when evaluating review policy")
 

--- a/.github/scripts/evaluate_review_policy.py
+++ b/.github/scripts/evaluate_review_policy.py
@@ -146,19 +146,40 @@ def path_matches(path: str, pattern: str) -> bool:
     return False
 
 
-def denied_paths(files: list[dict[str, Any]], deny_patterns: list[str]) -> list[str]:
+def denied_paths(
+    files: list[dict[str, Any]],
+    deny_patterns: list[str],
+    exception_patterns: list[str] | None = None,
+) -> list[str]:
     denied: list[str] = []
+    exceptions = exception_patterns or []
     for item in files:
         paths = [item.get("filename"), item.get("previous_filename")]
         for path in (value for value in paths if value):
-            if any(path_matches(path, pattern) for pattern in deny_patterns):
+            if any(path_matches(path, pattern) for pattern in deny_patterns) and not any(
+                path_matches(path, pattern) for pattern in exceptions
+            ):
                 denied.append(path)
     return sorted(set(denied))
+
+
+def is_test_path(path: str) -> bool:
+    lowered = path.casefold()
+    return (
+        lowered.endswith("_test.go")
+        or ".test." in lowered
+        or ".spec." in lowered
+        or "/test/" in lowered
+        or "/tests/" in lowered
+        or "/__tests__/" in lowered
+        or "/e2etests/" in lowered
+    )
 
 
 def deterministic_content_blockers(files: list[dict[str, Any]], low_config: dict[str, Any]) -> list[str]:
     blockers: list[str] = []
     max_file_changes = int(low_config.get("max_file_changes", 0) or 0)
+    max_test_file_changes = int(low_config.get("max_test_file_changes", max_file_changes) or 0)
     pattern_rules = low_config.get("content_deny_added_patterns", [])
 
     compiled_rules: list[tuple[re.Pattern[str], str]] = []
@@ -175,8 +196,9 @@ def deterministic_content_blockers(files: list[dict[str, Any]], low_config: dict
         additions = int(item.get("additions", 0))
         deletions = int(item.get("deletions", 0))
         changed_lines = additions + deletions
-        if max_file_changes and changed_lines > max_file_changes:
-            blockers.append(f"{path} has {changed_lines} changed lines, exceeds per-file limit {max_file_changes}")
+        file_limit = max_test_file_changes if is_test_path(path) else max_file_changes
+        if file_limit and changed_lines > file_limit:
+            blockers.append(f"{path} has {changed_lines} changed lines, exceeds per-file limit {file_limit}")
 
         patch = item.get("patch")
         if patch is None:
@@ -555,7 +577,7 @@ def evaluate_low_risk_preflight(
     else:
         reasons.append(f"{total_changes} changed lines within limit")
 
-    denied = denied_paths(files, low_config.get("deny_paths", []))
+    denied = denied_paths(files, low_config.get("deny_paths", []), low_config.get("deny_path_exceptions", []))
     if denied:
         blockers.append("denied paths changed: " + ", ".join(denied))
     else:
@@ -949,7 +971,7 @@ def evaluate_policy(
     else:
         low_reasons.append(f"{total_changes} changed lines within limit")
 
-    denied = denied_paths(files, low_config.get("deny_paths", []))
+    denied = denied_paths(files, low_config.get("deny_paths", []), low_config.get("deny_path_exceptions", []))
     if denied:
         low_blockers.append("denied paths changed: " + ", ".join(denied))
     else:

--- a/.github/scripts/evaluate_review_policy.py
+++ b/.github/scripts/evaluate_review_policy.py
@@ -1116,12 +1116,12 @@ def write_preflight(preflight: dict[str, Any], path: str | None) -> None:
         handle.write("\n")
 
 
-def effective_enforcement(config_enforce: bool, base_ref: str | None, default_branch: str | None) -> bool:
-    if not config_enforce:
+def effective_enforcement(config_enforce: bool, override: str | None) -> bool:
+    if override == "true":
+        return True
+    if override == "false":
         return False
-    if base_ref and default_branch and base_ref != default_branch:
-        return False
-    return True
+    return config_enforce
 
 
 def parse_args() -> argparse.Namespace:
@@ -1135,8 +1135,6 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--pr-number", required=True, type=int)
     parser.add_argument("--author", required=True)
     parser.add_argument("--base-sha")
-    parser.add_argument("--base-ref")
-    parser.add_argument("--default-branch")
     parser.add_argument("--head-sha", required=True)
     return parser.parse_args()
 
@@ -1169,7 +1167,7 @@ def main() -> int:
             print(f"- {blocker}")
         return 0
 
-    enforced = effective_enforcement(bool(config.get("enforce", True)), args.base_ref, args.default_branch)
+    enforced = effective_enforcement(bool(config.get("enforce", True)), os.environ.get("REVIEW_POLICY_ENFORCED"))
     if not args.base_sha:
         raise PolicyError("--base-sha is required when evaluating review policy")
 

--- a/.github/scripts/evaluate_review_policy.py
+++ b/.github/scripts/evaluate_review_policy.py
@@ -169,6 +169,10 @@ def is_test_path(path: str) -> bool:
         lowered.endswith("_test.go")
         or ".test." in lowered
         or ".spec." in lowered
+        or lowered.startswith("test/")
+        or lowered.startswith("tests/")
+        or lowered.startswith("__tests__/")
+        or lowered.startswith("e2etests/")
         or "/test/" in lowered
         or "/tests/" in lowered
         or "/__tests__/" in lowered

--- a/.github/scripts/evaluate_review_policy_test.py
+++ b/.github/scripts/evaluate_review_policy_test.py
@@ -104,30 +104,47 @@ class ReviewPolicyTest(unittest.TestCase):
         workflow = load_workflow("review-policy.yml")
         publish_env = workflow["jobs"]["publish-status"]["steps"][0]["env"]
         evaluate_outputs = workflow["jobs"]["evaluate"]["outputs"]
+        evaluate_steps = workflow["jobs"]["evaluate"]["steps"]
         classifier_step = next(
             step
-            for step in workflow["jobs"]["evaluate"]["steps"]
+            for step in evaluate_steps
             if step.get("id") == "ai_classifier"
+        )
+        mode_index, mode_step = next(
+            (index, step)
+            for index, step in enumerate(evaluate_steps)
+            if step.get("id") == "policy_mode"
         )
         checkout_step = next(
             step
-            for step in workflow["jobs"]["evaluate"]["steps"]
+            for step in evaluate_steps
             if step.get("name") == "Checkout trusted default-branch policy"
+        )
+        checkout_index = evaluate_steps.index(checkout_step)
+        config_index, config_step = next(
+            (index, step)
+            for index, step in enumerate(evaluate_steps)
+            if step.get("id") == "policy_config"
         )
 
         self.assertIn("core.setOutput('default_branch', pr.base.repo.default_branch)", workflow_text)
         self.assertNotIn("core.setOutput('trusted_base'", workflow_text)
+        self.assertLess(mode_index, checkout_index)
+        self.assertGreater(config_index, checkout_index)
+        self.assertEqual(mode_step["if"], "steps.pr.outputs.found == 'true'")
+        self.assertNotIn("POLICY_ROOT", mode_step["env"])
+        self.assertEqual(config_step["env"]["STACKED_ADVISORY"], "${{ steps.policy_mode.outputs.stacked_advisory || 'false' }}")
         self.assertEqual(checkout_step["with"]["ref"], "${{ steps.pr.outputs.default_branch }}")
         self.assertNotIn("Review policy only evaluates PRs based on the repository default branch", workflow_text)
         self.assertIn("Using review policy code from the trusted default branch", workflow_text)
         self.assertIn("REVIEW_BASE_SHA: ${{ steps.pr.outputs.base_sha }}", workflow_text)
-        self.assertIn("REVIEW_POLICY_ENFORCED: ${{ steps.policy_mode.outputs.enforced || 'true' }}", workflow_text)
+        self.assertIn("REVIEW_POLICY_ENFORCED: ${{ steps.policy_config.outputs.enforced || steps.policy_mode.outputs.enforced || 'true' }}", workflow_text)
         self.assertNotIn('--base-ref "$BASE_REF"', workflow_text)
         self.assertNotIn('--default-branch "$DEFAULT_BRANCH"', workflow_text)
         self.assertIn('enforced="${REVIEW_POLICY_ENFORCED}"', workflow_text)
-        self.assertEqual(evaluate_outputs["enforced"], "${{ steps.evaluate_policy.outputs.enforced || steps.policy_mode.outputs.enforced || steps.bootstrap_policy.outputs.enforced || 'true' }}")
+        self.assertEqual(evaluate_outputs["enforced"], "${{ steps.evaluate_policy.outputs.enforced || steps.policy_config.outputs.enforced || steps.bootstrap_policy.outputs.enforced || steps.policy_mode.outputs.enforced || 'true' }}")
         self.assertEqual(evaluate_outputs["stacked_advisory"], "${{ steps.policy_mode.outputs.stacked_advisory || 'false' }}")
-        self.assertEqual(evaluate_outputs["config_enforced"], "${{ steps.policy_mode.outputs.config_enforced || 'true' }}")
+        self.assertEqual(evaluate_outputs["config_enforced"], "${{ steps.policy_config.outputs.config_enforced || 'true' }}")
         self.assertIn("stacked_advisory=true", workflow_text)
         self.assertEqual(publish_env["DECISION"], "${{ needs.evaluate.outputs.decision || 'needs-human-review' }}")
         self.assertEqual(publish_env["PASSED"], "${{ needs.evaluate.outputs.passed || 'false' }}")

--- a/.github/scripts/evaluate_review_policy_test.py
+++ b/.github/scripts/evaluate_review_policy_test.py
@@ -159,10 +159,11 @@ class ReviewPolicyTest(unittest.TestCase):
 
         self.assertEqual(publish_env["CONFIG_ENFORCED"], "${{ needs.evaluate.outputs.config_enforced || 'true' }}")
         self.assertEqual(publish_env["STACKED_ADVISORY"], "${{ needs.evaluate.outputs.stacked_advisory || 'false' }}")
-        self.assertIn("stackedAdvisory && configEnforced", workflow_text)
+        self.assertIn("const enforcedAdvisoryState = stackedAdvisory && configEnforced ? 'pending' : 'success'", workflow_text)
         self.assertIn("context: 'Review Policy'", workflow_text)
-        self.assertIn("state: 'pending'", workflow_text)
+        self.assertIn("state: enforcedAdvisoryState", workflow_text)
         self.assertIn("Stacked PR result is advisory; default-branch PR must pass Review Policy.", workflow_text)
+        self.assertIn("Review Policy is advisory; see Review Policy Advisory.", workflow_text)
 
     def test_workflow_label_sync_is_bound_to_base_and_head(self):
         workflow_text = read_workflow("review-policy.yml")

--- a/.github/scripts/evaluate_review_policy_test.py
+++ b/.github/scripts/evaluate_review_policy_test.py
@@ -420,6 +420,30 @@ class ReviewPolicyTest(unittest.TestCase):
                 "deletions": 0,
                 "patch": "@@\n+func TestSafe(t *testing.T) {}",
             },
+            {
+                "filename": "test/helpers/policy_fixture.ts",
+                "additions": 95,
+                "deletions": 0,
+                "patch": "@@\n+export const fixture = true;",
+            },
+            {
+                "filename": "tests/helpers/policy_fixture.ts",
+                "additions": 95,
+                "deletions": 0,
+                "patch": "@@\n+export const fixture = true;",
+            },
+            {
+                "filename": "__tests__/policy_fixture.ts",
+                "additions": 95,
+                "deletions": 0,
+                "patch": "@@\n+export const fixture = true;",
+            },
+            {
+                "filename": "e2etests/policy_fixture.ts",
+                "additions": 95,
+                "deletions": 0,
+                "patch": "@@\n+export const fixture = true;",
+            },
         ]
 
         blockers = policy.deterministic_content_blockers(

--- a/.github/scripts/evaluate_review_policy_test.py
+++ b/.github/scripts/evaluate_review_policy_test.py
@@ -166,6 +166,8 @@ class ReviewPolicyTest(unittest.TestCase):
         self.assertIn("context: 'Review Policy'", workflow_text)
         self.assertIn("state: enforcedAdvisoryState", workflow_text)
         self.assertIn("Stacked PR result is advisory; default-branch PR must pass Review Policy.", workflow_text)
+        self.assertIn("enforcedAdvisoryState = stackedAdvisory ? 'pending' : 'failure'", workflow_text)
+        self.assertIn("Stacked PR policy source unavailable; default-branch PR must pass Review Policy.", workflow_text)
         self.assertIn("Review Policy is advisory; see Review Policy Advisory.", workflow_text)
         self.assertIn("Trusted Review Policy source unavailable; human review required.", workflow_text)
 

--- a/.github/scripts/evaluate_review_policy_test.py
+++ b/.github/scripts/evaluate_review_policy_test.py
@@ -103,6 +103,7 @@ class ReviewPolicyTest(unittest.TestCase):
         workflow_text = read_workflow("review-policy.yml")
         workflow = load_workflow("review-policy.yml")
         publish_env = workflow["jobs"]["publish-status"]["steps"][0]["env"]
+        evaluate_outputs = workflow["jobs"]["evaluate"]["outputs"]
         classifier_step = next(
             step
             for step in workflow["jobs"]["evaluate"]["steps"]
@@ -120,11 +121,42 @@ class ReviewPolicyTest(unittest.TestCase):
         self.assertNotIn("Review policy only evaluates PRs based on the repository default branch", workflow_text)
         self.assertIn("Using review policy code from the trusted default branch", workflow_text)
         self.assertIn("REVIEW_BASE_SHA: ${{ steps.pr.outputs.base_sha }}", workflow_text)
+        self.assertIn("BASE_REF: ${{ steps.pr.outputs.base_ref }}", workflow_text)
+        self.assertIn("DEFAULT_BRANCH: ${{ steps.pr.outputs.default_branch }}", workflow_text)
+        self.assertIn('--base-ref "$BASE_REF"', workflow_text)
+        self.assertIn('--default-branch "$DEFAULT_BRANCH"', workflow_text)
+        self.assertEqual(evaluate_outputs["enforced"], "${{ steps.evaluate_policy.outputs.enforced || steps.policy_mode.outputs.enforced || steps.bootstrap_policy.outputs.enforced || 'true' }}")
+        self.assertEqual(evaluate_outputs["stacked_advisory"], "${{ steps.policy_mode.outputs.stacked_advisory || 'false' }}")
+        self.assertEqual(evaluate_outputs["config_enforced"], "${{ steps.policy_mode.outputs.config_enforced || 'true' }}")
+        self.assertIn("stacked_advisory=true", workflow_text)
         self.assertEqual(publish_env["DECISION"], "${{ needs.evaluate.outputs.decision || 'needs-human-review' }}")
         self.assertEqual(publish_env["PASSED"], "${{ needs.evaluate.outputs.passed || 'false' }}")
         self.assertEqual(publish_env["ENFORCED"], "${{ needs.evaluate.outputs.enforced || 'true' }}")
         self.assertEqual(classifier_step["timeout-minutes"], 10)
         self.assertIn("Tiny non-sensitive server utility changes are eligible", classifier_step["with"]["prompt"])
+
+    def test_workflow_invalidates_enforced_status_for_enforced_stacked_advisory(self):
+        workflow_text = read_workflow("review-policy.yml")
+        workflow = load_workflow("review-policy.yml")
+        publish_env = workflow["jobs"]["publish-status"]["steps"][0]["env"]
+
+        self.assertEqual(publish_env["CONFIG_ENFORCED"], "${{ needs.evaluate.outputs.config_enforced || 'true' }}")
+        self.assertEqual(publish_env["STACKED_ADVISORY"], "${{ needs.evaluate.outputs.stacked_advisory || 'false' }}")
+        self.assertIn("stackedAdvisory && configEnforced", workflow_text)
+        self.assertIn("context: 'Review Policy'", workflow_text)
+        self.assertIn("state: 'pending'", workflow_text)
+        self.assertIn("Stacked PR result is advisory; default-branch PR must pass Review Policy.", workflow_text)
+
+    def test_workflow_label_sync_is_bound_to_base_and_head(self):
+        workflow_text = read_workflow("review-policy.yml")
+        workflow = load_workflow("review-policy.yml")
+        label_env = workflow["jobs"]["sync-label"]["steps"][0]["env"]
+
+        self.assertEqual(label_env["BASE_SHA"], "${{ needs.evaluate.outputs.base_sha }}")
+        self.assertEqual(label_env["HEAD_SHA"], "${{ needs.evaluate.outputs.head_sha }}")
+        self.assertIn("Missing evaluated base SHA for review policy label sync", workflow_text)
+        self.assertIn("pr.head.sha !== headSha || pr.base.sha !== baseSha", workflow_text)
+        self.assertIn("Skipping stale Review Policy label sync for ${baseSha}...${headSha}", workflow_text)
 
     def test_path_matches_double_star_root_file(self):
         self.assertTrue(policy.path_matches("package.json", "**/package.json"))
@@ -181,6 +213,12 @@ class ReviewPolicyTest(unittest.TestCase):
             ),
             ["deployment-files/docker-compose.yaml", "deployment-files/ha/install.sh"],
         )
+
+    def test_effective_enforcement_keeps_stacked_prs_advisory(self):
+        self.assertFalse(policy.effective_enforcement(False, "main", "main"))
+        self.assertTrue(policy.effective_enforcement(True, "main", "main"))
+        self.assertFalse(policy.effective_enforcement(True, "feature-base", "main"))
+        self.assertTrue(policy.effective_enforcement(True, None, "main"))
 
     def test_low_risk_config_allows_small_server_app_changes_to_reach_classifier(self):
         deny_paths = load_policy_config()["low_risk"]["deny_paths"]

--- a/.github/scripts/evaluate_review_policy_test.py
+++ b/.github/scripts/evaluate_review_policy_test.py
@@ -145,6 +145,7 @@ class ReviewPolicyTest(unittest.TestCase):
         self.assertEqual(evaluate_outputs["enforced"], "${{ steps.evaluate_policy.outputs.enforced || steps.policy_config.outputs.enforced || steps.bootstrap_policy.outputs.enforced || steps.policy_mode.outputs.enforced || 'true' }}")
         self.assertEqual(evaluate_outputs["stacked_advisory"], "${{ steps.policy_mode.outputs.stacked_advisory || 'false' }}")
         self.assertEqual(evaluate_outputs["config_enforced"], "${{ steps.policy_config.outputs.config_enforced || 'true' }}")
+        self.assertEqual(evaluate_outputs["policy_source_available"], "${{ steps.policy_source.outputs.available || 'false' }}")
         self.assertIn("stacked_advisory=true", workflow_text)
         self.assertEqual(publish_env["DECISION"], "${{ needs.evaluate.outputs.decision || 'needs-human-review' }}")
         self.assertEqual(publish_env["PASSED"], "${{ needs.evaluate.outputs.passed || 'false' }}")
@@ -159,11 +160,14 @@ class ReviewPolicyTest(unittest.TestCase):
 
         self.assertEqual(publish_env["CONFIG_ENFORCED"], "${{ needs.evaluate.outputs.config_enforced || 'true' }}")
         self.assertEqual(publish_env["STACKED_ADVISORY"], "${{ needs.evaluate.outputs.stacked_advisory || 'false' }}")
-        self.assertIn("const enforcedAdvisoryState = stackedAdvisory && configEnforced ? 'pending' : 'success'", workflow_text)
+        self.assertEqual(publish_env["POLICY_SOURCE_AVAILABLE"], "${{ needs.evaluate.outputs.policy_source_available || 'false' }}")
+        self.assertIn("function hasNewerStatusRun(contextName)", workflow_text)
+        self.assertIn("if (!hasNewerStatusRun('Review Policy'))", workflow_text)
         self.assertIn("context: 'Review Policy'", workflow_text)
         self.assertIn("state: enforcedAdvisoryState", workflow_text)
         self.assertIn("Stacked PR result is advisory; default-branch PR must pass Review Policy.", workflow_text)
         self.assertIn("Review Policy is advisory; see Review Policy Advisory.", workflow_text)
+        self.assertIn("Trusted Review Policy source unavailable; human review required.", workflow_text)
 
     def test_workflow_label_sync_is_bound_to_base_and_head(self):
         workflow_text = read_workflow("review-policy.yml")

--- a/.github/scripts/evaluate_review_policy_test.py
+++ b/.github/scripts/evaluate_review_policy_test.py
@@ -121,10 +121,10 @@ class ReviewPolicyTest(unittest.TestCase):
         self.assertNotIn("Review policy only evaluates PRs based on the repository default branch", workflow_text)
         self.assertIn("Using review policy code from the trusted default branch", workflow_text)
         self.assertIn("REVIEW_BASE_SHA: ${{ steps.pr.outputs.base_sha }}", workflow_text)
-        self.assertIn("BASE_REF: ${{ steps.pr.outputs.base_ref }}", workflow_text)
-        self.assertIn("DEFAULT_BRANCH: ${{ steps.pr.outputs.default_branch }}", workflow_text)
-        self.assertIn('--base-ref "$BASE_REF"', workflow_text)
-        self.assertIn('--default-branch "$DEFAULT_BRANCH"', workflow_text)
+        self.assertIn("REVIEW_POLICY_ENFORCED: ${{ steps.policy_mode.outputs.enforced || 'true' }}", workflow_text)
+        self.assertNotIn('--base-ref "$BASE_REF"', workflow_text)
+        self.assertNotIn('--default-branch "$DEFAULT_BRANCH"', workflow_text)
+        self.assertIn('enforced="${REVIEW_POLICY_ENFORCED}"', workflow_text)
         self.assertEqual(evaluate_outputs["enforced"], "${{ steps.evaluate_policy.outputs.enforced || steps.policy_mode.outputs.enforced || steps.bootstrap_policy.outputs.enforced || 'true' }}")
         self.assertEqual(evaluate_outputs["stacked_advisory"], "${{ steps.policy_mode.outputs.stacked_advisory || 'false' }}")
         self.assertEqual(evaluate_outputs["config_enforced"], "${{ steps.policy_mode.outputs.config_enforced || 'true' }}")
@@ -214,11 +214,11 @@ class ReviewPolicyTest(unittest.TestCase):
             ["deployment-files/docker-compose.yaml", "deployment-files/ha/install.sh"],
         )
 
-    def test_effective_enforcement_keeps_stacked_prs_advisory(self):
-        self.assertFalse(policy.effective_enforcement(False, "main", "main"))
-        self.assertTrue(policy.effective_enforcement(True, "main", "main"))
-        self.assertFalse(policy.effective_enforcement(True, "feature-base", "main"))
-        self.assertTrue(policy.effective_enforcement(True, None, "main"))
+    def test_effective_enforcement_honors_workflow_override(self):
+        self.assertFalse(policy.effective_enforcement(False, None))
+        self.assertTrue(policy.effective_enforcement(True, None))
+        self.assertFalse(policy.effective_enforcement(True, "false"))
+        self.assertTrue(policy.effective_enforcement(False, "true"))
 
     def test_low_risk_config_allows_small_server_app_changes_to_reach_classifier(self):
         deny_paths = load_policy_config()["low_risk"]["deny_paths"]

--- a/.github/scripts/evaluate_review_policy_test.py
+++ b/.github/scripts/evaluate_review_policy_test.py
@@ -99,7 +99,7 @@ class ReviewPolicyTest(unittest.TestCase):
         )
         self.assertEqual(label_job["permissions"], {"issues": "write", "pull-requests": "write"})
 
-    def test_workflow_keeps_fail_closed_non_cancelled_failures(self):
+    def test_workflow_uses_default_branch_policy_for_stacked_prs(self):
         workflow_text = read_workflow("review-policy.yml")
         workflow = load_workflow("review-policy.yml")
         publish_env = workflow["jobs"]["publish-status"]["steps"][0]["env"]
@@ -108,13 +108,23 @@ class ReviewPolicyTest(unittest.TestCase):
             for step in workflow["jobs"]["evaluate"]["steps"]
             if step.get("id") == "ai_classifier"
         )
+        checkout_step = next(
+            step
+            for step in workflow["jobs"]["evaluate"]["steps"]
+            if step.get("name") == "Checkout trusted default-branch policy"
+        )
 
-        self.assertIn('exit 1', workflow_text)
-        self.assertIn("got base ref ${BASE_REF}.", workflow_text)
+        self.assertIn("core.setOutput('default_branch', pr.base.repo.default_branch)", workflow_text)
+        self.assertNotIn("core.setOutput('trusted_base'", workflow_text)
+        self.assertEqual(checkout_step["with"]["ref"], "${{ steps.pr.outputs.default_branch }}")
+        self.assertNotIn("Review policy only evaluates PRs based on the repository default branch", workflow_text)
+        self.assertIn("Using review policy code from the trusted default branch", workflow_text)
+        self.assertIn("REVIEW_BASE_SHA: ${{ steps.pr.outputs.base_sha }}", workflow_text)
         self.assertEqual(publish_env["DECISION"], "${{ needs.evaluate.outputs.decision || 'needs-human-review' }}")
         self.assertEqual(publish_env["PASSED"], "${{ needs.evaluate.outputs.passed || 'false' }}")
         self.assertEqual(publish_env["ENFORCED"], "${{ needs.evaluate.outputs.enforced || 'true' }}")
         self.assertEqual(classifier_step["timeout-minutes"], 10)
+        self.assertIn("Tiny non-sensitive server utility changes are eligible", classifier_step["with"]["prompt"])
 
     def test_path_matches_double_star_root_file(self):
         self.assertTrue(policy.path_matches("package.json", "**/package.json"))
@@ -152,6 +162,26 @@ class ReviewPolicyTest(unittest.TestCase):
             [".github/workflows/review-policy.yml", "server/main.go"],
         )
 
+    def test_denied_paths_honors_explicit_exceptions(self):
+        files = [
+            {"filename": "deployment-files/README.md"},
+            {"filename": "deployment-files/ha/QUALIFICATION.md"},
+            {"filename": "deployment-files/docker-compose.yaml"},
+            {
+                "filename": "deployment-files/ha/README.md",
+                "previous_filename": "deployment-files/ha/install.sh",
+            },
+        ]
+
+        self.assertEqual(
+            policy.denied_paths(
+                files,
+                ["deployment-files/**"],
+                ["deployment-files/*.md", "deployment-files/**/*.md"],
+            ),
+            ["deployment-files/docker-compose.yaml", "deployment-files/ha/install.sh"],
+        )
+
     def test_low_risk_config_allows_small_server_app_changes_to_reach_classifier(self):
         deny_paths = load_policy_config()["low_risk"]["deny_paths"]
         files = [
@@ -162,6 +192,27 @@ class ReviewPolicyTest(unittest.TestCase):
         ]
 
         self.assertEqual(policy.denied_paths(files, deny_paths), [])
+
+    def test_low_risk_config_allows_deployment_markdown_docs_to_reach_classifier(self):
+        low_risk = load_policy_config()["low_risk"]
+        files = [
+            {"filename": "deployment-files/README.md"},
+            {"filename": "deployment-files/ha/QUALIFICATION.md"},
+        ]
+
+        self.assertEqual(policy.denied_paths(files, low_risk["deny_paths"], low_risk["deny_path_exceptions"]), [])
+
+    def test_low_risk_config_keeps_deployment_runtime_files_denied(self):
+        low_risk = load_policy_config()["low_risk"]
+        files = [
+            {"filename": "deployment-files/docker-compose.yaml"},
+            {"filename": "deployment-files/ha/scripts/install.sh"},
+        ]
+
+        self.assertEqual(
+            policy.denied_paths(files, low_risk["deny_paths"], low_risk["deny_path_exceptions"]),
+            ["deployment-files/docker-compose.yaml", "deployment-files/ha/scripts/install.sh"],
+        )
 
     def test_low_risk_config_keeps_sensitive_server_paths_denied(self):
         deny_paths = load_policy_config()["low_risk"]["deny_paths"]
@@ -292,6 +343,36 @@ class ReviewPolicyTest(unittest.TestCase):
         self.assertIn("client/src/foo.ts adds blocked content: adds process execution or shell-out code", blockers)
         self.assertIn("client/src/opaque.bin diff content is unavailable for deterministic content checks", blockers)
         self.assertEqual(len(blockers), 3)
+
+    def test_deterministic_content_blockers_allows_larger_test_files(self):
+        files = [
+            {
+                "filename": "server/internal/domain/alerts/grafana_client.go",
+                "additions": 95,
+                "deletions": 0,
+                "patch": "@@\n+const safe = true",
+            },
+            {
+                "filename": "server/internal/domain/alerts/grafana_client_test.go",
+                "additions": 95,
+                "deletions": 0,
+                "patch": "@@\n+func TestSafe(t *testing.T) {}",
+            },
+        ]
+
+        blockers = policy.deterministic_content_blockers(
+            files,
+            {
+                "max_file_changes": 80,
+                "max_test_file_changes": 120,
+                "content_deny_added_patterns": [],
+            },
+        )
+
+        self.assertEqual(
+            blockers,
+            ["server/internal/domain/alerts/grafana_client.go has 95 changed lines, exceeds per-file limit 80"],
+        )
 
     def test_low_risk_preflight_blocks_before_classifier(self):
         original_paginate = policy.github_paginate

--- a/.github/workflows/review-policy.yml
+++ b/.github/workflows/review-policy.yml
@@ -63,10 +63,14 @@ jobs:
       found: ${{ steps.pr.outputs.found }}
       number: ${{ steps.pr.outputs.number }}
       base_sha: ${{ steps.pr.outputs.base_sha }}
+      base_ref: ${{ steps.pr.outputs.base_ref }}
+      default_branch: ${{ steps.pr.outputs.default_branch }}
       head_sha: ${{ steps.pr.outputs.head_sha }}
+      config_enforced: ${{ steps.policy_mode.outputs.config_enforced || 'true' }}
+      stacked_advisory: ${{ steps.policy_mode.outputs.stacked_advisory || 'false' }}
       decision: ${{ steps.evaluate_policy.outputs.decision || steps.bootstrap_policy.outputs.decision || 'needs-human-review' }}
       passed: ${{ steps.evaluate_policy.outputs.passed || steps.bootstrap_policy.outputs.passed || 'false' }}
-      enforced: ${{ steps.evaluate_policy.outputs.enforced || steps.bootstrap_policy.outputs.enforced || 'true' }}
+      enforced: ${{ steps.evaluate_policy.outputs.enforced || steps.policy_mode.outputs.enforced || steps.bootstrap_policy.outputs.enforced || 'true' }}
     env:
       CODEX_MODEL: gpt-5.5
       CODEX_REASONING_EFFORT: high
@@ -199,6 +203,39 @@ jobs:
           echo "available=true" >> "$GITHUB_OUTPUT"
           echo "path=$(pwd)" >> "$GITHUB_OUTPUT"
           echo "Using review policy code from the trusted default branch ${DEFAULT_BRANCH}."
+
+      - name: Select review policy mode
+        id: policy_mode
+        if: steps.pr.outputs.found == 'true' && steps.policy_source.outputs.available == 'true'
+        env:
+          POLICY_ROOT: ${{ steps.policy_source.outputs.path }}
+          BASE_REF: ${{ steps.pr.outputs.base_ref }}
+          DEFAULT_BRANCH: ${{ steps.pr.outputs.default_branch }}
+        run: |
+          stacked_advisory=false
+          if [ "$BASE_REF" != "$DEFAULT_BRANCH" ]; then
+            stacked_advisory=true
+          fi
+
+          config_enforced="$(python3 - <<'PY'
+          import json
+          import os
+
+          config_path = os.path.join(os.environ["POLICY_ROOT"], ".github", "review-policy.json")
+          with open(config_path, encoding="utf-8") as handle:
+              config = json.load(handle)
+          print("false" if config.get("enforce", True) is False else "true")
+          PY
+          )"
+
+          enforced="$config_enforced"
+          if [ "$stacked_advisory" = "true" ]; then
+            enforced=false
+          fi
+
+          echo "config_enforced=${config_enforced}" >> "$GITHUB_OUTPUT"
+          echo "stacked_advisory=${stacked_advisory}" >> "$GITHUB_OUTPUT"
+          echo "enforced=${enforced}" >> "$GITHUB_OUTPUT"
 
       - name: Use bootstrap fallback decision
         id: bootstrap_policy
@@ -420,6 +457,8 @@ jobs:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           AUTHOR: ${{ steps.pr.outputs.author }}
           BASE_SHA: ${{ steps.pr.outputs.base_sha }}
+          BASE_REF: ${{ steps.pr.outputs.base_ref }}
+          DEFAULT_BRANCH: ${{ steps.pr.outputs.default_branch }}
           HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
         run: |
           set +e
@@ -432,6 +471,8 @@ jobs:
             --pr-number "$PR_NUMBER" \
             --author "$AUTHOR" \
             --base-sha "$BASE_SHA" \
+            --base-ref "$BASE_REF" \
+            --default-branch "$DEFAULT_BRANCH" \
             --head-sha "$HEAD_SHA"
           status=$?
           decision="$(python3 -c 'import json, os; print(json.load(open(os.environ["RESULT_JSON"]))["decision"])' 2>/dev/null || echo error)"
@@ -467,6 +508,8 @@ jobs:
           PR_NUMBER: ${{ needs.evaluate.outputs.number }}
           BASE_SHA: ${{ needs.evaluate.outputs.base_sha }}
           HEAD_SHA: ${{ needs.evaluate.outputs.head_sha }}
+          CONFIG_ENFORCED: ${{ needs.evaluate.outputs.config_enforced || 'true' }}
+          STACKED_ADVISORY: ${{ needs.evaluate.outputs.stacked_advisory || 'false' }}
           DECISION: ${{ needs.evaluate.outputs.decision || 'needs-human-review' }}
           PASSED: ${{ needs.evaluate.outputs.passed || 'false' }}
           ENFORCED: ${{ needs.evaluate.outputs.enforced || 'true' }}
@@ -481,6 +524,8 @@ jobs:
             const issue_number = Number(process.env.PR_NUMBER);
             const baseSha = process.env.BASE_SHA;
             const headSha = process.env.HEAD_SHA;
+            const configEnforced = process.env.CONFIG_ENFORCED === 'true';
+            const stackedAdvisory = process.env.STACKED_ADVISORY === 'true';
             const statusContext = enforced ? 'Review Policy' : 'Review Policy Advisory';
             const descriptions = {
               'trusted-author-low-risk': 'Trusted author and low-risk gates passed.',
@@ -530,6 +575,18 @@ jobs:
               return;
             }
 
+            if (stackedAdvisory && configEnforced) {
+              await github.rest.repos.createCommitStatus({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                sha: headSha,
+                state: 'pending',
+                context: 'Review Policy',
+                description: 'Stacked PR result is advisory; default-branch PR must pass Review Policy.',
+                target_url: process.env.TARGET_URL,
+              });
+            }
+
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -561,6 +618,7 @@ jobs:
         env:
           DECISION: ${{ needs.evaluate.outputs.decision || 'needs-human-review' }}
           PR_NUMBER: ${{ needs.evaluate.outputs.number }}
+          BASE_SHA: ${{ needs.evaluate.outputs.base_sha }}
           HEAD_SHA: ${{ needs.evaluate.outputs.head_sha }}
         with:
           script: |
@@ -576,9 +634,14 @@ jobs:
               : 'needs-human-review';
             const desired = labels[decision] || labels['needs-human-review'];
             const issue_number = Number(process.env.PR_NUMBER);
+            const baseSha = process.env.BASE_SHA;
             const headSha = process.env.HEAD_SHA;
             if (!Number.isInteger(issue_number) || issue_number <= 0) {
               core.setFailed(`Invalid pull request number for review policy label sync: ${process.env.PR_NUMBER}`);
+              return;
+            }
+            if (!baseSha) {
+              core.setFailed('Missing evaluated base SHA for review policy label sync.');
               return;
             }
             if (!headSha) {
@@ -616,10 +679,10 @@ jobs:
                 repo: context.repo.repo,
                 pull_number: issue_number,
               });
-              if (pr.state !== 'open' || pr.head.sha !== headSha) {
+              if (pr.state !== 'open' || pr.head.sha !== headSha || pr.base.sha !== baseSha) {
                 core.notice(
-                  `Skipping stale Review Policy label sync for ${headSha}; ` +
-                  `pull request #${issue_number} now points at ${pr.head.sha}.`
+                  `Skipping stale Review Policy label sync for ${baseSha}...${headSha}; ` +
+                  `pull request #${issue_number} now points at ${pr.base.sha}...${pr.head.sha}.`
                 );
                 return;
               }

--- a/.github/workflows/review-policy.yml
+++ b/.github/workflows/review-policy.yml
@@ -174,13 +174,13 @@ jobs:
             core.setOutput('head_repo', pr.head.repo.full_name);
             core.setOutput('base_repo', pr.base.repo.full_name);
             core.setOutput('same_repo', String(pr.head.repo.full_name === pr.base.repo.full_name));
-            core.setOutput('trusted_base', String(pr.base.ref === pr.base.repo.default_branch));
+            core.setOutput('default_branch', pr.base.repo.default_branch);
 
-      - name: Checkout trusted base policy
+      - name: Checkout trusted default-branch policy
         if: steps.pr.outputs.found == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ steps.pr.outputs.base_sha }}
+          ref: ${{ steps.pr.outputs.default_branch }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -188,22 +188,17 @@ jobs:
         id: policy_source
         if: steps.pr.outputs.found == 'true'
         env:
-          BASE_REF: ${{ steps.pr.outputs.base_ref }}
-          TRUSTED_BASE: ${{ steps.pr.outputs.trusted_base }}
+          DEFAULT_BRANCH: ${{ steps.pr.outputs.default_branch }}
         run: |
-          if [ "$TRUSTED_BASE" != "true" ]; then
-            echo "Review policy only evaluates PRs based on the repository default branch; got base ref ${BASE_REF}." >&2
-            exit 1
-          fi
           if [ ! -f .github/scripts/evaluate_review_policy.py ] || [ ! -f .github/review-policy.json ]; then
-            echo "Trusted base commit does not contain review policy code and config; publishing a fail-closed bootstrap decision without executing PR-head policy code."
+            echo "Trusted default branch ${DEFAULT_BRANCH} does not contain review policy code and config; publishing a fail-closed bootstrap decision without executing PR-head policy code."
             echo "available=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           echo "available=true" >> "$GITHUB_OUTPUT"
           echo "path=$(pwd)" >> "$GITHUB_OUTPUT"
-          echo "Using review policy code from the trusted base commit."
+          echo "Using review policy code from the trusted default branch ${DEFAULT_BRANCH}."
 
       - name: Use bootstrap fallback decision
         id: bootstrap_policy
@@ -219,7 +214,7 @@ jobs:
             echo "**Status:** fail"
             echo "**Mode:** advisory"
             echo
-            echo "Trusted base policy code is not available yet, so this bootstrap run did not execute PR-controlled policy code."
+            echo "Trusted default-branch policy code is not available yet, so this bootstrap run did not execute PR-controlled policy code."
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Run deterministic low-risk preflight
@@ -329,6 +324,18 @@ jobs:
             - The change is mechanically simple and localized.
             - The behavior change is absent or trivial to reason about.
             - Tests were added or updated when behavior changes.
+            - Pure test-helper/test-coverage changes are eligible when they do not
+              alter product code, generated code, build/deploy behavior, secrets, or
+              infrastructure.
+            - Literal presentational UI polish is eligible when the diff only changes
+              styles, class names, copy-free layout constants, or focused tests and
+              does not alter user flows, permissions, data loading, or ambiguous
+              product semantics.
+            - Tiny non-sensitive server utility changes are eligible when they stay
+              outside denied control/security/persistence/RPC paths and do not change
+              auth, authorization, sessions, tokens, command execution, pool/wallet
+              configuration, migrations, storage semantics, networking, deployment,
+              or generated code.
             - No auth, authorization, persistence, migrations, networking, dependency,
               build, deployment, generated-code, GitHub Actions, secret handling, mining
               pool/wallet, plugin, protobuf, or infrastructure behavior changed.

--- a/.github/workflows/review-policy.yml
+++ b/.github/workflows/review-policy.yml
@@ -585,14 +585,18 @@ jobs:
               return;
             }
 
-            if (stackedAdvisory && configEnforced) {
+            if (!enforced) {
+              const enforcedAdvisoryState = stackedAdvisory && configEnforced ? 'pending' : 'success';
+              const enforcedAdvisoryDescription = stackedAdvisory && configEnforced
+                ? 'Stacked PR result is advisory; default-branch PR must pass Review Policy.'
+                : 'Review Policy is advisory; see Review Policy Advisory.';
               await github.rest.repos.createCommitStatus({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 sha: headSha,
-                state: 'pending',
+                state: enforcedAdvisoryState,
                 context: 'Review Policy',
-                description: 'Stacked PR result is advisory; default-branch PR must pass Review Policy.',
+                description: enforcedAdvisoryDescription,
                 target_url: process.env.TARGET_URL,
               });
             }

--- a/.github/workflows/review-policy.yml
+++ b/.github/workflows/review-policy.yml
@@ -457,9 +457,8 @@ jobs:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           AUTHOR: ${{ steps.pr.outputs.author }}
           BASE_SHA: ${{ steps.pr.outputs.base_sha }}
-          BASE_REF: ${{ steps.pr.outputs.base_ref }}
-          DEFAULT_BRANCH: ${{ steps.pr.outputs.default_branch }}
           HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          REVIEW_POLICY_ENFORCED: ${{ steps.policy_mode.outputs.enforced || 'true' }}
         run: |
           set +e
           python3 "$POLICY_ROOT/.github/scripts/evaluate_review_policy.py" \
@@ -471,13 +470,11 @@ jobs:
             --pr-number "$PR_NUMBER" \
             --author "$AUTHOR" \
             --base-sha "$BASE_SHA" \
-            --base-ref "$BASE_REF" \
-            --default-branch "$DEFAULT_BRANCH" \
             --head-sha "$HEAD_SHA"
           status=$?
           decision="$(python3 -c 'import json, os; print(json.load(open(os.environ["RESULT_JSON"]))["decision"])' 2>/dev/null || echo error)"
           passed="$(python3 -c 'import json, os; print(str(json.load(open(os.environ["RESULT_JSON"]))["passed"]).lower())' 2>/dev/null || echo false)"
-          enforced="$(python3 -c 'import json, os; print(str(json.load(open(os.environ["RESULT_JSON"]))["enforced"]).lower())' 2>/dev/null || echo true)"
+          enforced="${REVIEW_POLICY_ENFORCED}"
           echo "decision=${decision}" >> "$GITHUB_OUTPUT"
           echo "passed=${passed}" >> "$GITHUB_OUTPUT"
           echo "enforced=${enforced}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/review-policy.yml
+++ b/.github/workflows/review-policy.yml
@@ -66,6 +66,7 @@ jobs:
       base_ref: ${{ steps.pr.outputs.base_ref }}
       default_branch: ${{ steps.pr.outputs.default_branch }}
       head_sha: ${{ steps.pr.outputs.head_sha }}
+      policy_source_available: ${{ steps.policy_source.outputs.available || 'false' }}
       config_enforced: ${{ steps.policy_config.outputs.config_enforced || 'true' }}
       stacked_advisory: ${{ steps.policy_mode.outputs.stacked_advisory || 'false' }}
       decision: ${{ steps.evaluate_policy.outputs.decision || steps.bootstrap_policy.outputs.decision || 'needs-human-review' }}
@@ -520,6 +521,7 @@ jobs:
           HEAD_SHA: ${{ needs.evaluate.outputs.head_sha }}
           CONFIG_ENFORCED: ${{ needs.evaluate.outputs.config_enforced || 'true' }}
           STACKED_ADVISORY: ${{ needs.evaluate.outputs.stacked_advisory || 'false' }}
+          POLICY_SOURCE_AVAILABLE: ${{ needs.evaluate.outputs.policy_source_available || 'false' }}
           DECISION: ${{ needs.evaluate.outputs.decision || 'needs-human-review' }}
           PASSED: ${{ needs.evaluate.outputs.passed || 'false' }}
           ENFORCED: ${{ needs.evaluate.outputs.enforced || 'true' }}
@@ -536,6 +538,7 @@ jobs:
             const headSha = process.env.HEAD_SHA;
             const configEnforced = process.env.CONFIG_ENFORCED === 'true';
             const stackedAdvisory = process.env.STACKED_ADVISORY === 'true';
+            const policySourceAvailable = process.env.POLICY_SOURCE_AVAILABLE === 'true';
             const statusContext = enforced ? 'Review Policy' : 'Review Policy Advisory';
             const descriptions = {
               'trusted-author-low-risk': 'Trusted author and low-risk gates passed.',
@@ -568,6 +571,19 @@ jobs:
               return match ? Number(match[1]) : 0;
             }
 
+            function hasNewerStatusRun(contextName) {
+              const existing = statuses.find((status) => status.context === contextName);
+              const existingRunId = runIdFromUrl(existing?.target_url);
+              if (existingRunId > currentRunId) {
+                core.notice(
+                  `Skipping stale Review Policy status publish from run ${currentRunId}; ` +
+                  `${contextName} already points at newer run ${existingRunId}.`
+                );
+                return true;
+              }
+              return false;
+            }
+
             const currentRunId = Number(process.env.GITHUB_RUN_ID || 0);
             const { data: statuses } = await github.rest.repos.listCommitStatusesForRef({
               owner: context.repo.owner,
@@ -575,30 +591,32 @@ jobs:
               ref: headSha,
               per_page: 100,
             });
-            const existing = statuses.find((status) => status.context === statusContext);
-            const existingRunId = runIdFromUrl(existing?.target_url);
-            if (existingRunId > currentRunId) {
-              core.notice(
-                `Skipping stale Review Policy status publish from run ${currentRunId}; ` +
-                `${statusContext} already points at newer run ${existingRunId}.`
-              );
+            if (hasNewerStatusRun(statusContext)) {
               return;
             }
 
             if (!enforced) {
-              const enforcedAdvisoryState = stackedAdvisory && configEnforced ? 'pending' : 'success';
-              const enforcedAdvisoryDescription = stackedAdvisory && configEnforced
-                ? 'Stacked PR result is advisory; default-branch PR must pass Review Policy.'
-                : 'Review Policy is advisory; see Review Policy Advisory.';
-              await github.rest.repos.createCommitStatus({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                sha: headSha,
-                state: enforcedAdvisoryState,
-                context: 'Review Policy',
-                description: enforcedAdvisoryDescription,
-                target_url: process.env.TARGET_URL,
-              });
+              let enforcedAdvisoryState = 'success';
+              let enforcedAdvisoryDescription = 'Review Policy is advisory; see Review Policy Advisory.';
+              if (!policySourceAvailable) {
+                enforcedAdvisoryState = 'failure';
+                enforcedAdvisoryDescription = 'Trusted Review Policy source unavailable; human review required.';
+              } else if (stackedAdvisory && configEnforced) {
+                enforcedAdvisoryState = 'pending';
+                enforcedAdvisoryDescription = 'Stacked PR result is advisory; default-branch PR must pass Review Policy.';
+              }
+
+              if (!hasNewerStatusRun('Review Policy')) {
+                await github.rest.repos.createCommitStatus({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  sha: headSha,
+                  state: enforcedAdvisoryState,
+                  context: 'Review Policy',
+                  description: enforcedAdvisoryDescription,
+                  target_url: process.env.TARGET_URL,
+                });
+              }
             }
 
             await github.rest.repos.createCommitStatus({

--- a/.github/workflows/review-policy.yml
+++ b/.github/workflows/review-policy.yml
@@ -599,8 +599,10 @@ jobs:
               let enforcedAdvisoryState = 'success';
               let enforcedAdvisoryDescription = 'Review Policy is advisory; see Review Policy Advisory.';
               if (!policySourceAvailable) {
-                enforcedAdvisoryState = 'failure';
-                enforcedAdvisoryDescription = 'Trusted Review Policy source unavailable; human review required.';
+                enforcedAdvisoryState = stackedAdvisory ? 'pending' : 'failure';
+                enforcedAdvisoryDescription = stackedAdvisory
+                  ? 'Stacked PR policy source unavailable; default-branch PR must pass Review Policy.'
+                  : 'Trusted Review Policy source unavailable; human review required.';
               } else if (stackedAdvisory && configEnforced) {
                 enforcedAdvisoryState = 'pending';
                 enforcedAdvisoryDescription = 'Stacked PR result is advisory; default-branch PR must pass Review Policy.';

--- a/.github/workflows/review-policy.yml
+++ b/.github/workflows/review-policy.yml
@@ -66,11 +66,11 @@ jobs:
       base_ref: ${{ steps.pr.outputs.base_ref }}
       default_branch: ${{ steps.pr.outputs.default_branch }}
       head_sha: ${{ steps.pr.outputs.head_sha }}
-      config_enforced: ${{ steps.policy_mode.outputs.config_enforced || 'true' }}
+      config_enforced: ${{ steps.policy_config.outputs.config_enforced || 'true' }}
       stacked_advisory: ${{ steps.policy_mode.outputs.stacked_advisory || 'false' }}
       decision: ${{ steps.evaluate_policy.outputs.decision || steps.bootstrap_policy.outputs.decision || 'needs-human-review' }}
       passed: ${{ steps.evaluate_policy.outputs.passed || steps.bootstrap_policy.outputs.passed || 'false' }}
-      enforced: ${{ steps.evaluate_policy.outputs.enforced || steps.policy_mode.outputs.enforced || steps.bootstrap_policy.outputs.enforced || 'true' }}
+      enforced: ${{ steps.evaluate_policy.outputs.enforced || steps.policy_config.outputs.enforced || steps.bootstrap_policy.outputs.enforced || steps.policy_mode.outputs.enforced || 'true' }}
     env:
       CODEX_MODEL: gpt-5.5
       CODEX_REASONING_EFFORT: high
@@ -180,6 +180,26 @@ jobs:
             core.setOutput('same_repo', String(pr.head.repo.full_name === pr.base.repo.full_name));
             core.setOutput('default_branch', pr.base.repo.default_branch);
 
+      - name: Select pull request review policy mode
+        id: policy_mode
+        if: steps.pr.outputs.found == 'true'
+        env:
+          BASE_REF: ${{ steps.pr.outputs.base_ref }}
+          DEFAULT_BRANCH: ${{ steps.pr.outputs.default_branch }}
+        run: |
+          stacked_advisory=false
+          if [ "$BASE_REF" != "$DEFAULT_BRANCH" ]; then
+            stacked_advisory=true
+          fi
+
+          enforced=true
+          if [ "$stacked_advisory" = "true" ]; then
+            enforced=false
+          fi
+
+          echo "stacked_advisory=${stacked_advisory}" >> "$GITHUB_OUTPUT"
+          echo "enforced=${enforced}" >> "$GITHUB_OUTPUT"
+
       - name: Checkout trusted default-branch policy
         if: steps.pr.outputs.found == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -204,19 +224,13 @@ jobs:
           echo "path=$(pwd)" >> "$GITHUB_OUTPUT"
           echo "Using review policy code from the trusted default branch ${DEFAULT_BRANCH}."
 
-      - name: Select review policy mode
-        id: policy_mode
+      - name: Select review policy config mode
+        id: policy_config
         if: steps.pr.outputs.found == 'true' && steps.policy_source.outputs.available == 'true'
         env:
           POLICY_ROOT: ${{ steps.policy_source.outputs.path }}
-          BASE_REF: ${{ steps.pr.outputs.base_ref }}
-          DEFAULT_BRANCH: ${{ steps.pr.outputs.default_branch }}
+          STACKED_ADVISORY: ${{ steps.policy_mode.outputs.stacked_advisory || 'false' }}
         run: |
-          stacked_advisory=false
-          if [ "$BASE_REF" != "$DEFAULT_BRANCH" ]; then
-            stacked_advisory=true
-          fi
-
           config_enforced="$(python3 - <<'PY'
           import json
           import os
@@ -229,12 +243,11 @@ jobs:
           )"
 
           enforced="$config_enforced"
-          if [ "$stacked_advisory" = "true" ]; then
+          if [ "$STACKED_ADVISORY" = "true" ]; then
             enforced=false
           fi
 
           echo "config_enforced=${config_enforced}" >> "$GITHUB_OUTPUT"
-          echo "stacked_advisory=${stacked_advisory}" >> "$GITHUB_OUTPUT"
           echo "enforced=${enforced}" >> "$GITHUB_OUTPUT"
 
       - name: Use bootstrap fallback decision
@@ -458,7 +471,7 @@ jobs:
           AUTHOR: ${{ steps.pr.outputs.author }}
           BASE_SHA: ${{ steps.pr.outputs.base_sha }}
           HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
-          REVIEW_POLICY_ENFORCED: ${{ steps.policy_mode.outputs.enforced || 'true' }}
+          REVIEW_POLICY_ENFORCED: ${{ steps.policy_config.outputs.enforced || steps.policy_mode.outputs.enforced || 'true' }}
         run: |
           set +e
           python3 "$POLICY_ROOT/.github/scripts/evaluate_review_policy.py" \


### PR DESCRIPTION
Reviewable diff: +174/-31 across 3 files (excludes generated, test, and story files).

**Summary**
Review Policy can now evaluate stacked PRs without executing policy code or config from an unmerged stack base. The workflow loads the evaluator and policy config from the repository default branch while preserving the PR's actual base/head SHAs for diff evaluation, stale-status checks, classifier input, labels, and status publishing. It keeps stacked-PR results advisory from the start of the job and avoids stale primary `Review Policy` statuses from either failing advisory runs incorrectly or satisfying enforced branch protection incorrectly. The deterministic low-risk policy is widened for narrow mechanical cases: deployment markdown docs, larger companion test files, pure test coverage changes, literal presentational UI polish, and tiny non-sensitive server utility changes.

**How it works**
When Review Policy resolves a pull request, it records the PR number, author, base ref, default branch, base SHA, and head SHA. Before any checkout, it classifies whether the PR is stacked by comparing the base ref with the repository default branch; stacked PRs are marked advisory immediately, while default-branch PRs remain enforced unless trusted config later disables enforcement.

The job then checks out the default branch only for `.github/scripts/evaluate_review_policy.py` and `.github/review-policy.json`. The trusted evaluator still inspects the event PR, fetches the PR base and head SHAs, builds the `base_sha...head_sha` diff, and applies deterministic plus classifier-backed low-risk checks. The workflow passes the precomputed enforcement mode through `REVIEW_POLICY_ENFORCED` so the evaluator stays compatible with the trusted default-branch code path while the workflow owns stacked advisory mode.

Status and label publishing are bound to the evaluated base/head pair. If the PR moved after evaluation, publishing is skipped. Advisory runs also guard the primary `Review Policy` context against newer runs before writing it. Config-disabled advisory mode clears stale primary failures as success, stacked advisory mode keeps the primary context pending in enforced repositories, and missing trusted policy source fails closed for default-branch PRs while remaining pending for stacked PRs.

The deterministic policy now supports explicit deny-path exceptions before classifier evaluation. Deployment runtime files stay denied, while markdown-only deployment docs can pass to the classifier. Per-file size checks use a larger cap for recognized test paths, including root-level `test/`, `tests/`, `__tests__/`, and `e2etests/` trees.

**Diagrams**
```mermaid
flowchart TD
  E["Review Policy event"] --> R["Resolve PR metadata"]
  R --> M["Select enforced or stacked advisory mode"]
  R --> P["Checkout evaluator and config from default branch"]
  R --> B["Keep PR base and head SHAs"]
  P --> V["Run trusted policy code"]
  B --> D["Build base...head PR diff"]
  M --> C["Evaluate deterministic and AI low-risk checks"]
  D --> C
  V --> C
  C --> S["Publish labels and commit statuses on PR head"]
```

```mermaid
flowchart TD
  R["Resolved PR"] --> Q{"Base ref equals default branch?"}
  Q -->|"Yes"| E["Start in enforced mode"]
  Q -->|"No"| A["Start in stacked advisory mode"]
  E --> C{"Trusted config available?"}
  C -->|"Enforce false"| D["Clear stale primary status as success"]
  C -->|"Unavailable"| F["Fail primary status"]
  A --> P["Keep primary status pending"]
  D --> S["Publish Review Policy Advisory"]
  F --> S
  P --> S
```

**Areas of the code involved**
| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `.github/workflows/review-policy.yml` | Checks out policy code/config from the default branch, selects stacked advisory mode before checkout, uses base/head-bound status and label publishing, and guards advisory writes across both `Review Policy` and `Review Policy Advisory` contexts. | This is the trust boundary and lifecycle behavior for stacked PR policy evaluation. |
| `.github/review-policy.json` | Adds a test-file size cap and markdown-only deployment-file exceptions. | This is the deterministic relaxation that lets more review-light PRs reach classifier evaluation without opening runtime deployment files. |
| `.github/scripts/evaluate_review_policy.py` | Applies deny-path exceptions, uses the larger per-file cap for recognized test paths including root test trees, and honors the workflow-provided enforcement override. | This implements the config semantics and keeps evaluator behavior compatible with workflow-owned stacked advisory mode. |
| `.github/scripts/evaluate_review_policy_test.py` | Adds coverage for default-branch policy checkout, pre-checkout stacked advisory fallback, stale status/label guards, source-unavailable advisory behavior, deny exceptions, deployment markdown handling, runtime deployment denial, and test-file sizing. | Review support for the CI policy behavior; excluded from the reviewable diff count. |

**Key technical decisions & trade-offs**
- Execute trusted default-branch policy code while preserving PR base/head diff scope, instead of executing unmerged policy code from a stacked base.
- Classify stacked advisory mode before checkout, instead of waiting for trusted policy files and risking enforced fallback on checkout failures.
- Write the primary context during advisory runs only with explicit freshness and source-availability rules, instead of letting stale statuses linger or overwrite newer decisions.
- Add targeted deny-path exceptions for deployment markdown, instead of weakening the broader deployment deny rule.
- Raise the per-file cap only for recognized test paths, instead of increasing the global changed-line threshold.

**Testing & validation**
- `python3 .github/scripts/evaluate_review_policy_test.py`
- `python3 -m json.tool .github/review-policy.json >/tmp/review-policy-json-check.txt`
- `git diff --check`
- Final PR Gate on `cc21ad8edd72f48e213b18edd23512e3a0b6ec0f` passed before merge.
