### PR TITLE
Publish the HA service CA through the virtual IP

### DIFF
--- a/deployment-files/ha/README.md
+++ b/deployment-files/ha/README.md
@@ -87,6 +87,26 @@ The database-node commands return after the local HA service has started; the
 cluster keeps converging under systemd as the remaining nodes join. The
 `ha-c` command returns after Fleet is active and reachable through the VIP.
 
+### 3. Trust the public service CA
+
+When `ha-a` creates the cluster, it prints the SHA-256 fingerprint of the
+public service CA. After `ha-c` proves that the VIP is ready, it prints commands
+like these for the operator machine:
+
+```bash
+curl --insecure --fail --noproxy '*' --output proto-fleet-ha-service-ca.download https://10.40.0.50/proto-fleet-ha-service-ca.crt
+openssl x509 -in proto-fleet-ha-service-ca.download -out proto-fleet-ha-service-ca.crt
+rm proto-fleet-ha-service-ca.download
+openssl x509 -in proto-fleet-ha-service-ca.crt -noout -fingerprint -sha256
+```
+
+The initial download permits the cluster's private CA only for this request.
+Compare the displayed fingerprint with the value from the authenticated
+`ha-a` session before importing `proto-fleet-ha-service-ca.crt` into a browser
+or operating-system trust store. Import only that canonical certificate. The
+VIP exposes no private key or service credential, and the installer does not
+modify client trust stores.
+
 ### Installer behavior and failure handling
 
 The installer verifies the official archive checksum before executing the

--- a/deployment-files/ha/fleet-compose.yaml
+++ b/deployment-files/ha/fleet-compose.yaml
@@ -28,3 +28,4 @@ services:
     volumes: !override
       - "${HA_SECRETS_DIR}/fleet-client.crt:/etc/nginx/ssl/cert.pem:ro"
       - "${HA_SECRETS_DIR}/fleet-client.key:/etc/nginx/ssl/key.pem:ro"
+      - "${HA_SECRETS_DIR}/service-ca.crt:/usr/share/nginx/html/proto-fleet-ha-service-ca.crt:ro"

