### PR TITLE
Add updates settings E2E coverage

### DIFF
--- a/client/e2eTests/protoFleet/fixtures/pageFixtures.ts
+++ b/client/e2eTests/protoFleet/fixtures/pageFixtures.ts
@@ -25,6 +25,7 @@ import { SettingsPoolsPage } from "../pages/settingsPools";
 import { SettingsSchedulesPage } from "../pages/settingsSchedules";
 import { SettingsSecurityPage } from "../pages/settingsSecurity";
 import { SettingsTeamPage } from "../pages/settingsTeam";
+import { SettingsUpdatesPage } from "../pages/settingsUpdates";
 import { SingleMinerPage } from "../pages/singleMiner";
 
 type PageFixtures = {
@@ -45,6 +46,7 @@ type PageFixtures = {
   settingsSchedulesPage: SettingsSchedulesPage;
   settingsSecurityPage: SettingsSecurityPage;
   settingsTeamPage: SettingsTeamPage;
+  settingsUpdatesPage: SettingsUpdatesPage;
   settingsPoolsPage: SettingsPoolsPage;
   alertsPage: AlertsPage;
   editPoolPage: EditPoolPage;
@@ -106,6 +108,9 @@ export const test = base.extend<PageFixtures>({
   },
   settingsTeamPage: async ({ page, isMobile }, use) => {
     await use(new SettingsTeamPage(page, isMobile));
+  },
+  settingsUpdatesPage: async ({ page, isMobile }, use) => {
+    await use(new SettingsUpdatesPage(page, isMobile));
   },
   settingsPoolsPage: async ({ page, isMobile }, use) => {
     await use(new SettingsPoolsPage(page, isMobile));

--- a/client/e2eTests/protoFleet/helpers/updatesSettingsMocks.ts
+++ b/client/e2eTests/protoFleet/helpers/updatesSettingsMocks.ts
@@ -31,7 +31,7 @@ const SET_RELEASE_CHANNEL_RPC_PATTERN = /InstanceUpdateService\/SetReleaseChanne
 const GET_UPGRADE_STATUS_RPC_PATTERN = /InstanceUpdateService\/GetUpgradeStatus/;
 const TRIGGER_UPGRADE_RPC_PATTERN = /InstanceUpdateService\/TriggerUpgrade/;
 const AUTH_STORAGE_KEY = "proto-fleet-auth";
-const FORCED_SESSION_EXPIRY = "2026-12-31T00:00:00.000Z";
+const AUTH_SESSION_TTL_MS = 24 * 60 * 60 * 1000;
 
 type MessageOverrides<T> = Omit<Partial<T>, "$typeName" | "$unknown">;
 
@@ -100,9 +100,18 @@ export async function mockUpdatesSettings(
   const triggerUpgradeRequests: string[] = [];
 
   await page.addInitScript(
-    ({ authStorageKey, forcedSessionExpiry }) => {
+    ({ authStorageKey, authSessionTtlMs }) => {
       const raw = window.localStorage.getItem(authStorageKey);
-      const parsed = raw ? (JSON.parse(raw) as { state?: { auth?: Record<string, unknown> }; version?: number }) : {};
+      let parsed: { state?: { auth?: Record<string, unknown> }; version?: number } = {};
+
+      if (raw) {
+        try {
+          parsed = JSON.parse(raw) as { state?: { auth?: Record<string, unknown> }; version?: number };
+        } catch {
+          parsed = {};
+        }
+      }
+
       const auth = parsed.state?.auth ?? {};
       const permissions = Array.isArray(auth.permissions)
         ? auth.permissions.filter((value) => typeof value === "string")
@@ -110,6 +119,7 @@ export async function mockUpdatesSettings(
       const nextPermissions = permissions.includes("instance:update")
         ? permissions
         : [...permissions, "instance:update"];
+      const sessionExpiry = new Date(Date.now() + authSessionTtlMs).toISOString();
 
       window.localStorage.setItem(
         authStorageKey,
@@ -121,13 +131,13 @@ export async function mockUpdatesSettings(
               authLoading: false,
               isAuthenticated: true,
               permissions: nextPermissions,
-              sessionExpiry: forcedSessionExpiry,
+              sessionExpiry,
             },
           },
         }),
       );
     },
-    { authStorageKey: AUTH_STORAGE_KEY, forcedSessionExpiry: FORCED_SESSION_EXPIRY },
+    { authStorageKey: AUTH_STORAGE_KEY, authSessionTtlMs: AUTH_SESSION_TTL_MS },
   );
 
   await page.route(GET_FLEET_INIT_STATUS_RPC_PATTERN, async (route) => {

--- a/client/e2eTests/protoFleet/helpers/updatesSettingsMocks.ts
+++ b/client/e2eTests/protoFleet/helpers/updatesSettingsMocks.ts
@@ -1,0 +1,178 @@
+import { create, fromJsonString, toJsonString } from "@bufbuild/protobuf";
+import type { Message } from "@bufbuild/protobuf";
+import type { GenMessage } from "@bufbuild/protobuf/codegenv2";
+import type { Page, Route } from "@playwright/test";
+import type {
+  GetUpdateStatusResponse,
+  GetUpgradeStatusResponse,
+  ReleaseInfo,
+  UpgradeOperation,
+} from "@/protoFleet/api/generated/instance/v1/updates_pb";
+import {
+  GetUpdateStatusResponseSchema,
+  GetUpgradeStatusResponseSchema,
+  ReleaseChannel,
+  ReleaseInfoSchema,
+  SetReleaseChannelRequestSchema,
+  SetReleaseChannelResponseSchema,
+  TriggerUpgradeRequestSchema,
+  TriggerUpgradeResponseSchema,
+  UpgradeOperationSchema,
+  UpgradePhase,
+} from "@/protoFleet/api/generated/instance/v1/updates_pb";
+import {
+  FleetInitStatusSchema,
+  GetFleetInitStatusResponseSchema,
+} from "@/protoFleet/api/generated/onboarding/v1/onboarding_pb";
+
+const GET_FLEET_INIT_STATUS_RPC_PATTERN = /OnboardingService\/GetFleetInitStatus/;
+const GET_UPDATE_STATUS_RPC_PATTERN = /InstanceUpdateService\/GetUpdateStatus/;
+const SET_RELEASE_CHANNEL_RPC_PATTERN = /InstanceUpdateService\/SetReleaseChannel/;
+const GET_UPGRADE_STATUS_RPC_PATTERN = /InstanceUpdateService\/GetUpgradeStatus/;
+const TRIGGER_UPGRADE_RPC_PATTERN = /InstanceUpdateService\/TriggerUpgrade/;
+const AUTH_STORAGE_KEY = "proto-fleet-auth";
+const FORCED_SESSION_EXPIRY = "2026-12-31T00:00:00.000Z";
+
+type MessageOverrides<T> = Omit<Partial<T>, "$typeName" | "$unknown">;
+
+export interface UpdatesSettingsMockController {
+  releaseChannelRequests: ReleaseChannel[];
+  triggerUpgradeRequests: string[];
+}
+
+interface MockUpdatesSettingsOptions {
+  initialStatus: GetUpdateStatusResponse;
+  initialUpgradeStatus?: GetUpgradeStatusResponse;
+  onSetReleaseChannel?: (channel: ReleaseChannel) => GetUpdateStatusResponse;
+  onTriggerUpgrade?: (targetVersion: string) => UpgradeOperation | undefined;
+}
+
+export const buildReleaseInfo = (overrides?: MessageOverrides<ReleaseInfo>): ReleaseInfo =>
+  create(ReleaseInfoSchema, {
+    version: "v1.3.0",
+    releaseNotesUrl: "https://github.com/block/proto-fleet/releases/tag/v1.3.0",
+    prerelease: false,
+    ...overrides,
+  });
+
+export const buildUpdateStatus = (overrides?: MessageOverrides<GetUpdateStatusResponse>): GetUpdateStatusResponse =>
+  create(GetUpdateStatusResponseSchema, {
+    currentVersion: "v1.2.0",
+    channel: ReleaseChannel.STABLE,
+    latestEligible: buildReleaseInfo(),
+    updateAvailable: true,
+    installCommand: "curl -fsSL https://fleet.example.com/install.sh | sh -s -- v1.3.0",
+    oneClickAvailable: false,
+    statusAvailable: true,
+    ...overrides,
+  });
+
+export const buildUpgradeStatus = (overrides?: MessageOverrides<GetUpgradeStatusResponse>): GetUpgradeStatusResponse =>
+  create(GetUpgradeStatusResponseSchema, {
+    executorAvailable: true,
+    ...overrides,
+  });
+
+export const buildUpgradeOperation = (
+  phase: UpgradePhase,
+  overrides?: MessageOverrides<UpgradeOperation>,
+): UpgradeOperation =>
+  create(UpgradeOperationSchema, {
+    id: "operation-1",
+    targetVersion: "v1.3.0",
+    phase,
+    message: "Preparing upgrade",
+    ...overrides,
+  });
+
+export async function mockUpdatesSettings(
+  page: Page,
+  {
+    initialStatus,
+    initialUpgradeStatus = buildUpgradeStatus(),
+    onSetReleaseChannel,
+    onTriggerUpgrade,
+  }: MockUpdatesSettingsOptions,
+): Promise<UpdatesSettingsMockController> {
+  let currentStatus = initialStatus;
+  let currentUpgradeStatus = initialUpgradeStatus;
+  const releaseChannelRequests: ReleaseChannel[] = [];
+  const triggerUpgradeRequests: string[] = [];
+
+  await page.addInitScript(
+    ({ authStorageKey, forcedSessionExpiry }) => {
+      const raw = window.localStorage.getItem(authStorageKey);
+      const parsed = raw ? (JSON.parse(raw) as { state?: { auth?: Record<string, unknown> }; version?: number }) : {};
+      const auth = parsed.state?.auth ?? {};
+      const permissions = Array.isArray(auth.permissions)
+        ? auth.permissions.filter((value) => typeof value === "string")
+        : [];
+      const nextPermissions = permissions.includes("instance:update")
+        ? permissions
+        : [...permissions, "instance:update"];
+
+      window.localStorage.setItem(
+        authStorageKey,
+        JSON.stringify({
+          version: parsed.version ?? 0,
+          state: {
+            auth: {
+              ...auth,
+              authLoading: false,
+              isAuthenticated: true,
+              permissions: nextPermissions,
+              sessionExpiry: forcedSessionExpiry,
+            },
+          },
+        }),
+      );
+    },
+    { authStorageKey: AUTH_STORAGE_KEY, forcedSessionExpiry: FORCED_SESSION_EXPIRY },
+  );
+
+  await page.route(GET_FLEET_INIT_STATUS_RPC_PATTERN, async (route) => {
+    return await fulfill(
+      route,
+      GetFleetInitStatusResponseSchema,
+      create(GetFleetInitStatusResponseSchema, {
+        status: create(FleetInitStatusSchema, { adminCreated: true }),
+      }),
+    );
+  });
+
+  await page.route(GET_UPDATE_STATUS_RPC_PATTERN, async (route) => {
+    return await fulfill(route, GetUpdateStatusResponseSchema, currentStatus);
+  });
+
+  await page.route(SET_RELEASE_CHANNEL_RPC_PATTERN, async (route) => {
+    const request = fromJsonString(SetReleaseChannelRequestSchema, route.request().postData() ?? "{}");
+    releaseChannelRequests.push(request.channel);
+    currentStatus = onSetReleaseChannel?.(request.channel) ?? currentStatus;
+    return await fulfill(route, SetReleaseChannelResponseSchema, create(SetReleaseChannelResponseSchema));
+  });
+
+  await page.route(GET_UPGRADE_STATUS_RPC_PATTERN, async (route) => {
+    return await fulfill(route, GetUpgradeStatusResponseSchema, currentUpgradeStatus);
+  });
+
+  await page.route(TRIGGER_UPGRADE_RPC_PATTERN, async (route) => {
+    const request = fromJsonString(TriggerUpgradeRequestSchema, route.request().postData() ?? "{}");
+    triggerUpgradeRequests.push(request.targetVersion);
+    const operation = onTriggerUpgrade?.(request.targetVersion);
+    currentUpgradeStatus = buildUpgradeStatus({ operation });
+    return await fulfill(route, TriggerUpgradeResponseSchema, create(TriggerUpgradeResponseSchema, { operation }));
+  });
+
+  return {
+    releaseChannelRequests,
+    triggerUpgradeRequests,
+  };
+}
+
+async function fulfill<T extends Message>(route: Route, schema: GenMessage<T>, message: T) {
+  return await route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: toJsonString(schema, message),
+  });
+}

--- a/client/e2eTests/protoFleet/pages/base.ts
+++ b/client/e2eTests/protoFleet/pages/base.ts
@@ -918,6 +918,11 @@ export class BasePage {
     await expect(this.page).toHaveURL(/.*\/settings\/alerts/);
   }
 
+  async navigateToUpdatesSettings() {
+    await this.page.goto("/settings/updates");
+    await expect(this.page).toHaveURL(/.*\/settings\/updates/);
+  }
+
   async navigateToServerLogsSettings() {
     await this.clickNavigationMenuIfMobile();
     await this.clickExpandSettingsIfMobile();

--- a/client/e2eTests/protoFleet/pages/settingsUpdates.ts
+++ b/client/e2eTests/protoFleet/pages/settingsUpdates.ts
@@ -1,0 +1,66 @@
+import { expect } from "@playwright/test";
+import { BasePage } from "./base";
+
+export class SettingsUpdatesPage extends BasePage {
+  async validateUpdatesPageOpened() {
+    await expect(this.page).toHaveURL(/.*\/settings\/updates/);
+    await this.validateTitle("Updates");
+  }
+
+  async validateCurrentVersion(version: string) {
+    await expect(this.page.getByText(version, { exact: true }).first()).toBeVisible();
+  }
+
+  async validateLatestAvailableVersion(version: string) {
+    await expect(this.page.getByText(version, { exact: true }).last()).toBeVisible();
+  }
+
+  async validateReleaseNotesLink(url: string) {
+    await expect(this.page.getByRole("link", { name: "Release notes", exact: true })).toHaveAttribute("href", url);
+  }
+
+  async validateInstallCommand(command: string) {
+    await expect(this.page.locator("code").filter({ hasText: command })).toBeVisible();
+  }
+
+  async validateCopyInstallCommandEnabled() {
+    await expect(this.page.getByRole("button", { name: "Copy install command", exact: true })).toBeEnabled();
+  }
+
+  async validateCopyInstallCommandDisabled() {
+    await expect(this.page.getByRole("button", { name: "Copy install command", exact: true })).toBeDisabled();
+  }
+
+  async clickIncludeReleaseCandidates() {
+    await this.page.getByRole("checkbox", { name: "Include release candidates", exact: true }).click();
+  }
+
+  async validateIncludeReleaseCandidatesChecked() {
+    await expect(this.page.getByRole("checkbox", { name: "Include release candidates", exact: true })).toBeChecked();
+  }
+
+  async validateIncludeReleaseCandidatesUnchecked() {
+    await expect(
+      this.page.getByRole("checkbox", { name: "Include release candidates", exact: true }),
+    ).not.toBeChecked();
+  }
+
+  async clickUpgradeToVersion(version: string) {
+    await this.page.getByRole("button", { name: `Upgrade to ${version}`, exact: true }).click();
+  }
+
+  async validateUpgradeConfirmationOpened(version: string) {
+    const modal = this.page.getByTestId("upgrade-operation-modal");
+    await expect(modal).toBeVisible();
+    await expect(modal).toContainText(`Upgrade Fleet to ${version}`);
+    await expect(modal).toContainText("Fleet will validate and build this exact release");
+  }
+
+  async confirmUpgradeToVersion(version: string) {
+    await this.page.getByRole("button", { name: `Confirm upgrade to ${version}`, exact: true }).click();
+  }
+
+  async validateUpgradeModalText(text: string) {
+    await expect(this.page.getByTestId("upgrade-operation-modal")).toContainText(text);
+  }
+}

--- a/client/e2eTests/protoFleet/pages/settingsUpdates.ts
+++ b/client/e2eTests/protoFleet/pages/settingsUpdates.ts
@@ -8,11 +8,11 @@ export class SettingsUpdatesPage extends BasePage {
   }
 
   async validateCurrentVersion(version: string) {
-    await expect(this.page.getByText(version, { exact: true }).first()).toBeVisible();
+    await expect(this.rowByLabel("Current version").locator("> div").last()).toHaveText(version);
   }
 
   async validateLatestAvailableVersion(version: string) {
-    await expect(this.page.getByText(version, { exact: true }).last()).toBeVisible();
+    await expect(this.rowByLabel("Latest available").locator("span").first()).toHaveText(version);
   }
 
   async validateReleaseNotesLink(url: string) {
@@ -62,5 +62,9 @@ export class SettingsUpdatesPage extends BasePage {
 
   async validateUpgradeModalText(text: string) {
     await expect(this.page.getByTestId("upgrade-operation-modal")).toContainText(text);
+  }
+
+  private rowByLabel(label: string) {
+    return this.page.getByText(label, { exact: true }).locator("xpath=..");
   }
 }

--- a/client/e2eTests/protoFleet/spec/updatesSettings.spec.ts
+++ b/client/e2eTests/protoFleet/spec/updatesSettings.spec.ts
@@ -1,0 +1,87 @@
+import { test } from "../fixtures/pageFixtures";
+import {
+  buildReleaseInfo,
+  buildUpdateStatus,
+  buildUpgradeOperation,
+  mockUpdatesSettings,
+} from "../helpers/updatesSettingsMocks";
+import { ReleaseChannel, UpgradePhase } from "@/protoFleet/api/generated/instance/v1/updates_pb";
+
+test.describe("Proto Fleet - Updates Settings", () => {
+  test(
+    "View update details and refresh the offer after enabling release candidates",
+    { tag: "@smoke" },
+    async ({ page, settingsUpdatesPage }) => {
+      const updatesMock = await mockUpdatesSettings(page, {
+        initialStatus: buildUpdateStatus(),
+        onSetReleaseChannel: (channel) =>
+          buildUpdateStatus({
+            channel,
+            installCommand: "curl -fsSL https://fleet.example.com/install.sh | sh -s -- v1.4.0-rc.1",
+            latestEligible: buildReleaseInfo({
+              version: "v1.4.0-rc.1",
+              releaseNotesUrl: "https://github.com/block/proto-fleet/releases/tag/v1.4.0-rc.1",
+              prerelease: true,
+            }),
+          }),
+      });
+
+      await test.step("Open Updates settings and validate the initial stable release offer", async () => {
+        await settingsUpdatesPage.navigateToUpdatesSettings();
+        await settingsUpdatesPage.validateUpdatesPageOpened();
+        await settingsUpdatesPage.validateCurrentVersion("v1.2.0");
+        await settingsUpdatesPage.validateLatestAvailableVersion("v1.3.0");
+        await settingsUpdatesPage.validateReleaseNotesLink("https://github.com/block/proto-fleet/releases/tag/v1.3.0");
+        await settingsUpdatesPage.validateInstallCommand(
+          "curl -fsSL https://fleet.example.com/install.sh | sh -s -- v1.3.0",
+        );
+        await settingsUpdatesPage.validateCopyInstallCommandEnabled();
+        await settingsUpdatesPage.validateIncludeReleaseCandidatesUnchecked();
+      });
+
+      await test.step("Enable release candidates and validate the refreshed offer", async () => {
+        await settingsUpdatesPage.clickIncludeReleaseCandidates();
+        await settingsUpdatesPage.validateTextInToast("Release channel updated");
+        test.expect(updatesMock.releaseChannelRequests).toEqual([ReleaseChannel.STABLE_AND_RC]);
+        await settingsUpdatesPage.validateIncludeReleaseCandidatesChecked();
+        await settingsUpdatesPage.validateLatestAvailableVersion("v1.4.0-rc.1");
+        await settingsUpdatesPage.validateReleaseNotesLink(
+          "https://github.com/block/proto-fleet/releases/tag/v1.4.0-rc.1",
+        );
+        await settingsUpdatesPage.validateInstallCommand(
+          "curl -fsSL https://fleet.example.com/install.sh | sh -s -- v1.4.0-rc.1",
+        );
+      });
+    },
+  );
+
+  test("Confirm the exact offered version before triggering a one-click upgrade", async ({
+    page,
+    settingsUpdatesPage,
+  }) => {
+    const updatesMock = await mockUpdatesSettings(page, {
+      initialStatus: buildUpdateStatus({ oneClickAvailable: true }),
+      onTriggerUpgrade: (targetVersion) =>
+        buildUpgradeOperation(UpgradePhase.QUEUED, {
+          targetVersion,
+          message: `Preparing ${targetVersion}`,
+        }),
+    });
+
+    await settingsUpdatesPage.navigateToUpdatesSettings();
+    await settingsUpdatesPage.validateUpdatesPageOpened();
+
+    await test.step("Open the upgrade confirmation modal without triggering the request yet", async () => {
+      await settingsUpdatesPage.clickUpgradeToVersion("v1.3.0");
+      await settingsUpdatesPage.validateUpgradeConfirmationOpened("v1.3.0");
+      test.expect(updatesMock.triggerUpgradeRequests).toEqual([]);
+    });
+
+    await test.step("Confirm the upgrade and validate the exact requested version", async () => {
+      await settingsUpdatesPage.confirmUpgradeToVersion("v1.3.0");
+      await settingsUpdatesPage.validateUpgradeModalText("Preparing v1.3.0");
+      await settingsUpdatesPage.validateCopyInstallCommandDisabled();
+      test.expect(updatesMock.triggerUpgradeRequests).toEqual(["v1.3.0"]);
+    });
+  });
+});


### PR DESCRIPTION
Reviewable diff: +254/-0 across 4 files (excludes generated, test, and story files).

## Summary
This PR adds isolated ProtoFleet E2E coverage for the Updates settings surface so we can verify the release-offer UI and one-click upgrade flow without depending on a live backend. It introduces dedicated mocks and a page object for `/settings/updates`, then exercises both the release-channel toggle and the exact-version upgrade confirmation path.

## How it works
The new spec installs route mocks for fleet init, update status, release-channel updates, and upgrade triggering before the page loads. A small init script refreshes the saved auth state in `localStorage` and ensures `instance:update` is present, which keeps the test deterministic even when the checked-in storage state is stale. From there, the page object drives `/settings/updates` directly and validates both the stable-to-RC offer refresh and the exact target version sent by one-click upgrade.

## Diagrams
```mermaid
flowchart TD
  A["updatesSettings.spec.ts"] --> B["mockUpdatesSettings()"]
  B --> C["Mock fleet init + update RPCs"]
  B --> D["Refresh auth state in localStorage"]
  A --> E["SettingsUpdatesPage"]
  E --> F["/settings/updates UI"]
  F --> G["Validate stable offer"]
  F --> H["Toggle release candidates"]
  H --> I["Assert refreshed RC offer"]
  F --> J["Trigger one-click upgrade"]
  J --> K["Assert exact target version request"]
```

## Areas of the code involved
| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/e2eTests/protoFleet/spec/updatesSettings.spec.ts` | Adds the new Updates settings scenarios | Main user-facing assertions and scenario coverage |
| `client/e2eTests/protoFleet/helpers/updatesSettingsMocks.ts` | Adds RPC mocks plus auth-state patching for deterministic setup | Validates the mocked contract and isolation strategy |
| `client/e2eTests/protoFleet/pages/settingsUpdates.ts` | Adds a page object for Updates settings interactions and assertions | Centralizes selectors and expectations reviewers will rely on later |
| `client/e2eTests/protoFleet/pages/base.ts` | Adds Updates settings navigation helper | Connects the new page object to shared navigation |
| `client/e2eTests/protoFleet/fixtures/pageFixtures.ts` | Registers the new page fixture | Makes the new page object available to specs |

## Key technical decisions & trade-offs
- Use RPC mocks plus a localStorage auth patch instead of the shared onboarding setup project, because the target flow only needs UI contract verification and should stay runnable without a live backend.
- Navigate directly to `/settings/updates` instead of desktop subnav clicks, because this mocked test path must avoid the desktop settings navigation timing issue we hit locally.

## Testing & validation
- `./node_modules/.bin/eslint e2eTests/protoFleet/fixtures/pageFixtures.ts e2eTests/protoFleet/pages/base.ts e2eTests/protoFleet/pages/settingsUpdates.ts e2eTests/protoFleet/helpers/updatesSettingsMocks.ts e2eTests/protoFleet/spec/updatesSettings.spec.ts`
- `npx playwright test spec/updatesSettings.spec.ts --project=desktop --no-deps`
- Not covered: shared onboarding setup or live backend integration; this PR keeps the new coverage intentionally isolated to the Updates settings UI contract.
