### PR TITLE
Fix release manifest scope for one-click upgrades

### DIFF
--- a/.github/workflows/deployment-config-checks.yml
+++ b/.github/workflows/deployment-config-checks.yml
@@ -19,6 +19,7 @@ jobs:
           for script in \
             deployment-files/install.sh \
             deployment-files/run-fleet.sh \
+            deployment-files/scripts/create-release-manifest.sh \
             deployment-files/uninstall.sh \
             deployment-files/tests/test-install-overlay-migration.sh \
             deployment-files/tests/test-profiles.sh \

--- a/.github/workflows/proto-fleet-artifact-build.yml
+++ b/.github/workflows/proto-fleet-artifact-build.yml
@@ -562,18 +562,7 @@ jobs:
           fi
 
       - name: Create immutable deployment manifest
-        run: |
-          cd deployment
-          unsupported_entries=$(find . ! -type f ! -type d -print)
-          if [ -n "$unsupported_entries" ]; then
-            echo "Deployment bundle contains unsupported non-regular entries:" >&2
-            printf '  %s\n' "$unsupported_entries" >&2
-            exit 1
-          fi
-          find . -type f ! -path './deployment-manifest.sha256' -print0 \
-            | LC_ALL=C sort -z \
-            | xargs -0 sha256sum \
-            > deployment-manifest.sha256
+        run: deployment/scripts/create-release-manifest.sh deployment
 
       - name: Package ProtoFleet deployment bundle
         run: |

--- a/deployment-files/scripts/create-release-manifest.sh
+++ b/deployment-files/scripts/create-release-manifest.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: create-release-manifest.sh DEPLOYMENT_ROOT" >&2
+    exit 1
+fi
+
+deployment_root="$1"
+
+if [ ! -d "$deployment_root" ]; then
+    echo "Error: deployment root must be an existing directory: $deployment_root" >&2
+    exit 1
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+    sha256_cmd=(sha256sum)
+elif command -v shasum >/dev/null 2>&1; then
+    sha256_cmd=(shasum -a 256)
+else
+    echo "Error: SHA-256 support requires sha256sum or shasum." >&2
+    exit 1
+fi
+
+(
+    cd "$deployment_root"
+
+    unsupported_entries=$(find . ! -type f ! -type d -print)
+    if [ -n "$unsupported_entries" ]; then
+        echo "Deployment bundle contains unsupported non-regular entries:" >&2
+        printf '  %s\n' "$unsupported_entries" >&2
+        exit 1
+    fi
+
+    # Keep this scope aligned with find_release_entries in run-fleet.sh. These
+    # paths are operator-owned or generated runtime state and are validated or
+    # fingerprinted separately during upgrade preflight.
+    find . -type f \
+        ! -path './.env' \
+        ! -path './.update-preflight-complete' \
+        ! -path './.update-preflight-complete.tmp.*' \
+        ! -path './.fleet-startup-complete' \
+        ! -path './.fleet-startup-complete.tmp.*' \
+        ! -path './client/nginx.conf' \
+        ! -path './ssl/*' \
+        ! -path './server/influx_config/.env' \
+        ! -path './ha/node.env' \
+        ! -path './deployment-manifest.sha256' \
+        -print0 \
+        | LC_ALL=C sort -z \
+        | xargs -0 "${sha256_cmd[@]}" \
+        > deployment-manifest.sha256
+)

--- a/deployment-files/scripts/create-release-manifest.sh
+++ b/deployment-files/scripts/create-release-manifest.sh
@@ -28,25 +28,37 @@ fi
     unsupported_entries=$(find . ! -type f ! -type d -print)
     if [ -n "$unsupported_entries" ]; then
         echo "Deployment bundle contains unsupported non-regular entries:" >&2
-        printf '  %s\n' "$unsupported_entries" >&2
+        while IFS= read -r unsupported_entry; do
+            printf '  %s\n' "$unsupported_entry" >&2
+        done <<< "$unsupported_entries"
         exit 1
     fi
 
     # Keep this scope aligned with find_release_entries in run-fleet.sh. These
     # paths are operator-owned or generated runtime state and are validated or
     # fingerprinted separately during upgrade preflight.