--- a/deployment-files/ha/tests/test-profile.sh
+++ b/deployment-files/ha/tests/test-profile.sh
@@ -133,8 +133,11 @@ test_fleet_ha_contract() {
     assert_contains "$rendered" "target: /etc/nginx/ssl/cert.pem"
     assert_contains "$rendered" "source: /etc/proto-fleet/ha/fleet-client.key"
     assert_contains "$rendered" "target: /etc/nginx/ssl/key.pem"
+    assert_contains "$rendered" "target: /usr/share/nginx/html/proto-fleet-ha-service-ca.crt"
+    assert_contains "${HA_DIR}/fleet-compose.yaml" '${HA_SECRETS_DIR}/service-ca.crt:/usr/share/nginx/html/proto-fleet-ha-service-ca.crt:ro'
+    assert_not_contains "${HA_DIR}/fleet-compose.yaml" '.key:/usr/share/nginx/html/'
     secret_mount_count="$(grep -c 'source: /etc/proto-fleet/ha/' "$rendered")"
-    [[ "$secret_mount_count" -eq 4 ]] || fail "Fleet services must mount only their required HA secret files"
+    [[ "$secret_mount_count" -eq 5 ]] || fail "Fleet services must mount only their required HA secret files"
     assert_not_contains "$rendered" "source: ${release_dir}/ssl"
     assert_not_contains "$rendered" "/run/proto-fleet-updater"
 

--- a/server/internal/ha/deployment/guided_install.go
+++ b/server/internal/ha/deployment/guided_install.go
@@ -4,7 +4,10 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"io"
@@ -216,6 +219,18 @@ func prepareAndInstallCluster(ctx context.Context, source string, release cluste
 	if err := prepareInstallBundles(exportDir, metadata); err != nil {
 		return fmt.Errorf("bundle generation failed; partial exports remain at %s: %w", exportDir, err)
 	}
+	haABundle := filepath.Join(exportDir, hostBundleName("ha-a"))
+	bundle, err := readHostBundle(haABundle)
+	if err != nil {
+		return err
+	}
+	fingerprint, err := serviceCAFingerprint(bundle.Secrets["service-ca.crt"])
+	if err != nil {
+		return err
+	}
+	if err := writeInstallerOutput(deps.output, "Public service CA SHA-256 fingerprint: %s\n", fingerprint); err != nil {
+		return err
+	}
 	peers := []struct {
 		role    string
 		address string
@@ -237,7 +252,6 @@ func prepareAndInstallCluster(ctx context.Context, source string, release cluste
 		}
 	}
 
-	haABundle := filepath.Join(exportDir, hostBundleName("ha-a"))
 	if err := installPreparedHost(ctx, source, haABundle, release, true, deps); err != nil {
 		return err
 	}
@@ -440,6 +454,20 @@ func decodeHostBundle(contents []byte) (preparedHostBundle, error) {
 		return preparedHostBundle{}, errors.New("host bundle rejected: etcd root password is only valid for ha-a")
 	}
 	return bundle, nil
+}
+
+func serviceCAFingerprint(contents []byte) (string, error) {
+	block, _ := pem.Decode(contents)
+	if block == nil || block.Type != "CERTIFICATE" {
+		return "", errors.New("host bundle contains an invalid public service CA")
+	}
+	digest := sha256.Sum256(block.Bytes)
+	encoded := strings.ToUpper(hex.EncodeToString(digest[:]))
+	pairs := make([]string, 0, len(encoded)/2)
+	for index := 0; index < len(encoded); index += 2 {
+		pairs = append(pairs, encoded[index:index+2])
+	}
+	return strings.Join(pairs, ":"), nil
 }
 
 func validateBundleMetadata(metadata bundleMetadata) error {

--- a/server/internal/ha/deployment/guided_install.go
+++ b/server/internal/ha/deployment/guided_install.go
@@ -222,11 +222,11 @@ func prepareAndInstallCluster(ctx context.Context, source string, release cluste
 	haABundle := filepath.Join(exportDir, hostBundleName("ha-a"))
 	bundle, err := readHostBundle(haABundle)
 	if err != nil {
-		return err
+		return fmt.Errorf("read generated ha-a bundle; bundle exports remain at %s: %w", exportDir, err)
 	}
 	fingerprint, err := serviceCAFingerprint(bundle.Secrets["service-ca.crt"])
 	if err != nil {
-		return err
+		return fmt.Errorf("fingerprint public service CA; bundle exports remain at %s: %w", exportDir, err)
 	}
 	if err := writeInstallerOutput(deps.output, "Public service CA SHA-256 fingerprint: %s\n", fingerprint); err != nil {
 		return err

--- a/server/internal/ha/deployment/guided_install_test.go
+++ b/server/internal/ha/deployment/guided_install_test.go
@@ -103,6 +103,29 @@ func TestGuidedInstallPreparesClusterAndInstallsHAA(t *testing.T) {
 	require.NoFileExists(t, filepath.Join(exportDir, hostBundleName("ha-c")))
 }
 
+func TestServiceCAFingerprintMatchesOpenSSL(t *testing.T) {
+	// Arrange
+	const certificate = `-----BEGIN CERTIFICATE-----
+MIIBoTCCAUegAwIBAgIUXLAXgfn7OuXjkUfB2NO7RzuV25UwCgYIKoZIzj0EAwIw
+JjEkMCIGA1UEAwwbUHJvdG8gRmxlZXQgdGVzdCBzZXJ2aWNlIENBMB4XDTI2MDgx
+ODIxNTgyOVoXDTM2MDgxNTIxNTgyOVowJjEkMCIGA1UEAwwbUHJvdG8gRmxlZXQg
+dGVzdCBzZXJ2aWNlIENBMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEMRNxVvQt
+K6p55t4/fA9/wapZwOrPVqANtGHEPhTKo+2PqqBTccydn1Xn6vp0xi/6eONi1er3
+R0wwLDNMKKUsTaNTMFEwHQYDVR0OBBYEFLWxZhcDBioJ+WxBjThpXsInI0LUMB8G
+A1UdIwQYMBaAFLWxZhcDBioJ+WxBjThpXsInI0LUMA8GA1UdEwEB/wQFMAMBAf8w
+CgYIKoZIzj0EAwIDSAAwRQIhANLd2j3ndHOTdvuP3OQamgqu2vgcntLR2RVshe/S
+ebCBAiACqqak+Din9945lq0fFYzfw1ybLTC+HvyDSRCMT1bk0A==
+-----END CERTIFICATE-----
+`
+
+	// Act
+	fingerprint, err := serviceCAFingerprint([]byte(certificate))
+
+	// Assert
+	require.NoError(t, err)
+	require.Equal(t, "43:0C:7C:D7:B8:4B:1C:47:AA:D0:0B:78:CF:DA:A6:AD:CC:54:CD:A3:B3:BD:66:DF:8D:4D:83:E0:CC:96:38:1B", fingerprint)
+}
+
 func TestGuidedInstallUsesPeerSSHUsernameOverride(t *testing.T) {
 	// Arrange
 	source := testGuidedRelease(t, "v0.2.10", "abc123")

--- a/server/internal/ha/deployment/guided_install_test.go
+++ b/server/internal/ha/deployment/guided_install_test.go
@@ -25,6 +25,7 @@ func TestGuidedInstallPreparesClusterAndInstallsHAA(t *testing.T) {
 	deps := testGuidedDependencies(source, input, &output, &prompts)
 	deps.operatorUsername = func() string { return "operator" }
 	var sshEvents []string
+	var expectedFingerprint string
 	deps.checkPeer = func(_ context.Context, localUser, target string) error {
 		require.Equal(t, "operator", localUser)
 		sshEvents = append(sshEvents, "check "+target)
@@ -34,6 +35,12 @@ func TestGuidedInstallPreparesClusterAndInstallsHAA(t *testing.T) {
 		require.Equal(t, "operator", localUser)
 		require.FileExists(t, bundlePath)
 		requireMode(t, bundlePath, 0o600)
+		if expectedFingerprint == "" {
+			bundle, err := readHostBundle(bundlePath)
+			require.NoError(t, err)
+			expectedFingerprint, err = serviceCAFingerprint(bundle.Secrets["service-ca.crt"])
+			require.NoError(t, err)
+		}
 		sshEvents = append(sshEvents, "transfer "+target)
 		return nil
 	}
@@ -84,6 +91,7 @@ func TestGuidedInstallPreparesClusterAndInstallsHAA(t *testing.T) {
 	require.Contains(t, output.String(), "test -f /var/tmp/proto-fleet-ha-host.json")
 	require.Contains(t, output.String(), "releases/download/v0.2.10/install.sh")
 	require.NotContains(t, output.String(), "curl -fsSL https://fleet.proto.xyz/install.sh |")
+	require.Contains(t, output.String(), "Public service CA SHA-256 fingerprint: "+expectedFingerprint)
 	require.Equal(t, []string{
 		"check operator@" + testHostIPs[1],
 		"check operator@" + testHostIPs[2],

--- a/server/internal/ha/deployment/install.go
+++ b/server/internal/ha/deployment/install.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -647,7 +648,8 @@ func installRelease(ctx context.Context, config NodeConfig, deps installDependen
 		}
 	}
 	for _, name := range copiedSecretFiles(config) {
-		if err := placeFile(ctx, deps, "install HA secret "+name, filepath.Join(config.SecretsDir, name), filepath.Join(configRoot, name), "0600"); err != nil {
+		mode := fmt.Sprintf("%04o", secretFileMode(name))
+		if err := placeFile(ctx, deps, "install HA secret "+name, filepath.Join(config.SecretsDir, name), filepath.Join(configRoot, name), mode); err != nil {
 			return err
 		}
 	}
@@ -894,6 +896,7 @@ func initialStart(ctx context.Context, config NodeConfig, deps installDependenci
 		}
 		if state == "active" && deps.vipReady(ctx, config) {
 			fmt.Println("[final readiness] Fleet is reachable through the virtual IP")
+			printPublicCAInstructions(os.Stdout, config.VirtualIP)
 			return nil
 		}
 		if err := ctx.Err(); err != nil {
@@ -901,6 +904,22 @@ func initialStart(ctx context.Context, config NodeConfig, deps installDependenci
 		}
 		deps.sleep(2 * time.Second)
 	}
+}
+
+func printPublicCAInstructions(output io.Writer, virtualIP string) {
+	_, _ = fmt.Fprintf(output, `
+On your operator machine, download the public service CA:
+  curl --insecure --fail --noproxy '*' --output proto-fleet-ha-service-ca.download https://%s/proto-fleet-ha-service-ca.crt
+
+Write only the verified certificate to the file you will import:
+  openssl x509 -in proto-fleet-ha-service-ca.download -out proto-fleet-ha-service-ca.crt
+  rm proto-fleet-ha-service-ca.download
+
+Display its SHA-256 fingerprint:
+  openssl x509 -in proto-fleet-ha-service-ca.crt -noout -fingerprint -sha256
+
+Compare it with the fingerprint printed by ha-a. Import only proto-fleet-ha-service-ca.crt.
+`, virtualIP)
 }
 
 func probeInstalledActiveVIP(ctx context.Context, config NodeConfig) bool {

--- a/server/internal/ha/deployment/install_test.go
+++ b/server/internal/ha/deployment/install_test.go
@@ -74,6 +74,8 @@ func TestInstallGoldenPathOrdersFirewallBeforeServices(t *testing.T) {
 	joined := strings.Join(calls, "\n")
 	require.Contains(t, joined, "wait-local-etcd "+testHostIPs[0])
 	require.NotContains(t, joined, "fleet-ha status")
+	require.Contains(t, joined, "sudo install -D -o root -g root -m 0644 "+filepath.Join(secrets, "service-ca.crt")+" "+filepath.Join(configRoot, "service-ca.crt"))
+	require.Contains(t, joined, "sudo install -D -o root -g root -m 0600 "+filepath.Join(secrets, "fleet-client.key")+" "+filepath.Join(configRoot, "fleet-client.key"))
 }
 
 func TestInstallRejectsExistingNftablesInputFilteringBeforeConfiguration(t *testing.T) {
@@ -324,6 +326,20 @@ func TestInitialStartCancellationDuringLocalEtcdWaitLeavesServicesEnabled(t *tes
 	require.Contains(t, joined, "sudo systemctl start --no-block proto-fleet-ha.service")
 	require.NotContains(t, joined, "sudo systemctl disable --now proto-fleet-updater.service")
 	require.NotContains(t, joined, "sudo systemctl disable --now proto-fleet-ha.service")
+}
+
+func TestPublicCAInstructionsUseTheVIP(t *testing.T) {
+	// Arrange
+	var output strings.Builder
+
+	// Act
+	printPublicCAInstructions(&output, testVirtualIP)
+
+	// Assert
+	require.Contains(t, output.String(), "https://"+testVirtualIP+"/proto-fleet-ha-service-ca.crt")
+	require.Contains(t, output.String(), "--noproxy '*'")
+	require.Contains(t, output.String(), "openssl x509 -in proto-fleet-ha-service-ca.download -out proto-fleet-ha-service-ca.crt")
+	require.Contains(t, output.String(), "Import only proto-fleet-ha-service-ca.crt")
 }
 
 func TestInitialStartCleansUpWhenLocalEtcdDoesNotStart(t *testing.T) {


### PR DESCRIPTION
Reviewable diff: +70/-2 across 4 files (excludes generated, test, and story files).

## Summary

Operators can retrieve the HA cluster's public service CA through the working VIP after installation. The authenticated `ha-a` session prints the trust fingerprint, and the final `ha-c` session prints a constrained download and comparison workflow without exposing any private credential.

**Stack:** [#935](https://github.com/block/proto-fleet/pull/935) → [#936](https://github.com/block/proto-fleet/pull/936) (this PR). The diff is relative to #935, which establishes the one-command-per-host install and automated peer handoff. This PR adds only client trust bootstrap; automatic trust-store mutation remains out of scope.

## How it works

1. During cluster preparation, `ha-a` computes the SHA-256 fingerprint from the generated service CA certificate and prints it in the authenticated SSH session.
2. Installation keeps private keys and credentials at mode `0600`, while public certificates and public keys are installed root-owned at mode `0644` so the unprivileged web process can read them.
3. The Fleet web container mounts only `service-ca.crt` at `/proto-fleet-ha-service-ca.crt`. No directory of secrets and no private key enters the static content root.
4. After `ha-c` proves that the VIP serves active Fleet health, it prints commands that bypass proxy configuration, download the certificate, canonicalize a single PEM certificate, and display its fingerprint.
5. The operator compares that value with the fingerprint from `ha-a` before importing the canonical certificate. The installer does not change any client trust store.

```mermaid
sequenceDiagram
  participant A as "Authenticated ha-a session"
  participant V as "Fleet VIP"
  participant O as "Operator machine"
  A->>O: "Trusted CA SHA-256 fingerprint"
  O->>V: "Download public service CA"
  V-->>O: "service-ca.crt only"
  O->>O: "Canonicalize and calculate fingerprint"
  O->>O: "Compare before import"
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/internal/ha/deployment/guided_install.go` | Prints the generated public CA fingerprint on `ha-a` | Establishes the authenticated trust anchor |
| `server/internal/ha/deployment/install.go` | Installs public material readably and prints the post-VIP download workflow | Separates public certificate access from protected secrets and avoids proxy-mediated LAN retrieval |
| `deployment-files/ha/fleet-compose.yaml` | Mounts one public CA file into nginx static content | Defines the exact public exposure boundary |
| `deployment-files/ha/README.md` | Documents fingerprint comparison and client trust | Keeps the operator flow visible without automating trust-store changes |

## Key technical decisions & trade-offs

- Serve the CA as a static file through the existing VIP rather than adding an API or remote diagnostic endpoint.
- Use the `ha-a` SSH output as the trust anchor. The initial HTTPS download allows the private CA only for transport, so the operator must compare fingerprints before import.
- Canonicalize one parsed certificate before fingerprinting and importing it. This prevents appended certificate material from becoming trusted.
- Keep the public certificate world-readable while every private key and password remains owner-only.
- Do not automate browser or operating-system trust. Client trust policy remains an operator decision.

## Testing & validation

- `go test ./internal/ha/deployment -count=1`
- Hermit-backed `golangci-lint` for `./internal/ha/deployment/...`
- `./deployment-files/ha/tests/test-profile.sh`
- `git diff --check`

Focused coverage verifies the fingerprint format, public-versus-private install modes, exact nginx mount, witness-only instructions, proxy bypass, and canonical output. A real HTTPS download and browser trust import remain part of three-host manual qualification.
