### PR TITLE
Remove unintended Dialog dismiss button

### DIFF
--- a/client/src/protoFleet/features/settings/components/Updates.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Updates.test.tsx
@@ -300,9 +300,9 @@ describe("Updates", () => {
     const page = render(<Updates />);
     expect(await page.findByText("First failure")).toBeInTheDocument();
 
-    fireEvent.click(page.getByRole("button", { name: "Close dialog" }));
+    fireEvent.click(page.getByRole("button", { name: "Close" }));
     await waitFor(() => expect(page.queryByText("First failure")).not.toBeInTheDocument());
-    await waitFor(() => expect(page.queryByRole("button", { name: "Close dialog" })).not.toBeInTheDocument());
+    await waitFor(() => expect(page.queryByTestId("upgrade-operation-modal")).not.toBeInTheDocument());
 
     upgradeHookMock.current = {
       ...upgradeHookMock.current,
@@ -328,9 +328,9 @@ describe("Updates", () => {
     const page = render(<Updates />);
     expect(await page.findByText("Session-scoped failure")).toBeInTheDocument();
 
-    fireEvent.click(page.getByRole("button", { name: "Close dialog" }));
+    fireEvent.click(page.getByRole("button", { name: "Close" }));
     await waitFor(() => expect(page.queryByText("Session-scoped failure")).not.toBeInTheDocument());
-    await waitFor(() => expect(page.queryByRole("button", { name: "Close dialog" })).not.toBeInTheDocument());
+    await waitFor(() => expect(page.queryByTestId("upgrade-operation-modal")).not.toBeInTheDocument());
 
     permissionsMock.sessionGeneration = 2;
     upgradeHookMock.current = { ...upgradeHookMock.current, operationStatusPending: true };
@@ -442,7 +442,7 @@ describe("Updates", () => {
     // the same upgrade again. Waited separately because the dialog's exit
     // transition keeps its frame in the DOM briefly after the content clears.
     await waitFor(() => expect(page.queryByText("new stack failed to start")).not.toBeInTheDocument());
-    await waitFor(() => expect(page.queryByRole("button", { name: "Close dialog" })).not.toBeInTheDocument());
+    await waitFor(() => expect(page.queryByTestId("upgrade-operation-modal")).not.toBeInTheDocument());
   });
 
   it("acknowledges the exact successful outcome before reloading Fleet", async () => {

--- a/client/src/protoFleet/features/settings/components/UpgradeOperationModal.test.tsx
+++ b/client/src/protoFleet/features/settings/components/UpgradeOperationModal.test.tsx
@@ -80,6 +80,7 @@ describe("UpgradeOperationModal", () => {
 
     const confirmButton = screen.getByRole("button", { name: "Update now" });
     expect(screen.getByTestId("upgrade-dialog-icon")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Close dialog" })).not.toBeInTheDocument();
     expect(confirmButton).toBeInTheDocument();
     fireEvent.click(confirmButton);
 

--- a/client/src/protoFleet/features/settings/components/UpgradeOperationModal.tsx
+++ b/client/src/protoFleet/features/settings/components/UpgradeOperationModal.tsx
@@ -366,7 +366,6 @@ const UpgradeOperationModal = ({
     <Dialog
       open={open}
       onDismiss={onDismiss}
-      dismissButton
       testId="upgrade-operation-modal"
       icon={dialogVisual.icon}
       title={dialogVisual.title}

--- a/client/src/shared/components/Dialog/Dialog.tsx
+++ b/client/src/shared/components/Dialog/Dialog.tsx
@@ -2,7 +2,6 @@ import { motion } from "motion/react";
 import { ReactNode, useCallback } from "react";
 import clsx from "clsx";
 
-import { DismissCircleDark } from "@/shared/assets/icons";
 import { variants } from "@/shared/components/Button";
 import ButtonGroup from "@/shared/components/ButtonGroup";
 import { groupVariants } from "@/shared/components/ButtonGroup/constants";
@@ -16,7 +15,6 @@ import useSlideUpAnimation from "@/shared/hooks/useSlideUpAnimation";
 interface DialogProps {
   className?: string;
   children?: ReactNode;
-  dismissButton?: boolean;
   icon?: ReactNode;
   loading?: boolean;
   preventScroll?: boolean;
@@ -36,7 +34,6 @@ interface DialogProps {
 const Dialog = ({
   className,
   children,
-  dismissButton = false,
   icon,
   loading,
   preventScroll,
@@ -76,7 +73,6 @@ const Dialog = ({
       >
         <div className="p-6">
           <div className="flex flex-col gap-3">
-            {dismissButton ? <DismissCircleDark ariaLabel="Close dialog" onClick={dismissDialog} /> : null}
             {loading ? (
               <div className="flex w-10 items-center justify-center rounded-lg bg-surface-5 py-2.5">
                 <ProgressCircular indeterminate />


### PR DESCRIPTION
Reviewable diff: +0/-5 across 2 files (excludes generated, test, and story files).

## Summary

Removes the unintended icon dismiss button added to the shared `Dialog` component in #922. Update dialogs continue to support their explicit footer actions and Escape-key dismissal without exposing a second, redundant close affordance.

## How it works

The shared `Dialog` no longer accepts or renders a `dismissButton` prop. `UpgradeOperationModal` relies on the action appropriate to its current state—`Cancel`, `Dismiss`, `Close`, or `Relaunch`—and the update-page tests now exercise those footer actions while waiting on the dialog itself to close.

## Diagrams

```mermaid
flowchart LR
  A["Update dialog state"] --> B["State-specific footer action"]
  B --> C["Dialog onDismiss or state transition"]
  C --> D["Dialog closes"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/src/shared/components/Dialog/Dialog.tsx` | Removes the dismiss-button prop, icon import, and rendering | Restores the shared Dialog API and visual contract |
| `client/src/protoFleet/features/settings/components/UpgradeOperationModal.tsx` | Stops requesting the removed icon | Keeps update dialogs on their explicit action model |
| Update component tests | Uses footer Close actions and asserts the icon is absent | Test-only — verifies dismissal and lifecycle behavior |

## Key technical decisions & trade-offs

- Remove the shared API entirely instead of only hiding the icon in one modal, preventing other Dialog consumers from adopting the unintended affordance.
- Preserve `onDismiss` and Escape handling; only the icon button introduced by #922 is removed.

## Testing & validation

- Focused Vitest: 73 tests passing across Dialog, UpgradeOperationModal, and Updates
- Changed-file ESLint
- Prettier check
- TypeScript `tsc --noEmit`
- Lefthook pre-commit formatting and pre-push client typecheck
- `git diff --check`