### PR TITLE
Tolerate transient HA promotion observations

### DIFF
--- a/server/internal/ha/coordinator.go
+++ b/server/internal/ha/coordinator.go
@@ -305,16 +305,8 @@ func (c *Coordinator) renewActive(ctx context.Context, expectedCtx context.Conte
 	observed, err := c.observer.ObserveAndRun(
 		activeCtx,
 		func(actionCtx context.Context, observed WriterObservation) error {
-			if observed.DCSClusterID != current.DCSClusterID ||
-				observed.WriterGeneration != current.Token.WriterGeneration {
-				return fmt.Errorf(
-					"%w: held %s@%d, observed %s@%d",
-					ErrWriterChanged,
-					current.DCSClusterID,
-					current.Token.WriterGeneration,
-					observed.DCSClusterID,
-					observed.WriterGeneration,
-				)
+			if err := validateObservedWriter(current, observed); err != nil {
+				return err
 			}
 			requestStarted = time.Now()
 			var renewErr error
@@ -329,6 +321,10 @@ func (c *Coordinator) renewActive(ctx context.Context, expectedCtx context.Conte
 	)
 	if err != nil {
 		if errors.Is(err, ErrTimelineMismatch) {
+			if writerErr := validateObservedWriter(current, observed); writerErr != nil {
+				c.deactivate(writerErr)
+				return writerErr
+			}
 			return c.markActiveObservationUnavailable(activeCtx)
 		}
 		c.deactivate(err)
@@ -344,6 +340,21 @@ func (c *Coordinator) renewActive(ctx context.Context, expectedCtx context.Conte
 		return err
 	}
 	return nil
+}
+
+func validateObservedWriter(current Ownership, observed WriterObservation) error {
+	if observed.DCSClusterID == current.DCSClusterID &&
+		observed.WriterGeneration == current.Token.WriterGeneration {
+		return nil
+	}
+	return fmt.Errorf(
+		"%w: held %s@%d, observed %s@%d",
+		ErrWriterChanged,
+		current.DCSClusterID,
+		current.Token.WriterGeneration,
+		observed.DCSClusterID,
+		observed.WriterGeneration,
+	)
 }
 
 func (c *Coordinator) markActiveObservationUnavailable(expectedCtx context.Context) error {

--- a/server/internal/ha/coordinator.go
+++ b/server/internal/ha/coordinator.go
@@ -328,6 +328,9 @@ func (c *Coordinator) renewActive(ctx context.Context, expectedCtx context.Conte
 		},
 	)
 	if err != nil {
+		if errors.Is(err, ErrTimelineMismatch) {
+			return c.markActiveObservationUnavailable(activeCtx)
+		}
 		c.deactivate(err)
 		return err
 	}
@@ -340,6 +343,16 @@ func (c *Coordinator) renewActive(ctx context.Context, expectedCtx context.Conte
 		c.deactivate(err)
 		return err
 	}
+	return nil
+}
+
+func (c *Coordinator) markActiveObservationUnavailable(expectedCtx context.Context) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.activeCtx != expectedCtx {
+		return ErrOwnershipLost
+	}
+	c.observed = false
 	return nil
 }
 

--- a/server/internal/ha/coordinator_test.go
+++ b/server/internal/ha/coordinator_test.go
@@ -140,46 +140,6 @@ func TestCoordinatorCancelsLifetimeOnObservationLoss(t *testing.T) {
 	require.Equal(t, holder, coordinator.HolderID())
 }
 
-func TestCoordinatorRetainsActiveLifetimeAcrossTransientTimelineMismatch(t *testing.T) {
-	store := &fakeLeaseStore{}
-	coordinator := newCoordinatorWithHolder(
-		&sequenceObserver{results: []observerResult{
-			{observation: coordinatorObservation("cluster-a", 41, time.Second)},
-			{
-				observation: coordinatorObservation("cluster-a", 41, time.Second),
-				err:         fmt.Errorf("promotion observation: %w", ErrTimelineMismatch),
-			},
-			{observation: coordinatorObservation("cluster-a", 41, time.Second)},
-		}},
-		store,
-		coordinatorTestConfig(),
-		uuid.New(),
-	)
-	require.NoError(t, coordinator.step(t.Context()))
-	activeCtx, _, active := coordinator.ActiveLifetime()
-	require.True(t, active)
-	validSnapshot := coordinator.Snapshot()
-	validTimer := coordinator.leaseTimer
-
-	require.NoError(t, coordinator.step(t.Context()))
-	retainedCtx, _, active := coordinator.ActiveLifetime()
-	require.True(t, active)
-	require.Same(t, activeCtx, retainedCtx)
-	require.NoError(t, activeCtx.Err())
-	require.False(t, coordinator.Snapshot().ObservationAvailable)
-	require.Equal(t, validSnapshot.FreshUntil, coordinator.Snapshot().FreshUntil)
-	require.Same(t, validTimer, coordinator.leaseTimer)
-	require.Equal(t, []string{"acquire", "renew"}, store.callSequence())
-
-	require.NoError(t, coordinator.step(t.Context()))
-	convergedCtx, _, active := coordinator.ActiveLifetime()
-	require.True(t, active)
-	require.Same(t, activeCtx, convergedCtx)
-	require.NoError(t, activeCtx.Err())
-	require.True(t, coordinator.Snapshot().ObservationAvailable)
-	require.Equal(t, []string{"acquire", "renew", "renew"}, store.callSequence())
-}
-
 func TestCoordinatorRejectsTimelineMismatchFromNewWriter(t *testing.T) {
 	store := &fakeLeaseStore{}
 	coordinator := newCoordinatorWithHolder(
@@ -532,36 +492,6 @@ func (s staticObserver) ObserveAndRun(
 type actionThenErrorObserver struct {
 	observation WriterObservation
 	err         error
-}
-
-type succeedOnceThenErrorObserver struct {
-	mu          sync.Mutex
-	observation WriterObservation
-	err         error
-	calls       int
-}
-
-func (o *succeedOnceThenErrorObserver) ObserveAndRun(
-	ctx context.Context,
-	action func(context.Context, WriterObservation) error,
-) (WriterObservation, error) {
-	o.mu.Lock()
-	o.calls++
-	calls := o.calls
-	o.mu.Unlock()
-	if calls > 1 {
-		return o.observation, o.err
-	}
-	if err := action(ctx, o.observation); err != nil {
-		return WriterObservation{}, err
-	}
-	return o.observation, nil
-}
-
-func (o *succeedOnceThenErrorObserver) callCount() int {
-	o.mu.Lock()
-	defer o.mu.Unlock()
-	return o.calls
 }
 
 func (o actionThenErrorObserver) ObserveAndRun(

--- a/server/internal/ha/coordinator_test.go
+++ b/server/internal/ha/coordinator_test.go
@@ -140,6 +140,43 @@ func TestCoordinatorCancelsLifetimeOnObservationLoss(t *testing.T) {
 	require.Equal(t, holder, coordinator.HolderID())
 }
 
+func TestCoordinatorRetainsActiveLifetimeAcrossTransientTimelineMismatch(t *testing.T) {
+	store := &fakeLeaseStore{}
+	coordinator := newCoordinatorWithHolder(
+		&sequenceObserver{results: []observerResult{
+			{observation: coordinatorObservation("cluster-a", 41, time.Second)},
+			{err: fmt.Errorf("promotion observation: %w", ErrTimelineMismatch)},
+			{observation: coordinatorObservation("cluster-a", 41, time.Second)},
+		}},
+		store,
+		coordinatorTestConfig(),
+		uuid.New(),
+	)
+	require.NoError(t, coordinator.step(t.Context()))
+	activeCtx, _, active := coordinator.ActiveLifetime()
+	require.True(t, active)
+	validSnapshot := coordinator.Snapshot()
+	validTimer := coordinator.leaseTimer
+
+	require.NoError(t, coordinator.step(t.Context()))
+	retainedCtx, _, active := coordinator.ActiveLifetime()
+	require.True(t, active)
+	require.Same(t, activeCtx, retainedCtx)
+	require.NoError(t, activeCtx.Err())
+	require.False(t, coordinator.Snapshot().ObservationAvailable)
+	require.Equal(t, validSnapshot.FreshUntil, coordinator.Snapshot().FreshUntil)
+	require.Same(t, validTimer, coordinator.leaseTimer)
+	require.Equal(t, []string{"acquire", "renew"}, store.callSequence())
+
+	require.NoError(t, coordinator.step(t.Context()))
+	convergedCtx, _, active := coordinator.ActiveLifetime()
+	require.True(t, active)
+	require.Same(t, activeCtx, convergedCtx)
+	require.NoError(t, activeCtx.Err())
+	require.True(t, coordinator.Snapshot().ObservationAvailable)
+	require.Equal(t, []string{"acquire", "renew", "renew"}, store.callSequence())
+}
+
 func TestCoordinatorGivesPeersAnAcquisitionWindowAfterPassiveProofFailure(t *testing.T) {
 	// Arrange
 	holder := uuid.New()
@@ -469,6 +506,36 @@ type actionThenErrorObserver struct {
 	err         error
 }
 
+type succeedOnceThenErrorObserver struct {
+	mu          sync.Mutex
+	observation WriterObservation
+	err         error
+	calls       int
+}
+
+func (o *succeedOnceThenErrorObserver) ObserveAndRun(
+	ctx context.Context,
+	action func(context.Context, WriterObservation) error,
+) (WriterObservation, error) {
+	o.mu.Lock()
+	o.calls++
+	calls := o.calls
+	o.mu.Unlock()
+	if calls > 1 {
+		return WriterObservation{}, o.err
+	}
+	if err := action(ctx, o.observation); err != nil {
+		return WriterObservation{}, err
+	}
+	return o.observation, nil
+}
+
+func (o *succeedOnceThenErrorObserver) callCount() int {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.calls
+}
+
 func (o actionThenErrorObserver) ObserveAndRun(
 	ctx context.Context,
 	action func(context.Context, WriterObservation) error,
@@ -487,6 +554,7 @@ type observerResult struct {
 type sequenceObserver struct {
 	mu      sync.Mutex
 	results []observerResult
+	calls   chan struct{}
 }
 
 func (s *sequenceObserver) ObserveAndRun(
@@ -497,6 +565,9 @@ func (s *sequenceObserver) ObserveAndRun(
 	result := s.results[0]
 	s.results = s.results[1:]
 	s.mu.Unlock()
+	if s.calls != nil {
+		s.calls <- struct{}{}
+	}
 	if result.err != nil {
 		return WriterObservation{}, result.err
 	}

--- a/server/internal/ha/coordinator_test.go
+++ b/server/internal/ha/coordinator_test.go
@@ -145,7 +145,10 @@ func TestCoordinatorRetainsActiveLifetimeAcrossTransientTimelineMismatch(t *test
 	coordinator := newCoordinatorWithHolder(
 		&sequenceObserver{results: []observerResult{
 			{observation: coordinatorObservation("cluster-a", 41, time.Second)},
-			{err: fmt.Errorf("promotion observation: %w", ErrTimelineMismatch)},
+			{
+				observation: coordinatorObservation("cluster-a", 41, time.Second),
+				err:         fmt.Errorf("promotion observation: %w", ErrTimelineMismatch),
+			},
 			{observation: coordinatorObservation("cluster-a", 41, time.Second)},
 		}},
 		store,
@@ -175,6 +178,31 @@ func TestCoordinatorRetainsActiveLifetimeAcrossTransientTimelineMismatch(t *test
 	require.NoError(t, activeCtx.Err())
 	require.True(t, coordinator.Snapshot().ObservationAvailable)
 	require.Equal(t, []string{"acquire", "renew", "renew"}, store.callSequence())
+}
+
+func TestCoordinatorRejectsTimelineMismatchFromNewWriter(t *testing.T) {
+	store := &fakeLeaseStore{}
+	coordinator := newCoordinatorWithHolder(
+		&sequenceObserver{results: []observerResult{
+			{observation: coordinatorObservation("cluster-a", 41, time.Second)},
+			{
+				observation: coordinatorObservation("cluster-a", 42, time.Second),
+				err:         fmt.Errorf("promotion observation: %w", ErrTimelineMismatch),
+			},
+		}},
+		store,
+		coordinatorTestConfig(),
+		uuid.New(),
+	)
+	require.NoError(t, coordinator.step(t.Context()))
+	activeCtx, _, active := coordinator.ActiveLifetime()
+	require.True(t, active)
+
+	require.ErrorIs(t, coordinator.step(t.Context()), ErrWriterChanged)
+	require.ErrorIs(t, context.Cause(activeCtx), ErrWriterChanged)
+	_, _, active = coordinator.ActiveLifetime()
+	require.False(t, active)
+	require.Equal(t, []string{"acquire", "renew"}, store.callSequence())
 }
 
 func TestCoordinatorGivesPeersAnAcquisitionWindowAfterPassiveProofFailure(t *testing.T) {
@@ -522,7 +550,7 @@ func (o *succeedOnceThenErrorObserver) ObserveAndRun(
 	calls := o.calls
 	o.mu.Unlock()
 	if calls > 1 {
-		return WriterObservation{}, o.err
+		return o.observation, o.err
 	}
 	if err := action(ctx, o.observation); err != nil {
 		return WriterObservation{}, err
@@ -569,7 +597,7 @@ func (s *sequenceObserver) ObserveAndRun(
 		s.calls <- struct{}{}
 	}
 	if result.err != nil {
-		return WriterObservation{}, result.err
+		return result.observation, result.err
 	}
 	if err := action(ctx, result.observation); err != nil {
 		return WriterObservation{}, err

--- a/server/internal/ha/observer.go
+++ b/server/internal/ha/observer.go
@@ -165,15 +165,15 @@ func (o *Observer) observeAndRun(
 	if !isPrimaryRole(patroni.Role) {
 		return WriterObservation{}, fmt.Errorf("%w: Patroni role is %q", ErrWritableServerMismatch, patroni.Role)
 	}
+	observed := writerObservation(first, connected)
 	if patroni.Timeline != connected.Timeline {
-		return WriterObservation{}, fmt.Errorf(
+		return observed, fmt.Errorf(
 			"%w: PostgreSQL=%d Patroni=%d",
 			ErrTimelineMismatch,
 			connected.Timeline,
 			patroni.Timeline,
 		)
 	}
-	observed := writerObservation(first, connected)
 	if action != nil {
 		if err := action(ctx, observed); err != nil {
 			return WriterObservation{}, err

--- a/server/internal/ha/observer.go
+++ b/server/internal/ha/observer.go
@@ -167,7 +167,11 @@ func (o *Observer) observeAndRun(
 	}
 	observed := writerObservation(first, connected)
 	if patroni.Timeline != connected.Timeline {
-		return observed, fmt.Errorf(
+		second, closingErr := o.confirmDCSUnchanged(ctx, first)
+		if closingErr != nil {
+			return WriterObservation{}, closingErr
+		}
+		return writerObservation(second, connected), fmt.Errorf(
 			"%w: PostgreSQL=%d Patroni=%d",
 			ErrTimelineMismatch,
 			connected.Timeline,
@@ -180,34 +184,9 @@ func (o *Observer) observeAndRun(
 		}
 	}
 
-	second, err := o.dcs.Snapshot(ctx, o.clusterPath)
+	second, err := o.confirmDCSUnchanged(ctx, first)
 	if err != nil {
-		return WriterObservation{}, fmt.Errorf("read final DCS snapshot: %w", err)
-	}
-	if err := validateDCSSnapshot(second); err != nil {
 		return WriterObservation{}, err
-	}
-	if second.ClusterID != first.ClusterID {
-		return WriterObservation{}, fmt.Errorf(
-			"%w: started with %s, finished with %s",
-			ErrDCSClusterIdentityMismatch,
-			first.ClusterID,
-			second.ClusterID,
-		)
-	}
-	if second.LeaderName != first.LeaderName ||
-		second.WriterGeneration != first.WriterGeneration ||
-		second.LeaderLeaseID != first.LeaderLeaseID ||
-		second.Member.APIURL != first.Member.APIURL ||
-		second.Member.ConnURL != first.Member.ConnURL {
-		return WriterObservation{}, fmt.Errorf(
-			"%w: started with %s@%d, finished with %s@%d",
-			ErrWriterChanged,
-			first.LeaderName,
-			first.WriterGeneration,
-			second.LeaderName,
-			second.WriterGeneration,
-		)
 	}
 
 	ttlRequestStarted := time.Now()
@@ -226,6 +205,42 @@ func (o *Observer) observeAndRun(
 	observed = writerObservation(second, connected)
 	observed.DCSProofDeadline = proofDeadline
 	return observed, nil
+}
+
+func (o *Observer) confirmDCSUnchanged(
+	ctx context.Context,
+	first DCSSnapshot,
+) (DCSSnapshot, error) {
+	second, err := o.dcs.Snapshot(ctx, o.clusterPath)
+	if err != nil {
+		return DCSSnapshot{}, fmt.Errorf("read final DCS snapshot: %w", err)
+	}
+	if err := validateDCSSnapshot(second); err != nil {
+		return DCSSnapshot{}, err
+	}
+	if second.ClusterID != first.ClusterID {
+		return DCSSnapshot{}, fmt.Errorf(
+			"%w: started with %s, finished with %s",
+			ErrDCSClusterIdentityMismatch,
+			first.ClusterID,
+			second.ClusterID,
+		)
+	}
+	if second.LeaderName != first.LeaderName ||
+		second.WriterGeneration != first.WriterGeneration ||
+		second.LeaderLeaseID != first.LeaderLeaseID ||
+		second.Member.APIURL != first.Member.APIURL ||
+		second.Member.ConnURL != first.Member.ConnURL {
+		return DCSSnapshot{}, fmt.Errorf(
+			"%w: started with %s@%d, finished with %s@%d",
+			ErrWriterChanged,
+			first.LeaderName,
+			first.WriterGeneration,
+			second.LeaderName,
+			second.WriterGeneration,
+		)
+	}
+	return second, nil
 }
 
 func writerObservation(

--- a/server/internal/ha/observer.go
+++ b/server/internal/ha/observer.go
@@ -171,6 +171,9 @@ func (o *Observer) observeAndRun(
 		if closingErr != nil {
 			return WriterObservation{}, closingErr
 		}
+		if _, leaseErr := o.leaderLeaseDeadline(ctx, second.LeaderLeaseID); leaseErr != nil {
+			return WriterObservation{}, leaseErr
+		}
 		return writerObservation(second, connected), fmt.Errorf(
 			"%w: PostgreSQL=%d Patroni=%d",
 			ErrTimelineMismatch,
@@ -189,22 +192,27 @@ func (o *Observer) observeAndRun(
 		return WriterObservation{}, err
 	}
 
-	ttlRequestStarted := time.Now()
-	ttl, err := o.dcs.LeaseTTL(ctx, second.LeaderLeaseID)
+	proofDeadline, err := o.leaderLeaseDeadline(ctx, second.LeaderLeaseID)
 	if err != nil {
-		return WriterObservation{}, fmt.Errorf("validate DCS leader lease: %w", err)
-	}
-	if ttl <= 0 {
-		return WriterObservation{}, ErrLeaderLeaseExpired
-	}
-	proofDeadline := ttlRequestStarted.Add(ttl)
-	if !proofDeadline.After(time.Now()) {
-		return WriterObservation{}, ErrLeaderLeaseExpired
+		return WriterObservation{}, err
 	}
 
 	observed = writerObservation(second, connected)
 	observed.DCSProofDeadline = proofDeadline
 	return observed, nil
+}
+
+func (o *Observer) leaderLeaseDeadline(ctx context.Context, leaseID int64) (time.Time, error) {
+	ttlRequestStarted := time.Now()
+	ttl, err := o.dcs.LeaseTTL(ctx, leaseID)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("validate DCS leader lease: %w", err)
+	}
+	proofDeadline := ttlRequestStarted.Add(ttl)
+	if ttl <= 0 || !proofDeadline.After(time.Now()) {
+		return time.Time{}, ErrLeaderLeaseExpired
+	}
+	return proofDeadline, nil
 }
 
 func (o *Observer) confirmDCSUnchanged(

--- a/server/internal/ha/observer_test.go
+++ b/server/internal/ha/observer_test.go
@@ -393,8 +393,11 @@ func TestObserverRejectsTimelineMismatch(t *testing.T) {
 		Timeline: 8,
 	}}
 
-	_, err := observer.Observe(t.Context())
+	observed, err := observer.Observe(t.Context())
 	require.ErrorIs(t, err, ErrTimelineMismatch)
+	require.Equal(t, "cluster-a", observed.DCSClusterID)
+	require.EqualValues(t, 41, observed.WriterGeneration)
+	require.Zero(t, observed.DCSProofDeadline)
 }
 
 func TestObserverRejectsNonPrimaryPatroniMember(t *testing.T) {

--- a/server/internal/ha/observer_test.go
+++ b/server/internal/ha/observer_test.go
@@ -387,7 +387,7 @@ func TestObserverRejectsPostgresReplica(t *testing.T) {
 }
 
 func TestObserverRejectsTimelineMismatch(t *testing.T) {
-	observer := validObserver([]DCSSnapshot{validDCSSnapshot()})
+	observer := validObserver([]DCSSnapshot{validDCSSnapshot(), validDCSSnapshot()})
 	observer.patroni = fakePatroniReader{identity: PatroniIdentity{
 		Role:     "primary",
 		Timeline: 8,
@@ -398,6 +398,19 @@ func TestObserverRejectsTimelineMismatch(t *testing.T) {
 	require.Equal(t, "cluster-a", observed.DCSClusterID)
 	require.EqualValues(t, 41, observed.WriterGeneration)
 	require.Zero(t, observed.DCSProofDeadline)
+}
+
+func TestObserverRejectsTimelineMismatchWhenDCSWriterChanges(t *testing.T) {
+	second := validDCSSnapshot()
+	second.WriterGeneration++
+	observer := validObserver([]DCSSnapshot{validDCSSnapshot(), second})
+	observer.patroni = fakePatroniReader{identity: PatroniIdentity{
+		Role:     "primary",
+		Timeline: 8,
+	}}
+
+	_, err := observer.Observe(t.Context())
+	require.ErrorIs(t, err, ErrWriterChanged)
 }
 
 func TestObserverRejectsNonPrimaryPatroniMember(t *testing.T) {

--- a/server/internal/ha/observer_test.go
+++ b/server/internal/ha/observer_test.go
@@ -413,6 +413,21 @@ func TestObserverRejectsTimelineMismatchWhenDCSWriterChanges(t *testing.T) {
 	require.ErrorIs(t, err, ErrWriterChanged)
 }
 
+func TestObserverRejectsExpiredLeaderLeaseBeforeTimelineMismatch(t *testing.T) {
+	observer := validObserver([]DCSSnapshot{validDCSSnapshot(), validDCSSnapshot()})
+	dcs, ok := observer.dcs.(*fakeDCSReader)
+	require.True(t, ok)
+	dcs.leaseTTL = 0
+	observer.patroni = fakePatroniReader{identity: PatroniIdentity{
+		Role:     "primary",
+		Timeline: 8,
+	}}
+
+	observed, err := observer.Observe(t.Context())
+	require.ErrorIs(t, err, ErrLeaderLeaseExpired)
+	require.Equal(t, WriterObservation{}, observed)
+}
+
 func TestObserverRejectsNonPrimaryPatroniMember(t *testing.T) {
 	observer := validObserver([]DCSSnapshot{validDCSSnapshot()})
 	observer.patroni = fakePatroniReader{identity: PatroniIdentity{

--- a/server/internal/ha/runtime_test.go
+++ b/server/internal/ha/runtime_test.go
@@ -7,9 +7,11 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/block/proto-fleet/server/internal/runtimejobs"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -196,6 +198,139 @@ func TestHARuntimeAbortsOnOwnershipLoss(t *testing.T) {
 	require.Eventually(t, func() bool { return requestCtx.Err() != nil }, eventuallyTimeout, eventuallyInterval)
 	require.False(t, runtime.Active())
 	require.Error(t, jobCtx.Err())
+}
+
+func TestHARuntimeSurvivesTransientTimelineMismatch(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		config := coordinatorTestConfig()
+		config.LeaseDuration = 10 * time.Second
+		config.RenewInterval = 3 * time.Second
+		observer := &sequenceObserver{
+			results: []observerResult{
+				{observation: coordinatorObservation("cluster-a", 41, 20*time.Second)},
+				{err: fmt.Errorf("promotion observation: %w", ErrTimelineMismatch)},
+				{observation: coordinatorObservation("cluster-a", 41, 20*time.Second)},
+			},
+			calls: make(chan struct{}, 3),
+		}
+		store := &fakeLeaseStore{}
+		coordinator := newCoordinatorWithHolder(observer, store, config, uuid.New())
+		group := newRuntimeTestGroup()
+		runtimeConfig := runtimeTestConfig()
+		runtimeConfig.HealthCheckInterval = time.Second
+		runtime := newRuntime(coordinator, group, alwaysHealthy, runtimeConfig)
+		runCtx, cancelRun := context.WithCancel(context.Background())
+		runResult := make(chan error, 1)
+		go func() { runResult <- runtime.Run(runCtx) }()
+
+		requireReceive(t, observer.calls)
+		requireReceiveContext(t, group.startedCh)
+		synctest.Wait()
+		require.True(t, runtime.Active())
+
+		time.Sleep(config.RenewInterval)
+		synctest.Wait()
+		requireReceive(t, observer.calls)
+		require.True(t, runtime.Active())
+		require.False(t, coordinator.Snapshot().ObservationAvailable)
+		require.Equal(t, []string{"acquire", "renew"}, store.callSequence())
+
+		time.Sleep(config.RenewInterval)
+		synctest.Wait()
+		requireReceive(t, observer.calls)
+		require.True(t, runtime.Active())
+		require.True(t, coordinator.Snapshot().ObservationAvailable)
+		require.Equal(t, []string{"acquire", "renew", "renew"}, store.callSequence())
+
+		cancelRun()
+		synctest.Wait()
+		requireReceive(t, group.stoppedCh)
+		require.NoError(t, <-runResult)
+		select {
+		case <-group.abortedCh:
+			t.Fatal("transient timeline mismatch aborted the Fleet runtime")
+		default:
+		}
+	})
+}
+
+func TestHARuntimeRetriesTimelineMismatchBeforeActivation(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		config := coordinatorTestConfig()
+		observer := &sequenceObserver{
+			results: []observerResult{
+				{err: fmt.Errorf("promotion observation: %w", ErrTimelineMismatch)},
+				{observation: coordinatorObservation("cluster-a", 42, 20*time.Second)},
+			},
+			calls: make(chan struct{}, 2),
+		}
+		store := &fakeLeaseStore{}
+		coordinator := newCoordinatorWithHolder(observer, store, config, uuid.New())
+		group := newRuntimeTestGroup()
+		runtime := newRuntime(coordinator, group, alwaysHealthy, runtimeTestConfig())
+		runCtx, cancelRun := context.WithCancel(context.Background())
+		runResult := make(chan error, 1)
+		go func() { runResult <- runtime.Run(runCtx) }()
+
+		requireReceive(t, observer.calls)
+		synctest.Wait()
+		require.False(t, runtime.Active())
+		require.Empty(t, store.callSequence())
+		select {
+		case err := <-runResult:
+			t.Fatalf("Fleet runtime exited after transient timeline mismatch: %v", err)
+		default:
+		}
+
+		time.Sleep(config.RetryInterval)
+		synctest.Wait()
+		requireReceive(t, observer.calls)
+		requireReceiveContext(t, group.startedCh)
+		require.True(t, runtime.Active())
+		require.Equal(t, []string{"acquire", "renew"}, store.callSequence())
+
+		cancelRun()
+		synctest.Wait()
+		requireReceive(t, group.stoppedCh)
+		require.NoError(t, <-runResult)
+		select {
+		case <-group.abortedCh:
+			t.Fatal("pre-activation timeline mismatch aborted the Fleet runtime")
+		default:
+		}
+	})
+}
+
+func TestHARuntimePersistentTimelineMismatchExpiresExistingProof(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		config := coordinatorTestConfig()
+		config.LeaseDuration = 10 * time.Second
+		config.RenewInterval = 3 * time.Second
+		observer := &succeedOnceThenErrorObserver{
+			observation: coordinatorObservation("cluster-a", 41, 20*time.Second),
+			err:         fmt.Errorf("promotion observation: %w", ErrTimelineMismatch),
+		}
+		store := &fakeLeaseStore{}
+		coordinator := newCoordinatorWithHolder(observer, store, config, uuid.New())
+		group := newRuntimeTestGroup()
+		runtimeConfig := runtimeTestConfig()
+		runtimeConfig.HealthCheckInterval = time.Second
+		runtime := newRuntime(coordinator, group, alwaysHealthy, runtimeConfig)
+		runResult := make(chan error, 1)
+		go func() { runResult <- runtime.Run(context.Background()) }()
+
+		requireReceiveContext(t, group.startedCh)
+		synctest.Wait()
+		require.True(t, runtime.Active())
+
+		runErr := <-runResult
+		require.ErrorIs(t, runErr, ErrRuntimeAborted)
+		require.ErrorIs(t, runErr, ErrOwnershipExpired)
+		requireReceiveContext(t, group.abortedCh)
+		require.False(t, runtime.Active())
+		require.GreaterOrEqual(t, observer.callCount(), 2)
+		require.Equal(t, []string{"acquire", "renew"}, store.callSequence())
+	})
 }
 
 func TestHARuntimeExitsWhenCriticalHealthFails(t *testing.T) {

--- a/server/internal/ha/runtime_test.go
+++ b/server/internal/ha/runtime_test.go
@@ -208,7 +208,10 @@ func TestHARuntimeSurvivesTransientTimelineMismatch(t *testing.T) {
 		observer := &sequenceObserver{
 			results: []observerResult{
 				{observation: coordinatorObservation("cluster-a", 41, 20*time.Second)},
-				{err: fmt.Errorf("promotion observation: %w", ErrTimelineMismatch)},
+				{
+					observation: coordinatorObservation("cluster-a", 41, 20*time.Second),
+					err:         fmt.Errorf("promotion observation: %w", ErrTimelineMismatch),
+				},
 				{observation: coordinatorObservation("cluster-a", 41, 20*time.Second)},
 			},
 			calls: make(chan struct{}, 3),

--- a/server/internal/ha/runtime_test.go
+++ b/server/internal/ha/runtime_test.go
@@ -230,12 +230,16 @@ func TestHARuntimeSurvivesTransientTimelineMismatch(t *testing.T) {
 		requireReceiveContext(t, group.startedCh)
 		synctest.Wait()
 		require.True(t, runtime.Active())
+		validSnapshot := coordinator.Snapshot()
+		validTimer := coordinator.leaseTimer
 
 		time.Sleep(config.RenewInterval)
 		synctest.Wait()
 		requireReceive(t, observer.calls)
 		require.True(t, runtime.Active())
 		require.False(t, coordinator.Snapshot().ObservationAvailable)
+		require.Equal(t, validSnapshot.FreshUntil, coordinator.Snapshot().FreshUntil)
+		require.Same(t, validTimer, coordinator.leaseTimer)
 		require.Equal(t, []string{"acquire", "renew"}, store.callSequence())
 
 		time.Sleep(config.RenewInterval)
@@ -309,10 +313,17 @@ func TestHARuntimePersistentTimelineMismatchExpiresExistingProof(t *testing.T) {
 		config := coordinatorTestConfig()
 		config.LeaseDuration = 10 * time.Second
 		config.RenewInterval = 3 * time.Second
-		observer := &succeedOnceThenErrorObserver{
-			observation: coordinatorObservation("cluster-a", 41, 20*time.Second),
+		observed := coordinatorObservation("cluster-a", 41, 20*time.Second)
+		mismatch := observerResult{
+			observation: observed,
 			err:         fmt.Errorf("promotion observation: %w", ErrTimelineMismatch),
 		}
+		observer := &sequenceObserver{results: []observerResult{
+			{observation: observed},
+			mismatch,
+			mismatch,
+			mismatch,
+		}}
 		store := &fakeLeaseStore{}
 		coordinator := newCoordinatorWithHolder(observer, store, config, uuid.New())
 		group := newRuntimeTestGroup()
@@ -331,7 +342,6 @@ func TestHARuntimePersistentTimelineMismatchExpiresExistingProof(t *testing.T) {
 		require.ErrorIs(t, runErr, ErrOwnershipExpired)
 		requireReceiveContext(t, group.abortedCh)
 		require.False(t, runtime.Active())
-		require.GreaterOrEqual(t, observer.callCount(), 2)
 		require.Equal(t, []string{"acquire", "renew"}, store.callSequence())
 	})
 }


### PR DESCRIPTION
Reviewable diff: +82/-35 across 2 files (excludes generated, test, and story files).

## Summary

Keeps Fleet available when Patroni and the connected PostgreSQL server briefly report different timelines during promotion. Fleet now treats that mismatch as unavailable ownership evidence and retries within the last valid proof's existing deadline; convergence avoids an unnecessary process restart and VIP withdrawal, while persistent disagreement still causes crash-only demotion.

**Stack:** [#888](https://github.com/block/proto-fleet/pull/888) -> **#914** -> [#890](https://github.com/block/proto-fleet/pull/890) -> [#891](https://github.com/block/proto-fleet/pull/891). This diff is relative to #888, which supplies the HA observer, ownership lease, crash-only runtime, and keepalived health contract. #890 and #891 remain responsible for passive and active application updates. Guided-installer behavior, update behavior, keepalived policy, topology, and qualification evidence are out of scope here.

## How it works

The observer still requires one consistent ownership sample: the Patroni primary and connected PostgreSQL server must agree on address, port, recovery state, and timeline before the lease store can acquire or renew ownership. A mismatch therefore never writes or renews the Fleet ownership lease. Before returning the mismatch, the observer repeats its linearizable DCS read, requires the cluster, leader, writer generation, lease, and member endpoints to remain unchanged, and verifies that the unchanged leader lease is still live.

Before activation, the existing coordinator loop leaves the node passive and retries after its normal interval. After activation, only a timeline mismatch keeps the active lifetime alive. The coordinator marks the current observation unavailable but preserves the prior ownership, proof deadline, and watchdog timer unchanged. A matching observation before that deadline renews ownership and restores current status. If disagreement persists, the unchanged watchdog cancels the active lifetime, closes the command gate, aborts the runtime, and lets keepalived withdraw the VIP.

```mermaid
flowchart TD
  P["Patroni reports primary identity"] --> O["Fleet ownership observer"]
  D["Connected PostgreSQL reports server identity"] --> O
  O --> M{"Address, port, recovery, and timeline match?"}
  M -->|"Yes"| R["Acquire or renew ownership proof"]
  M -->|"No timeline match"| U["Observation unavailable; no lease write"]
  U --> C{"Prior proof still valid?"}
  C -->|"Yes"| T["Retry on existing coordinator cadence"]
  C -->|"No"| A["Crash-only runtime abort"]
  T --> O
  A --> V["keepalived withdraws VIP"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/internal/ha/observer.go` | Closes the DCS observation and validates the unchanged leader lease before returning a timeline mismatch, without running the lease action or creating a fresh proof | Review the unchanged-DCS and live-lease checks plus the partial-observation contract |
| `server/internal/ha/observer_test.go` | Covers partial mismatch evidence, DCS writer changes, and expired leader-lease precedence | Tests; review the fail-closed observation boundaries |
| `server/internal/ha/coordinator.go` | Retains active lifetime only when the mismatched sample still names the held DCS cluster and writer generation | Review the writer-generation guard and unchanged expiry behavior |
| `server/internal/ha/coordinator_test.go` | Proves a mismatched sample from a new writer term still demotes immediately | Tests; review the writer-generation guard |
| `server/internal/ha/runtime_test.go` | Uses fake time to cover passive convergence, active convergence without proof extension, and persistent expiry | Tests; review process survival, unchanged watchdog, and crash-only abort assertions |

## Key technical decisions & trade-offs

- Only `ErrTimelineMismatch` bracketed by unchanged DCS snapshots for the held writer gets bounded convergence handling; a changed cluster, leader, writer generation, lease, member endpoint, wrong PostgreSQL identity, or DCS failure remains fail closed.
- The last valid proof survives only until its existing lease/DCS deadline; the failed observation does not update ownership, freshness timestamps, or the watchdog.
- Retries use the existing coordinator cadence. There is no promotion sleep, retry counter, new timer, state machine, or configuration.
- The observer and SQL identity checks remain strict. The coordinator owns the narrow decision to retain an already-valid active proof.
- keepalived remains unchanged and continues to follow Fleet's active endpoint.

## Testing & validation

- Focused observer, coordinator, runtime, endpoint, and fleetd tests pass.
- Focused tests prove an expired leader lease takes precedence over mismatch evidence; a passive process survives one mismatch and activates only after a matching sample; an active process survives same-writer convergence before expiry; a writer change during observation demotes immediately; persistent mismatch aborts at the unchanged proof deadline; and no mismatched sample renews the lease.
- HA deployment profile checks pass.
- Hermit-backed `just _lint-server` reports zero issues.
- `git diff --check` passes.
- Exact-head Raspberry Pi qualification passed with [`v0.2.10-ha-promotion.2`](https://github.com/block/proto-fleet/releases/tag/v0.2.10-ha-promotion.2) at `25b6dcac28e5750a49dc3106cb51fe82b331c6aa`: Patroni promoted at `21:38:58.325Z`, PostgreSQL accepted connections at `21:38:58.398Z`, Fleet opened active jobs at `21:39:00.196Z`, and keepalived entered MASTER at `21:39:04Z`.
- The one-second VIP probe last succeeded at `21:38:54Z`, first failed at `21:38:55Z`, and returned stable HTTPS beginning at `21:39:04Z` (9-second interruption, below the 15-second target). The promoted Fleet container kept the same ID and start time with restart count zero; no timeline-mismatch abort occurred. The old active rejoined as a synchronous standby with about 6 ms replay lag, and both hosts returned to `failover_ready: true`.

## Post-Deploy Monitoring & Validation

- Search Fleet logs for `Patroni and PostgreSQL timelines do not match`, `active lifetime ended`, and `HA Fleet runtime aborted` around promotion.
- Confirm the promoted peer reaches a matching timeline before the existing ownership deadline and that no lease renewal is recorded for a mismatched sample.
- Watch one-second HTTPS probes through the VIP and keepalived state transitions during the three-node reboot test.
- Healthy result: no Fleet container restart, one VIP move, stable HTTPS within 15 seconds, old primary rejoins passive, and both database hosts return to `failover_ready: true`.
- Failure trigger: persistent mismatch outlives the existing proof deadline, Fleet fails to abort, or VIP recovery exceeds 15 seconds. Stop qualification and retain the previous release while the timeline is analyzed.
- Validation owner and window: completed by the HA release qualifier on the three-node Raspberry Pi cluster on 2026-08-12.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