-    find . -type f \
-        ! -path './.env' \
-        ! -path './.update-preflight-complete' \
-        ! -path './.update-preflight-complete.tmp.*' \
-        ! -path './.fleet-startup-complete' \
-        ! -path './.fleet-startup-complete.tmp.*' \
-        ! -path './client/nginx.conf' \
-        ! -path './ssl/*' \
-        ! -path './server/influx_config/.env' \
-        ! -path './ha/node.env' \
-        ! -path './deployment-manifest.sha256' \
-        -print0 \
+    find_immutable_release_files() {
+        find . -type f \
+            ! -path './.env' \
+            ! -path './.update-preflight-complete' \
+            ! -path './.update-preflight-complete.tmp.*' \
+            ! -path './.fleet-startup-complete' \
+            ! -path './.fleet-startup-complete.tmp.*' \
+            ! -path './client/nginx.conf' \
+            ! -path './ssl/*' \
+            ! -path './server/influx_config/.env' \
+            ! -path './ha/node.env' \
+            ! -path './deployment-manifest.sha256' \
+            "$@"
+    }
+
+    first_immutable_file=$(find_immutable_release_files -print -quit)
+    if [ -z "$first_immutable_file" ]; then
+        echo "Error: deployment bundle contains no immutable release files." >&2
+        exit 1
+    fi
+
+    find_immutable_release_files -print0 \
         | LC_ALL=C sort -z \
         | xargs -0 "${sha256_cmd[@]}" \
         > deployment-manifest.sha256

