### PR TITLE
Add local HA uninstall command

### DIFF
--- a/deployment-files/ha/README.md
+++ b/deployment-files/ha/README.md
@@ -209,6 +209,31 @@ If the target version is already installed and healthy, do not rerun the
 update. Retry only if the old version remains: use the ordinary update while
 passive, or `--complete` while active after the peer reaches the target.
 
+## Uninstall or reinstall HA
+
+Run the `fleet-ha` binary from the new extracted release, not the copy inside
+the installation being removed. The command is local to one host and requires
+an interactive root session:
+
+```bash
+sudo ./deployment/ha/fleet-ha uninstall --purge-data
+```
+
+Use `--purge-data` when preparing the host for a fresh guided installation. It
+removes the HA configuration, credentials, PostgreSQL and etcd data only after
+the local services and firewall have stopped successfully. Without the flag,
+the command preserves `/etc/proto-fleet/ha` and `/var/lib/proto-fleet/ha` as
+inert local state. That retained state blocks a fresh install and cannot be
+purged by a later uninstall invocation.
+
+The command preserves Docker, installed packages, images, volumes, unrelated
+nftables configuration, host networking, and SSH access. For a complete
+three-host reset, run it on the witness, then the passive Fleet host, then the
+active Fleet host. It does not connect to or modify the peer hosts.
+
+The uninstaller supports intact HA installations only. Missing or corrupt
+installation ownership files still require manual recovery or reimaging.
+
 ## Qualification
 
 The distributions above are installer-compatible targets. The HA profile is

--- a/server/cmd/fleet-ha/main.go
+++ b/server/cmd/fleet-ha/main.go
@@ -33,6 +33,7 @@ type cli struct {
 	Compose           composeCmd           `cmd:"" help:"run Docker Compose with the installed HA environment" passthrough:""`
 	Status            statusCmd            `cmd:"" help:"print local HA status as JSON"`
 	Install           installCmd           `cmd:"" help:"prepare a new cluster or install a prepared host bundle"`
+	Uninstall         uninstallCmd         `cmd:"" help:"remove the local HA runtime"`
 	Update            updateCmd            `cmd:"" help:"update the application services on a passive HA host"`
 	Start             startCmd             `cmd:"" help:"start installed HA services"`
 	Stop              stopCmd              `cmd:"" help:"stop installed HA services"`
@@ -110,6 +111,14 @@ func (c *installCmd) Run(ctx context.Context) error {
 	}
 	fmt.Println("Proto Fleet HA installation completed")
 	return nil
+}
+
+type uninstallCmd struct {
+	PurgeData bool `help:"also permanently delete HA configuration, credentials, database, and DCS data"`
+}
+
+func (c *uninstallCmd) Run(ctx context.Context) error {
+	return deployment.Uninstall(ctx, c.PurgeData)
 }
 
 type updateCmd struct {

--- a/server/internal/ha/deployment/compose.go
+++ b/server/internal/ha/deployment/compose.go
@@ -8,9 +8,11 @@ import (
 	"slices"
 )
 
+const localDockerHost = "unix:///var/run/docker.sock"
+
 // RunCompose prevents parent variables from overriding generated HA identity and secrets.
 func RunCompose(ctx context.Context, args []string) error {
-	protected := []string{"AUTH_CLIENT_SECRET_KEY", "DB_DSN", "ENCRYPT_SERVICE_MASTER_KEY"}
+	protected := []string{"AUTH_CLIENT_SECRET_KEY", "COMPOSE_PROJECT_NAME", "DB_DSN", "ENCRYPT_SERVICE_MASTER_KEY"}
 	for key := range allowedEnvKeys {
 		protected = append(protected, key)
 	}
@@ -21,7 +23,7 @@ func RunCompose(ctx context.Context, args []string) error {
 		}
 	}
 
-	commandArgs := append([]string{"compose"}, args...)
+	commandArgs := append([]string{"--host", localDockerHost, "compose", "--project-name", "proto-fleet-ha"}, args...)
 	command := exec.CommandContext(ctx, "docker", commandArgs...)
 	command.Stdin = os.Stdin
 	command.Stdout = os.Stdout

--- a/server/internal/ha/deployment/compose.go
+++ b/server/internal/ha/deployment/compose.go
@@ -23,7 +23,7 @@ func RunCompose(ctx context.Context, args []string) error {
 		}
 	}
 
-	commandArgs := append([]string{"--host", localDockerHost, "compose", "--project-name", "proto-fleet-ha"}, args...)
+	commandArgs := append([]string{"--host", localDockerHost, "compose"}, args...)
 	command := exec.CommandContext(ctx, "docker", commandArgs...)
 	command.Stdin = os.Stdin
 	command.Stdout = os.Stdout

