### PR TITLE
Standardize progress indicator color

### DIFF
--- a/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.tsx
+++ b/client/src/protoFleet/features/energy/ActiveCurtailmentStatus.tsx
@@ -769,7 +769,7 @@ function getActiveCurtailmentStatusIcon({
     return <Success className="text-core-primary-fill" />;
   }
 
-  return <ProgressCircular indeterminate className="text-core-primary-fill" />;
+  return <ProgressCircular indeterminate />;
 }
 
 export default function ActiveCurtailmentStatus({

--- a/client/src/protoOS/components/PageHeader/PowerTarget/PowerTargetPopover.test.tsx
+++ b/client/src/protoOS/components/PageHeader/PowerTarget/PowerTargetPopover.test.tsx
@@ -181,11 +181,12 @@ describe("Power Target Popover", () => {
     // Override mock to set pending to true for this test
     mockReturnValue.pending = true;
 
-    const { getByText } = render(
+    const { getByText, getByTestId } = render(
       <PopoverProvider>
         <PowerTargetPopover onDismiss={vi.fn()} onUpdateStart={vi.fn()} />,
       </PopoverProvider>,
     );
     expect(getByText("Applying")).toBeInTheDocument();
+    expect(getByTestId("power-target-apply-button").querySelector("svg")).toHaveClass("!text-text-contrast");
   });
 });

--- a/client/src/protoOS/components/PageHeader/PowerTarget/PowerTargetPopover.tsx
+++ b/client/src/protoOS/components/PageHeader/PowerTarget/PowerTargetPopover.tsx
@@ -171,7 +171,7 @@ const PowerTargetPopover = ({ onDismiss, onUpdateStart }: PowerTargetPopoverProp
           className="grow"
           size={sizes.base}
           disabled={pending || (!!error && selectedPowerTargetMode === powerTargetModes.custom)}
-          prefixIcon={pending ? <ProgressCircular indeterminate size={12} /> : undefined}
+          prefixIcon={pending ? <ProgressCircular color="inverse" indeterminate size={12} /> : undefined}
           testId="power-target-apply-button"
           onClick={handleUpdate}
         />

--- a/client/src/protoOS/features/firmwareUpdate/components/FirmwareUpdateStatusModal/FirmwareUpdateStatusModal.tsx
+++ b/client/src/protoOS/features/firmwareUpdate/components/FirmwareUpdateStatusModal/FirmwareUpdateStatusModal.tsx
@@ -211,7 +211,7 @@ const FirmwareUpdateStatusModal = ({
     <Dialog
       open={open}
       testId="firmware-status-modal"
-      icon={statusConfig.icon ?? <ProgressCircular indeterminate className="text-core-accent-fill" />}
+      icon={statusConfig.icon ?? <ProgressCircular indeterminate />}
       title={statusConfig.title}
       buttons={statusConfig.getButtons({
         onUpdate,

--- a/client/src/shared/components/Button/Button.test.tsx
+++ b/client/src/shared/components/Button/Button.test.tsx
@@ -75,6 +75,14 @@ describe("Button", () => {
     expect(screen.getByRole("button", { name: "Update now" }).querySelector("svg")).toHaveClass("!text-text-contrast");
   });
 
+  test.each([variants.accent, variants.danger])("uses a static contrast spinner for a loading %s button", (variant) => {
+    render(<Button text="Update now" loading variant={variant} />);
+
+    expect(screen.getByRole("button", { name: "Update now" }).querySelector("svg")).toHaveClass(
+      "!text-text-base-contrast-static",
+    );
+  });
+
   test("keeps the default spinner color for a loading secondary button", () => {
     render(<Button text="Update now" loading variant={variants.secondary} />);
 

--- a/client/src/shared/components/Button/Button.test.tsx
+++ b/client/src/shared/components/Button/Button.test.tsx
@@ -68,4 +68,18 @@ describe("Button", () => {
     expect(buttonElement).toHaveClass("focus-visible:ring-core-primary-fill");
     expect(buttonElement).toHaveClass("focus-visible:ring-offset-2");
   });
+
+  test("uses an inverse spinner for a loading primary button", () => {
+    render(<Button text="Update now" loading variant={variants.primary} />);
+
+    expect(screen.getByRole("button", { name: "Update now" }).querySelector("svg")).toHaveClass("!text-text-contrast");
+  });
+
+  test("keeps the default spinner color for a loading secondary button", () => {
+    render(<Button text="Update now" loading variant={variants.secondary} />);
+
+    expect(screen.getByRole("button", { name: "Update now" }).querySelector("svg")).toHaveClass(
+      "!text-core-primary-fill",
+    );
+  });
 });

--- a/client/src/shared/components/Button/Button.tsx
+++ b/client/src/shared/components/Button/Button.tsx
@@ -62,7 +62,8 @@ const Button = ({
   const base = size === sizes.base;
   const compact = size === sizes.compact;
   const gap = compact ? "w-2" : "w-3";
-  const prefix = loading ? <ProgressCircular size={12} indeterminate /> : prefixIcon;
+  const loadingSpinnerColor = primary || accent || danger ? "inverse" : "default";
+  const prefix = loading ? <ProgressCircular color={loadingSpinnerColor} size={12} indeterminate /> : prefixIcon;
   const disabledState = disabled || loading;
 
   const containerClassName = clsx(

--- a/client/src/shared/components/Button/Button.tsx
+++ b/client/src/shared/components/Button/Button.tsx
@@ -62,7 +62,7 @@ const Button = ({
   const base = size === sizes.base;
   const compact = size === sizes.compact;
   const gap = compact ? "w-2" : "w-3";
-  const loadingSpinnerColor = primary || accent || danger ? "inverse" : "default";
+  const loadingSpinnerColor = accent || danger ? "staticContrast" : primary ? "inverse" : "default";
   const prefix = loading ? <ProgressCircular color={loadingSpinnerColor} size={12} indeterminate /> : prefixIcon;
   const disabledState = disabled || loading;
 

--- a/client/src/shared/components/Dialog/Dialog.tsx
+++ b/client/src/shared/components/Dialog/Dialog.tsx
@@ -72,7 +72,7 @@ const Dialog = ({
           <div className="flex flex-col gap-3">
             {loading ? (
               <div className="flex w-10 items-center justify-center rounded-lg bg-surface-5 py-2.5">
-                <ProgressCircular indeterminate className="text-text-primary" />
+                <ProgressCircular indeterminate />
               </div>
             ) : null}
             {!loading ? icon : null}

--- a/client/src/shared/components/ProgressCircular/ProgressCircular.test.tsx
+++ b/client/src/shared/components/ProgressCircular/ProgressCircular.test.tsx
@@ -16,4 +16,10 @@ describe("ProgressCircular", () => {
 
     expect(screen.getByTestId("inverse-progress-spinner")).toHaveClass("!text-text-contrast");
   });
+
+  it("renders with a static contrast color when the control foreground is fixed", () => {
+    render(<ProgressCircular color="staticContrast" dataTestId="static-progress-spinner" indeterminate />);
+
+    expect(screen.getByTestId("static-progress-spinner")).toHaveClass("!text-text-base-contrast-static");
+  });
 });

--- a/client/src/shared/components/ProgressCircular/ProgressCircular.test.tsx
+++ b/client/src/shared/components/ProgressCircular/ProgressCircular.test.tsx
@@ -4,10 +4,16 @@ import { describe, expect, it } from "vitest";
 import ProgressCircular from ".";
 
 describe("ProgressCircular", () => {
-  it("always renders with the neutral primary color", () => {
+  it("renders with the neutral primary color by default", () => {
     render(<ProgressCircular className="text-core-accent-fill" dataTestId="progress-spinner" indeterminate />);
 
     expect(screen.getByTestId("progress-spinner")).toHaveClass("!text-core-primary-fill");
     expect(screen.getByTestId("progress-spinner")).toHaveClass("text-core-accent-fill");
+  });
+
+  it("renders with the inverse color when used on a filled control", () => {
+    render(<ProgressCircular color="inverse" dataTestId="inverse-progress-spinner" indeterminate />);
+
+    expect(screen.getByTestId("inverse-progress-spinner")).toHaveClass("!text-text-contrast");
   });
 });

--- a/client/src/shared/components/ProgressCircular/ProgressCircular.test.tsx
+++ b/client/src/shared/components/ProgressCircular/ProgressCircular.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import ProgressCircular from ".";
+
+describe("ProgressCircular", () => {
+  it("always renders with the neutral primary color", () => {
+    render(<ProgressCircular className="text-core-accent-fill" dataTestId="progress-spinner" indeterminate />);
+
+    expect(screen.getByTestId("progress-spinner")).toHaveClass("!text-core-primary-fill");
+    expect(screen.getByTestId("progress-spinner")).toHaveClass("text-core-accent-fill");
+  });
+});

--- a/client/src/shared/components/ProgressCircular/ProgressCircular.tsx
+++ b/client/src/shared/components/ProgressCircular/ProgressCircular.tsx
@@ -24,7 +24,9 @@ const ProgressCircular = ({
 
   return (
     <svg
-      className={clsx({ "animate-spin": indeterminate }, className)}
+      // Progress is an activity indicator, not a status indicator. Keep its color
+      // neutral at the component boundary so callers cannot accidentally signal an intent.
+      className={clsx("!text-core-primary-fill", { "animate-spin": indeterminate }, className)}
       xmlns="http://www.w3.org/2000/svg"
       fill="none"
       viewBox={`0 0 ${size} ${size}`}

--- a/client/src/shared/components/ProgressCircular/ProgressCircular.tsx
+++ b/client/src/shared/components/ProgressCircular/ProgressCircular.tsx
@@ -2,6 +2,7 @@ import clsx from "clsx";
 
 interface ProgressCircularProps {
   className?: string;
+  color?: "default" | "inverse";
   dataTestId?: string;
   size?: number;
   value?: number;
@@ -10,6 +11,7 @@ interface ProgressCircularProps {
 
 const ProgressCircular = ({
   className,
+  color = "default",
   dataTestId,
   size = 20,
   value = 0,
@@ -25,8 +27,12 @@ const ProgressCircular = ({
   return (
     <svg
       // Progress is an activity indicator, not a status indicator. Keep its color
-      // neutral at the component boundary so callers cannot accidentally signal an intent.
-      className={clsx("!text-core-primary-fill", { "animate-spin": indeterminate }, className)}
+      // neutral by default, with an explicit inverse option for filled controls.
+      className={clsx(
+        color === "inverse" ? "!text-text-contrast" : "!text-core-primary-fill",
+        { "animate-spin": indeterminate },
+        className,
+      )}
       xmlns="http://www.w3.org/2000/svg"
       fill="none"
       viewBox={`0 0 ${size} ${size}`}

--- a/client/src/shared/components/ProgressCircular/ProgressCircular.tsx
+++ b/client/src/shared/components/ProgressCircular/ProgressCircular.tsx
@@ -2,7 +2,7 @@ import clsx from "clsx";
 
 interface ProgressCircularProps {
   className?: string;
-  color?: "default" | "inverse";
+  color?: "default" | "inverse" | "staticContrast";
   dataTestId?: string;
   size?: number;
   value?: number;
@@ -29,7 +29,11 @@ const ProgressCircular = ({
       // Progress is an activity indicator, not a status indicator. Keep its color
       // neutral by default, with an explicit inverse option for filled controls.
       className={clsx(
-        color === "inverse" ? "!text-text-contrast" : "!text-core-primary-fill",
+        {
+          "!text-core-primary-fill": color === "default",
+          "!text-text-contrast": color === "inverse",
+          "!text-text-base-contrast-static": color === "staticContrast",
+        },
         { "animate-spin": indeterminate },
         className,
       )}


### PR DESCRIPTION
Reviewable diff: +6/-4 across 4 product files (excludes test files).

## Summary

Standardizes progress indicators as neutral black activity signals at the shared component boundary. Existing Dialog, firmware-update, and Energy consumers now rely on that shared rule rather than supplying their own color overrides.

## How it works

`ProgressCircular` applies the neutral primary-fill color with higher specificity than caller classes. Consumers retain their existing loading and status logic, but cannot accidentally turn a progress spinner into an accent or status-colored indicator.

## Diagrams

```mermaid
flowchart LR
  A["ProgressCircular"] --> B["Dialog loading state"]
  A --> C["Firmware update status"]
  A --> D["Energy curtailment status"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/src/shared/components/ProgressCircular/ProgressCircular.tsx` | Enforces the neutral spinner color at the shared component root | Defines the rule for every spinner consumer |
| `client/src/shared/components/Dialog/Dialog.tsx` | Removes redundant loading-spinner color override | Confirms Dialog inherits the shared rule |
| `client/src/protoOS/features/firmwareUpdate/components/FirmwareUpdateStatusModal/FirmwareUpdateStatusModal.tsx` | Removes accent spinner override | Keeps firmware progress neutral |
| `client/src/protoFleet/features/energy/ActiveCurtailmentStatus.tsx` | Removes redundant neutral spinner override | Keeps consumer code aligned with the shared primitive |

## Key technical decisions & trade-offs

- Enforce color at the shared component boundary instead of relying on every consumer; prevents future semantic-color drift.
- Preserve status icons for status communication; a spinner signals activity only.

## Testing & validation

- `just lint`
- Focused Vitest: 63 passing tests across ProgressCircular, Dialog, and Energy status consumers
- `npm run build:protoFleet`
- `git diff --check`
