### PR TITLE
Simplify HA installation to one command per host

### DIFF
--- a/deployment-files/ha/README.md
+++ b/deployment-files/ha/README.md
@@ -33,7 +33,7 @@ stable LAN address is supported.
 ## Install
 
 The installer targets dedicated apt/systemd hosts on amd64 or arm64 with a
-4096-byte page size and the base `sudo` and `iproute2` packages:
+4096-byte page size and the base `sudo`, `curl`, and `iproute2` packages:
 
 - Debian 12 or 13
 - Ubuntu 22.04 or 24.04

--- a/deployment-files/ha/README.md
+++ b/deployment-files/ha/README.md
@@ -56,12 +56,12 @@ From the operator machine, run the public installer on `ha-a`. Replace the SSH
 destination with the user and address for that host:
 
 ```bash
-ssh -A -t admin@10.40.0.11 'curl -fsSL https://fleet.proto.xyz/install.sh | sudo bash -s -- --ha'
+ssh -A -t admin@10.40.0.11 'curl -fsSL https://fleet.proto.xyz/install.sh | sudo --preserve-env=SSH_AUTH_SOCK bash -s -- --ha'
 ```
 
-`-A` lets the installer use the operator's SSH agent for the peer checks. It
-can be omitted when the peers use password authentication or a key already
-available on `ha-a`.
+`-A` forwards the operator's SSH agent, and `--preserve-env=SSH_AUTH_SOCK`
+makes it available to the peer checks after `sudo`. Normal password and
+host-key prompts still work when the agent has no applicable key.
 
 The wizard asks for the `ha-b` address, `ha-c` address, VIP, and the SSH
 username shared by the peer hosts. It derives `ha-a`'s local address and

--- a/deployment-files/ha/README.md
+++ b/deployment-files/ha/README.md
@@ -56,8 +56,12 @@ From the operator machine, run the public installer on `ha-a`. Replace the SSH
 destination with the user and address for that host:
 
 ```bash
-ssh -t admin@10.40.0.11 'curl -fsSL https://fleet.proto.xyz/install.sh | sudo bash -s -- --ha'
+ssh -A -t admin@10.40.0.11 'curl -fsSL https://fleet.proto.xyz/install.sh | sudo bash -s -- --ha'
 ```
+
+`-A` lets the installer use the operator's SSH agent for the peer checks. It
+can be omitted when the peers use password authentication or a key already
+available on `ha-a`.
 
 The wizard asks for the `ha-b` address, `ha-c` address, VIP, and the SSH
 username shared by the peer hosts. It derives `ha-a`'s local address and

--- a/deployment-files/ha/README.md
+++ b/deployment-files/ha/README.md
@@ -46,78 +46,47 @@ their reported release codename. Installation stops if Docker does not publish
 that suite. RPM-based, non-systemd, and 32-bit hosts are not supported.
 
 Before starting, reserve each node's IPv4 address in DHCP and exclude the VIP
-from the DHCP pool. Download the release archive and its official `.sha256`
-file for each host's architecture. Hosts may mix `amd64` and `arm64`, but every
-host must use the same release version and commit.
+from the DHCP pool. Hosts may mix `amd64` and `arm64`; each host downloads the
+correct artifact for its architecture and the installer pins every node to the
+same release.
 
 ### 1. Prepare and install `ha-a`
 
-From the operator machine, transfer the release and run the guided installer.
-Replace `VERSION`, `ARCH`, and `ha-a` with the downloaded release and SSH host:
+From the operator machine, run the public installer on `ha-a`. Replace the SSH
+destination with the user and address for that host:
 
 ```bash
-VERSION=v0.0.0 ARCH=arm64 HOST=ha-a; scp "proto-fleet-${VERSION}-${ARCH}.tar.gz" "proto-fleet-${VERSION}-${ARCH}.tar.gz.sha256" "${HOST}:/var/tmp/"
+ssh -t admin@10.40.0.11 'curl -fsSL https://fleet.proto.xyz/install.sh | sudo bash -s -- --ha'
 ```
 
-```bash
-VERSION=v0.0.0 ARCH=arm64 HOST=ha-a; ssh -t "$HOST" "set -eu; umask 077; cd /var/tmp; sha256sum --check 'proto-fleet-${VERSION}-${ARCH}.tar.gz.sha256'; stage=\$(mktemp -d /var/tmp/proto-fleet-ha.XXXXXX); tar -xzf 'proto-fleet-${VERSION}-${ARCH}.tar.gz' -C \"\$stage\"; exec \"\$stage/deployment/ha/fleet-ha\" install"
-```
+The wizard asks for the `ha-b` address, `ha-c` address, VIP, and the SSH
+username shared by the peer hosts. It derives `ha-a`'s local address and
+interface, validates the release and all three addresses, and shows the
+topology and planned host changes. Type `INSTALL` to authorize the cluster
+installation.
 
-The wizard asks for the `ha-b` address, `ha-c` address, and VIP, then derives
-`ha-a`'s local address and interface from the route to `ha-b`. It validates the
-host and release, shows the complete topology and planned changes, and waits
-for `INSTALL` before changing the host.
-
-The wizard then creates protected bundles for all three hosts and a separate
-public service CA certificate. Run the single copy command it prints
-from the operator machine. Return to the wizard and type `COPIED`; it deletes
-the copied peer exports from `ha-a` and continues installing that host. Protect
-the host bundles while installing the peers, then delete the operator copies
-after all three installations succeed.
+Before changing `ha-a`, the installer proves that it can connect to both peers
+using the invoking operator's normal SSH identity. It then transfers a
+role-scoped bundle to each peer, installs `ha-a`, and prints the two commands
+needed to finish the cluster. It never copies release archives or SSH keys
+between hosts.
 
 ### 2. Install `ha-b` and `ha-c`
 
-For each peer, transfer the release, official checksum, and matching host
-bundle. For example, for `ha-b`:
+Run the first command printed by `ha-a` to install `ha-b`, then run the second
+to install `ha-c`. Each command downloads and verifies the architecture-specific
+artifact for the exact release selected by `ha-a`, then consumes the prepared
+bundle already on that host. No extra confirmation or configuration editing is
+required.
 
-```bash
-VERSION=v0.0.0 ARCH=arm64 HOST=ha-b; scp "proto-fleet-${VERSION}-${ARCH}.tar.gz" "proto-fleet-${VERSION}-${ARCH}.tar.gz.sha256" proto-fleet-ha-bundles/proto-fleet-ha-ha-b.json "${HOST}:/var/tmp/"
-```
-
-```bash
-VERSION=v0.0.0 ARCH=arm64 HOST=ha-b; ssh -t "$HOST" "set -eu; umask 077; cd /var/tmp; sha256sum --check 'proto-fleet-${VERSION}-${ARCH}.tar.gz.sha256'; stage=\$(mktemp -d /var/tmp/proto-fleet-ha.XXXXXX); tar -xzf 'proto-fleet-${VERSION}-${ARCH}.tar.gz' -C \"\$stage\"; exec \"\$stage/deployment/ha/fleet-ha\" install /var/tmp/proto-fleet-ha-ha-b.json"
-```
-
-Repeat with `HOST=ha-c` and the `ha-c` bundle. Each installer verifies the
-bundle, derives the local interface, shows its plan, and waits for `INSTALL`.
-No environment or secret file is edited by hand.
-
-### 3. Trust the service CA on clients
-
-The copied `proto-fleet-ha-service-ca.crt` is public and is safe to distribute
-to browsers and API clients. Verify that its fingerprint matches the value
-printed in the authenticated `ha-a` installer session:
-
-```bash
-openssl x509 -in proto-fleet-ha-bundles/proto-fleet-ha-service-ca.crt -noout -fingerprint -sha256
-```
-
-Import only this certificate into each client's trusted root store. On
-Debian-based clients:
-
-```bash
-sudo install -m 0644 proto-fleet-ha-bundles/proto-fleet-ha-service-ca.crt /usr/local/share/ca-certificates/proto-fleet-ha-service-ca.crt
-sudo update-ca-certificates
-```
-
-Use the platform trust-store UI or equivalent managed policy on other clients.
-Never distribute or import a host bundle; it contains that node's private keys
-and cluster credentials.
+The database-node commands return after the local HA service has started; the
+cluster keeps converging under systemd as the remaining nodes join. The
+`ha-c` command returns after Fleet is active and reachable through the VIP.
 
 ### Installer behavior and failure handling
 
-The official archive checksum verified in the commands above is the release
-integrity check. Before changing the host, the installer checks the packaged
+The installer verifies the official archive checksum before executing the
+packaged HA binary. Before changing the host, it checks the packaged
 entrypoints, Linux platform, apt/systemd prerequisites, architecture, page
 size, network identity and routes, free ports, empty data paths, and the exact
 host secret file set. A 16K-page host is rejected with instructions to boot a
@@ -139,11 +108,11 @@ restarts propagate through the role-aware HA service before keepalived can
 return. That service starts etcd, then Patroni and Fleet on `ha-a` and `ha-b`.
 keepalived is enabled only on those two Fleet hosts and remains ineligible for
 the VIP until local active health passes. The witness starts etcd only.
-Only allowlisted host secret files are installed. A successful install consumes
-the copied host bundle. The one-time etcd root password is also removed from
-`/etc/proto-fleet/ha` after authentication is enabled.
+Only allowlisted host secret files are installed. A successful peer install
+consumes its prepared host bundle. The one-time etcd root password is removed
+from `/etc/proto-fleet/ha` after authentication is enabled.
 
-If installation fails after changing the host, the copied inputs are retained
+If installation fails after changing the host, its inputs are retained
 for diagnosis. The installer intentionally has no resume or rollback state
 machine. An interrupted install may require reimaging the dedicated host and
 running the guided install again.

