### PR TITLE
Keep staged deployment modes intact under the updater umask

### DIFF
--- a/deployment-files/run-fleet.sh
+++ b/deployment-files/run-fleet.sh
@@ -4,6 +4,14 @@
 # Proto Fleet Installation and Setup Script
 # ============================================================================
 
+# Deployment files this script generates are read inside containers by
+# non-root users (Grafana, Prometheus, ...), so they must stay world-readable
+# regardless of the invoker's umask — the privileged host updater invokes this
+# script with a restrictive 0077 umask that would otherwise strip that access.
+# Secrets (.env, markers, nginx temp files) set their own stricter umask or
+# chmod where they are created.
+umask 022
+
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RUN_FLEET_ORIGINAL_ARGS=("$@")
 FLEET_COMPOSE_PROJECT_NAME=""

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -2288,19 +2288,28 @@ func extractArchiveWithUpdaterCopy(
 		switch header.Typeflag {
 		case tar.TypeDir:
 			mode := os.FileMode(uint32(header.Mode & 0o755)) // #nosec G115 -- masked to nine permission bits
-			if err := os.MkdirAll(target, mode); err != nil {
+			if err := mkdirAllUnmasked(target, mode); err != nil {
 				return fmt.Errorf("create archive directory %s: %w", header.Name, err)
+			}
+			// A file entry may already have created this directory as a
+			// parent; the archive's own directory entry is authoritative.
+			if err := os.Chmod(target, mode); err != nil {
+				return fmt.Errorf("apply archive directory mode %s: %w", header.Name, err)
 			}
 		case tar.TypeReg, tar.TypeRegA:
 			// #nosec G301 -- extracted deployment parents must be traversable
 			// by the account that owns and manually maintains the install.
-			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			if err := mkdirAllUnmasked(filepath.Dir(target), 0o755); err != nil {
 				return fmt.Errorf("create archive parent for %s: %w", header.Name, err)
 			}
 			mode := os.FileMode(uint32(header.Mode & 0o755)) // #nosec G115 -- masked to nine permission bits
 			out, err := os.OpenFile(target, os.O_CREATE|os.O_EXCL|os.O_WRONLY, mode)
 			if err != nil {
 				return fmt.Errorf("create archive file %s: %w", header.Name, err)
+			}
+			if err := out.Chmod(mode); err != nil {
+				out.Close()
+				return fmt.Errorf("apply archive file mode %s: %w", header.Name, err)
 			}
 			writer := io.Writer(out)
 			copyUpdater := updaterCopy != nil && filepath.ToSlash(name) == "deployment/updater/proto-fleet-updater"
@@ -2426,6 +2435,39 @@ func setDeploymentTreeOwnership(ctx context.Context, staged string, uid, gid int
 	return nil
 }
 
+// mkdirAllUnmasked creates any missing directories on path, re-applying mode
+// to each directory it creates. os.MkdirAll alone is narrowed by the process
+// umask — 0o077 in this daemon, to protect its own state — which would leave
+// staged deployment directories untraversable for the deployment owner and
+// for the container users that bind-mount configuration out of the tree.
+func mkdirAllUnmasked(path string, mode os.FileMode) error {
+	info, err := os.Stat(path)
+	if err == nil {
+		if info.IsDir() {
+			return nil
+		}
+		return fmt.Errorf("create directory %s: path exists and is not a directory", path)
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("inspect directory %s: %w", path, err)
+	}
+	if parent := filepath.Dir(path); parent != path {
+		if err := mkdirAllUnmasked(parent, mode); err != nil {
+			return err
+		}
+	}
+	if err := os.Mkdir(path, mode); err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return nil
+		}
+		return fmt.Errorf("create directory %s: %w", path, err)
+	}
+	if err := os.Chmod(path, mode); err != nil {
+		return fmt.Errorf("apply directory mode %s: %w", path, err)
+	}
+	return nil
+}
+
 func copyFile(ctx context.Context, source, destination string) error {
 	info, err := os.Lstat(source)
 	if err != nil {
@@ -2434,7 +2476,7 @@ func copyFile(ctx context.Context, source, destination string) error {
 	if !info.Mode().IsRegular() {
 		return fmt.Errorf("refusing to copy non-regular file %s", source)
 	}
-	if err := os.MkdirAll(filepath.Dir(destination), 0o750); err != nil {
+	if err := mkdirAllUnmasked(filepath.Dir(destination), 0o750); err != nil {
 		return fmt.Errorf("create destination parent: %w", err)
 	}
 	in, err := os.Open(source)
@@ -2445,6 +2487,10 @@ func copyFile(ctx context.Context, source, destination string) error {
 	out, err := os.OpenFile(destination, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, info.Mode().Perm())
 	if err != nil {
 		return fmt.Errorf("open destination file: %w", err)
+	}
+	if err := out.Chmod(info.Mode().Perm()); err != nil {
+		out.Close()
+		return fmt.Errorf("apply destination file mode: %w", err)
 	}
 	if _, err := io.Copy(out, readerWithContext(ctx, in)); err != nil {
 		out.Close()
@@ -2741,7 +2787,7 @@ func copyTree(ctx context.Context, source, destination string) error {
 			return fmt.Errorf("inspect preserved tree entry: %w", err)
 		}
 		if entry.IsDir() {
-			if err := os.MkdirAll(target, info.Mode().Perm()); err != nil {
+			if err := mkdirAllUnmasked(target, info.Mode().Perm()); err != nil {
 				return fmt.Errorf("create preserved directory: %w", err)
 			}
 			return nil

--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -2441,12 +2441,9 @@ func setDeploymentTreeOwnership(ctx context.Context, staged string, uid, gid int
 // staged deployment directories untraversable for the deployment owner and
 // for the container users that bind-mount configuration out of the tree.
 func mkdirAllUnmasked(path string, mode os.FileMode) error {
-	info, err := os.Stat(path)
+	info, err := os.Lstat(path)
 	if err == nil {
-		if info.IsDir() {
-			return nil
-		}
-		return fmt.Errorf("create directory %s: path exists and is not a directory", path)
+		return requireRealDirectory(path, info)
 	}
 	if !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("inspect directory %s: %w", path, err)
@@ -2457,13 +2454,30 @@ func mkdirAllUnmasked(path string, mode os.FileMode) error {
 		}
 	}
 	if err := os.Mkdir(path, mode); err != nil {
-		if errors.Is(err, os.ErrExist) {
-			return nil
+		if !errors.Is(err, os.ErrExist) {
+			return fmt.Errorf("create directory %s: %w", path, err)
 		}
-		return fmt.Errorf("create directory %s: %w", path, err)
+		info, statErr := os.Lstat(path)
+		if statErr != nil {
+			return fmt.Errorf("inspect directory %s: %w", path, statErr)
+		}
+		return requireRealDirectory(path, info)
 	}
 	if err := os.Chmod(path, mode); err != nil {
 		return fmt.Errorf("apply directory mode %s: %w", path, err)
+	}
+	return nil
+}
+
+// requireRealDirectory rejects anything other than an actual directory —
+// notably symlinks, which os.Stat would silently follow and which would let a
+// crafted path redirect staged writes outside the staging root.
+func requireRealDirectory(path string, info os.FileInfo) error {
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("create directory %s: refusing to follow symlink", path)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("create directory %s: path exists and is not a directory", path)
 	}
 	return nil
 }

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -2567,6 +2567,24 @@ func TestCopyTreePreservesModesDespiteRestrictiveUmask(t *testing.T) {
 	assertMode("privkey.pem", 0o600)
 }
 
+func TestMkdirAllUnmaskedRefusesSymlinks(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(root, "real"), 0o750))
+	require.NoError(t, os.Symlink(filepath.Join(root, "real"), filepath.Join(root, "link")))
+
+	err := mkdirAllUnmasked(filepath.Join(root, "link"), 0o750)
+	require.ErrorContains(t, err, "refusing to follow symlink")
+
+	err = mkdirAllUnmasked(filepath.Join(root, "link", "child"), 0o750)
+	require.ErrorContains(t, err, "refusing to follow symlink")
+
+	require.NoError(t, os.WriteFile(filepath.Join(root, "file"), []byte("x"), 0o600))
+	err = mkdirAllUnmasked(filepath.Join(root, "file"), 0o750)
+	require.ErrorContains(t, err, "path exists and is not a directory")
+}
+
 func TestInstallExecutableCandidateRetainsAndRestoresThePreviousUpdater(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -2484,6 +2484,89 @@ func TestExtractArchiveRejectsExcessiveEntryCount(t *testing.T) {
 	require.ErrorContains(t, err, fmt.Sprintf("archive contains more than %d entries", maxArchiveEntries))
 }
 
+// Not parallel: the test manipulates the process-global umask, mirroring the
+// restrictive 0o077 umask the daemon establishes at startup.
+func TestExtractArchiveAppliesArchiveModesDespiteRestrictiveUmask(t *testing.T) {
+	previousUmask := syscall.Umask(0o077)
+	defer syscall.Umask(previousUmask)
+
+	archive := filepath.Join(t.TempDir(), "release.tar.gz")
+	var buffer bytes.Buffer
+	gzipWriter := gzip.NewWriter(&buffer)
+	tarWriter := tar.NewWriter(gzipWriter)
+	require.NoError(t, tarWriter.WriteHeader(&tar.Header{
+		Name:     "deployment/server/monitoring/grafana",
+		Mode:     0o755,
+		Typeflag: tar.TypeDir,
+	}))
+	content := []byte("[server]\n")
+	require.NoError(t, tarWriter.WriteHeader(&tar.Header{
+		Name:     "deployment/server/monitoring/grafana/grafana.ini",
+		Mode:     0o644,
+		Size:     int64(len(content)),
+		Typeflag: tar.TypeReg,
+	}))
+	_, err := tarWriter.Write(content)
+	require.NoError(t, err)
+	// A file whose parent directories carry no archive entries of their own
+	// must still end up under traversable parents.
+	require.NoError(t, tarWriter.WriteHeader(&tar.Header{
+		Name:     "deployment/orphan/config.yaml",
+		Mode:     0o644,
+		Size:     int64(len(content)),
+		Typeflag: tar.TypeReg,
+	}))
+	_, err = tarWriter.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, tarWriter.Close())
+	require.NoError(t, gzipWriter.Close())
+	require.NoError(t, os.WriteFile(archive, buffer.Bytes(), 0o600))
+
+	destination := t.TempDir()
+	require.NoError(t, extractArchive(archive, destination))
+
+	assertMode := func(path string, want os.FileMode) {
+		t.Helper()
+		info, err := os.Stat(filepath.Join(destination, path))
+		require.NoError(t, err)
+		assert.Equal(t, want, info.Mode().Perm(), path)
+	}
+	assertMode("deployment", 0o755)
+	assertMode("deployment/server/monitoring/grafana", 0o755)
+	assertMode("deployment/server/monitoring/grafana/grafana.ini", 0o644)
+	assertMode("deployment/orphan", 0o755)
+	assertMode("deployment/orphan/config.yaml", 0o644)
+}
+
+// Not parallel: the test manipulates the process-global umask.
+func TestCopyTreePreservesModesDespiteRestrictiveUmask(t *testing.T) {
+	previousUmask := syscall.Umask(0o077)
+	defer syscall.Umask(previousUmask)
+
+	// World-readable modes are the fixture under test: chmod is umask-exempt,
+	// so it pins the source modes the copy must reproduce.
+	source := t.TempDir()
+	require.NoError(t, os.Chmod(source, 0o755))                         //nolint:gosec // fixture mode under test
+	require.NoError(t, os.Mkdir(filepath.Join(source, "certs"), 0o755)) //nolint:gosec // fixture mode under test
+	require.NoError(t, os.Chmod(filepath.Join(source, "certs"), 0o755)) //nolint:gosec // fixture mode under test
+	require.NoError(t, os.WriteFile(filepath.Join(source, "certs", "fullchain.pem"), []byte("cert"), 0o644))
+	require.NoError(t, os.Chmod(filepath.Join(source, "certs", "fullchain.pem"), 0o644)) //nolint:gosec // fixture mode under test
+	require.NoError(t, os.WriteFile(filepath.Join(source, "privkey.pem"), []byte("key"), 0o600))
+
+	destination := filepath.Join(t.TempDir(), "ssl")
+	require.NoError(t, copyTree(context.Background(), source, destination))
+
+	assertMode := func(path string, want os.FileMode) {
+		t.Helper()
+		info, err := os.Stat(filepath.Join(destination, path))
+		require.NoError(t, err)
+		assert.Equal(t, want, info.Mode().Perm(), path)
+	}
+	assertMode("certs", 0o755)
+	assertMode("certs/fullchain.pem", 0o644)
+	assertMode("privkey.pem", 0o600)
+}
+
 func TestInstallExecutableCandidateRetainsAndRestoresThePreviousUpdater(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Problem

Every one-click upgrade on a lab host failed at `new stack failed to start`: Grafana crash-looped (`unhealthy restarts=40`) with

```
GF_PATHS_CONFIG='/etc/grafana/grafana.ini' is not readable.
open /etc/grafana/grafana.ini: permission denied
```

while manual installs of the exact same release always succeeded.

## Root cause

The host updater daemon deliberately runs with a **0077 umask** (set in `fleet-updater/main.go` and again via `UMask=0077` in its systemd unit) to keep its socket, state, and logs private. But the code that stages a new deployment creates files through umask-honoring calls:

- `extractArchive`: `os.MkdirAll(target, mode)` / `os.OpenFile(target, ..., mode)`
- `copyFile` / `copyTree` (preserved `.env`, `ssl/`): same pattern

So the intended 0644/0755 modes silently became 0600/0700 for **every file in the staged deployment**. The ownership-preservation pass then chowns the tree to the deployment owner, which is why the operator can still traverse and run everything — but container processes that read bind-mounted configs as non-root users (Grafana uid 472, Prometheus, Loki, ...) get permission denied. Grafana simply dies first, `compose up --wait` reports unhealthy, and the upgrade records a terminal failure. Deterministic: one-click always broke, manual (umask 022) always worked.

`run-fleet.sh` has the same exposure one layer down: the updater invokes it as a child process, so anything the script generates inherited the 0077 umask too.

## Fix

- New `mkdirAllUnmasked(path, mode)` helper: creates missing directories and re-applies the mode via `chmod` (umask-exempt) to each directory it creates.
- Archive extraction applies the archive's modes explicitly: directory entries are chmodded to their header mode, files get `out.Chmod(mode)` after creation, and parents of files that lack their own directory entry are created traversable (0755).
- `copyFile` / `copyTree` re-apply the source modes the same way, so preserved secrets stay exactly as strict as their source (`.env` remains 0600).
- `run-fleet.sh` sets `umask 022` at the top so generated deployment files stay readable regardless of the invoker; secret files already set their own stricter `umask 077` subshells or explicit chmods where they are created.

Security posture is unchanged: the staging root stays 0700 root-owned while staging, so intended modes inside the tree expose nothing before activation, and the daemon's own state/log/socket files keep their private modes.

## Testing

- Two new regression tests run with the process umask set to 0077 (exactly what the daemon does at startup) and assert extraction and tree-copy reproduce the archive/source modes, including the orphan-parent case. They run non-parallel because umask is process-global.
- `go test ./server/internal/updater/...` and `golangci-lint` clean; `bash -n run-fleet.sh` passes.
- Root cause validated on the affected host: `grafana.ini` was owner-only after a one-click upgrade, and restoring group/other read (`chmod -R go+rX .../deployment/server`) immediately let Grafana come up healthy.

## Operator note

The fix has to be present in the release **being installed** (it is the new updater/script that stages files), so hosts already broken by a prior one-click upgrade need the one-time repair above.