### PR TITLE
fix(fake-proto-rig): improve firmware update simulation

### DIFF
--- a/server/fake-proto-rig/README.md
+++ b/server/fake-proto-rig/README.md
@@ -17,6 +17,35 @@ This simulator allows the fleet management system to be tested without physical 
 - Error injection via environment variables
 - REST API for both ProtoFleet plugin and ProtoOS dashboard
 
+### Firmware Update Simulation
+
+Firmware uploads move through `downloaded`, `installing`, and `installed`.
+Rebooting after `installed` promotes the staged version to the running version.
+A second upload is rejected while any update is pending.
+
+The simulator detects an uploaded version in this order:
+
+1. A semantic version in the filename, such as `protoos-1.4.4.swu`.
+2. A marker in the first 64 KiB of the file:
+   - `firmware_version=1.4.4`
+   - `{"firmware_version":"1.4.4"}`
+   - A line containing only `1.4.4` or `v1.4.4`
+3. A one-patch increment from the currently running version.
+
+Fake uploads are streamed with a 512 MiB request limit. Only the version scan
+prefix is retained in memory.
+
+Tests can set the one-shot outcome for the next update through the fake-only
+`PUT /fake-api/v1/test/firmware-update/outcome` endpoint:
+
+```json
+{"outcome":"success"}
+```
+
+Supported outcomes are `success`, `error`, and `attention`. Both failure
+outcomes expose the real API's `error` update state with a deterministic error
+message. This endpoint is not part of the real device API.
+
 ## Usage
 
 ### Running Directly

--- a/server/fake-proto-rig/README.md
+++ b/server/fake-proto-rig/README.md
@@ -36,7 +36,10 @@ Fake uploads are streamed with a 512 MiB request limit. Only the version scan
 prefix is retained in memory.
 
 Tests can set the one-shot outcome for the next update through the fake-only