--- a/deployment-files/install.sh
+++ b/deployment-files/install.sh
@@ -1565,7 +1565,7 @@ run_ha_install() {
       echo "❌ Prepared HA host bundle must be a regular file: $HA_BUNDLE_PATH" >&2
       return 1
     fi
-    local bundle_owner bundle_mode
+    local bundle_owner bundle_mode trusted_uid
     read -r bundle_owner bundle_mode <<< "$(install_path_metadata "$HA_BUNDLE_PATH")" || {
       echo "❌ Could not inspect prepared HA host bundle: $HA_BUNDLE_PATH" >&2
       return 1
@@ -1574,11 +1574,15 @@ run_ha_install() {
       echo "❌ Prepared HA host bundle must have mode 0600: $HA_BUNDLE_PATH" >&2
       return 1
     fi
-    if [ "$(id -u)" -eq 0 ] && [ -n "${SUDO_UID:-}" ]; then
-      if [ "$bundle_owner" != "$SUDO_UID" ] && [ "$bundle_owner" != "0" ]; then
-        echo "❌ Prepared HA host bundle is not owned by the invoking administrator: $HA_BUNDLE_PATH" >&2
-        return 1
-      fi
+    trusted_uid=$(install_admin_uid) || {
+      echo "❌ Could not determine the invoking installation administrator." >&2
+      return 1
+    }
+    if [ "$bundle_owner" != "$trusted_uid" ] && [ "$bundle_owner" != "0" ]; then
+      echo "❌ Prepared HA host bundle is not owned by the invoking administrator: $HA_BUNDLE_PATH" >&2
+      return 1
+    fi
+    if [ "$(id -u)" -eq 0 ]; then
       chown 0:0 "$HA_BUNDLE_PATH"
     fi
     "$fleet_ha" install "$HA_BUNDLE_PATH"

--- a/deployment-files/install.sh
+++ b/deployment-files/install.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 DEPLOYMENT_DIR="deployment"
+HA_BUNDLE_PATH="/var/tmp/proto-fleet-ha-host.json"
 DOWNLOAD_DIR=""
 UPDATER_BOOTSTRAP_DIR=""
 UPDATER_CLEANUP_FAILED=0
@@ -1545,6 +1546,58 @@ service_docker_id_with() {
   fi
 }
 
+run_ha_install() {
+  local tar_path="$1"
+  local download_dir="$2"
+  local release_dir="${download_dir%/}/ha-release"
+  local fleet_ha
+  local bundle_path=""
+
+  mkdir -m 700 "$release_dir"
+  tar --no-same-owner -xzf "$tar_path" -C "$release_dir"
+  fleet_ha="${release_dir}/${DEPLOYMENT_DIR}/ha/fleet-ha"
+  if [ -L "$fleet_ha" ] || [ ! -f "$fleet_ha" ] || [ ! -x "$fleet_ha" ]; then
+    echo "❌ Release archive does not contain an executable deployment/ha/fleet-ha." >&2
+    return 1
+  fi
+
+  if [ -e "$HA_BUNDLE_PATH" ] || [ -L "$HA_BUNDLE_PATH" ]; then
+    if [ -L "$HA_BUNDLE_PATH" ] || [ ! -f "$HA_BUNDLE_PATH" ]; then
+      echo "❌ Prepared HA host bundle must be a regular file: $HA_BUNDLE_PATH" >&2
+      return 1
+    fi
+    local bundle_mode
+    bundle_mode=$(stat -c '%a' "$HA_BUNDLE_PATH") || {
+      echo "❌ Could not inspect prepared HA host bundle: $HA_BUNDLE_PATH" >&2
+      return 1
+    }
+    if [ "$bundle_mode" != "600" ]; then
+      echo "❌ Prepared HA host bundle must have mode 0600: $HA_BUNDLE_PATH" >&2
+      return 1
+    fi
+    if [ "$(id -u)" -eq 0 ] && [ -n "${SUDO_UID:-}" ]; then
+      local bundle_owner
+      bundle_owner=$(stat -c '%u' "$HA_BUNDLE_PATH") || return 1
+      if [ "$bundle_owner" != "$SUDO_UID" ] && [ "$bundle_owner" != "0" ]; then
+        echo "❌ Prepared HA host bundle is not owned by the invoking administrator: $HA_BUNDLE_PATH" >&2
+        return 1
+      fi
+      chown 0:0 "$HA_BUNDLE_PATH"
+    fi
+    bundle_path="$HA_BUNDLE_PATH"
+  fi
+
+  if [ -n "$bundle_path" ]; then
+    "$fleet_ha" install "$bundle_path"
+    return
+  fi
+  if [ ! -r /dev/tty ]; then
+    echo "❌ HA cluster preparation requires an interactive terminal." >&2
+    return 1
+  fi
+  "$fleet_ha" install </dev/tty
+}
+
 # END INSTALLER TESTABLE HELPERS
 
 # Function to extract files to the installation directory and cd to it
@@ -1584,6 +1637,7 @@ Usage: install.sh [options] [VERSION]
 If you omit VERSION or pass "latest", installs the latest GitHub release.
 Pass "nightly" to install the latest successful nightly prerelease.
 Options:
+  --ha                     Install the three-node high-availability profile.
   --install-dir PATH       Use PATH without prompting.
   --non-interactive        Fail instead of prompting; for an existing install
                            with a complete deployment .env.
@@ -1687,11 +1741,16 @@ check_page_size() {
 }
 
 NON_INTERACTIVE=0
+HA_INSTALL=0
 REQUESTED_INSTALL_DIR=""
 REQUESTED_VERSION=""
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
+    --ha)
+      HA_INSTALL=1
+      shift
+      ;;
     --install-dir)
       [ "$#" -ge 2 ] || { echo "Error: --install-dir requires a path." >&2; usage; }
       REQUESTED_INSTALL_DIR="$2"
@@ -1725,6 +1784,11 @@ done
 
 if [ "$#" -gt 0 ]; then
   echo "Error: unexpected arguments: $*" >&2
+  usage
+fi
+
+if [ "$HA_INSTALL" = "1" ] && { [ -n "$REQUESTED_INSTALL_DIR" ] || [ "$NON_INTERACTIVE" = "1" ]; }; then
+  echo "Error: --ha cannot be combined with --install-dir or --non-interactive." >&2
   usage
 fi
 
@@ -1799,6 +1863,11 @@ else
   exit 1
 fi
 rm -f "${CHECKSUM_PATH}"
+
+if [ "$HA_INSTALL" = "1" ]; then
+  run_ha_install "$TAR_PATH" "$DOWNLOAD_DIR"
+  exit $?
+fi
 
 UPDATER_BOOTSTRAP_DIR="${DOWNLOAD_DIR}/updater-bootstrap"
 if ! extract_updater_bootstrap "$TAR_PATH" "$UPDATER_BOOTSTRAP_DIR"; then

--- a/deployment-files/install.sh
+++ b/deployment-files/install.sh
@@ -1551,7 +1551,6 @@ run_ha_install() {
   local download_dir="$2"
   local release_dir="${download_dir%/}/ha-release"
   local fleet_ha
-  local bundle_path=""
 
   mkdir -m 700 "$release_dir"
   tar --no-same-owner -xzf "$tar_path" -C "$release_dir"
@@ -1566,8 +1565,8 @@ run_ha_install() {
       echo "❌ Prepared HA host bundle must be a regular file: $HA_BUNDLE_PATH" >&2
       return 1
     fi
-    local bundle_mode
-    bundle_mode=$(stat -c '%a' "$HA_BUNDLE_PATH") || {
+    local bundle_owner bundle_mode
+    read -r bundle_owner bundle_mode <<< "$(install_path_metadata "$HA_BUNDLE_PATH")" || {
       echo "❌ Could not inspect prepared HA host bundle: $HA_BUNDLE_PATH" >&2
       return 1
     }
@@ -1576,19 +1575,13 @@ run_ha_install() {
       return 1
     fi
     if [ "$(id -u)" -eq 0 ] && [ -n "${SUDO_UID:-}" ]; then
-      local bundle_owner
-      bundle_owner=$(stat -c '%u' "$HA_BUNDLE_PATH") || return 1
       if [ "$bundle_owner" != "$SUDO_UID" ] && [ "$bundle_owner" != "0" ]; then
         echo "❌ Prepared HA host bundle is not owned by the invoking administrator: $HA_BUNDLE_PATH" >&2
         return 1
       fi
       chown 0:0 "$HA_BUNDLE_PATH"
     fi
-    bundle_path="$HA_BUNDLE_PATH"
-  fi
-
-  if [ -n "$bundle_path" ]; then
-    "$fleet_ha" install "$bundle_path"
+    "$fleet_ha" install "$HA_BUNDLE_PATH"
     return
   fi
   if [ ! -r /dev/tty ]; then

--- a/deployment-files/tests/test-install-overlay-migration.sh
+++ b/deployment-files/tests/test-install-overlay-migration.sh
@@ -81,6 +81,18 @@ make_install() {
   : > "$root/deployment/docker-compose.tracing.yaml"
 }
 
+make_ha_release_archive() {
+  local release_root="$1"
+  local tar_path="$2"
+  mkdir -p "$release_root/deployment/ha"
+  cat > "$release_root/deployment/ha/fleet-ha" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "$HA_TEST_LOG"
+EOF
+  chmod 755 "$release_root/deployment/ha/fleet-ha"
+  tar -czf "$tar_path" -C "$release_root" deployment
+}
+
 # Defaults consumed by the docker test double. Individual cases override only
 # the state they need.
 FAKE_IDS="fleet-container"
@@ -1498,28 +1510,51 @@ fi
 # ordinary installer path remains covered by the migration cases above.
 if (
   release_root="$TEST_TMP/ha-release-fixture"
-  mkdir -p "$release_root/deployment/ha"
-  cat > "$release_root/deployment/ha/fleet-ha" <<'EOF'
-#!/usr/bin/env bash
-printf '%s\n' "$*" > "$HA_TEST_LOG"
-EOF
-  chmod 755 "$release_root/deployment/ha/fleet-ha"
   tar_path="$TEST_TMP/proto-fleet-v0.2.10-arm64.tar.gz"
-  tar -czf "$tar_path" -C "$release_root" deployment
+  make_ha_release_archive "$release_root" "$tar_path"
   HA_TEST_LOG="$TEST_TMP/ha-invocation"
   export HA_TEST_LOG
   HA_BUNDLE_PATH="$TEST_TMP/proto-fleet-ha-host.json"
   printf '%s' '{"prepared":true}' > "$HA_BUNDLE_PATH"
   chmod 600 "$HA_BUNDLE_PATH"
+  FAKE_UID=0
+  SUDO_UID=1000
   stat() { printf '1000 600\n'; }
+  chown() { printf '%s\n' "$*" > "$TEST_TMP/ha-chown"; }
   download_dir="$TEST_TMP/ha-download"
   mkdir -m 700 "$download_dir"
   run_ha_install "$tar_path" "$download_dir" \
-    && grep -Fxq "install $HA_BUNDLE_PATH" "$HA_TEST_LOG"
+    && grep -Fxq "install $HA_BUNDLE_PATH" "$HA_TEST_LOG" \
+    && grep -Fxq "0:0 $HA_BUNDLE_PATH" "$TEST_TMP/ha-chown"
 ); then
-  pass "HA install invokes the packaged operator with the prepared peer bundle"
+  pass "sudo HA installs accept the invoking administrator's prepared peer bundle"
 else
-  fail "HA install should use the verified archive and prepared peer bundle"
+  fail "sudo HA install rejected the invoking administrator's prepared peer bundle"
+fi
+
+if (
+  release_root="$TEST_TMP/ha-foreign-release-fixture"
+  tar_path="$TEST_TMP/proto-fleet-v0.2.10-foreign-arm64.tar.gz"
+  make_ha_release_archive "$release_root" "$tar_path"
+  HA_TEST_LOG="$TEST_TMP/ha-foreign-invocation"
+  export HA_TEST_LOG
+  HA_BUNDLE_PATH="$TEST_TMP/proto-fleet-ha-foreign-host.json"
+  printf '%s' '{"prepared":true}' > "$HA_BUNDLE_PATH"
+  chmod 600 "$HA_BUNDLE_PATH"
+  FAKE_UID=0
+  unset SUDO_UID
+  stat() { printf '1234 600\n'; }
+  download_dir="$TEST_TMP/ha-foreign-download"
+  mkdir -m 700 "$download_dir"
+  ! run_ha_install "$tar_path" "$download_dir" \
+    > /dev/null 2> "$TEST_TMP/ha-foreign-owner.err" \
+    && grep -q 'not owned by the invoking administrator' \
+      "$TEST_TMP/ha-foreign-owner.err" \
+    && [ ! -e "$HA_TEST_LOG" ]
+); then
+  pass "direct-root HA installs reject prepared peer bundles owned by another user"
+else
+  fail "direct-root HA install trusted an unrelated prepared peer bundle owner"
 fi
 
 if [ "$FAILURES" -ne 0 ]; then

--- a/deployment-files/tests/test-install-overlay-migration.sh
+++ b/deployment-files/tests/test-install-overlay-migration.sh
@@ -1493,6 +1493,35 @@ else
   fail "active or enabled updater state should make fallback fatal"
 fi
 
+# HA mode extracts into its private download workspace and invokes the
+# packaged operator with the protected, pre-positioned peer bundle. The
+# ordinary installer path remains covered by the migration cases above.
+if (
+  release_root="$TEST_TMP/ha-release-fixture"
+  mkdir -p "$release_root/deployment/ha"
+  cat > "$release_root/deployment/ha/fleet-ha" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "$HA_TEST_LOG"
+EOF
+  chmod 755 "$release_root/deployment/ha/fleet-ha"
+  tar_path="$TEST_TMP/proto-fleet-v0.2.10-arm64.tar.gz"
+  tar -czf "$tar_path" -C "$release_root" deployment
+  HA_TEST_LOG="$TEST_TMP/ha-invocation"
+  export HA_TEST_LOG
+  HA_BUNDLE_PATH="$TEST_TMP/proto-fleet-ha-host.json"
+  printf '%s' '{"prepared":true}' > "$HA_BUNDLE_PATH"
+  chmod 600 "$HA_BUNDLE_PATH"
+  stat() { printf '600\n'; }
+  download_dir="$TEST_TMP/ha-download"
+  mkdir -m 700 "$download_dir"
+  run_ha_install "$tar_path" "$download_dir" \
+    && grep -Fxq "install $HA_BUNDLE_PATH" "$HA_TEST_LOG"
+); then
+  pass "HA install invokes the packaged operator with the prepared peer bundle"
+else
+  fail "HA install should use the verified archive and prepared peer bundle"
+fi
+
 if [ "$FAILURES" -ne 0 ]; then
   echo "$FAILURES failure(s)"
   exit 1

--- a/deployment-files/tests/test-install-overlay-migration.sh
+++ b/deployment-files/tests/test-install-overlay-migration.sh
@@ -1511,7 +1511,7 @@ EOF
   HA_BUNDLE_PATH="$TEST_TMP/proto-fleet-ha-host.json"
   printf '%s' '{"prepared":true}' > "$HA_BUNDLE_PATH"
   chmod 600 "$HA_BUNDLE_PATH"
-  stat() { printf '600\n'; }
+  stat() { printf '1000 600\n'; }
   download_dir="$TEST_TMP/ha-download"
   mkdir -m 700 "$download_dir"
   run_ha_install "$tar_path" "$download_dir" \

--- a/server/internal/ha/deployment/guided_install.go
+++ b/server/internal/ha/deployment/guided_install.go
@@ -4,15 +4,16 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"crypto/sha256"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net"
 	"os"
+	"os/exec"
 	"os/user"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 
@@ -24,6 +25,8 @@ const (
 	publicCAName        = "proto-fleet-ha-service-ca.crt"
 	maxBundleSize       = 2 << 20
 )
+
+var sshUsernamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_.-]*$`)
 
 type clusterMetadata struct {
 	Version     string
@@ -58,16 +61,19 @@ type hostIdentity struct {
 }
 
 type guidedInstallDependencies struct {
-	input           io.Reader
-	output          io.Writer
-	prompts         io.Writer
-	terminal        func() bool
-	sourceRoot      func() (string, error)
-	primaryIdentity func(context.Context, string) (hostIdentity, error)
-	interfaceForIP  func(string) (string, error)
-	makeExportDir   func(string) (string, error)
-	inspect         func(context.Context, string, NodeConfig) (installedDependencies, error)
-	install         func(context.Context, InstallOptions) error
+	input            io.Reader
+	output           io.Writer
+	prompts          io.Writer
+	terminal         func() bool
+	sourceRoot       func() (string, error)
+	primaryIdentity  func(context.Context, string) (hostIdentity, error)
+	interfaceForIP   func(string) (string, error)
+	makeExportDir    func(string) (string, error)
+	operatorUsername func() string
+	checkPeer        func(context.Context, string, string) error
+	transferBundle   func(context.Context, string, string, string) error
+	inspect          func(context.Context, string, NodeConfig) (installedDependencies, error)
+	install          func(context.Context, InstallOptions) error
 }
 
 // GuidedInstall prepares a new HA cluster when bundlePath is empty, or installs
@@ -95,8 +101,20 @@ func defaultGuidedInstallDependencies() guidedInstallDependencies {
 			}
 			return hostIdentity{address: address, networkInterface: networkInterface}, nil
 		},
-		interfaceForIP: networkInterfaceForIP,
-		makeExportDir:  makeBundleExportDir,
+		interfaceForIP:   networkInterfaceForIP,
+		makeExportDir:    makeBundleExportDir,
+		operatorUsername: invokingUsername,
+		checkPeer: func(ctx context.Context, localUsername, target string) error {
+			return runSSH(ctx, localUsername, nil, target, "true")
+		},
+		transferBundle: func(ctx context.Context, localUsername, target, bundlePath string) error {
+			bundle, err := os.Open(bundlePath)
+			if err != nil {
+				return fmt.Errorf("open host bundle: %w", err)
+			}
+			defer bundle.Close()
+			return runSSH(ctx, localUsername, bundle, target, remoteBundleInstallCommand)
+		},
 		inspect: func(ctx context.Context, source string, config NodeConfig) (installedDependencies, error) {
 			host := hostEnvironment{
 				goos: runtime.GOOS, localIPs: localAddresses, interfacePrefixes: interfaceIPv4Prefixes,
@@ -115,9 +133,6 @@ func defaultGuidedInstallDependencies() guidedInstallDependencies {
 }
 
 func guidedInstall(ctx context.Context, bundlePath string, deps guidedInstallDependencies) error {
-	if !deps.terminal() {
-		return errors.New("fleet-ha install requires an interactive terminal; use ssh -t HOST 'fleet-ha install [HOST_BUNDLE]'")
-	}
 	source, err := deps.sourceRoot()
 	if err != nil {
 		return err
@@ -126,10 +141,13 @@ func guidedInstall(ctx context.Context, bundlePath string, deps guidedInstallDep
 	if err != nil {
 		return err
 	}
-	scanner := bufio.NewScanner(deps.input)
 	if bundlePath != "" {
-		return installPreparedHost(ctx, source, bundlePath, release, scanner, true, deps)
+		return installPreparedHost(ctx, source, bundlePath, release, false, deps)
 	}
+	if !deps.terminal() {
+		return errors.New("fleet-ha install requires an interactive terminal; use ssh -t HOST 'fleet-ha install'")
+	}
+	scanner := bufio.NewScanner(deps.input)
 	return prepareAndInstallCluster(ctx, source, release, scanner, deps)
 }
 
@@ -144,6 +162,14 @@ func prepareAndInstallCluster(ctx context.Context, source string, release cluste
 	}
 	if metadata.VirtualIP, err = readPrompt(scanner, deps.prompts, "Virtual IPv4 address: "); err != nil {
 		return err
+	}
+	localUsername := deps.operatorUsername()
+	peerUsername, err := readPromptWithDefault(scanner, deps.prompts, "Peer SSH username", localUsername)
+	if err != nil {
+		return err
+	}
+	if !sshUsernamePattern.MatchString(peerUsername) {
+		return errors.New("peer SSH username contains unsupported characters")
 	}
 	identity, err := deps.primaryIdentity(ctx, metadata.DatabaseBIP)
 	if err != nil {
@@ -186,22 +212,36 @@ func prepareAndInstallCluster(ctx context.Context, source string, release cluste
 	if err := prepareInstallBundles(exportDir, metadata); err != nil {
 		return fmt.Errorf("bundle generation failed; partial exports remain at %s: %w", exportDir, err)
 	}
-	if err := printBundleCopyCommand(deps.output, exportDir, metadata.DatabaseAIP); err != nil {
-		return err
+	peers := []struct {
+		role    string
+		address string
+	}{
+		{role: "ha-b", address: metadata.DatabaseBIP},
+		{role: "ha-c", address: metadata.WitnessIP},
 	}
-	if err := requireAcknowledgement(scanner, deps.prompts, "Type COPIED after the command succeeds: ", "COPIED"); err != nil {
-		return fmt.Errorf("bundle exports remain at %s: %w", exportDir, err)
+	for _, peer := range peers {
+		target := peerUsername + "@" + peer.address
+		if err := deps.checkPeer(ctx, localUsername, target); err != nil {
+			return fmt.Errorf("connect to %s for %s; bundle exports remain at %s: %w", target, peer.role, exportDir, err)
+		}
+	}
+	for _, peer := range peers {
+		target := peerUsername + "@" + peer.address
+		bundlePath := filepath.Join(exportDir, hostBundleName(peer.role))
+		if err := deps.transferBundle(ctx, localUsername, target, bundlePath); err != nil {
+			return fmt.Errorf("transfer %s bundle to %s; bundle exports remain at %s: %w", peer.role, target, exportDir, err)
+		}
+	}
+
+	haABundle := filepath.Join(exportDir, hostBundleName("ha-a"))
+	if err := installPreparedHost(ctx, source, haABundle, release, true, deps); err != nil {
+		return err
 	}
 	if err := removeCopiedExports(exportDir); err != nil {
 		return err
 	}
-
-	haABundle := filepath.Join(exportDir, hostBundleName("ha-a"))
-	if err := installPreparedHost(ctx, source, haABundle, release, scanner, false, deps); err != nil {
-		return err
-	}
 	_ = os.Remove(exportDir)
-	return nil
+	return printPeerInstallCommands(deps.output, peerUsername, metadata)
 }
 
 func makeBundleExportDir(source string) (string, error) {
@@ -221,7 +261,7 @@ func makeBundleExportDir(source string) (string, error) {
 	return absoluteDir, nil
 }
 
-func installPreparedHost(ctx context.Context, source, bundlePath string, release clusterMetadata, scanner *bufio.Scanner, confirm bool, deps guidedInstallDependencies) error {
+func installPreparedHost(ctx context.Context, source, bundlePath string, release clusterMetadata, prevalidated bool, deps guidedInstallDependencies) error {
 	bundle, err := readHostBundle(bundlePath)
 	if err != nil {
 		return err
@@ -250,7 +290,7 @@ func installPreparedHost(ctx context.Context, source, bundlePath string, release
 	if err != nil {
 		return err
 	}
-	if confirm {
+	if !prevalidated {
 		if err := writeInstallerOutput(deps.output, "[validation] Checking the bundle, release, network, and dedicated host...\n"); err != nil {
 			return err
 		}
@@ -259,9 +299,6 @@ func installPreparedHost(ctx context.Context, source, bundlePath string, release
 			return err
 		}
 		if err := printInstallSummary(deps.prompts, bundle.Metadata, networkInterface, installed); err != nil {
-			return err
-		}
-		if err := requireAcknowledgement(scanner, deps.prompts, "Type INSTALL to continue: ", "INSTALL"); err != nil {
 			return err
 		}
 	}
@@ -510,24 +547,50 @@ func installAction(installed bool) string {
 	return "install"
 }
 
-func printBundleCopyCommand(output io.Writer, exportDir, nodeIP string) error {
-	username := "USER"
-	if current, err := user.Current(); err == nil && current.Username != "" {
-		username = current.Username
+func printPeerInstallCommands(output io.Writer, username string, metadata clusterMetadata) error {
+	return writeInstallerOutput(output, "\nRun these commands from your operator machine:\n"+
+		"ssh -t %s@%s 'curl -fsSL https://fleet.proto.xyz/install.sh | sudo bash -s -- --ha %s'\n"+
+		"ssh -t %s@%s 'curl -fsSL https://fleet.proto.xyz/install.sh | sudo bash -s -- --ha %s'\n",
+		username, metadata.DatabaseBIP, metadata.Version,
+		username, metadata.WitnessIP, metadata.Version)
+}
+
+func invokingUsername() string {
+	if username := strings.TrimSpace(os.Getenv("SUDO_USER")); username != "" && username != "root" {
+		return username
 	}
-	ca, err := readCertificate(filepath.Join(exportDir, publicCAName))
-	if err != nil {
-		return fmt.Errorf("read exported service CA: %w", err)
+	if current, err := user.Current(); err == nil {
+		return current.Username
 	}
-	digest := sha256.Sum256(ca.Raw)
-	fingerprint := make([]string, len(digest))
-	for index, value := range digest {
-		fingerprint[index] = fmt.Sprintf("%02X", value)
+	return ""
+}
+
+const remoteBundleInstallCommand = `set -eu; umask 077; tmp=$(mktemp /var/tmp/proto-fleet-ha-host.json.XXXXXX); trap 'rm -f "$tmp"' EXIT HUP INT TERM; cat >"$tmp"; chmod 0600 "$tmp"; mv -f "$tmp" /var/tmp/proto-fleet-ha-host.json; trap - EXIT`
+
+func runSSH(ctx context.Context, localUsername string, input io.Reader, args ...string) error {
+	name := "ssh"
+	commandArgs := args
+	if os.Geteuid() == 0 && localUsername != "" && localUsername != "root" {
+		name = "sudo"
+		commandArgs = []string{"-H", "-u", localUsername}
+		if socket := os.Getenv("SSH_AUTH_SOCK"); socket != "" {
+			commandArgs = append(commandArgs, "env", "SSH_AUTH_SOCK="+socket)
+		}
+		commandArgs = append(commandArgs, "ssh")
+		commandArgs = append(commandArgs, args...)
 	}
-	return writeInstallerOutput(output, "\nService CA SHA-256 fingerprint: %s\n"+
-		"On your operator machine, run this command to copy the host bundles and public service CA from ha-a:\n"+
-		"mkdir -p proto-fleet-ha-bundles && scp -p '%s@%s:%s/*' proto-fleet-ha-bundles/\n",
-		strings.Join(fingerprint, ":"), username, nodeIP, exportDir)
+	command := exec.CommandContext(ctx, name, commandArgs...)
+	if input == nil {
+		command.Stdin = os.Stdin
+	} else {
+		command.Stdin = input
+	}
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	if err := command.Run(); err != nil {
+		return fmt.Errorf("run SSH command: %w", err)
+	}
+	return nil
 }
 
 func readPrompt(scanner *bufio.Scanner, output io.Writer, prompt string) (string, error) {
@@ -541,6 +604,14 @@ func readPrompt(scanner *bufio.Scanner, output io.Writer, prompt string) (string
 		return "", errors.New("installation canceled: input closed")
 	}
 	return strings.TrimSpace(scanner.Text()), nil
+}
+
+func readPromptWithDefault(scanner *bufio.Scanner, output io.Writer, prompt, defaultValue string) (string, error) {
+	value, err := readPrompt(scanner, output, fmt.Sprintf("%s [%s]: ", prompt, defaultValue))
+	if value == "" {
+		value = defaultValue
+	}
+	return value, err
 }
 
 func writeInstallerOutput(output io.Writer, format string, args ...any) error {

--- a/server/internal/ha/deployment/guided_install.go
+++ b/server/internal/ha/deployment/guided_install.go
@@ -25,7 +25,11 @@ const (
 	maxBundleSize       = 2 << 20
 )
 
-var sshUsernamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_.-]*$`)
+var (
+	sshUsernamePattern    = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_.-]*$`)
+	releaseVersionPattern = regexp.MustCompile(`^(v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z]+)*|nightly-[0-9]{8}-[0-9a-f]{12})$`)
+	releaseCommitPattern  = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+)
 
 type clusterMetadata struct {
 	Version     string
@@ -488,7 +492,7 @@ func readReleaseIdentity(path string) (clusterMetadata, error) {
 			identity.Commit = strings.TrimSpace(value)
 		}
 	}
-	if identity.Version == "" || identity.Commit == "" || strings.ContainsAny(identity.Version+identity.Commit, " \t\r\n") {
+	if !releaseVersionPattern.MatchString(identity.Version) || !releaseCommitPattern.MatchString(identity.Commit) {
 		return clusterMetadata{}, errors.New("packaged release identity must contain safe version and commit values")
 	}
 	return identity, nil
@@ -542,11 +546,15 @@ func installAction(installed bool) string {
 }
 
 func printPeerInstallCommands(output io.Writer, username string, metadata clusterMetadata) error {
-	return writeInstallerOutput(output, "\nRun these commands from your operator machine:\n"+
-		"ssh -t %s@%s 'curl -fsSL https://fleet.proto.xyz/install.sh | sudo bash -s -- --ha %s'\n"+
-		"ssh -t %s@%s 'curl -fsSL https://fleet.proto.xyz/install.sh | sudo bash -s -- --ha %s'\n",
-		username, metadata.DatabaseBIP, metadata.Version,
-		username, metadata.WitnessIP, metadata.Version)
+	return writeInstallerOutput(output, "\nRun these commands from your operator machine:\n%s\n%s\n",
+		peerInstallCommand(username, metadata.DatabaseBIP, metadata.Version),
+		peerInstallCommand(username, metadata.WitnessIP, metadata.Version))
+}
+
+func peerInstallCommand(username, address, version string) string {
+	installerURL := fmt.Sprintf("https://github.com/block/proto-fleet/releases/download/%s/install.sh", version)
+	return fmt.Sprintf(`ssh -t %s@%s 'test -f /var/tmp/proto-fleet-ha-host.json || { echo "Prepared HA bundle is missing: /var/tmp/proto-fleet-ha-host.json" >&2; exit 1; }; tmp=$(mktemp /var/tmp/proto-fleet-install.sh.XXXXXX) || exit; trap "rm -f $tmp" EXIT; curl -fsSL %s -o "$tmp" && sudo bash "$tmp" --ha %s'`,
+		username, address, installerURL, version)
 }
 
 func invokingUsername() string {

--- a/server/internal/ha/deployment/guided_install.go
+++ b/server/internal/ha/deployment/guided_install.go
@@ -71,7 +71,7 @@ type guidedInstallDependencies struct {
 	sourceRoot       func() (string, error)
 	primaryIdentity  func(context.Context, string) (hostIdentity, error)
 	interfaceForIP   func(string) (string, error)
-	makeExportDir    func(string) (string, error)
+	makeExportDir    func() (string, error)
 	operatorUsername func() string
 	checkPeer        func(context.Context, string, string) error
 	transferBundle   func(context.Context, string, string, string) error
@@ -108,7 +108,8 @@ func defaultGuidedInstallDependencies() guidedInstallDependencies {
 		makeExportDir:    makeBundleExportDir,
 		operatorUsername: invokingUsername,
 		checkPeer: func(ctx context.Context, localUsername, target string) error {
-			return runSSH(ctx, localUsername, nil, target, "true")
+			return runSSH(ctx, localUsername, nil, target,
+				`command -v curl >/dev/null 2>&1 || { echo "curl is required for Proto Fleet HA installation" >&2; exit 1; }`)
 		},
 		transferBundle: func(ctx context.Context, localUsername, target, bundlePath string) error {
 			bundle, err := os.Open(bundlePath)
@@ -208,7 +209,7 @@ func prepareAndInstallCluster(ctx context.Context, source string, release cluste
 	if err := writeInstallerOutput(deps.output, "[bundle generation] Creating protected host bundles...\n"); err != nil {
 		return err
 	}
-	exportDir, err := deps.makeExportDir(source)
+	exportDir, err := deps.makeExportDir()
 	if err != nil {
 		return err
 	}
@@ -247,8 +248,8 @@ func prepareAndInstallCluster(ctx context.Context, source string, release cluste
 	return printPeerInstallCommands(deps.output, peerUsername, metadata)
 }
 
-func makeBundleExportDir(source string) (string, error) {
-	dir, err := os.MkdirTemp(filepath.Dir(source), "proto-fleet-ha-bundles-")
+func makeBundleExportDir() (string, error) {
+	dir, err := os.MkdirTemp("", "proto-fleet-ha-bundles-")
 	if err != nil {
 		return "", fmt.Errorf("create protected bundle export directory: %w", err)
 	}

--- a/server/internal/ha/deployment/guided_install.go
+++ b/server/internal/ha/deployment/guided_install.go
@@ -572,14 +572,14 @@ const remoteBundleInstallCommand = `set -eu; umask 077; tmp=$(mktemp /var/tmp/pr
 
 func runSSH(ctx context.Context, localUsername string, input io.Reader, args ...string) error {
 	name := "ssh"
-	commandArgs := args
+	commandArgs := append([]string{"-o", "ConnectTimeout=10"}, args...)
 	if os.Geteuid() == 0 && localUsername != "" && localUsername != "root" {
 		name = "sudo"
 		commandArgs = []string{"-H", "-u", localUsername}
 		if socket := os.Getenv("SSH_AUTH_SOCK"); socket != "" {
 			commandArgs = append(commandArgs, "env", "SSH_AUTH_SOCK="+socket)
 		}
-		commandArgs = append(commandArgs, "ssh")
+		commandArgs = append(commandArgs, "ssh", "-o", "ConnectTimeout=10")
 		commandArgs = append(commandArgs, args...)
 	}
 	command := exec.CommandContext(ctx, name, commandArgs...)

--- a/server/internal/ha/deployment/guided_install.go
+++ b/server/internal/ha/deployment/guided_install.go
@@ -22,7 +22,6 @@ import (
 
 const (
 	bundleFormatVersion = 1
-	publicCAName        = "proto-fleet-ha-service-ca.crt"
 	maxBundleSize       = 2 << 20
 )
 
@@ -261,7 +260,7 @@ func makeBundleExportDir(source string) (string, error) {
 	return absoluteDir, nil
 }
 
-func installPreparedHost(ctx context.Context, source, bundlePath string, release clusterMetadata, prevalidated bool, deps guidedInstallDependencies) error {
+func installPreparedHost(ctx context.Context, source, bundlePath string, release clusterMetadata, skipPreflight bool, deps guidedInstallDependencies) error {
 	bundle, err := readHostBundle(bundlePath)
 	if err != nil {
 		return err
@@ -290,7 +289,7 @@ func installPreparedHost(ctx context.Context, source, bundlePath string, release
 	if err != nil {
 		return err
 	}
-	if !prevalidated {
+	if !skipPreflight {
 		if err := writeInstallerOutput(deps.output, "[validation] Checking the bundle, release, network, and dedicated host...\n"); err != nil {
 			return err
 		}
@@ -386,12 +385,7 @@ func prepareInstallBundles(exportDir string, metadata clusterMetadata) (err erro
 		}
 	}
 
-	publicCA, err := os.ReadFile(filepath.Join(secretsRoot, "offline", "service-ca.crt"))
-	if err != nil {
-		return fmt.Errorf("read generated service CA: %w", err)
-	}
-	publicCAPath := filepath.Join(exportDir, publicCAName)
-	return writeFile(publicCAPath, publicCA, 0o644)
+	return nil
 }
 
 func readHostBundle(path string) (preparedHostBundle, error) {
@@ -633,7 +627,7 @@ func requireAcknowledgement(scanner *bufio.Scanner, output io.Writer, prompt, ex
 }
 
 func removeCopiedExports(exportDir string) error {
-	for _, name := range []string{hostBundleName("ha-b"), hostBundleName("ha-c"), publicCAName} {
+	for _, name := range []string{hostBundleName("ha-b"), hostBundleName("ha-c")} {
 		path := filepath.Join(exportDir, name)
 		if err := os.Remove(path); err != nil {
 			return fmt.Errorf("remove copied bundle export %s: %w", path, err)

--- a/server/internal/ha/deployment/guided_install_test.go
+++ b/server/internal/ha/deployment/guided_install_test.go
@@ -46,7 +46,7 @@ func TestGuidedInstallPreparesClusterAndInstallsHAA(t *testing.T) {
 		return hostIdentity{address: testHostIPs[0], networkInterface: "enp1s0"}, nil
 	}
 	deps.interfaceForIP = func(string) (string, error) { return "enp1s0", nil }
-	deps.makeExportDir = func(string) (string, error) {
+	deps.makeExportDir = func() (string, error) {
 		return exportDir, os.Mkdir(exportDir, 0o700)
 	}
 	deps.inspect = func(_ context.Context, _ string, config NodeConfig) (installedDependencies, error) {
@@ -102,7 +102,7 @@ func TestGuidedInstallUsesPeerSSHUsernameOverride(t *testing.T) {
 	input := strings.NewReader(testHostIPs[1] + "\n" + testHostIPs[2] + "\n" + testVirtualIP + "\npeer-admin\nINSTALL\n")
 	deps := testGuidedDependencies(source, input, &bytes.Buffer{}, &bytes.Buffer{})
 	deps.operatorUsername = func() string { return "operator" }
-	deps.makeExportDir = func(string) (string, error) { return exportDir, os.Mkdir(exportDir, 0o700) }
+	deps.makeExportDir = func() (string, error) { return exportDir, os.Mkdir(exportDir, 0o700) }
 	var targets []string
 	deps.checkPeer = func(_ context.Context, localUser, target string) error {
 		require.Equal(t, "operator", localUser)
@@ -134,7 +134,7 @@ func TestGuidedInstallRetainsExportsWhenPeerTransferFails(t *testing.T) {
 	input := strings.NewReader(testHostIPs[1] + "\n" + testHostIPs[2] + "\n" + testVirtualIP + "\n\nINSTALL\n")
 	deps := testGuidedDependencies(source, input, &bytes.Buffer{}, &bytes.Buffer{})
 	deps.operatorUsername = func() string { return "operator" }
-	deps.makeExportDir = func(string) (string, error) { return exportDir, os.Mkdir(exportDir, 0o700) }
+	deps.makeExportDir = func() (string, error) { return exportDir, os.Mkdir(exportDir, 0o700) }
 	deps.checkPeer = func(context.Context, string, string) error { return nil }
 	deps.transferBundle = func(_ context.Context, _, target, _ string) error {
 		if target == "operator@"+testHostIPs[2] {
@@ -167,12 +167,14 @@ func TestBundleExportDirectoryIsOutsideRelease(t *testing.T) {
 	require.NoError(t, os.Mkdir(source, 0o700))
 
 	// Act
-	exportDir, err := makeBundleExportDir(source)
+	exportDir, err := makeBundleExportDir()
 
 	// Assert
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, os.RemoveAll(exportDir)) })
-	require.Equal(t, parent, filepath.Dir(exportDir))
+	relative, err := filepath.Rel(parent, exportDir)
+	require.NoError(t, err)
+	require.True(t, relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)))
 	info, err := os.Stat(exportDir)
 	require.NoError(t, err)
 	require.Equal(t, os.FileMode(0o700), info.Mode().Perm())
@@ -371,7 +373,7 @@ func testGuidedDependencies(source string, input *strings.Reader, output, prompt
 			return hostIdentity{address: testHostIPs[0], networkInterface: "eth0"}, nil
 		},
 		interfaceForIP:   func(string) (string, error) { return "eth0", nil },
-		makeExportDir:    func(string) (string, error) { return os.MkdirTemp("", "fleet-ha-test-exports-") },
+		makeExportDir:    func() (string, error) { return os.MkdirTemp("", "fleet-ha-test-exports-") },
 		operatorUsername: func() string { return "operator" },
 		checkPeer:        func(context.Context, string, string) error { return nil },
 		transferBundle:   func(context.Context, string, string, string) error { return nil },

--- a/server/internal/ha/deployment/guided_install_test.go
+++ b/server/internal/ha/deployment/guided_install_test.go
@@ -79,8 +79,11 @@ func TestGuidedInstallPreparesClusterAndInstallsHAA(t *testing.T) {
 	require.NotContains(t, prompts.String(), "Type COPIED")
 	require.Contains(t, prompts.String(), "Docker:    reuse existing installation")
 	require.NotContains(t, output.String(), testEtcdRootPassword)
-	require.Contains(t, output.String(), "ssh -t operator@"+testHostIPs[1]+" 'curl -fsSL https://fleet.proto.xyz/install.sh | sudo bash -s -- --ha v0.2.10'")
-	require.Contains(t, output.String(), "ssh -t operator@"+testHostIPs[2]+" 'curl -fsSL https://fleet.proto.xyz/install.sh | sudo bash -s -- --ha v0.2.10'")
+	require.Contains(t, output.String(), peerInstallCommand("operator", testHostIPs[1], "v0.2.10"))
+	require.Contains(t, output.String(), peerInstallCommand("operator", testHostIPs[2], "v0.2.10"))
+	require.Contains(t, output.String(), "test -f /var/tmp/proto-fleet-ha-host.json")
+	require.Contains(t, output.String(), "releases/download/v0.2.10/install.sh")
+	require.NotContains(t, output.String(), "curl -fsSL https://fleet.proto.xyz/install.sh |")
 	require.Equal(t, []string{
 		"check operator@" + testHostIPs[1],
 		"check operator@" + testHostIPs[2],
@@ -268,6 +271,18 @@ func TestInstallHostBundleValidatesIdentityAndRelease(t *testing.T) {
 	// Assert
 	require.ErrorContains(t, err, "release does not match")
 	require.FileExists(t, bundlePath)
+}
+
+func TestGuidedInstallRejectsUnsafePackagedReleaseVersion(t *testing.T) {
+	// Arrange
+	source := testGuidedRelease(t, "v0.2.10'", "abc123")
+	deps := testGuidedDependencies(source, strings.NewReader(""), &bytes.Buffer{}, &bytes.Buffer{})
+
+	// Act
+	err := guidedInstall(t.Context(), "", deps)
+
+	// Assert
+	require.ErrorContains(t, err, "safe version and commit values")
 }
 
 func TestInstallHostBundleConsumption(t *testing.T) {

--- a/server/internal/ha/deployment/guided_install_test.go
+++ b/server/internal/ha/deployment/guided_install_test.go
@@ -90,7 +90,6 @@ func TestGuidedInstallPreparesClusterAndInstallsHAA(t *testing.T) {
 	require.NoFileExists(t, filepath.Join(exportDir, hostBundleName("ha-a")))
 	require.NoFileExists(t, filepath.Join(exportDir, hostBundleName("ha-b")))
 	require.NoFileExists(t, filepath.Join(exportDir, hostBundleName("ha-c")))
-	require.NoFileExists(t, filepath.Join(exportDir, publicCAName))
 }
 
 func TestGuidedInstallUsesPeerSSHUsernameOverride(t *testing.T) {
@@ -190,24 +189,17 @@ func TestPrepareInstallBundlesCreatesRoleScopedBundles(t *testing.T) {
 
 	// Assert
 	require.NoError(t, err)
-	var serviceCA []byte
 	for _, role := range []string{"ha-a", "ha-b", "ha-c"} {
 		bundle, err := readHostBundle(filepath.Join(exportDir, hostBundleName(role)))
 		require.NoError(t, err)
 		require.Equal(t, role, bundle.Metadata.Role)
 		require.NotContains(t, bundle.Secrets, "service-ca.key")
-		serviceCA = bundle.Secrets["service-ca.crt"]
 		require.Equal(t, role == "ha-a", len(bundle.EtcdRootPassword) != 0)
 	}
 	for _, name := range []string{hostBundleName("ha-a"), hostBundleName("ha-b"), hostBundleName("ha-c")} {
 		requireMode(t, filepath.Join(exportDir, name), 0o600)
 		require.NoFileExists(t, filepath.Join(exportDir, name+".sha256"))
 	}
-	publicCA, err := os.ReadFile(filepath.Join(exportDir, publicCAName))
-	require.NoError(t, err)
-	require.Equal(t, serviceCA, publicCA)
-	requireMode(t, filepath.Join(exportDir, publicCAName), 0o644)
-	require.NoFileExists(t, filepath.Join(exportDir, publicCAName+".sha256"))
 }
 
 func TestDecodeHostBundleRejectsUnexpectedContent(t *testing.T) {

--- a/server/internal/ha/deployment/guided_install_test.go
+++ b/server/internal/ha/deployment/guided_install_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -19,9 +20,23 @@ func TestGuidedInstallPreparesClusterAndInstallsHAA(t *testing.T) {
 	source := testGuidedRelease(t, "v0.2.10", "abc123")
 	exportDir := filepath.Join(t.TempDir(), "exports")
 	inspected := false
-	input := strings.NewReader(testHostIPs[1] + "\n" + testHostIPs[2] + "\n" + testVirtualIP + "\nINSTALL\ncopied\n")
+	input := strings.NewReader(testHostIPs[1] + "\n" + testHostIPs[2] + "\n" + testVirtualIP + "\n\nINSTALL\n")
 	var output, prompts bytes.Buffer
 	deps := testGuidedDependencies(source, input, &output, &prompts)
+	deps.operatorUsername = func() string { return "operator" }
+	var sshEvents []string
+	deps.checkPeer = func(_ context.Context, localUser, target string) error {
+		require.Equal(t, "operator", localUser)
+		sshEvents = append(sshEvents, "check "+target)
+		return nil
+	}
+	deps.transferBundle = func(_ context.Context, localUser, target, bundlePath string) error {
+		require.Equal(t, "operator", localUser)
+		require.FileExists(t, bundlePath)
+		requireMode(t, bundlePath, 0o600)
+		sshEvents = append(sshEvents, "transfer "+target)
+		return nil
+	}
 	identityPeer := ""
 	deps.primaryIdentity = func(_ context.Context, peer string) (hostIdentity, error) {
 		require.Contains(t, prompts.String(), "ha-b IPv4 address")
@@ -42,6 +57,8 @@ func TestGuidedInstallPreparesClusterAndInstallsHAA(t *testing.T) {
 	}
 	deps.install = func(_ context.Context, options InstallOptions) error {
 		require.True(t, inspected)
+		require.FileExists(t, filepath.Join(exportDir, hostBundleName("ha-b")))
+		require.FileExists(t, filepath.Join(exportDir, hostBundleName("ha-c")))
 		config, err := loadNodeConfig(options.NodeEnvPath)
 		require.NoError(t, err)
 		require.Equal(t, "ha-a", config.NodeName)
@@ -58,16 +75,87 @@ func TestGuidedInstallPreparesClusterAndInstallsHAA(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, testHostIPs[1], identityPeer)
 	require.Contains(t, prompts.String(), "Type INSTALL")
-	require.Contains(t, prompts.String(), "Type COPIED")
+	require.Contains(t, prompts.String(), "Peer SSH username [operator]")
+	require.NotContains(t, prompts.String(), "Type COPIED")
 	require.Contains(t, prompts.String(), "Docker:    reuse existing installation")
 	require.NotContains(t, output.String(), testEtcdRootPassword)
-	require.Contains(t, output.String(), "Service CA SHA-256 fingerprint:")
-	require.Contains(t, output.String(), "On your operator machine")
-	require.Contains(t, output.String(), "from ha-a")
-	require.Contains(t, output.String(), "scp -p")
+	require.Contains(t, output.String(), "ssh -t operator@"+testHostIPs[1]+" 'curl -fsSL https://fleet.proto.xyz/install.sh | sudo bash -s -- --ha v0.2.10'")
+	require.Contains(t, output.String(), "ssh -t operator@"+testHostIPs[2]+" 'curl -fsSL https://fleet.proto.xyz/install.sh | sudo bash -s -- --ha v0.2.10'")
+	require.Equal(t, []string{
+		"check operator@" + testHostIPs[1],
+		"check operator@" + testHostIPs[2],
+		"transfer operator@" + testHostIPs[1],
+		"transfer operator@" + testHostIPs[2],
+	}, sshEvents)
 	require.NoFileExists(t, filepath.Join(exportDir, hostBundleName("ha-a")))
 	require.NoFileExists(t, filepath.Join(exportDir, hostBundleName("ha-b")))
+	require.NoFileExists(t, filepath.Join(exportDir, hostBundleName("ha-c")))
 	require.NoFileExists(t, filepath.Join(exportDir, publicCAName))
+}
+
+func TestGuidedInstallUsesPeerSSHUsernameOverride(t *testing.T) {
+	// Arrange
+	source := testGuidedRelease(t, "v0.2.10", "abc123")
+	exportDir := filepath.Join(t.TempDir(), "exports")
+	input := strings.NewReader(testHostIPs[1] + "\n" + testHostIPs[2] + "\n" + testVirtualIP + "\npeer-admin\nINSTALL\n")
+	deps := testGuidedDependencies(source, input, &bytes.Buffer{}, &bytes.Buffer{})
+	deps.operatorUsername = func() string { return "operator" }
+	deps.makeExportDir = func(string) (string, error) { return exportDir, os.Mkdir(exportDir, 0o700) }
+	var targets []string
+	deps.checkPeer = func(_ context.Context, localUser, target string) error {
+		require.Equal(t, "operator", localUser)
+		targets = append(targets, target)
+		return nil
+	}
+	deps.transferBundle = func(_ context.Context, _, target, _ string) error {
+		targets = append(targets, target)
+		return nil
+	}
+
+	// Act
+	err := guidedInstall(t.Context(), "", deps)
+
+	// Assert
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"peer-admin@" + testHostIPs[1],
+		"peer-admin@" + testHostIPs[2],
+		"peer-admin@" + testHostIPs[1],
+		"peer-admin@" + testHostIPs[2],
+	}, targets)
+}
+
+func TestGuidedInstallRetainsExportsWhenPeerTransferFails(t *testing.T) {
+	// Arrange
+	source := testGuidedRelease(t, "v0.2.10", "abc123")
+	exportDir := filepath.Join(t.TempDir(), "exports")
+	input := strings.NewReader(testHostIPs[1] + "\n" + testHostIPs[2] + "\n" + testVirtualIP + "\n\nINSTALL\n")
+	deps := testGuidedDependencies(source, input, &bytes.Buffer{}, &bytes.Buffer{})
+	deps.operatorUsername = func() string { return "operator" }
+	deps.makeExportDir = func(string) (string, error) { return exportDir, os.Mkdir(exportDir, 0o700) }
+	deps.checkPeer = func(context.Context, string, string) error { return nil }
+	deps.transferBundle = func(_ context.Context, _, target, _ string) error {
+		if target == "operator@"+testHostIPs[2] {
+			return errors.New("connection lost")
+		}
+		return nil
+	}
+	installed := false
+	deps.install = func(context.Context, InstallOptions) error {
+		installed = true
+		return nil
+	}
+
+	// Act
+	err := guidedInstall(t.Context(), "", deps)
+
+	// Assert
+	require.ErrorContains(t, err, "operator@"+testHostIPs[2])
+	require.ErrorContains(t, err, "connection lost")
+	require.False(t, installed)
+	require.FileExists(t, filepath.Join(exportDir, hostBundleName("ha-a")))
+	require.FileExists(t, filepath.Join(exportDir, hostBundleName("ha-b")))
+	require.FileExists(t, filepath.Join(exportDir, hostBundleName("ha-c")))
 }
 
 func TestBundleExportDirectoryIsOutsideRelease(t *testing.T) {
@@ -206,7 +294,14 @@ func TestInstallHostBundleConsumption(t *testing.T) {
 			source := testGuidedRelease(t, "v0.2.10", "abc123")
 			bundlePath := filepath.Join(t.TempDir(), hostBundleName("ha-c"))
 			writeValidTestBundle(t, bundlePath, testBundleMetadata("ha-c"))
-			deps := testGuidedDependencies(source, strings.NewReader("INSTALL\n"), &bytes.Buffer{}, &bytes.Buffer{})
+			var prompts bytes.Buffer
+			deps := testGuidedDependencies(source, strings.NewReader(""), &bytes.Buffer{}, &prompts)
+			deps.terminal = func() bool { return false }
+			inspected := false
+			deps.inspect = func(context.Context, string, NodeConfig) (installedDependencies, error) {
+				inspected = true
+				return installedDependencies{}, nil
+			}
 			deps.install = func(context.Context, InstallOptions) error { return tt.installErr }
 
 			// Act
@@ -214,6 +309,8 @@ func TestInstallHostBundleConsumption(t *testing.T) {
 
 			// Assert
 			require.ErrorIs(t, err, tt.installErr)
+			require.True(t, inspected)
+			require.NotContains(t, prompts.String(), "Type INSTALL")
 			if tt.wantExists {
 				require.FileExists(t, bundlePath)
 			} else {
@@ -266,8 +363,11 @@ func testGuidedDependencies(source string, input *strings.Reader, output, prompt
 		primaryIdentity: func(context.Context, string) (hostIdentity, error) {
 			return hostIdentity{address: testHostIPs[0], networkInterface: "eth0"}, nil
 		},
-		interfaceForIP: func(string) (string, error) { return "eth0", nil },
-		makeExportDir:  func(string) (string, error) { return os.MkdirTemp("", "fleet-ha-test-exports-") },
+		interfaceForIP:   func(string) (string, error) { return "eth0", nil },
+		makeExportDir:    func(string) (string, error) { return os.MkdirTemp("", "fleet-ha-test-exports-") },
+		operatorUsername: func() string { return "operator" },
+		checkPeer:        func(context.Context, string, string) error { return nil },
+		transferBundle:   func(context.Context, string, string, string) error { return nil },
 		inspect: func(context.Context, string, NodeConfig) (installedDependencies, error) {
 			return installedDependencies{}, nil
 		},

--- a/server/internal/ha/deployment/install.go
+++ b/server/internal/ha/deployment/install.go
@@ -878,6 +878,9 @@ func initialStart(ctx context.Context, config NodeConfig, deps installDependenci
 		return stopIncompleteHA(ctx, deps, fmt.Errorf("start HA services: %s", commandError(output, err)), cleanupUpdater)
 	}
 	if err := deps.localReady(ctx, config); err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return fmt.Errorf("%w; reconnect and run systemctl status proto-fleet-ha.service: %v", errInstallConverging, err)
+		}
 		return stopIncompleteHA(ctx, deps, err, cleanupUpdater)
 	}
 	fmt.Println("[peer waiting] HA service is enabled and will keep converging while peers join")

--- a/server/internal/ha/deployment/install.go
+++ b/server/internal/ha/deployment/install.go
@@ -885,15 +885,15 @@ func initialStart(ctx context.Context, config NodeConfig, deps installDependenci
 		return nil
 	}
 	for {
+		if state, _ := systemdUnitState(ctx, deps, "is-failed", "proto-fleet-ha.service"); state == "failed" {
+			return stopIncompleteHA(ctx, deps, errors.New("proto-fleet-ha.service failed; inspect journalctl -u proto-fleet-ha.service"), false)
+		}
 		if deps.vipReady(ctx, config) {
 			fmt.Println("[final readiness] Fleet is reachable through the virtual IP")
 			return nil
 		}
 		if err := ctx.Err(); err != nil {
 			return fmt.Errorf("%w; reconnect and run systemctl status proto-fleet-ha.service: %v", errInstallConverging, err)
-		}
-		if state, _ := systemdUnitState(ctx, deps, "is-failed", "proto-fleet-ha.service"); state == "failed" {
-			return stopIncompleteHA(ctx, deps, errors.New("proto-fleet-ha.service failed; inspect journalctl -u proto-fleet-ha.service"), false)
 		}
 		deps.sleep(2 * time.Second)
 	}

--- a/server/internal/ha/deployment/install.go
+++ b/server/internal/ha/deployment/install.go
@@ -15,6 +15,8 @@ import (
 	"time"
 
 	"golang.org/x/mod/semver"
+
+	"github.com/block/proto-fleet/server/internal/ha"
 )
 
 const (
@@ -97,6 +99,8 @@ type installDependencies struct {
 	runInput     func(context.Context, string, string, ...string) error
 	sourceRoot   func() (string, error)
 	verifyVIP    func(context.Context, NodeConfig) error
+	localReady   func(context.Context, NodeConfig) error
+	vipReady     func(context.Context, NodeConfig) bool
 	sleep        func(time.Duration)
 }
 
@@ -105,7 +109,8 @@ func defaultInstallDependencies() installDependencies {
 		goos: runtime.GOOS, goarch: runtime.GOARCH, pageSize: os.Getpagesize(),
 		readFile: os.ReadFile, lstat: os.Lstat, lookPath: exec.LookPath, requireEmpty: requireEmptyDir, validateHost: ValidateHost,
 		run: runCommand, runInput: runWithInput,
-		sourceRoot: ReleaseRoot, verifyVIP: verifyInstallVirtualIP, sleep: time.Sleep,
+		sourceRoot: ReleaseRoot, verifyVIP: verifyInstallVirtualIP,
+		localReady: waitForLocalEtcd, vipReady: probeInstalledActiveVIP, sleep: time.Sleep,
 	}
 }
 
@@ -872,25 +877,36 @@ func initialStart(ctx context.Context, config NodeConfig, deps installDependenci
 	if output, err := deps.run(ctx, "sudo", "systemctl", "start", "--no-block", "proto-fleet-ha.service"); err != nil {
 		return stopIncompleteHA(ctx, deps, fmt.Errorf("start HA services: %s", commandError(output, err)), cleanupUpdater)
 	}
+	if err := deps.localReady(ctx, config); err != nil {
+		return stopIncompleteHA(ctx, deps, err, cleanupUpdater)
+	}
 	fmt.Println("[peer waiting] HA service is enabled and will keep converging while peers join")
+	if config.isDatabaseNode() {
+		return nil
+	}
 	for {
-		if config.isDatabaseNode() {
-			if _, err := deps.run(ctx, "sudo", filepath.Join(installRoot, "ha", "fleet-ha"), "status", filepath.Join(configRoot, "node.env")); err == nil {
-				fmt.Println("[final readiness] HA control and failover paths are ready")
-				return nil
-			}
-		} else if state, _ := systemdUnitState(ctx, deps, "is-active", "proto-fleet-ha.service"); state == "active" {
-			fmt.Println("[final readiness] HA witness joined the etcd quorum")
+		if deps.vipReady(ctx, config) {
+			fmt.Println("[final readiness] Fleet is reachable through the virtual IP")
 			return nil
 		}
 		if err := ctx.Err(); err != nil {
 			return fmt.Errorf("%w; reconnect and run systemctl status proto-fleet-ha.service: %v", errInstallConverging, err)
 		}
 		if state, _ := systemdUnitState(ctx, deps, "is-failed", "proto-fleet-ha.service"); state == "failed" {
-			return stopIncompleteHA(ctx, deps, errors.New("HA service failed during local startup; inspect journalctl -u proto-fleet-ha.service"), cleanupUpdater)
+			return fmt.Errorf("%w; proto-fleet-ha.service is failed, inspect journalctl -u proto-fleet-ha.service", errInstallConverging)
 		}
 		deps.sleep(2 * time.Second)
 	}
+}
+
+func probeInstalledActiveVIP(ctx context.Context, config NodeConfig) bool {
+	tlsConfig, err := ha.LoadServiceTLS(filepath.Join(configRoot, "service-ca.crt"))
+	if err != nil {
+		return false
+	}
+	client, cleanup := newProbeHTTPClient(tlsConfig, nil)
+	defer cleanup()
+	return endpointReadyWithClient(ctx, client, "https://"+config.VirtualIP+"/api-proxy/health/active")
 }
 
 func stopIncompleteHA(ctx context.Context, deps installDependencies, cause error, cleanupUpdater bool) error {

--- a/server/internal/ha/deployment/install.go
+++ b/server/internal/ha/deployment/install.go
@@ -885,10 +885,11 @@ func initialStart(ctx context.Context, config NodeConfig, deps installDependenci
 		return nil
 	}
 	for {
-		if state, _ := systemdUnitState(ctx, deps, "is-failed", "proto-fleet-ha.service"); state == "failed" {
+		state, _ := systemdUnitState(ctx, deps, "is-active", "proto-fleet-ha.service")
+		if state == "failed" {
 			return stopIncompleteHA(ctx, deps, errors.New("proto-fleet-ha.service failed; inspect journalctl -u proto-fleet-ha.service"), false)
 		}
-		if deps.vipReady(ctx, config) {
+		if state == "active" && deps.vipReady(ctx, config) {
 			fmt.Println("[final readiness] Fleet is reachable through the virtual IP")
 			return nil
 		}

--- a/server/internal/ha/deployment/install.go
+++ b/server/internal/ha/deployment/install.go
@@ -893,7 +893,7 @@ func initialStart(ctx context.Context, config NodeConfig, deps installDependenci
 			return fmt.Errorf("%w; reconnect and run systemctl status proto-fleet-ha.service: %v", errInstallConverging, err)
 		}
 		if state, _ := systemdUnitState(ctx, deps, "is-failed", "proto-fleet-ha.service"); state == "failed" {
-			return fmt.Errorf("%w; proto-fleet-ha.service is failed, inspect journalctl -u proto-fleet-ha.service", errInstallConverging)
+			return stopIncompleteHA(ctx, deps, errors.New("proto-fleet-ha.service failed; inspect journalctl -u proto-fleet-ha.service"), false)
 		}
 		deps.sleep(2 * time.Second)
 	}

--- a/server/internal/ha/deployment/install_test.go
+++ b/server/internal/ha/deployment/install_test.go
@@ -71,6 +71,9 @@ func TestInstallGoldenPathOrdersFirewallBeforeServices(t *testing.T) {
 	if callIndex(calls, "build fleet-api fleet-client") >= 0 {
 		t.Fatalf("installer rebuilt checksum-covered Fleet images:\n%s", strings.Join(calls, "\n"))
 	}
+	joined := strings.Join(calls, "\n")
+	require.Contains(t, joined, "wait-local-etcd "+testHostIPs[0])
+	require.NotContains(t, joined, "fleet-ha status")
 }
 
 func TestInstallRejectsExistingNftablesInputFilteringBeforeConfiguration(t *testing.T) {
@@ -207,27 +210,21 @@ func TestInstallInterruptedDuringConvergenceLeavesHAEnabled(t *testing.T) {
 	// Arrange
 	source := testInstallRelease(t)
 	config := NodeConfig{
-		NodeName: "ha-a", NodeIP: testHostIPs[0], DatabaseAIP: testHostIPs[0],
+		NodeName: "ha-c", NodeIP: testHostIPs[2], DatabaseAIP: testHostIPs[0],
 		DatabaseBIP: testHostIPs[1], WitnessIP: testHostIPs[2], VirtualIP: testVirtualIP,
 		NetworkInterface: "eth0", DataDir: dataRoot, SecretsDir: t.TempDir(),
 	}
 	writeTestSecretBundle(t, config)
-	rootPassword := filepath.Join(t.TempDir(), "etcd-root-password")
-	require.NoError(t, os.WriteFile(rootPassword, []byte(testEtcdRootPassword+"\n"), 0o600))
 	var calls []string
 	deps := testInstallerDependencies(source, config, &calls)
-	run := deps.run
 	ctx, cancel := context.WithCancel(t.Context())
-	deps.run = func(ctx context.Context, name string, args ...string) ([]byte, error) {
-		if strings.Contains(strings.Join(args, " "), "fleet-ha status") {
-			cancel()
-			return nil, errors.New("not ready")
-		}
-		return run(ctx, name, args...)
+	deps.vipReady = func(context.Context, NodeConfig) bool {
+		cancel()
+		return false
 	}
 
 	// Act
-	err := install(ctx, InstallOptions{NodeEnvPath: "node.env", EtcdRootPasswordFile: rootPassword}, deps)
+	err := install(ctx, InstallOptions{NodeEnvPath: "node.env"}, deps)
 
 	// Assert
 	require.ErrorContains(t, err, "remains enabled and is still converging")
@@ -239,6 +236,30 @@ func TestInstallInterruptedDuringConvergenceLeavesHAEnabled(t *testing.T) {
 	require.NotContains(t, joined, "sudo systemctl disable --now proto-fleet-ha.service")
 	require.Contains(t, joined, "docker-ha-recovery-systemd.conf "+dockerRecoveryDropIn)
 	require.NotContains(t, joined, "sudo rm -f "+dockerRecoveryDropIn)
+}
+
+func TestInitialStartCleansUpWhenLocalEtcdDoesNotStart(t *testing.T) {
+	// Arrange
+	config := NodeConfig{NodeName: "ha-a", NodeIP: testHostIPs[0], DatabaseAIP: testHostIPs[0]}
+	var calls []string
+	deps := installDependencies{
+		run: func(_ context.Context, name string, args ...string) ([]byte, error) {
+			calls = append(calls, strings.Join(append([]string{name}, args...), " "))
+			return nil, nil
+		},
+		localReady: func(context.Context, NodeConfig) error {
+			return errors.New("local etcd member did not start within one minute")
+		},
+	}
+
+	// Act
+	err := initialStart(t.Context(), config, deps)
+
+	// Assert
+	require.ErrorContains(t, err, "local etcd member did not start within one minute")
+	joined := strings.Join(calls, "\n")
+	require.Contains(t, joined, "sudo systemctl disable --now proto-fleet-updater.service")
+	require.Contains(t, joined, "sudo systemctl disable --now proto-fleet-ha.service")
 }
 
 func TestInstallRejectsUnavailableSystemdBeforeMutation(t *testing.T) {
@@ -332,6 +353,11 @@ func TestInstallWitnessSelectsOnlyEtcd(t *testing.T) {
 	writeTestSecretBundle(t, config)
 	var calls []string
 	deps := testInstallerDependencies(source, config, &calls)
+	vipProbes := 0
+	deps.vipReady = func(context.Context, NodeConfig) bool {
+		vipProbes++
+		return vipProbes == 3
+	}
 
 	// Act
 	err := install(t.Context(), InstallOptions{NodeEnvPath: "node.env"}, deps)
@@ -340,6 +366,7 @@ func TestInstallWitnessSelectsOnlyEtcd(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	require.Equal(t, 3, vipProbes)
 	joined := strings.Join(calls, "\n")
 	if !strings.Contains(joined, "sudo systemctl disable --now keepalived.service") {
 		t.Fatalf("witness did not disable keepalived:\n%s", joined)
@@ -797,7 +824,15 @@ func testInstallerDependencies(source string, config NodeConfig, calls *[]string
 			return nil
 		},
 		sourceRoot: func() (string, error) { return source, nil },
-		sleep:      func(time.Duration) {},
+		localReady: func(_ context.Context, config NodeConfig) error {
+			record("wait-local-etcd", config.NodeIP)
+			return nil
+		},
+		vipReady: func(context.Context, NodeConfig) bool {
+			record("probe-active-vip")
+			return true
+		},
+		sleep: func(time.Duration) {},
 	}
 }
 

--- a/server/internal/ha/deployment/install_test.go
+++ b/server/internal/ha/deployment/install_test.go
@@ -238,6 +238,33 @@ func TestInstallInterruptedDuringConvergenceLeavesHAEnabled(t *testing.T) {
 	require.NotContains(t, joined, "sudo rm -f "+dockerRecoveryDropIn)
 }
 
+func TestInitialStartCleansUpFailedWitnessService(t *testing.T) {
+	// Arrange
+	config := NodeConfig{NodeName: "ha-c", NodeIP: testHostIPs[2], WitnessIP: testHostIPs[2]}
+	var calls []string
+	deps := installDependencies{
+		run: func(_ context.Context, name string, args ...string) ([]byte, error) {
+			call := strings.Join(append([]string{name}, args...), " ")
+			calls = append(calls, call)
+			if call == "systemctl is-failed proto-fleet-ha.service" {
+				return []byte("failed\n"), nil
+			}
+			return nil, nil
+		},
+		localReady: func(context.Context, NodeConfig) error { return nil },
+		vipReady:   func(context.Context, NodeConfig) bool { return false },
+		sleep:      func(time.Duration) {},
+	}
+
+	// Act
+	err := initialStart(t.Context(), config, deps)
+
+	// Assert
+	require.ErrorContains(t, err, "proto-fleet-ha.service failed")
+	require.NotErrorIs(t, err, errInstallConverging)
+	require.Contains(t, strings.Join(calls, "\n"), "sudo systemctl disable --now proto-fleet-ha.service")
+}
+
 func TestInitialStartCleansUpWhenLocalEtcdDoesNotStart(t *testing.T) {
 	// Arrange
 	config := NodeConfig{NodeName: "ha-a", NodeIP: testHostIPs[0], DatabaseAIP: testHostIPs[0]}

--- a/server/internal/ha/deployment/install_test.go
+++ b/server/internal/ha/deployment/install_test.go
@@ -246,7 +246,7 @@ func TestInitialStartCleansUpFailedWitnessService(t *testing.T) {
 		run: func(_ context.Context, name string, args ...string) ([]byte, error) {
 			call := strings.Join(append([]string{name}, args...), " ")
 			calls = append(calls, call)
-			if call == "sudo systemctl is-failed proto-fleet-ha.service" {
+			if call == "sudo systemctl is-active proto-fleet-ha.service" {
 				return []byte("failed\n"), nil
 			}
 			return nil, nil
@@ -263,6 +263,39 @@ func TestInitialStartCleansUpFailedWitnessService(t *testing.T) {
 	require.ErrorContains(t, err, "proto-fleet-ha.service failed")
 	require.NotErrorIs(t, err, errInstallConverging)
 	require.Contains(t, strings.Join(calls, "\n"), "sudo systemctl disable --now proto-fleet-ha.service")
+}
+
+func TestInitialStartWaitsForWitnessServiceToBecomeActive(t *testing.T) {
+	// Arrange
+	config := NodeConfig{NodeName: "ha-c", NodeIP: testHostIPs[2], WitnessIP: testHostIPs[2]}
+	stateChecks := 0
+	vipChecks := 0
+	deps := installDependencies{
+		run: func(_ context.Context, name string, args ...string) ([]byte, error) {
+			if strings.Join(append([]string{name}, args...), " ") != "sudo systemctl is-active proto-fleet-ha.service" {
+				return nil, nil
+			}
+			stateChecks++
+			if stateChecks == 1 {
+				return []byte("activating\n"), nil
+			}
+			return []byte("active\n"), nil
+		},
+		localReady: func(context.Context, NodeConfig) error { return nil },
+		vipReady: func(context.Context, NodeConfig) bool {
+			vipChecks++
+			return true
+		},
+		sleep: func(time.Duration) {},
+	}
+
+	// Act
+	err := initialStart(t.Context(), config, deps)
+
+	// Assert
+	require.NoError(t, err)
+	require.Equal(t, 2, stateChecks)
+	require.Equal(t, 1, vipChecks)
 }
 
 func TestInitialStartCleansUpWhenLocalEtcdDoesNotStart(t *testing.T) {

--- a/server/internal/ha/deployment/install_test.go
+++ b/server/internal/ha/deployment/install_test.go
@@ -246,13 +246,13 @@ func TestInitialStartCleansUpFailedWitnessService(t *testing.T) {
 		run: func(_ context.Context, name string, args ...string) ([]byte, error) {
 			call := strings.Join(append([]string{name}, args...), " ")
 			calls = append(calls, call)
-			if call == "systemctl is-failed proto-fleet-ha.service" {
+			if call == "sudo systemctl is-failed proto-fleet-ha.service" {
 				return []byte("failed\n"), nil
 			}
 			return nil, nil
 		},
 		localReady: func(context.Context, NodeConfig) error { return nil },
-		vipReady:   func(context.Context, NodeConfig) bool { return false },
+		vipReady:   func(context.Context, NodeConfig) bool { return true },
 		sleep:      func(time.Duration) {},
 	}
 

--- a/server/internal/ha/deployment/install_test.go
+++ b/server/internal/ha/deployment/install_test.go
@@ -298,6 +298,34 @@ func TestInitialStartWaitsForWitnessServiceToBecomeActive(t *testing.T) {
 	require.Equal(t, 1, vipChecks)
 }
 
+func TestInitialStartCancellationDuringLocalEtcdWaitLeavesServicesEnabled(t *testing.T) {
+	// Arrange
+	config := NodeConfig{NodeName: "ha-a", NodeIP: testHostIPs[0], DatabaseAIP: testHostIPs[0]}
+	var calls []string
+	deps := installDependencies{
+		run: func(_ context.Context, name string, args ...string) ([]byte, error) {
+			calls = append(calls, strings.Join(append([]string{name}, args...), " "))
+			return nil, nil
+		},
+		localReady: func(context.Context, NodeConfig) error {
+			return fmt.Errorf("stopped waiting for local etcd member: %w", context.Canceled)
+		},
+	}
+
+	// Act
+	err := initialStart(t.Context(), config, deps)
+
+	// Assert
+	require.ErrorIs(t, err, errInstallConverging)
+	require.ErrorContains(t, err, "reconnect and run systemctl status proto-fleet-ha.service")
+	joined := strings.Join(calls, "\n")
+	require.Contains(t, joined, "sudo systemctl enable proto-fleet-ha.service")
+	require.Contains(t, joined, "sudo systemctl enable proto-fleet-updater.service")
+	require.Contains(t, joined, "sudo systemctl start --no-block proto-fleet-ha.service")
+	require.NotContains(t, joined, "sudo systemctl disable --now proto-fleet-updater.service")
+	require.NotContains(t, joined, "sudo systemctl disable --now proto-fleet-ha.service")
+}
+
 func TestInitialStartCleansUpWhenLocalEtcdDoesNotStart(t *testing.T) {
 	// Arrange
 	config := NodeConfig{NodeName: "ha-a", NodeIP: testHostIPs[0], DatabaseAIP: testHostIPs[0]}


### PR DESCRIPTION
Reviewable diff: +250/-126 across 4 files (excludes generated, test, and story files).

## Summary

Proto Fleet HA now installs with one operator command per host. `ha-a` selects and verifies the release, gathers the fixed three-node topology, securely prepares both peers, and prints release-pinned commands that finish `ha-b` and `ha-c` without manual archive or bundle handling.

**Stack:** [#935](https://github.com/block/proto-fleet/pull/935) (this PR) → [#936](https://github.com/block/proto-fleet/pull/936) (public service CA download). This PR owns release acquisition, peer handoff, and role-specific install completion. Client certificate distribution is intentionally isolated in #936.

## How it works

1. The operator runs the existing public installer with `--ha` on `ha-a`. The script detects the host architecture, resolves the requested or latest release, verifies its official checksum, and invokes the packaged `fleet-ha` binary.
2. The guided installer asks for the two peer addresses, VIP, and peer SSH username. It derives the local address and interface, validates the topology and dedicated host, shows the complete plan, and requires one `INSTALL` confirmation.
3. Before mutating `ha-a`, the installer proves both SSH destinations are reachable. It then streams each role-scoped JSON bundle through the invoking operator's existing SSH identity to `/var/tmp/proto-fleet-ha-host.json` with mode `0600`. It does not copy release archives or SSH keys.
4. After `ha-a` starts locally, the installer removes the copied peer exports and prints exact commands for `ha-b` and `ha-c`. Each peer independently downloads and verifies the correct architecture artifact for the exact selected release.
5. A valid prepared bundle authorizes the peer install without another TTY prompt. Database nodes return after bounded local startup; the witness returns only after Fleet is active through the VIP. Missing peers continue converging under systemd.

```mermaid
flowchart LR
  O["Operator machine"] -->|"run public installer"| A["ha-a"]
  A -->|"protected role bundle over SSH"| B["ha-b"]
  A -->|"protected role bundle over SSH"| C["ha-c"]
  O -->|"run printed pinned command"| B
  O -->|"run printed pinned command"| C
  B -->|"download verified release"| R["GitHub release"]
  C -->|"download verified release"| R
  A --> Q["local service ready"]
  B --> Q
  C --> V["VIP active health ready"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `deployment-files/install.sh` | Adds `--ha`, prepared-bundle detection, and packaged HA invocation | Reuses the standard release resolution and checksum boundary without changing the standard install path |
| `server/internal/ha/deployment/guided_install.go` | Automates peer validation, protected bundle transfer, and pinned peer commands | Owns the SSH and secret-handling boundary before local mutation |
| `server/internal/ha/deployment/install.go` | Makes completion role-specific | Prevents early database nodes from waiting on quorum while still requiring the final witness to prove VIP service |
| `deployment-files/ha/README.md` | Replaces manual archive and bundle staging with the three-command flow | Keeps the engineering runbook aligned with packaged behavior |

## Key technical decisions & trade-offs

- Reuse the invoking operator's normal SSH identity and host-key policy. The installer does not provision credentials or weaken SSH verification.
- Check both peers before sending either secret bundle or changing `ha-a`. A failed connection leaves protected exports for a clean retry but does not add resume orchestration.
- Let each peer fetch its own architecture artifact at the exact release selected by `ha-a`. This supports mixed `amd64` and `arm64` hosts without copying large archives.
- Treat a validated prepared bundle as prior authorization for peer mutation. Only `ha-a` requires the cluster-level `INSTALL` acknowledgement.
- Keep cluster convergence under systemd. The installer has a bounded local-startup check but no cross-host controller, rollback engine, or SSH remote execution of the install itself.

## Testing & validation

- `go test ./internal/ha/deployment -count=1`
- Hermit-backed `golangci-lint` for `./internal/ha/deployment/...`
- `./deployment-files/tests/test-install-overlay-migration.sh`
- `./deployment-files/ha/tests/test-profile.sh`
- `bash -n deployment-files/install.sh`
- `git diff --check`

The automated coverage includes standard-installer isolation, architecture-specific HA download, SSH username selection, all-peer prechecks, protected transfer, failure-before-mutation, pinned peer commands, prepared-peer authorization, local-startup bounds, and witness VIP readiness. Real three-host password-based and agent-based SSH installation remains manual qualification.