--- a/deployment-files/tests/test-run-fleet-upgrade.sh
+++ b/deployment-files/tests/test-run-fleet-upgrade.sh
@@ -109,25 +109,7 @@ enable_valid_alerts() {
 
 write_release_manifest() {
     local stage="$1"
-    local -a hasher=(sha256sum)
-    command -v sha256sum >/dev/null 2>&1 || hasher=(shasum -a 256)
-    (
-        cd "$stage" || exit 1
-        # Must exclude the same operator-owned paths as find_release_entries
-        # in run-fleet.sh.
-        find . -type f \
-            ! -path './.env' \
-            ! -path './.update-preflight-complete' \
-            ! -path './.update-preflight-complete.tmp.*' \
-            ! -path './.fleet-startup-complete' \
-            ! -path './.fleet-startup-complete.tmp.*' \
-            ! -path './client/nginx.conf' \
-            ! -path './ssl/*' \
-            ! -path './server/influx_config/.env' \
-            ! -path './ha/node.env' \
-            ! -path './deployment-manifest.sha256' \
-            -print0 | LC_ALL=C sort -z | xargs -0 "${hasher[@]}" > deployment-manifest.sha256
-    )
+    "$DEPLOY_DIR/scripts/create-release-manifest.sh" "$stage"
 }
 
 make_stage() {
@@ -1256,6 +1238,27 @@ done
 
 # A successful preflight validates and prepares images, but never stops or
 # starts the active stack. It records a same-directory activation marker.
+make_stage packaged-symlink
+ln -s base.yaml "$STAGE/server/monitoring/grafana/provisioning/datasources/packaged-symlink.yaml"
+if write_release_manifest "$STAGE"; then
+    fail "production manifest generation should reject packaged symlinks"
+else
+    pass "production manifest generation rejects packaged symlinks"
+fi
+
+make_stage packaged-generated-nginx
+cp "$STAGE/client/nginx.https.conf" "$STAGE/client/nginx.conf"
+write_release_manifest "$STAGE"
+assert_not_contains \
+    "packaged manifest excludes generated nginx config" \
+    "$STAGE/deployment-manifest.sha256" \
+    "  ./client/nginx.conf"
+if run_stage "$STAGE" --non-interactive --preflight-only; then
+    pass "a production-generated manifest passes preflight with packaged nginx config"
+else
+    fail "packaged generated nginx config should stay outside the immutable release set"
+fi
+
 make_stage preflight-parent/deployment
 printf 'NO_TRAILING_NEWLINE=preserved' >> "$STAGE/.env"
 if ! preflight_env_owner=$(file_owner_group "$STAGE/.env"); then

--- a/deployment-files/tests/test-run-fleet-upgrade.sh
+++ b/deployment-files/tests/test-run-fleet-upgrade.sh
@@ -1238,13 +1238,39 @@ done
 
 # A successful preflight validates and prepares images, but never stops or
 # starts the active stack. It records a same-directory activation marker.
+empty_deployment="$TMP_DIR/empty-deployment"
+empty_manifest_log="$TMP_DIR/empty-manifest.log"
+mkdir -p "$empty_deployment"
+if write_release_manifest "$empty_deployment" > "$empty_manifest_log" 2>&1; then
+    fail "production manifest generation should reject an empty immutable file set"
+else
+    pass "production manifest generation rejects an empty immutable file set"
+fi
+assert_contains \
+    "empty immutable file set is diagnosed" \
+    "$empty_manifest_log" \
+    "contains no immutable release files"
+[ ! -e "$empty_deployment/deployment-manifest.sha256" ] || \
+    fail "failed empty manifest generation should not create a manifest"
+
 make_stage packaged-symlink
 ln -s base.yaml "$STAGE/server/monitoring/grafana/provisioning/datasources/packaged-symlink.yaml"
-if write_release_manifest "$STAGE"; then
+ln -s base.yaml "$STAGE/server/monitoring/grafana/provisioning/datasources/packaged-symlink-2.yaml"
+unsupported_manifest_log="$TMP_DIR/unsupported-manifest.log"
+if write_release_manifest "$STAGE" > "$unsupported_manifest_log" 2>&1; then
     fail "production manifest generation should reject packaged symlinks"
 else
     pass "production manifest generation rejects packaged symlinks"
 fi
+for unsupported_entry in \
+    "./server/monitoring/grafana/provisioning/datasources/packaged-symlink.yaml" \
+    "./server/monitoring/grafana/provisioning/datasources/packaged-symlink-2.yaml"; do
+    if grep -qxF "  $unsupported_entry" "$unsupported_manifest_log"; then
+        pass "unsupported manifest entry is indented: $unsupported_entry"
+    else
+        fail "unsupported manifest entry is not indented: $unsupported_entry"
+    fi
+done
 
 make_stage packaged-generated-nginx
 cp "$STAGE/client/nginx.https.conf" "$STAGE/client/nginx.conf"


### PR DESCRIPTION
Reviewable diff: +55/-12 across 3 files (excludes generated, test, and story files).

## Summary

One-click upgrades no longer reject valid release bundles when the packaged client contains the generated `nginx.conf`. Release packaging now uses the same runtime-state exclusions as upgrade preflight, while preserving the immutable-file and non-regular-entry safety checks.

## How it works

The release workflow copies the deployment tree and builds the client image, which creates `client/nginx.conf` for the build. A shared manifest generator now excludes that generated runtime file, along with the existing operator-owned runtime paths, and hashes every remaining regular file. When the host updater stages the bundle, `run-fleet.sh` regenerates `nginx.conf` for the selected HTTP/HTTPS mode and compares the staged immutable path set against a manifest built from the same boundary.

## Diagrams

```mermaid
flowchart LR
  A["Release artifact workflow"] --> B["Shared manifest generator"]
  B --> C["Immutable file checksums"]
  C --> D["Published deployment bundle"]
  D --> E["Host updater stages release"]
  E --> F["run-fleet regenerates nginx.conf"]
  F --> G["Matching immutable path set"]
  G --> H["Image preflight"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `.github/workflows/proto-fleet-artifact-build.yml` | Delegates manifest creation to the packaged helper | Ensures release artifacts use the same runtime-state boundary exercised by tests |
| `deployment-files/scripts/create-release-manifest.sh` | Centralizes exclusions, checksum generation, and non-regular-entry rejection | This is the release-time trust boundary reviewers should scrutinize |
| `deployment-files/tests/test-run-fleet-upgrade.sh` | Uses the production generator and reproduces packaged `nginx.conf`; verifies symlinks remain rejected | Prevents the production workflow and test fixture from drifting again |
| `.github/workflows/deployment-config-checks.yml` | Adds the generator to shell syntax validation | Makes malformed packaging logic fail the PR gate |

## Key technical decisions & trade-offs

- Use one production manifest generator for CI packaging and test fixtures instead of maintaining duplicated `find` expressions.
- Keep `client/nginx.conf` outside the immutable manifest because preflight rewrites it for the preserved protocol mode; its entry type remains validated separately.
- Preserve fail-closed rejection of every packaged symlink, FIFO, or other non-regular entry rather than relaxing manifest verification.

## Testing & validation

- `./deployment-files/tests/test-run-fleet-upgrade.sh`
- `./deployment-files/tests/test-profiles.sh`
- `./deployment-files/ha/tests/test-profile.sh`
- `./deployment-files/tests/test-install-overlay-migration.sh`
- `./deployment-files/tests/test-uninstall-updater-cleanup.sh`
- `bash -n` across deployment scripts covered by the deployment config workflow
- Pre-push client typecheck, server lint, and proto-plugin lint

A full multi-architecture release bundle was not built locally; the artifact workflow exercises that packaging path in CI.