-`PUT /fake-api/v1/test/firmware-update/outcome` endpoint:
+`PUT /fake-api/v1/test/firmware-update/outcome` endpoint. Set
+`FAKE_RIG_ENABLE_TEST_CONTROLS=true` to register this endpoint, then authenticate
+with a bearer token issued by `/api/v1/auth/login`. The endpoint is unavailable
+by default.
 
 ```json
 {"outcome":"success"}
@@ -68,6 +71,7 @@ docker run -p 8080:8080 fake-proto-rig
 | `HTTP_PORT` | Port to listen on | `8080` |
 | `SERIAL_NUMBER` | Device serial number | `PROTO-SIM-<uuid>` |
 | `MAC_ADDRESS` | Device MAC address | Generated from instance ID |
+| `FAKE_RIG_ENABLE_TEST_CONTROLS` | Enable authenticated fake-only test control endpoints | `false` |
 
 ### Error Injection
 

--- a/server/fake-proto-rig/models.go
+++ b/server/fake-proto-rig/models.go
@@ -272,10 +272,14 @@ type MinerState struct {
 	TelemetryEnabled bool
 
 	// Firmware update simulation
-	FWUpdateStatus    string // "current", "downloading", "downloaded", "installing", "installed"
-	FWCurrentVersion  string // running firmware version; initialized to defaultFirmwareVersion
-	FWNewVersion      string // staged version after a successful upload; promoted to current on reboot
-	FWPreviousVersion string // set after reboot following a firmware update
+	FWUpdateStatus      string // "current", "downloading", "downloaded", "installing", "installed", "error"
+	FWCurrentVersion    string // running firmware version; initialized to defaultFirmwareVersion
+	FWNewVersion        string // staged version after a successful upload; promoted to current on reboot
+	FWPreviousVersion   string // set after reboot following a firmware update
+	FWUpdateError       string // deterministic error exposed when the active fake update fails
+	FWUpdateSequence    uint64 // invalidates stale lifecycle goroutines after reboot or a new update
+	FWUpdateOutcome     string // outcome consumed by the active update
+	FWNextUpdateOutcome string // one-shot fake test control; reset to success when consumed
 
 	// Reboot simulation
 	Rebooting bool
@@ -331,6 +335,7 @@ func NewMinerState(serialNumber, macAddress string) *MinerState {
 		Pools:                make([]*Pool, 0),
 		PoolNames:            make(map[uint32]string),
 		FWCurrentVersion:     defaultFirmwareVersion,
+		FWNextUpdateOutcome:  firmwareUpdateOutcomeSuccess,
 		CurtailmentConfigVal: defaultCurtailmentConfig(),
 		StartTime:            time.Now(),
 	}

--- a/server/fake-proto-rig/rest_api_handler.go
+++ b/server/fake-proto-rig/rest_api_handler.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"log"
 	"math/big"
+	"mime/multipart"
 	"net"
 	"net/http"
 	"net/url"
@@ -22,11 +23,26 @@ import (
 )
 
 const (
-	minPasswordLength      = 8
-	maxLocateLEDOnTimeSecs = 300
+	minPasswordLength                    = 8
+	maxLocateLEDOnTimeSecs               = 300
+	firmwareVersionScanLimit       int64 = 64 * 1024
+	maxFirmwareUploadBytes         int64 = 512 * 1024 * 1024
+	defaultFirmwareStepDelay             = 1 * time.Second
+	defaultFirmwareInstallDelay          = 2 * time.Second
+	firmwareUpdateOutcomeSuccess         = "success"
+	firmwareUpdateOutcomeError           = "error"
+	firmwareUpdateOutcomeAttention       = "attention"
+	firmwareUpdateFailureMessage         = "Simulated firmware update failure"
+	firmwareUpdateAttentionMessage       = "Simulated firmware update requires attention"
 )
 
 var firmwareFilenameVersionRE = regexp.MustCompile(`(?:^|[^0-9.])v?([0-9]+\.[0-9]+\.[0-9]+)(?:$|[^0-9.]|\.[A-Za-z])`)
+
+var firmwareContentVersionREs = []*regexp.Regexp{
+	regexp.MustCompile(`(?:^|[^[:alnum:]_])firmware_version[[:space:]]*=[[:space:]]*v?([0-9]+\.[0-9]+\.[0-9]+)(?:$|[^0-9.])`),
+	regexp.MustCompile(`"firmware_version"[[:space:]]*:[[:space:]]*"v?([0-9]+\.[0-9]+\.[0-9]+)"`),
+	regexp.MustCompile(`(?m)^[ \t]*v?([0-9]+\.[0-9]+\.[0-9]+)[ \t]*\r?$`),
+}
 
 var secp256k1FieldPrime = func() *big.Int {
 	prime, ok := new(big.Int).SetString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F", 16)
@@ -205,14 +221,34 @@ func firmwareVersionFromFilename(filename string) (string, bool) {
 	return matches[1], true
 }
 
-func stagedFirmwareVersion(filename, currentVersion string) string {
-	if version, ok := firmwareVersionFromFilename(filename); ok {
-		return version
+func firmwareVersionFromContent(content io.Reader) (string, bool, error) {
+	prefix, err := io.ReadAll(io.LimitReader(content, firmwareVersionScanLimit))
+	if err != nil {
+		return "", false, fmt.Errorf("read firmware version prefix: %w", err)
 	}
-	return nextFirmwareVersion(currentVersion)
+
+	for _, expression := range firmwareContentVersionREs {
+		matches := expression.FindSubmatch(prefix)
+		if len(matches) == 2 {
+			return string(matches[1]), true, nil
+		}
+	}
+	return "", false, nil
 }
 
-func buildSystemUpdateStatus(status, currentVersion, previousVersion, newVersion string) UpdateStatus {
+func stagedFirmwareVersion(filename string, content io.Reader, currentVersion string) (string, error) {
+	if version, ok := firmwareVersionFromFilename(filename); ok {
+		return version, nil
+	}
+	if version, ok, err := firmwareVersionFromContent(content); err != nil {
+		return "", err
+	} else if ok {
+		return version, nil
+	}
+	return nextFirmwareVersion(currentVersion), nil
+}
+
+func buildSystemUpdateStatus(status, currentVersion, previousVersion, newVersion, updateError string) UpdateStatus {
 	updateStatus := UpdateStatus{
 		Status:          status,
 		CurrentVersion:  currentVersion,
@@ -232,6 +268,12 @@ func buildSystemUpdateStatus(status, currentVersion, previousVersion, newVersion
 	case "installed":
 		message := "Reboot required"
 		updateStatus.Message = &message
+	case "error":
+		message := "Update failed"
+		updateStatus.Message = &message
+		if updateError != "" {
+			updateStatus.Error = &updateError
+		}
 	}
 
 	if newVersion != "" {
@@ -611,16 +653,20 @@ type PSUTelemetry struct {
 
 // RESTApiHandler handles REST API requests
 type RESTApiHandler struct {
-	state               *MinerState
-	locateTimerMu       sync.Mutex
-	cancelLocateTimer   func()
-	scheduleLocateClear func(time.Duration, func()) func()
+	state                *MinerState
+	locateTimerMu        sync.Mutex
+	cancelLocateTimer    func()
+	scheduleLocateClear  func(time.Duration, func()) func()
+	firmwareStepDelay    time.Duration
+	firmwareInstallDelay time.Duration
 }
 
 // NewRESTApiHandler creates a new REST API handler
 func NewRESTApiHandler(state *MinerState) *RESTApiHandler {
 	return &RESTApiHandler{
-		state: state,
+		state:                state,
+		firmwareStepDelay:    defaultFirmwareStepDelay,
+		firmwareInstallDelay: defaultFirmwareInstallDelay,
 		scheduleLocateClear: func(duration time.Duration, callback func()) func() {
 			timer := time.AfterFunc(duration, callback)
 			return func() {
@@ -641,6 +687,9 @@ func NewRESTApiHandler(state *MinerState) *RESTApiHandler {
 //   - Everything else: auth requirements still apply, but default_password_active
 //     does not block the route.
 func (h *RESTApiHandler) RegisterRoutes(mux *http.ServeMux) {
+	// This test-control route is intentionally outside the real device API.
+	mux.HandleFunc("/fake-api/v1/test/firmware-update/outcome", h.handleFakeFirmwareUpdateOutcome)
+
 	// Pools: auth required, not blocked by default_password_active per firmware.
 	// Fleet onboarding configures pools before the operator changes the password.
 	mux.HandleFunc("/api/v1/pools", h.requireBearerAuth(h.handlePools))
@@ -1587,6 +1636,7 @@ func (h *RESTApiHandler) handleSystem(w http.ResponseWriter, r *http.Request) {
 	fwCurrentVersion := h.state.FWCurrentVersion
 	fwPreviousVersion := h.state.FWPreviousVersion
 	fwNewVersion := h.state.FWNewVersion
+	fwUpdateError := h.state.FWUpdateError
 	h.state.mu.RUnlock()
 	if fwStatus == "" {
 		fwStatus = "current"
@@ -1611,7 +1661,13 @@ func (h *RESTApiHandler) handleSystem(w http.ResponseWriter, r *http.Request) {
 				GitHash:  "abc123def456",
 				Hostname: h.state.Hostname,
 			},
-			SWUpdateState: buildSystemUpdateStatus(fwStatus, fwCurrentVersion, fwPreviousVersion, fwNewVersion),
+			SWUpdateState: buildSystemUpdateStatus(
+				fwStatus,
+				fwCurrentVersion,
+				fwPreviousVersion,
+				fwNewVersion,
+				fwUpdateError,
+			),
 			MiningDriverSW: &SWInfo{
 				Name:    "mcdd",
 				Version: fwCurrentVersion,
@@ -1660,9 +1716,12 @@ func (h *RESTApiHandler) handleReboot(w http.ResponseWriter, r *http.Request) {
 	if h.state.FWUpdateStatus == "installed" && h.state.FWNewVersion != "" {
 		h.state.FWPreviousVersion = h.state.FWCurrentVersion
 		h.state.FWCurrentVersion = h.state.FWNewVersion
-		h.state.FWNewVersion = ""
 	}
+	h.state.FWNewVersion = ""
 	h.state.FWUpdateStatus = "current"
+	h.state.FWUpdateError = ""
+	h.state.FWUpdateOutcome = ""
+	h.state.FWUpdateSequence++
 	h.state.Rebooting = true
 	h.state.mu.Unlock()
 
@@ -1798,88 +1857,136 @@ func (h *RESTApiHandler) handleLogs(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func (h *RESTApiHandler) startFirmwareDownloadLifecycle() {
-	go func() {
-		time.Sleep(1 * time.Second)
+func isFirmwareUpdatePending(status string) bool {
+	switch status {
+	case "downloading", "downloaded", "installing", "installed":
+		return true
+	default:
+		return false
+	}
+}
 
-		h.state.mu.Lock()
-		if h.state.Rebooting {
-			h.state.FWUpdateStatus = "current"
-			h.state.FWNewVersion = ""
-			h.state.mu.Unlock()
-			log.Printf("[FAKE-RIG] Firmware update aborted during reboot")
+// beginFirmwareUpdateLocked starts a new lifecycle and consumes the one-shot
+// fake outcome. The caller must hold h.state.mu.
+func (h *RESTApiHandler) beginFirmwareUpdateLocked(status, newVersion string) uint64 {
+	outcome := h.state.FWNextUpdateOutcome
+	switch outcome {
+	case firmwareUpdateOutcomeError, firmwareUpdateOutcomeAttention:
+	default:
+		outcome = firmwareUpdateOutcomeSuccess
+	}
+
+	h.state.FWNextUpdateOutcome = firmwareUpdateOutcomeSuccess
+	h.state.FWUpdateOutcome = outcome
+	h.state.FWUpdateError = ""
+	h.state.FWUpdateStatus = status
+	h.state.FWNewVersion = newVersion
+	h.state.FWUpdateSequence++
+	return h.state.FWUpdateSequence
+}
+
+func (h *RESTApiHandler) transitionFirmwareStatus(sequence uint64, from, to string) bool {
+	h.state.mu.Lock()
+	defer h.state.mu.Unlock()
+
+	if h.state.Rebooting ||
+		h.state.FWUpdateSequence != sequence ||
+		h.state.FWUpdateStatus != from {
+		return false
+	}
+	h.state.FWUpdateStatus = to
+	return true
+}
+
+func (h *RESTApiHandler) completeFirmwareInstall(sequence uint64) {
+	time.Sleep(h.firmwareInstallDelay)
+
+	h.state.mu.Lock()
+	if h.state.Rebooting ||
+		h.state.FWUpdateSequence != sequence ||
+		h.state.FWUpdateStatus != "installing" {
+		h.state.mu.Unlock()
+		return
+	}
+
+	switch h.state.FWUpdateOutcome {
+	case firmwareUpdateOutcomeError:
+		h.state.FWUpdateStatus = "error"
+		h.state.FWUpdateError = firmwareUpdateFailureMessage
+	case firmwareUpdateOutcomeAttention:
+		h.state.FWUpdateStatus = "error"
+		h.state.FWUpdateError = firmwareUpdateAttentionMessage
+	default:
+		h.state.FWUpdateStatus = "installed"
+		h.state.FWUpdateError = ""
+	}
+	status := h.state.FWUpdateStatus
+	h.state.mu.Unlock()
+
+	if status == "installed" {
+		log.Printf("[FAKE-RIG] Firmware update status: installed (reboot required)")
+		return
+	}
+	log.Printf("[FAKE-RIG] Firmware update status: %s", status)
+}
+
+func (h *RESTApiHandler) startFirmwareUploadLifecycle(sequence uint64) {
+	go func() {
+		time.Sleep(h.firmwareStepDelay)
+		if !h.transitionFirmwareStatus(sequence, "downloaded", "installing") {
 			return
 		}
-		h.state.FWUpdateStatus = "downloaded"
-		h.state.mu.Unlock()
+		log.Printf("[FAKE-RIG] Firmware update status: installing")
+		h.completeFirmwareInstall(sequence)
+	}()
+}
+
+func (h *RESTApiHandler) startFirmwareOTALifecycle(sequence uint64) {
+	go func() {
+		time.Sleep(h.firmwareStepDelay)
+		if !h.transitionFirmwareStatus(sequence, "downloading", "downloaded") {
+			return
+		}
 		log.Printf("[FAKE-RIG] Firmware update status: downloaded")
+
+		time.Sleep(h.firmwareStepDelay)
+		if !h.transitionFirmwareStatus(sequence, "downloaded", "installing") {
+			return
+		}
+		log.Printf("[FAKE-RIG] Firmware update status: installing")
+		h.completeFirmwareInstall(sequence)
 	}()
 }
 
-func (h *RESTApiHandler) startFirmwareOTALifecycle() {
-	go func() {
-		time.Sleep(1 * time.Second)
-
-		h.state.mu.Lock()
-		if h.state.Rebooting {
-			h.state.FWUpdateStatus = "current"
-			h.state.FWNewVersion = ""
-			h.state.mu.Unlock()
-			log.Printf("[FAKE-RIG] Firmware update aborted during reboot")
-			return
-		}
-		h.state.FWUpdateStatus = "installing"
-		h.state.mu.Unlock()
-		log.Printf("[FAKE-RIG] Firmware update status: installing")
-
-		time.Sleep(2 * time.Second)
-
-		h.state.mu.Lock()
-		if h.state.Rebooting {
-			h.state.FWUpdateStatus = "current"
-			h.state.FWNewVersion = ""
-			h.state.mu.Unlock()
-			log.Printf("[FAKE-RIG] Firmware update aborted during reboot")
-			return
-		}
-		h.state.FWUpdateStatus = "installed"
-		h.state.mu.Unlock()
-		log.Printf("[FAKE-RIG] Firmware update status: installed (reboot required)")
-	}()
+func (h *RESTApiHandler) startFirmwareInstallLifecycle(sequence uint64) {
+	go h.completeFirmwareInstall(sequence)
 }
 
-func (h *RESTApiHandler) startFirmwareInstallLifecycle(fromDownloaded bool) {
-	go func() {
-		if fromDownloaded {
-			time.Sleep(1 * time.Second)
-		}
+func readFirmwareUploadPart(w http.ResponseWriter, r *http.Request) (*multipart.Part, error) {
+	if r.ContentLength > maxFirmwareUploadBytes {
+		return nil, fmt.Errorf("firmware upload exceeds %d bytes", maxFirmwareUploadBytes)
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, maxFirmwareUploadBytes)
+	reader, err := r.MultipartReader()
+	if err != nil {
+		return nil, fmt.Errorf("parse multipart upload: %w", err)
+	}
 
-		h.state.mu.Lock()
-		if h.state.Rebooting {
-			h.state.FWUpdateStatus = "current"
-			h.state.FWNewVersion = ""
-			h.state.mu.Unlock()
-			log.Printf("[FAKE-RIG] Firmware update aborted during reboot")
-			return
+	for {
+		part, nextErr := reader.NextPart()
+		if nextErr == io.EOF {
+			return nil, fmt.Errorf("missing file part")
 		}
-		h.state.FWUpdateStatus = "installing"
-		h.state.mu.Unlock()
-		log.Printf("[FAKE-RIG] Firmware update status: installing")
-
-		time.Sleep(2 * time.Second)
-
-		h.state.mu.Lock()
-		if h.state.Rebooting {
-			h.state.FWUpdateStatus = "current"
-			h.state.FWNewVersion = ""
-			h.state.mu.Unlock()
-			log.Printf("[FAKE-RIG] Firmware update aborted during reboot")
-			return
+		if nextErr != nil {
+			return nil, fmt.Errorf("read multipart upload: %w", nextErr)
 		}
-		h.state.FWUpdateStatus = "installed"
-		h.state.mu.Unlock()
-		log.Printf("[FAKE-RIG] Firmware update status: installed (reboot required)")
-	}()
+		if part.FormName() == "file" && part.FileName() != "" {
+			return part, nil
+		}
+		if closeErr := part.Close(); closeErr != nil {
+			return nil, fmt.Errorf("skip multipart field: %w", closeErr)
+		}
+	}
 }
 
 func (h *RESTApiHandler) handleUpdate(w http.ResponseWriter, r *http.Request) {
@@ -1903,22 +2010,26 @@ func (h *RESTApiHandler) handleUpdate(w http.ResponseWriter, r *http.Request) {
 			currentVersion = defaultFirmwareVersion
 		}
 
-		if h.state.FWNewVersion == "" {
-			h.state.FWNewVersion = nextFirmwareVersion(currentVersion)
-		}
-
 		installFromDownloaded := h.state.FWUpdateStatus == "downloaded"
+		var sequence uint64
 		if installFromDownloaded {
 			h.state.FWUpdateStatus = "installing"
+			if h.state.FWUpdateSequence == 0 {
+				h.state.FWUpdateSequence++
+			}
+			if h.state.FWUpdateOutcome == "" {
+				h.state.FWUpdateOutcome = firmwareUpdateOutcomeSuccess
+			}
+			sequence = h.state.FWUpdateSequence
 		} else {
-			h.state.FWUpdateStatus = "downloading"
+			sequence = h.beginFirmwareUpdateLocked("downloading", nextFirmwareVersion(currentVersion))
 		}
 		h.state.mu.Unlock()
 
 		if installFromDownloaded {
-			h.startFirmwareInstallLifecycle(true)
+			h.startFirmwareInstallLifecycle(sequence)
 		} else {
-			h.startFirmwareOTALifecycle()
+			h.startFirmwareOTALifecycle(sequence)
 		}
 		h.writeJSON(w, http.StatusAccepted, MessageResponse{Message: "Update started"})
 	case http.MethodPut:
@@ -1935,47 +2046,85 @@ func (h *RESTApiHandler) handleUpdate(w http.ResponseWriter, r *http.Request) {
 			h.writeJSON(w, http.StatusServiceUnavailable, MessageResponse{Message: "System reboot is in progress."})
 			return
 		}
-		// Reject re-uploads whenever an update is pending (downloaded/installing)
-		// OR has already completed install and is awaiting reboot. Treating
-		// "installed" as in-progress prevents a second upload from clobbering
-		// FWUpdateStatus/FWNewVersion and causing handleReboot to skip promotion.
-		switch h.state.FWUpdateStatus {
-		case "downloading", "downloaded", "installing", "installed":
+		if isFirmwareUpdatePending(h.state.FWUpdateStatus) {
 			h.state.mu.Unlock()
 			h.writeJSON(w, http.StatusConflict, MessageResponse{Message: "System update is already in progress."})
 			return
 		}
 		h.state.mu.Unlock()
 
-		file, header, err := r.FormFile("file")
+		file, err := readFirmwareUploadPart(w, r)
 		if err != nil {
 			h.writeError(w, http.StatusBadRequest, "BAD_REQUEST", "Missing or invalid 'file' field in multipart form")
 			return
 		}
-		defer file.Close()
+
+		h.state.mu.RLock()
+		currentVersion := h.state.FWCurrentVersion
+		h.state.mu.RUnlock()
+		if currentVersion == "" {
+			currentVersion = defaultFirmwareVersion
+		}
+		newVersion, err := stagedFirmwareVersion(file.FileName(), file, currentVersion)
+		if err != nil {
+			h.writeError(w, http.StatusBadRequest, "BAD_REQUEST", "Unable to inspect firmware upload")
+			return
+		}
 
 		h.state.mu.Lock()
-		switch h.state.FWUpdateStatus {
-		case "downloading", "downloaded", "installing", "installed":
+		if h.state.Rebooting {
+			h.state.mu.Unlock()
+			h.writeJSON(w, http.StatusServiceUnavailable, MessageResponse{Message: "System reboot is in progress."})
+			return
+		}
+		if isFirmwareUpdatePending(h.state.FWUpdateStatus) {
 			h.state.mu.Unlock()
 			h.writeJSON(w, http.StatusConflict, MessageResponse{Message: "System update is already in progress."})
 			return
 		}
-		currentVersion := h.state.FWCurrentVersion
-		if currentVersion == "" {
-			currentVersion = defaultFirmwareVersion
-		}
-		h.state.FWUpdateStatus = "downloading"
-		h.state.FWNewVersion = stagedFirmwareVersion(header.Filename, currentVersion)
+		sequence := h.beginFirmwareUpdateLocked("downloaded", newVersion)
 		h.state.mu.Unlock()
 
-		log.Printf("Firmware upload received: filename=%s, size=%d", header.Filename, header.Size)
-		h.startFirmwareOTALifecycle()
+		log.Printf("Firmware upload received: filename=%s", file.FileName())
+		h.startFirmwareUploadLifecycle(sequence)
 
 		h.writeJSON(w, http.StatusOK, MessageResponse{Message: "Firmware uploaded successfully"})
 	default:
 		h.writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Method not allowed")
 	}
+}
+
+func (h *RESTApiHandler) handleFakeFirmwareUpdateOutcome(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPut {
+		h.writeError(w, http.StatusMethodNotAllowed, "METHOD_NOT_ALLOWED", "Method not allowed")
+		return
+	}
+
+	var request struct {
+		Outcome string `json:"outcome"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		h.writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
+		return
+	}
+
+	outcome := strings.ToLower(strings.TrimSpace(request.Outcome))
+	switch outcome {
+	case firmwareUpdateOutcomeSuccess, firmwareUpdateOutcomeError, firmwareUpdateOutcomeAttention:
+	default:
+		h.writeError(
+			w,
+			http.StatusUnprocessableEntity,
+			"INVALID_REQUEST",
+			"outcome must be success, error, or attention",
+		)
+		return
+	}
+
+	h.state.mu.Lock()
+	h.state.FWNextUpdateOutcome = outcome
+	h.state.mu.Unlock()
+	h.writeJSON(w, http.StatusOK, map[string]string{"next_outcome": outcome})
 }
 
 func (h *RESTApiHandler) handleUpdateCheck(w http.ResponseWriter, r *http.Request) {

--- a/server/fake-proto-rig/rest_api_handler.go
+++ b/server/fake-proto-rig/rest_api_handler.go
@@ -661,6 +661,7 @@ type RESTApiHandler struct {
 	locateTimerMu        sync.Mutex
 	cancelLocateTimer    func()
 	scheduleLocateClear  func(time.Duration, func()) func()
+	firmwareUploadLimit  int64
 	firmwareStepDelay    time.Duration
 	firmwareInstallDelay time.Duration
 }
@@ -670,6 +671,7 @@ func NewRESTApiHandler(state *MinerState) *RESTApiHandler {
 	return &RESTApiHandler{
 		state:                state,
 		testControlsEnabled:  getEnvBool(fakeRigEnableTestControlsEnv, false),
+		firmwareUploadLimit:  maxFirmwareUploadBytes,
 		firmwareStepDelay:    defaultFirmwareStepDelay,
 		firmwareInstallDelay: defaultFirmwareInstallDelay,
 		scheduleLocateClear: func(duration time.Duration, callback func()) func() {
@@ -1972,11 +1974,36 @@ func (h *RESTApiHandler) startFirmwareInstallLifecycle(sequence uint64) {
 	go h.completeFirmwareInstall(sequence)
 }
 
-func readFirmwareUploadPart(w http.ResponseWriter, r *http.Request) (*multipart.Part, error) {
-	if r.ContentLength > maxFirmwareUploadBytes {
-		return nil, fmt.Errorf("firmware upload exceeds %d bytes", maxFirmwareUploadBytes)
+var errFirmwareUploadTooLarge = errors.New("firmware upload is too large")
+
+type firmwareUpload struct {
+	body   io.Reader
+	reader *multipart.Reader
+	file   *multipart.Part
+}
+
+func normalizeFirmwareUploadError(err error) error {
+	if err == nil {
+		return nil
 	}
-	r.Body = http.MaxBytesReader(w, r.Body, maxFirmwareUploadBytes)
+
+	var maxBytesError *http.MaxBytesError
+	if errors.As(err, &maxBytesError) {
+		return fmt.Errorf("%w: %v", errFirmwareUploadTooLarge, err)
+	}
+	return err
+}
+
+func readFirmwareUploadPart(w http.ResponseWriter, r *http.Request, limit int64) (*firmwareUpload, error) {
+	if r.ContentLength > limit {
+		return nil, fmt.Errorf(
+			"%w: declared content length %d exceeds %d bytes",
+			errFirmwareUploadTooLarge,
+			r.ContentLength,
+			limit,
+		)
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, limit)
 	reader, err := r.MultipartReader()
 	if err != nil {
 		return nil, fmt.Errorf("parse multipart upload: %w", err)
@@ -1988,15 +2015,64 @@ func readFirmwareUploadPart(w http.ResponseWriter, r *http.Request) (*multipart.
 			return nil, fmt.Errorf("missing file part")
 		}
 		if nextErr != nil {
-			return nil, fmt.Errorf("read multipart upload: %w", nextErr)
+			return nil, fmt.Errorf("read multipart upload: %w", normalizeFirmwareUploadError(nextErr))
 		}
 		if part.FormName() == "file" && part.FileName() != "" {
-			return part, nil
+			return &firmwareUpload{
+				body:   r.Body,
+				reader: reader,
+				file:   part,
+			}, nil
 		}
 		if closeErr := part.Close(); closeErr != nil {
-			return nil, fmt.Errorf("skip multipart field: %w", closeErr)
+			return nil, fmt.Errorf("skip multipart field: %w", normalizeFirmwareUploadError(closeErr))
 		}
 	}
+}
+
+func consumeFirmwareUpload(upload *firmwareUpload) error {
+	if _, err := io.Copy(io.Discard, upload.file); err != nil {
+		_ = upload.file.Close()
+		return fmt.Errorf("read firmware file: %w", normalizeFirmwareUploadError(err))
+	}
+	if err := upload.file.Close(); err != nil {
+		return fmt.Errorf("close firmware file: %w", normalizeFirmwareUploadError(err))
+	}
+
+	for {
+		part, err := upload.reader.NextPart()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("read trailing multipart part: %w", normalizeFirmwareUploadError(err))
+		}
+		if _, err := io.Copy(io.Discard, part); err != nil {
+			_ = part.Close()
+			return fmt.Errorf("read trailing multipart data: %w", normalizeFirmwareUploadError(err))
+		}
+		if err := part.Close(); err != nil {
+			return fmt.Errorf("close trailing multipart part: %w", normalizeFirmwareUploadError(err))
+		}
+	}
+
+	if _, err := io.Copy(io.Discard, upload.body); err != nil {
+		return fmt.Errorf("read multipart body through EOF: %w", normalizeFirmwareUploadError(err))
+	}
+	return nil
+}
+
+func (h *RESTApiHandler) writeFirmwareUploadError(w http.ResponseWriter, err error, malformedMessage string) {
+	if errors.Is(err, errFirmwareUploadTooLarge) {
+		h.writeError(
+			w,
+			http.StatusRequestEntityTooLarge,
+			"REQUEST_TOO_LARGE",
+			"Firmware upload exceeds the 512 MiB limit",
+		)
+		return
+	}
+	h.writeError(w, http.StatusBadRequest, "BAD_REQUEST", malformedMessage)
 }
 
 func (h *RESTApiHandler) handleUpdate(w http.ResponseWriter, r *http.Request) {
@@ -2063,26 +2139,22 @@ func (h *RESTApiHandler) handleUpdate(w http.ResponseWriter, r *http.Request) {
 		}
 		h.state.mu.Unlock()
 
-		file, err := readFirmwareUploadPart(w, r)
+		upload, err := readFirmwareUploadPart(w, r, h.firmwareUploadLimit)
 		if err != nil {
-			h.writeError(w, http.StatusBadRequest, "BAD_REQUEST", "Missing or invalid 'file' field in multipart form")
+			h.writeFirmwareUploadError(w, err, "Missing or invalid 'file' field in multipart form")
 			return
 		}
 
+		file := upload.file
 		filename := file.FileName()
 		explicitVersion, hasExplicitVersion, err := explicitFirmwareVersion(filename, file)
 		if err != nil {
 			_ = file.Close()
-			h.writeError(w, http.StatusBadRequest, "BAD_REQUEST", "Unable to inspect firmware upload")
+			h.writeFirmwareUploadError(w, normalizeFirmwareUploadError(err), "Unable to inspect firmware upload")
 			return
 		}
-		if _, err := io.Copy(io.Discard, file); err != nil {
-			_ = file.Close()
-			h.writeError(w, http.StatusBadRequest, "BAD_REQUEST", "Unable to read firmware upload")
-			return
-		}
-		if err := file.Close(); err != nil {
-			h.writeError(w, http.StatusBadRequest, "BAD_REQUEST", "Unable to close firmware upload")
+		if err := consumeFirmwareUpload(upload); err != nil {
+			h.writeFirmwareUploadError(w, err, "Unable to read complete firmware upload")
 			return
 		}
 

--- a/server/fake-proto-rig/rest_api_handler.go
+++ b/server/fake-proto-rig/rest_api_handler.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -27,8 +28,10 @@ const (
 	maxLocateLEDOnTimeSecs               = 300
 	firmwareVersionScanLimit       int64 = 64 * 1024
 	maxFirmwareUploadBytes         int64 = 512 * 1024 * 1024
+	maxTestControlRequestBytes     int64 = 1024
 	defaultFirmwareStepDelay             = 1 * time.Second
 	defaultFirmwareInstallDelay          = 2 * time.Second
+	fakeRigEnableTestControlsEnv         = "FAKE_RIG_ENABLE_TEST_CONTROLS"
 	firmwareUpdateOutcomeSuccess         = "success"
 	firmwareUpdateOutcomeError           = "error"
 	firmwareUpdateOutcomeAttention       = "attention"
@@ -236,16 +239,16 @@ func firmwareVersionFromContent(content io.Reader) (string, bool, error) {
 	return "", false, nil
 }
 
-func stagedFirmwareVersion(filename string, content io.Reader, currentVersion string) (string, error) {
+func explicitFirmwareVersion(filename string, content io.Reader) (string, bool, error) {
 	if version, ok := firmwareVersionFromFilename(filename); ok {
-		return version, nil
+		return version, true, nil
 	}
 	if version, ok, err := firmwareVersionFromContent(content); err != nil {
-		return "", err
+		return "", false, err
 	} else if ok {
-		return version, nil
+		return version, true, nil
 	}
-	return nextFirmwareVersion(currentVersion), nil
+	return "", false, nil
 }
 
 func buildSystemUpdateStatus(status, currentVersion, previousVersion, newVersion, updateError string) UpdateStatus {
@@ -654,6 +657,7 @@ type PSUTelemetry struct {
 // RESTApiHandler handles REST API requests
 type RESTApiHandler struct {
 	state                *MinerState
+	testControlsEnabled  bool
 	locateTimerMu        sync.Mutex
 	cancelLocateTimer    func()
 	scheduleLocateClear  func(time.Duration, func()) func()
@@ -665,6 +669,7 @@ type RESTApiHandler struct {
 func NewRESTApiHandler(state *MinerState) *RESTApiHandler {
 	return &RESTApiHandler{
 		state:                state,
+		testControlsEnabled:  getEnvBool(fakeRigEnableTestControlsEnv, false),
 		firmwareStepDelay:    defaultFirmwareStepDelay,
 		firmwareInstallDelay: defaultFirmwareInstallDelay,
 		scheduleLocateClear: func(duration time.Duration, callback func()) func() {
@@ -687,8 +692,13 @@ func NewRESTApiHandler(state *MinerState) *RESTApiHandler {
 //   - Everything else: auth requirements still apply, but default_password_active
 //     does not block the route.
 func (h *RESTApiHandler) RegisterRoutes(mux *http.ServeMux) {
-	// This test-control route is intentionally outside the real device API.
-	mux.HandleFunc("/fake-api/v1/test/firmware-update/outcome", h.handleFakeFirmwareUpdateOutcome)
+	if h.testControlsEnabled {
+		// This authenticated test-control route is intentionally outside the real device API.
+		mux.HandleFunc(
+			"/fake-api/v1/test/firmware-update/outcome",
+			h.requireBearerAuth(h.handleFakeFirmwareUpdateOutcome),
+		)
+	}
 
 	// Pools: auth required, not blocked by default_password_active per firmware.
 	// Fleet onboarding configures pools before the operator changes the password.
@@ -2059,13 +2069,8 @@ func (h *RESTApiHandler) handleUpdate(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		h.state.mu.RLock()
-		currentVersion := h.state.FWCurrentVersion
-		h.state.mu.RUnlock()
-		if currentVersion == "" {
-			currentVersion = defaultFirmwareVersion
-		}
-		newVersion, err := stagedFirmwareVersion(file.FileName(), file, currentVersion)
+		filename := file.FileName()
+		explicitVersion, hasExplicitVersion, err := explicitFirmwareVersion(filename, file)
 		if err != nil {
 			_ = file.Close()
 			h.writeError(w, http.StatusBadRequest, "BAD_REQUEST", "Unable to inspect firmware upload")
@@ -2092,10 +2097,18 @@ func (h *RESTApiHandler) handleUpdate(w http.ResponseWriter, r *http.Request) {
 			h.writeJSON(w, http.StatusConflict, MessageResponse{Message: "System update is already in progress."})
 			return
 		}
+		newVersion := explicitVersion
+		if !hasExplicitVersion {
+			currentVersion := h.state.FWCurrentVersion
+			if currentVersion == "" {
+				currentVersion = defaultFirmwareVersion
+			}
+			newVersion = nextFirmwareVersion(currentVersion)
+		}
 		sequence := h.beginFirmwareUpdateLocked("downloaded", newVersion)
 		h.state.mu.Unlock()
 
-		log.Printf("Firmware upload received: filename=%s", file.FileName())
+		log.Printf("Firmware upload received: filename=%s", filename)
 		h.startFirmwareUploadLifecycle(sequence)
 
 		h.writeJSON(w, http.StatusOK, MessageResponse{Message: "Firmware uploaded successfully"})
@@ -2113,8 +2126,24 @@ func (h *RESTApiHandler) handleFakeFirmwareUpdateOutcome(w http.ResponseWriter, 
 	var request struct {
 		Outcome string `json:"outcome"`
 	}
-	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+	r.Body = http.MaxBytesReader(w, r.Body, maxTestControlRequestBytes)
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&request); err != nil {
+		var maxBytesError *http.MaxBytesError
+		if errors.As(err, &maxBytesError) {
+			h.writeError(w, http.StatusRequestEntityTooLarge, "REQUEST_TOO_LARGE", "Request body is too large")
+			return
+		}
 		h.writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "Invalid request body")
+		return
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		var maxBytesError *http.MaxBytesError
+		if errors.As(err, &maxBytesError) {
+			h.writeError(w, http.StatusRequestEntityTooLarge, "REQUEST_TOO_LARGE", "Request body is too large")
+			return
+		}
+		h.writeError(w, http.StatusBadRequest, "INVALID_REQUEST", "Request body must contain exactly one JSON value")
 		return
 	}
 

--- a/server/fake-proto-rig/rest_api_handler.go
+++ b/server/fake-proto-rig/rest_api_handler.go
@@ -2067,7 +2067,17 @@ func (h *RESTApiHandler) handleUpdate(w http.ResponseWriter, r *http.Request) {
 		}
 		newVersion, err := stagedFirmwareVersion(file.FileName(), file, currentVersion)
 		if err != nil {
+			_ = file.Close()
 			h.writeError(w, http.StatusBadRequest, "BAD_REQUEST", "Unable to inspect firmware upload")
+			return
+		}
+		if _, err := io.Copy(io.Discard, file); err != nil {
+			_ = file.Close()
+			h.writeError(w, http.StatusBadRequest, "BAD_REQUEST", "Unable to read firmware upload")
+			return
+		}
+		if err := file.Close(); err != nil {
+			h.writeError(w, http.StatusBadRequest, "BAD_REQUEST", "Unable to close firmware upload")
 			return
 		}
 

--- a/server/fake-proto-rig/rest_api_handler_test.go
+++ b/server/fake-proto-rig/rest_api_handler_test.go
@@ -7,12 +7,15 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"testing/iotest"
 	"time"
 )
 
@@ -2945,6 +2948,250 @@ func newFirmwareUploadRequest(t *testing.T, filename, content string) *http.Requ
 	req := httptest.NewRequest(http.MethodPut, "/api/v1/system/update", &body)
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	return req
+}
+
+func TestHandleUpdate_PutConsumesCompleteStreamBeforeResponding(t *testing.T) {
+	tests := []struct {
+		name             string
+		filename         string
+		contentVersion   string
+		wantVersion      string
+		pauseAfterHeader bool
+	}{
+		{
+			name:           "content version",
+			filename:       "protoos-update.swu",
+			contentVersion: "3.4.5",
+			wantVersion:    "3.4.5",
+		},
+		{
+			name:             "filename version wins",
+			filename:         "protoos-2.4.6.swu",
+			contentVersion:   "9.9.9",
+			wantVersion:      "2.4.6",
+			pauseAfterHeader: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := NewMinerState("SN12345678", "00:11:22:33:44:55")
+			state.mu.Lock()
+			state.FWNextUpdateOutcome = firmwareUpdateOutcomeAttention
+			state.mu.Unlock()
+
+			h := NewRESTApiHandler(state)
+			h.firmwareStepDelay = time.Hour
+
+			uploadReader, uploadWriter := io.Pipe()
+			multipartWriter := multipart.NewWriter(uploadWriter)
+			req := httptest.NewRequest(http.MethodPut, "/api/v1/system/update", uploadReader)
+			req.Header.Set("Content-Type", multipartWriter.FormDataContentType())
+			rr := httptest.NewRecorder()
+
+			streamPaused := make(chan struct{})
+			resumeStream := make(chan struct{})
+			writerDone := make(chan error, 1)
+			go func() {
+				part, err := multipartWriter.CreateFormFile("file", tt.filename)
+				if err != nil {
+					_ = uploadWriter.CloseWithError(err)
+					writerDone <- err
+					return
+				}
+
+				if tt.pauseAfterHeader {
+					close(streamPaused)
+					<-resumeStream
+				}
+
+				marker := "firmware_version=" + tt.contentVersion + "\n"
+				prefix := marker + strings.Repeat("x", int(firmwareVersionScanLimit)-len(marker))
+				if _, err = io.WriteString(part, prefix); err != nil {
+					_ = uploadWriter.CloseWithError(err)
+					writerDone <- err
+					return
+				}
+
+				if !tt.pauseAfterHeader {
+					close(streamPaused)
+					<-resumeStream
+				}
+
+				if _, err = io.WriteString(part, strings.Repeat("y", int(4*firmwareVersionScanLimit))); err != nil {
+					_ = uploadWriter.CloseWithError(err)
+					writerDone <- err
+					return
+				}
+				if err = multipartWriter.Close(); err != nil {
+					_ = uploadWriter.CloseWithError(err)
+					writerDone <- err
+					return
+				}
+				writerDone <- uploadWriter.Close()
+			}()
+
+			handlerDone := make(chan struct{})
+			go func() {
+				h.handleUpdate(rr, req)
+				_ = uploadReader.Close()
+				close(handlerDone)
+			}()
+
+			select {
+			case <-streamPaused:
+			case <-time.After(time.Second):
+				t.Fatal("timed out waiting for the upload stream to pause")
+			}
+
+			respondedEarly := false
+			select {
+			case <-handlerDone:
+				respondedEarly = true
+			case <-time.After(50 * time.Millisecond):
+			}
+
+			state.mu.RLock()
+			statusBeforeCompletion := state.FWUpdateStatus
+			versionBeforeCompletion := state.FWNewVersion
+			outcomeBeforeCompletion := state.FWNextUpdateOutcome
+			state.mu.RUnlock()
+
+			close(resumeStream)
+
+			var writerErr error
+			select {
+			case writerErr = <-writerDone:
+			case <-time.After(time.Second):
+				t.Fatal("timed out waiting for the upload writer")
+			}
+			if !respondedEarly {
+				select {
+				case <-handlerDone:
+				case <-time.After(time.Second):
+					t.Fatal("timed out waiting for the upload handler")
+				}
+			}
+
+			if respondedEarly {
+				t.Error("handler responded before the complete multipart file was available")
+			}
+			if statusBeforeCompletion != "" {
+				t.Errorf("firmware lifecycle started before upload completion: status=%q", statusBeforeCompletion)
+			}
+			if versionBeforeCompletion != "" {
+				t.Errorf("firmware version staged before upload completion: version=%q", versionBeforeCompletion)
+			}
+			if outcomeBeforeCompletion != firmwareUpdateOutcomeAttention {
+				t.Errorf("one-shot outcome consumed before upload completion: got %q", outcomeBeforeCompletion)
+			}
+			if writerErr != nil {
+				t.Errorf("upload writer failed before sending the complete file: %v", writerErr)
+			}
+			if rr.Code != http.StatusOK {
+				t.Fatalf("expected %d, got %d; body=%s", http.StatusOK, rr.Code, rr.Body.String())
+			}
+
+			state.mu.RLock()
+			gotStatus := state.FWUpdateStatus
+			gotVersion := state.FWNewVersion
+			gotNextOutcome := state.FWNextUpdateOutcome
+			state.mu.RUnlock()
+			if gotStatus != "downloaded" {
+				t.Errorf("expected status %q after complete upload, got %q", "downloaded", gotStatus)
+			}
+			if gotVersion != tt.wantVersion {
+				t.Errorf("expected staged version %q, got %q", tt.wantVersion, gotVersion)
+			}
+			if gotNextOutcome != firmwareUpdateOutcomeSuccess {
+				t.Errorf("expected one-shot outcome to reset after complete upload, got %q", gotNextOutcome)
+			}
+		})
+	}
+}
+
+func TestHandleUpdate_PutStreamFailureDoesNotMutateFirmwareState(t *testing.T) {
+	state := NewMinerState("SN12345678", "00:11:22:33:44:55")
+	state.mu.Lock()
+	state.FWNextUpdateOutcome = firmwareUpdateOutcomeAttention
+	state.mu.Unlock()
+	h := NewRESTApiHandler(state)
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, err := writer.CreateFormFile("file", "protoos-update.swu")
+	if err != nil {
+		t.Fatalf("failed to create multipart file: %v", err)
+	}
+	marker := "firmware_version=4.5.6\n"
+	payload := marker + strings.Repeat("x", int(2*firmwareVersionScanLimit)-len(marker))
+	if _, err = io.WriteString(part, payload); err != nil {
+		t.Fatalf("failed to write multipart file: %v", err)
+	}
+	if err = writer.Close(); err != nil {
+		t.Fatalf("failed to close multipart writer: %v", err)
+	}
+
+	payloadOffset := bytes.Index(body.Bytes(), []byte(marker))
+	if payloadOffset < 0 {
+		t.Fatal("failed to locate firmware payload in multipart body")
+	}
+	streamErr := errors.New("simulated upload stream failure")
+	readBeforeFailure := int64(payloadOffset) + firmwareVersionScanLimit
+	interruptedBody := io.MultiReader(
+		io.LimitReader(bytes.NewReader(body.Bytes()), readBeforeFailure),
+		iotest.ErrReader(streamErr),
+	)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/system/update", interruptedBody)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	rr := httptest.NewRecorder()
+
+	h.handleUpdate(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected %d for interrupted upload, got %d; body=%s",
+			http.StatusBadRequest, rr.Code, rr.Body.String())
+	}
+	state.mu.RLock()
+	defer state.mu.RUnlock()
+	if state.FWUpdateStatus != "" {
+		t.Errorf("expected no firmware lifecycle after stream failure, got status %q", state.FWUpdateStatus)
+	}
+	if state.FWNewVersion != "" {
+		t.Errorf("expected no staged version after stream failure, got %q", state.FWNewVersion)
+	}
+	if state.FWNextUpdateOutcome != firmwareUpdateOutcomeAttention {
+		t.Errorf("expected stream failure not to consume one-shot outcome, got %q", state.FWNextUpdateOutcome)
+	}
+}
+
+func TestHandleUpdate_PutOversizeDeclarationDoesNotMutateFirmwareState(t *testing.T) {
+	state := NewMinerState("SN12345678", "00:11:22:33:44:55")
+	state.mu.Lock()
+	state.FWNextUpdateOutcome = firmwareUpdateOutcomeAttention
+	state.mu.Unlock()
+	h := NewRESTApiHandler(state)
+
+	req := newFirmwareUploadRequest(t, "protoos-2.4.6.swu", "fake firmware bundle")
+	req.ContentLength = maxFirmwareUploadBytes + 1
+	rr := httptest.NewRecorder()
+	h.handleUpdate(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected %d for oversized upload, got %d; body=%s",
+			http.StatusBadRequest, rr.Code, rr.Body.String())
+	}
+	state.mu.RLock()
+	defer state.mu.RUnlock()
+	if state.FWUpdateStatus != "" {
+		t.Errorf("expected no firmware lifecycle after size failure, got status %q", state.FWUpdateStatus)
+	}
+	if state.FWNewVersion != "" {
+		t.Errorf("expected no staged version after size failure, got %q", state.FWNewVersion)
+	}
+	if state.FWNextUpdateOutcome != firmwareUpdateOutcomeAttention {
+		t.Errorf("expected size failure not to consume one-shot outcome, got %q", state.FWNextUpdateOutcome)
+	}
 }
 
 func getFirmwareStatus(state *MinerState) string {

--- a/server/fake-proto-rig/rest_api_handler_test.go
+++ b/server/fake-proto-rig/rest_api_handler_test.go
@@ -2957,6 +2957,22 @@ func newFirmwareUploadRequest(t *testing.T, filename, content string) *http.Requ
 	return req
 }
 
+func assertFirmwareUploadDidNotMutateState(t *testing.T, state *MinerState, wantNextOutcome string) {
+	t.Helper()
+
+	state.mu.RLock()
+	defer state.mu.RUnlock()
+	if state.FWUpdateStatus != "" {
+		t.Errorf("expected no firmware lifecycle, got status %q", state.FWUpdateStatus)
+	}
+	if state.FWNewVersion != "" {
+		t.Errorf("expected no staged version, got %q", state.FWNewVersion)
+	}
+	if state.FWNextUpdateOutcome != wantNextOutcome {
+		t.Errorf("expected one-shot outcome to remain %q, got %q", wantNextOutcome, state.FWNextUpdateOutcome)
+	}
+}
+
 func TestHandleUpdate_PutConsumesCompleteStreamBeforeResponding(t *testing.T) {
 	tests := []struct {
 		name             string
@@ -3113,6 +3129,188 @@ func TestHandleUpdate_PutConsumesCompleteStreamBeforeResponding(t *testing.T) {
 			if gotNextOutcome != firmwareUpdateOutcomeSuccess {
 				t.Errorf("expected one-shot outcome to reset after complete upload, got %q", gotNextOutcome)
 			}
+		})
+	}
+}
+
+func TestHandleUpdate_PutConsumesTrailingPartsBeforeResponding(t *testing.T) {
+	state := NewMinerState("SN12345678", "00:11:22:33:44:55")
+	state.mu.Lock()
+	state.FWNextUpdateOutcome = firmwareUpdateOutcomeAttention
+	state.mu.Unlock()
+
+	h := NewRESTApiHandler(state)
+	h.firmwareStepDelay = time.Hour
+
+	uploadReader, uploadWriter := io.Pipe()
+	multipartWriter := multipart.NewWriter(uploadWriter)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/system/update", uploadReader)
+	req.Header.Set("Content-Type", multipartWriter.FormDataContentType())
+	rr := httptest.NewRecorder()
+
+	trailingPartPaused := make(chan struct{})
+	resumeTrailingPart := make(chan struct{})
+	finalBoundaryWritten := make(chan struct{})
+	closeUploadStream := make(chan struct{})
+	writerDone := make(chan error, 1)
+	go func() {
+		file, err := multipartWriter.CreateFormFile("file", "protoos-2.4.6.swu")
+		if err != nil {
+			_ = uploadWriter.CloseWithError(err)
+			writerDone <- err
+			return
+		}
+		if _, err = io.WriteString(file, "fake firmware bundle"); err != nil {
+			_ = uploadWriter.CloseWithError(err)
+			writerDone <- err
+			return
+		}
+
+		trailing, err := multipartWriter.CreateFormField("metadata")
+		if err != nil {
+			_ = uploadWriter.CloseWithError(err)
+			writerDone <- err
+			return
+		}
+		if _, err = io.WriteString(trailing, "metadata-start"); err != nil {
+			_ = uploadWriter.CloseWithError(err)
+			writerDone <- err
+			return
+		}
+		close(trailingPartPaused)
+		<-resumeTrailingPart
+		if _, err = io.WriteString(trailing, "-and-end"); err != nil {
+			_ = uploadWriter.CloseWithError(err)
+			writerDone <- err
+			return
+		}
+		if err = multipartWriter.Close(); err != nil {
+			_ = uploadWriter.CloseWithError(err)
+			writerDone <- err
+			return
+		}
+		close(finalBoundaryWritten)
+		<-closeUploadStream
+		writerDone <- uploadWriter.Close()
+	}()
+
+	handlerDone := make(chan struct{})
+	go func() {
+		h.handleUpdate(rr, req)
+		_ = uploadReader.Close()
+		close(handlerDone)
+	}()
+
+	select {
+	case <-trailingPartPaused:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for trailing multipart part to pause")
+	}
+
+	select {
+	case <-handlerDone:
+		t.Fatal("handler responded before the trailing multipart part reached final EOF")
+	case <-time.After(50 * time.Millisecond):
+	}
+	assertFirmwareUploadDidNotMutateState(t, state, firmwareUpdateOutcomeAttention)
+
+	close(resumeTrailingPart)
+	select {
+	case <-finalBoundaryWritten:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for final multipart boundary")
+	}
+	select {
+	case <-handlerDone:
+		t.Fatal("handler responded before the upload stream reached EOF")
+	case <-time.After(50 * time.Millisecond):
+	}
+	assertFirmwareUploadDidNotMutateState(t, state, firmwareUpdateOutcomeAttention)
+
+	close(closeUploadStream)
+	select {
+	case err := <-writerDone:
+		if err != nil {
+			t.Fatalf("upload writer failed: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for upload writer")
+	}
+	select {
+	case <-handlerDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for upload handler")
+	}
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected %d, got %d; body=%s", http.StatusOK, rr.Code, rr.Body.String())
+	}
+	state.mu.RLock()
+	defer state.mu.RUnlock()
+	if state.FWUpdateStatus != "downloaded" {
+		t.Errorf("expected status %q after complete upload, got %q", "downloaded", state.FWUpdateStatus)
+	}
+	if state.FWNewVersion != "2.4.6" {
+		t.Errorf("expected staged version %q, got %q", "2.4.6", state.FWNewVersion)
+	}
+	if state.FWNextUpdateOutcome != firmwareUpdateOutcomeSuccess {
+		t.Errorf("expected one-shot outcome to reset after complete upload, got %q", state.FWNextUpdateOutcome)
+	}
+}
+
+func TestHandleUpdate_PutRejectsInvalidMultipartRemainder(t *testing.T) {
+	tests := []struct {
+		name      string
+		remainder func(boundary string) string
+	}{
+		{
+			name: "missing final boundary",
+			remainder: func(boundary string) string {
+				return "\r\n--" + boundary + "\r\n" +
+					"Content-Disposition: form-data; name=\"metadata\"\r\n\r\n" +
+					"truncated trailing data"
+			},
+		},
+		{
+			name: "malformed trailing part headers",
+			remainder: func(boundary string) string {
+				return "\r\n--" + boundary + "\r\n" +
+					"not-a-valid-mime-header\r\n\r\n" +
+					"trailing data\r\n--" + boundary + "--\r\n"
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := NewMinerState("SN12345678", "00:11:22:33:44:55")
+			state.mu.Lock()
+			state.FWNextUpdateOutcome = firmwareUpdateOutcomeAttention
+			state.mu.Unlock()
+			h := NewRESTApiHandler(state)
+
+			var body bytes.Buffer
+			writer := multipart.NewWriter(&body)
+			file, err := writer.CreateFormFile("file", "protoos-2.4.6.swu")
+			if err != nil {
+				t.Fatalf("failed to create multipart file: %v", err)
+			}
+			if _, err = io.WriteString(file, "fake firmware bundle"); err != nil {
+				t.Fatalf("failed to write multipart file: %v", err)
+			}
+			if _, err = io.WriteString(&body, tt.remainder(writer.Boundary())); err != nil {
+				t.Fatalf("failed to write multipart remainder: %v", err)
+			}
+
+			req := httptest.NewRequest(http.MethodPut, "/api/v1/system/update", &body)
+			req.Header.Set("Content-Type", writer.FormDataContentType())
+			rr := httptest.NewRecorder()
+			h.handleUpdate(rr, req)
+
+			if rr.Code != http.StatusBadRequest {
+				t.Errorf("expected %d, got %d; body=%s", http.StatusBadRequest, rr.Code, rr.Body.String())
+			}
+			assertFirmwareUploadDidNotMutateState(t, state, firmwareUpdateOutcomeAttention)
 		})
 	}
 }
@@ -3275,20 +3473,84 @@ func TestHandleUpdate_PutOversizeDeclarationDoesNotMutateFirmwareState(t *testin
 	rr := httptest.NewRecorder()
 	h.handleUpdate(rr, req)
 
-	if rr.Code != http.StatusBadRequest {
+	if rr.Code != http.StatusRequestEntityTooLarge {
 		t.Errorf("expected %d for oversized upload, got %d; body=%s",
-			http.StatusBadRequest, rr.Code, rr.Body.String())
+			http.StatusRequestEntityTooLarge, rr.Code, rr.Body.String())
 	}
-	state.mu.RLock()
-	defer state.mu.RUnlock()
-	if state.FWUpdateStatus != "" {
-		t.Errorf("expected no firmware lifecycle after size failure, got status %q", state.FWUpdateStatus)
+	assertFirmwareUploadDidNotMutateState(t, state, firmwareUpdateOutcomeAttention)
+}
+
+func TestHandleUpdate_PutStreamedOversizeDoesNotMutateFirmwareState(t *testing.T) {
+	const uploadLimit = int64(1024)
+
+	tests := []struct {
+		name      string
+		writeBody func(t *testing.T, writer *multipart.Writer)
+	}{
+		{
+			name: "file part",
+			writeBody: func(t *testing.T, writer *multipart.Writer) {
+				t.Helper()
+				file, err := writer.CreateFormFile("file", "protoos-2.4.6.swu")
+				if err != nil {
+					t.Fatalf("failed to create multipart file: %v", err)
+				}
+				if _, err = io.WriteString(file, strings.Repeat("x", int(2*uploadLimit))); err != nil {
+					t.Fatalf("failed to write multipart file: %v", err)
+				}
+			},
+		},
+		{
+			name: "trailing part",
+			writeBody: func(t *testing.T, writer *multipart.Writer) {
+				t.Helper()
+				file, err := writer.CreateFormFile("file", "protoos-2.4.6.swu")
+				if err != nil {
+					t.Fatalf("failed to create multipart file: %v", err)
+				}
+				if _, err = io.WriteString(file, "fake firmware bundle"); err != nil {
+					t.Fatalf("failed to write multipart file: %v", err)
+				}
+				trailing, err := writer.CreateFormField("metadata")
+				if err != nil {
+					t.Fatalf("failed to create trailing multipart part: %v", err)
+				}
+				if _, err = io.WriteString(trailing, strings.Repeat("x", int(2*uploadLimit))); err != nil {
+					t.Fatalf("failed to write trailing multipart part: %v", err)
+				}
+			},
+		},
 	}
-	if state.FWNewVersion != "" {
-		t.Errorf("expected no staged version after size failure, got %q", state.FWNewVersion)
-	}
-	if state.FWNextUpdateOutcome != firmwareUpdateOutcomeAttention {
-		t.Errorf("expected size failure not to consume one-shot outcome, got %q", state.FWNextUpdateOutcome)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := NewMinerState("SN12345678", "00:11:22:33:44:55")
+			state.mu.Lock()
+			state.FWNextUpdateOutcome = firmwareUpdateOutcomeAttention
+			state.mu.Unlock()
+			h := NewRESTApiHandler(state)
+			h.firmwareUploadLimit = uploadLimit
+
+			var body bytes.Buffer
+			writer := multipart.NewWriter(&body)
+			tt.writeBody(t, writer)
+			if err := writer.Close(); err != nil {
+				t.Fatalf("failed to close multipart writer: %v", err)
+			}
+
+			req := httptest.NewRequest(http.MethodPut, "/api/v1/system/update", bytes.NewReader(body.Bytes()))
+			req.ContentLength = -1
+			req.TransferEncoding = []string{"chunked"}
+			req.Header.Set("Content-Type", writer.FormDataContentType())
+			rr := httptest.NewRecorder()
+			h.handleUpdate(rr, req)
+
+			if rr.Code != http.StatusRequestEntityTooLarge {
+				t.Errorf("expected %d, got %d; body=%s",
+					http.StatusRequestEntityTooLarge, rr.Code, rr.Body.String())
+			}
+			assertFirmwareUploadDidNotMutateState(t, state, firmwareUpdateOutcomeAttention)
+		})
 	}
 }
 

--- a/server/fake-proto-rig/rest_api_handler_test.go
+++ b/server/fake-proto-rig/rest_api_handler_test.go
@@ -2698,86 +2698,93 @@ func TestHandleSystem_SwUpdateStatusUsesSpecFieldNames(t *testing.T) {
 	}
 }
 
-func TestStagedFirmwareVersion(t *testing.T) {
+func TestExplicitFirmwareVersion(t *testing.T) {
 	tests := []struct {
-		name           string
-		filename       string
-		content        string
-		currentVersion string
-		want           string
+		name     string
+		filename string
+		content  string
+		want     string
+		wantOK   bool
 	}{
 		{
-			name:           "plain semantic version",
-			filename:       "protoos-1.9.0.swu",
-			content:        `firmware_version=9.9.9`,
-			currentVersion: "1.8.0",
-			want:           "1.9.0",
+			name:     "plain semantic version",
+			filename: "protoos-1.9.0.swu",
+			content:  `firmware_version=9.9.9`,
+			want:     "1.9.0",
+			wantOK:   true,
 		},
 		{
-			name:           "v-prefixed semantic version",
-			filename:       "firmware-update-v2.0.2.swu",
-			currentVersion: "1.8.0",
-			want:           "2.0.2",
+			name:     "v-prefixed semantic version",
+			filename: "firmware-update-v2.0.2.swu",
+			want:     "2.0.2",
+			wantOK:   true,
 		},
 		{
-			name:           "key value payload marker",
-			filename:       "protoos-update.swu",
-			content:        "bundle header\nfirmware_version=1.4.4\nbinary data",
-			currentVersion: "1.8.0",
-			want:           "1.4.4",
+			name:     "key value payload marker",
+			filename: "protoos-update.swu",
+			content:  "bundle header\nfirmware_version=1.4.4\nbinary data",
+			want:     "1.4.4",
+			wantOK:   true,
 		},
 		{
-			name:           "JSON payload marker",
-			filename:       "protoos-update.swu",
-			content:        `{"firmware_version":"2.5.7"}`,
-			currentVersion: "1.8.0",
-			want:           "2.5.7",
+			name:     "JSON payload marker",
+			filename: "protoos-update.swu",
+			content:  `{"firmware_version":"2.5.7"}`,
+			want:     "2.5.7",
+			wantOK:   true,
 		},
 		{
-			name:           "plain semantic version payload marker",
-			filename:       "protoos-update.swu",
-			content:        "fake firmware bundle\nv3.6.9\n",
-			currentVersion: "1.8.0",
-			want:           "3.6.9",
+			name:     "plain semantic version payload marker",
+			filename: "protoos-update.swu",
+			content:  "fake firmware bundle\nv3.6.9\n",
+			want:     "3.6.9",
+			wantOK:   true,
 		},
 		{
-			name:           "fallback when no explicit version exists",
-			filename:       "protoos-update.swu",
-			content:        "fake firmware bundle",
-			currentVersion: "1.8.0",
-			want:           defaultNextFirmwareVersion,
+			name:     "no explicit version",
+			filename: "protoos-update.swu",
+			content:  "fake firmware bundle",
 		},
 		{
-			name:           "fallback increments non-default current version",
-			filename:       "protoos-update.swu",
-			content:        "fake firmware bundle",
-			currentVersion: "2.3.4",
-			want:           "2.3.5",
+			name:     "does not extract partial four-part version",
+			filename: "protoos-1.2.3.4.swu",
+			content:  "fake firmware bundle",
 		},
 		{
-			name:           "does not extract partial four-part version",
-			filename:       "protoos-1.2.3.4.swu",
-			content:        "fake firmware bundle",
-			currentVersion: "1.8.0",
-			want:           defaultNextFirmwareVersion,
-		},
-		{
-			name:           "ignores payload marker beyond bounded prefix",
-			filename:       "protoos-update.swu",
-			content:        strings.Repeat("x", int(firmwareVersionScanLimit)) + "\nfirmware_version=8.8.8\n",
-			currentVersion: "2.3.4",
-			want:           "2.3.5",
+			name:     "ignores payload marker beyond bounded prefix",
+			filename: "protoos-update.swu",
+			content:  strings.Repeat("x", int(firmwareVersionScanLimit)) + "\nfirmware_version=8.8.8\n",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := stagedFirmwareVersion(tt.filename, strings.NewReader(tt.content), tt.currentVersion)
+			got, ok, err := explicitFirmwareVersion(tt.filename, strings.NewReader(tt.content))
 			if err != nil {
-				t.Fatalf("stagedFirmwareVersion returned an error: %v", err)
+				t.Fatalf("explicitFirmwareVersion returned an error: %v", err)
 			}
 			if got != tt.want {
-				t.Fatalf("expected staged version %q, got %q", tt.want, got)
+				t.Fatalf("expected explicit version %q, got %q", tt.want, got)
+			}
+			if ok != tt.wantOK {
+				t.Fatalf("expected explicit version present=%t, got %t", tt.wantOK, ok)
+			}
+		})
+	}
+}
+
+func TestNextFirmwareVersion(t *testing.T) {
+	for _, tt := range []struct {
+		current string
+		want    string
+	}{
+		{current: defaultFirmwareVersion, want: defaultNextFirmwareVersion},
+		{current: "2.3.4", want: "2.3.5"},
+		{current: "invalid", want: defaultNextFirmwareVersion},
+	} {
+		t.Run(tt.current, func(t *testing.T) {
+			if got := nextFirmwareVersion(tt.current); got != tt.want {
+				t.Fatalf("expected next version %q, got %q", tt.want, got)
 			}
 		})
 	}
@@ -3110,6 +3117,97 @@ func TestHandleUpdate_PutConsumesCompleteStreamBeforeResponding(t *testing.T) {
 	}
 }
 
+func TestHandleUpdate_SlowMarkerlessUploadUsesFinalCurrentVersion(t *testing.T) {
+	state := NewMinerState("SN12345678", "00:11:22:33:44:55")
+	h := NewRESTApiHandler(state)
+	h.firmwareStepDelay = time.Hour
+
+	uploadReader, uploadWriter := io.Pipe()
+	multipartWriter := multipart.NewWriter(uploadWriter)
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/system/update", uploadReader)
+	req.Header.Set("Content-Type", multipartWriter.FormDataContentType())
+	rr := httptest.NewRecorder()
+
+	streamPaused := make(chan struct{})
+	resumeStream := make(chan struct{})
+	writerDone := make(chan error, 1)
+	go func() {
+		part, err := multipartWriter.CreateFormFile("file", "protoos-update.swu")
+		if err != nil {
+			_ = uploadWriter.CloseWithError(err)
+			writerDone <- err
+			return
+		}
+		if _, err = io.WriteString(part, strings.Repeat("x", int(firmwareVersionScanLimit))); err != nil {
+			_ = uploadWriter.CloseWithError(err)
+			writerDone <- err
+			return
+		}
+		close(streamPaused)
+		<-resumeStream
+		if err = multipartWriter.Close(); err != nil {
+			_ = uploadWriter.CloseWithError(err)
+			writerDone <- err
+			return
+		}
+		writerDone <- uploadWriter.Close()
+	}()
+
+	handlerDone := make(chan struct{})
+	go func() {
+		h.handleUpdate(rr, req)
+		_ = uploadReader.Close()
+		close(handlerDone)
+	}()
+
+	select {
+	case <-streamPaused:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for markerless upload to pause")
+	}
+
+	state.mu.Lock()
+	state.FWUpdateStatus = "installed"
+	state.FWNewVersion = "2.0.0"
+	state.mu.Unlock()
+	rebootRR := httptest.NewRecorder()
+	h.handleReboot(rebootRR, httptest.NewRequest(http.MethodPost, "/api/v1/system/reboot", nil))
+	if rebootRR.Code != http.StatusAccepted {
+		t.Fatalf("expected %d from overlapping reboot, got %d; body=%s",
+			http.StatusAccepted, rebootRR.Code, rebootRR.Body.String())
+	}
+	state.mu.Lock()
+	state.Rebooting = false
+	state.mu.Unlock()
+
+	close(resumeStream)
+	select {
+	case err := <-writerDone:
+		if err != nil {
+			t.Fatalf("upload writer failed: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for markerless upload writer")
+	}
+	select {
+	case <-handlerDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for markerless upload handler")
+	}
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected %d, got %d; body=%s", http.StatusOK, rr.Code, rr.Body.String())
+	}
+	state.mu.RLock()
+	defer state.mu.RUnlock()
+	if state.FWCurrentVersion != "2.0.0" {
+		t.Fatalf("expected current version %q, got %q", "2.0.0", state.FWCurrentVersion)
+	}
+	if state.FWNewVersion != "2.0.1" {
+		t.Fatalf("expected markerless upload to stage %q, got %q", "2.0.1", state.FWNewVersion)
+	}
+}
+
 func TestHandleUpdate_PutStreamFailureDoesNotMutateFirmwareState(t *testing.T) {
 	state := NewMinerState("SN12345678", "00:11:22:33:44:55")
 	state.mu.Lock()
@@ -3219,20 +3317,6 @@ func TestHandleUpdate_PutProgressesToInstalled(t *testing.T) {
 	h.firmwareStepDelay = 20 * time.Millisecond
 	h.firmwareInstallDelay = 50 * time.Millisecond
 	const uploadedVersion = "2.4.6"
-
-	controlRR := httptest.NewRecorder()
-	h.handleFakeFirmwareUpdateOutcome(
-		controlRR,
-		httptest.NewRequest(
-			http.MethodPut,
-			"/fake-api/v1/test/firmware-update/outcome",
-			strings.NewReader(`{"outcome":"success"}`),
-		),
-	)
-	if controlRR.Code != http.StatusOK {
-		t.Fatalf("expected %d from fake success control, got %d; body=%s",
-			http.StatusOK, controlRR.Code, controlRR.Body.String())
-	}
 
 	rr := httptest.NewRecorder()
 	h.handleUpdate(rr, newFirmwareUploadRequest(t, "protoos-"+uploadedVersion+".swu", "fake firmware bundle"))
@@ -3351,7 +3435,118 @@ func TestHandleUpdate_PutWhilePending_RejectsAndPreservesStagedVersion(t *testin
 	}
 }
 
+func newFirmwareOutcomeControlMux(t *testing.T, enabled bool) (*MinerState, *http.ServeMux) {
+	t.Helper()
+	envValue := ""
+	if enabled {
+		envValue = "true"
+	}
+	t.Setenv(fakeRigEnableTestControlsEnv, envValue)
+	state := NewMinerState("SN12345678", "00:11:22:33:44:55")
+	state.SetAccessToken("test-token")
+	h := NewRESTApiHandler(state)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+	return state, mux
+}
+
+func requestFirmwareOutcomeControl(mux *http.ServeMux, body string, authenticated bool) *httptest.ResponseRecorder {
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(
+		http.MethodPut,
+		"/fake-api/v1/test/firmware-update/outcome",
+		strings.NewReader(body),
+	)
+	if authenticated {
+		req.Header.Set("Authorization", "Bearer test-token")
+	}
+	mux.ServeHTTP(rr, req)
+	return rr
+}
+
+func TestFakeFirmwareUpdateOutcomeRoute_DisabledByDefault(t *testing.T) {
+	state, mux := newFirmwareOutcomeControlMux(t, false)
+	rr := requestFirmwareOutcomeControl(mux, `{"outcome":"error"}`, true)
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected %d when test controls are disabled, got %d; body=%s",
+			http.StatusNotFound, rr.Code, rr.Body.String())
+	}
+	state.mu.RLock()
+	defer state.mu.RUnlock()
+	if state.FWNextUpdateOutcome != firmwareUpdateOutcomeSuccess {
+		t.Fatalf("expected disabled control not to change outcome, got %q", state.FWNextUpdateOutcome)
+	}
+}
+
+func TestFakeFirmwareUpdateOutcomeRoute_EnabledRequiresBearerAuth(t *testing.T) {
+	state, mux := newFirmwareOutcomeControlMux(t, true)
+	rr := requestFirmwareOutcomeControl(mux, `{"outcome":"error"}`, false)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected %d without bearer auth, got %d; body=%s",
+			http.StatusUnauthorized, rr.Code, rr.Body.String())
+	}
+	state.mu.RLock()
+	defer state.mu.RUnlock()
+	if state.FWNextUpdateOutcome != firmwareUpdateOutcomeSuccess {
+		t.Fatalf("expected unauthorized control not to change outcome, got %q", state.FWNextUpdateOutcome)
+	}
+}
+
+func TestFakeFirmwareUpdateOutcomeRoute_EnabledAcceptsAuthenticatedRequest(t *testing.T) {
+	state, mux := newFirmwareOutcomeControlMux(t, true)
+	rr := requestFirmwareOutcomeControl(mux, `{"outcome":"error"}`, true)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected %d with test controls and bearer auth, got %d; body=%s",
+			http.StatusOK, rr.Code, rr.Body.String())
+	}
+	state.mu.RLock()
+	defer state.mu.RUnlock()
+	if state.FWNextUpdateOutcome != firmwareUpdateOutcomeError {
+		t.Fatalf("expected authenticated control to set outcome %q, got %q",
+			firmwareUpdateOutcomeError, state.FWNextUpdateOutcome)
+	}
+}
+
+func TestFakeFirmwareUpdateOutcomeRoute_RejectsOversizedBody(t *testing.T) {
+	state, mux := newFirmwareOutcomeControlMux(t, true)
+	body := `{"outcome":"` + strings.Repeat("x", int(maxTestControlRequestBytes))
+	rr := requestFirmwareOutcomeControl(mux, body, true)
+
+	if rr.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected %d for oversized control body, got %d; body=%s",
+			http.StatusRequestEntityTooLarge, rr.Code, rr.Body.String())
+	}
+	state.mu.RLock()
+	defer state.mu.RUnlock()
+	if state.FWNextUpdateOutcome != firmwareUpdateOutcomeSuccess {
+		t.Fatalf("expected oversized control not to change outcome, got %q", state.FWNextUpdateOutcome)
+	}
+}
+
+func TestFakeFirmwareUpdateOutcomeRoute_RejectsTrailingJSONValue(t *testing.T) {
+	state, mux := newFirmwareOutcomeControlMux(t, true)
+	rr := requestFirmwareOutcomeControl(
+		mux,
+		`{"outcome":"error"} {"outcome":"attention"}`,
+		true,
+	)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected %d for trailing JSON value, got %d; body=%s",
+			http.StatusBadRequest, rr.Code, rr.Body.String())
+	}
+	state.mu.RLock()
+	defer state.mu.RUnlock()
+	if state.FWNextUpdateOutcome != firmwareUpdateOutcomeSuccess {
+		t.Fatalf("expected rejected control not to change outcome, got %q", state.FWNextUpdateOutcome)
+	}
+}
+
 func TestFakeFirmwareUpdateOutcome_FailsNextUpdateWithoutPromoting(t *testing.T) {
+	t.Setenv(fakeRigEnableTestControlsEnv, "true")
 	tests := []struct {
 		outcome       string
 		expectedError string
@@ -3363,19 +3558,18 @@ func TestFakeFirmwareUpdateOutcome_FailsNextUpdateWithoutPromoting(t *testing.T)
 	for _, tt := range tests {
 		t.Run(tt.outcome, func(t *testing.T) {
 			state := NewMinerState("SN12345678", "00:11:22:33:44:55")
+			state.SetAccessToken("test-token")
 			h := NewRESTApiHandler(state)
 			h.firmwareStepDelay = 5 * time.Millisecond
 			h.firmwareInstallDelay = 5 * time.Millisecond
 
 			mux := http.NewServeMux()
 			h.RegisterRoutes(mux)
-			controlRR := httptest.NewRecorder()
-			controlReq := httptest.NewRequest(
-				http.MethodPut,
-				"/fake-api/v1/test/firmware-update/outcome",
-				strings.NewReader(fmt.Sprintf(`{"outcome":%q}`, tt.outcome)),
+			controlRR := requestFirmwareOutcomeControl(
+				mux,
+				fmt.Sprintf(`{"outcome":%q}`, tt.outcome),
+				true,
 			)
-			mux.ServeHTTP(controlRR, controlReq)
 			if controlRR.Code != http.StatusOK {
 				t.Fatalf("expected %d from fake outcome control, got %d; body=%s",
 					http.StatusOK, controlRR.Code, controlRR.Body.String())

--- a/server/fake-proto-rig/rest_api_handler_test.go
+++ b/server/fake-proto-rig/rest_api_handler_test.go
@@ -2695,16 +2695,18 @@ func TestHandleSystem_SwUpdateStatusUsesSpecFieldNames(t *testing.T) {
 	}
 }
 
-func TestStagedFirmwareVersion_UsesFilenameVersionWhenPresent(t *testing.T) {
+func TestStagedFirmwareVersion(t *testing.T) {
 	tests := []struct {
 		name           string
 		filename       string
+		content        string
 		currentVersion string
 		want           string
 	}{
 		{
 			name:           "plain semantic version",
 			filename:       "protoos-1.9.0.swu",
+			content:        `firmware_version=9.9.9`,
 			currentVersion: "1.8.0",
 			want:           "1.9.0",
 		},
@@ -2715,28 +2717,63 @@ func TestStagedFirmwareVersion_UsesFilenameVersionWhenPresent(t *testing.T) {
 			want:           "2.0.2",
 		},
 		{
-			name:           "fallback when filename has no version",
+			name:           "key value payload marker",
 			filename:       "protoos-update.swu",
+			content:        "bundle header\nfirmware_version=1.4.4\nbinary data",
+			currentVersion: "1.8.0",
+			want:           "1.4.4",
+		},
+		{
+			name:           "JSON payload marker",
+			filename:       "protoos-update.swu",
+			content:        `{"firmware_version":"2.5.7"}`,
+			currentVersion: "1.8.0",
+			want:           "2.5.7",
+		},
+		{
+			name:           "plain semantic version payload marker",
+			filename:       "protoos-update.swu",
+			content:        "fake firmware bundle\nv3.6.9\n",
+			currentVersion: "1.8.0",
+			want:           "3.6.9",
+		},
+		{
+			name:           "fallback when no explicit version exists",
+			filename:       "protoos-update.swu",
+			content:        "fake firmware bundle",
 			currentVersion: "1.8.0",
 			want:           defaultNextFirmwareVersion,
 		},
 		{
 			name:           "fallback increments non-default current version",
 			filename:       "protoos-update.swu",
+			content:        "fake firmware bundle",
 			currentVersion: "2.3.4",
 			want:           "2.3.5",
 		},
 		{
 			name:           "does not extract partial four-part version",
 			filename:       "protoos-1.2.3.4.swu",
+			content:        "fake firmware bundle",
 			currentVersion: "1.8.0",
 			want:           defaultNextFirmwareVersion,
+		},
+		{
+			name:           "ignores payload marker beyond bounded prefix",
+			filename:       "protoos-update.swu",
+			content:        strings.Repeat("x", int(firmwareVersionScanLimit)) + "\nfirmware_version=8.8.8\n",
+			currentVersion: "2.3.4",
+			want:           "2.3.5",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := stagedFirmwareVersion(tt.filename, tt.currentVersion); got != tt.want {
+			got, err := stagedFirmwareVersion(tt.filename, strings.NewReader(tt.content), tt.currentVersion)
+			if err != nil {
+				t.Fatalf("stagedFirmwareVersion returned an error: %v", err)
+			}
+			if got != tt.want {
 				t.Fatalf("expected staged version %q, got %q", tt.want, got)
 			}
 		})
@@ -2889,73 +2926,72 @@ func TestHandleUpdate_PutWhileInstalled_RejectsAndPreservesStagedVersion(t *test
 	}
 }
 
-func TestHandleUpdate_PutProgressesToInstalled(t *testing.T) {
-	state := NewMinerState("SN12345678", "00:11:22:33:44:55")
-	h := NewRESTApiHandler(state)
-	const uploadedVersion = "2.4.6"
+func newFirmwareUploadRequest(t *testing.T, filename, content string) *http.Request {
+	t.Helper()
 
 	var body bytes.Buffer
 	writer := multipart.NewWriter(&body)
-	part, err := writer.CreateFormFile("file", "protoos-"+uploadedVersion+".swu")
+	part, err := writer.CreateFormFile("file", filename)
 	if err != nil {
 		t.Fatalf("failed to create multipart file: %v", err)
 	}
-	if _, err := part.Write([]byte("fake firmware bundle")); err != nil {
+	if _, err := part.Write([]byte(content)); err != nil {
 		t.Fatalf("failed to write multipart file: %v", err)
 	}
 	if err := writer.Close(); err != nil {
 		t.Fatalf("failed to close multipart writer: %v", err)
 	}
 
-	rr := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPut, "/api/v1/system/update", &body)
 	req.Header.Set("Content-Type", writer.FormDataContentType())
-	h.handleUpdate(rr, req)
+	return req
+}
+
+func getFirmwareStatus(state *MinerState) string {
+	state.mu.RLock()
+	defer state.mu.RUnlock()
+	return state.FWUpdateStatus
+}
+
+func waitForFirmwareStatus(t *testing.T, state *MinerState, want string) {
+	t.Helper()
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if getFirmwareStatus(state) == want {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("expected firmware status to reach %q, got %q", want, getFirmwareStatus(state))
+}
+
+func TestHandleUpdate_PutProgressesToInstalled(t *testing.T) {
+	state := NewMinerState("SN12345678", "00:11:22:33:44:55")
+	h := NewRESTApiHandler(state)
+	h.firmwareStepDelay = 20 * time.Millisecond
+	h.firmwareInstallDelay = 50 * time.Millisecond
+	const uploadedVersion = "2.4.6"
+
+	controlRR := httptest.NewRecorder()
+	h.handleFakeFirmwareUpdateOutcome(
+		controlRR,
+		httptest.NewRequest(
+			http.MethodPut,
+			"/fake-api/v1/test/firmware-update/outcome",
+			strings.NewReader(`{"outcome":"success"}`),
+		),
+	)
+	if controlRR.Code != http.StatusOK {
+		t.Fatalf("expected %d from fake success control, got %d; body=%s",
+			http.StatusOK, controlRR.Code, controlRR.Body.String())
+	}
+
+	rr := httptest.NewRecorder()
+	h.handleUpdate(rr, newFirmwareUploadRequest(t, "protoos-"+uploadedVersion+".swu", "fake firmware bundle"))
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected %d, got %d; body=%s", http.StatusOK, rr.Code, rr.Body.String())
-	}
-
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		info := getSystemInfo(t, h)
-		swUpdate, ok := info["sw_update_status"].(map[string]any)
-		if !ok {
-			t.Fatalf("expected sw_update_status object, got: %v", info["sw_update_status"])
-		}
-
-		if got := swUpdate["new_version"]; got != uploadedVersion {
-			t.Fatalf("expected new_version %q after upload, got %v", uploadedVersion, got)
-		}
-
-		if swUpdate["status"] == "installed" {
-			rebootRR := httptest.NewRecorder()
-			rebootReq := httptest.NewRequest(http.MethodPost, "/api/v1/system/reboot", nil)
-			h.handleReboot(rebootRR, rebootReq)
-
-			if rebootRR.Code != http.StatusAccepted {
-				t.Fatalf("expected %d from reboot, got %d; body=%s", http.StatusAccepted, rebootRR.Code, rebootRR.Body.String())
-			}
-
-			state.mu.Lock()
-			state.Rebooting = false
-			state.mu.Unlock()
-
-			info = getSystemInfo(t, h)
-			swUpdate, ok = info["sw_update_status"].(map[string]any)
-			if !ok {
-				t.Fatalf("expected sw_update_status object after reboot, got: %v", info["sw_update_status"])
-			}
-			if got := swUpdate["current_version"]; got != uploadedVersion {
-				t.Fatalf("expected current_version %q after reboot, got %v", uploadedVersion, got)
-			}
-			if got := swUpdate["previous_version"]; got != defaultFirmwareVersion {
-				t.Fatalf("expected previous_version %q after reboot, got %v", defaultFirmwareVersion, got)
-			}
-			return
-		}
-
-		time.Sleep(200 * time.Millisecond)
 	}
 
 	info := getSystemInfo(t, h)
@@ -2963,7 +2999,57 @@ func TestHandleUpdate_PutProgressesToInstalled(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected sw_update_status object, got: %v", info["sw_update_status"])
 	}
-	t.Fatalf("expected uploaded firmware to reach %q, got %v", "installed", swUpdate["status"])
+	if got := swUpdate["status"]; got != "downloaded" {
+		t.Fatalf("expected status %q immediately after upload, got %v", "downloaded", got)
+	}
+	if got := swUpdate["new_version"]; got != uploadedVersion {
+		t.Fatalf("expected new_version %q after upload, got %v", uploadedVersion, got)
+	}
+
+	waitForFirmwareStatus(t, state, "installing")
+	waitForFirmwareStatus(t, state, "installed")
+
+	rebootRR := httptest.NewRecorder()
+	rebootReq := httptest.NewRequest(http.MethodPost, "/api/v1/system/reboot", nil)
+	h.handleReboot(rebootRR, rebootReq)
+	if rebootRR.Code != http.StatusAccepted {
+		t.Fatalf("expected %d from reboot, got %d; body=%s", http.StatusAccepted, rebootRR.Code, rebootRR.Body.String())
+	}
+
+	state.mu.Lock()
+	state.Rebooting = false
+	state.mu.Unlock()
+
+	info = getSystemInfo(t, h)
+	swUpdate, ok = info["sw_update_status"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected sw_update_status object after reboot, got: %v", info["sw_update_status"])
+	}
+	if got := swUpdate["status"]; got != "current" {
+		t.Fatalf("expected status %q after reboot, got %v", "current", got)
+	}
+	if got := swUpdate["current_version"]; got != uploadedVersion {
+		t.Fatalf("expected current_version %q after reboot, got %v", uploadedVersion, got)
+	}
+	if got := swUpdate["previous_version"]; got != defaultFirmwareVersion {
+		t.Fatalf("expected previous_version %q after reboot, got %v", defaultFirmwareVersion, got)
+	}
+	osInfo, ok := info["os"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected os object after reboot, got: %v", info["os"])
+	}
+	if got := osInfo["version"]; got != uploadedVersion {
+		t.Fatalf("expected os.version %q after reboot, got %v", uploadedVersion, got)
+	}
+	for _, component := range []string{"mining_driver_sw", "web_server", "web_dashboard", "pool_interface_sw"} {
+		componentInfo, ok := info[component].(map[string]any)
+		if !ok {
+			t.Fatalf("expected %s object after reboot, got: %v", component, info[component])
+		}
+		if got := componentInfo["version"]; got != uploadedVersion {
+			t.Fatalf("expected %s.version %q after reboot, got %v", component, uploadedVersion, got)
+		}
+	}
 }
 
 func TestHandleUpdate_PostFromDownloadedInstallsUpdate(t *testing.T) {
@@ -2974,6 +3060,7 @@ func TestHandleUpdate_PostFromDownloadedInstallsUpdate(t *testing.T) {
 	state.mu.Unlock()
 
 	h := NewRESTApiHandler(state)
+	h.firmwareInstallDelay = 10 * time.Millisecond
 
 	rr := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/system/update", nil)
@@ -2983,52 +3070,125 @@ func TestHandleUpdate_PostFromDownloadedInstallsUpdate(t *testing.T) {
 		t.Fatalf("expected %d, got %d; body=%s", http.StatusAccepted, rr.Code, rr.Body.String())
 	}
 
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		state.mu.RLock()
-		status := state.FWUpdateStatus
-		state.mu.RUnlock()
-		if status == "installed" {
-			return
-		}
-		time.Sleep(200 * time.Millisecond)
-	}
-
-	state.mu.RLock()
-	gotStatus := state.FWUpdateStatus
-	state.mu.RUnlock()
-	t.Fatalf("expected firmware status to reach %q, got %q", "installed", gotStatus)
+	waitForFirmwareStatus(t, state, "installed")
 }
 
-func TestHandleUpdate_PutWhileDownloading_Rejects(t *testing.T) {
-	state := NewMinerState("SN12345678", "00:11:22:33:44:55")
-	state.mu.Lock()
-	state.FWUpdateStatus = "downloading"
-	state.FWNewVersion = defaultNextFirmwareVersion
-	state.mu.Unlock()
+func TestHandleUpdate_PutWhilePending_RejectsAndPreservesStagedVersion(t *testing.T) {
+	for _, pendingStatus := range []string{"downloading", "downloaded", "installing", "installed"} {
+		t.Run(pendingStatus, func(t *testing.T) {
+			state := NewMinerState("SN12345678", "00:11:22:33:44:55")
+			state.mu.Lock()
+			state.FWUpdateStatus = pendingStatus
+			state.FWNewVersion = defaultNextFirmwareVersion
+			state.mu.Unlock()
 
-	h := NewRESTApiHandler(state)
+			h := NewRESTApiHandler(state)
+			rr := httptest.NewRecorder()
+			h.handleUpdate(rr, newFirmwareUploadRequest(t, "protoos-9.9.9.swu", "fake firmware bundle"))
 
-	var body bytes.Buffer
-	writer := multipart.NewWriter(&body)
-	part, err := writer.CreateFormFile("file", "protoos-update.swu")
-	if err != nil {
-		t.Fatalf("failed to create multipart file: %v", err)
+			if rr.Code != http.StatusConflict {
+				t.Fatalf("expected %d, got %d; body=%s", http.StatusConflict, rr.Code, rr.Body.String())
+			}
+
+			state.mu.RLock()
+			gotStatus := state.FWUpdateStatus
+			gotVersion := state.FWNewVersion
+			state.mu.RUnlock()
+			if gotStatus != pendingStatus {
+				t.Fatalf("expected status to remain %q, got %q", pendingStatus, gotStatus)
+			}
+			if gotVersion != defaultNextFirmwareVersion {
+				t.Fatalf("expected staged version to remain %q, got %q", defaultNextFirmwareVersion, gotVersion)
+			}
+		})
 	}
-	if _, err := part.Write([]byte("fake firmware bundle")); err != nil {
-		t.Fatalf("failed to write multipart file: %v", err)
-	}
-	if err := writer.Close(); err != nil {
-		t.Fatalf("failed to close multipart writer: %v", err)
+}
+
+func TestFakeFirmwareUpdateOutcome_FailsNextUpdateWithoutPromoting(t *testing.T) {
+	tests := []struct {
+		outcome       string
+		expectedError string
+	}{
+		{outcome: firmwareUpdateOutcomeError, expectedError: firmwareUpdateFailureMessage},
+		{outcome: firmwareUpdateOutcomeAttention, expectedError: firmwareUpdateAttentionMessage},
 	}
 
-	rr := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPut, "/api/v1/system/update", &body)
-	req.Header.Set("Content-Type", writer.FormDataContentType())
-	h.handleUpdate(rr, req)
+	for _, tt := range tests {
+		t.Run(tt.outcome, func(t *testing.T) {
+			state := NewMinerState("SN12345678", "00:11:22:33:44:55")
+			h := NewRESTApiHandler(state)
+			h.firmwareStepDelay = 5 * time.Millisecond
+			h.firmwareInstallDelay = 5 * time.Millisecond
 
-	if rr.Code != http.StatusConflict {
-		t.Fatalf("expected %d, got %d; body=%s", http.StatusConflict, rr.Code, rr.Body.String())
+			mux := http.NewServeMux()
+			h.RegisterRoutes(mux)
+			controlRR := httptest.NewRecorder()
+			controlReq := httptest.NewRequest(
+				http.MethodPut,
+				"/fake-api/v1/test/firmware-update/outcome",
+				strings.NewReader(fmt.Sprintf(`{"outcome":%q}`, tt.outcome)),
+			)
+			mux.ServeHTTP(controlRR, controlReq)
+			if controlRR.Code != http.StatusOK {
+				t.Fatalf("expected %d from fake outcome control, got %d; body=%s",
+					http.StatusOK, controlRR.Code, controlRR.Body.String())
+			}
+
+			uploadRR := httptest.NewRecorder()
+			h.handleUpdate(
+				uploadRR,
+				newFirmwareUploadRequest(t, "protoos-update.swu", "firmware_version=4.5.6\n"),
+			)
+			if uploadRR.Code != http.StatusOK {
+				t.Fatalf("expected %d from upload, got %d; body=%s",
+					http.StatusOK, uploadRR.Code, uploadRR.Body.String())
+			}
+			waitForFirmwareStatus(t, state, "error")
+
+			info := getSystemInfo(t, h)
+			swUpdate, ok := info["sw_update_status"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected sw_update_status object, got: %v", info["sw_update_status"])
+			}
+			if got := swUpdate["new_version"]; got != "4.5.6" {
+				t.Fatalf("expected payload version %q, got %v", "4.5.6", got)
+			}
+			if got := swUpdate["error"]; got != tt.expectedError {
+				t.Fatalf("expected update error %q, got %v", tt.expectedError, got)
+			}
+
+			state.mu.RLock()
+			nextOutcome := state.FWNextUpdateOutcome
+			state.mu.RUnlock()
+			if nextOutcome != firmwareUpdateOutcomeSuccess {
+				t.Fatalf("expected one-shot outcome to reset to %q, got %q",
+					firmwareUpdateOutcomeSuccess, nextOutcome)
+			}
+
+			rebootRR := httptest.NewRecorder()
+			h.handleReboot(
+				rebootRR,
+				httptest.NewRequest(http.MethodPost, "/api/v1/system/reboot", nil),
+			)
+			if rebootRR.Code != http.StatusAccepted {
+				t.Fatalf("expected %d from reboot, got %d", http.StatusAccepted, rebootRR.Code)
+			}
+			state.mu.Lock()
+			state.Rebooting = false
+			state.mu.Unlock()
+
+			info = getSystemInfo(t, h)
+			swUpdate, ok = info["sw_update_status"].(map[string]any)
+			if !ok {
+				t.Fatalf("expected sw_update_status object after reboot, got: %v", info["sw_update_status"])
+			}
+			if got := swUpdate["current_version"]; got != defaultFirmwareVersion {
+				t.Fatalf("expected failed update to keep current version %q, got %v", defaultFirmwareVersion, got)
+			}
+			if _, present := swUpdate["previous_version"]; present {
+				t.Fatalf("expected no previous version after failed update, got %v", swUpdate["previous_version"])
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Reviewable diff: +401/-103 across 3 files (excludes generated, test, and story files).

## Summary
Fake Proto rigs now complete large streamed firmware uploads before reporting acceptance, preventing the plugin-side `io: read/write on closed pipe` failure that previously produced false `attention_required` outcomes. The simulator also reports the intended firmware version after reboot, models the install lifecycle deterministically, and provides one-shot fake-only failure outcomes. This remains standalone simulator work; firmware rollout tests are one consumer, not part of the implementation.

## How it works
A file upload resolves an explicit staged version from the filename first, then scans at most the first 64 KiB for a marker. It retains the multipart reader and drains the file, every trailing part, and the bounded request through final EOF before mutating simulator state or returning success. This prevents large uploads, delayed trailing fields, and malformed final boundaries from producing false acceptance or closed uploader pipes. When no explicit version exists, the patch-increment fallback is calculated under the final state lock so a concurrent completed update cannot make it stale. The fake rig then moves through downloaded, installing, and installed states, rejects overlapping uploads, and promotes the staged version only after reboot.

The fake-only outcome control is disabled by default. Enabling it requires `FAKE_RIG_ENABLE_TEST_CONTROLS=true`; requests then pass through the existing bearer authentication and a strict 1 KiB, single-JSON-value parser.

```mermaid
flowchart TD
    Upload["Firmware upload"] --> Resolve["Resolve staged version from filename or bounded prefix"]
    Resolve --> Drain["Consume and close the complete stream"]
    Drain --> Downloaded["downloaded"]
    Downloaded --> Installing["installing"]
    Installing --> Outcome{"Configured outcome"}
    Outcome -->|"success"| Installed["installed"]
    Outcome -->|"error or attention"| Failed["error"]
    Installed --> Reboot["Reboot"]
    Reboot --> Running["Report staged version"]
```

## Areas of the code involved
| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/fake-proto-rig/rest_api_handler.go` | Version resolution, complete stream consumption, lifecycle, and guarded outcome control | Core simulator behavior, streaming correctness, concurrency safety, and test-control isolation |
| `server/fake-proto-rig/models.go` | One-shot outcomes and lifecycle sequencing state | Prevents concurrent updates from overwriting each other |
| `server/fake-proto-rig/README.md` | Version markers and fake-only controls | Defines the simulator contract for local and E2E users |
| `server/fake-proto-rig/rest_api_handler_test.go` | Large streams, interrupted streams, lifecycle, version, conflict, and outcome coverage | Test-only; validates the externally observable fake behavior |

## Key technical decisions & trade-offs
- Filename versions take precedence over payload markers so existing behavior remains stable.
- Payload inspection is capped at 64 KiB, but the remaining stream is consumed without buffering before success is returned.
- The complete multipart envelope must parse through final EOF before firmware state changes.
- Declared and streamed size violations return HTTP `413`, preserving the Proto client's size-limit classification.
- Stream interruption fails without staging a version or starting the lifecycle.
- Failure injection uses a clearly namespaced, disabled-by-default, authenticated fake-only endpoint instead of changing the real Proto device API.
- Test-control bodies are capped at 1 KiB and must contain exactly one JSON value.
- Missing explicit versions retain the prior patch-increment fallback, calculated from the final locked firmware state.

## Testing & validation
- `GOWORK=off go test -count=20 ./...` in `server/fake-proto-rig`
- `GOWORK=off go test -race ./...` in `server/fake-proto-rig`
- Large streaming regression verifies the handler cannot respond or enter `downloaded` before the writer reaches EOF
- Interrupted-stream regression verifies no firmware state is staged on read failure
- Multipart regressions cover delayed trailing fields, missing final boundaries, and oversized file or trailing-part streams
- Concurrent markerless upload regression verifies a completed overlapping update cannot produce a stale fallback version
- Test-control coverage verifies disabled, unauthenticated, authenticated, oversized, and trailing-JSON requests
- `just lint`
- Pre-push server lint
- `just test-contract` reached and passed `TestAntminerStock`; ASIC-rs cases were blocked by an existing macOS-binary/Linux-container `exec format error`
- ProtoFleet E2E setup was blocked by the local database rejecting the configured admin credentials, so the firmware scenario did not run

## Post-Deploy Monitoring & Validation
No additional production monitoring is required because this changes only the fake Proto rig used by tests and local development. During local validation, watch fake-rig logs for the full upload followed by firmware state transitions, and verify `/api/v1/system` reports the staged version only after reboot. Treat any plugin-side `closed pipe` or fake-rig lifecycle start before upload completion as a regression.