--- a/server/internal/ha/deployment/compose_test.go
+++ b/server/internal/ha/deployment/compose_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestRunComposeRejectsParentOverrides(t *testing.T) {
-	for _, key := range []string{"AUTH_CLIENT_SECRET_KEY", "DB_DSN", "HA_NODE_IP"} {
+	for _, key := range []string{"AUTH_CLIENT_SECRET_KEY", "COMPOSE_PROJECT_NAME", "DB_DSN", "HA_NODE_IP"} {
 		t.Run(key, func(t *testing.T) {
 			// Arrange
 			const value = "must-not-appear-in-errors"

--- a/server/internal/ha/deployment/install.go
+++ b/server/internal/ha/deployment/install.go
@@ -33,6 +33,12 @@ const (
 	minimumComposeVersion = "v2.24.4" // fleet-compose.yaml uses !override, added in this Compose release.
 	updaterDropIn         = "/etc/systemd/system/proto-fleet-updater.service.d/proto-fleet-ha.conf"
 	haUpdaterDropIn       = "/etc/systemd/system/proto-fleet-ha.service.d/proto-fleet-updater.conf"
+	updaterBinary         = "/usr/local/libexec/proto-fleet/proto-fleet-updater"
+	updaterUnit           = "/etc/systemd/system/proto-fleet-updater.service"
+	updaterEnvironment    = "/etc/proto-fleet/updater.env"
+	keepalivedConfig      = "/etc/keepalived/keepalived.conf"
+	keepalivedOverride    = "/etc/systemd/system/keepalived.service.d/override.conf"
+	keepalivedHealthCheck = "/usr/local/libexec/proto-fleet/check-fleet-active"
 )
 
 var errInstallConverging = errors.New("HA service remains enabled and is still converging")
@@ -229,10 +235,10 @@ func inspectDedicatedHost(ctx context.Context, deps installDependencies) (instal
 	}
 	for _, path := range []string{
 		serviceUnit, firewallUnit, nftablesDropIn, nftablesReloadConfig,
-		"/usr/local/libexec/proto-fleet/check-fleet-active",
-		"/usr/local/libexec/proto-fleet/proto-fleet-updater",
-		"/etc/systemd/system/proto-fleet-updater.service",
-		"/etc/proto-fleet/updater.env",
+		keepalivedHealthCheck,
+		updaterBinary,
+		updaterUnit,
+		updaterEnvironment,
 	} {
 		if _, err := deps.lstat(path); err == nil {
 			return installedDependencies{}, fmt.Errorf("HA install requires a dedicated host without existing Proto Fleet state; found %s", path)
@@ -246,7 +252,7 @@ func inspectDedicatedHost(ctx context.Context, deps installDependencies) (instal
 	if err := rejectExistingPath(deps, "/etc/systemd/system/docker.service", "foreign Docker systemd unit"); err != nil {
 		return installedDependencies{}, err
 	}
-	if err := rejectExistingPath(deps, "/etc/keepalived/keepalived.conf", "existing keepalived configuration"); err != nil {
+	if err := rejectExistingPath(deps, keepalivedConfig, "existing keepalived configuration"); err != nil {
 		return installedDependencies{}, err
 	}
 	if err := rejectExistingPath(deps, "/etc/systemd/system/keepalived.service", "foreign keepalived systemd unit"); err != nil {
@@ -668,10 +674,10 @@ func installRelease(ctx context.Context, config NodeConfig, deps installDependen
 		}
 	}
 	if config.isDatabaseNode() {
-		if output, err := deps.run(ctx, "sudo", "install", "-D", "-o", "root", "-g", "root", "-m", "0755", filepath.Join(installRoot, "updater", "proto-fleet-updater"), "/usr/local/libexec/proto-fleet/proto-fleet-updater"); err != nil {
+		if output, err := deps.run(ctx, "sudo", "install", "-D", "-o", "root", "-g", "root", "-m", "0755", filepath.Join(installRoot, "updater", "proto-fleet-updater"), updaterBinary); err != nil {
 			return fmt.Errorf("install host updater: %s", commandError(output, err))
 		}
-		if output, err := deps.run(ctx, "sudo", "install", "-o", "root", "-g", "root", "-m", "0644", filepath.Join(installRoot, "updater", "proto-fleet-updater.service"), "/etc/systemd/system/proto-fleet-updater.service"); err != nil {
+		if output, err := deps.run(ctx, "sudo", "install", "-o", "root", "-g", "root", "-m", "0644", filepath.Join(installRoot, "updater", "proto-fleet-updater.service"), updaterUnit); err != nil {
 			return fmt.Errorf("install host updater service: %s", commandError(output, err))
 		}
 		for sourceName, target := range map[string]string{
@@ -691,7 +697,7 @@ func installRelease(ctx context.Context, config NodeConfig, deps installDependen
 			return err
 		}
 		defer os.Remove(temp)
-		if output, err := deps.run(ctx, "sudo", "install", "-o", "root", "-g", "root", "-m", "0600", temp, "/etc/proto-fleet/updater.env"); err != nil {
+		if output, err := deps.run(ctx, "sudo", "install", "-o", "root", "-g", "root", "-m", "0600", temp, updaterEnvironment); err != nil {
 			return fmt.Errorf("install host updater configuration: %s", commandError(output, err))
 		}
 	}
@@ -748,8 +754,8 @@ func installKeepalived(ctx context.Context, source string, config NodeConfig, de
 		return fmt.Errorf("read keepalived systemd template: %w", err)
 	}
 	for name, contents := range map[string]string{
-		"/etc/keepalived/keepalived.conf": rendered,
-		"/etc/systemd/system/keepalived.service.d/override.conf": strings.NewReplacer(
+		keepalivedConfig: rendered,
+		keepalivedOverride: strings.NewReplacer(
 			"${HA_VIRTUAL_IP}", config.VirtualIP,
 			"${HA_NETWORK_INTERFACE}", config.NetworkInterface,
 		).Replace(string(systemdTemplate)),
@@ -763,7 +769,7 @@ func installKeepalived(ctx context.Context, source string, config NodeConfig, de
 			return err
 		}
 	}
-	if err := placeFile(ctx, deps, "install keepalived health check", filepath.Join(source, "ha", "scripts", "check-fleet-active.sh"), "/usr/local/libexec/proto-fleet/check-fleet-active", "0755"); err != nil {
+	if err := placeFile(ctx, deps, "install keepalived health check", filepath.Join(source, "ha", "scripts", "check-fleet-active.sh"), keepalivedHealthCheck, "0755"); err != nil {
 		return err
 	}
 	return placeFile(ctx, deps, "install keepalived service dependency", filepath.Join(source, "ha", "proto-fleet-ha-keepalived.conf"), "/etc/systemd/system/proto-fleet-ha.service.d/keepalived.conf", "0644")

--- a/server/internal/ha/deployment/install.go
+++ b/server/internal/ha/deployment/install.go
@@ -920,6 +920,7 @@ func fleetComposeArgs(operation string, services ...string) []string {
 
 func fleetComposeArgsAt(root, operation string, services ...string) []string {
 	args := []string{
+		"--project-name", "deployment",
 		"--env-file", filepath.Join(configRoot, "base.env"),
 		"--env-file", filepath.Join(configRoot, fleetEnvironmentFile),
 		"--env-file", filepath.Join(configRoot, "node.env"),

--- a/server/internal/ha/deployment/install.go
+++ b/server/internal/ha/deployment/install.go
@@ -36,6 +36,9 @@ const (
 	updaterBinary         = "/usr/local/libexec/proto-fleet/proto-fleet-updater"
 	updaterUnit           = "/etc/systemd/system/proto-fleet-updater.service"
 	updaterEnvironment    = "/etc/proto-fleet/updater.env"
+	updaterStateRoot      = "/var/lib/proto-fleet-updater"
+	updaterRuntimeRoot    = "/run/proto-fleet-updater"
+	updaterLock           = updaterStateRoot + "/updater.lock"
 	keepalivedConfig      = "/etc/keepalived/keepalived.conf"
 	keepalivedOverride    = "/etc/systemd/system/keepalived.service.d/override.conf"
 	keepalivedHealthCheck = "/usr/local/libexec/proto-fleet/check-fleet-active"
@@ -689,8 +692,8 @@ func installRelease(ctx context.Context, config NodeConfig, deps installDependen
 			}
 		}
 		updaterEnv := fmt.Sprintf(
-			"PROTO_FLEET_UPDATER_DEPLOYMENT_MODE=ha\nPROTO_FLEET_INSTALL_ROOT=%s\nPROTO_FLEET_UPDATER_BINARY_PATH=/usr/local/libexec/proto-fleet/proto-fleet-updater\n",
-			installBase,
+			"PROTO_FLEET_UPDATER_DEPLOYMENT_MODE=ha\nPROTO_FLEET_INSTALL_ROOT=%s\nPROTO_FLEET_UPDATER_BINARY_PATH=%s\n",
+			installBase, updaterBinary,
 		)
 		temp, err := writeInstallTemp("updater.env", updaterEnv, 0o600)
 		if err != nil {

--- a/server/internal/ha/deployment/start.go
+++ b/server/internal/ha/deployment/start.go
@@ -2,7 +2,6 @@ package deployment
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"net"
@@ -97,20 +96,12 @@ func removeBootstrapCredential(path string) error {
 }
 
 func waitForLocalEtcd(ctx context.Context, config NodeConfig) error {
-	tlsConfig, err := ha.LoadServiceTLS(filepath.Join(config.SecretsDir, "service-ca.crt"))
-	if err != nil {
-		return fmt.Errorf("load local etcd TLS configuration: %w", err)
-	}
-	tlsConfig.ServerName = config.NodeIP
-	address := net.JoinHostPort(config.NodeIP, "2379")
+	// The peer listener opens before quorum, unlike the client TLS endpoint.
+	address := net.JoinHostPort(config.NodeIP, "2380")
 	deadline := time.NewTimer(time.Minute)
 	defer deadline.Stop()
 	for {
-		ready, err := probeLocalEtcdTLS(ctx, address, tlsConfig)
-		if err != nil {
-			return fmt.Errorf("validate local etcd TLS: %w", err)
-		}
-		if ready {
+		if probeLocalEtcdListener(ctx, address) {
 			return nil
 		}
 		select {
@@ -123,19 +114,13 @@ func waitForLocalEtcd(ctx context.Context, config NodeConfig) error {
 	}
 }
 
-func probeLocalEtcdTLS(ctx context.Context, address string, tlsConfig *tls.Config) (bool, error) {
+func probeLocalEtcdListener(ctx context.Context, address string) bool {
 	connection, err := (&net.Dialer{Timeout: 2 * time.Second}).DialContext(ctx, "tcp", address)
 	if err != nil {
-		return false, nil
+		return false
 	}
-	defer connection.Close()
-	tlsConnection := tls.Client(connection, tlsConfig)
-	handshakeCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
-	defer cancel()
-	if err := tlsConnection.HandshakeContext(handshakeCtx); err != nil {
-		return false, fmt.Errorf("handshake with local etcd: %w", err)
-	}
-	return true, nil
+	_ = connection.Close()
+	return true
 }
 
 func etcdAuthRequired(err error) bool {

--- a/server/internal/ha/deployment/start_test.go
+++ b/server/internal/ha/deployment/start_test.go
@@ -1,10 +1,7 @@
 package deployment
 
 import (
-	"crypto/tls"
-	"crypto/x509"
-	"net/http"
-	"net/http/httptest"
+	"net"
 	"os"
 	"path/filepath"
 	"testing"
@@ -12,35 +9,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestProbeLocalEtcdTLSRejectsUntrustedServer(t *testing.T) {
+func TestProbeLocalEtcdListenerAcceptsPreQuorumProcess(t *testing.T) {
 	// Arrange
-	server := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
-	defer server.Close()
-	trustedRoots := x509.NewCertPool()
-	trustedRoots.AddCert(server.Certificate())
-	serverName := server.Certificate().DNSNames[0]
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer listener.Close()
 
-	for _, test := range []struct {
-		name    string
-		roots   *x509.CertPool
-		wantErr bool
-	}{
-		{name: "trusted", roots: trustedRoots},
-		{name: "untrusted", roots: x509.NewCertPool(), wantErr: true},
-	} {
-		t.Run(test.name, func(t *testing.T) {
-			// Act
-			ready, err := probeLocalEtcdTLS(t.Context(), server.Listener.Addr().String(), &tls.Config{RootCAs: test.roots, ServerName: serverName, MinVersion: tls.VersionTLS12})
+	// Act
+	ready := probeLocalEtcdListener(t.Context(), listener.Addr().String())
 
-			// Assert
-			require.Equal(t, !test.wantErr, ready)
-			if test.wantErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
+	// Assert
+	require.True(t, ready)
 }
 
 func TestInfrastructureDownArgsSelectsDatabaseProfile(t *testing.T) {

--- a/server/internal/ha/deployment/uninstall.go
+++ b/server/internal/ha/deployment/uninstall.go
@@ -1,0 +1,254 @@
+package deployment
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"golang.org/x/term"
+)
+
+const installedNodeEnvironment = configRoot + "/node.env"
+
+type uninstallDependencies struct {
+	input        io.Reader
+	output       io.Writer
+	euid         func() int
+	terminal     func() bool
+	loadConfig   func(string) (NodeConfig, error)
+	lstat        func(string) (os.FileInfo, error)
+	run          func(context.Context, string, ...string) ([]byte, error)
+	stopServices func(context.Context, string) error
+}
+
+// Uninstall removes the local HA runtime while preserving host-level dependencies.
+func Uninstall(ctx context.Context, purgeData bool) error {
+	return uninstall(ctx, purgeData, defaultUninstallDependencies())
+}
+
+func defaultUninstallDependencies() uninstallDependencies {
+	return uninstallDependencies{
+		input: os.Stdin, output: os.Stdout, euid: os.Geteuid,
+		terminal:   func() bool { return term.IsTerminal(int(os.Stdin.Fd())) },
+		loadConfig: loadNodeConfig, lstat: os.Lstat, run: runCommand,
+		stopServices: StopInstalledServices,
+	}
+}
+
+func uninstall(ctx context.Context, purgeData bool, deps uninstallDependencies) error {
+	config, err := validateUninstall(ctx, deps)
+	if err != nil {
+		return err
+	}
+	if err := printUninstallSummary(deps.output, config, purgeData); err != nil {
+		return err
+	}
+	if err := confirmUninstall(deps.input, deps.output); err != nil {
+		return err
+	}
+
+	if _, err := fmt.Fprintln(deps.output, "[shutdown] Stopping the local HA runtime..."); err != nil {
+		return fmt.Errorf("write uninstall output: %w", err)
+	}
+	if config.isDatabaseNode() {
+		if err := uninstallStep(ctx, deps, "stop host updater", "systemctl", "disable", "--now", "proto-fleet-updater.service"); err != nil {
+			return err
+		}
+		if err := uninstallStep(ctx, deps, "stop VIP routing", "systemctl", "disable", "--now", "keepalived.service"); err != nil {
+			return err
+		}
+		if err := uninstallStep(ctx, deps, "withdraw virtual IP", "ip", "address", "flush", "to", config.VirtualIP+"/32", "dev", config.NetworkInterface); err != nil {
+			return err
+		}
+	}
+	if err := uninstallStep(ctx, deps, "disable HA services", "systemctl", "disable", "--now", "proto-fleet-ha.service"); err != nil {
+		return err
+	}
+	if err := deps.stopServices(ctx, installedNodeEnvironment); err != nil {
+		return fmt.Errorf("stop installed HA containers: %w", err)
+	}
+
+	if _, err := fmt.Fprintln(deps.output, "[host cleanup] Removing HA-owned services, firewall, and runtime files..."); err != nil {
+		return fmt.Errorf("write uninstall output: %w", err)
+	}
+	if err := uninstallStep(ctx, deps, "remove Docker HA dependencies", "rm", "-f", "--", dockerDropIn, dockerRecoveryDropIn); err != nil {
+		return err
+	}
+	if err := uninstallStep(ctx, deps, "reload systemd without Docker HA dependencies", "systemctl", "daemon-reload"); err != nil {
+		return err
+	}
+	if err := uninstallStep(ctx, deps, "disable HA firewall", "systemctl", "disable", "--now", "proto-fleet-ha-firewall.service"); err != nil {
+		return err
+	}
+	if err := deleteHAFirewallTable(ctx, deps); err != nil {
+		return err
+	}
+
+	resetUnits := []string{"reset-failed", "proto-fleet-ha.service", "proto-fleet-ha-firewall.service"}
+	if config.isDatabaseNode() {
+		resetUnits = append(resetUnits, "keepalived.service")
+		resetUnits = append(resetUnits, "proto-fleet-updater.service")
+	}
+	if err := uninstallStep(ctx, deps, "clear HA service failures", "systemctl", resetUnits...); err != nil {
+		return err
+	}
+	if err := removeHAArtifacts(ctx, deps, config.isDatabaseNode()); err != nil {
+		return err
+	}
+	if err := uninstallStep(ctx, deps, "reload systemd after HA removal", "systemctl", "daemon-reload"); err != nil {
+		return err
+	}
+
+	if purgeData {
+		if _, err := fmt.Fprintln(deps.output, "[data removal] Deleting HA database, DCS, configuration, and credentials..."); err != nil {
+			return fmt.Errorf("write uninstall output: %w", err)
+		}
+		if err := uninstallStep(ctx, deps, "remove HA data", "rm", "-rf", "--", dataRoot); err != nil {
+			return err
+		}
+		if err := uninstallStep(ctx, deps, "remove HA configuration", "rm", "-rf", "--", configRoot); err != nil {
+			return err
+		}
+	}
+
+	if purgeData {
+		_, err = fmt.Fprintln(deps.output, "Proto Fleet HA was removed; this host is ready for a fresh guided installation")
+	} else {
+		_, err = fmt.Fprintf(deps.output, "Proto Fleet HA was removed; retained state remains at %s and %s and blocks a fresh install\n", configRoot, dataRoot)
+	}
+	if err != nil {
+		return fmt.Errorf("write uninstall output: %w", err)
+	}
+	return nil
+}
+
+func validateUninstall(ctx context.Context, deps uninstallDependencies) (NodeConfig, error) {
+	if deps.euid() != 0 {
+		return NodeConfig{}, errors.New("fleet-ha uninstall requires root; run it with sudo")
+	}
+	if !deps.terminal() {
+		return NodeConfig{}, errors.New("fleet-ha uninstall requires an interactive terminal; use ssh -t HOST 'sudo fleet-ha uninstall [--purge-data]'")
+	}
+	config, err := deps.loadConfig(installedNodeEnvironment)
+	if err != nil {
+		return NodeConfig{}, err
+	}
+	if err := validateNodeConfig(config); err != nil {
+		return NodeConfig{}, fmt.Errorf("installed HA configuration is invalid: %w", err)
+	}
+	if config.DataDir != dataRoot {
+		return NodeConfig{}, fmt.Errorf("installed HA_DATA_DIR must be %s", dataRoot)
+	}
+	if config.SecretsDir != configRoot {
+		return NodeConfig{}, fmt.Errorf("installed HA_SECRETS_DIR must be %s", configRoot)
+	}
+
+	required := []string{serviceUnit, firewallUnit, nftablesDropIn, dockerDropIn, infrastructureCompose, installRoot + "/ha/fleet-ha"}
+	if config.isDatabaseNode() {
+		required = append(required,
+			keepalivedConfig,
+			updaterDropIn, haUpdaterDropIn,
+			updaterBinary, updaterUnit, updaterEnvironment,
+		)
+	}
+	for _, path := range required {
+		info, err := deps.lstat(path)
+		if err != nil {
+			return NodeConfig{}, fmt.Errorf("HA installation is incomplete: inspect %s: %w", path, err)
+		}
+		if !info.Mode().IsRegular() {
+			return NodeConfig{}, fmt.Errorf("HA installation is incomplete: expected a regular file at %s", path)
+		}
+	}
+	if output, err := deps.run(ctx, "docker", "info"); err != nil {
+		return NodeConfig{}, fmt.Errorf("Docker must be running before uninstall: %s", commandError(output, err))
+	}
+	return config, nil
+}
+
+func printUninstallSummary(output io.Writer, config NodeConfig, purgeData bool) error {
+	role := "witness"
+	if config.isDatabaseNode() {
+		role = "database"
+	}
+	dataAction := fmt.Sprintf("preserve %s and %s", configRoot, dataRoot)
+	if purgeData {
+		dataAction = fmt.Sprintf("permanently delete %s and %s", configRoot, dataRoot)
+	}
+	if _, err := fmt.Fprintf(output, "Proto Fleet HA uninstall\n  node: %s (%s)\n  runtime: remove\n  persistent state: %s\n", config.NodeName, role, dataAction); err != nil {
+		return fmt.Errorf("write uninstall summary: %w", err)
+	}
+	if !purgeData {
+		if _, err := fmt.Fprintln(output, "Retained state blocks a fresh guided install and cannot be purged by a later uninstall invocation."); err != nil {
+			return fmt.Errorf("write uninstall summary: %w", err)
+		}
+	}
+	return nil
+}
+
+func confirmUninstall(input io.Reader, output io.Writer) error {
+	if _, err := fmt.Fprint(output, "Type UNINSTALL to continue: "); err != nil {
+		return fmt.Errorf("write uninstall prompt: %w", err)
+	}
+	scanner := bufio.NewScanner(input)
+	if !scanner.Scan() {
+		if err := scanner.Err(); err != nil {
+			return fmt.Errorf("read uninstall input: %w", err)
+		}
+		return errors.New("uninstall canceled: input closed")
+	}
+	if !strings.EqualFold(strings.TrimSpace(scanner.Text()), "UNINSTALL") {
+		return errors.New("uninstall canceled")
+	}
+	return nil
+}
+
+func uninstallStep(ctx context.Context, deps uninstallDependencies, action, name string, args ...string) error {
+	output, err := deps.run(ctx, name, args...)
+	if err != nil {
+		return fmt.Errorf("%s: %s", action, commandError(output, err))
+	}
+	return nil
+}
+
+func deleteHAFirewallTable(ctx context.Context, deps uninstallDependencies) error {
+	output, err := deps.run(ctx, "nft", "delete", "table", "inet", "proto_fleet_ha")
+	if err == nil || strings.Contains(string(output), "No such file or directory") {
+		return nil
+	}
+	return fmt.Errorf("remove HA firewall table: %s", commandError(output, err))
+}
+
+func removeHAArtifacts(ctx context.Context, deps uninstallDependencies, databaseNode bool) error {
+	files := []string{
+		serviceUnit, firewallUnit, nftablesDropIn,
+	}
+	if databaseNode {
+		files = append(files,
+			updaterDropIn, haUpdaterDropIn,
+			"/etc/systemd/system/proto-fleet-ha.service.d/keepalived.conf",
+			keepalivedOverride,
+			keepalivedConfig, keepalivedHealthCheck,
+			updaterUnit, updaterEnvironment,
+			updaterBinary, updaterBinary+".candidate", updaterBinary+".previous",
+			updaterBinary+".handoff", updaterBinary+".handoff.tmp", updaterBinary+".restore",
+		)
+	}
+	if err := uninstallStep(ctx, deps, "remove HA service files", "rm", append([]string{"-f", "--"}, files...)...); err != nil {
+		return err
+	}
+	paths := []string{"/run/proto-fleet-ha", installBase}
+	if databaseNode {
+		paths = append([]string{"/var/lib/proto-fleet-updater", "/run/proto-fleet-updater"}, paths...)
+	}
+	for _, path := range paths {
+		if err := uninstallStep(ctx, deps, "remove HA runtime path "+path, "rm", "-rf", "--", path); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/server/internal/ha/deployment/uninstall.go
+++ b/server/internal/ha/deployment/uninstall.go
@@ -58,6 +58,9 @@ func uninstall(ctx context.Context, purgeData bool, deps uninstallDependencies) 
 		if err := uninstallStep(ctx, deps, "stop host updater", "systemctl", "disable", "--now", "proto-fleet-updater.service"); err != nil {
 			return err
 		}
+		if err := uninstallStep(ctx, deps, "verify host updater stopped", "flock", "-n", updaterLock, "true"); err != nil {
+			return err
+		}
 		if err := uninstallStep(ctx, deps, "stop VIP routing", "systemctl", "disable", "--now", "keepalived.service"); err != nil {
 			return err
 		}
@@ -150,9 +153,9 @@ func validateUninstall(ctx context.Context, deps uninstallDependencies) (NodeCon
 	required := []string{serviceUnit, firewallUnit, nftablesDropIn, dockerDropIn, infrastructureCompose, installRoot + "/ha/fleet-ha"}
 	if config.isDatabaseNode() {
 		required = append(required,
-			keepalivedConfig,
+			keepalivedConfig, keepalivedOverride, keepalivedHealthCheck,
 			updaterDropIn, haUpdaterDropIn,
-			updaterBinary, updaterUnit, updaterEnvironment,
+			updaterBinary, updaterUnit, updaterEnvironment, updaterLock,
 		)
 	}
 	for _, path := range required {
@@ -164,7 +167,7 @@ func validateUninstall(ctx context.Context, deps uninstallDependencies) (NodeCon
 			return NodeConfig{}, fmt.Errorf("HA installation is incomplete: expected a regular file at %s", path)
 		}
 	}
-	if output, err := deps.run(ctx, "docker", "info"); err != nil {
+	if output, err := deps.run(ctx, "docker", "--host", localDockerHost, "info"); err != nil {
 		return NodeConfig{}, fmt.Errorf("Docker must be running before uninstall: %s", commandError(output, err))
 	}
 	return config, nil
@@ -243,7 +246,7 @@ func removeHAArtifacts(ctx context.Context, deps uninstallDependencies, database
 	}
 	paths := []string{"/run/proto-fleet-ha", installBase}
 	if databaseNode {
-		paths = append([]string{"/var/lib/proto-fleet-updater", "/run/proto-fleet-updater"}, paths...)
+		paths = append([]string{updaterStateRoot, updaterRuntimeRoot}, paths...)
 	}
 	for _, path := range paths {
 		if err := uninstallStep(ctx, deps, "remove HA runtime path "+path, "rm", "-rf", "--", path); err != nil {

--- a/server/internal/ha/deployment/uninstall_test.go
+++ b/server/internal/ha/deployment/uninstall_test.go
@@ -29,6 +29,7 @@ func TestUninstallDatabaseNodePreservesPersistentState(t *testing.T) {
 	require.Contains(t, output.String(), dataRoot)
 	requireCallOrder(t, calls,
 		"systemctl disable --now proto-fleet-updater.service",
+		"flock -n "+updaterLock+" true",
 		"systemctl disable --now keepalived.service",
 		"ip address flush to "+testVirtualIP+"/32 dev eth0",
 		"systemctl disable --now proto-fleet-ha.service",
@@ -110,6 +111,16 @@ func TestUninstallFailureDoesNotDeletePersistentState(t *testing.T) {
 				return output, err
 			}
 		}, message: "remove HA firewall table"},
+		{name: "updater still running", fail: func(deps *uninstallDependencies, _ *[]string) {
+			run := deps.run
+			deps.run = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+				output, err := run(ctx, name, args...)
+				if name == "flock" {
+					return nil, errors.New("exit status 1")
+				}
+				return output, err
+			}
+		}, message: "verify host updater stopped"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -155,7 +166,7 @@ func TestUninstallRejectsUnsafeInvocationBeforeMutation(t *testing.T) {
 				return lstat(path)
 			}
 		}, message: "installation is incomplete"},
-		{name: "confirmation refused", mutate: func(deps *uninstallDependencies) { deps.input = strings.NewReader("no\n") }, message: "uninstall canceled", calls: []string{"docker info"}},
+		{name: "confirmation refused", mutate: func(deps *uninstallDependencies) { deps.input = strings.NewReader("no\n") }, message: "uninstall canceled", calls: []string{"docker --host " + localDockerHost + " info"}},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -187,9 +198,11 @@ func testUninstallDependencies(t *testing.T, config NodeConfig, calls *[]string)
 	installed := map[string]bool{
 		serviceUnit: true, firewallUnit: true, nftablesDropIn: true, dockerDropIn: true,
 		infrastructureCompose: true, installRoot + "/ha/fleet-ha": true,
-		keepalivedConfig: config.isDatabaseNode(), updaterDropIn: config.isDatabaseNode(),
+		keepalivedConfig: config.isDatabaseNode(), keepalivedOverride: config.isDatabaseNode(),
+		keepalivedHealthCheck: config.isDatabaseNode(), updaterDropIn: config.isDatabaseNode(),
 		haUpdaterDropIn: config.isDatabaseNode(), updaterBinary: config.isDatabaseNode(),
 		updaterUnit: config.isDatabaseNode(), updaterEnvironment: config.isDatabaseNode(),
+		updaterLock: config.isDatabaseNode(),
 	}
 	return uninstallDependencies{
 		input: strings.NewReader("UNINSTALL\n"), output: io.Discard,

--- a/server/internal/ha/deployment/uninstall_test.go
+++ b/server/internal/ha/deployment/uninstall_test.go
@@ -1,0 +1,233 @@
+package deployment
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUninstallDatabaseNodePreservesPersistentState(t *testing.T) {
+	// Arrange
+	var calls []string
+	output := &bytes.Buffer{}
+	deps := testUninstallDependencies(t, testUninstallNodeConfig("ha-a"), &calls)
+	deps.output = output
+
+	// Act
+	err := uninstall(t.Context(), false, deps)
+
+	// Assert
+	require.NoError(t, err)
+	require.Contains(t, output.String(), "preserve")
+	require.Contains(t, output.String(), configRoot)
+	require.Contains(t, output.String(), dataRoot)
+	requireCallOrder(t, calls,
+		"systemctl disable --now proto-fleet-updater.service",
+		"systemctl disable --now keepalived.service",
+		"ip address flush to "+testVirtualIP+"/32 dev eth0",
+		"systemctl disable --now proto-fleet-ha.service",
+		"stop-installed-services",
+	)
+	requireCallOrder(t, calls,
+		"rm -f -- "+dockerDropIn+" "+dockerRecoveryDropIn,
+		"systemctl disable --now proto-fleet-ha-firewall.service",
+		"nft delete table inet proto_fleet_ha",
+	)
+
+	joined := strings.Join(calls, "\n")
+	require.NotContains(t, joined, "rm -rf -- "+dataRoot)
+	require.NotContains(t, joined, "rm -rf -- "+configRoot)
+	require.NotContains(t, joined, "--volumes")
+	require.NotContains(t, joined, "--rmi")
+	require.NotContains(t, joined, "apt-get")
+	require.NotContains(t, joined, "systemctl disable --now docker")
+}
+
+func TestUninstallPurgeDeletesPersistentStateLast(t *testing.T) {
+	// Arrange
+	var calls []string
+	output := &bytes.Buffer{}
+	deps := testUninstallDependencies(t, testUninstallNodeConfig("ha-b"), &calls)
+	deps.output = output
+
+	// Act
+	err := uninstall(t.Context(), true, deps)
+
+	// Assert
+	require.NoError(t, err)
+	require.Contains(t, output.String(), "permanently delete")
+	cleanup := callIndex(calls, "rm -rf -- "+installBase)
+	data := callIndex(calls, "rm -rf -- "+dataRoot)
+	config := callIndex(calls, "rm -rf -- "+configRoot)
+	require.Greater(t, data, cleanup)
+	require.Greater(t, config, data)
+}
+
+func TestUninstallWitnessSkipsDatabaseServices(t *testing.T) {
+	// Arrange
+	var calls []string
+	deps := testUninstallDependencies(t, testUninstallNodeConfig("ha-c"), &calls)
+	deps.input = strings.NewReader("uninstall\n")
+
+	// Act
+	err := uninstall(t.Context(), true, deps)
+
+	// Assert
+	require.NoError(t, err)
+	joined := strings.Join(calls, "\n")
+	require.NotContains(t, joined, "proto-fleet-updater.service")
+	require.NotContains(t, joined, "keepalived.service")
+	require.NotContains(t, joined, "ip address flush")
+	require.Contains(t, joined, "stop-installed-services")
+	require.Contains(t, joined, "rm -rf -- "+dataRoot)
+}
+
+func TestUninstallFailureDoesNotDeletePersistentState(t *testing.T) {
+	tests := []struct {
+		name    string
+		fail    func(*uninstallDependencies, *[]string)
+		message string
+	}{
+		{name: "Compose shutdown", fail: func(deps *uninstallDependencies, calls *[]string) {
+			deps.stopServices = func(context.Context, string) error {
+				*calls = append(*calls, "stop-installed-services")
+				return errors.New("compose failed")
+			}
+		}, message: "compose failed"},
+		{name: "firewall cleanup", fail: func(deps *uninstallDependencies, _ *[]string) {
+			run := deps.run
+			deps.run = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+				output, err := run(ctx, name, args...)
+				if name == "nft" {
+					return []byte("permission denied"), errors.New("exit status 1")
+				}
+				return output, err
+			}
+		}, message: "remove HA firewall table"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Arrange
+			var calls []string
+			deps := testUninstallDependencies(t, testUninstallNodeConfig("ha-a"), &calls)
+			test.fail(&deps, &calls)
+
+			// Act
+			err := uninstall(t.Context(), true, deps)
+
+			// Assert
+			require.ErrorContains(t, err, test.message)
+			joined := strings.Join(calls, "\n")
+			require.NotContains(t, joined, "rm -rf -- "+dataRoot)
+			require.NotContains(t, joined, "rm -rf -- "+configRoot)
+		})
+	}
+}
+
+func TestUninstallRejectsUnsafeInvocationBeforeMutation(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*uninstallDependencies)
+		message string
+		calls   []string
+	}{
+		{name: "not root", mutate: func(deps *uninstallDependencies) { deps.euid = func() int { return 1000 } }, message: "requires root"},
+		{name: "not interactive", mutate: func(deps *uninstallDependencies) { deps.terminal = func() bool { return false } }, message: "interactive terminal"},
+		{name: "wrong data path", mutate: func(deps *uninstallDependencies) {
+			deps.loadConfig = func(string) (NodeConfig, error) {
+				config := testUninstallNodeConfig("ha-a")
+				config.DataDir = "/tmp/data"
+				return config, nil
+			}
+		}, message: "HA_DATA_DIR"},
+		{name: "missing updater", mutate: func(deps *uninstallDependencies) {
+			lstat := deps.lstat
+			deps.lstat = func(path string) (os.FileInfo, error) {
+				if path == updaterUnit {
+					return nil, os.ErrNotExist
+				}
+				return lstat(path)
+			}
+		}, message: "installation is incomplete"},
+		{name: "confirmation refused", mutate: func(deps *uninstallDependencies) { deps.input = strings.NewReader("no\n") }, message: "uninstall canceled", calls: []string{"docker info"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Arrange
+			var calls []string
+			deps := testUninstallDependencies(t, testUninstallNodeConfig("ha-a"), &calls)
+			test.mutate(&deps)
+
+			// Act
+			err := uninstall(t.Context(), true, deps)
+
+			// Assert
+			require.ErrorContains(t, err, test.message)
+			require.Equal(t, test.calls, calls)
+		})
+	}
+}
+
+func testUninstallDependencies(t *testing.T, config NodeConfig, calls *[]string) uninstallDependencies {
+	t.Helper()
+	file := t.TempDir() + "/regular"
+	require.NoError(t, os.WriteFile(file, []byte("test"), 0o600))
+	info, err := os.Stat(file)
+	require.NoError(t, err)
+
+	record := func(name string, args ...string) {
+		*calls = append(*calls, strings.TrimSpace(name+" "+strings.Join(args, " ")))
+	}
+	installed := map[string]bool{
+		serviceUnit: true, firewallUnit: true, nftablesDropIn: true, dockerDropIn: true,
+		infrastructureCompose: true, installRoot + "/ha/fleet-ha": true,
+		keepalivedConfig: config.isDatabaseNode(), updaterDropIn: config.isDatabaseNode(),
+		haUpdaterDropIn: config.isDatabaseNode(), updaterBinary: config.isDatabaseNode(),
+		updaterUnit: config.isDatabaseNode(), updaterEnvironment: config.isDatabaseNode(),
+	}
+	return uninstallDependencies{
+		input: strings.NewReader("UNINSTALL\n"), output: io.Discard,
+		euid: func() int { return 0 }, terminal: func() bool { return true },
+		loadConfig: func(string) (NodeConfig, error) { return config, nil },
+		lstat: func(path string) (os.FileInfo, error) {
+			if installed[path] {
+				return info, nil
+			}
+			return nil, os.ErrNotExist
+		},
+		run: func(_ context.Context, name string, args ...string) ([]byte, error) {
+			record(name, args...)
+			return nil, nil
+		},
+		stopServices: func(context.Context, string) error {
+			record("stop-installed-services")
+			return nil
+		},
+	}
+}
+
+func testUninstallNodeConfig(role string) NodeConfig {
+	nodeIP := map[string]string{"ha-a": testHostIPs[0], "ha-b": testHostIPs[1], "ha-c": testHostIPs[2]}[role]
+	return NodeConfig{
+		NodeName: role, NodeIP: nodeIP, DatabaseAIP: testHostIPs[0], DatabaseBIP: testHostIPs[1],
+		WitnessIP: testHostIPs[2], VirtualIP: testVirtualIP, NetworkInterface: "eth0",
+		DataDir: dataRoot, SecretsDir: configRoot,
+	}
+}
+
+func requireCallOrder(t *testing.T, calls []string, expected ...string) {
+	t.Helper()
+	previous := -1
+	for _, command := range expected {
+		index := callIndex(calls, command)
+		require.NotEqual(t, -1, index, "missing command %q", command)
+		require.Greater(t, index, previous, "command %q ran out of order", command)
+		previous = index
+	}
+}

--- a/server/internal/ha/deployment/update_test.go
+++ b/server/internal/ha/deployment/update_test.go
@@ -97,6 +97,7 @@ func TestPrepareApplicationUpdateStopsBeforeImageLoadWhenComposeValidationFails(
 	// Assert
 	require.ErrorIs(t, err, composeErr)
 	require.Equal(t, []string{
+		"--project-name", "deployment",
 		"--env-file", filepath.Join(configRoot, "base.env"),
 		"--env-file", filepath.Join(configRoot, fleetEnvironmentFile),
 		"--env-file", filepath.Join(configRoot, "node.env"),


### PR DESCRIPTION
Reviewable diff: +318/-15 across 5 files (excludes generated, test, and story files).

## Summary

Operators can now remove an intact HA installation locally with `sudo fleet-ha uninstall [--purge-data]`. The default removes the runtime but retains configuration, credentials, PostgreSQL data, and etcd data. `--purge-data` removes that retained state only after the runtime and firewall teardown succeeds, leaving the host ready for a fresh guided installation.

## How it works

The command first verifies root access, an interactive terminal, the fixed installer-owned layout, and a reachable Docker daemon. It shows the detected database or witness role and the exact preservation choice, then requires `UNINSTALL` before changing the host.

Database hosts stop the updater, verify its lifetime lock is free, and withdraw VIP routing before the HA service and containers. Witness hosts stop only their HA service and etcd container. Compose teardown is pinned to the local rootful Docker socket and preserves the established `deployment` application project and `proto-fleet-ha` infrastructure project. Both paths remove the HA systemd dependencies before disabling the dedicated nftables table, then remove only installer-owned runtime files. Persistent HA data and credentials are the final step and are deleted only with `--purge-data`.

```mermaid
flowchart TD
    A["fleet-ha uninstall"] --> B["Validate root, TTY, fixed layout, and Docker"]
    B --> C["Show role and preservation choice"]
    C --> D["Require UNINSTALL"]
    D --> E{"Database host?"}
    E -->|"yes"| F["Stop updater and withdraw VIP"]
    E -->|"no"| G["Skip database-only services"]
    F --> H["Stop HA service and role-specific containers"]
    G --> H
    H --> I["Remove Docker drop-ins and HA firewall table"]
    I --> J["Remove installer-owned units and runtime files"]
    J --> K{"--purge-data?"}
    K -->|"no"| L["Retain configuration and data"]
    K -->|"yes"| M["Delete data, then configuration"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/cmd/fleet-ha/main.go` | Adds the Kong `uninstall` command and `--purge-data` flag. | Confirms the public CLI stays narrow and HA-only. |
| `server/internal/ha/deployment/uninstall.go` | Implements validation, confirmation, role-aware teardown, fixed-path cleanup, and the late purge boundary. | Contains the destructive ordering and preservation guarantees. |
| `server/internal/ha/deployment/compose.go` | Pins HA Compose operations to the local Docker socket while preserving the established application and infrastructure project names. | Keeps the local-only teardown boundary independent of ambient Docker configuration. |
| `server/internal/ha/deployment/install.go` | Names installer-owned updater and keepalived paths once for install and uninstall. | Keeps ownership validation aligned with the files the installer creates. |
| `server/internal/ha/deployment/uninstall_test.go` | Covers database and witness ordering, default preservation, late purge, cleanup failures, and zero-mutation rejection paths. | Proves the destructive boundary and role split without touching the host. |
| `deployment-files/ha/README.md` | Documents reset and reinstall usage. | Makes the one-shot preservation choice and three-host teardown order explicit. |

## Key technical decisions & trade-offs

- The command supports intact fixed-layout installations only. It rejects partial or foreign layouts instead of adding repair or discovery logic.
- Default uninstall preserves state. A later purge command is intentionally unsupported, so operators who intend to reinstall must use `--purge-data` on the original invocation.
- Compose shutdown is explicit and role-aware even after systemd is disabled. This keeps container cleanup independent of prior unit state.
- Docker, packages, images, volumes, unrelated nftables tables, host networking, and SSH remain outside the command's ownership boundary.
- There is no rollback or resume flow. Any failure stops immediately, and persistent state is never deleted until every preceding cleanup step has succeeded.

## Testing & validation

- `go test ./server/internal/ha/deployment ./server/cmd/fleet-ha -count=1`
- `just _lint-server`
- `./deployment-files/ha/tests/test-profile.sh`
- `git diff --check`

The dependency-injected tests do not exercise real systemd, Docker Compose, or nftables teardown. Final qualification remains a three-Raspberry-Pi uninstall with `--purge-data`, host-state inspection, guided reinstall, and VIP failover test.

## Post-Deploy Monitoring & Validation

- Owner: the operator running the next three-Raspberry-Pi HA qualification.
- Validation window: during each host uninstall and through the subsequent guided reinstall and first VIP failover.
- Watch `journalctl -u proto-fleet-ha.service -u proto-fleet-updater.service -u keepalived.service -u proto-fleet-ha-firewall.service` while uninstall runs.
- Healthy signals: SSH and `docker info` remain available; HA units and containers are absent; `nft list table inet proto_fleet_ha` reports no table; unrelated containers, images, volumes, packages, and nftables tables remain; `--purge-data` removes `/etc/proto-fleet/ha` and `/var/lib/proto-fleet/ha`.
- Failure signals: any quiescing, Compose, firewall, or file-removal error; a remaining VIP; loss of Docker or SSH; or deletion of unrelated host resources.
- Mitigation trigger: stop the reset sequence on the first failed host. Before the purge boundary, retain the HA data for diagnosis. Because uninstall is deliberately non-resumable, reimage a partially removed dedicated host before reinstalling.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

