### PR TITLE
Resolve curtailment topology targets for previews and profiles

### DIFF
--- a/server/generated/sqlc/curtailment.sql.go
+++ b/server/generated/sqlc/curtailment.sql.go
@@ -1897,6 +1897,96 @@ func (q *Queries) ListActiveCurtailmentTargetDevicesByOrg(ctx context.Context, o
 	return items, nil
 }
 
+const listCurtailmentBuildingScopeCoverage = `-- name: ListCurtailmentBuildingScopeCoverage :many
+WITH selected_buildings AS (
+    SELECT b.id, b.site_id
+    FROM building b
+    WHERE b.org_id = $1
+      AND b.deleted_at IS NULL
+      AND b.id = ANY($2::BIGINT[])
+), members AS MATERIALIZED (
+    SELECT DISTINCT d.id AS device_id, d.site_id
+    FROM device d
+    WHERE d.org_id = $1
+      AND d.deleted_at IS NULL
+      AND EXISTS (
+          SELECT 1
+          FROM selected_buildings sb
+          WHERE d.building_id = sb.id
+             OR EXISTS (
+                 SELECT 1
+                 FROM device_set_membership dsm
+                 JOIN device_set ds
+                   ON ds.id = dsm.device_set_id
+                  AND ds.org_id = dsm.org_id
+                  AND ds.type = 'rack'
+                  AND ds.deleted_at IS NULL
+                 JOIN device_set_rack dsr
+                   ON dsr.device_set_id = ds.id
+                  AND dsr.org_id = ds.org_id
+                 WHERE dsm.org_id = $1
+                   AND dsm.device_id = d.id
+                   AND dsm.device_set_type = 'rack'
+                   AND dsr.building_id = sb.id
+             )
+      )
+    ORDER BY d.id
+    LIMIT 10001
+)
+SELECT sb.id AS selector_id,
+       sb.site_id AS resource_site_id,
+       NULL::BIGINT AS member_site_id,
+       NULL::BIGINT AS member_device_id
+FROM selected_buildings sb
+UNION ALL
+SELECT 0 AS selector_id,
+       NULL::BIGINT AS resource_site_id,
+       m.site_id AS member_site_id,
+       m.device_id AS member_device_id
+FROM members m
+ORDER BY selector_id, member_device_id
+`
+
+type ListCurtailmentBuildingScopeCoverageParams struct {
+	OrgID       int64
+	BuildingIds []int64
+}
+
+type ListCurtailmentBuildingScopeCoverageRow struct {
+	SelectorID     int64
+	ResourceSiteID sql.NullInt64
+	MemberSiteID   sql.NullInt64
+	MemberDeviceID sql.NullInt64
+}
+
+func (q *Queries) ListCurtailmentBuildingScopeCoverage(ctx context.Context, arg ListCurtailmentBuildingScopeCoverageParams) ([]ListCurtailmentBuildingScopeCoverageRow, error) {
+	rows, err := q.query(ctx, q.listCurtailmentBuildingScopeCoverageStmt, listCurtailmentBuildingScopeCoverage, arg.OrgID, pq.Array(arg.BuildingIds))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListCurtailmentBuildingScopeCoverageRow
+	for rows.Next() {
+		var i ListCurtailmentBuildingScopeCoverageRow
+		if err := rows.Scan(
+			&i.SelectorID,
+			&i.ResourceSiteID,
+			&i.MemberSiteID,
+			&i.MemberDeviceID,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listCurtailmentCandidatesByOrg = `-- name: ListCurtailmentCandidatesByOrg :many
 WITH latest_metrics AS (
     SELECT DISTINCT ON (device_metrics.device_identifier)
@@ -1945,23 +2035,93 @@ LEFT JOIN latest_hourly lh ON lh.device_identifier = d.device_identifier
 WHERE d.org_id = $1
     AND d.deleted_at IS NULL
     AND (
-        ($2::BIGINT[] IS NULL AND $3::text[] IS NULL)
+        ($2::BIGINT[] IS NULL
+            AND $3::BIGINT[] IS NULL
+            AND $4::BIGINT[] IS NULL
+            AND $5::BIGINT[] IS NULL
+            AND $6::text[] IS NULL)
         OR (
             $2::BIGINT[] IS NOT NULL
             AND d.site_id = ANY($2::BIGINT[])
         )
         OR (
-            $3::text[] IS NOT NULL
-            AND d.device_identifier = ANY($3::text[])
+            $3::BIGINT[] IS NOT NULL
+            AND EXISTS (
+                SELECT 1
+                FROM building b
+                WHERE b.org_id = $1
+                  AND b.deleted_at IS NULL
+                  AND b.id = ANY($3::BIGINT[])
+                  AND (
+                    d.building_id = b.id
+                    OR EXISTS (
+                        SELECT 1
+                        FROM device_set_membership dsm
+                        JOIN device_set ds
+                          ON ds.id = dsm.device_set_id
+                         AND ds.org_id = dsm.org_id
+                         AND ds.type = 'rack'
+                         AND ds.deleted_at IS NULL
+                        JOIN device_set_rack dsr
+                          ON dsr.device_set_id = ds.id
+                         AND dsr.org_id = ds.org_id
+                        WHERE dsm.org_id = $1
+                          AND dsm.device_id = d.id
+                          AND dsm.device_set_type = 'rack'
+                          AND dsr.building_id = b.id
+                    )
+                  )
+            )
+        )
+        OR (
+            $4::BIGINT[] IS NOT NULL
+            AND EXISTS (
+                SELECT 1
+                FROM device_set_membership dsm
+                JOIN device_set ds
+                  ON ds.id = dsm.device_set_id
+                 AND ds.org_id = dsm.org_id
+                 AND ds.type = 'rack'
+                 AND ds.deleted_at IS NULL
+                WHERE dsm.org_id = $1
+                  AND dsm.device_id = d.id
+                  AND dsm.device_set_type = 'rack'
+                  AND dsm.device_set_id = ANY($4::BIGINT[])
+            )
+        )
+        OR (
+            $5::BIGINT[] IS NOT NULL
+            AND EXISTS (
+                SELECT 1
+                FROM device_set_membership dsm
+                JOIN device_set ds
+                  ON ds.id = dsm.device_set_id
+                 AND ds.org_id = dsm.org_id
+                 AND ds.type = 'group'
+                 AND ds.deleted_at IS NULL
+                WHERE dsm.org_id = $1
+                  AND dsm.device_id = d.id
+                  AND dsm.device_set_type = 'group'
+                  AND dsm.device_set_id = ANY($5::BIGINT[])
+            )
+        )
+        OR (
+            $6::text[] IS NOT NULL
+            AND d.device_identifier = ANY($6::text[])
         )
     )
 ORDER BY d.device_identifier
+LIMIT NULLIF($7::BIGINT, 0)
 `
 
 type ListCurtailmentCandidatesByOrgParams struct {
 	OrgID             int64
 	SiteIds           []int64
+	BuildingIds       []int64
+	RackIds           []int64
+	GroupIds          []int64
 	DeviceIdentifiers []string
+	ResultLimit       int64
 }
 
 type ListCurtailmentCandidatesByOrgRow struct {
@@ -1978,10 +2138,18 @@ type ListCurtailmentCandidatesByOrgRow struct {
 
 // Per-device state for the selector. Returns every in-scope device;
 // service applies skip-reason attribution. nil power/hash = stale
-// (15-min window). site_ids and device_identifiers nil = whole-org.
+// (15-min window). All selector arrays nil = whole-org.
 // Stable order so the selector's stable sort is deterministic on ties.
 func (q *Queries) ListCurtailmentCandidatesByOrg(ctx context.Context, arg ListCurtailmentCandidatesByOrgParams) ([]ListCurtailmentCandidatesByOrgRow, error) {
-	rows, err := q.query(ctx, q.listCurtailmentCandidatesByOrgStmt, listCurtailmentCandidatesByOrg, arg.OrgID, pq.Array(arg.SiteIds), pq.Array(arg.DeviceIdentifiers))
+	rows, err := q.query(ctx, q.listCurtailmentCandidatesByOrgStmt, listCurtailmentCandidatesByOrg,
+		arg.OrgID,
+		pq.Array(arg.SiteIds),
+		pq.Array(arg.BuildingIds),
+		pq.Array(arg.RackIds),
+		pq.Array(arg.GroupIds),
+		pq.Array(arg.DeviceIdentifiers),
+		arg.ResultLimit,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -2183,6 +2351,188 @@ func (q *Queries) ListCurtailmentEventsForOrg(ctx context.Context, arg ListCurta
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.CreatedByUserID,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listCurtailmentGroupScopeCoverage = `-- name: ListCurtailmentGroupScopeCoverage :many
+WITH selected_groups AS (
+    SELECT ds.id
+    FROM device_set ds
+    WHERE ds.org_id = $1
+      AND ds.type = 'group'
+      AND ds.deleted_at IS NULL
+      AND ds.id = ANY($2::BIGINT[])
+), selector_rows AS (
+    SELECT sg.id,
+           EXISTS (
+               SELECT 1
+               FROM device_set_membership dsm
+               JOIN device d
+                 ON d.id = dsm.device_id
+                AND d.org_id = dsm.org_id
+                AND d.deleted_at IS NULL
+               WHERE dsm.org_id = $1
+                 AND dsm.device_set_id = sg.id
+                 AND dsm.device_set_type = 'group'
+           ) AS has_members
+    FROM selected_groups sg
+), members AS MATERIALIZED (
+    SELECT DISTINCT d.id AS device_id, d.site_id
+    FROM device_set_membership dsm
+    JOIN selected_groups sg ON sg.id = dsm.device_set_id
+    JOIN device d
+      ON d.id = dsm.device_id
+     AND d.org_id = dsm.org_id
+     AND d.deleted_at IS NULL
+    WHERE dsm.org_id = $1
+      AND dsm.device_set_type = 'group'
+    ORDER BY d.id
+    LIMIT 10001
+)
+SELECT sr.id AS selector_id,
+       sr.has_members AS selector_has_members,
+       NULL::BIGINT AS member_site_id,
+       NULL::BIGINT AS member_device_id
+FROM selector_rows sr
+UNION ALL
+SELECT 0 AS selector_id,
+       TRUE AS selector_has_members,
+       m.site_id AS member_site_id,
+       m.device_id AS member_device_id
+FROM members m
+ORDER BY selector_id, member_device_id
+`
+
+type ListCurtailmentGroupScopeCoverageParams struct {
+	OrgID    int64
+	GroupIds []int64
+}
+
+type ListCurtailmentGroupScopeCoverageRow struct {
+	SelectorID         int64
+	SelectorHasMembers bool
+	MemberSiteID       sql.NullInt64
+	MemberDeviceID     sql.NullInt64
+}
+
+func (q *Queries) ListCurtailmentGroupScopeCoverage(ctx context.Context, arg ListCurtailmentGroupScopeCoverageParams) ([]ListCurtailmentGroupScopeCoverageRow, error) {
+	rows, err := q.query(ctx, q.listCurtailmentGroupScopeCoverageStmt, listCurtailmentGroupScopeCoverage, arg.OrgID, pq.Array(arg.GroupIds))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListCurtailmentGroupScopeCoverageRow
+	for rows.Next() {
+		var i ListCurtailmentGroupScopeCoverageRow
+		if err := rows.Scan(
+			&i.SelectorID,
+			&i.SelectorHasMembers,
+			&i.MemberSiteID,
+			&i.MemberDeviceID,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listCurtailmentRackScopeCoverage = `-- name: ListCurtailmentRackScopeCoverage :many
+WITH selected_racks AS (
+    SELECT ds.id,
+           dsr.site_id,
+           dsr.building_id,
+           b.site_id AS building_site_id
+    FROM device_set ds
+    JOIN device_set_rack dsr
+      ON dsr.device_set_id = ds.id
+     AND dsr.org_id = ds.org_id
+    LEFT JOIN building b
+      ON b.id = dsr.building_id
+     AND b.org_id = dsr.org_id
+     AND b.deleted_at IS NULL
+    WHERE ds.org_id = $1
+      AND ds.type = 'rack'
+      AND ds.deleted_at IS NULL
+      AND ds.id = ANY($2::BIGINT[])
+), members AS MATERIALIZED (
+    SELECT DISTINCT d.id AS device_id, d.site_id
+    FROM device_set_membership dsm
+    JOIN selected_racks sr ON sr.id = dsm.device_set_id
+    JOIN device d
+      ON d.id = dsm.device_id
+     AND d.org_id = dsm.org_id
+     AND d.deleted_at IS NULL
+    WHERE dsm.org_id = $1
+      AND dsm.device_set_type = 'rack'
+    ORDER BY d.id
+    LIMIT 10001
+)
+SELECT sr.id AS selector_id,
+       sr.site_id AS resource_site_id,
+       sr.building_id,
+       sr.building_site_id,
+       NULL::BIGINT AS member_site_id,
+       NULL::BIGINT AS member_device_id
+FROM selected_racks sr
+UNION ALL
+SELECT 0 AS selector_id,
+       NULL::BIGINT AS resource_site_id,
+       NULL::BIGINT AS building_id,
+       NULL::BIGINT AS building_site_id,
+       m.site_id AS member_site_id,
+       m.device_id AS member_device_id
+FROM members m
+ORDER BY selector_id, member_device_id
+`
+
+type ListCurtailmentRackScopeCoverageParams struct {
+	OrgID   int64
+	RackIds []int64
+}
+
+type ListCurtailmentRackScopeCoverageRow struct {
+	SelectorID     int64
+	ResourceSiteID sql.NullInt64
+	BuildingID     sql.NullInt64
+	BuildingSiteID sql.NullInt64
+	MemberSiteID   sql.NullInt64
+	MemberDeviceID sql.NullInt64
+}
+
+func (q *Queries) ListCurtailmentRackScopeCoverage(ctx context.Context, arg ListCurtailmentRackScopeCoverageParams) ([]ListCurtailmentRackScopeCoverageRow, error) {
+	rows, err := q.query(ctx, q.listCurtailmentRackScopeCoverageStmt, listCurtailmentRackScopeCoverage, arg.OrgID, pq.Array(arg.RackIds))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []ListCurtailmentRackScopeCoverageRow
+	for rows.Next() {
+		var i ListCurtailmentRackScopeCoverageRow
+		if err := rows.Scan(
+			&i.SelectorID,
+			&i.ResourceSiteID,
+			&i.BuildingID,
+			&i.BuildingSiteID,
+			&i.MemberSiteID,
+			&i.MemberDeviceID,
 		); err != nil {
 			return nil, err
 		}

--- a/server/generated/sqlc/curtailment_response_profile.sql.go
+++ b/server/generated/sqlc/curtailment_response_profile.sql.go
@@ -378,9 +378,9 @@ type LockCurtailmentResponseProfileAutomationMutationParams struct {
 	ProfileID int64
 }
 
-// Serializes profile fan changes with automation create/update/enable. Both
-// sides re-read their compatibility condition after acquiring this lock so a
-// concurrent pair cannot commit an automation binding to a fan profile.
+// Serializes profile changes with automation create/update/enable. Both sides
+// re-read their compatibility conditions after acquiring this lock so a
+// concurrent pair cannot commit an invalid automation binding.
 func (q *Queries) LockCurtailmentResponseProfileAutomationMutation(ctx context.Context, arg LockCurtailmentResponseProfileAutomationMutationParams) error {
 	_, err := q.exec(ctx, q.lockCurtailmentResponseProfileAutomationMutationStmt, lockCurtailmentResponseProfileAutomationMutation, arg.OrgID, arg.ProfileID)
 	return err

--- a/server/generated/sqlc/db.go
+++ b/server/generated/sqlc/db.go
@@ -963,11 +963,20 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.listCurtailmentAutomationRulesByOrgStmt, err = db.PrepareContext(ctx, listCurtailmentAutomationRulesByOrg); err != nil {
 		return nil, fmt.Errorf("error preparing query ListCurtailmentAutomationRulesByOrg: %w", err)
 	}
+	if q.listCurtailmentBuildingScopeCoverageStmt, err = db.PrepareContext(ctx, listCurtailmentBuildingScopeCoverage); err != nil {
+		return nil, fmt.Errorf("error preparing query ListCurtailmentBuildingScopeCoverage: %w", err)
+	}
 	if q.listCurtailmentCandidatesByOrgStmt, err = db.PrepareContext(ctx, listCurtailmentCandidatesByOrg); err != nil {
 		return nil, fmt.Errorf("error preparing query ListCurtailmentCandidatesByOrg: %w", err)
 	}
 	if q.listCurtailmentEventsForOrgStmt, err = db.PrepareContext(ctx, listCurtailmentEventsForOrg); err != nil {
 		return nil, fmt.Errorf("error preparing query ListCurtailmentEventsForOrg: %w", err)
+	}
+	if q.listCurtailmentGroupScopeCoverageStmt, err = db.PrepareContext(ctx, listCurtailmentGroupScopeCoverage); err != nil {
+		return nil, fmt.Errorf("error preparing query ListCurtailmentGroupScopeCoverage: %w", err)
+	}
+	if q.listCurtailmentRackScopeCoverageStmt, err = db.PrepareContext(ctx, listCurtailmentRackScopeCoverage); err != nil {
+		return nil, fmt.Errorf("error preparing query ListCurtailmentRackScopeCoverage: %w", err)
 	}
 	if q.listCurtailmentResponseProfileDeviceSitesByOrgStmt, err = db.PrepareContext(ctx, listCurtailmentResponseProfileDeviceSitesByOrg); err != nil {
 		return nil, fmt.Errorf("error preparing query ListCurtailmentResponseProfileDeviceSitesByOrg: %w", err)
@@ -3205,6 +3214,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing listCurtailmentAutomationRulesByOrgStmt: %w", cerr)
 		}
 	}
+	if q.listCurtailmentBuildingScopeCoverageStmt != nil {
+		if cerr := q.listCurtailmentBuildingScopeCoverageStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing listCurtailmentBuildingScopeCoverageStmt: %w", cerr)
+		}
+	}
 	if q.listCurtailmentCandidatesByOrgStmt != nil {
 		if cerr := q.listCurtailmentCandidatesByOrgStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing listCurtailmentCandidatesByOrgStmt: %w", cerr)
@@ -3213,6 +3227,16 @@ func (q *Queries) Close() error {
 	if q.listCurtailmentEventsForOrgStmt != nil {
 		if cerr := q.listCurtailmentEventsForOrgStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing listCurtailmentEventsForOrgStmt: %w", cerr)
+		}
+	}
+	if q.listCurtailmentGroupScopeCoverageStmt != nil {
+		if cerr := q.listCurtailmentGroupScopeCoverageStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing listCurtailmentGroupScopeCoverageStmt: %w", cerr)
+		}
+	}
+	if q.listCurtailmentRackScopeCoverageStmt != nil {
+		if cerr := q.listCurtailmentRackScopeCoverageStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing listCurtailmentRackScopeCoverageStmt: %w", cerr)
 		}
 	}
 	if q.listCurtailmentResponseProfileDeviceSitesByOrgStmt != nil {
@@ -4677,8 +4701,11 @@ type Queries struct {
 	listBuildingsByOrgStmt                                       *sql.Stmt
 	listBuiltinRolesForOrgStmt                                   *sql.Stmt
 	listCurtailmentAutomationRulesByOrgStmt                      *sql.Stmt
+	listCurtailmentBuildingScopeCoverageStmt                     *sql.Stmt
 	listCurtailmentCandidatesByOrgStmt                           *sql.Stmt
 	listCurtailmentEventsForOrgStmt                              *sql.Stmt
+	listCurtailmentGroupScopeCoverageStmt                        *sql.Stmt
+	listCurtailmentRackScopeCoverageStmt                         *sql.Stmt
 	listCurtailmentResponseProfileDeviceSitesByOrgStmt           *sql.Stmt
 	listCurtailmentResponseProfilesByOrgStmt                     *sql.Stmt
 	listCurtailmentTargetSiteCoverageByEventStmt                 *sql.Stmt
@@ -5220,8 +5247,11 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		listBuildingsByOrgStmt:                                       q.listBuildingsByOrgStmt,
 		listBuiltinRolesForOrgStmt:                                   q.listBuiltinRolesForOrgStmt,
 		listCurtailmentAutomationRulesByOrgStmt:                      q.listCurtailmentAutomationRulesByOrgStmt,
+		listCurtailmentBuildingScopeCoverageStmt:                     q.listCurtailmentBuildingScopeCoverageStmt,
 		listCurtailmentCandidatesByOrgStmt:                           q.listCurtailmentCandidatesByOrgStmt,
 		listCurtailmentEventsForOrgStmt:                              q.listCurtailmentEventsForOrgStmt,
+		listCurtailmentGroupScopeCoverageStmt:                        q.listCurtailmentGroupScopeCoverageStmt,
+		listCurtailmentRackScopeCoverageStmt:                         q.listCurtailmentRackScopeCoverageStmt,
 		listCurtailmentResponseProfileDeviceSitesByOrgStmt:           q.listCurtailmentResponseProfileDeviceSitesByOrgStmt,
 		listCurtailmentResponseProfilesByOrgStmt:                     q.listCurtailmentResponseProfilesByOrgStmt,
 		listCurtailmentTargetSiteCoverageByEventStmt:                 q.listCurtailmentTargetSiteCoverageByEventStmt,

--- a/server/generated/sqlc/querier.go
+++ b/server/generated/sqlc/querier.go
@@ -1162,9 +1162,9 @@ type Querier interface {
 	// The row lock turns the authorization snapshot into an insert-time invariant:
 	// a concurrent move/delete must wait until this transaction commits.
 	LockCurtailmentFanDevicesForWrite(ctx context.Context, arg LockCurtailmentFanDevicesForWriteParams) ([]LockCurtailmentFanDevicesForWriteRow, error)
-	// Serializes profile fan changes with automation create/update/enable. Both
-	// sides re-read their compatibility condition after acquiring this lock so a
-	// concurrent pair cannot commit an automation binding to a fan profile.
+	// Serializes profile changes with automation create/update/enable. Both sides
+	// re-read their compatibility conditions after acquiring this lock so a
+	// concurrent pair cannot commit an invalid automation binding.
 	LockCurtailmentResponseProfileAutomationMutation(ctx context.Context, arg LockCurtailmentResponseProfileAutomationMutationParams) error
 	// Serialize hierarchy start checks by org so conflict detection and event
 	// insertion happen under one database-backed critical section.

--- a/server/generated/sqlc/querier.go
+++ b/server/generated/sqlc/querier.go
@@ -911,9 +911,10 @@ type Querier interface {
 	// onboarding hook that seeds built-ins for a new org.
 	ListBuiltinRolesForOrg(ctx context.Context, organizationID sql.NullInt64) ([]Role, error)
 	ListCurtailmentAutomationRulesByOrg(ctx context.Context, orgID int64) ([]ListCurtailmentAutomationRulesByOrgRow, error)
+	ListCurtailmentBuildingScopeCoverage(ctx context.Context, arg ListCurtailmentBuildingScopeCoverageParams) ([]ListCurtailmentBuildingScopeCoverageRow, error)
 	// Per-device state for the selector. Returns every in-scope device;
 	// service applies skip-reason attribution. nil power/hash = stale
-	// (15-min window). site_ids and device_identifiers nil = whole-org.
+	// (15-min window). All selector arrays nil = whole-org.
 	// Stable order so the selector's stable sort is deterministic on ties.
 	ListCurtailmentCandidatesByOrg(ctx context.Context, arg ListCurtailmentCandidatesByOrgParams) ([]ListCurtailmentCandidatesByOrgRow, error)
 	// Cursor-paginated history (newest-first). cursor_id=0 is the first page;
@@ -923,6 +924,8 @@ type Querier interface {
 	// stripped into a `skipped_aggregate` reason→count map so 10K-miner
 	// snapshots don't ride the wire on every list row.
 	ListCurtailmentEventsForOrg(ctx context.Context, arg ListCurtailmentEventsForOrgParams) ([]ListCurtailmentEventsForOrgRow, error)
+	ListCurtailmentGroupScopeCoverage(ctx context.Context, arg ListCurtailmentGroupScopeCoverageParams) ([]ListCurtailmentGroupScopeCoverageRow, error)
+	ListCurtailmentRackScopeCoverage(ctx context.Context, arg ListCurtailmentRackScopeCoverageParams) ([]ListCurtailmentRackScopeCoverageRow, error)
 	ListCurtailmentResponseProfileDeviceSitesByOrg(ctx context.Context, arg ListCurtailmentResponseProfileDeviceSitesByOrgParams) ([]ListCurtailmentResponseProfileDeviceSitesByOrgRow, error)
 	ListCurtailmentResponseProfilesByOrg(ctx context.Context, orgID int64) ([]CurtailmentResponseProfile, error)
 	// Coverage for explicit-device event authorization. target_count is every

--- a/server/generated/sqlc/retrying_querier.gen.go
+++ b/server/generated/sqlc/retrying_querier.gen.go
@@ -3600,6 +3600,18 @@ func (q *retryingQuerier) ListCurtailmentAutomationRulesByOrg(ctx context.Contex
 	return result, err
 }
 
+func (q *retryingQuerier) ListCurtailmentBuildingScopeCoverage(ctx context.Context, arg ListCurtailmentBuildingScopeCoverageParams) ([]ListCurtailmentBuildingScopeCoverageRow, error) {
+	var result []ListCurtailmentBuildingScopeCoverageRow
+	err := q.retrier.RetryQuery(ctx, "ListCurtailmentBuildingScopeCoverage", func() error {
+		callResult, callErr := q.next.ListCurtailmentBuildingScopeCoverage(ctx, arg)
+		if callErr == nil {
+			result = callResult
+		}
+		return callErr
+	})
+	return result, err
+}
+
 func (q *retryingQuerier) ListCurtailmentCandidatesByOrg(ctx context.Context, arg ListCurtailmentCandidatesByOrgParams) ([]ListCurtailmentCandidatesByOrgRow, error) {
 	var result []ListCurtailmentCandidatesByOrgRow
 	err := q.retrier.RetryQuery(ctx, "ListCurtailmentCandidatesByOrg", func() error {
@@ -3616,6 +3628,30 @@ func (q *retryingQuerier) ListCurtailmentEventsForOrg(ctx context.Context, arg L
 	var result []ListCurtailmentEventsForOrgRow
 	err := q.retrier.RetryQuery(ctx, "ListCurtailmentEventsForOrg", func() error {
 		callResult, callErr := q.next.ListCurtailmentEventsForOrg(ctx, arg)
+		if callErr == nil {
+			result = callResult
+		}
+		return callErr
+	})
+	return result, err
+}
+
+func (q *retryingQuerier) ListCurtailmentGroupScopeCoverage(ctx context.Context, arg ListCurtailmentGroupScopeCoverageParams) ([]ListCurtailmentGroupScopeCoverageRow, error) {
+	var result []ListCurtailmentGroupScopeCoverageRow
+	err := q.retrier.RetryQuery(ctx, "ListCurtailmentGroupScopeCoverage", func() error {
+		callResult, callErr := q.next.ListCurtailmentGroupScopeCoverage(ctx, arg)
+		if callErr == nil {
+			result = callResult
+		}
+		return callErr
+	})
+	return result, err
+}
+
+func (q *retryingQuerier) ListCurtailmentRackScopeCoverage(ctx context.Context, arg ListCurtailmentRackScopeCoverageParams) ([]ListCurtailmentRackScopeCoverageRow, error) {
+	var result []ListCurtailmentRackScopeCoverageRow
+	err := q.retrier.RetryQuery(ctx, "ListCurtailmentRackScopeCoverage", func() error {
+		callResult, callErr := q.next.ListCurtailmentRackScopeCoverage(ctx, arg)
 		if callErr == nil {
 			result = callResult
 		}

--- a/server/internal/domain/curtailment/automation.go
+++ b/server/internal/domain/curtailment/automation.go
@@ -492,6 +492,15 @@ func validateAutomationProfileBinding(profile *models.ResponseProfile, canUseAdm
 	if profile == nil {
 		return nil
 	}
+	scope, err := ResponseProfileScope(*profile)
+	if err != nil {
+		return err
+	}
+	if hasTopologySelectors(scope) {
+		return fleeterror.NewFailedPreconditionError(
+			"topology-scoped response profiles cannot be used by automation until topology curtailment execution is supported",
+		)
+	}
 	if canUseAdminControls || !responseProfileRequiresAdminControls(*profile) {
 		return nil
 	}

--- a/server/internal/domain/curtailment/automation_test.go
+++ b/server/internal/domain/curtailment/automation_test.go
@@ -173,6 +173,80 @@ func TestAutomationService_CreateAllowsAdminOnlyProfileWithAdminControls(t *test
 	assert.Equal(t, 1, h.rules.createCalls)
 }
 
+func TestAutomationService_RejectsTopologyProfileAcrossBindingMutations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		run  func(*automationHarness) error
+	}{
+		{
+			name: "create",
+			run: func(h *automationHarness) error {
+				_, err := h.automation.Create(h.t.Context(), SaveAutomationRuleRequest{
+					Rule: models.AutomationRule{
+						OrgID:             h.orgID,
+						RuleName:          "Topology automation",
+						MQTTSourceID:      h.source.ID,
+						ResponseProfileID: h.profile.ID,
+					},
+					CanUseAdminControls: true,
+				})
+				return err
+			},
+		},
+		{
+			name: "update",
+			run: func(h *automationHarness) error {
+				_, err := h.automation.Update(h.t.Context(), SaveAutomationRuleRequest{
+					Rule: models.AutomationRule{
+						ID:                h.rule.ID,
+						OrgID:             h.orgID,
+						RuleName:          "Topology automation",
+						MQTTSourceID:      h.source.ID,
+						ResponseProfileID: h.profile.ID,
+					},
+					CanUseAdminControls: true,
+				})
+				return err
+			},
+		},
+		{
+			name: "enable",
+			run: func(h *automationHarness) error {
+				h.rule.Enabled = false
+				_, err := h.automation.SetEnabled(
+					h.t.Context(),
+					h.orgID,
+					h.rule.ID,
+					true,
+					true,
+					models.ResponseProfileFanSettings{},
+				)
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newAutomationHarness(t)
+			h.profile.SiteID = nil
+			h.profile.ScopeJSON = []byte(`{"scope_schema_version":1,"building_ids":[7]}`)
+
+			err := tt.run(h)
+
+			require.Error(t, err)
+			assert.True(t, fleeterror.IsFailedPreconditionError(err))
+			assert.Contains(t, err.Error(), "topology-scoped response profiles cannot be used by automation")
+			assert.Equal(t, "MaestroOS curtailment", h.rule.RuleName)
+			assert.Equal(t, 0, h.rules.createCalls)
+		})
+	}
+}
+
 func TestAutomationService_AllowsFacilityFanProfilesAcrossBindingMutations(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/domain/curtailment/response_profile.go
+++ b/server/internal/domain/curtailment/response_profile.go
@@ -143,6 +143,9 @@ func (s *ResponseProfileService) Update(ctx context.Context, req SaveResponsePro
 	if err != nil {
 		return nil, err
 	}
+	if err := s.validateTopologyProfileAutomationBinding(ctx, profile); err != nil {
+		return nil, err
+	}
 	return s.store.UpdateResponseProfile(
 		ctx,
 		profile,
@@ -150,6 +153,29 @@ func (s *ResponseProfileService) Update(ctx context.Context, req SaveResponsePro
 		req.ExpectedSiteID,
 		req.ExpectedScopeJSON,
 		req.ExpectedFacilityFanSettings,
+	)
+}
+
+func (s *ResponseProfileService) validateTopologyProfileAutomationBinding(
+	ctx context.Context,
+	profile models.ResponseProfile,
+) error {
+	scope, err := ResponseProfileScope(profile)
+	if err != nil {
+		return err
+	}
+	if !hasTopologySelectors(scope) {
+		return nil
+	}
+	count, err := s.store.CountAutomationRulesByResponseProfile(ctx, profile.OrgID, profile.ID)
+	if err != nil {
+		return err
+	}
+	if count == 0 {
+		return nil
+	}
+	return fleeterror.NewFailedPreconditionError(
+		"topology-scoped response profiles cannot be used by automation until topology curtailment execution is supported; update the automation rules first",
 	)
 }
 

--- a/server/internal/domain/curtailment/response_profile.go
+++ b/server/internal/domain/curtailment/response_profile.go
@@ -283,7 +283,7 @@ func (s *ResponseProfileService) validateResponseProfileScope(ctx context.Contex
 	if listCandidatesFilterHasTopology(filter) {
 		resolver, ok := s.store.(interfaces.CurtailmentTopologyScopeStore)
 		if !ok {
-			return fleeterror.NewUnimplementedError("curtailment topology scope resolver is not configured")
+			return fleeterror.NewInternalError("curtailment topology scope resolver is not configured")
 		}
 		_, err = resolver.ResolveCurtailmentTopologyScope(ctx, filter)
 		return err

--- a/server/internal/domain/curtailment/response_profile.go
+++ b/server/internal/domain/curtailment/response_profile.go
@@ -215,6 +215,12 @@ func (s *ResponseProfileService) validateAndNormalize(
 			return models.ResponseProfile{}, nil, fleeterror.NewNotFoundErrorf("site not found: %d", siteID)
 		}
 	}
+	if err := validateResponseProfileBehavior(profile, req.CanUseAdminControls); err != nil {
+		return models.ResponseProfile{}, nil, err
+	}
+	if err := s.validateResponseProfileScope(ctx, profile.OrgID, scope); err != nil {
+		return models.ResponseProfile{}, nil, err
+	}
 	var infrastructureDevices map[int64]models.ResponseProfileInfrastructureDevice
 	var existingFacilityFanDeviceIDs []int64
 	if allowLegacyFacilityFans {
@@ -239,10 +245,32 @@ func (s *ResponseProfileService) validateAndNormalize(
 	}
 	profile.ScopeJSON = scopeJSON
 	profile.SiteID = responseProfileLegacySiteID(scope)
-	if err := validateResponseProfileBehavior(profile, req.CanUseAdminControls); err != nil {
-		return models.ResponseProfile{}, nil, err
-	}
 	return profile, infrastructureDevices, nil
+}
+
+func (s *ResponseProfileService) validateResponseProfileScope(ctx context.Context, orgID int64, scope Scope) error {
+	filter, err := resolveScope(scope)
+	if err != nil {
+		return err
+	}
+	filter.OrgID = orgID
+	if listCandidatesFilterHasTopology(filter) {
+		resolver, ok := s.store.(interfaces.CurtailmentTopologyScopeStore)
+		if !ok {
+			return fleeterror.NewUnimplementedError("curtailment topology scope resolver is not configured")
+		}
+		_, err = resolver.ResolveCurtailmentTopologyScope(ctx, filter)
+		return err
+	}
+	if len(filter.DeviceIdentifiers) > 0 {
+		return nil
+	}
+	filter.ResultLimit = ScopeResolvedMinerMax + 1
+	candidates, err := s.store.ListCandidates(ctx, filter)
+	if err != nil {
+		return err
+	}
+	return validateResolvedMinerCount(len(candidates))
 }
 
 func (s *ResponseProfileService) validateFacilityFanDevices(

--- a/server/internal/domain/curtailment/response_profile_test.go
+++ b/server/internal/domain/curtailment/response_profile_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"testing"
 
+	"connectrpc.com/connect"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/block/proto-fleet/server/internal/domain/curtailment/models"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
+	"github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
 )
 
 func TestResponseProfileService_CreatePersistsSiteScopedFixedKW(t *testing.T) {
@@ -303,11 +305,12 @@ func TestResponseProfileService_CreateAllowsFacilityFanOutsideExplicitMinerSite(
 	assert.Equal(t, []int64{31}, profile.FacilityFanDeviceIDs)
 }
 
-func TestResponseProfileService_CreateRejectsTopologyScopeUntilResolverLands(t *testing.T) {
+func TestResponseProfileService_CreateValidatesTopologyScope(t *testing.T) {
 	t.Parallel()
 
 	targetKW := 2500.0
-	_, err := NewResponseProfileService(newResponseProfileFakeStore()).Create(t.Context(), SaveResponseProfileRequest{
+	store := newResponseProfileFakeStore()
+	profile, err := NewResponseProfileService(store).Create(t.Context(), SaveResponseProfileRequest{
 		Profile: models.ResponseProfile{
 			OrgID:       42,
 			ProfileName: "Building shed",
@@ -317,9 +320,91 @@ func TestResponseProfileService_CreateRejectsTopologyScopeUntilResolverLands(t *
 		},
 	})
 
+	require.NoError(t, err)
+	assert.Equal(t, int64(42), store.lastTopologyFilter.OrgID)
+	assert.Equal(t, []int64{7}, store.lastTopologyFilter.BuildingIDs)
+	assert.JSONEq(t, `{"scope_schema_version":1,"building_ids":[7]}`, string(profile.ScopeJSON))
+}
+
+func TestResponseProfileService_CreateRejectsMissingTopologyResource(t *testing.T) {
+	t.Parallel()
+
+	targetKW := 2500.0
+	store := newResponseProfileFakeStore()
+	store.topologyCoverageErr = fleeterror.NewNotFoundError("buildings not found in caller's org: [7]")
+
+	_, err := NewResponseProfileService(store).Create(t.Context(), SaveResponseProfileRequest{
+		Profile: models.ResponseProfile{
+			OrgID:       42,
+			ProfileName: "Missing building",
+			Mode:        models.ModeFixedKw,
+			TargetKW:    &targetKW,
+			ScopeJSON:   []byte(`{"scope_schema_version":1,"building_ids":[7]}`),
+		},
+	})
+
 	require.Error(t, err)
-	assert.True(t, fleeterror.IsUnimplementedError(err))
-	assert.Contains(t, err.Error(), "building, rack, and group scope resolution is not implemented yet")
+	assert.True(t, fleeterror.IsNotFoundError(err))
+	assert.Nil(t, store.created)
+}
+
+func TestResponseProfileService_CreateEnforcesResolvedMinerLimit(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		scopeJSON string
+		count     int
+		wantErr   bool
+	}{
+		{
+			name:      "whole org overflow",
+			scopeJSON: `{"scope_schema_version":1,"whole_org":true}`,
+			count:     ScopeResolvedMinerMax + 1,
+			wantErr:   true,
+		},
+		{
+			name:      "site overflow",
+			scopeJSON: `{"scope_schema_version":1,"site_ids":[7]}`,
+			count:     ScopeResolvedMinerMax + 1,
+			wantErr:   true,
+		},
+		{
+			name:      "site exact bound",
+			scopeJSON: `{"scope_schema_version":1,"site_ids":[7]}`,
+			count:     ScopeResolvedMinerMax,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			targetKW := 2500.0
+			store := newResponseProfileFakeStore()
+			store.candidates = make([]*models.Candidate, tc.count)
+
+			_, err := NewResponseProfileService(store).Create(t.Context(), SaveResponseProfileRequest{
+				Profile: models.ResponseProfile{
+					OrgID:       42,
+					ProfileName: "Bounded profile",
+					Mode:        models.ModeFixedKw,
+					TargetKW:    &targetKW,
+					ScopeJSON:   []byte(tc.scopeJSON),
+				},
+			})
+
+			assert.Equal(t, int32(ScopeResolvedMinerMax+1), store.lastCandidateFilter.ResultLimit)
+			if !tc.wantErr {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			var fleetErr fleeterror.FleetError
+			require.ErrorAs(t, err, &fleetErr)
+			assert.Equal(t, connect.CodeResourceExhausted, fleetErr.GRPCCode)
+			assert.Nil(t, store.created)
+		})
+	}
 }
 
 func TestScopeFromJSONRejectsRemovedDeviceSetKey(t *testing.T) {
@@ -751,6 +836,11 @@ type responseProfileFakeStore struct {
 	profiles              []*models.ResponseProfile
 	infrastructureDevices map[int64]models.ResponseProfileInfrastructureDevice
 	deviceSites           map[string]*int64
+	topologyCoverage      interfaces.CurtailmentTopologyScopeCoverage
+	topologyCoverageErr   error
+	lastTopologyFilter    interfaces.ListCandidatesParams
+	candidates            []*models.Candidate
+	lastCandidateFilter   interfaces.ListCandidatesParams
 }
 
 func newResponseProfileFakeStore() *responseProfileFakeStore {
@@ -772,6 +862,17 @@ func (s *responseProfileFakeStore) GetResponseProfile(_ context.Context, _ int64
 		}
 	}
 	return nil, fleeterror.NewNotFoundErrorf("curtailment response profile not found: %d", profileID)
+}
+
+func (s *responseProfileFakeStore) ListCandidates(
+	_ context.Context,
+	params interfaces.ListCandidatesParams,
+) ([]*models.Candidate, error) {
+	s.lastCandidateFilter = params
+	if params.ResultLimit > 0 && len(s.candidates) > int(params.ResultLimit) {
+		return s.candidates[:params.ResultLimit], nil
+	}
+	return s.candidates, nil
 }
 
 func (s *responseProfileFakeStore) ListResponseProfileDeviceSites(_ context.Context, _ int64, deviceIdentifiers []string) (map[string]*int64, error) {
@@ -819,6 +920,14 @@ func (s *responseProfileFakeStore) SiteBelongsToOrg(_ context.Context, orgID, si
 	s.siteCheckOrgID = orgID
 	s.siteCheckSiteID = siteID
 	return s.siteBelongs, nil
+}
+
+func (s *responseProfileFakeStore) ResolveCurtailmentTopologyScope(
+	_ context.Context,
+	params interfaces.ListCandidatesParams,
+) (interfaces.CurtailmentTopologyScopeCoverage, error) {
+	s.lastTopologyFilter = params
+	return s.topologyCoverage, s.topologyCoverageErr
 }
 
 func ptrInt64(v int64) *int64 {

--- a/server/internal/domain/curtailment/response_profile_test.go
+++ b/server/internal/domain/curtailment/response_profile_test.go
@@ -348,6 +348,32 @@ func TestResponseProfileService_CreateRejectsMissingTopologyResource(t *testing.
 	assert.Nil(t, store.created)
 }
 
+func TestResponseProfileService_CreateReturnsInternalWhenTopologyResolverIsMissing(t *testing.T) {
+	t.Parallel()
+
+	targetKW := 2500.0
+	store := newResponseProfileFakeStore()
+	storeWithoutTopology := struct {
+		interfaces.ResponseProfileStore
+	}{ResponseProfileStore: store}
+
+	_, err := NewResponseProfileService(storeWithoutTopology).Create(t.Context(), SaveResponseProfileRequest{
+		Profile: models.ResponseProfile{
+			OrgID:       42,
+			ProfileName: "Building shed",
+			Mode:        models.ModeFixedKw,
+			TargetKW:    &targetKW,
+			ScopeJSON:   []byte(`{"scope_schema_version":1,"building_ids":[7]}`),
+		},
+	})
+
+	require.Error(t, err)
+	var fleetErr fleeterror.FleetError
+	require.ErrorAs(t, err, &fleetErr)
+	assert.Equal(t, fleeterror.NewInternalError("").GRPCCode, fleetErr.GRPCCode)
+	assert.Contains(t, err.Error(), "topology scope resolver is not configured")
+}
+
 func TestResponseProfileService_CreateEnforcesResolvedMinerLimit(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/domain/curtailment/response_profile_test.go
+++ b/server/internal/domain/curtailment/response_profile_test.go
@@ -598,6 +598,30 @@ func TestResponseProfileService_UpdateAllowsFacilityFansWhenProfileHasAutomation
 	assert.Equal(t, []int64{31}, store.updated.FacilityFanDeviceIDs)
 }
 
+func TestResponseProfileService_UpdateRejectsTopologyScopeWhenProfileHasAutomationRules(t *testing.T) {
+	t.Parallel()
+
+	targetKW := 2500.0
+	store := newResponseProfileFakeStore()
+	store.automationRuleCount = 1
+
+	_, err := NewResponseProfileService(store).Update(t.Context(), SaveResponseProfileRequest{
+		Profile: models.ResponseProfile{
+			ID:          101,
+			OrgID:       42,
+			ProfileName: "Automated building shed",
+			Mode:        models.ModeFixedKw,
+			TargetKW:    &targetKW,
+			ScopeJSON:   []byte(`{"scope_schema_version":1,"building_ids":[7]}`),
+		},
+	})
+
+	require.Error(t, err)
+	assert.True(t, fleeterror.IsFailedPreconditionError(err))
+	assert.Contains(t, err.Error(), "topology-scoped response profiles cannot be used by automation")
+	assert.Nil(t, store.updated)
+}
+
 func TestResponseProfileService_CreateRejectsUnknownSite(t *testing.T) {
 	t.Parallel()
 

--- a/server/internal/domain/curtailment/service.go
+++ b/server/internal/domain/curtailment/service.go
@@ -27,6 +27,7 @@ const (
 	ScopeSchemaVersionCurrent  uint32 = 1
 	ScopeTopologyIDsPerTypeMax        = 256
 	ScopeDeviceIdentifiersMax         = 10000
+	ScopeResolvedMinerMax             = interfaces.CurtailmentResolvedMinerMax
 )
 
 // Scope identifies one terminal target type. A terminal type may contain
@@ -194,6 +195,11 @@ func (s *Service) Preview(ctx context.Context, req PreviewRequest) (*Plan, error
 func (s *Service) Start(ctx context.Context, req StartRequest) (*Plan, error) {
 	if err := validateStartRequest(req); err != nil {
 		return nil, err
+	}
+	if hasTopologySelectors(req.Scope) {
+		return nil, fleeterror.NewUnimplementedError(
+			"topology-scoped Start requires durable authorization and lifecycle support",
+		)
 	}
 	req.PostEventCooldownSec = effectivePostEventCooldownSec(req.PreviewRequest)
 
@@ -1227,29 +1233,15 @@ func (s *Service) ListTargetSiteCoverageByEvents(
 // candidate floor (for the decision snapshot) and the OrgConfig (so Start
 // can resolve max_duration_seconds=0 without a second DB read).
 func (s *Service) runSelector(ctx context.Context, req PreviewRequest) (*Plan, int32, *models.OrgConfig, error) {
-	candidateFilter, err := resolveScope(req.Scope)
+	candidateFilter, err := s.resolveScopeForOrg(ctx, req.OrgID, req.Scope)
 	if err != nil {
 		return nil, 0, nil, err
-	}
-	// Empty-but-non-nil would match nothing under the query's `IS NULL` check.
-	if len(candidateFilter.DeviceIdentifiers) == 0 {
-		candidateFilter.DeviceIdentifiers = nil
 	}
 
 	orgConfig, err := s.store.GetOrgConfig(ctx, req.OrgID)
 	if err != nil {
 		return nil, 0, nil, err
 	}
-	for _, siteID := range candidateFilter.SiteIDs {
-		exists, err := s.store.SiteBelongsToOrg(ctx, req.OrgID, siteID)
-		if err != nil {
-			return nil, 0, nil, err
-		}
-		if !exists {
-			return nil, 0, nil, fleeterror.NewNotFoundErrorf("site %d not found", siteID)
-		}
-	}
-
 	// Effective candidate floor: per-org default, admin-overridable.
 	// Handler enforces the admin role gate.
 	minPowerW := orgConfig.CandidateMinPowerW
@@ -1263,9 +1255,12 @@ func (s *Service) runSelector(ctx context.Context, req PreviewRequest) (*Plan, i
 	}
 	activeSet := toStringSet(activeDevices)
 
-	candidateFilter.OrgID = req.OrgID
+	candidateFilter.ResultLimit = ScopeResolvedMinerMax + 1
 	candidates, err := s.store.ListCandidates(ctx, candidateFilter)
 	if err != nil {
+		return nil, 0, nil, err
+	}
+	if err := validateResolvedMinerCount(len(candidates)); err != nil {
 		return nil, 0, nil, err
 	}
 
@@ -1293,14 +1288,13 @@ func (s *Service) runSelector(ctx context.Context, req PreviewRequest) (*Plan, i
 	}
 
 	cooldownSet := map[string]struct{}{}
-	if req.PostEventCooldownSec > 0 {
+	if req.PostEventCooldownSec > 0 && len(candidates) > 0 {
 		cooldownDevices, err := s.store.ListRecentlyResolvedCurtailedDevices(
 			ctx,
 			interfaces.ListRecentlyResolvedCurtailedDevicesParams{
 				OrgID:             req.OrgID,
 				CooldownSec:       req.PostEventCooldownSec,
-				DeviceIdentifiers: candidateFilter.DeviceIdentifiers,
-				SiteIDs:           candidateFilter.SiteIDs,
+				DeviceIdentifiers: candidateDeviceIdentifiers(candidates),
 			},
 		)
 		if err != nil {
@@ -1325,6 +1319,26 @@ func (s *Service) runSelector(ctx context.Context, req PreviewRequest) (*Plan, i
 
 	plan := BuildPlan(eligible, preFiltered, minPowerW, mode)
 	return &plan, minPowerW, orgConfig, nil
+}
+
+func candidateDeviceIdentifiers(candidates []*models.Candidate) []string {
+	identifiers := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		if candidate != nil && candidate.DeviceIdentifier != "" {
+			identifiers = append(identifiers, candidate.DeviceIdentifier)
+		}
+	}
+	return identifiers
+}
+
+func validateResolvedMinerCount(count int) error {
+	if count <= ScopeResolvedMinerMax {
+		return nil
+	}
+	return fleeterror.NewResourceExhaustedErrorf(
+		"scope resolves to more than %d miners",
+		ScopeResolvedMinerMax,
+	)
 }
 
 // buildMode constructs the selection mode from the request. FULL_FLEET takes
@@ -1646,13 +1660,17 @@ func resolveScope(s Scope) (interfaces.ListCandidatesParams, error) {
 		}
 		return interfaces.ListCandidatesParams{DeviceIdentifiers: s.DeviceIdentifiers}, nil
 	case models.ScopeTypeMixed:
-		if hasTopologySelectors(s) {
-			return interfaces.ListCandidatesParams{}, fleeterror.NewUnimplementedErrorf(
-				"building, rack, and group scope resolution is not implemented yet",
-			)
-		}
 		if len(s.SiteIDs) == 0 && len(s.DeviceIdentifiers) == 0 {
-			return interfaces.ListCandidatesParams{}, fleeterror.NewInvalidArgumentError("scope must include terminal selector IDs")
+			switch {
+			case len(s.BuildingIDs) > 0:
+				return interfaces.ListCandidatesParams{BuildingIDs: s.BuildingIDs}, nil
+			case len(s.RackIDs) > 0:
+				return interfaces.ListCandidatesParams{RackIDs: s.RackIDs}, nil
+			case len(s.GroupIDs) > 0:
+				return interfaces.ListCandidatesParams{GroupIDs: s.GroupIDs}, nil
+			default:
+				return interfaces.ListCandidatesParams{}, fleeterror.NewInvalidArgumentError("scope must include terminal selector IDs")
+			}
 		}
 		return interfaces.ListCandidatesParams{
 			SiteIDs:           s.SiteIDs,
@@ -1661,6 +1679,48 @@ func resolveScope(s Scope) (interfaces.ListCandidatesParams, error) {
 	default:
 		return interfaces.ListCandidatesParams{}, fleeterror.NewInvalidArgumentErrorf("unrecognized scope type: %q", s.Type)
 	}
+}
+
+func (s *Service) resolveScopeForOrg(
+	ctx context.Context,
+	orgID int64,
+	scope Scope,
+) (interfaces.ListCandidatesParams, error) {
+	filter, err := resolveScope(scope)
+	if err != nil {
+		return interfaces.ListCandidatesParams{}, err
+	}
+	filter.OrgID = orgID
+	if len(filter.SiteIDs) > 0 {
+		for _, siteID := range filter.SiteIDs {
+			exists, err := s.store.SiteBelongsToOrg(ctx, orgID, siteID)
+			if err != nil {
+				return interfaces.ListCandidatesParams{}, err
+			}
+			if !exists {
+				return interfaces.ListCandidatesParams{}, fleeterror.NewNotFoundErrorf("site %d not found", siteID)
+			}
+		}
+		return filter, nil
+	}
+	if !listCandidatesFilterHasTopology(filter) {
+		return filter, nil
+	}
+	topologyStore, ok := s.store.(interfaces.CurtailmentTopologyScopeStore)
+	if !ok {
+		return interfaces.ListCandidatesParams{}, fleeterror.NewInternalErrorf(
+			"curtailment topology scope resolver is not configured",
+		)
+	}
+	_, err = topologyStore.ResolveCurtailmentTopologyScope(ctx, filter)
+	if err != nil {
+		return interfaces.ListCandidatesParams{}, err
+	}
+	return filter, nil
+}
+
+func listCandidatesFilterHasTopology(filter interfaces.ListCandidatesParams) bool {
+	return len(filter.BuildingIDs) > 0 || len(filter.RackIDs) > 0 || len(filter.GroupIDs) > 0
 }
 
 func normalizeScope(s Scope) Scope {

--- a/server/internal/domain/curtailment/service_start_test.go
+++ b/server/internal/domain/curtailment/service_start_test.go
@@ -53,6 +53,25 @@ func TestService_Start_RejectsEmptyReason(t *testing.T) {
 	}
 }
 
+func TestService_Start_RejectsTopologyScopeUntilAuthorizationLifecycleLands(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeStore()
+	svc := NewService(store)
+	req := validStartRequest(1)
+	req.Scope = Scope{
+		SchemaVersion: ScopeSchemaVersionCurrent,
+		BuildingIDs:   []int64{7},
+	}
+
+	_, err := svc.Start(t.Context(), req)
+
+	require.Error(t, err)
+	assert.True(t, fleeterror.IsUnimplementedError(err))
+	assert.Contains(t, err.Error(), "durable authorization and lifecycle")
+	assert.Zero(t, store.listCandidatesCalls)
+}
+
 func TestService_Start_RejectsAllowUnboundedWithMaxDuration(t *testing.T) {
 	t.Parallel()
 	svc := NewService(newFakeStore())
@@ -939,7 +958,7 @@ func TestService_Start_StampsEffectiveBatchSize(t *testing.T) {
 		want             int32
 	}{
 		{"immediate_restore_claims_all_selected", 0, 5, 5},
-		{"immediate_restore_is_safety_limited", 0, int(RestoreBatchSizeMax) + 1, RestoreBatchSizeMax},
+		{"immediate_restore_at_resolved_miner_limit", 0, int(RestoreBatchSizeMax), RestoreBatchSizeMax},
 		{"positive_restore_batch_size_used_verbatim", 60, 5, 60},
 		{"positive_restore_batch_size_not_increased_by_large_fleet", 10, 5000, 10},
 		{"positive_restore_batch_size_not_clamped_at_100", 250, 10_000, 250},

--- a/server/internal/domain/curtailment/service_test.go
+++ b/server/internal/domain/curtailment/service_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"connectrpc.com/connect"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -35,20 +36,30 @@ type fakeStore struct {
 	cooldownDevicesByOrg map[int64][]string
 	candidatesByOrg      map[int64][]*models.Candidate
 	candidatesBySite     map[int64]map[int64][]*models.Candidate
+	candidatesByBuilding map[int64]map[int64][]*models.Candidate
+	candidatesByRack     map[int64]map[int64][]*models.Candidate
+	candidatesByGroup    map[int64]map[int64][]*models.Candidate
 	sitesByOrg           map[int64]map[int64]bool
+	topologyCoverage     interfaces.CurtailmentTopologyScopeCoverage
+	topologyCoverageErr  error
+	lastTopologyFilter   interfaces.ListCandidatesParams
 
 	// Captures for assertions.
-	listCandidatesCalls       int
-	lastListCandidatesOrgID   int64
-	lastListCandidatesFilter  []string
-	lastListCandidatesSiteIDs []int64
-	cooldownCalls             int
-	lastCooldownOrgID         int64
-	lastCooldownSec           int32
-	lastCooldownFilter        []string
-	lastCooldownSiteIDs       []int64
-	activeDevicesCalls        int
-	lastActiveDevicesOrgID    int64
+	listCandidatesCalls        int
+	lastListCandidatesOrgID    int64
+	lastListCandidatesLimit    int32
+	lastListCandidatesFilter   []string
+	lastListCandidatesSiteIDs  []int64
+	lastListCandidateBuildings []int64
+	lastListCandidateRacks     []int64
+	lastListCandidateGroups    []int64
+	cooldownCalls              int
+	lastCooldownOrgID          int64
+	lastCooldownSec            int32
+	lastCooldownFilter         []string
+	lastCooldownSiteIDs        []int64
+	activeDevicesCalls         int
+	lastActiveDevicesOrgID     int64
 
 	// InsertEventWithTargets state. nextEventID is the synthetic id sequence
 	// returned to the service so plan.EventUUID is populated; Start tests
@@ -405,6 +416,9 @@ func newFakeStore() *fakeStore {
 		cooldownDevicesByOrg:         map[int64][]string{},
 		candidatesByOrg:              map[int64][]*models.Candidate{},
 		candidatesBySite:             map[int64]map[int64][]*models.Candidate{},
+		candidatesByBuilding:         map[int64]map[int64][]*models.Candidate{},
+		candidatesByRack:             map[int64]map[int64][]*models.Candidate{},
+		candidatesByGroup:            map[int64]map[int64][]*models.Candidate{},
 		sitesByOrg:                   map[int64]map[int64]bool{},
 		eventsByUUID:                 map[uuid.UUID]*models.Event{},
 		targetsByEventUUID:           map[uuid.UUID][]*models.Target{},
@@ -450,10 +464,15 @@ func (f *fakeStore) SiteBelongsToOrg(_ context.Context, orgID, siteID int64) (bo
 func (f *fakeStore) ListCandidates(_ context.Context, params interfaces.ListCandidatesParams) ([]*models.Candidate, error) {
 	f.listCandidatesCalls++
 	f.lastListCandidatesOrgID = params.OrgID
+	f.lastListCandidatesLimit = params.ResultLimit
 	f.lastListCandidatesFilter = append([]string(nil), params.DeviceIdentifiers...)
 	f.lastListCandidatesSiteIDs = append([]int64(nil), params.SiteIDs...)
+	f.lastListCandidateBuildings = append([]int64(nil), params.BuildingIDs...)
+	f.lastListCandidateRacks = append([]int64(nil), params.RackIDs...)
+	f.lastListCandidateGroups = append([]int64(nil), params.GroupIDs...)
 	allCandidates := f.candidatesByOrg[params.OrgID]
-	if len(params.SiteIDs) == 0 && len(params.DeviceIdentifiers) == 0 {
+	if len(params.SiteIDs) == 0 && len(params.BuildingIDs) == 0 && len(params.RackIDs) == 0 &&
+		len(params.GroupIDs) == 0 && len(params.DeviceIdentifiers) == 0 {
 		return allCandidates, nil
 	}
 	seen := map[string]struct{}{}
@@ -473,6 +492,21 @@ func (f *fakeStore) ListCandidates(_ context.Context, params interfaces.ListCand
 			appendCandidate(candidate)
 		}
 	}
+	for _, buildingID := range params.BuildingIDs {
+		for _, candidate := range f.candidatesByBuilding[params.OrgID][buildingID] {
+			appendCandidate(candidate)
+		}
+	}
+	for _, rackID := range params.RackIDs {
+		for _, candidate := range f.candidatesByRack[params.OrgID][rackID] {
+			appendCandidate(candidate)
+		}
+	}
+	for _, groupID := range params.GroupIDs {
+		for _, candidate := range f.candidatesByGroup[params.OrgID][groupID] {
+			appendCandidate(candidate)
+		}
+	}
 	if len(params.DeviceIdentifiers) == 0 {
 		return out, nil
 	}
@@ -486,6 +520,14 @@ func (f *fakeStore) ListCandidates(_ context.Context, params interfaces.ListCand
 		}
 	}
 	return out, nil
+}
+
+func (f *fakeStore) ResolveCurtailmentTopologyScope(
+	_ context.Context,
+	params interfaces.ListCandidatesParams,
+) (interfaces.CurtailmentTopologyScopeCoverage, error) {
+	f.lastTopologyFilter = params
+	return f.topologyCoverage, f.topologyCoverageErr
 }
 
 // --- panic stubs for methods Preview / Start do not exercise; Stop tests
@@ -1201,19 +1243,98 @@ func TestService_Preview_RejectsZeroOrNegativeTarget(t *testing.T) {
 
 // --- scope resolution ---
 
-func TestService_Preview_TopologyScopeIsUnimplementedUntilResolverLands(t *testing.T) {
+func TestService_Preview_TopologyScopesResolveCandidatesAndCooldowns(t *testing.T) {
 	t.Parallel()
+
+	for _, tc := range []struct {
+		name      string
+		scope     Scope
+		seed      func(*fakeStore, int64, *models.Candidate)
+		assertIDs func(*testing.T, *fakeStore)
+	}{
+		{
+			name:  "building",
+			scope: Scope{SchemaVersion: ScopeSchemaVersionCurrent, BuildingIDs: []int64{7}},
+			seed: func(store *fakeStore, orgID int64, candidate *models.Candidate) {
+				store.candidatesByBuilding[orgID] = map[int64][]*models.Candidate{7: {candidate}}
+			},
+			assertIDs: func(t *testing.T, store *fakeStore) {
+				assert.Equal(t, []int64{7}, store.lastListCandidateBuildings)
+			},
+		},
+		{
+			name:  "rack",
+			scope: Scope{SchemaVersion: ScopeSchemaVersionCurrent, RackIDs: []int64{8}},
+			seed: func(store *fakeStore, orgID int64, candidate *models.Candidate) {
+				store.candidatesByRack[orgID] = map[int64][]*models.Candidate{8: {candidate}}
+			},
+			assertIDs: func(t *testing.T, store *fakeStore) {
+				assert.Equal(t, []int64{8}, store.lastListCandidateRacks)
+			},
+		},
+		{
+			name:  "group",
+			scope: Scope{SchemaVersion: ScopeSchemaVersionCurrent, GroupIDs: []int64{9}},
+			seed: func(store *fakeStore, orgID int64, candidate *models.Candidate) {
+				store.candidatesByGroup[orgID] = map[int64][]*models.Candidate{9: {candidate}}
+			},
+			assertIDs: func(t *testing.T, store *fakeStore) {
+				assert.Equal(t, []int64{9}, store.lastListCandidateGroups)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			const orgID = int64(1)
+			candidate := minerWithEff(tc.name+"-miner", 3000, 100, 30)
+			store := newFakeStore()
+			store.orgConfigByOrg[orgID] = defaultOrgConfig(orgID)
+			store.topologyCoverage = interfaces.CurtailmentTopologyScopeCoverage{SiteIDs: []int64{42}}
+			tc.seed(store, orgID, candidate)
+			svc := NewService(store)
+			req := validRequest(orgID)
+			req.Scope = tc.scope
+			req.PostEventCooldownSec = 60
+
+			_, err := svc.Preview(t.Context(), req)
+
+			require.NoError(t, err)
+			tc.assertIDs(t, store)
+			assert.Equal(t, orgID, store.lastTopologyFilter.OrgID)
+			assert.Equal(t, []string{tc.name + "-miner"}, store.lastCooldownFilter)
+			assert.Empty(t, store.lastListCandidatesSiteIDs)
+			assert.Empty(t, store.lastListCandidatesFilter)
+		})
+	}
+}
+
+func TestService_Preview_RejectsTopologyExpansionOverResolvedMinerLimit(t *testing.T) {
+	t.Parallel()
+
 	const orgID = int64(1)
 	store := newFakeStore()
 	store.orgConfigByOrg[orgID] = defaultOrgConfig(orgID)
+	store.topologyCoverage = interfaces.CurtailmentTopologyScopeCoverage{SiteIDs: []int64{42}}
+	store.candidatesByBuilding[orgID] = map[int64][]*models.Candidate{
+		7: make([]*models.Candidate, ScopeResolvedMinerMax+1),
+	}
+	for i := range store.candidatesByBuilding[orgID][7] {
+		store.candidatesByBuilding[orgID][7][i] = minerWithEff(fmt.Sprintf("miner-%05d", i), 3000, 100, 30)
+	}
 	svc := NewService(store)
 	req := validRequest(orgID)
-	req.Scope = Scope{SchemaVersion: 1, BuildingIDs: []int64{7}}
+	req.Scope = Scope{SchemaVersion: ScopeSchemaVersionCurrent, BuildingIDs: []int64{7}}
+
 	_, err := svc.Preview(t.Context(), req)
+
 	require.Error(t, err)
-	// Topology scope is reported via UnimplementedError; the handler maps
-	// fleeterror codes to Connect codes elsewhere.
-	assert.Contains(t, err.Error(), "building, rack, and group")
+	var fleetErr fleeterror.FleetError
+	require.ErrorAs(t, err, &fleetErr)
+	assert.Equal(t, connect.CodeResourceExhausted, fleetErr.GRPCCode)
+	assert.Contains(t, err.Error(), "more than 10000 miners")
+	assert.Equal(t, int32(ScopeResolvedMinerMax+1), store.lastListCandidatesLimit)
+	assert.Zero(t, store.cooldownCalls)
 }
 
 func TestService_Preview_DeviceListScopePassesFilterToStore(t *testing.T) {

--- a/server/internal/domain/fleeterror/error.go
+++ b/server/internal/domain/fleeterror/error.go
@@ -276,6 +276,10 @@ func NewAlreadyExistsErrorf(format string, a ...any) FleetError {
 	return newErrorfWithCode(format, connect.CodeAlreadyExists, a...)
 }
 
+func NewResourceExhaustedErrorf(format string, a ...any) FleetError {
+	return newErrorfWithCode(format, connect.CodeResourceExhausted, a...)
+}
+
 func NewUnimplementedError(debugMessage string) FleetError {
 	return NewPlainError(debugMessage, connect.CodeUnimplemented).WithCallerStackTrace()
 }

--- a/server/internal/domain/stores/interfaces/curtailment.go
+++ b/server/internal/domain/stores/interfaces/curtailment.go
@@ -173,6 +173,7 @@ type ListTargetsByEventPageParams struct {
 type ResponseProfileStore interface {
 	ListResponseProfiles(ctx context.Context, orgID int64) ([]*models.ResponseProfile, error)
 	GetResponseProfile(ctx context.Context, orgID, profileID int64) (*models.ResponseProfile, error)
+	ListCandidates(ctx context.Context, params ListCandidatesParams) ([]*models.Candidate, error)
 	ListResponseProfileDeviceSites(ctx context.Context, orgID int64, deviceIdentifiers []string) (map[string]*int64, error)
 	ListResponseProfileInfrastructureDevices(ctx context.Context, orgID int64, infrastructureDeviceIDs []int64) (map[int64]models.ResponseProfileInfrastructureDevice, error)
 	CreateResponseProfile(ctx context.Context, profile models.ResponseProfile, expectedInfrastructureDevices map[int64]models.ResponseProfileInfrastructureDevice) (*models.ResponseProfile, error)
@@ -205,13 +206,21 @@ type AutomationStore interface {
 	RecordAutomationExecutionError(ctx context.Context, ruleID int64, message string, at time.Time) error
 }
 
-// ListCandidatesParams scopes selector candidate reads. Empty SiteIDs and
-// DeviceIdentifiers means whole-org. When both are present, results are the
-// union of matching sites and explicit device identifiers.
+const CurtailmentResolvedMinerMax = 10000
+
+// ListCandidatesParams scopes selector candidate reads. Empty selector slices
+// mean whole-org. Curtailment validates that no more than one selector type is
+// set before crossing the store boundary.
 type ListCandidatesParams struct {
-	OrgID             int64
+	OrgID int64
+	// ResultLimit is zero for no limit; selector entry points use max+1 so
+	// they can distinguish an exact-bound result from overflow.
+	ResultLimit       int32
 	DeviceIdentifiers []string
 	SiteIDs           []int64
+	BuildingIDs       []int64
+	RackIDs           []int64
+	GroupIDs          []int64
 }
 
 type ListRecentlyResolvedCurtailedDevicesParams struct {
@@ -219,6 +228,26 @@ type ListRecentlyResolvedCurtailedDevicesParams struct {
 	CooldownSec       int32
 	DeviceIdentifiers []string
 	SiteIDs           []int64
+}
+
+// CurtailmentTopologyScopeCoverage is the authorization envelope derived from
+// a validated topology selector. SiteIDs includes selected-resource and live
+// member sites. RequireOrgWide is set when any selected resource or member is
+// unassigned, or when a group has no members and therefore unbounded future
+// coverage.
+type CurtailmentTopologyScopeCoverage struct {
+	SiteIDs        []int64
+	RequireOrgWide bool
+}
+
+// CurtailmentTopologyScopeStore validates topology selectors and derives their
+// current authorization coverage. It is separate from CurtailmentStore so
+// non-topology test stores do not need to implement an unused capability.
+type CurtailmentTopologyScopeStore interface {
+	ResolveCurtailmentTopologyScope(
+		ctx context.Context,
+		params ListCandidatesParams,
+	) (CurtailmentTopologyScopeCoverage, error)
 }
 
 // UpdateOperatorFieldsParams carries the optional patch fields for a

--- a/server/internal/domain/stores/sqlstores/curtailment.go
+++ b/server/internal/domain/stores/sqlstores/curtailment.go
@@ -58,6 +58,7 @@ func mapOrgConfigError(err error, orgID int64) error {
 }
 
 var _ interfaces.CurtailmentStore = &SQLCurtailmentStore{}
+var _ interfaces.CurtailmentTopologyScopeStore = &SQLCurtailmentStore{}
 var _ interfaces.ResponseProfileStore = &SQLCurtailmentStore{}
 var _ interfaces.AutomationStore = &SQLCurtailmentStore{}
 var _ interfaces.CurtailmentFanStateStore = &SQLCurtailmentStore{}
@@ -1899,7 +1900,11 @@ func (s *SQLCurtailmentStore) ListCandidates(ctx context.Context, params interfa
 	params = normalizeListCandidatesParams(params)
 	rows, err := s.GetQueries(ctx).ListCurtailmentCandidatesByOrg(ctx, sqlc.ListCurtailmentCandidatesByOrgParams{
 		OrgID:             params.OrgID,
+		ResultLimit:       int64(params.ResultLimit),
 		SiteIds:           params.SiteIDs,
+		BuildingIds:       params.BuildingIDs,
+		RackIds:           params.RackIDs,
+		GroupIds:          params.GroupIDs,
 		DeviceIdentifiers: params.DeviceIdentifiers,
 	})
 	if err != nil {
@@ -1929,7 +1934,212 @@ func normalizeListCandidatesParams(params interfaces.ListCandidatesParams) inter
 	if len(params.SiteIDs) == 0 {
 		params.SiteIDs = nil
 	}
+	if len(params.BuildingIDs) == 0 {
+		params.BuildingIDs = nil
+	}
+	if len(params.RackIDs) == 0 {
+		params.RackIDs = nil
+	}
+	if len(params.GroupIDs) == 0 {
+		params.GroupIDs = nil
+	}
 	return params
+}
+
+type curtailmentTopologyCoverageRow struct {
+	selectorID         int64
+	selectorHasMembers bool
+	resourceSiteID     sql.NullInt64
+	buildingID         sql.NullInt64
+	buildingSiteID     sql.NullInt64
+	memberSiteID       sql.NullInt64
+	memberDeviceID     sql.NullInt64
+}
+
+func (s *SQLCurtailmentStore) ResolveCurtailmentTopologyScope(
+	ctx context.Context,
+	params interfaces.ListCandidatesParams,
+) (interfaces.CurtailmentTopologyScopeCoverage, error) {
+	selectedTypeCount := 0
+	for _, ids := range [][]int64{params.BuildingIDs, params.RackIDs, params.GroupIDs} {
+		if len(ids) > 0 {
+			selectedTypeCount++
+		}
+	}
+	if selectedTypeCount != 1 {
+		return interfaces.CurtailmentTopologyScopeCoverage{}, fleeterror.NewInvalidArgumentError(
+			"topology scope must contain exactly one selector type",
+		)
+	}
+
+	switch {
+	case len(params.BuildingIDs) > 0:
+		rows, err := s.GetQueries(ctx).ListCurtailmentBuildingScopeCoverage(ctx, sqlc.ListCurtailmentBuildingScopeCoverageParams{
+			OrgID:       params.OrgID,
+			BuildingIds: params.BuildingIDs,
+		})
+		if err != nil {
+			return interfaces.CurtailmentTopologyScopeCoverage{}, fleeterror.NewInternalErrorf(
+				"failed to resolve curtailment building scope: %v",
+				err,
+			)
+		}
+		coverageRows := make([]curtailmentTopologyCoverageRow, 0, len(rows))
+		for _, row := range rows {
+			coverageRows = append(coverageRows, curtailmentTopologyCoverageRow{
+				selectorID:     row.SelectorID,
+				resourceSiteID: row.ResourceSiteID,
+				memberSiteID:   row.MemberSiteID,
+				memberDeviceID: row.MemberDeviceID,
+			})
+		}
+		return buildCurtailmentTopologyScopeCoverage(
+			params.BuildingIDs,
+			coverageRows,
+			"buildings",
+			curtailmentTopologyCoverageRules{requireAssignedResource: true},
+		)
+	case len(params.RackIDs) > 0:
+		rows, err := s.GetQueries(ctx).ListCurtailmentRackScopeCoverage(ctx, sqlc.ListCurtailmentRackScopeCoverageParams{
+			OrgID:   params.OrgID,
+			RackIds: params.RackIDs,
+		})
+		if err != nil {
+			return interfaces.CurtailmentTopologyScopeCoverage{}, fleeterror.NewInternalErrorf(
+				"failed to resolve curtailment rack scope: %v",
+				err,
+			)
+		}
+		coverageRows := make([]curtailmentTopologyCoverageRow, 0, len(rows))
+		for _, row := range rows {
+			coverageRows = append(coverageRows, curtailmentTopologyCoverageRow{
+				selectorID:     row.SelectorID,
+				resourceSiteID: row.ResourceSiteID,
+				buildingID:     row.BuildingID,
+				buildingSiteID: row.BuildingSiteID,
+				memberSiteID:   row.MemberSiteID,
+				memberDeviceID: row.MemberDeviceID,
+			})
+		}
+		return buildCurtailmentTopologyScopeCoverage(
+			params.RackIDs,
+			coverageRows,
+			"racks",
+			curtailmentTopologyCoverageRules{requireAssignedResource: true},
+		)
+	default:
+		rows, err := s.GetQueries(ctx).ListCurtailmentGroupScopeCoverage(ctx, sqlc.ListCurtailmentGroupScopeCoverageParams{
+			OrgID:    params.OrgID,
+			GroupIds: params.GroupIDs,
+		})
+		if err != nil {
+			return interfaces.CurtailmentTopologyScopeCoverage{}, fleeterror.NewInternalErrorf(
+				"failed to resolve curtailment group scope: %v",
+				err,
+			)
+		}
+		coverageRows := make([]curtailmentTopologyCoverageRow, 0, len(rows))
+		for _, row := range rows {
+			coverageRows = append(coverageRows, curtailmentTopologyCoverageRow{
+				selectorID:         row.SelectorID,
+				selectorHasMembers: row.SelectorHasMembers,
+				memberSiteID:       row.MemberSiteID,
+				memberDeviceID:     row.MemberDeviceID,
+			})
+		}
+		return buildCurtailmentTopologyScopeCoverage(
+			params.GroupIDs,
+			coverageRows,
+			"groups",
+			curtailmentTopologyCoverageRules{emptyResourceIsUnbounded: true},
+		)
+	}
+}
+
+type curtailmentTopologyCoverageRules struct {
+	requireAssignedResource  bool
+	emptyResourceIsUnbounded bool
+}
+
+func buildCurtailmentTopologyScopeCoverage(
+	requestedIDs []int64,
+	rows []curtailmentTopologyCoverageRow,
+	selectorLabel string,
+	rules curtailmentTopologyCoverageRules,
+) (interfaces.CurtailmentTopologyScopeCoverage, error) {
+	requestedIDs = uniqueSortedInt64s(requestedIDs)
+	selectorHasMembers := make(map[int64]bool, len(requestedIDs))
+	memberDeviceIDs := make(map[int64]struct{}, interfaces.CurtailmentResolvedMinerMax+1)
+	siteIDs := make(map[int64]struct{})
+	requireOrgWide := false
+	resolvedMinerLimitExceeded := false
+	var mismatchedRackID int64
+	for _, row := range rows {
+		if row.selectorID > 0 {
+			selectorHasMembers[row.selectorID] = selectorHasMembers[row.selectorID] || row.selectorHasMembers
+			if mismatchedRackID == 0 && row.buildingID.Valid && row.resourceSiteID != row.buildingSiteID {
+				mismatchedRackID = row.selectorID
+			}
+			if rules.requireAssignedResource {
+				if row.resourceSiteID.Valid {
+					siteIDs[row.resourceSiteID.Int64] = struct{}{}
+				} else {
+					requireOrgWide = true
+				}
+			}
+		}
+		if !row.memberDeviceID.Valid {
+			continue
+		}
+		memberDeviceIDs[row.memberDeviceID.Int64] = struct{}{}
+		if len(memberDeviceIDs) > interfaces.CurtailmentResolvedMinerMax {
+			resolvedMinerLimitExceeded = true
+		}
+		if row.memberSiteID.Valid {
+			siteIDs[row.memberSiteID.Int64] = struct{}{}
+		} else {
+			requireOrgWide = true
+		}
+	}
+	missingIDs := make([]int64, 0)
+	for _, id := range requestedIDs {
+		hasMembers, exists := selectorHasMembers[id]
+		if !exists {
+			missingIDs = append(missingIDs, id)
+			continue
+		}
+		if rules.emptyResourceIsUnbounded && !hasMembers {
+			requireOrgWide = true
+		}
+	}
+	if len(missingIDs) > 0 {
+		return interfaces.CurtailmentTopologyScopeCoverage{}, fleeterror.NewNotFoundErrorf(
+			"%s not found in caller's org: %v",
+			selectorLabel,
+			missingIDs,
+		)
+	}
+	if mismatchedRackID > 0 {
+		return interfaces.CurtailmentTopologyScopeCoverage{}, fleeterror.NewFailedPreconditionErrorf(
+			"rack %d site does not match its building site",
+			mismatchedRackID,
+		)
+	}
+	if resolvedMinerLimitExceeded {
+		return interfaces.CurtailmentTopologyScopeCoverage{}, fleeterror.NewResourceExhaustedErrorf(
+			"scope resolves to more than %d miners",
+			interfaces.CurtailmentResolvedMinerMax,
+		)
+	}
+	coverageSiteIDs := make([]int64, 0, len(siteIDs))
+	for siteID := range siteIDs {
+		coverageSiteIDs = append(coverageSiteIDs, siteID)
+	}
+	sort.Slice(coverageSiteIDs, func(i, j int) bool { return coverageSiteIDs[i] < coverageSiteIDs[j] })
+	return interfaces.CurtailmentTopologyScopeCoverage{
+		SiteIDs:        coverageSiteIDs,
+		RequireOrgWide: requireOrgWide,
+	}, nil
 }
 
 func (s *SQLCurtailmentStore) ListNonTerminalEvents(ctx context.Context) ([]*models.Event, error) {

--- a/server/internal/domain/stores/sqlstores/curtailment.go
+++ b/server/internal/domain/stores/sqlstores/curtailment.go
@@ -2135,7 +2135,8 @@ func buildCurtailmentTopologyScopeCoverage(
 	for _, row := range rows {
 		if row.selectorID > 0 {
 			selectorHasMembers[row.selectorID] = selectorHasMembers[row.selectorID] || row.selectorHasMembers
-			if mismatchedRackID == 0 && row.buildingID.Valid && row.resourceSiteID != row.buildingSiteID {
+			if mismatchedRackID == 0 && row.buildingID.Valid && row.resourceSiteID.Valid &&
+				row.buildingSiteID.Valid && row.resourceSiteID.Int64 != row.buildingSiteID.Int64 {
 				mismatchedRackID = row.selectorID
 			}
 			if rules.requireAssignedResource {

--- a/server/internal/domain/stores/sqlstores/curtailment.go
+++ b/server/internal/domain/stores/sqlstores/curtailment.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"slices"
 	"sort"
@@ -253,6 +254,9 @@ func (s *SQLCurtailmentStore) UpdateResponseProfile(
 	normalizedExpectedScopeJSON := normalizedResponseProfileScopeJSON(expectedScopeJSON)
 	row, err := db.WithTransaction(ctx, s.conn.DB, func(q sqlc.Querier) (sqlc.CurtailmentResponseProfile, error) {
 		if err := lockResponseProfileAutomationMutation(ctx, q, profile.OrgID, profile.ID); err != nil {
+			return sqlc.CurtailmentResponseProfile{}, err
+		}
+		if err := rejectTopologyProfileWithAutomationRules(ctx, q, profile); err != nil {
 			return sqlc.CurtailmentResponseProfile{}, err
 		}
 		if err := lockResponseProfileSitesForWrite(
@@ -860,10 +864,64 @@ func requireResponseProfileForAutomation(
 	if err != nil {
 		return fleeterror.NewInternalErrorf("failed to get response profile during automation mutation: %v", err)
 	}
+	hasTopology, err := responseProfileScopeHasTopology(profile.ScopeJson)
+	if err != nil {
+		return fleeterror.NewInternalErrorf("invalid response profile scope during automation mutation: %v", err)
+	}
+	if hasTopology {
+		return fleeterror.NewFailedPreconditionError(
+			"topology-scoped response profiles cannot be used by automation until topology curtailment execution is supported",
+		)
+	}
 	if !responseProfileFanSettingsMatch(profile, expectedFanSettings) {
 		return fleeterror.NewFailedPreconditionError("curtailment response profile changed before automation rule save; retry")
 	}
 	return nil
+}
+
+func rejectTopologyProfileWithAutomationRules(
+	ctx context.Context,
+	q sqlc.Querier,
+	profile models.ResponseProfile,
+) error {
+	hasTopology, err := responseProfileScopeHasTopology(profile.ScopeJSON)
+	if err != nil {
+		return fleeterror.NewInvalidArgumentErrorf("invalid curtailment response profile scope_json: %v", err)
+	}
+	if !hasTopology {
+		return nil
+	}
+	count, err := q.CountCurtailmentAutomationRulesByResponseProfile(
+		ctx,
+		sqlc.CountCurtailmentAutomationRulesByResponseProfileParams{
+			OrgID:             profile.OrgID,
+			ResponseProfileID: profile.ID,
+		},
+	)
+	if err != nil {
+		return fleeterror.NewInternalErrorf("failed to count automation rules for response profile: %v", err)
+	}
+	if count == 0 {
+		return nil
+	}
+	return fleeterror.NewFailedPreconditionError(
+		"topology-scoped response profiles cannot be used by automation until topology curtailment execution is supported; update the automation rules first",
+	)
+}
+
+func responseProfileScopeHasTopology(scopeJSON []byte) (bool, error) {
+	if len(scopeJSON) == 0 {
+		return false, nil
+	}
+	var payload struct {
+		BuildingIDs []int64 `json:"building_ids"`
+		RackIDs     []int64 `json:"rack_ids"`
+		GroupIDs    []int64 `json:"group_ids"`
+	}
+	if err := json.Unmarshal(scopeJSON, &payload); err != nil {
+		return false, fmt.Errorf("decode response profile scope: %w", err)
+	}
+	return len(payload.BuildingIDs) > 0 || len(payload.RackIDs) > 0 || len(payload.GroupIDs) > 0, nil
 }
 
 func responseProfileFanSettingsMatch(

--- a/server/internal/domain/stores/sqlstores/curtailment_test.go
+++ b/server/internal/domain/stores/sqlstores/curtailment_test.go
@@ -241,6 +241,24 @@ func TestBuildCurtailmentTopologyScopeCoverage(t *testing.T) {
 		assert.True(t, fleeterror.IsFailedPreconditionError(err))
 	})
 
+	t.Run("rack with unavailable building site is not treated as mismatched", func(t *testing.T) {
+		t.Parallel()
+		coverage, err := buildCurtailmentTopologyScopeCoverage(
+			[]int64{8},
+			[]curtailmentTopologyCoverageRow{
+				{
+					selectorID:     8,
+					resourceSiteID: validSite(11),
+					buildingID:     validDevice(3),
+				},
+			},
+			"racks",
+			assignedResourceRules,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, []int64{11}, coverage.SiteIDs)
+	})
+
 	t.Run("missing rack takes precedence over site mismatch", func(t *testing.T) {
 		t.Parallel()
 		_, err := buildCurtailmentTopologyScopeCoverage(

--- a/server/internal/domain/stores/sqlstores/curtailment_test.go
+++ b/server/internal/domain/stores/sqlstores/curtailment_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"testing"
 
+	"connectrpc.com/connect"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -165,17 +166,200 @@ func TestNormalizeListCandidatesParams(t *testing.T) {
 		OrgID:             7,
 		DeviceIdentifiers: []string{},
 		SiteIDs:           []int64{},
+		BuildingIDs:       []int64{},
+		RackIDs:           []int64{},
+		GroupIDs:          []int64{},
 	})
 	assert.Nil(t, empty.DeviceIdentifiers, "empty slices must bind as SQL NULL so they match whole-org")
 	assert.Nil(t, empty.SiteIDs, "empty site slices must bind as SQL NULL so they match whole-org")
+	assert.Nil(t, empty.BuildingIDs)
+	assert.Nil(t, empty.RackIDs)
+	assert.Nil(t, empty.GroupIDs)
 
 	nonEmpty := normalizeListCandidatesParams(interfaces.ListCandidatesParams{
 		OrgID:             7,
 		DeviceIdentifiers: []string{"miner-1"},
 		SiteIDs:           []int64{3},
+		BuildingIDs:       []int64{4},
+		RackIDs:           []int64{5},
+		GroupIDs:          []int64{6},
 	})
 	assert.Equal(t, []string{"miner-1"}, nonEmpty.DeviceIdentifiers)
 	assert.Equal(t, []int64{3}, nonEmpty.SiteIDs)
+	assert.Equal(t, []int64{4}, nonEmpty.BuildingIDs)
+	assert.Equal(t, []int64{5}, nonEmpty.RackIDs)
+	assert.Equal(t, []int64{6}, nonEmpty.GroupIDs)
+}
+
+func TestBuildCurtailmentTopologyScopeCoverage(t *testing.T) {
+	t.Parallel()
+
+	validSite := func(id int64) sql.NullInt64 { return sql.NullInt64{Int64: id, Valid: true} }
+	validDevice := func(id int64) sql.NullInt64 { return sql.NullInt64{Int64: id, Valid: true} }
+	assignedResourceRules := curtailmentTopologyCoverageRules{requireAssignedResource: true}
+	groupRules := curtailmentTopologyCoverageRules{emptyResourceIsUnbounded: true}
+
+	t.Run("assigned empty building uses its owning site", func(t *testing.T) {
+		t.Parallel()
+		coverage, err := buildCurtailmentTopologyScopeCoverage(
+			[]int64{7},
+			[]curtailmentTopologyCoverageRow{{selectorID: 7, resourceSiteID: validSite(11)}},
+			"buildings",
+			assignedResourceRules,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, []int64{11}, coverage.SiteIDs)
+		assert.False(t, coverage.RequireOrgWide)
+	})
+
+	t.Run("unassigned rack requires org-wide coverage", func(t *testing.T) {
+		t.Parallel()
+		coverage, err := buildCurtailmentTopologyScopeCoverage(
+			[]int64{8},
+			[]curtailmentTopologyCoverageRow{{selectorID: 8}},
+			"racks",
+			assignedResourceRules,
+		)
+		require.NoError(t, err)
+		assert.True(t, coverage.RequireOrgWide)
+	})
+
+	t.Run("rack and building site mismatch is rejected", func(t *testing.T) {
+		t.Parallel()
+		_, err := buildCurtailmentTopologyScopeCoverage(
+			[]int64{8},
+			[]curtailmentTopologyCoverageRow{{
+				selectorID:     8,
+				resourceSiteID: validSite(11),
+				buildingID:     validDevice(3),
+				buildingSiteID: validSite(12),
+			}},
+			"racks",
+			assignedResourceRules,
+		)
+		require.Error(t, err)
+		assert.True(t, fleeterror.IsFailedPreconditionError(err))
+	})
+
+	t.Run("missing rack takes precedence over site mismatch", func(t *testing.T) {
+		t.Parallel()
+		_, err := buildCurtailmentTopologyScopeCoverage(
+			[]int64{8, 9},
+			[]curtailmentTopologyCoverageRow{{
+				selectorID:     8,
+				resourceSiteID: validSite(11),
+				buildingID:     validDevice(3),
+				buildingSiteID: validSite(12),
+			}},
+			"racks",
+			assignedResourceRules,
+		)
+
+		require.Error(t, err)
+		assert.True(t, fleeterror.IsNotFoundError(err))
+		assert.Contains(t, err.Error(), "9")
+	})
+
+	t.Run("empty group requires org-wide coverage", func(t *testing.T) {
+		t.Parallel()
+		coverage, err := buildCurtailmentTopologyScopeCoverage(
+			[]int64{9},
+			[]curtailmentTopologyCoverageRow{{selectorID: 9}},
+			"groups",
+			groupRules,
+		)
+		require.NoError(t, err)
+		assert.True(t, coverage.RequireOrgWide)
+	})
+
+	t.Run("group coverage includes every member site", func(t *testing.T) {
+		t.Parallel()
+		coverage, err := buildCurtailmentTopologyScopeCoverage(
+			[]int64{9},
+			[]curtailmentTopologyCoverageRow{
+				{selectorID: 9, selectorHasMembers: true},
+				{memberSiteID: validSite(12), memberDeviceID: validDevice(1)},
+				{memberSiteID: validSite(11), memberDeviceID: validDevice(2)},
+				{memberSiteID: validSite(12), memberDeviceID: validDevice(3)},
+			},
+			"groups",
+			groupRules,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, []int64{11, 12}, coverage.SiteIDs)
+		assert.False(t, coverage.RequireOrgWide)
+	})
+
+	t.Run("unassigned member requires org-wide coverage", func(t *testing.T) {
+		t.Parallel()
+		coverage, err := buildCurtailmentTopologyScopeCoverage(
+			[]int64{9},
+			[]curtailmentTopologyCoverageRow{
+				{selectorID: 9, selectorHasMembers: true},
+				{memberDeviceID: validDevice(1)},
+			},
+			"groups",
+			groupRules,
+		)
+		require.NoError(t, err)
+		assert.True(t, coverage.RequireOrgWide)
+	})
+
+	t.Run("missing selector is not found", func(t *testing.T) {
+		t.Parallel()
+		_, err := buildCurtailmentTopologyScopeCoverage(
+			[]int64{9, 10},
+			[]curtailmentTopologyCoverageRow{{selectorID: 9}},
+			"groups",
+			groupRules,
+		)
+		require.Error(t, err)
+		assert.True(t, fleeterror.IsNotFoundError(err))
+		assert.Contains(t, err.Error(), "10")
+	})
+
+	t.Run("resolved miner limit accepts exact bound and rejects overflow", func(t *testing.T) {
+		t.Parallel()
+		rows := make([]curtailmentTopologyCoverageRow, 1, interfaces.CurtailmentResolvedMinerMax+2)
+		rows[0] = curtailmentTopologyCoverageRow{selectorID: 9, selectorHasMembers: true}
+		for i := 1; i <= interfaces.CurtailmentResolvedMinerMax; i++ {
+			rows = append(rows, curtailmentTopologyCoverageRow{
+				memberDeviceID: validDevice(int64(i)),
+				memberSiteID:   validSite(11),
+			})
+		}
+
+		_, err := buildCurtailmentTopologyScopeCoverage([]int64{9}, rows, "groups", groupRules)
+		require.NoError(t, err)
+
+		rows = append(rows, curtailmentTopologyCoverageRow{
+			memberDeviceID: validDevice(interfaces.CurtailmentResolvedMinerMax + 1),
+			memberSiteID:   validSite(11),
+		})
+		_, err = buildCurtailmentTopologyScopeCoverage([]int64{9}, rows, "groups", groupRules)
+		require.Error(t, err)
+		var fleetErr fleeterror.FleetError
+		require.ErrorAs(t, err, &fleetErr)
+		assert.Equal(t, connect.CodeResourceExhausted, fleetErr.GRPCCode)
+	})
+
+	t.Run("missing selector takes precedence over resolved miner overflow", func(t *testing.T) {
+		t.Parallel()
+		rows := make([]curtailmentTopologyCoverageRow, 1, interfaces.CurtailmentResolvedMinerMax+2)
+		rows[0] = curtailmentTopologyCoverageRow{selectorID: 9, selectorHasMembers: true}
+		for i := 1; i <= interfaces.CurtailmentResolvedMinerMax+1; i++ {
+			rows = append(rows, curtailmentTopologyCoverageRow{
+				memberDeviceID: validDevice(int64(i)),
+				memberSiteID:   validSite(11),
+			})
+		}
+
+		_, err := buildCurtailmentTopologyScopeCoverage([]int64{9, 10}, rows, "groups", groupRules)
+
+		require.Error(t, err)
+		assert.True(t, fleeterror.IsNotFoundError(err))
+		assert.Contains(t, err.Error(), "10")
+	})
 }
 
 func TestResponseProfileSiteIDsForLock(t *testing.T) {

--- a/server/internal/domain/stores/sqlstores/response_profile_automation_scope_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/response_profile_automation_scope_integration_test.go
@@ -1,0 +1,86 @@
+package sqlstores_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/proto-fleet/server/internal/domain/curtailment/models"
+	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
+	"github.com/block/proto-fleet/server/internal/domain/stores/sqlstores"
+	"github.com/block/proto-fleet/server/internal/testutil"
+)
+
+func TestSQLCurtailmentStore_TopologyProfilesCannotBeAutomated(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping database integration test in short mode")
+	}
+
+	testContext := testutil.InitializeDBServiceInfrastructure(t)
+	user := testContext.DatabaseService.CreateSuperAdminUser()
+	ctx := t.Context()
+	database := testContext.DatabaseService.DB
+	store := sqlstores.NewSQLCurtailmentStore(database)
+	orgID := user.OrganizationID
+	sourceID := seedMQTTSourceConfig(t, database, orgID, user.DatabaseID, "topology-profile-source", true)
+	topologyProfileID := seedResponseProfile(t, database, orgID, "topology-profile")
+	topologyProfile, err := store.GetResponseProfile(ctx, orgID, topologyProfileID)
+	require.NoError(t, err)
+	topologyProfile.ScopeJSON = []byte(`{"scope_schema_version":1,"building_ids":[7]}`)
+	_, err = store.UpdateResponseProfile(
+		ctx,
+		*topologyProfile,
+		nil,
+		topologyProfile.SiteID,
+		[]byte(`{}`),
+		models.ResponseProfileFanSettings{},
+	)
+	require.NoError(t, err)
+
+	_, err = store.CreateAutomationRule(ctx, models.AutomationRule{
+		OrgID:             orgID,
+		RuleName:          "topology-create",
+		TriggerType:       models.AutomationTriggerTypeMQTT,
+		MQTTSourceID:      sourceID,
+		ResponseProfileID: topologyProfileID,
+		Enabled:           true,
+	}, models.ResponseProfileFanSettings{})
+	require.Error(t, err)
+	assert.True(t, fleeterror.IsFailedPreconditionError(err))
+
+	cleanProfileID := seedResponseProfile(t, database, orgID, "clean-profile")
+	ruleID := seedAutomationRule(t, database, orgID, sourceID, cleanProfileID, "clean-rule", false)
+	_, err = store.UpdateAutomationRule(ctx, models.AutomationRule{
+		ID:                ruleID,
+		OrgID:             orgID,
+		RuleName:          "topology-update",
+		MQTTSourceID:      sourceID,
+		ResponseProfileID: topologyProfileID,
+	}, models.ResponseProfileFanSettings{})
+	require.Error(t, err)
+	assert.True(t, fleeterror.IsFailedPreconditionError(err))
+
+	topologyRuleID := seedAutomationRule(t, database, orgID, sourceID, topologyProfileID, "topology-enable", false)
+	_, err = store.SetAutomationRuleEnabled(ctx, orgID, topologyRuleID, true, models.ResponseProfileFanSettings{})
+	require.Error(t, err)
+	assert.True(t, fleeterror.IsFailedPreconditionError(err))
+
+	cleanProfile, err := store.GetResponseProfile(ctx, orgID, cleanProfileID)
+	require.NoError(t, err)
+	cleanProfile.ScopeJSON = []byte(`{"scope_schema_version":1,"rack_ids":[8]}`)
+	_, err = store.UpdateResponseProfile(
+		ctx,
+		*cleanProfile,
+		nil,
+		cleanProfile.SiteID,
+		[]byte(`{}`),
+		models.ResponseProfileFanSettings{},
+	)
+	require.Error(t, err)
+	assert.True(t, fleeterror.IsFailedPreconditionError(err))
+
+	unchanged, err := store.GetResponseProfile(ctx, orgID, cleanProfileID)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{}`, string(unchanged.ScopeJSON))
+}

--- a/server/internal/handlers/curtailment/handler.go
+++ b/server/internal/handlers/curtailment/handler.go
@@ -512,9 +512,10 @@ func (h *Handler) scopeResourceContextRequirements(
 		return out, nil
 	}
 	if len(scope.BuildingIDs) > 0 || len(scope.RackIDs) > 0 || len(scope.GroupIDs) > 0 {
-		// Topology resolution will eventually derive the complete site envelope.
-		// Until then, fail closed instead of authorizing an unresolved selector
-		// against an empty resource context.
+		// Scoped topology authorization must be bound to the same snapshot used
+		// for candidate resolution. Until the durable authorization envelope and
+		// dispatch-time recheck land, require org-wide permission so membership
+		// changes cannot broaden a site-scoped request after authorization.
 		out.requireOrgWide = true
 		return out, nil
 	}

--- a/server/internal/handlers/curtailment/handler_response_profiles_test.go
+++ b/server/internal/handlers/curtailment/handler_response_profiles_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/block/proto-fleet/server/internal/domain/curtailment/models"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 	"github.com/block/proto-fleet/server/internal/domain/session"
+	"github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
 )
 
 func TestHandler_CreateCurtailmentResponseProfile(t *testing.T) {
@@ -1020,6 +1021,13 @@ func (s *handlerResponseProfileStore) GetResponseProfile(_ context.Context, _ in
 		}
 	}
 	return nil, fleeterror.NewNotFoundErrorf("curtailment response profile not found: %d", profileID)
+}
+
+func (*handlerResponseProfileStore) ListCandidates(
+	context.Context,
+	interfaces.ListCandidatesParams,
+) ([]*models.Candidate, error) {
+	return nil, nil
 }
 
 func (s *handlerResponseProfileStore) ListResponseProfileDeviceSites(_ context.Context, _ int64, deviceIdentifiers []string) (map[string]*int64, error) {

--- a/server/sqlc/queries/curtailment.sql
+++ b/server/sqlc/queries/curtailment.sql
@@ -1454,7 +1454,7 @@ SET last_tick_at          = EXCLUDED.last_tick_at,
 -- name: ListCurtailmentCandidatesByOrg :many
 -- Per-device state for the selector. Returns every in-scope device;
 -- service applies skip-reason attribution. nil power/hash = stale
--- (15-min window). site_ids and device_identifiers nil = whole-org.
+-- (15-min window). All selector arrays nil = whole-org.
 WITH latest_metrics AS (
     SELECT DISTINCT ON (device_metrics.device_identifier)
         device_metrics.device_identifier,
@@ -1502,10 +1502,75 @@ LEFT JOIN latest_hourly lh ON lh.device_identifier = d.device_identifier
 WHERE d.org_id = sqlc.arg('org_id')
     AND d.deleted_at IS NULL
     AND (
-        (sqlc.narg('site_ids')::BIGINT[] IS NULL AND sqlc.narg('device_identifiers')::text[] IS NULL)
+        (sqlc.narg('site_ids')::BIGINT[] IS NULL
+            AND sqlc.narg('building_ids')::BIGINT[] IS NULL
+            AND sqlc.narg('rack_ids')::BIGINT[] IS NULL
+            AND sqlc.narg('group_ids')::BIGINT[] IS NULL
+            AND sqlc.narg('device_identifiers')::text[] IS NULL)
         OR (
             sqlc.narg('site_ids')::BIGINT[] IS NOT NULL
             AND d.site_id = ANY(sqlc.narg('site_ids')::BIGINT[])
+        )
+        OR (
+            sqlc.narg('building_ids')::BIGINT[] IS NOT NULL
+            AND EXISTS (
+                SELECT 1
+                FROM building b
+                WHERE b.org_id = sqlc.arg('org_id')
+                  AND b.deleted_at IS NULL
+                  AND b.id = ANY(sqlc.narg('building_ids')::BIGINT[])
+                  AND (
+                    d.building_id = b.id
+                    OR EXISTS (
+                        SELECT 1
+                        FROM device_set_membership dsm
+                        JOIN device_set ds
+                          ON ds.id = dsm.device_set_id
+                         AND ds.org_id = dsm.org_id
+                         AND ds.type = 'rack'
+                         AND ds.deleted_at IS NULL
+                        JOIN device_set_rack dsr
+                          ON dsr.device_set_id = ds.id
+                         AND dsr.org_id = ds.org_id
+                        WHERE dsm.org_id = sqlc.arg('org_id')
+                          AND dsm.device_id = d.id
+                          AND dsm.device_set_type = 'rack'
+                          AND dsr.building_id = b.id
+                    )
+                  )
+            )
+        )
+        OR (
+            sqlc.narg('rack_ids')::BIGINT[] IS NOT NULL
+            AND EXISTS (
+                SELECT 1
+                FROM device_set_membership dsm
+                JOIN device_set ds
+                  ON ds.id = dsm.device_set_id
+                 AND ds.org_id = dsm.org_id
+                 AND ds.type = 'rack'
+                 AND ds.deleted_at IS NULL
+                WHERE dsm.org_id = sqlc.arg('org_id')
+                  AND dsm.device_id = d.id
+                  AND dsm.device_set_type = 'rack'
+                  AND dsm.device_set_id = ANY(sqlc.narg('rack_ids')::BIGINT[])
+            )
+        )
+        OR (
+            sqlc.narg('group_ids')::BIGINT[] IS NOT NULL
+            AND EXISTS (
+                SELECT 1
+                FROM device_set_membership dsm
+                JOIN device_set ds
+                  ON ds.id = dsm.device_set_id
+                 AND ds.org_id = dsm.org_id
+                 AND ds.type = 'group'
+                 AND ds.deleted_at IS NULL
+                WHERE dsm.org_id = sqlc.arg('org_id')
+                  AND dsm.device_id = d.id
+                  AND dsm.device_set_type = 'group'
+                  AND dsm.device_set_id = ANY(sqlc.narg('group_ids')::BIGINT[])
+            )
         )
         OR (
             sqlc.narg('device_identifiers')::text[] IS NOT NULL
@@ -1513,4 +1578,150 @@ WHERE d.org_id = sqlc.arg('org_id')
         )
     )
 -- Stable order so the selector's stable sort is deterministic on ties.
-ORDER BY d.device_identifier;
+ORDER BY d.device_identifier
+LIMIT NULLIF(sqlc.arg('result_limit')::BIGINT, 0);
+
+-- name: ListCurtailmentBuildingScopeCoverage :many
+WITH selected_buildings AS (
+    SELECT b.id, b.site_id
+    FROM building b
+    WHERE b.org_id = sqlc.arg('org_id')
+      AND b.deleted_at IS NULL
+      AND b.id = ANY(sqlc.arg('building_ids')::BIGINT[])
+), members AS MATERIALIZED (
+    SELECT DISTINCT d.id AS device_id, d.site_id
+    FROM device d
+    WHERE d.org_id = sqlc.arg('org_id')
+      AND d.deleted_at IS NULL
+      AND EXISTS (
+          SELECT 1
+          FROM selected_buildings sb
+          WHERE d.building_id = sb.id
+             OR EXISTS (
+                 SELECT 1
+                 FROM device_set_membership dsm
+                 JOIN device_set ds
+                   ON ds.id = dsm.device_set_id
+                  AND ds.org_id = dsm.org_id
+                  AND ds.type = 'rack'
+                  AND ds.deleted_at IS NULL
+                 JOIN device_set_rack dsr
+                   ON dsr.device_set_id = ds.id
+                  AND dsr.org_id = ds.org_id
+                 WHERE dsm.org_id = sqlc.arg('org_id')
+                   AND dsm.device_id = d.id
+                   AND dsm.device_set_type = 'rack'
+                   AND dsr.building_id = sb.id
+             )
+      )
+    ORDER BY d.id
+    LIMIT 10001
+)
+SELECT sb.id AS selector_id,
+       sb.site_id AS resource_site_id,
+       NULL::BIGINT AS member_site_id,
+       NULL::BIGINT AS member_device_id
+FROM selected_buildings sb
+UNION ALL
+SELECT 0 AS selector_id,
+       NULL::BIGINT AS resource_site_id,
+       m.site_id AS member_site_id,
+       m.device_id AS member_device_id
+FROM members m
+ORDER BY selector_id, member_device_id;
+
+-- name: ListCurtailmentRackScopeCoverage :many
+WITH selected_racks AS (
+    SELECT ds.id,
+           dsr.site_id,
+           dsr.building_id,
+           b.site_id AS building_site_id
+    FROM device_set ds
+    JOIN device_set_rack dsr
+      ON dsr.device_set_id = ds.id
+     AND dsr.org_id = ds.org_id
+    LEFT JOIN building b
+      ON b.id = dsr.building_id
+     AND b.org_id = dsr.org_id
+     AND b.deleted_at IS NULL
+    WHERE ds.org_id = sqlc.arg('org_id')
+      AND ds.type = 'rack'
+      AND ds.deleted_at IS NULL
+      AND ds.id = ANY(sqlc.arg('rack_ids')::BIGINT[])
+), members AS MATERIALIZED (
+    SELECT DISTINCT d.id AS device_id, d.site_id
+    FROM device_set_membership dsm
+    JOIN selected_racks sr ON sr.id = dsm.device_set_id
+    JOIN device d
+      ON d.id = dsm.device_id
+     AND d.org_id = dsm.org_id
+     AND d.deleted_at IS NULL
+    WHERE dsm.org_id = sqlc.arg('org_id')
+      AND dsm.device_set_type = 'rack'
+    ORDER BY d.id
+    LIMIT 10001
+)
+SELECT sr.id AS selector_id,
+       sr.site_id AS resource_site_id,
+       sr.building_id,
+       sr.building_site_id,
+       NULL::BIGINT AS member_site_id,
+       NULL::BIGINT AS member_device_id
+FROM selected_racks sr
+UNION ALL
+SELECT 0 AS selector_id,
+       NULL::BIGINT AS resource_site_id,
+       NULL::BIGINT AS building_id,
+       NULL::BIGINT AS building_site_id,
+       m.site_id AS member_site_id,
+       m.device_id AS member_device_id
+FROM members m
+ORDER BY selector_id, member_device_id;
+
+-- name: ListCurtailmentGroupScopeCoverage :many
+WITH selected_groups AS (
+    SELECT ds.id
+    FROM device_set ds
+    WHERE ds.org_id = sqlc.arg('org_id')
+      AND ds.type = 'group'
+      AND ds.deleted_at IS NULL
+      AND ds.id = ANY(sqlc.arg('group_ids')::BIGINT[])
+), selector_rows AS (
+    SELECT sg.id,
+           EXISTS (
+               SELECT 1
+               FROM device_set_membership dsm
+               JOIN device d
+                 ON d.id = dsm.device_id
+                AND d.org_id = dsm.org_id
+                AND d.deleted_at IS NULL
+               WHERE dsm.org_id = sqlc.arg('org_id')
+                 AND dsm.device_set_id = sg.id
+                 AND dsm.device_set_type = 'group'
+           ) AS has_members
+    FROM selected_groups sg
+), members AS MATERIALIZED (
+    SELECT DISTINCT d.id AS device_id, d.site_id
+    FROM device_set_membership dsm
+    JOIN selected_groups sg ON sg.id = dsm.device_set_id
+    JOIN device d
+      ON d.id = dsm.device_id
+     AND d.org_id = dsm.org_id
+     AND d.deleted_at IS NULL
+    WHERE dsm.org_id = sqlc.arg('org_id')
+      AND dsm.device_set_type = 'group'
+    ORDER BY d.id
+    LIMIT 10001
+)
+SELECT sr.id AS selector_id,
+       sr.has_members AS selector_has_members,
+       NULL::BIGINT AS member_site_id,
+       NULL::BIGINT AS member_device_id
+FROM selector_rows sr
+UNION ALL
+SELECT 0 AS selector_id,
+       TRUE AS selector_has_members,
+       m.site_id AS member_site_id,
+       m.device_id AS member_device_id
+FROM members m
+ORDER BY selector_id, member_device_id;

--- a/server/sqlc/queries/curtailment_response_profile.sql
+++ b/server/sqlc/queries/curtailment_response_profile.sql
@@ -11,9 +11,9 @@ WHERE id = sqlc.arg('id')
   AND org_id = sqlc.arg('org_id');
 
 -- name: LockCurtailmentResponseProfileAutomationMutation :exec
--- Serializes profile fan changes with automation create/update/enable. Both
--- sides re-read their compatibility condition after acquiring this lock so a
--- concurrent pair cannot commit an automation binding to a fan profile.
+-- Serializes profile changes with automation create/update/enable. Both sides
+-- re-read their compatibility conditions after acquiring this lock so a
+-- concurrent pair cannot commit an invalid automation binding.
 SELECT pg_advisory_xact_lock(
     hashtextextended(
         'curtailment_response_profile_automation:'


### PR DESCRIPTION
Reviewable diff: +678/-41 across 9 files (excludes generated, test, and story files).

## Summary

This PR adds backend resolution for building, rack, and group curtailment scopes so topology targets can be validated for previews and response-profile saves. It derives current site coverage, resolves concrete miner candidates, applies cooldowns to only those miners, and rejects expansions beyond 10,000 miners. Topology-scoped Start and automation remain fail-closed until durable authorization envelopes, lifecycle reconciliation, and dispatch-time reauthorization land in later work tracked by #909.

## How it works

Preview and response-profile requests enter with one typed terminal scope. The domain converts that scope into a store filter, then the SQL store validates every selected topology resource against its organization, type, deletion state, owning site, and current member sites. Building scopes include directly assigned miners and miners in racks assigned to the building; rack and group scopes use live device-set membership.

Preview reads at most 10,001 candidate rows, rejects scopes above the 10,000-miner bound, and uses the resolved identifiers for cooldown filtering before building the plan. Profile Create and Update run the same resource validation and resolved-miner bounds before persisting the logical selector. During this staged rollout, topology profiles cannot be bound to or enabled for automation, and an automation-bound profile cannot be converted to topology; the SQL store re-checks both directions under one advisory lock to prevent concurrent mutations from bypassing the rule.

Until the durable authorization envelope is implemented, topology RPCs require organization-wide permission and Start returns `Unimplemented` before creating an event.

## Diagrams

```mermaid
flowchart TD
  A["Preview or profile request"] --> B["Typed terminal scope"]
  B --> C["Fail-closed handler authorization"]
  C --> D["Topology resource validation"]
  D --> E["Current membership and site coverage"]
  E --> F["Bounded candidate resolution"]
  F --> G["10,000-miner limit"]
  G --> H["Preview plan with scoped cooldowns"]
  G --> I["Persist logical response-profile scope"]
  I --> J["Automation binding guard under advisory lock"]
  B --> K["Topology Start"]
  J --> L["Failed precondition until lifecycle support"]
  K --> M["Unimplemented until durable lifecycle support"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/sqlc/queries/curtailment.sql` | Adds building, rack, and group candidate predicates plus bounded topology coverage queries. | Defines membership semantics, organization isolation, resource validation, and query bounds. |
| `server/sqlc/queries/curtailment_response_profile.sql` | Generalizes the existing profile/automation advisory-lock contract. | Serializes profile changes with automation mutations. |
| `server/internal/domain/stores/sqlstores/curtailment.go` | Maps topology queries into a validated coverage envelope and enforces missing-resource, rack-site, expansion-limit, and automation-compatibility rules. | Main persistence boundary for fail-closed topology resolution and concurrent mutations. |
| `server/internal/domain/curtailment/` | Resolves typed scopes for Preview, scopes cooldowns to resolved miners, validates profile saves, gates topology Start, and blocks topology automation. | Main behavior and staged-rollout boundary. |
| `server/internal/handlers/curtailment/handler.go` | Requires organization-wide permission for topology selectors during the staged rollout. | Prevents membership changes from broadening a site-scoped authorization decision. |
| `server/internal/domain/stores/interfaces/curtailment.go` and `fleeterror/error.go` | Extends candidate filters and introduces the shared resolved-miner bound and ResourceExhausted constructor. | Shared contracts used by the domain and SQL store. |
| `server/generated/sqlc/` | Regenerated sqlc bindings and retrying querier output. | Generated — skip. |
| Curtailment domain, handler, and SQL-store tests | Covers each topology type, profile validation, cooldown scoping, exact/overflow bounds, nullable rack/building sites, and automation mutation guards. | Verifies the security, concurrency, and cardinality edge cases. |

## Key technical decisions & trade-offs

- Resolve topology on the server from current membership instead of expanding selectors in the browser, keeping logical profile scopes dynamic.
- Require organization-wide authorization temporarily instead of deriving a non-transactional site grant that membership changes could broaden.
- Persist topology profiles but reject their automation use and Start execution until durable lifecycle support exists, allowing staged backend work without accepting configurations that fail only on signal delivery.
- Share the existing profile/automation advisory lock and re-read compatibility after acquisition instead of relying only on race-prone service checks.
- Fetch a max+1 sentinel and return `ResourceExhausted` above 10,000 resolved miners instead of materializing unbounded result sets.
- Validate every selected resource before overflow and consistency errors so deleted, wrong-type, and cross-org IDs deterministically return `NotFound`.
- Reuse existing topology and profile storage; no migration is required.

## Testing & validation

- Ran `server/just gen`; generated sqlc and server outputs are current.
- Ran `server/just lint`; zero issues.
- Ran `go test ./internal/domain/curtailment -count=1`.
- Ran focused SQL-store unit tests for topology coverage and candidate parameter normalization.
- Compile-checked the SQL-store package and added database integration coverage for topology automation create/update/enable and profile conversion. Local integration execution was blocked because Postgres was not running; CI runs the database-backed suite.
- Did not run E2E or UI tests; this PR does not enable the topology picker or topology-scoped Start lifecycle.

Part of #909
