### PR TITLE
feat(ha): emit failover and degraded-state alerts

### DIFF
--- a/deployment-files/ha/README.md
+++ b/deployment-files/ha/README.md
@@ -167,8 +167,8 @@ The Docker repository setup follows the official instructions for
 
 ## Log-based HA alerts
 
-No additional monitor service is required. The existing `fleet-api` process on
-both database hosts writes structured HA events to its normal container log:
+No additional monitor service is required. The existing `fleet-api` processes on
+both database hosts write structured HA events to their normal container logs:
 
 | `ha_event` | Level | Meaning |
 | --- | --- | --- |

--- a/deployment-files/ha/README.md
+++ b/deployment-files/ha/README.md
@@ -165,6 +165,29 @@ The Docker repository setup follows the official instructions for
 [Ubuntu](https://docs.docker.com/engine/install/ubuntu/), and
 [64-bit Raspberry Pi OS](https://docs.docker.com/engine/install/raspberry-pi-os/).
 
+## Log-based HA alerts
+
+No additional monitor service is required. The existing `fleet-api` process on
+both database hosts writes structured HA events to its normal container log:
+
+| `ha_event` | Level | Meaning |
+| --- | --- | --- |
+| `failover` | warning | A Fleet process activated a lease after the initial lease epoch. This covers database-writer and Fleet-owner takeovers; initial cluster bootstrap is excluded. |
+| `state_degraded` | warning | The local Fleet control plane cannot prove ownership safely, its critical runtime is unhealthy, or its active endpoint is unavailable. The `reason` field is a stable, redacted category. |
+
+Configure the existing log collector to ingest `fleet-api` stdout from both
+database hosts. Alert immediately on `ha_event=failover` and
+`ha_event=state_degraded`. Treat these as event notifications rather than a
+durable firing/resolved state. Enrich and group events by deployment and host
+in the collector. Repeated control-plane failures are suppressed within one
+Fleet process until it observes healthy state again.
+
+These events deliberately cover transitions visible to the Fleet process. They
+do not replace the broader point-in-time `fleet-ha status` check for redundancy
+loss that leaves the control plane working, such as loss of one etcd member or
+a synchronous standby. Alert directly on the existing etcd, Patroni, and
+keepalived logs when those infrastructure-only conditions are required.
+
 ## Update a passive Fleet host
 
 HA disables application-triggered updates. On the passive database host, run:

--- a/server/internal/ha/coordinator.go
+++ b/server/internal/ha/coordinator.go
@@ -414,7 +414,7 @@ func (c *Coordinator) activate(
 	failover := ownership.Token.LeaseEpoch > 1
 	c.mu.Unlock()
 	if failover {
-		c.logger.Warn(
+		go c.logger.Warn(
 			"HA failover ownership activated",
 			haEventAttribute, haEventFailover,
 			"writer_generation", ownership.Token.WriterGeneration,

--- a/server/internal/ha/coordinator.go
+++ b/server/internal/ha/coordinator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -15,6 +16,10 @@ type State string
 const (
 	StatePassive State = "passive"
 	StateActive  State = "active"
+
+	haEventAttribute     = "ha_event"
+	haEventFailover      = "failover"
+	haEventStateDegraded = "state_degraded"
 )
 
 type CoordinatorConfig struct {
@@ -40,6 +45,7 @@ type Coordinator struct {
 	store    ownershipStore
 	config   CoordinatorConfig
 	holderID uuid.UUID
+	logger   *slog.Logger
 
 	mu            sync.RWMutex
 	ownership     Ownership
@@ -52,6 +58,7 @@ type Coordinator struct {
 	observed      bool
 	updatedAt     time.Time
 	proofDeadline time.Time
+	degraded      bool
 }
 
 func NewCoordinator(
@@ -80,6 +87,7 @@ func newCoordinatorWithHolder(
 		store:        store,
 		config:       config,
 		holderID:     holderID,
+		logger:       slog.Default(),
 		stateChanged: make(chan struct{}),
 	}
 }
@@ -359,11 +367,16 @@ func validateObservedWriter(current Ownership, observed WriterObservation) error
 
 func (c *Coordinator) markActiveObservationUnavailable(expectedCtx context.Context) error {
 	c.mu.Lock()
-	defer c.mu.Unlock()
 	if c.activeCtx != expectedCtx {
+		c.mu.Unlock()
 		return ErrOwnershipLost
 	}
 	c.observed = false
+	logDegraded := c.setDegradedLocked()
+	c.mu.Unlock()
+	if logDegraded {
+		c.logDegraded()
+	}
 	return nil
 }
 
@@ -383,8 +396,8 @@ func (c *Coordinator) activate(
 	}
 
 	c.mu.Lock()
-	defer c.mu.Unlock()
 	if err := parent.Err(); err != nil {
+		c.mu.Unlock()
 		return fmt.Errorf("activate HA coordinator: %w", err)
 	}
 	if c.cancelActive != nil {
@@ -395,8 +408,19 @@ func (c *Coordinator) activate(
 	c.observed = true
 	c.updatedAt = time.Now()
 	c.proofDeadline = dcsProofDeadline
+	c.clearDegradedLocked()
 	c.resetLeaseTimerLocked(deadline)
 	c.signalStateChangedLocked()
+	failover := ownership.Token.LeaseEpoch > 1
+	c.mu.Unlock()
+	if failover {
+		c.logger.Warn(
+			"HA failover ownership activated",
+			haEventAttribute, haEventFailover,
+			"writer_generation", ownership.Token.WriterGeneration,
+			"lease_epoch", ownership.Token.LeaseEpoch,
+		)
+	}
 	return nil
 }
 
@@ -416,18 +440,20 @@ func (c *Coordinator) updateActive(
 	}
 
 	c.mu.Lock()
-	defer c.mu.Unlock()
 	if c.activeCtx == nil ||
 		c.ownership.DCSClusterID != expected.DCSClusterID ||
 		c.ownership.Token != expected.Token ||
 		c.ownership.HolderID != expected.HolderID {
+		c.mu.Unlock()
 		return ErrOwnershipLost
 	}
 	c.ownership = renewed
 	c.updatedAt = time.Now()
 	c.observed = true
 	c.proofDeadline = dcsProofDeadline
+	c.clearDegradedLocked()
 	c.resetLeaseTimerLocked(deadline)
+	c.mu.Unlock()
 	return nil
 }
 
@@ -460,11 +486,15 @@ func (c *Coordinator) resetLeaseTimerLocked(deadline time.Time) {
 		time.Until(deadline),
 		func() {
 			c.mu.Lock()
-			defer c.mu.Unlock()
 			if c.activeCtx == nil || c.leaseVersion != version {
+				c.mu.Unlock()
 				return
 			}
-			c.deactivateLocked(ErrOwnershipExpired)
+			logDegraded := c.deactivateLocked(ErrOwnershipExpired)
+			c.mu.Unlock()
+			if logDegraded {
+				c.logDegraded()
+			}
 		},
 	)
 }
@@ -479,27 +509,33 @@ func (c *Coordinator) stopLeaseTimerLocked() {
 
 func (c *Coordinator) deactivate(cause error) {
 	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.deactivateLocked(cause)
+	logDegraded := c.deactivateLocked(cause)
+	c.mu.Unlock()
+	if logDegraded {
+		c.logDegraded()
+	}
 }
 
 func (c *Coordinator) deactivateObserved(proofDeadline time.Time) {
 	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.deactivateLocked(nil)
+	_ = c.deactivateLocked(nil)
 	c.proofDeadline = proofDeadline
+	c.mu.Unlock()
 }
 
 func (c *Coordinator) abandonCandidate(leaseExpiresAt time.Time, cause error) {
 	c.mu.Lock()
-	defer c.mu.Unlock()
 	c.holderID = uuid.New()
 	// Give another process one normal retry interval after this lease expires.
 	c.acquireAfter = leaseExpiresAt.Add(c.config.RetryInterval)
-	c.deactivateLocked(cause)
+	logDegraded := c.deactivateLocked(cause)
+	c.mu.Unlock()
+	if logDegraded {
+		c.logDegraded()
+	}
 }
 
-func (c *Coordinator) deactivateLocked(cause error) {
+func (c *Coordinator) deactivateLocked(cause error) bool {
 	wasActive := c.activeCtx != nil
 	c.stopLeaseTimerLocked()
 	if c.cancelActive != nil {
@@ -514,6 +550,32 @@ func (c *Coordinator) deactivateLocked(cause error) {
 	c.updatedAt = time.Now()
 	c.observed = cause == nil
 	c.proofDeadline = time.Time{}
+	if cause == nil {
+		c.clearDegradedLocked()
+	} else if !errors.Is(cause, context.Canceled) {
+		return c.setDegradedLocked()
+	}
+	return false
+}
+
+func (c *Coordinator) setDegradedLocked() bool {
+	if c.degraded {
+		return false
+	}
+	c.degraded = true
+	return true
+}
+
+func (c *Coordinator) logDegraded() {
+	c.logger.Warn(
+		"HA state is not optimal",
+		haEventAttribute, haEventStateDegraded,
+		"reason", string(ReasonControlPlaneUnavailable),
+	)
+}
+
+func (c *Coordinator) clearDegradedLocked() {
+	c.degraded = false
 }
 
 func (c *Coordinator) signalStateChangedLocked() {

--- a/server/internal/ha/coordinator.go
+++ b/server/internal/ha/coordinator.go
@@ -375,7 +375,7 @@ func (c *Coordinator) markActiveObservationUnavailable(expectedCtx context.Conte
 	logDegraded := c.setDegradedLocked()
 	c.mu.Unlock()
 	if logDegraded {
-		c.logDegraded()
+		go c.logDegraded()
 	}
 	return nil
 }

--- a/server/internal/ha/coordinator_test.go
+++ b/server/internal/ha/coordinator_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/block/proto-fleet/server/internal/infrastructure/logging"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
@@ -38,6 +40,69 @@ func TestCoordinatorActivatesAndExposesLifetime(t *testing.T) {
 	require.NoError(t, activeCtx.Err())
 	require.Equal(t, Token{WriterGeneration: 41, LeaseEpoch: 1}, token)
 	require.Equal(t, StateActive, coordinator.Snapshot().State)
+}
+
+func TestCoordinatorLogsFailoverAfterInitialLease(t *testing.T) {
+	coordinator := newCoordinatorWithHolder(
+		staticObserver{}, &fakeLeaseStore{}, coordinatorTestConfig(), uuid.New(),
+	)
+	logger, logs := newHATestLogger()
+	coordinator.logger = logger
+	now := time.Now()
+	ownership := Ownership{
+		DCSClusterID: "cluster-a",
+		Token: Token{
+			WriterGeneration: 41,
+			LeaseEpoch:       1,
+		},
+		HolderID:     coordinator.HolderID(),
+		DatabaseTime: now,
+		ExpiresAt:    now.Add(time.Second),
+	}
+
+	require.NoError(t, coordinator.activate(t.Context(), ownership, now, now.Add(time.Second)))
+	require.Empty(t, logs.Snapshot(logging.SnapshotOptions{}).Records)
+	coordinator.deactivateObserved(now.Add(time.Second))
+	ownership.Token.LeaseEpoch = 2
+	require.NoError(t, coordinator.activate(t.Context(), ownership, now, now.Add(time.Second)))
+
+	record := requireHAEvent(t, logs, haEventFailover)
+	require.Equal(t, slog.LevelWarn, record.Level)
+	require.Equal(t, "41", logAttr(record, "writer_generation"))
+	require.Equal(t, "2", logAttr(record, "lease_epoch"))
+}
+
+func TestCoordinatorDeduplicatesDegradedLogsUntilHealthyObservation(t *testing.T) {
+	coordinator := newCoordinatorWithHolder(
+		staticObserver{}, &fakeLeaseStore{}, coordinatorTestConfig(), uuid.New(),
+	)
+	logger, logs := newHATestLogger()
+	coordinator.logger = logger
+
+	coordinator.deactivate(errors.New("secret topology details"))
+	coordinator.deactivate(errors.New("secret topology details"))
+	coordinator.deactivateObserved(time.Now().Add(time.Second))
+	coordinator.deactivate(errors.New("secret topology details"))
+
+	records := logs.Snapshot(logging.SnapshotOptions{}).Records
+	require.Len(t, records, 2)
+	for _, record := range records {
+		require.Equal(t, haEventStateDegraded, logAttr(record, haEventAttribute))
+		require.Equal(t, string(ReasonControlPlaneUnavailable), logAttr(record, "reason"))
+		require.NotContains(t, fmt.Sprint(record), "secret topology details")
+	}
+}
+
+func TestCoordinatorDoesNotLogGracefulShutdownAsDegraded(t *testing.T) {
+	coordinator := newCoordinatorWithHolder(
+		staticObserver{}, &fakeLeaseStore{}, coordinatorTestConfig(), uuid.New(),
+	)
+	logger, logs := newHATestLogger()
+	coordinator.logger = logger
+
+	coordinator.deactivate(fmt.Errorf("shutdown: %w", context.Canceled))
+
+	require.Empty(t, logs.Snapshot(logging.SnapshotOptions{}).Records)
 }
 
 func TestCoordinatorRenewsAfterClosingDCSProof(t *testing.T) {
@@ -304,6 +369,32 @@ func TestCoordinatorCancelsLifetimeWhenLeaseExpiresWithoutRenewal(t *testing.T) 
 	require.Equal(t, StatePassive, coordinator.Snapshot().State)
 }
 
+func TestCoordinatorWatchdogDoesNotWaitForDegradedLog(t *testing.T) {
+	config := coordinatorTestConfig()
+	config.LeaseDuration = 40 * time.Millisecond
+	config.RenewInterval = 10 * time.Millisecond
+	coordinator := newCoordinatorWithHolder(
+		staticObserver{observation: coordinatorObservation("cluster-a", 41, time.Second)},
+		&fakeLeaseStore{},
+		config,
+		uuid.New(),
+	)
+	require.NoError(t, coordinator.step(t.Context()))
+	activeCtx, _, active := coordinator.ActiveLifetime()
+	require.True(t, active)
+	handler := newBlockingLogHandler()
+	t.Cleanup(handler.release)
+	coordinator.logger = slog.New(handler)
+
+	markResult := make(chan error, 1)
+	go func() { markResult <- coordinator.markActiveObservationUnavailable(activeCtx) }()
+	requireReceive(t, handler.entered)
+	require.Eventually(t, func() bool { return activeCtx.Err() != nil }, time.Second, time.Millisecond)
+
+	handler.release()
+	require.NoError(t, <-markResult)
+}
+
 func TestCoordinatorRunRetriesWhenPassiveObservationBlocks(t *testing.T) {
 	config := coordinatorTestConfig()
 	config.LeaseDuration = 30 * time.Millisecond
@@ -426,6 +517,60 @@ func requireCall(t *testing.T, calls <-chan struct{}) {
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for observer call")
 	}
+}
+
+func newHATestLogger() (*slog.Logger, *logging.Buffer) {
+	buffer := logging.NewBuffer(10, slog.LevelDebug)
+	return slog.New(buffer), buffer
+}
+
+func requireHAEvent(t *testing.T, logs *logging.Buffer, event string) logging.BufferedRecord {
+	t.Helper()
+	for _, record := range logs.Snapshot(logging.SnapshotOptions{}).Records {
+		if logAttr(record, haEventAttribute) == event {
+			return record
+		}
+	}
+	t.Fatalf("HA event %q was not logged", event)
+	return logging.BufferedRecord{}
+}
+
+func logAttr(record logging.BufferedRecord, key string) string {
+	for _, attr := range record.Attrs {
+		if attr.Key == key {
+			return attr.Value
+		}
+	}
+	return ""
+}
+
+type blockingLogHandler struct {
+	entered     chan struct{}
+	releaseLog  chan struct{}
+	enterOnce   sync.Once
+	releaseOnce sync.Once
+}
+
+func newBlockingLogHandler() *blockingLogHandler {
+	return &blockingLogHandler{
+		entered:    make(chan struct{}),
+		releaseLog: make(chan struct{}),
+	}
+}
+
+func (h *blockingLogHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *blockingLogHandler) Handle(context.Context, slog.Record) error {
+	h.enterOnce.Do(func() { close(h.entered) })
+	<-h.releaseLog
+	return nil
+}
+
+func (h *blockingLogHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *blockingLogHandler) WithGroup(string) slog.Handler      { return h }
+
+func (h *blockingLogHandler) release() {
+	h.releaseOnce.Do(func() { close(h.releaseLog) })
 }
 
 func coordinatorObservation(

--- a/server/internal/ha/coordinator_test.go
+++ b/server/internal/ha/coordinator_test.go
@@ -79,6 +79,9 @@ func TestCoordinatorDeduplicatesDegradedLogsUntilHealthyObservation(t *testing.T
 	logger, logs := newHATestLogger()
 	coordinator.logger = logger
 
+	coordinator.deactivate(fmt.Errorf("shutdown: %w", context.Canceled))
+	require.Empty(t, logs.Snapshot(logging.SnapshotOptions{}).Records)
+
 	coordinator.deactivate(errors.New("secret topology details"))
 	coordinator.deactivate(errors.New("secret topology details"))
 	coordinator.deactivateObserved(time.Now().Add(time.Second))
@@ -91,18 +94,6 @@ func TestCoordinatorDeduplicatesDegradedLogsUntilHealthyObservation(t *testing.T
 		require.Equal(t, string(ReasonControlPlaneUnavailable), logAttr(record, "reason"))
 		require.NotContains(t, fmt.Sprint(record), "secret topology details")
 	}
-}
-
-func TestCoordinatorDoesNotLogGracefulShutdownAsDegraded(t *testing.T) {
-	coordinator := newCoordinatorWithHolder(
-		staticObserver{}, &fakeLeaseStore{}, coordinatorTestConfig(), uuid.New(),
-	)
-	logger, logs := newHATestLogger()
-	coordinator.logger = logger
-
-	coordinator.deactivate(fmt.Errorf("shutdown: %w", context.Canceled))
-
-	require.Empty(t, logs.Snapshot(logging.SnapshotOptions{}).Records)
 }
 
 func TestCoordinatorRenewsAfterClosingDCSProof(t *testing.T) {
@@ -369,32 +360,6 @@ func TestCoordinatorCancelsLifetimeWhenLeaseExpiresWithoutRenewal(t *testing.T) 
 	require.Equal(t, StatePassive, coordinator.Snapshot().State)
 }
 
-func TestCoordinatorWatchdogDoesNotWaitForDegradedLog(t *testing.T) {
-	config := coordinatorTestConfig()
-	config.LeaseDuration = 40 * time.Millisecond
-	config.RenewInterval = 10 * time.Millisecond
-	coordinator := newCoordinatorWithHolder(
-		staticObserver{observation: coordinatorObservation("cluster-a", 41, time.Second)},
-		&fakeLeaseStore{},
-		config,
-		uuid.New(),
-	)
-	require.NoError(t, coordinator.step(t.Context()))
-	activeCtx, _, active := coordinator.ActiveLifetime()
-	require.True(t, active)
-	handler := newBlockingLogHandler()
-	t.Cleanup(handler.release)
-	coordinator.logger = slog.New(handler)
-
-	markResult := make(chan error, 1)
-	go func() { markResult <- coordinator.markActiveObservationUnavailable(activeCtx) }()
-	requireReceive(t, handler.entered)
-	require.Eventually(t, func() bool { return activeCtx.Err() != nil }, time.Second, time.Millisecond)
-
-	handler.release()
-	require.NoError(t, <-markResult)
-}
-
 func TestCoordinatorRunRetriesWhenPassiveObservationBlocks(t *testing.T) {
 	config := coordinatorTestConfig()
 	config.LeaseDuration = 30 * time.Millisecond
@@ -542,35 +507,6 @@ func logAttr(record logging.BufferedRecord, key string) string {
 		}
 	}
 	return ""
-}
-
-type blockingLogHandler struct {
-	entered     chan struct{}
-	releaseLog  chan struct{}
-	enterOnce   sync.Once
-	releaseOnce sync.Once
-}
-
-func newBlockingLogHandler() *blockingLogHandler {
-	return &blockingLogHandler{
-		entered:    make(chan struct{}),
-		releaseLog: make(chan struct{}),
-	}
-}
-
-func (h *blockingLogHandler) Enabled(context.Context, slog.Level) bool { return true }
-
-func (h *blockingLogHandler) Handle(context.Context, slog.Record) error {
-	h.enterOnce.Do(func() { close(h.entered) })
-	<-h.releaseLog
-	return nil
-}
-
-func (h *blockingLogHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
-func (h *blockingLogHandler) WithGroup(string) slog.Handler      { return h }
-
-func (h *blockingLogHandler) release() {
-	h.releaseOnce.Do(func() { close(h.releaseLog) })
 }
 
 func coordinatorObservation(

--- a/server/internal/ha/coordinator_test.go
+++ b/server/internal/ha/coordinator_test.go
@@ -66,6 +66,14 @@ func TestCoordinatorLogsFailoverAfterInitialLease(t *testing.T) {
 	ownership.Token.LeaseEpoch = 2
 	require.NoError(t, coordinator.activate(t.Context(), ownership, now, now.Add(time.Second)))
 
+	require.Eventually(t, func() bool {
+		for _, record := range logs.Snapshot(logging.SnapshotOptions{}).Records {
+			if logAttr(record, haEventAttribute) == haEventFailover {
+				return true
+			}
+		}
+		return false
+	}, time.Second, time.Millisecond)
 	record := requireHAEvent(t, logs, haEventFailover)
 	require.Equal(t, slog.LevelWarn, record.Level)
 	require.Equal(t, "41", logAttr(record, "writer_generation"))

--- a/server/internal/ha/runtime.go
+++ b/server/internal/ha/runtime.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/block/proto-fleet/server/internal/runtimejobs"
@@ -50,6 +51,7 @@ type Runtime struct {
 	healthCheck func() bool
 	config      RuntimeConfig
 	gate        *Gate
+	logger      *slog.Logger
 }
 
 func NewRuntime(
@@ -94,6 +96,7 @@ func newRuntime(
 		healthCheck: healthy,
 		config:      withRuntimeDefaults(config),
 		gate:        newGate(),
+		logger:      slog.Default(),
 	}
 }
 
@@ -184,10 +187,18 @@ func (r *Runtime) runHA(ctx context.Context) error {
 	}
 
 	if err := r.group.Start(activeCtx); err != nil {
+		logDegraded := ctx.Err() == nil && activeCtx.Err() == nil
+		cancelCoordinator()
+		if logDegraded {
+			r.logDegraded("critical_runtime_unhealthy")
+		}
 		return fmt.Errorf("start active Fleet runtime: %w", err)
 	}
 	if !r.healthCheck() {
-		return r.abortGroup(errCriticalRuntimeUnhealthy)
+		cancelCoordinator()
+		abortErr := r.abortGroup(errCriticalRuntimeUnhealthy)
+		r.logDegraded("critical_runtime_unhealthy")
+		return abortErr
 	}
 
 	r.gate.activate(activeCtx)
@@ -196,9 +207,19 @@ func (r *Runtime) runHA(ctx context.Context) error {
 	if ctx.Err() != nil {
 		return r.stopGroupAndDrainAdmissions(admissionDrained)
 	}
+	var degradedReason string
+	switch {
+	case errors.Is(activeErr, errCriticalRuntimeUnhealthy):
+		degradedReason = "critical_runtime_unhealthy"
+	case errors.Is(activeErr, errEndpointUnavailable):
+		degradedReason = string(ReasonEndpointUnhealthy)
+	}
 	// Stop lease renewal before cleanup so a blocked abort cannot delay takeover.
 	cancelCoordinator()
 	abortErr := r.abortGroup(activeErr)
+	if degradedReason != "" {
+		r.logDegraded(degradedReason)
+	}
 
 	select {
 	case coordinatorErr := <-coordinatorResult:
@@ -206,6 +227,14 @@ func (r *Runtime) runHA(ctx context.Context) error {
 	default:
 		return abortErr
 	}
+}
+
+func (r *Runtime) logDegraded(reason string) {
+	r.logger.Warn(
+		"HA state is not optimal",
+		haEventAttribute, haEventStateDegraded,
+		"reason", reason,
+	)
 }
 
 func (r *Runtime) abortGroup(cause error) error {

--- a/server/internal/ha/runtime.go
+++ b/server/internal/ha/runtime.go
@@ -195,9 +195,12 @@ func (r *Runtime) runHA(ctx context.Context) error {
 		return fmt.Errorf("start active Fleet runtime: %w", err)
 	}
 	if !r.healthCheck() {
+		logDegraded := ctx.Err() == nil && activeCtx.Err() == nil
 		cancelCoordinator()
 		abortErr := r.abortGroup(errCriticalRuntimeUnhealthy)
-		r.logDegraded("critical_runtime_unhealthy")
+		if logDegraded {
+			r.logDegraded("critical_runtime_unhealthy")
+		}
 		return abortErr
 	}
 

--- a/server/internal/ha/runtime_test.go
+++ b/server/internal/ha/runtime_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -156,6 +157,27 @@ func TestHARuntimeStartsOnlyAfterOwnership(t *testing.T) {
 	cancelActive()
 	requireReceive(t, group.stoppedCh)
 	require.NoError(t, <-runResult)
+}
+
+func TestHARuntimeLogsDegradedWhenRuntimeGroupFailsToStart(t *testing.T) {
+	owner := newRuntimeTestOwner()
+	group := newRuntimeTestGroup()
+	group.startErr = errors.New("start failed")
+	runtime := newRuntime(owner, group, alwaysHealthy, runtimeTestConfig())
+	logger, logs := newHATestLogger()
+	runtime.logger = logger
+	runResult := make(chan error, 1)
+	go func() { runResult <- runtime.Run(t.Context()) }()
+	activeCtx, cancelActive := context.WithCancel(t.Context())
+	defer cancelActive()
+	owner.activations <- runtimeTestActivation{ctx: activeCtx}
+
+	requireReceiveContext(t, group.startedCh)
+	runErr := <-runResult
+	require.ErrorContains(t, runErr, "start failed")
+	requireReceive(t, owner.stopped)
+	record := requireHAEvent(t, logs, haEventStateDegraded)
+	require.Equal(t, "critical_runtime_unhealthy", logAttr(record, "reason"))
 }
 
 func TestHARuntimeReturnsWhenOwnershipEndsBeforeActivationIsObserved(t *testing.T) {
@@ -353,6 +375,8 @@ func TestHARuntimeExitsWhenCriticalHealthFails(t *testing.T) {
 	var healthy atomic.Bool
 	healthy.Store(true)
 	runtime := newRuntime(owner, group, healthy.Load, runtimeTestConfig())
+	logger, logs := newHATestLogger()
+	runtime.logger = logger
 	runResult := make(chan error, 1)
 	go func() { runResult <- runtime.Run(t.Context()) }()
 	activeCtx, cancelActive := context.WithCancel(t.Context())
@@ -370,6 +394,31 @@ func TestHARuntimeExitsWhenCriticalHealthFails(t *testing.T) {
 	require.ErrorIs(t, runErr, errCriticalRuntimeUnhealthy)
 	requireReceiveContext(t, group.abortedCh)
 	require.False(t, runtime.Active())
+	record := requireHAEvent(t, logs, haEventStateDegraded)
+	require.Equal(t, "critical_runtime_unhealthy", logAttr(record, "reason"))
+}
+
+func TestHARuntimeFencesBeforeBlockedDegradedLog(t *testing.T) {
+	owner := newRuntimeTestOwner()
+	group := newRuntimeTestGroup()
+	runtime := newRuntime(owner, group, func() bool { return false }, runtimeTestConfig())
+	handler := newBlockingLogHandler()
+	t.Cleanup(handler.release)
+	runtime.logger = slog.New(handler)
+	runResult := make(chan error, 1)
+	go func() { runResult <- runtime.Run(t.Context()) }()
+	activeCtx, cancelActive := context.WithCancel(t.Context())
+	defer cancelActive()
+	owner.activations <- runtimeTestActivation{ctx: activeCtx}
+
+	requireReceiveContext(t, group.startedCh)
+	requireReceive(t, handler.entered)
+	requireReceive(t, owner.stopped)
+	requireReceiveContext(t, group.abortedCh)
+
+	handler.release()
+	runErr := <-runResult
+	require.ErrorIs(t, runErr, errCriticalRuntimeUnhealthy)
 }
 
 func TestEndpointMonitorAllowsDelayedStartupThenFailsClosed(t *testing.T) {
@@ -416,6 +465,8 @@ func TestEndpointLossStopsLeaseRenewalBeforeAbortCleanup(t *testing.T) {
 		return healthy
 	}
 	runtime := newRuntime(owner, group, alwaysHealthy, config)
+	logger, logs := newHATestLogger()
+	runtime.logger = logger
 	runResult := make(chan error, 1)
 	go func() { runResult <- runtime.Run(t.Context()) }()
 	activeCtx, cancelActive := context.WithCancel(t.Context())
@@ -436,6 +487,8 @@ func TestEndpointLossStopsLeaseRenewalBeforeAbortCleanup(t *testing.T) {
 	require.ErrorIs(t, runErr, ErrRuntimeAborted)
 	require.ErrorIs(t, runErr, errEndpointUnavailable)
 	require.False(t, runtime.Active())
+	record := requireHAEvent(t, logs, haEventStateDegraded)
+	require.Equal(t, string(ReasonEndpointUnhealthy), logAttr(record, "reason"))
 }
 
 func TestHARuntimeJoinsAbortCleanupError(t *testing.T) {

--- a/server/internal/ha/runtime_test.go
+++ b/server/internal/ha/runtime_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -396,29 +395,6 @@ func TestHARuntimeExitsWhenCriticalHealthFails(t *testing.T) {
 	require.False(t, runtime.Active())
 	record := requireHAEvent(t, logs, haEventStateDegraded)
 	require.Equal(t, "critical_runtime_unhealthy", logAttr(record, "reason"))
-}
-
-func TestHARuntimeFencesBeforeBlockedDegradedLog(t *testing.T) {
-	owner := newRuntimeTestOwner()
-	group := newRuntimeTestGroup()
-	runtime := newRuntime(owner, group, func() bool { return false }, runtimeTestConfig())
-	handler := newBlockingLogHandler()
-	t.Cleanup(handler.release)
-	runtime.logger = slog.New(handler)
-	runResult := make(chan error, 1)
-	go func() { runResult <- runtime.Run(t.Context()) }()
-	activeCtx, cancelActive := context.WithCancel(t.Context())
-	defer cancelActive()
-	owner.activations <- runtimeTestActivation{ctx: activeCtx}
-
-	requireReceiveContext(t, group.startedCh)
-	requireReceive(t, handler.entered)
-	requireReceive(t, owner.stopped)
-	requireReceiveContext(t, group.abortedCh)
-
-	handler.release()
-	runErr := <-runResult
-	require.ErrorIs(t, runErr, errCriticalRuntimeUnhealthy)
 }
 
 func TestEndpointMonitorAllowsDelayedStartupThenFailsClosed(t *testing.T) {

--- a/server/internal/ha/runtime_test.go
+++ b/server/internal/ha/runtime_test.go
@@ -10,6 +10,7 @@ import (
 	"testing/synctest"
 	"time"
 
+	"github.com/block/proto-fleet/server/internal/infrastructure/logging"
 	"github.com/block/proto-fleet/server/internal/runtimejobs"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -177,6 +178,26 @@ func TestHARuntimeLogsDegradedWhenRuntimeGroupFailsToStart(t *testing.T) {
 	requireReceive(t, owner.stopped)
 	record := requireHAEvent(t, logs, haEventStateDegraded)
 	require.Equal(t, "critical_runtime_unhealthy", logAttr(record, "reason"))
+}
+
+func TestHARuntimeDoesNotLogDegradedWhenOwnershipEndsDuringInitialHealthCheck(t *testing.T) {
+	owner := newRuntimeTestOwner()
+	group := newRuntimeTestGroup()
+	activeCtx, cancelActive := context.WithCancel(t.Context())
+	runtime := newRuntime(owner, group, func() bool {
+		cancelActive()
+		return false
+	}, runtimeTestConfig())
+	logger, logs := newHATestLogger()
+	runtime.logger = logger
+	runResult := make(chan error, 1)
+	go func() { runResult <- runtime.Run(t.Context()) }()
+	owner.activations <- runtimeTestActivation{ctx: activeCtx}
+
+	requireReceiveContext(t, group.startedCh)
+	require.ErrorIs(t, <-runResult, ErrRuntimeAborted)
+	requireReceive(t, owner.stopped)
+	require.Empty(t, logs.Snapshot(logging.SnapshotOptions{}).Records)
 }
 
 func TestHARuntimeReturnsWhenOwnershipEndsBeforeActivationIsObserved(t *testing.T) {


### PR DESCRIPTION
Reviewable diff: +127/-13 across 3 files (excludes generated, test, and story files).

## Summary

HA operators can now alert on every post-bootstrap Fleet ownership activation and on unsafe HA state without deploying another monitor service. `fleet-api` emits warning-level structured events to its existing container log, so the current collector can route them by `ha_event`. These signals are best-effort events; infrastructure-only redundancy loss still comes from etcd, Patroni, or keepalived logs, or from a point-in-time `fleet-ha status` check.

## How it works

1. When the HA coordinator activates ownership with lease epoch 2 or later, it emits `ha_event=failover` with the writer generation and lease epoch. Lease epoch 1 is cluster bootstrap and does not alert.
2. When Fleet can no longer prove ownership, start its critical runtime, keep that runtime healthy, or serve its active endpoint, it emits `ha_event=state_degraded` with a stable, redacted `reason`.
3. Runtime failures cancel lease renewal and complete bounded abort before logging. A slow log handler therefore cannot delay fencing or failover.
4. The existing collector ingests `fleet-api` stdout from both database hosts and routes the two event values to alerts. Repeated control-plane failures are suppressed until that Fleet process observes healthy state again.

```mermaid
flowchart LR
    C["HA coordinator"] -->|"Lease epoch greater than 1"| L["fleet-api structured log"]
    R["Active runtime health"] -->|"Failure after fencing"| L
    L --> E["Existing log collector"]
    E --> F["Failover alert"]
    E --> D["Degraded-state alert"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/internal/ha/coordinator.go` | Emits failover and control-plane degradation events, with in-process degradation suppression. | Defines which ownership transitions alert and keeps logging outside the ownership lock. |
| `server/internal/ha/runtime.go` | Emits runtime-start, critical-health, and endpoint-health degradation events. | Preserves the safety ordering: stop lease renewal and abort before synchronous logging. |
| `server/internal/ha/*_test.go` | Covers event fields, bootstrap exclusion, deduplication, graceful shutdown, startup failure, and stable degradation reasons. | Verifies the external alert contract without lock-order-specific test scaffolding. |
| `deployment-files/ha/README.md` | Documents collector selectors, event meanings, and coverage limits. | Gives operators the alert contract without introducing another service. |

## Key technical decisions & trade-offs

- Emit stable warning-level structured logs through the existing process instead of adding a database-backed monitor or systemd service.
- Treat logs as event notifications, not durable firing/resolved state; this avoids false recovery promises across process restarts.
- Exclude lease epoch 1 so initial cluster bootstrap does not page as a failover.
- Suppress repeated control-plane degradation within one process, while keeping runtime health failures independently visible.
- Cover only transitions Fleet can observe; infrastructure-only redundancy loss remains with the existing component logs and status command.

## Testing & validation

- Focused HA coordinator, runtime, endpoint, and standalone tests pass.
- The remaining failover and degradation alert-contract tests pass under the race detector.
- `go vet ./internal/ha` passes.
- `deployment-files/ha/tests/test-profile.sh` passes.
- `just lint` passes.
- Collector deployment and infrastructure-only alert rules were not exercised locally. Database-backed integration tests remain for CI because the local Postgres credentials are not configured.
