### PR TITLE
fix(ci): ignore reference-only vendored protobuf findings

### DIFF
--- a/.github/workflows/codex-security-review.yml
+++ b/.github/workflows/codex-security-review.yml
@@ -85,6 +85,24 @@ jobs:
             - **Infrastructure**: Docker multi-stage builds, Docker Compose orchestration,
               Nginx reverse proxy, multi-arch (amd64/arm64) deployment
 
+            ## Repository Provenance Boundaries
+
+            Files under `proto-rig-api/grpc/**` are byte-identical protobuf snapshots
+            copied from the upstream `miner-firmware` repository. They are retained for
+            reference and provenance only: Proto Fleet does not generate code from them,
+            compile them, or load them at runtime.
+
+            Do not emit findings or increase `overall_risk` for defects that exist solely
+            in these vendored gRPC files, including upstream wire-compatibility or enum
+            numbering changes. Such defects must be corrected upstream and incorporated
+            through a later snapshot. Report a finding only when repo-owned code or
+            tooling consumes these files and the PR introduces a concrete Proto Fleet
+            risk; cite that repo-owned consumption site.
+
+            This exclusion does not apply to `proto-rig-api/openapi/MDK-API.json`, which
+            generates the ProtoOS REST client, or to repo-owned adapters and simulators
+            that implement that contract.
+
             Perform a review focused strictly on the latest changes.
             Start by reading `${{ env.REVIEW_DIFF_FILE }}` and treat it as the authoritative review scope.
             - The checked out repository contents are pinned to commit `${{ env.REVIEW_HEAD_SHA }}`.


### PR DESCRIPTION
Reviewable diff: +18/-0 across 1 file (excludes generated, test, and story files).

## Summary
Codex security reviews now ignore defects that exist solely in reference-only gRPC snapshots copied from `miner-firmware`, preventing repeated findings that cannot be fixed safely in Proto Fleet. Consumed OpenAPI contracts and repo-owned integrations remain fully in scope.

## How it works
The review prompt classifies `proto-rig-api/grpc/**` as provenance-only input: those files are neither compiled nor used for code generation in this repository. Findings remain allowed when repo-owned code or tooling consumes a contract and introduces a concrete Proto Fleet risk.

## Diagrams
```mermaid
flowchart LR
  D["Pull request diff"] --> C{"Changed surface"}
  C -->|"proto-rig-api/grpc/**"| V["Treat as upstream provenance"]
  C -->|"OpenAPI or repo-owned code"| R["Review normally"]
  V --> U["Correct upstream, then re-vendor"]
```

## Areas of the code involved
| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `.github/workflows/codex-security-review.yml` | Defines the provenance boundary for copied gRPC snapshots | Ensures true repo-owned security risks remain visible without repeatedly reporting upstream-only protobuf defects |

## Key technical decisions & trade-offs
- Keep vendored protobufs visible in the review diff, but exclude findings based solely on them; removing them from the diff would hide useful provenance context.
- Limit the exclusion to `proto-rig-api/grpc/**`; `MDK-API.json`, generated REST clients, adapters, and simulators remain reviewable because Proto Fleet consumes them.

## Testing & validation
- Parsed the updated workflow successfully with Ruby's YAML parser.
- `.github/scripts/evaluate_review_policy_test.py`: 53 tests passed.
- Pre-commit and pre-push hooks passed. Full `just lint` could not complete in the isolated worktree because client dependencies were not installed there (`eslint: command not found`).
