### PR TITLE
Speed up ProtoFleet Playwright browser setup

### DIFF
--- a/.github/workflows/protofleet-e2e-tests.yml
+++ b/.github/workflows/protofleet-e2e-tests.yml
@@ -121,8 +121,7 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         working-directory: client/e2eTests/protoFleet
         run: |
-          # CI only runs headless Chromium, so the smaller headless shell is enough.
-          npx playwright install --with-deps --only-shell chromium
+          npx playwright install --with-deps chromium
 
       - name: Build ProtoFleet
         working-directory: client

--- a/.github/workflows/protofleet-e2e-tests.yml
+++ b/.github/workflows/protofleet-e2e-tests.yml
@@ -78,6 +78,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.cache/ms-playwright
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -102,9 +104,25 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-npm-
 
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
+          key: ${{ runner.os }}-playwright-${{ hashFiles('client/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
       - name: Install client dependencies
         working-directory: client
         run: npm ci --include=optional
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        working-directory: client/e2eTests/protoFleet
+        run: |
+          # CI only runs headless Chromium, so the smaller headless shell is enough.
+          npx playwright install --with-deps --only-shell chromium
 
       - name: Build ProtoFleet
         working-directory: client
@@ -191,6 +209,14 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+      - name: Upload Playwright browsers
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: protofleet-playwright-browsers
+          path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
+          if-no-files-found: error
+          retention-days: 1
+
       - name: Upload Docker images
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -206,6 +232,7 @@ jobs:
     permissions:
       contents: read
     env:
+      PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.cache/ms-playwright
       # Total shard count. Keep in sync with the length of matrix.shard below.
       SHARD_TOTAL: "16"
     strategy:
@@ -236,26 +263,21 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-npm-
 
-      - name: Cache Playwright browsers
-        id: playwright-cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('client/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-playwright-
-
       - name: Install client dependencies
         working-directory: client
         run: npm ci --include=optional
 
-      - name: Install Playwright browsers
+      - name: Download Playwright browsers
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: protofleet-playwright-browsers
+          path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
+
+      - name: Install Playwright system dependencies
         working-directory: client/e2eTests/protoFleet
-        env:
-          PLAYWRIGHT_CACHE_HIT: ${{ steps.playwright-cache.outputs.cache-hit }}
         run: |
-          # Runners are fresh each job; keep OS deps installation deterministic.
-          npx playwright install --with-deps chromium
+          # Each runner is fresh, so OS deps still need to be present locally.
+          npx playwright install-deps chromium
 
       - name: Download prebuilt client
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -392,6 +414,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      PLAYWRIGHT_BROWSERS_PATH: ${{ github.workspace }}/.cache/ms-playwright
     strategy:
       fail-fast: false
       matrix:
@@ -416,25 +440,19 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-npm-
 
-      - name: Cache Playwright browsers
-        id: playwright-cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('client/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-playwright-
-
       - name: Install client dependencies
         working-directory: client
         run: npm ci --include=optional
 
-      - name: Install Playwright browsers
+      - name: Download Playwright browsers
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: protofleet-playwright-browsers
+          path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
+
+      - name: Install Playwright system dependencies
         working-directory: client/e2eTests/protoFleet
-        env:
-          PLAYWRIGHT_CACHE_HIT: ${{ steps.playwright-cache.outputs.cache-hit }}
-        run: |
-          npx playwright install --with-deps chromium
+        run: npx playwright install-deps chromium
 
       - name: Download prebuilt client
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/client/e2eTests/protoFleet/fixtures/pageFixtures.ts
+++ b/client/e2eTests/protoFleet/fixtures/pageFixtures.ts
@@ -25,6 +25,7 @@ import { SettingsPoolsPage } from "../pages/settingsPools";
 import { SettingsSchedulesPage } from "../pages/settingsSchedules";
 import { SettingsSecurityPage } from "../pages/settingsSecurity";
 import { SettingsTeamPage } from "../pages/settingsTeam";
+import { SettingsUpdatesPage } from "../pages/settingsUpdates";
 import { SingleMinerPage } from "../pages/singleMiner";
 
 type PageFixtures = {
@@ -45,6 +46,7 @@ type PageFixtures = {
   settingsSchedulesPage: SettingsSchedulesPage;
   settingsSecurityPage: SettingsSecurityPage;
   settingsTeamPage: SettingsTeamPage;
+  settingsUpdatesPage: SettingsUpdatesPage;
   settingsPoolsPage: SettingsPoolsPage;
   alertsPage: AlertsPage;
   editPoolPage: EditPoolPage;
@@ -106,6 +108,9 @@ export const test = base.extend<PageFixtures>({
   },
   settingsTeamPage: async ({ page, isMobile }, use) => {
     await use(new SettingsTeamPage(page, isMobile));
+  },
+  settingsUpdatesPage: async ({ page, isMobile }, use) => {
+    await use(new SettingsUpdatesPage(page, isMobile));
   },
   settingsPoolsPage: async ({ page, isMobile }, use) => {
     await use(new SettingsPoolsPage(page, isMobile));

--- a/client/e2eTests/protoFleet/helpers/updatesSettingsMocks.ts
+++ b/client/e2eTests/protoFleet/helpers/updatesSettingsMocks.ts
@@ -31,7 +31,7 @@ const SET_RELEASE_CHANNEL_RPC_PATTERN = /InstanceUpdateService\/SetReleaseChanne
 const GET_UPGRADE_STATUS_RPC_PATTERN = /InstanceUpdateService\/GetUpgradeStatus/;
 const TRIGGER_UPGRADE_RPC_PATTERN = /InstanceUpdateService\/TriggerUpgrade/;
 const AUTH_STORAGE_KEY = "proto-fleet-auth";
-const FORCED_SESSION_EXPIRY = "2026-12-31T00:00:00.000Z";
+const AUTH_SESSION_TTL_MS = 24 * 60 * 60 * 1000;
 
 type MessageOverrides<T> = Omit<Partial<T>, "$typeName" | "$unknown">;
 
@@ -100,9 +100,18 @@ export async function mockUpdatesSettings(
   const triggerUpgradeRequests: string[] = [];
 
   await page.addInitScript(
-    ({ authStorageKey, forcedSessionExpiry }) => {
+    ({ authStorageKey, authSessionTtlMs }) => {
       const raw = window.localStorage.getItem(authStorageKey);
-      const parsed = raw ? (JSON.parse(raw) as { state?: { auth?: Record<string, unknown> }; version?: number }) : {};
+      let parsed: { state?: { auth?: Record<string, unknown> }; version?: number } = {};
+
+      if (raw) {
+        try {
+          parsed = JSON.parse(raw) as { state?: { auth?: Record<string, unknown> }; version?: number };
+        } catch {
+          parsed = {};
+        }
+      }
+
       const auth = parsed.state?.auth ?? {};
       const permissions = Array.isArray(auth.permissions)
         ? auth.permissions.filter((value) => typeof value === "string")
@@ -110,6 +119,7 @@ export async function mockUpdatesSettings(
       const nextPermissions = permissions.includes("instance:update")
         ? permissions
         : [...permissions, "instance:update"];
+      const sessionExpiry = new Date(Date.now() + authSessionTtlMs).toISOString();
 
       window.localStorage.setItem(
         authStorageKey,
@@ -121,13 +131,13 @@ export async function mockUpdatesSettings(
               authLoading: false,
               isAuthenticated: true,
               permissions: nextPermissions,
-              sessionExpiry: forcedSessionExpiry,
+              sessionExpiry,
             },
           },
         }),
       );
     },
-    { authStorageKey: AUTH_STORAGE_KEY, forcedSessionExpiry: FORCED_SESSION_EXPIRY },
+    { authStorageKey: AUTH_STORAGE_KEY, authSessionTtlMs: AUTH_SESSION_TTL_MS },
   );
 
   await page.route(GET_FLEET_INIT_STATUS_RPC_PATTERN, async (route) => {

--- a/client/e2eTests/protoFleet/helpers/updatesSettingsMocks.ts
+++ b/client/e2eTests/protoFleet/helpers/updatesSettingsMocks.ts
@@ -1,0 +1,178 @@
+import { create, fromJsonString, toJsonString } from "@bufbuild/protobuf";
+import type { Message } from "@bufbuild/protobuf";
+import type { GenMessage } from "@bufbuild/protobuf/codegenv2";
+import type { Page, Route } from "@playwright/test";
+import type {
+  GetUpdateStatusResponse,
+  GetUpgradeStatusResponse,
+  ReleaseInfo,
+  UpgradeOperation,
+} from "@/protoFleet/api/generated/instance/v1/updates_pb";
+import {
+  GetUpdateStatusResponseSchema,
+  GetUpgradeStatusResponseSchema,
+  ReleaseChannel,
+  ReleaseInfoSchema,
+  SetReleaseChannelRequestSchema,
+  SetReleaseChannelResponseSchema,
+  TriggerUpgradeRequestSchema,
+  TriggerUpgradeResponseSchema,
+  UpgradeOperationSchema,
+  UpgradePhase,
+} from "@/protoFleet/api/generated/instance/v1/updates_pb";
+import {
+  FleetInitStatusSchema,
+  GetFleetInitStatusResponseSchema,
+} from "@/protoFleet/api/generated/onboarding/v1/onboarding_pb";
+
+const GET_FLEET_INIT_STATUS_RPC_PATTERN = /OnboardingService\/GetFleetInitStatus/;
+const GET_UPDATE_STATUS_RPC_PATTERN = /InstanceUpdateService\/GetUpdateStatus/;
+const SET_RELEASE_CHANNEL_RPC_PATTERN = /InstanceUpdateService\/SetReleaseChannel/;
+const GET_UPGRADE_STATUS_RPC_PATTERN = /InstanceUpdateService\/GetUpgradeStatus/;
+const TRIGGER_UPGRADE_RPC_PATTERN = /InstanceUpdateService\/TriggerUpgrade/;
+const AUTH_STORAGE_KEY = "proto-fleet-auth";
+const FORCED_SESSION_EXPIRY = "2026-12-31T00:00:00.000Z";
+
+type MessageOverrides<T> = Omit<Partial<T>, "$typeName" | "$unknown">;
+
+export interface UpdatesSettingsMockController {
+  releaseChannelRequests: ReleaseChannel[];
+  triggerUpgradeRequests: string[];
+}
+
+interface MockUpdatesSettingsOptions {
+  initialStatus: GetUpdateStatusResponse;
+  initialUpgradeStatus?: GetUpgradeStatusResponse;
+  onSetReleaseChannel?: (channel: ReleaseChannel) => GetUpdateStatusResponse;
+  onTriggerUpgrade?: (targetVersion: string) => UpgradeOperation | undefined;
+}
+
+export const buildReleaseInfo = (overrides?: MessageOverrides<ReleaseInfo>): ReleaseInfo =>
+  create(ReleaseInfoSchema, {
+    version: "v1.3.0",
+    releaseNotesUrl: "https://github.com/block/proto-fleet/releases/tag/v1.3.0",
+    prerelease: false,
+    ...overrides,
+  });
+
+export const buildUpdateStatus = (overrides?: MessageOverrides<GetUpdateStatusResponse>): GetUpdateStatusResponse =>
+  create(GetUpdateStatusResponseSchema, {
+    currentVersion: "v1.2.0",
+    channel: ReleaseChannel.STABLE,
+    latestEligible: buildReleaseInfo(),
+    updateAvailable: true,
+    installCommand: "curl -fsSL https://fleet.example.com/install.sh | sh -s -- v1.3.0",
+    oneClickAvailable: false,
+    statusAvailable: true,
+    ...overrides,
+  });
+
+export const buildUpgradeStatus = (overrides?: MessageOverrides<GetUpgradeStatusResponse>): GetUpgradeStatusResponse =>
+  create(GetUpgradeStatusResponseSchema, {
+    executorAvailable: true,
+    ...overrides,
+  });
+
+export const buildUpgradeOperation = (
+  phase: UpgradePhase,
+  overrides?: MessageOverrides<UpgradeOperation>,
+): UpgradeOperation =>
+  create(UpgradeOperationSchema, {
+    id: "operation-1",
+    targetVersion: "v1.3.0",
+    phase,
+    message: "Preparing upgrade",
+    ...overrides,
+  });
+
+export async function mockUpdatesSettings(
+  page: Page,
+  {
+    initialStatus,
+    initialUpgradeStatus = buildUpgradeStatus(),
+    onSetReleaseChannel,
+    onTriggerUpgrade,
+  }: MockUpdatesSettingsOptions,
+): Promise<UpdatesSettingsMockController> {
+  let currentStatus = initialStatus;
+  let currentUpgradeStatus = initialUpgradeStatus;
+  const releaseChannelRequests: ReleaseChannel[] = [];
+  const triggerUpgradeRequests: string[] = [];
+
+  await page.addInitScript(
+    ({ authStorageKey, forcedSessionExpiry }) => {
+      const raw = window.localStorage.getItem(authStorageKey);
+      const parsed = raw ? (JSON.parse(raw) as { state?: { auth?: Record<string, unknown> }; version?: number }) : {};
+      const auth = parsed.state?.auth ?? {};
+      const permissions = Array.isArray(auth.permissions)
+        ? auth.permissions.filter((value) => typeof value === "string")
+        : [];
+      const nextPermissions = permissions.includes("instance:update")
+        ? permissions
+        : [...permissions, "instance:update"];
+
+      window.localStorage.setItem(
+        authStorageKey,
+        JSON.stringify({
+          version: parsed.version ?? 0,
+          state: {
+            auth: {
+              ...auth,
+              authLoading: false,
+              isAuthenticated: true,
+              permissions: nextPermissions,
+              sessionExpiry: forcedSessionExpiry,
+            },
+          },
+        }),
+      );
+    },
+    { authStorageKey: AUTH_STORAGE_KEY, forcedSessionExpiry: FORCED_SESSION_EXPIRY },
+  );
+
+  await page.route(GET_FLEET_INIT_STATUS_RPC_PATTERN, async (route) => {
+    return await fulfill(
+      route,
+      GetFleetInitStatusResponseSchema,
+      create(GetFleetInitStatusResponseSchema, {
+        status: create(FleetInitStatusSchema, { adminCreated: true }),
+      }),
+    );
+  });
+
+  await page.route(GET_UPDATE_STATUS_RPC_PATTERN, async (route) => {
+    return await fulfill(route, GetUpdateStatusResponseSchema, currentStatus);
+  });
+
+  await page.route(SET_RELEASE_CHANNEL_RPC_PATTERN, async (route) => {
+    const request = fromJsonString(SetReleaseChannelRequestSchema, route.request().postData() ?? "{}");
+    releaseChannelRequests.push(request.channel);
+    currentStatus = onSetReleaseChannel?.(request.channel) ?? currentStatus;
+    return await fulfill(route, SetReleaseChannelResponseSchema, create(SetReleaseChannelResponseSchema));
+  });
+
+  await page.route(GET_UPGRADE_STATUS_RPC_PATTERN, async (route) => {
+    return await fulfill(route, GetUpgradeStatusResponseSchema, currentUpgradeStatus);
+  });
+
+  await page.route(TRIGGER_UPGRADE_RPC_PATTERN, async (route) => {
+    const request = fromJsonString(TriggerUpgradeRequestSchema, route.request().postData() ?? "{}");
+    triggerUpgradeRequests.push(request.targetVersion);
+    const operation = onTriggerUpgrade?.(request.targetVersion);
+    currentUpgradeStatus = buildUpgradeStatus({ operation });
+    return await fulfill(route, TriggerUpgradeResponseSchema, create(TriggerUpgradeResponseSchema, { operation }));
+  });
+
+  return {
+    releaseChannelRequests,
+    triggerUpgradeRequests,
+  };
+}
+
+async function fulfill<T extends Message>(route: Route, schema: GenMessage<T>, message: T) {
+  return await route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: toJsonString(schema, message),
+  });
+}

--- a/client/e2eTests/protoFleet/pages/base.ts
+++ b/client/e2eTests/protoFleet/pages/base.ts
@@ -918,6 +918,11 @@ export class BasePage {
     await expect(this.page).toHaveURL(/.*\/settings\/alerts/);
   }
 
+  async navigateToUpdatesSettings() {
+    await this.page.goto("/settings/updates");
+    await expect(this.page).toHaveURL(/.*\/settings\/updates/);
+  }
+
   async navigateToServerLogsSettings() {
     await this.clickNavigationMenuIfMobile();
     await this.clickExpandSettingsIfMobile();

--- a/client/e2eTests/protoFleet/pages/settingsUpdates.ts
+++ b/client/e2eTests/protoFleet/pages/settingsUpdates.ts
@@ -1,0 +1,66 @@
+import { expect } from "@playwright/test";
+import { BasePage } from "./base";
+
+export class SettingsUpdatesPage extends BasePage {
+  async validateUpdatesPageOpened() {
+    await expect(this.page).toHaveURL(/.*\/settings\/updates/);
+    await this.validateTitle("Updates");
+  }
+
+  async validateCurrentVersion(version: string) {
+    await expect(this.page.getByText(version, { exact: true }).first()).toBeVisible();
+  }
+
+  async validateLatestAvailableVersion(version: string) {
+    await expect(this.page.getByText(version, { exact: true }).last()).toBeVisible();
+  }
+
+  async validateReleaseNotesLink(url: string) {
+    await expect(this.page.getByRole("link", { name: "Release notes", exact: true })).toHaveAttribute("href", url);
+  }
+
+  async validateInstallCommand(command: string) {
+    await expect(this.page.locator("code").filter({ hasText: command })).toBeVisible();
+  }
+
+  async validateCopyInstallCommandEnabled() {
+    await expect(this.page.getByRole("button", { name: "Copy install command", exact: true })).toBeEnabled();
+  }
+
+  async validateCopyInstallCommandDisabled() {
+    await expect(this.page.getByRole("button", { name: "Copy install command", exact: true })).toBeDisabled();
+  }
+
+  async clickIncludeReleaseCandidates() {
+    await this.page.getByRole("checkbox", { name: "Include release candidates", exact: true }).click();
+  }
+
+  async validateIncludeReleaseCandidatesChecked() {
+    await expect(this.page.getByRole("checkbox", { name: "Include release candidates", exact: true })).toBeChecked();
+  }
+
+  async validateIncludeReleaseCandidatesUnchecked() {
+    await expect(
+      this.page.getByRole("checkbox", { name: "Include release candidates", exact: true }),
+    ).not.toBeChecked();
+  }
+
+  async clickUpgradeToVersion(version: string) {
+    await this.page.getByRole("button", { name: `Upgrade to ${version}`, exact: true }).click();
+  }
+
+  async validateUpgradeConfirmationOpened(version: string) {
+    const modal = this.page.getByTestId("upgrade-operation-modal");
+    await expect(modal).toBeVisible();
+    await expect(modal).toContainText(`Upgrade Fleet to ${version}`);
+    await expect(modal).toContainText("Fleet will validate and build this exact release");
+  }
+
+  async confirmUpgradeToVersion(version: string) {
+    await this.page.getByRole("button", { name: `Confirm upgrade to ${version}`, exact: true }).click();
+  }
+
+  async validateUpgradeModalText(text: string) {
+    await expect(this.page.getByTestId("upgrade-operation-modal")).toContainText(text);
+  }
+}

--- a/client/e2eTests/protoFleet/pages/settingsUpdates.ts
+++ b/client/e2eTests/protoFleet/pages/settingsUpdates.ts
@@ -8,11 +8,11 @@ export class SettingsUpdatesPage extends BasePage {
   }
 
   async validateCurrentVersion(version: string) {
-    await expect(this.page.getByText(version, { exact: true }).first()).toBeVisible();
+    await expect(this.rowByLabel("Current version").locator("> div").last()).toHaveText(version);
   }
 
   async validateLatestAvailableVersion(version: string) {
-    await expect(this.page.getByText(version, { exact: true }).last()).toBeVisible();
+    await expect(this.rowByLabel("Latest available").locator("span").first()).toHaveText(version);
   }
 
   async validateReleaseNotesLink(url: string) {
@@ -62,5 +62,9 @@ export class SettingsUpdatesPage extends BasePage {
 
   async validateUpgradeModalText(text: string) {
     await expect(this.page.getByTestId("upgrade-operation-modal")).toContainText(text);
+  }
+
+  private rowByLabel(label: string) {
+    return this.page.getByText(label, { exact: true }).locator("xpath=..");
   }
 }

--- a/client/e2eTests/protoFleet/spec/updatesSettings.spec.ts
+++ b/client/e2eTests/protoFleet/spec/updatesSettings.spec.ts
@@ -1,0 +1,87 @@
+import { test } from "../fixtures/pageFixtures";
+import {
+  buildReleaseInfo,
+  buildUpdateStatus,
+  buildUpgradeOperation,
+  mockUpdatesSettings,
+} from "../helpers/updatesSettingsMocks";
+import { ReleaseChannel, UpgradePhase } from "@/protoFleet/api/generated/instance/v1/updates_pb";
+
+test.describe("Proto Fleet - Updates Settings", () => {
+  test(
+    "View update details and refresh the offer after enabling release candidates",
+    { tag: "@smoke" },
+    async ({ page, settingsUpdatesPage }) => {
+      const updatesMock = await mockUpdatesSettings(page, {
+        initialStatus: buildUpdateStatus(),
+        onSetReleaseChannel: (channel) =>
+          buildUpdateStatus({
+            channel,
+            installCommand: "curl -fsSL https://fleet.example.com/install.sh | sh -s -- v1.4.0-rc.1",
+            latestEligible: buildReleaseInfo({
+              version: "v1.4.0-rc.1",
+              releaseNotesUrl: "https://github.com/block/proto-fleet/releases/tag/v1.4.0-rc.1",
+              prerelease: true,
+            }),
+          }),
+      });
+
+      await test.step("Open Updates settings and validate the initial stable release offer", async () => {
+        await settingsUpdatesPage.navigateToUpdatesSettings();
+        await settingsUpdatesPage.validateUpdatesPageOpened();
+        await settingsUpdatesPage.validateCurrentVersion("v1.2.0");
+        await settingsUpdatesPage.validateLatestAvailableVersion("v1.3.0");
+        await settingsUpdatesPage.validateReleaseNotesLink("https://github.com/block/proto-fleet/releases/tag/v1.3.0");
+        await settingsUpdatesPage.validateInstallCommand(
+          "curl -fsSL https://fleet.example.com/install.sh | sh -s -- v1.3.0",
+        );
+        await settingsUpdatesPage.validateCopyInstallCommandEnabled();
+        await settingsUpdatesPage.validateIncludeReleaseCandidatesUnchecked();
+      });
+
+      await test.step("Enable release candidates and validate the refreshed offer", async () => {
+        await settingsUpdatesPage.clickIncludeReleaseCandidates();
+        await settingsUpdatesPage.validateTextInToast("Release channel updated");
+        test.expect(updatesMock.releaseChannelRequests).toEqual([ReleaseChannel.STABLE_AND_RC]);
+        await settingsUpdatesPage.validateIncludeReleaseCandidatesChecked();
+        await settingsUpdatesPage.validateLatestAvailableVersion("v1.4.0-rc.1");
+        await settingsUpdatesPage.validateReleaseNotesLink(
+          "https://github.com/block/proto-fleet/releases/tag/v1.4.0-rc.1",
+        );
+        await settingsUpdatesPage.validateInstallCommand(
+          "curl -fsSL https://fleet.example.com/install.sh | sh -s -- v1.4.0-rc.1",
+        );
+      });
+    },
+  );
+
+  test("Confirm the exact offered version before triggering a one-click upgrade", async ({
+    page,
+    settingsUpdatesPage,
+  }) => {
+    const updatesMock = await mockUpdatesSettings(page, {
+      initialStatus: buildUpdateStatus({ oneClickAvailable: true }),
+      onTriggerUpgrade: (targetVersion) =>
+        buildUpgradeOperation(UpgradePhase.QUEUED, {
+          targetVersion,
+          message: `Preparing ${targetVersion}`,
+        }),
+    });
+
+    await settingsUpdatesPage.navigateToUpdatesSettings();
+    await settingsUpdatesPage.validateUpdatesPageOpened();
+
+    await test.step("Open the upgrade confirmation modal without triggering the request yet", async () => {
+      await settingsUpdatesPage.clickUpgradeToVersion("v1.3.0");
+      await settingsUpdatesPage.validateUpgradeConfirmationOpened("v1.3.0");
+      test.expect(updatesMock.triggerUpgradeRequests).toEqual([]);
+    });
+
+    await test.step("Confirm the upgrade and validate the exact requested version", async () => {
+      await settingsUpdatesPage.confirmUpgradeToVersion("v1.3.0");
+      await settingsUpdatesPage.validateUpgradeModalText("Preparing v1.3.0");
+      await settingsUpdatesPage.validateCopyInstallCommandDisabled();
+      test.expect(updatesMock.triggerUpgradeRequests).toEqual(["v1.3.0"]);
+    });
+  });
+});


### PR DESCRIPTION
Reviewable diff: +46/-28 across 1 file (excludes generated, test, and story files).

## Summary
This PR reduces the repeated Playwright browser setup cost in ProtoFleet CI by moving the browser download into the shared build job and reusing it across the sharded E2E and visual jobs. It also switches CI from the full Chromium download to Playwright's Chromium headless shell, which is sufficient for the current headless test configuration and materially smaller.

## How it works
The build job now installs the Playwright Chromium headless shell once into a workflow-local browser path and publishes that directory as an artifact. Each fanout test job downloads the prepared browser payload into the same `PLAYWRIGHT_BROWSERS_PATH`, then installs only the Linux system dependencies that must exist on that fresh runner before executing the tests. This keeps the browser binary work out of the 16x2 shard matrix and the visual matrix while preserving the current test runtime behavior.

## Diagrams
```mermaid
flowchart LR
  A["Build job"] --> B["Install headless Chromium shell once"]
  B --> C["Upload protofleet-playwright-browsers artifact"]
  C --> D["E2E shard jobs download artifact"]
  C --> E["Visual jobs download artifact"]
  D --> F["Install OS deps only"]
  E --> G["Install OS deps only"]
  F --> H["Run Playwright tests"]
  G --> I["Run visual tests"]
```

## Areas of the code involved
| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `.github/workflows/protofleet-e2e-tests.yml` | Added a shared Playwright browser path, one-time browser install in `build`, browser artifact upload, and browser artifact download in the `e2e-tests` and `visual-tests` jobs. | This is the full behavior change; reviewers should validate that the artifact fanout and dependency install ordering still matches Playwright's CI requirements. |

## Key technical decisions & trade-offs
- Use a workflow artifact for browser reuse instead of per-job install because the current matrix multiplies cold-download cost across many jobs on the same run.
- Keep `install-deps chromium` in each test job because browser binaries are shareable across jobs but Linux packages are still runner-local.
- Use `--only-shell` instead of full Chromium because the checked-in Playwright configs do not request a headed browser or a branded `channel` on CI.

## Testing & validation
- Parsed the updated workflow YAML locally with Ruby's YAML loader.
- Verified the diff is isolated to the ProtoFleet E2E workflow.
- Passed the repo's push hooks during `git push`, including `server-lint` and `client-typecheck`.
- CI timing and behavioral validation will come from this PR's workflow run.
