### PR TITLE
feat(fleetnode): support HA control stream failover

### DIFF
--- a/client/nginx.runner-protofleet.conf
+++ b/client/nginx.runner-protofleet.conf
@@ -18,7 +18,7 @@ server {
     client_max_body_size 0;
     grpc_pass grpc://127.0.0.1:4000;
     grpc_set_header Host $host;
-    grpc_read_timeout 24h;
+    grpc_read_timeout 90s;
     grpc_send_timeout 24h;
     grpc_next_upstream off;
   }

--- a/client/nginx.runner-protofleet.conf
+++ b/client/nginx.runner-protofleet.conf
@@ -1,11 +1,26 @@
 server {
   listen 127.0.0.1:8080;
+  http2 on;
 
   root /usr/share/nginx/html;
   index index.html;
 
   location / {
     try_files $uri $uri/ /index.html;
+  }
+
+  # ControlStream is the only Fleet Node RPC that uses native gRPC. Strip the
+  # public /api-proxy prefix and keep this long-lived HTTP/2 stream pinned to
+  # the selected upstream; the node reconnect loop handles failures.
+  location = /api-proxy/fleetnodegateway.v1.FleetNodeGatewayService/ControlStream {
+    rewrite ^/api-proxy/(.*)$ /$1 break;
+    client_body_timeout 24h;
+    client_max_body_size 0;
+    grpc_pass grpc://127.0.0.1:4000;
+    grpc_set_header Host $host;
+    grpc_read_timeout 24h;
+    grpc_send_timeout 24h;
+    grpc_next_upstream off;
   }
 
   # Pair is a unary RPC that can wait for multiple fleet-node batches before

--- a/deployment-files/client/nginx.http.conf
+++ b/deployment-files/client/nginx.http.conf
@@ -1,5 +1,6 @@
 server {
     listen 80;
+    http2 on;
 
     # Runtime client config, regenerated from env at container start. Never cache
     # so operator changes take effect on restart.
@@ -14,6 +15,20 @@ server {
         root /usr/share/nginx/html;
         index index.html;
         try_files $uri $uri/ /index.html;
+    }
+
+    # ControlStream is the only Fleet Node RPC that uses native gRPC. Strip the
+    # public /api-proxy prefix and keep this long-lived HTTP/2 stream pinned to
+    # the selected upstream; the node reconnect loop handles failures.
+    location = /api-proxy/fleetnodegateway.v1.FleetNodeGatewayService/ControlStream {
+        rewrite ^/api-proxy/(.*)$ /$1 break;
+        client_body_timeout 24h;
+        client_max_body_size 0;
+        grpc_pass grpc://localhost:4000;
+        grpc_set_header Host $host;
+        grpc_read_timeout 24h;
+        grpc_send_timeout 24h;
+        grpc_next_upstream off;
     }
 
     # Pair is a unary RPC that can wait for multiple fleet-node batches before

--- a/deployment-files/client/nginx.http.conf
+++ b/deployment-files/client/nginx.http.conf
@@ -26,7 +26,7 @@ server {
         client_max_body_size 0;
         grpc_pass grpc://localhost:4000;
         grpc_set_header Host $host;
-        grpc_read_timeout 24h;
+        grpc_read_timeout 90s;
         grpc_send_timeout 24h;
         grpc_next_upstream off;
     }

--- a/deployment-files/client/nginx.https.conf
+++ b/deployment-files/client/nginx.https.conf
@@ -8,6 +8,7 @@ server {
 # HTTPS server
 server {
     listen 443 ssl;
+    http2 on;
     server_name _;
 
     # SSL certificate configuration
@@ -35,6 +36,20 @@ server {
         root /usr/share/nginx/html;
         index index.html;
         try_files $uri $uri/ /index.html;
+    }
+
+    # ControlStream is the only Fleet Node RPC that uses native gRPC. Strip the
+    # public /api-proxy prefix and keep this long-lived HTTP/2 stream pinned to
+    # the selected upstream; the node reconnect loop handles failures.
+    location = /api-proxy/fleetnodegateway.v1.FleetNodeGatewayService/ControlStream {
+        rewrite ^/api-proxy/(.*)$ /$1 break;
+        client_body_timeout 24h;
+        client_max_body_size 0;
+        grpc_pass grpc://localhost:4000;
+        grpc_set_header Host $host;
+        grpc_read_timeout 24h;
+        grpc_send_timeout 24h;
+        grpc_next_upstream off;
     }
 
     # Pair is a unary RPC that can wait for multiple fleet-node batches before

--- a/deployment-files/client/nginx.https.conf
+++ b/deployment-files/client/nginx.https.conf
@@ -47,7 +47,7 @@ server {
         client_max_body_size 0;
         grpc_pass grpc://localhost:4000;
         grpc_set_header Host $host;
-        grpc_read_timeout 24h;
+        grpc_read_timeout 90s;
         grpc_send_timeout 24h;
         grpc_next_upstream off;
     }

--- a/deployment-files/tests/test-profiles.sh
+++ b/deployment-files/tests/test-profiles.sh
@@ -203,7 +203,43 @@ else
 fi
 
 # ----------------------------------------------------------------------------
-# 5. Compose render smoke test (staged tarball layout)
+# 5. NGINX keeps only ControlStream on native gRPC
+# ----------------------------------------------------------------------------
+
+check_control_stream_route() { # config upstream_host
+    local config="$1" upstream_host="$2" block generic
+    block=$(sed -n '\|location = /api-proxy/fleetnodegateway.v1.FleetNodeGatewayService/ControlStream {|,/^[[:space:]]*}/p' "$config")
+    generic=$(sed -n '\|location /api-proxy/ {|,/^[[:space:]]*}/p' "$config")
+
+    if ! grep -Fq -- 'http2 on;' "$config"; then
+        fail "$(basename "$config"): HTTP/2 must remain enabled for gRPC"
+    fi
+
+    for expected in \
+        'location = /api-proxy/fleetnodegateway.v1.FleetNodeGatewayService/ControlStream {' \
+        'rewrite ^/api-proxy/(.*)$ /$1 break;' \
+        "grpc_pass grpc://${upstream_host}:4000;" \
+        'grpc_read_timeout 90s;' \
+        'grpc_next_upstream off;'; do
+        if ! printf '%s\n' "$block" | grep -Fq -- "$expected"; then
+            fail "$(basename "$config"): ControlStream route does not contain: $expected"
+        fi
+    done
+    if [ "$(grep -c 'grpc_pass ' "$config")" -ne 1 ]; then
+        fail "$(basename "$config"): exactly one RPC route must use grpc_pass"
+    fi
+    if ! printf '%s\n' "$generic" | grep -Fq -- "proxy_pass http://${upstream_host}:4000/;"; then
+        fail "$(basename "$config"): generic /api-proxy route must retain Connect proxy_pass"
+    fi
+}
+
+check_control_stream_route "$REPO_ROOT/deployment-files/client/nginx.http.conf" localhost
+check_control_stream_route "$REPO_ROOT/deployment-files/client/nginx.https.conf" localhost
+check_control_stream_route "$REPO_ROOT/client/nginx.runner-protofleet.conf" 127.0.0.1
+pass "NGINX routes only ControlStream through native gRPC"
+
+# ----------------------------------------------------------------------------
+# 6. Compose render smoke test (staged tarball layout)
 # ----------------------------------------------------------------------------
 
 if ! docker compose version >/dev/null 2>&1; then

--- a/server/cmd/fleetd/main.go
+++ b/server/cmd/fleetd/main.go
@@ -274,6 +274,7 @@ func start(config *Config) (result error) {
 	fleetNodePairingStore := sqlstores.NewSQLFleetNodePairingStore(conn)
 	fleetNodePairingSvc := fleetnodepairing.NewService(fleetNodePairingStore, fleetNodeEnrollmentStore, transactor)
 	fleetNodeControlRegistry := control.NewRegistry()
+	fleetNodeEnrollmentSvc.WithControlStreamInvalidator(fleetNodeControlRegistry.Disconnect)
 	fleetNodeDiscoverySvc := fleetnodediscovery.NewService(fleetNodeControlRegistry, fleetNodeEnrollmentSvc)
 	fleetNodeAuthStore := sqlstores.NewSQLFleetNodeAuthStore(conn)
 	fleetNodeAuthSvc := fleetnodeauth.NewService(fleetNodeAuthStore, fleetNodeEnrollmentStore, apiKeySvc)

--- a/server/cmd/fleetd/main.go
+++ b/server/cmd/fleetd/main.go
@@ -274,7 +274,7 @@ func start(config *Config) (result error) {
 	fleetNodePairingStore := sqlstores.NewSQLFleetNodePairingStore(conn)
 	fleetNodePairingSvc := fleetnodepairing.NewService(fleetNodePairingStore, fleetNodeEnrollmentStore, transactor)
 	fleetNodeControlRegistry := control.NewRegistry()
-	fleetNodeEnrollmentSvc.WithControlStreamInvalidator(fleetNodeControlRegistry.Disconnect)
+	fleetNodeEnrollmentSvc.WithControlStreamInvalidator(fleetNodeControlRegistry.RevokeSession)
 	fleetNodeDiscoverySvc := fleetnodediscovery.NewService(fleetNodeControlRegistry, fleetNodeEnrollmentSvc)
 	fleetNodeAuthStore := sqlstores.NewSQLFleetNodeAuthStore(conn)
 	fleetNodeAuthSvc := fleetnodeauth.NewService(fleetNodeAuthStore, fleetNodeEnrollmentStore, apiKeySvc)

--- a/server/cmd/fleetnode/control.go
+++ b/server/cmd/fleetnode/control.go
@@ -72,6 +72,8 @@ type acker interface {
 	Send(req *pb.ControlStreamRequest) error
 }
 
+var errControlSenderClosed = errors.New("control session sender closed")
+
 // connect-go bidi streams are not safe for concurrent Send. The receive
 // loop's busy-ack and the worker's completion ack now share a stream;
 // serialize through this wrapper.
@@ -83,12 +85,12 @@ type lockedAcker struct {
 
 func (l *lockedAcker) Send(req *pb.ControlStreamRequest) error {
 	if l.closed.Load() {
-		return io.ErrClosedPipe
+		return errControlSenderClosed
 	}
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	if l.closed.Load() {
-		return io.ErrClosedPipe
+		return errControlSenderClosed
 	}
 	return l.inner.Send(req)
 }
@@ -612,7 +614,7 @@ func (r *RunCmd) sendAckWithPayload(stream acker, commandID string, code pb.AckC
 		ErrorMessage: errMsg,
 		Code:         code,
 		Payload:      payload,
-	}}}); err != nil {
+	}}}); err != nil && !errors.Is(err, errControlSenderClosed) {
 		logger.Warn("send ack failed", "command_id", commandID, "err", err)
 	}
 }

--- a/server/cmd/fleetnode/control.go
+++ b/server/cmd/fleetnode/control.go
@@ -74,6 +74,11 @@ type acker interface {
 
 var errControlSenderClosed = errors.New("control session sender closed")
 
+var (
+	errControlSessionRotated = errors.New("control session credentials rotated")
+	errControlSessionExpired = errors.New("control session credentials expired")
+)
+
 // connect-go bidi streams are not safe for concurrent Send. The receive
 // loop's busy-ack and the worker's completion ack now share a stream;
 // serialize through this wrapper.
@@ -125,7 +130,7 @@ func (r *RunCmd) runControlLoop(ctx context.Context, client gatewayClient, st *b
 		default:
 		}
 		started := time.Now()
-		err := r.runControlSession(ctx, loopLogger, client)
+		err := r.runControlSession(ctx, loopLogger, client, st)
 		if err == nil {
 			return nil
 		}
@@ -185,9 +190,11 @@ func isNotActiveControlError(err error) bool {
 	return false
 }
 
-func (r *RunCmd) runControlSession(ctx context.Context, logger *slog.Logger, client gatewayClient) error {
+func (r *RunCmd) runControlSession(ctx context.Context, logger *slog.Logger, client gatewayClient, st *bootstrap.State) error {
 	r.initControlConcurrency()
-	stream := client.ControlStream(ctx)
+	credentialCtx, endSession := r.beginControlSession(ctx, st)
+	defer endSession()
+	stream := client.ControlStream(credentialCtx)
 	// stream.Receive parks in http2.pipe on a sync.Cond ctx can't unblock;
 	// the watcher below closes the stream so Ctrl+C returns. Defers run
 	// LIFO: close(done) fires first so the watcher exits quietly on normal
@@ -197,7 +204,7 @@ func (r *RunCmd) runControlSession(ctx context.Context, logger *slog.Logger, cli
 	defer close(done)
 	go func() {
 		select {
-		case <-ctx.Done():
+		case <-credentialCtx.Done():
 			_ = stream.CloseRequest()
 			_ = stream.CloseResponse()
 		case <-done:
@@ -205,10 +212,22 @@ func (r *RunCmd) runControlSession(ctx context.Context, logger *slog.Logger, cli
 	}()
 
 	if err := stream.Send(&pb.ControlStreamRequest{Kind: &pb.ControlStreamRequest_Hello{Hello: &pb.ControlHello{}}}); err != nil {
+		if ctx.Err() != nil {
+			return nil
+		}
+		if cause := context.Cause(credentialCtx); cause != nil {
+			return fmt.Errorf("control session ended while sending hello: %w", cause)
+		}
 		return fmt.Errorf("send hello: %w", err)
 	}
 	first, err := stream.Receive()
 	if err != nil {
+		if ctx.Err() != nil {
+			return nil
+		}
+		if cause := context.Cause(credentialCtx); cause != nil {
+			return fmt.Errorf("control session ended while awaiting acceptance: %w", cause)
+		}
 		return fmt.Errorf("await accepted: %w", err)
 	}
 	if first.GetAccepted() == nil {
@@ -219,7 +238,7 @@ func (r *RunCmd) runControlSession(ctx context.Context, logger *slog.Logger, cli
 	// sessionCtx so a dropped stream cancels the in-flight scan immediately;
 	// without it the agent would burn up to commandTimeout finishing an old
 	// scan before opening a new session.
-	sessionCtx, cancelSession := context.WithCancel(ctx)
+	sessionCtx, cancelSession := context.WithCancel(credentialCtx)
 
 	// Serialize all sends on the bidi: the worker's completion ack and the
 	// receive loop's busy ack would otherwise race on stream.Send.
@@ -230,9 +249,9 @@ func (r *RunCmd) runControlSession(ctx context.Context, logger *slog.Logger, cli
 	}()
 
 	// Two process-wide lanes owned by RunCmd:
-	//   - discovery (and the pairing effort's future pair) is a heavy, report-bearing
-	//     scan; it is single-flight per node via an exclusive slot, so a second
-	//     concurrent discovery is rejected BUSY rather than doubling the scan load.
+	//   - discovery and pairing are heavy, report-bearing scans that share an
+	//     exclusive slot, so a second concurrent scan is rejected BUSY rather than
+	//     doubling the load.
 	//   - quick per-miner commands use a broader pool, so they run concurrently and a
 	//     long discovery never head-of-line-blocks them.
 	// Both are non-blocking acquires: parking the receive loop would hide stream
@@ -240,9 +259,13 @@ func (r *RunCmd) runControlSession(ctx context.Context, logger *slog.Logger, cli
 	for {
 		msg, err := stream.Receive()
 		if err != nil {
-			// Watcher closed the stream because ctx is done; clean shutdown.
+			// Parent cancellation is daemon shutdown. Credential rotation or expiry
+			// retires only this stream so the reconnect loop can open a replacement.
 			if ctx.Err() != nil {
 				return nil
+			}
+			if cause := context.Cause(credentialCtx); cause != nil {
+				return fmt.Errorf("control session ended: %w", cause)
 			}
 			if errors.Is(err, io.EOF) {
 				return fmt.Errorf("control stream closed by server: %w", err)
@@ -278,10 +301,32 @@ func (r *RunCmd) runControlSession(ctx context.Context, logger *slog.Logger, cli
 	}
 }
 
+func (r *RunCmd) beginControlSession(parent context.Context, st *bootstrap.State) (context.Context, func()) {
+	r.stateMu.Lock()
+	expiresAt := st.SessionExpiresAt
+
+	deadlineCtx := parent
+	cancelDeadline := func() {}
+	if !expiresAt.IsZero() {
+		deadlineCtx, cancelDeadline = context.WithDeadlineCause(parent, expiresAt, errControlSessionExpired)
+	}
+	sessionCtx, cancelSession := context.WithCancelCause(deadlineCtx)
+	r.controlSessionCancel = cancelSession
+	r.stateMu.Unlock()
+
+	return sessionCtx, func() {
+		cancelSession(context.Canceled)
+		cancelDeadline()
+		r.stateMu.Lock()
+		r.controlSessionCancel = nil
+		r.stateMu.Unlock()
+	}
+}
+
 // decodeAgentCommand unmarshals the ControlCommand.payload envelope. The receive loop
 // decodes once and hands the result to handleCommand so the payload is parsed a single
-// time. Discovery (and the pairing effort's future pair) is the heavy, report-bearing
-// kind that takes the exclusive single-flight slot; everything else, including a
+// time. Discovery and pairing are the heavy, report-bearing commands that take the
+// exclusive single-flight slot; everything else, including a
 // malformed payload, takes the per-miner command pool and is acked by handleCommand.
 func decodeAgentCommand(payload []byte) (*pb.AgentCommand, error) {
 	env := &pb.AgentCommand{}

--- a/server/cmd/fleetnode/control.go
+++ b/server/cmd/fleetnode/control.go
@@ -14,12 +14,14 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"buf.build/go/protovalidate"
 	"connectrpc.com/connect"
 	"google.golang.org/protobuf/proto"
 
+	commonpb "github.com/block/proto-fleet/server/generated/grpc/common/v1"
 	pb "github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1"
 	pairingpb "github.com/block/proto-fleet/server/generated/grpc/pairing/v1"
 	"github.com/block/proto-fleet/server/internal/domain/discoverylimits"
@@ -45,10 +47,10 @@ const (
 	// Mirrors ControlAck.payload's proto cap; result-bearing commands must not
 	// make the ack itself invalid.
 	maxAckPayloadBytes = 1 << 20
-	// commandPoolSize bounds quick per-miner commands handled concurrently per
-	// session. Discovery does not draw from this pool; it has its own exclusive,
-	// single-flight slot (see runControlSession). Commands past the ceiling are
-	// acked BUSY.
+	// commandPoolSize bounds quick per-miner commands handled concurrently by
+	// the daemon across reconnects. Discovery does not draw from this pool; it
+	// has its own process-wide exclusive slot (see runControlSession). Commands
+	// past the ceiling are acked BUSY.
 	commandPoolSize = 16
 )
 
@@ -74,14 +76,25 @@ type acker interface {
 // loop's busy-ack and the worker's completion ack now share a stream;
 // serialize through this wrapper.
 type lockedAcker struct {
-	mu    sync.Mutex
-	inner acker
+	mu     sync.Mutex
+	inner  acker
+	closed atomic.Bool
 }
 
 func (l *lockedAcker) Send(req *pb.ControlStreamRequest) error {
+	if l.closed.Load() {
+		return io.ErrClosedPipe
+	}
 	l.mu.Lock()
 	defer l.mu.Unlock()
+	if l.closed.Load() {
+		return io.ErrClosedPipe
+	}
 	return l.inner.Send(req)
+}
+
+func (l *lockedAcker) Close() {
+	l.closed.Store(true)
 }
 
 type endpoint struct{ ip, port string }
@@ -98,6 +111,7 @@ func cmdErr(code pb.AckCode, format string, args ...any) *commandError {
 }
 
 func (r *RunCmd) runControlLoop(ctx context.Context, client gatewayClient, st *bootstrap.State, logger *slog.Logger) error {
+	r.initControlConcurrency()
 	loopLogger := logger.With("fleet_node_id", st.FleetNodeID)
 	backoff := controlReconnectInitial
 	// Per-loop rng so tests don't race on math/rand's global source.
@@ -121,10 +135,7 @@ func (r *RunCmd) runControlLoop(ctx context.Context, client gatewayClient, st *b
 			loopLogger.Info("control stream unimplemented by server; running heartbeat-only", "err", err)
 			return nil
 		}
-		if time.Since(started) > stableSessionThreshold {
-			backoff = controlReconnectInitial
-		}
-		sleep := min(backoff+time.Duration(rng.Int63n(int64(backoff/2)+1)), controlReconnectMax)
+		sleep, nextBackoff := controlReconnectDelay(err, time.Since(started), backoff, rng)
 		loopLogger.Warn("control stream disconnected; will reconnect", "backoff", sleep.String(), "err", err)
 		timer := time.NewTimer(sleep)
 		select {
@@ -133,11 +144,47 @@ func (r *RunCmd) runControlLoop(ctx context.Context, client gatewayClient, st *b
 			return nil
 		case <-timer.C:
 		}
-		backoff = min(backoff*2, controlReconnectMax)
+		backoff = nextBackoff
 	}
 }
 
+func controlReconnectDelay(err error, sessionDuration, backoff time.Duration, rng *rand.Rand) (time.Duration, time.Duration) {
+	if isNotActiveControlError(err) {
+		return jitterControlReconnect(controlReconnectInitial, rng), controlReconnectInitial
+	}
+	if sessionDuration > stableSessionThreshold {
+		backoff = controlReconnectInitial
+	}
+	return jitterControlReconnect(backoff, rng), min(backoff*2, controlReconnectMax)
+}
+
+func jitterControlReconnect(backoff time.Duration, rng *rand.Rand) time.Duration {
+	return min(backoff+time.Duration(rng.Int63n(int64(backoff/2)+1)), controlReconnectMax)
+}
+
+func isNotActiveControlError(err error) bool {
+	if connect.CodeOf(err) != connect.CodeUnavailable {
+		return false
+	}
+	var connectErr *connect.Error
+	if !errors.As(err, &connectErr) {
+		return false
+	}
+	for _, detail := range connectErr.Details() {
+		value, valueErr := detail.Value()
+		if valueErr != nil {
+			continue
+		}
+		fleetDetails, ok := value.(*commonpb.FleetErrorDetails)
+		if ok && fleetDetails.GetCommon() == commonpb.FleetErrorCode_FLEET_ERROR_CODE_NOT_ACTIVE {
+			return true
+		}
+	}
+	return false
+}
+
 func (r *RunCmd) runControlSession(ctx context.Context, logger *slog.Logger, client gatewayClient) error {
+	r.initControlConcurrency()
 	stream := client.ControlStream(ctx)
 	// stream.Receive parks in http2.pipe on a sync.Cond ctx can't unblock;
 	// the watcher below closes the stream so Ctrl+C returns. Defers run
@@ -171,13 +218,16 @@ func (r *RunCmd) runControlSession(ctx context.Context, logger *slog.Logger, cli
 	// without it the agent would burn up to commandTimeout finishing an old
 	// scan before opening a new session.
 	sessionCtx, cancelSession := context.WithCancel(ctx)
-	defer cancelSession()
 
 	// Serialize all sends on the bidi: the worker's completion ack and the
 	// receive loop's busy ack would otherwise race on stream.Send.
 	sender := &lockedAcker{inner: stream}
+	defer func() {
+		cancelSession()
+		sender.Close()
+	}()
 
-	// Two lanes per session:
+	// Two process-wide lanes owned by RunCmd:
 	//   - discovery (and the pairing effort's future pair) is a heavy, report-bearing
 	//     scan; it is single-flight per node via an exclusive slot, so a second
 	//     concurrent discovery is rejected BUSY rather than doubling the scan load.
@@ -185,14 +235,6 @@ func (r *RunCmd) runControlSession(ctx context.Context, logger *slog.Logger, cli
 	//     long discovery never head-of-line-blocks them.
 	// Both are non-blocking acquires: parking the receive loop would hide stream
 	// drops behind in-flight work, so at capacity we ack BUSY.
-	discoverySlot := make(chan struct{}, 1)
-	cmdSem := make(chan struct{}, commandPoolSize)
-	var wg sync.WaitGroup
-	defer func() {
-		cancelSession() // cancel every in-flight handler's ctx
-		wg.Wait()       // drain: handlers ack or abort fast on the cancelled ctx
-	}()
-
 	for {
 		msg, err := stream.Receive()
 		if err != nil {
@@ -213,17 +255,17 @@ func (r *RunCmd) runControlSession(ctx context.Context, logger *slog.Logger, cli
 		// need not re-parse the payload. A malformed payload is not report-bearing:
 		// it takes the pool lane and handleCommand acks it BAD_REQUEST.
 		env, parseErr := decodeAgentCommand(cmd.GetPayload())
-		slot := cmdSem
+		slot := r.controlCommandSlots
 		if parseErr == nil && (env.GetDiscover() != nil || env.GetPair() != nil) {
-			slot = discoverySlot
+			slot = r.controlDiscoverySlot
 		}
 		select {
 		case slot <- struct{}{}:
-			wg.Add(1)
+			r.controlWorkers.Add(1)
 			// All loop-scoped values the handler needs are passed as arguments,
 			// including the acquired lane, so each goroutine releases the same lane.
 			go func(c *pb.ControlCommand, e *pb.AgentCommand, pErr error, lane chan struct{}) {
-				defer wg.Done()
+				defer r.controlWorkers.Done()
 				defer func() { <-lane }()
 				r.handleCommand(sessionCtx, client, sender, c, e, pErr, logger)
 			}(cmd, env, parseErr, slot)

--- a/server/cmd/fleetnode/control_test.go
+++ b/server/cmd/fleetnode/control_test.go
@@ -211,6 +211,20 @@ func TestControlLoop_AcksAndReports(t *testing.T) {
 	}
 }
 
+func TestControlLoop_IgnoresRepeatedAccepted(t *testing.T) {
+	disc := &stubDiscoverer{probes: map[string]*pb.DiscoveredDeviceReport{
+		"10.0.0.5|4028": {DeviceIdentifier: "auto:1", IpAddress: "10.0.0.5", Port: "4028", UrlScheme: "http", DriverName: "antminer"},
+	}}
+	cmd := &RunCmd{discoverer: disc}
+	fake := &controlFakeGateway{}
+	fake.setBehavior(controlFakeBehavior{acceptedLiveness: 2})
+	fake.queue(discoverPayload(t, discoverIPList([]string{"10.0.0.5"}, []string{"4028"})))
+
+	runControlLoopOnce(t, cmd, fake)
+
+	require.Len(t, fake.acksCopy(), 1, "liveness frames must not interrupt later commands")
+}
+
 func TestResolveAndValidatePorts(t *testing.T) {
 	t.Parallel()
 
@@ -520,6 +534,7 @@ func (s *stubDiscoverer) DefaultDiscoveryPorts(_ context.Context) []string {
 
 type controlFakeBehavior struct {
 	closeAfterAccepted bool
+	acceptedLiveness   int
 	// closeOnSignal lets tests force a server-side stream close at a precise
 	// moment (e.g., after the agent has started executing a command). The
 	// fake closes its ControlStream handler when this channel becomes ready.
@@ -640,11 +655,17 @@ func (f *controlFakeGateway) ControlStream(ctx context.Context, stream *connect.
 	f.mu.Lock()
 	closeNow := f.behavior.closeAfterAccepted
 	closeOnSignal := f.behavior.closeOnSignal
+	acceptedLiveness := f.behavior.acceptedLiveness
 	pending := f.pending
 	f.pending = nil
 	f.mu.Unlock()
 	if closeNow {
 		return nil
+	}
+	for range acceptedLiveness {
+		if err := stream.Send(&pb.ControlStreamResponse{Kind: &pb.ControlStreamResponse_Accepted{Accepted: &pb.ControlAccepted{ServerTime: timestamppb.Now()}}}); err != nil {
+			return fmt.Errorf("send accepted liveness: %w", err)
+		}
 	}
 
 	for _, p := range pending {
@@ -952,15 +973,21 @@ func TestReportFromDiscovered(t *testing.T) {
 // blockingDiscoverer holds Probe open per-IP so tests can observe Receive
 // drain and ctx-cancel behavior while a command is in flight.
 type blockingDiscoverer struct {
-	mu      sync.Mutex
-	started map[string]chan struct{}
-	release map[string]chan struct{}
+	mu        sync.Mutex
+	started   map[string]chan struct{}
+	cancelled map[string]chan struct{}
+	release   map[string]chan struct{}
 }
 
 func newBlockingDiscoverer(ips ...string) *blockingDiscoverer {
-	d := &blockingDiscoverer{started: map[string]chan struct{}{}, release: map[string]chan struct{}{}}
+	d := &blockingDiscoverer{
+		started:   map[string]chan struct{}{},
+		cancelled: map[string]chan struct{}{},
+		release:   map[string]chan struct{}{},
+	}
 	for _, ip := range ips {
 		d.started[ip] = make(chan struct{}, 1)
+		d.cancelled[ip] = make(chan struct{}, 1)
 		d.release[ip] = make(chan struct{})
 	}
 	return d
@@ -969,6 +996,7 @@ func newBlockingDiscoverer(ips ...string) *blockingDiscoverer {
 func (b *blockingDiscoverer) Probe(ctx context.Context, ip, _ string) (*pb.DiscoveredDeviceReport, error) {
 	b.mu.Lock()
 	start, ok := b.started[ip]
+	cancelled := b.cancelled[ip]
 	release := b.release[ip]
 	b.mu.Unlock()
 	if !ok {
@@ -982,6 +1010,10 @@ func (b *blockingDiscoverer) Probe(ctx context.Context, ip, _ string) (*pb.Disco
 	case <-release:
 		return &pb.DiscoveredDeviceReport{DeviceIdentifier: "auto:" + ip, IpAddress: ip, Port: "4028", UrlScheme: "http", DriverName: "antminer"}, nil
 	case <-ctx.Done():
+		select {
+		case cancelled <- struct{}{}:
+		default:
+		}
 		return nil, fmt.Errorf("blocking discoverer cancelled: %w", ctx.Err())
 	}
 }
@@ -999,6 +1031,18 @@ func (b *blockingDiscoverer) waitStarted(t *testing.T, ip string) {
 	case <-start:
 	case <-time.After(2 * time.Second):
 		t.Fatalf("probe for %s never started", ip)
+	}
+}
+
+func (b *blockingDiscoverer) waitCancelled(t *testing.T, ip string) {
+	t.Helper()
+	b.mu.Lock()
+	cancelled := b.cancelled[ip]
+	b.mu.Unlock()
+	select {
+	case <-cancelled:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("probe for %s did not observe session cancellation", ip)
 	}
 }
 
@@ -1463,13 +1507,10 @@ func TestControlLoop_DroppedStreamCancelsInFlightScan(t *testing.T) {
 	disc.waitStarted(t, "10.0.0.42")
 	close(streamClose)
 
-	// Assert: with sessionCtx wiring, the dropped stream cancels the
-	// in-flight probe via the session-scoped ctx, the worker exits within
-	// the supervisor budget, runControlSession returns, and runControlLoop
-	// backs off and reconnects. helloCount reaching 2 within 4 seconds
-	// requires the unblock path -- without it, the loop's defer would
-	// hang for commandTimeout (30s) before reconnect.
+	// Assert: reconnect happens promptly, and the old probe independently
+	// observes session cancellation before the daemon's parent is cancelled.
 	require.Eventually(t, func() bool { return fake.helloCount() >= 2 }, 4*time.Second, 50*time.Millisecond)
+	disc.waitCancelled(t, "10.0.0.42")
 	cancel()
 	<-done
 	cmd.waitForControlWorkers(discardLogger(t))

--- a/server/cmd/fleetnode/control_test.go
+++ b/server/cmd/fleetnode/control_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math/rand"
 	"net/http"
 	"strings"
 	"sync"
@@ -21,9 +22,11 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	commonpb "github.com/block/proto-fleet/server/generated/grpc/common/v1"
 	pb "github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1"
 	"github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1/fleetnodegatewayv1connect"
 	pairingpb "github.com/block/proto-fleet/server/generated/grpc/pairing/v1"
+	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 	discoverymodels "github.com/block/proto-fleet/server/internal/domain/minerdiscovery/models"
 	"github.com/block/proto-fleet/server/internal/fleetnode/bootstrap"
 	"github.com/block/proto-fleet/server/internal/testutil"
@@ -51,6 +54,7 @@ func runControlLoopOnce(t *testing.T, cmd *RunCmd, fake *controlFakeGateway) {
 	require.Eventually(t, func() bool { return fake.ackCount() > 0 }, 4*time.Second, 20*time.Millisecond)
 	cancel()
 	<-done
+	cmd.waitForControlWorkers(discardLogger(t))
 }
 
 func TestControlLoop_AcksAndReports(t *testing.T) {
@@ -337,6 +341,7 @@ func TestControlLoop_PartialResultsSurviveScanDeadline(t *testing.T) {
 	require.Eventually(t, func() bool { return fake.ackCount() > 0 }, 4*time.Second, 20*time.Millisecond)
 	cancel()
 	<-done
+	cmd.waitForControlWorkers(discardLogger(t))
 
 	// Assert: fast IP reported, ack signals PARTIAL.
 	reports := fake.reportsCopy()
@@ -433,9 +438,61 @@ func TestControlLoop_ReconnectsAfterStreamEOF(t *testing.T) {
 	require.Eventually(t, func() bool { return fake.helloCount() >= 2 }, 3*time.Second, 50*time.Millisecond)
 	cancel()
 	<-done
+	cmd.waitForControlWorkers(discardLogger(t))
 
 	// Assert: the loop reconnected at least once.
 	assert.GreaterOrEqual(t, fake.helloCount(), 2)
+}
+
+func TestIsNotActiveControlErrorRequiresStructuredDetail(t *testing.T) {
+	t.Parallel()
+
+	notActive := fleeterror.NewNotActiveError().ConnectError()
+	require.True(t, isNotActiveControlError(fmt.Errorf("recv: %w", notActive)))
+	require.False(t, isNotActiveControlError(connect.NewError(connect.CodeUnavailable, errors.New("plain unavailable"))))
+	require.False(t, isNotActiveControlError(connect.NewError(connect.CodeCanceled, errors.New("client canceled"))))
+
+	// Guard against accidentally matching a different structured common code.
+	other := connect.NewError(connect.CodeUnavailable, errors.New("other structured error"))
+	detail, err := connect.NewErrorDetail(&commonpb.FleetErrorDetails{Code: &commonpb.FleetErrorDetails_Common{
+		Common: commonpb.FleetErrorCode_FLEET_ERROR_CODE_UNSPECIFIED,
+	}})
+	require.NoError(t, err)
+	other.AddDetail(detail)
+	require.False(t, isNotActiveControlError(other))
+}
+
+func TestControlReconnectDelayNotActiveStaysInInitialJitterWindow(t *testing.T) {
+	t.Parallel()
+
+	rng := rand.New(rand.NewSource(42)) //nolint:gosec // deterministic jitter test
+	err := fleeterror.NewNotActiveError().ConnectError()
+	backoff := 16 * time.Second
+	for range 20 {
+		delay, nextBackoff := controlReconnectDelay(err, time.Second, backoff, rng)
+		assert.GreaterOrEqual(t, delay, time.Second)
+		assert.LessOrEqual(t, delay, 1500*time.Millisecond)
+		assert.Equal(t, controlReconnectInitial, nextBackoff)
+		backoff = nextBackoff
+	}
+}
+
+func TestControlReconnectDelayGenericFailuresRemainExponential(t *testing.T) {
+	t.Parallel()
+
+	rng := rand.New(rand.NewSource(42)) //nolint:gosec // deterministic jitter test
+	err := connect.NewError(connect.CodeUnavailable, errors.New("network unavailable"))
+	backoff := controlReconnectInitial
+
+	firstDelay, backoff := controlReconnectDelay(err, time.Second, backoff, rng)
+	assert.GreaterOrEqual(t, firstDelay, time.Second)
+	assert.LessOrEqual(t, firstDelay, 1500*time.Millisecond)
+	assert.Equal(t, 2*time.Second, backoff)
+
+	secondDelay, backoff := controlReconnectDelay(err, time.Second, backoff, rng)
+	assert.GreaterOrEqual(t, secondDelay, 2*time.Second)
+	assert.LessOrEqual(t, secondDelay, 3*time.Second)
+	assert.Equal(t, 4*time.Second, backoff)
 }
 
 type stubDiscoverer struct {
@@ -642,6 +699,109 @@ func newControlClient(t *testing.T, fake *controlFakeGateway) gatewayClient {
 	mux := http.NewServeMux()
 	path, h := fleetnodegatewayv1connect.NewFleetNodeGatewayServiceHandler(fake)
 	mux.Handle(path, h)
+	srv := testutil.NewH2CServer(t, mux)
+	return fleetnodegatewayv1connect.NewFleetNodeGatewayServiceClient(testutil.NewH2CClient(), srv.URL, connect.WithGRPC())
+}
+
+type reconnectControlGateway struct {
+	fleetnodegatewayv1connect.UnimplementedFleetNodeGatewayServiceHandler
+
+	firstCommands       []pendingCommand
+	replacementCommands chan pendingCommand
+	closeFirst          chan struct{}
+	sessions            atomic.Int32
+	mu                  sync.Mutex
+	acksBySession       map[int32][]*pb.ControlAck
+}
+
+func (f *reconnectControlGateway) ControlStream(ctx context.Context, stream *connect.BidiStream[pb.ControlStreamRequest, pb.ControlStreamResponse]) error {
+	first, err := stream.Receive()
+	if err != nil {
+		return fmt.Errorf("receive hello: %w", err)
+	}
+	if first.GetHello() == nil {
+		return connect.NewError(connect.CodeInvalidArgument, errors.New("expected hello"))
+	}
+	session := f.sessions.Add(1)
+	if err := stream.Send(&pb.ControlStreamResponse{Kind: &pb.ControlStreamResponse_Accepted{
+		Accepted: &pb.ControlAccepted{ServerTime: timestamppb.Now()},
+	}}); err != nil {
+		return fmt.Errorf("send accepted: %w", err)
+	}
+	if session == 1 {
+		for _, command := range f.firstCommands {
+			if err := sendFakeControlCommand(stream, command); err != nil {
+				return err
+			}
+		}
+	}
+
+	type receiveResult struct {
+		message *pb.ControlStreamRequest
+		err     error
+	}
+	incoming := make(chan receiveResult, 1)
+	go func() {
+		for {
+			message, receiveErr := stream.Receive()
+			incoming <- receiveResult{message: message, err: receiveErr}
+			if receiveErr != nil {
+				return
+			}
+		}
+	}()
+
+	var replacementCommands <-chan pendingCommand
+	var closeFirst <-chan struct{}
+	if session == 1 {
+		closeFirst = f.closeFirst
+	} else {
+		replacementCommands = f.replacementCommands
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-closeFirst:
+			return nil
+		case command := <-replacementCommands:
+			if err := sendFakeControlCommand(stream, command); err != nil {
+				return err
+			}
+		case result := <-incoming:
+			if result.err != nil {
+				return result.err
+			}
+			if ack := result.message.GetAck(); ack != nil {
+				f.mu.Lock()
+				f.acksBySession[session] = append(f.acksBySession[session], ack)
+				f.mu.Unlock()
+			}
+		}
+	}
+}
+
+func sendFakeControlCommand(stream *connect.BidiStream[pb.ControlStreamRequest, pb.ControlStreamResponse], command pendingCommand) error {
+	if err := stream.Send(&pb.ControlStreamResponse{Kind: &pb.ControlStreamResponse_Command{Command: &pb.ControlCommand{
+		CommandId: command.id,
+		Payload:   command.payload,
+	}}}); err != nil {
+		return fmt.Errorf("send command %s: %w", command.id, err)
+	}
+	return nil
+}
+
+func (f *reconnectControlGateway) sessionAcks(session int32) []*pb.ControlAck {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]*pb.ControlAck(nil), f.acksBySession[session]...)
+}
+
+func newReconnectControlClient(t *testing.T, fake *reconnectControlGateway) gatewayClient {
+	t.Helper()
+	mux := http.NewServeMux()
+	path, handler := fleetnodegatewayv1connect.NewFleetNodeGatewayServiceHandler(fake)
+	mux.Handle(path, handler)
 	srv := testutil.NewH2CServer(t, mux)
 	return fleetnodegatewayv1connect.NewFleetNodeGatewayServiceClient(testutil.NewH2CClient(), srv.URL, connect.WithGRPC())
 }
@@ -885,6 +1045,7 @@ func TestControlLoop_SecondConcurrentDiscoveryGetsBusy(t *testing.T) {
 
 	cancel()
 	<-done
+	cmd.waitForControlWorkers(discardLogger(t))
 }
 
 func TestControlLoop_CommandPoolCeilingAcksBusy(t *testing.T) {
@@ -940,6 +1101,108 @@ func TestControlLoop_CommandPoolCeilingAcksBusy(t *testing.T) {
 	close(release)
 	cancel()
 	<-done
+	cmd.waitForControlWorkers(discardLogger(t))
+}
+
+func TestControlLoop_ReconnectDoesNotWaitForOldWorkersAndRetainsTheirPermits(t *testing.T) {
+	// Arrange: fill all ordinary command permits with plugin calls that ignore
+	// session cancellation. The first stream will be dropped while they remain stuck.
+	controller := gomock.NewController(t)
+	releases := make([]chan struct{}, commandPoolSize)
+	for i := range releases {
+		releases[i] = make(chan struct{})
+	}
+	started := make(chan int, commandPoolSize)
+	var rebootCalls atomic.Int32
+	device := mocks.NewMockDevice(controller)
+	device.EXPECT().Reboot(gomock.Any()).DoAndReturn(func(context.Context) error {
+		call := int(rebootCalls.Add(1)) - 1
+		if call < commandPoolSize {
+			started <- call
+			<-releases[call] // deliberately ignores ctx
+		}
+		return nil
+	}).Times(commandPoolSize + 1)
+	device.EXPECT().Close(gomock.Any()).Return(nil).AnyTimes()
+	driver := mocks.NewMockDriver(controller)
+	driver.EXPECT().NewDevice(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(sdk.NewDeviceResult{Device: device}, nil).AnyTimes()
+	cmd := &RunCmd{driverGetter: fakeDriverGetter{d: driver}, minerSecrets: nodeSecretProvider{}}
+	payload := mustMarshal(t, &pb.AgentCommand{
+		Command: &pb.AgentCommand_MinerCommand{MinerCommand: withTarget(
+			&pb.MinerCommand{Action: &pb.MinerCommand_Reboot{Reboot: &pb.RebootAction{}}},
+		)},
+	})
+	firstCommands := make([]pendingCommand, commandPoolSize)
+	for i := range firstCommands {
+		firstCommands[i] = pendingCommand{id: fmt.Sprintf("old-%d", i), payload: payload}
+	}
+	fake := &reconnectControlGateway{
+		firstCommands:       firstCommands,
+		replacementCommands: make(chan pendingCommand, 2),
+		closeFirst:          make(chan struct{}),
+		acksBySession:       make(map[int32][]*pb.ControlAck),
+	}
+	client := newReconnectControlClient(t, fake)
+	state := &bootstrap.State{FleetNodeID: 7}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- cmd.runControlLoop(ctx, client, state, discardLogger(t)) }()
+	for range commandPoolSize {
+		select {
+		case <-started:
+		case <-time.After(3 * time.Second):
+			t.Fatal("old command workers did not fill the process-wide pool")
+		}
+	}
+
+	// Act: disconnect the first stream. Reconnection must happen while every old
+	// worker is still stuck and every permit is still occupied.
+	close(fake.closeFirst)
+	require.Eventually(t, func() bool { return fake.sessions.Load() >= 2 }, 3*time.Second, 20*time.Millisecond,
+		"replacement stream should open without draining old command handlers")
+	fake.replacementCommands <- pendingCommand{id: "replacement-busy", payload: payload}
+	require.Eventually(t, func() bool {
+		for _, ack := range fake.sessionAcks(2) {
+			if ack.GetCommandId() == "replacement-busy" {
+				return ack.GetCode() == pb.AckCode_ACK_CODE_BUSY
+			}
+		}
+		return false
+	}, 2*time.Second, 20*time.Millisecond)
+	require.Len(t, cmd.controlCommandSlots, commandPoolSize, "old workers must retain all permits across reconnect")
+
+	// Releasing exactly one old worker creates exactly one slot for the new stream.
+	close(releases[0])
+	require.Eventually(t, func() bool { return len(cmd.controlCommandSlots) == commandPoolSize-1 }, 2*time.Second, 20*time.Millisecond)
+	fake.replacementCommands <- pendingCommand{id: "replacement-ok", payload: payload}
+	require.Eventually(t, func() bool {
+		for _, ack := range fake.sessionAcks(2) {
+			if ack.GetCommandId() == "replacement-ok" {
+				return ack.GetCode() == pb.AckCode_ACK_CODE_OK && ack.GetSucceeded()
+			}
+		}
+		return false
+	}, 2*time.Second, 20*time.Millisecond)
+
+	// A late old completion is bound to the discarded first-session sender and
+	// cannot appear on the replacement stream.
+	for _, ack := range fake.sessionAcks(2) {
+		assert.NotContains(t, ack.GetCommandId(), "old-")
+	}
+
+	// Cleanup after the assertions so stuck workers are observable during reconnect.
+	for i := 1; i < len(releases); i++ {
+		close(releases[i])
+	}
+	require.Eventually(t, func() bool { return len(cmd.controlCommandSlots) == 0 }, 2*time.Second, 20*time.Millisecond)
+	cancel()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("control loop did not stop")
+	}
 }
 
 func TestControlLoop_CtxCancelDuringInFlightUnblocks(t *testing.T) {
@@ -971,6 +1234,7 @@ func TestControlLoop_CtxCancelDuringInFlightUnblocks(t *testing.T) {
 	case <-time.After(3 * time.Second):
 		t.Fatal("runControlLoop did not return after ctx cancel")
 	}
+	cmd.waitForControlWorkers(discardLogger(t))
 }
 
 func TestFanOutProbes_SupervisorReturnsPartialOnStuckPlugin(t *testing.T) {
@@ -1082,6 +1346,7 @@ func TestControlLoop_SupervisorTruncatedScanAcksPartial(t *testing.T) {
 	require.Eventually(t, func() bool { return fake.ackCount() > 0 }, 3*time.Second, 20*time.Millisecond)
 	cancel()
 	<-done
+	cmd.waitForControlWorkers(discardLogger(t))
 
 	// Assert
 	acks := fake.acksCopy()
@@ -1206,6 +1471,7 @@ func TestControlLoop_DroppedStreamCancelsInFlightScan(t *testing.T) {
 	require.Eventually(t, func() bool { return fake.helloCount() >= 2 }, 4*time.Second, 50*time.Millisecond)
 	cancel()
 	<-done
+	cmd.waitForControlWorkers(discardLogger(t))
 }
 
 func TestDecodeAgentCommandLane(t *testing.T) {
@@ -1267,6 +1533,7 @@ func TestControlLoop_DropsCommandWithInvalidCommandID(t *testing.T) {
 	require.Eventually(t, func() bool { return fake.ackCount() >= 1 }, 3*time.Second, 20*time.Millisecond)
 	cancel()
 	<-done
+	cmd.waitForControlWorkers(discardLogger(t))
 
 	// Assert: exactly the valid command was acked.
 	acks := fake.acksCopy()
@@ -1308,6 +1575,7 @@ func TestControlLoop_ConcurrentAcksSerialize(t *testing.T) {
 	require.Eventually(t, func() bool { return fake.ackCount() >= 4 }, 4*time.Second, 20*time.Millisecond)
 	cancel()
 	<-done
+	cmd.waitForControlWorkers(discardLogger(t))
 }
 
 func TestSendAck_TruncationPreservesUTF8Boundaries(t *testing.T) {

--- a/server/cmd/fleetnode/control_test.go
+++ b/server/cmd/fleetnode/control_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -1620,6 +1621,35 @@ func TestSendAckWithPayload_DowngradesOversizedOKPayload(t *testing.T) {
 	assert.Contains(t, got.GetErrorMessage(), "ack payload too large")
 }
 
+func TestSendAck_ClosedSessionDropsWithoutWarning(t *testing.T) {
+	// Arrange
+	inner := &capturingAcker{}
+	sender := &lockedAcker{inner: inner}
+	sender.Close()
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, nil))
+
+	// Act
+	(&RunCmd{}).sendAck(sender, "old-command", pb.AckCode_ACK_CODE_OK, "", logger)
+
+	// Assert
+	assert.Empty(t, inner.sent, "a late ack must not reach the discarded session")
+	assert.NotContains(t, logs.String(), "send ack failed")
+}
+
+func TestSendAck_TransportFailureWarns(t *testing.T) {
+	// Arrange
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, nil))
+
+	// Act
+	(&RunCmd{}).sendAck(errorAcker{err: io.ErrClosedPipe}, "current-command", pb.AckCode_ACK_CODE_OK, "", logger)
+
+	// Assert
+	assert.Contains(t, logs.String(), "send ack failed")
+	assert.Contains(t, logs.String(), "current-command")
+}
+
 type capturingAcker struct {
 	sent []*pb.ControlStreamRequest
 }
@@ -1627,4 +1657,12 @@ type capturingAcker struct {
 func (c *capturingAcker) Send(req *pb.ControlStreamRequest) error {
 	c.sent = append(c.sent, req)
 	return nil
+}
+
+type errorAcker struct {
+	err error
+}
+
+func (a errorAcker) Send(*pb.ControlStreamRequest) error {
+	return a.err
 }

--- a/server/cmd/fleetnode/pair_test.go
+++ b/server/cmd/fleetnode/pair_test.go
@@ -346,6 +346,7 @@ func TestControlLoop_PairSupervisorTruncatedAcksPartial(t *testing.T) {
 	require.Eventually(t, func() bool { return fake.ackCount() > 0 }, 3*time.Second, 20*time.Millisecond)
 	cancel()
 	<-done
+	cmd.waitForControlWorkers(discardLogger(t))
 
 	// Assert
 	acks := fake.acksCopy()

--- a/server/cmd/fleetnode/run.go
+++ b/server/cmd/fleetnode/run.go
@@ -25,6 +25,9 @@ const (
 	sessionRefreshLeeway     = 1 * time.Hour
 )
 
+// Var so the bounded-shutdown path can be exercised without a 10-second test.
+var controlWorkerShutdownTimeout = 10 * time.Second
+
 type RunCmd struct {
 	HeartbeatInterval    time.Duration `name:"heartbeat-interval" default:"30s" help:"interval between UploadHeartbeat calls"`
 	LocalDiscoverySubnet string        `name:"local-discovery-subnet" env:"FLEETNODE_LOCAL_DISCOVERY_SUBNET" help:"CIDR to scan for automatic local-subnet discovery instead of detecting the host subnet"`
@@ -46,6 +49,11 @@ type RunCmd struct {
 
 	stateMu sync.Mutex `kong:"-"` // guards st.SessionToken across refreshAndSave + tokenSource.
 	pairMu  sync.Mutex `kong:"-"` // serializes pair commands; held until every pair worker exits (see handlePairCommand).
+
+	controlConcurrencyOnce sync.Once      `kong:"-"`
+	controlCommandSlots    chan struct{}  `kong:"-"`
+	controlDiscoverySlot   chan struct{}  `kong:"-"`
+	controlWorkers         sync.WaitGroup `kong:"-"`
 }
 
 type gatewayClient interface {
@@ -242,11 +250,43 @@ func (r *RunCmd) runLocked(ctx context.Context, c *Context, resolvedPluginsDir s
 
 	wg.Wait()
 	close(errCh)
+	var loopErr error
 	for err := range errCh {
-		return err
+		if loopErr == nil {
+			loopErr = err
+		}
+	}
+	r.waitForControlWorkers(logger)
+	if loopErr != nil {
+		return loopErr
 	}
 	logger.Info("daemon shutting down", "fleet_node_id", st.FleetNodeID)
 	return nil
+}
+
+func (r *RunCmd) initControlConcurrency() {
+	r.controlConcurrencyOnce.Do(func() {
+		r.controlCommandSlots = make(chan struct{}, commandPoolSize)
+		r.controlDiscoverySlot = make(chan struct{}, 1)
+	})
+}
+
+func (r *RunCmd) waitForControlWorkers(logger *slog.Logger) {
+	r.initControlConcurrency()
+	done := make(chan struct{})
+	go func() {
+		r.controlWorkers.Wait()
+		close(done)
+	}()
+	timer := time.NewTimer(controlWorkerShutdownTimeout)
+	defer timer.Stop()
+	select {
+	case <-done:
+	case <-timer.C:
+		logger.Warn("control command handlers still running; continuing daemon shutdown",
+			"timeout", controlWorkerShutdownTimeout.String(),
+			"workers", len(r.controlCommandSlots)+len(r.controlDiscoverySlot))
+	}
 }
 
 func (r *RunCmd) runHeartbeatLoop(ctx context.Context, client gatewayClient, st *bootstrap.State, path string, logger *slog.Logger) error {

--- a/server/cmd/fleetnode/run.go
+++ b/server/cmd/fleetnode/run.go
@@ -47,8 +47,10 @@ type RunCmd struct {
 	localSubnets             func() ([]string, error)                                                 `kong:"-"` // test seam for local-subnet detection
 	firmwareTempRoot         string                                                                   `kong:"-"`
 
-	stateMu sync.Mutex `kong:"-"` // guards st.SessionToken across refreshAndSave + tokenSource.
+	stateMu sync.Mutex `kong:"-"` // guards session state and the active control-session cancel func.
 	pairMu  sync.Mutex `kong:"-"` // serializes pair commands; held until every pair worker exits (see handlePairCommand).
+
+	controlSessionCancel context.CancelCauseFunc `kong:"-"`
 
 	controlConcurrencyOnce sync.Once      `kong:"-"`
 	controlCommandSlots    chan struct{}  `kong:"-"`
@@ -328,7 +330,11 @@ func (r *RunCmd) refreshAndSave(ctx context.Context, st *bootstrap.State, path s
 	// Snapshot under the lock so SaveState's yaml.Marshal doesn't race the
 	// tokenSource goroutine that the control loop will add later.
 	snapshot := *st
+	cancelControlSession := r.controlSessionCancel
 	r.stateMu.Unlock()
+	if cancelControlSession != nil {
+		cancelControlSession(errControlSessionRotated)
+	}
 	if err := bootstrap.SaveState(path, &snapshot); err != nil {
 		return fmt.Errorf("save state after refresh: %w", err)
 	}

--- a/server/cmd/fleetnode/run_test.go
+++ b/server/cmd/fleetnode/run_test.go
@@ -134,6 +134,25 @@ func TestRunCmd_HappyPathThreeTicks(t *testing.T) {
 	assert.GreaterOrEqual(t, calls, 3, "daemon must send at least 3 heartbeats before shutdown")
 }
 
+func TestRunCmd_ControlWorkerShutdownWaitIsBounded(t *testing.T) {
+	require.Equal(t, 10*time.Second, controlWorkerShutdownTimeout)
+	previousTimeout := controlWorkerShutdownTimeout
+	controlWorkerShutdownTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { controlWorkerShutdownTimeout = previousTimeout })
+
+	cmd := &RunCmd{}
+	cmd.initControlConcurrency()
+	cmd.controlWorkers.Add(1)
+	t.Cleanup(cmd.controlWorkers.Done)
+
+	started := time.Now()
+	cmd.waitForControlWorkers(discardLogger(t))
+	elapsed := time.Since(started)
+
+	assert.GreaterOrEqual(t, elapsed, controlWorkerShutdownTimeout)
+	assert.Less(t, elapsed, 500*time.Millisecond, "daemon shutdown must continue after its worker budget")
+}
+
 func TestRunCmd_RefreshesNearExpirySession(t *testing.T) {
 	t.Parallel()
 

--- a/server/cmd/fleetnode/run_test.go
+++ b/server/cmd/fleetnode/run_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
+	"net/http"
 	"os"
 	"path/filepath"
 	"sync"
@@ -19,8 +20,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	pb "github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1"
+	"github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1/fleetnodegatewayv1connect"
 
 	"github.com/block/proto-fleet/server/internal/fleetnode/bootstrap"
+	"github.com/block/proto-fleet/server/internal/testutil"
 )
 
 type stubGatewayClient struct {
@@ -30,6 +33,25 @@ type stubGatewayClient struct {
 	responder        func(call int) error
 	cancelAfterCalls int
 	cancel           context.CancelFunc
+}
+
+type authRecordingControlGateway struct {
+	controlFakeGateway
+	authMu      sync.Mutex
+	authHeaders []string
+}
+
+func (f *authRecordingControlGateway) ControlStream(ctx context.Context, stream *connect.BidiStream[pb.ControlStreamRequest, pb.ControlStreamResponse]) error {
+	f.authMu.Lock()
+	f.authHeaders = append(f.authHeaders, stream.RequestHeader().Get("Authorization"))
+	f.authMu.Unlock()
+	return f.controlFakeGateway.ControlStream(ctx, stream)
+}
+
+func (f *authRecordingControlGateway) controlAuthHeaders() []string {
+	f.authMu.Lock()
+	defer f.authMu.Unlock()
+	return append([]string(nil), f.authHeaders...)
 }
 
 func (s *stubGatewayClient) UploadHeartbeat(_ context.Context, req *connect.Request[pb.UploadHeartbeatRequest]) (*connect.Response[pb.UploadHeartbeatResponse], error) {
@@ -206,6 +228,114 @@ func TestRunCmd_RefreshesNearExpirySession(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "session-rotated", loaded.SessionToken, "near-expiry session must be refreshed before first heartbeat")
 	assert.Equal(t, 1, fake.heartbeatCount(), "exactly one heartbeat before shutdown")
+}
+
+func TestRunCmd_SuccessfulRefreshRetiresActiveControlSession(t *testing.T) {
+	dir := t.TempDir()
+	pubKey, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	fakeAuth := &fakeFleetNodeGateway{
+		expectedAPIKey:   "fleet_known_key",
+		identityPub:      pubKey,
+		challenge:        bytes.Repeat([]byte{0x34}, 32),
+		sessionToken:     "session-2",
+		sessionExpiresAt: time.Now().Add(24 * time.Hour),
+	}
+	authServer := newFakeServer(t, fakeAuth)
+	state := &bootstrap.State{
+		ServerURL:              authServer.URL,
+		AllowInsecureTransport: true,
+		FleetNodeID:            42,
+		IdentityPrivateKeyHex:  hex.EncodeToString(priv),
+		IdentityPublicKeyHex:   hex.EncodeToString(pubKey),
+		APIKey:                 "fleet_known_key",
+		SessionToken:           "session-1",
+		SessionExpiresAt:       time.Now().Add(12 * time.Hour),
+	}
+	statePath := bootstrap.StatePath(dir)
+	require.NoError(t, bootstrap.SaveState(statePath, state))
+
+	controlGateway := &authRecordingControlGateway{}
+	mux := http.NewServeMux()
+	path, handler := fleetnodegatewayv1connect.NewFleetNodeGatewayServiceHandler(controlGateway)
+	mux.Handle(path, handler)
+	controlServer := testutil.NewH2CServer(t, mux)
+	cmd := &RunCmd{}
+	client, err := bootstrap.NewAuthenticatedGatewayClient(controlServer.URL, func() string {
+		cmd.stateMu.Lock()
+		defer cmd.stateMu.Unlock()
+		return state.SessionToken
+	})
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.runControlLoop(ctx, client, state, discardLogger(t))
+	}()
+	require.Eventually(t, func() bool {
+		headers := controlGateway.controlAuthHeaders()
+		return len(headers) == 1 && headers[0] == "Bearer session-1"
+	}, time.Second, 10*time.Millisecond)
+
+	require.NoError(t, cmd.refreshAndSave(ctx, state, statePath, discardLogger(t)))
+	require.Eventually(t, func() bool {
+		headers := controlGateway.controlAuthHeaders()
+		return len(headers) == 2 && headers[0] == "Bearer session-1" && headers[1] == "Bearer session-2"
+	}, 2*time.Second, 10*time.Millisecond)
+	cancel()
+	require.NoError(t, <-done)
+	assert.Equal(t, "session-2", state.SessionToken)
+}
+
+func TestRunCmd_RefreshFailureCannotExtendControlStreamPastExpiry(t *testing.T) {
+	dir := t.TempDir()
+	pubKey, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	fakeAuth := &fakeFleetNodeGateway{
+		expectedAPIKey: "fleet_known_key",
+		identityPub:    pubKey,
+		beginAuthError: connect.NewError(connect.CodeUnavailable, errors.New("refresh unavailable")),
+	}
+	authServer := newFakeServer(t, fakeAuth)
+	expiresAt := time.Now().Add(2 * time.Second)
+	state := &bootstrap.State{
+		ServerURL:              authServer.URL,
+		AllowInsecureTransport: true,
+		FleetNodeID:            42,
+		IdentityPrivateKeyHex:  hex.EncodeToString(priv),
+		IdentityPublicKeyHex:   hex.EncodeToString(pubKey),
+		APIKey:                 "fleet_known_key",
+		SessionToken:           "session-1",
+		SessionExpiresAt:       expiresAt,
+	}
+	statePath := bootstrap.StatePath(dir)
+	require.NoError(t, bootstrap.SaveState(statePath, state))
+
+	controlGateway := &controlFakeGateway{}
+	client := newControlClient(t, controlGateway)
+	cmd := &RunCmd{}
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.runControlSession(ctx, discardLogger(t), client, state)
+	}()
+	require.Eventually(t, func() bool { return controlGateway.helloCount() == 1 }, time.Second, 10*time.Millisecond)
+
+	require.Error(t, cmd.refreshAndSave(ctx, state, statePath, discardLogger(t)))
+	select {
+	case sessionErr := <-done:
+		t.Fatalf("failed refresh retired the stream before token expiry: %v", sessionErr)
+	case <-time.After(100 * time.Millisecond):
+	}
+	select {
+	case sessionErr := <-done:
+		require.ErrorIs(t, sessionErr, errControlSessionExpired)
+	case <-time.After(time.Until(expiresAt) + time.Second):
+		t.Fatal("control session survived past the opening token expiry")
+	}
+	assert.Equal(t, "session-1", state.SessionToken)
 }
 
 func TestRunCmd_RefreshesOnUnauthenticatedResponse(t *testing.T) {

--- a/server/internal/domain/fleetnode/auth/service.go
+++ b/server/internal/domain/fleetnode/auth/service.go
@@ -36,10 +36,11 @@ type Store interface {
 
 // ResolvedFleetNode is the join of a fleet_node_session and its fleet_node row.
 type ResolvedFleetNode struct {
-	FleetNodeID    int64
-	OrgID          int64
-	Name           string
-	IdentityPubkey []byte
+	FleetNodeID      int64
+	OrgID            int64
+	Name             string
+	IdentityPubkey   []byte
+	SessionExpiresAt time.Time
 }
 
 type Service struct {
@@ -101,32 +102,32 @@ func (s *Service) BeginHandshake(ctx context.Context, apiKeyPlaintext string, id
 	return challenge, expiresAt, nil
 }
 
-func (s *Service) CompleteHandshake(ctx context.Context, challenge, signature []byte) (string, time.Time, error) {
+func (s *Service) CompleteHandshake(ctx context.Context, challenge, signature []byte) (string, time.Time, int64, error) {
 	now := time.Now().UTC()
 	// ConsumeChallenge is DELETE ... RETURNING; a replayed challenge finds
 	// nothing and returns NotFound.
 	agentID, err := s.store.ConsumeChallenge(ctx, challenge, now)
 	if err != nil {
 		if fleeterror.IsNotFoundError(err) {
-			return "", time.Time{}, fleeterror.NewUnauthenticatedError("challenge expired or not found")
+			return "", time.Time{}, 0, fleeterror.NewUnauthenticatedError("challenge expired or not found")
 		}
-		return "", time.Time{}, logInternal("consume challenge", clientErrAuth, err)
+		return "", time.Time{}, 0, logInternal("consume challenge", clientErrAuth, err)
 	}
 
 	agent, err := s.enrollmentStore.GetFleetNodeByIDUnscoped(ctx, agentID)
 	if err != nil {
 		if fleeterror.IsNotFoundError(err) {
-			return "", time.Time{}, fleeterror.NewUnauthenticatedError("fleet node not found")
+			return "", time.Time{}, 0, fleeterror.NewUnauthenticatedError("fleet node not found")
 		}
-		return "", time.Time{}, logInternal("fleet node lookup", clientErrAuth, err)
+		return "", time.Time{}, 0, logInternal("fleet node lookup", clientErrAuth, err)
 	}
 	if !ed25519.Verify(agent.IdentityPubkey, challenge, signature) {
-		return "", time.Time{}, fleeterror.NewUnauthenticatedError("signature verification failed")
+		return "", time.Time{}, 0, fleeterror.NewUnauthenticatedError("signature verification failed")
 	}
 
 	tokenBytes := make([]byte, sessionTokenBytes)
 	if _, err := rand.Read(tokenBytes); err != nil {
-		return "", time.Time{}, logInternal("generate session token", clientErrAuth, err)
+		return "", time.Time{}, 0, logInternal("generate session token", clientErrAuth, err)
 	}
 	plaintext := base64.RawURLEncoding.EncodeToString(tokenBytes)
 	expiresAt := now.Add(s.sessionTTL)
@@ -134,9 +135,9 @@ func (s *Service) CompleteHandshake(ctx context.Context, challenge, signature []
 	// (one session per fleet node enforced by uq_fleet_node_session_fleet_node_id), so
 	// re-authentication rotates the bearer token instead of accumulating.
 	if err := s.store.UpsertSession(ctx, hashToken(plaintext), agentID, expiresAt); err != nil {
-		return "", time.Time{}, logInternal("store session", clientErrAuth, err)
+		return "", time.Time{}, 0, logInternal("store session", clientErrAuth, err)
 	}
-	return plaintext, expiresAt, nil
+	return plaintext, expiresAt, agentID, nil
 }
 
 func (s *Service) ResolveSession(ctx context.Context, sessionTokenPlaintext string) (*ResolvedFleetNode, error) {

--- a/server/internal/domain/fleetnode/auth/service.go
+++ b/server/internal/domain/fleetnode/auth/service.go
@@ -36,11 +36,12 @@ type Store interface {
 
 // ResolvedFleetNode is the join of a fleet_node_session and its fleet_node row.
 type ResolvedFleetNode struct {
-	FleetNodeID      int64
-	OrgID            int64
-	Name             string
-	IdentityPubkey   []byte
-	SessionExpiresAt time.Time
+	FleetNodeID        int64
+	OrgID              int64
+	Name               string
+	IdentityPubkey     []byte
+	SessionExpiresAt   time.Time
+	SessionFingerprint string
 }
 
 type Service struct {
@@ -134,20 +135,22 @@ func (s *Service) CompleteHandshake(ctx context.Context, challenge, signature []
 	// UpsertSession atomically replaces any prior session for this fleet node
 	// (one session per fleet node enforced by uq_fleet_node_session_fleet_node_id), so
 	// re-authentication rotates the bearer token instead of accumulating.
-	if err := s.store.UpsertSession(ctx, hashToken(plaintext), agentID, expiresAt); err != nil {
+	if err := s.store.UpsertSession(ctx, SessionFingerprint(plaintext), agentID, expiresAt); err != nil {
 		return "", time.Time{}, 0, logInternal("store session", clientErrAuth, err)
 	}
 	return plaintext, expiresAt, agentID, nil
 }
 
 func (s *Service) ResolveSession(ctx context.Context, sessionTokenPlaintext string) (*ResolvedFleetNode, error) {
-	row, err := s.store.GetSessionFleetNode(ctx, hashToken(sessionTokenPlaintext), time.Now().UTC())
+	fingerprint := SessionFingerprint(sessionTokenPlaintext)
+	row, err := s.store.GetSessionFleetNode(ctx, fingerprint, time.Now().UTC())
 	if err != nil {
 		if fleeterror.IsNotFoundError(err) {
 			return nil, fleeterror.NewUnauthenticatedError("invalid session token")
 		}
 		return nil, logInternal("session lookup", clientErrAuth, err)
 	}
+	row.SessionFingerprint = fingerprint
 	return row, nil
 }
 
@@ -168,6 +171,7 @@ func logInternal(op, clientMsg string, err error) error {
 	return fleeterror.LogInternal(component, op, clientMsg, err)
 }
 
-func hashToken(plaintext string) string {
+// SessionFingerprint identifies a bearer session without retaining its secret.
+func SessionFingerprint(plaintext string) string {
 	return cryptohash.Sha256Hex(plaintext)
 }

--- a/server/internal/domain/fleetnode/auth/subject.go
+++ b/server/internal/domain/fleetnode/auth/subject.go
@@ -14,6 +14,7 @@ type Subject struct {
 	OrgID               int64
 	Name                string
 	IdentityFingerprint string
+	SessionFingerprint  string
 }
 
 func GetSubject(ctx context.Context) (*Subject, error) {

--- a/server/internal/domain/fleetnode/control/registry.go
+++ b/server/internal/domain/fleetnode/control/registry.go
@@ -67,6 +67,10 @@ var (
 	// ErrNoActiveStream: no ControlStream for the fleet_node (callers map to FailedPrecondition).
 	ErrNoActiveStream = errors.New("no active control stream for fleet_node")
 
+	// errSessionInvalidated: the authenticated session was replaced or revoked
+	// before its ControlStream could register.
+	errSessionInvalidated = errors.New("fleet_node session was replaced or revoked")
+
 	// errNoInFlightCommand: AdmitReport's command_id isn't an in-flight report-bearing
 	// command. Unexported; callers map it to FailedPrecondition like any non-quota admit failure.
 	errNoInFlightCommand = errors.New("no in-flight command for fleet_node")
@@ -202,13 +206,20 @@ func (c *inflightCommand) reportBearing() bool { return c.events != nil }
 type Registry struct {
 	mu                       sync.Mutex
 	conns                    map[int64]*connection
+	sessionFences            map[int64]sessionFence
 	commandArtifactUploads   map[int64]int
 	commandArtifactDownloads map[int64]int
+}
+
+type sessionFence struct {
+	fingerprint string
+	revoked     bool
 }
 
 func NewRegistry() *Registry {
 	return &Registry{
 		conns:                    make(map[int64]*connection),
+		sessionFences:            make(map[int64]sessionFence),
 		commandArtifactUploads:   make(map[int64]int),
 		commandArtifactDownloads: make(map[int64]int),
 	}

--- a/server/internal/domain/fleetnode/control/registry_test.go
+++ b/server/internal/domain/fleetnode/control/registry_test.go
@@ -48,6 +48,50 @@ func TestRegistry_ReRegisterEvictsPriorStream(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestRegistry_DelayedRegistrationRejectsInvalidatedSession(t *testing.T) {
+	tests := []struct {
+		name       string
+		invalidate func(*Registry)
+	}{
+		{
+			name: "replaced",
+			invalidate: func(r *Registry) {
+				r.ReplaceSession(7, "new-session")
+			},
+		},
+		{
+			name: "revoked",
+			invalidate: func(r *Registry) {
+				r.RevokeSession(7)
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r := NewRegistry()
+
+			// The old session authenticated before invalidation, but does not
+			// register until its delayed Hello arrives afterward.
+			test.invalidate(r)
+			stream, err := r.RegisterAuthenticated(7, "old-session")
+
+			require.ErrorIs(t, err, errSessionInvalidated)
+			require.Nil(t, stream)
+			require.Empty(t, r.ConnectedFleetNodeIDs())
+		})
+	}
+}
+
+func TestRegistry_ReplacedSessionAllowsCurrentCredential(t *testing.T) {
+	r := NewRegistry()
+	r.ReplaceSession(7, "new-session")
+
+	stream, err := r.RegisterAuthenticated(7, "new-session")
+
+	require.NoError(t, err)
+	defer stream.Unregister()
+}
+
 func TestRegistry_SendWithoutStreamReturnsErrNoActiveStream(t *testing.T) {
 	// Arrange
 	r := NewRegistry()

--- a/server/internal/domain/fleetnode/control/stream.go
+++ b/server/internal/domain/fleetnode/control/stream.go
@@ -38,6 +38,18 @@ func (r *Registry) Register(fleetNodeID int64) *Stream {
 	return &Stream{r: r, fleetNodeID: fleetNodeID, conn: conn, Outgoing: conn.outgoing, Done: conn.done}
 }
 
+// Disconnect tears down the active ControlStream for fleetNodeID, if any.
+func (r *Registry) Disconnect(fleetNodeID int64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	conn, ok := r.conns[fleetNodeID]
+	if !ok {
+		return
+	}
+	teardown(conn)
+	delete(r.conns, fleetNodeID)
+}
+
 // Unregister tears the connection down so blocked senders/the handler wake. No-op if
 // already evicted (newest-wins replacement).
 func (s *Stream) Unregister() {

--- a/server/internal/domain/fleetnode/control/stream.go
+++ b/server/internal/domain/fleetnode/control/stream.go
@@ -26,6 +26,23 @@ type Stream struct {
 func (r *Registry) Register(fleetNodeID int64) *Stream {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	return r.registerLocked(fleetNodeID)
+}
+
+// RegisterAuthenticated installs a connection only if its bearer session has
+// not been replaced or revoked since authentication. A missing fence is valid:
+// the database-backed authentication check is authoritative after process start.
+func (r *Registry) RegisterAuthenticated(fleetNodeID int64, sessionFingerprint string) (*Stream, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	fence, exists := r.sessionFences[fleetNodeID]
+	if exists && (fence.revoked || fence.fingerprint != sessionFingerprint) {
+		return nil, errSessionInvalidated
+	}
+	return r.registerLocked(fleetNodeID), nil
+}
+
+func (r *Registry) registerLocked(fleetNodeID int64) *Stream {
 	if old, exists := r.conns[fleetNodeID]; exists {
 		teardown(old)
 	}
@@ -38,10 +55,32 @@ func (r *Registry) Register(fleetNodeID int64) *Stream {
 	return &Stream{r: r, fleetNodeID: fleetNodeID, conn: conn, Outgoing: conn.outgoing, Done: conn.done}
 }
 
+// ReplaceSession fences out streams authenticated with older credentials and
+// disconnects the currently registered stream, if any.
+func (r *Registry) ReplaceSession(fleetNodeID int64, sessionFingerprint string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.sessionFences[fleetNodeID] = sessionFence{fingerprint: sessionFingerprint}
+	r.disconnectLocked(fleetNodeID)
+}
+
+// RevokeSession fences out every authenticated session and disconnects the
+// currently registered stream, if any.
+func (r *Registry) RevokeSession(fleetNodeID int64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.sessionFences[fleetNodeID] = sessionFence{revoked: true}
+	r.disconnectLocked(fleetNodeID)
+}
+
 // Disconnect tears down the active ControlStream for fleetNodeID, if any.
 func (r *Registry) Disconnect(fleetNodeID int64) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	r.disconnectLocked(fleetNodeID)
+}
+
+func (r *Registry) disconnectLocked(fleetNodeID int64) {
 	conn, ok := r.conns[fleetNodeID]
 	if !ok {
 		return

--- a/server/internal/domain/fleetnode/enrollment/integration_test.go
+++ b/server/internal/domain/fleetnode/enrollment/integration_test.go
@@ -77,9 +77,10 @@ func TestEnrollmentHappyPath(t *testing.T) {
 	challenge, _, err := auth.BeginHandshake(ctx, apiKeyPlaintext, pubKey)
 	require.NoError(t, err)
 	signature := ed25519.Sign(privKey, challenge)
-	sessionToken, _, err := auth.CompleteHandshake(ctx, challenge, signature)
+	sessionToken, sessionExpiresAt, authenticatedFleetNodeID, err := auth.CompleteHandshake(ctx, challenge, signature)
 	require.NoError(t, err)
 	require.NotEmpty(t, sessionToken)
+	require.Equal(t, agent.ID, authenticatedFleetNodeID)
 
 	// Act 5: session resolves to the same agent
 	resolved, err := auth.ResolveSession(ctx, sessionToken)
@@ -89,6 +90,7 @@ func TestEnrollmentHappyPath(t *testing.T) {
 	require.Equal(t, agent.ID, resolved.FleetNodeID)
 	require.Equal(t, orgID, resolved.OrgID)
 	require.Equal(t, "agent-1", resolved.Name)
+	require.WithinDuration(t, sessionExpiresAt, resolved.SessionExpiresAt, time.Microsecond)
 }
 
 func TestRegisterRejectsReplay(t *testing.T) {
@@ -136,11 +138,11 @@ func TestCompleteHandshakeRejectsReplayedChallenge(t *testing.T) {
 	challenge, _, err := auth.BeginHandshake(ctx, apiKeyPlaintext, pubKey)
 	require.NoError(t, err)
 	signature := ed25519.Sign(privKey, challenge)
-	_, _, err = auth.CompleteHandshake(ctx, challenge, signature)
+	_, _, _, err = auth.CompleteHandshake(ctx, challenge, signature)
 	require.NoError(t, err)
 
 	// Act
-	_, _, err2 := auth.CompleteHandshake(ctx, challenge, signature)
+	_, _, _, err2 := auth.CompleteHandshake(ctx, challenge, signature)
 
 	// Assert
 	require.Error(t, err2, "second CompleteHandshake with the same challenge must fail")
@@ -403,7 +405,7 @@ func TestConcurrentCompleteHandshakesYieldOneSession(t *testing.T) {
 	for _, sc := range signedChallenges {
 		go func(sc signed) {
 			defer wg.Done()
-			_, _, _ = auth.CompleteHandshake(ctx, sc.challenge, sc.sig)
+			_, _, _, _ = auth.CompleteHandshake(ctx, sc.challenge, sc.sig)
 		}(sc)
 	}
 	wg.Wait()
@@ -427,7 +429,7 @@ func TestCompleteHandshakeRaceWithRevokeReturnsUnauthenticated(t *testing.T) {
 	require.NoError(t, enrollment.RevokeFleetNode(ctx, agent.ID, orgID))
 
 	// Act
-	_, _, completeErr := auth.CompleteHandshake(ctx, challenge, ed25519.Sign(privKey, challenge))
+	_, _, _, completeErr := auth.CompleteHandshake(ctx, challenge, ed25519.Sign(privKey, challenge))
 
 	// Assert
 	require.Error(t, completeErr)

--- a/server/internal/domain/fleetnode/enrollment/service.go
+++ b/server/internal/domain/fleetnode/enrollment/service.go
@@ -84,7 +84,8 @@ type Service struct {
 	transactor  stores.Transactor
 	activitySvc *activity.Service
 
-	invalidateMiner func(context.Context, int64)
+	invalidateMiner         func(context.Context, int64)
+	invalidateControlStream func(int64)
 }
 
 func NewService(store Store, apiKeySvc *apikey.Service, transactor stores.Transactor, activitySvc *activity.Service) *Service {
@@ -96,6 +97,11 @@ func NewService(store Store, apiKeySvc *apikey.Service, transactor stores.Transa
 // for those devices must be evicted before another command can reuse its descriptor.
 func (s *Service) WithMinerInvalidator(invalidate func(context.Context, int64)) {
 	s.invalidateMiner = invalidate
+}
+
+// WithControlStreamInvalidator wires active stream eviction for node revocation.
+func (s *Service) WithControlStreamInvalidator(invalidate func(int64)) {
+	s.invalidateControlStream = invalidate
 }
 
 func (s *Service) CreateCodeWithEnrollmentID(ctx context.Context, userID, orgID int64, ttl time.Duration) (string, int64, time.Time, error) {
@@ -331,6 +337,9 @@ func (s *Service) revokeFleetNode(ctx context.Context, agentID, orgID, expectedP
 		return nil
 	}); err != nil {
 		return err
+	}
+	if s.invalidateControlStream != nil {
+		s.invalidateControlStream(agentID)
 	}
 	if s.invalidateMiner != nil {
 		for _, deviceID := range deviceIDs {

--- a/server/internal/domain/fleetnode/enrollment/service_test.go
+++ b/server/internal/domain/fleetnode/enrollment/service_test.go
@@ -78,7 +78,7 @@ func TestRevokeFleetNodeInvalidatesControlStreamAfterPersistence(t *testing.T) {
 			store := &revokeFleetNodeStore{pending: test.pending}
 			apiKeyService := apikey.NewService(revokeAPIKeyStore{}, nil)
 			service := NewService(store, apiKeyService, inlineTransactor{}, nil)
-			service.WithControlStreamInvalidator(registry.Disconnect)
+			service.WithControlStreamInvalidator(registry.RevokeSession)
 
 			err := test.revoke(t.Context(), service)
 
@@ -96,7 +96,7 @@ func TestRevokeFleetNodeFailurePreservesControlStream(t *testing.T) {
 	registry := control.NewRegistry()
 	stream := registry.Register(42)
 	service := NewService(nil, nil, failingTransactor{}, nil)
-	service.WithControlStreamInvalidator(registry.Disconnect)
+	service.WithControlStreamInvalidator(registry.RevokeSession)
 
 	err := service.RevokeFleetNode(t.Context(), 42, 7)
 

--- a/server/internal/domain/fleetnode/enrollment/service_test.go
+++ b/server/internal/domain/fleetnode/enrollment/service_test.go
@@ -2,11 +2,17 @@ package enrollment
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/block/proto-fleet/server/internal/domain/apikey"
+	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
+	"github.com/block/proto-fleet/server/internal/domain/fleetnode/control"
+	stores "github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
 )
 
 func TestRegisterFleetNode_CreatesFleetNodeWithIdentityAndEncryptionKeys(t *testing.T) {
@@ -45,6 +51,63 @@ func TestRegisterFleetNode_RequiresEncryptionPubkey(t *testing.T) {
 	assert.Contains(t, err.Error(), "encryption public key")
 }
 
+func TestRevokeFleetNodeInvalidatesControlStreamAfterPersistence(t *testing.T) {
+	tests := []struct {
+		name    string
+		pending *PendingEnrollment
+		revoke  func(context.Context, *Service) error
+	}{
+		{
+			name: "confirmed node",
+			revoke: func(ctx context.Context, service *Service) error {
+				return service.RevokeFleetNode(ctx, 42, 7)
+			},
+		},
+		{
+			name:    "awaiting enrollment",
+			pending: &PendingEnrollment{ID: 99},
+			revoke: func(ctx context.Context, service *Service) error {
+				return service.RevokeFleetNodeForEnrollment(ctx, 42, 7, 99)
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			registry := control.NewRegistry()
+			stream := registry.Register(42)
+			store := &revokeFleetNodeStore{pending: test.pending}
+			apiKeyService := apikey.NewService(revokeAPIKeyStore{}, nil)
+			service := NewService(store, apiKeyService, inlineTransactor{}, nil)
+			service.WithControlStreamInvalidator(registry.Disconnect)
+
+			err := test.revoke(t.Context(), service)
+
+			require.NoError(t, err)
+			select {
+			case <-stream.Done:
+			default:
+				t.Fatal("revoked Fleet Node's ControlStream remains connected")
+			}
+		})
+	}
+}
+
+func TestRevokeFleetNodeFailurePreservesControlStream(t *testing.T) {
+	registry := control.NewRegistry()
+	stream := registry.Register(42)
+	service := NewService(nil, nil, failingTransactor{}, nil)
+	service.WithControlStreamInvalidator(registry.Disconnect)
+
+	err := service.RevokeFleetNode(t.Context(), 42, 7)
+
+	require.EqualError(t, err, "persistence failed")
+	select {
+	case <-stream.Done:
+		t.Fatal("failed revocation disconnected the Fleet Node's ControlStream")
+	default:
+	}
+}
+
 type inlineTransactor struct{}
 
 func (inlineTransactor) RunInTx(ctx context.Context, fn func(context.Context) error) error {
@@ -53,6 +116,64 @@ func (inlineTransactor) RunInTx(ctx context.Context, fn func(context.Context) er
 
 func (inlineTransactor) RunInTxWithResult(ctx context.Context, fn func(context.Context) (any, error)) (any, error) {
 	return fn(ctx)
+}
+
+type failingTransactor struct{}
+
+func (failingTransactor) RunInTx(context.Context, func(context.Context) error) error {
+	return errors.New("persistence failed")
+}
+
+func (failingTransactor) RunInTxWithResult(context.Context, func(context.Context) (any, error)) (any, error) {
+	return nil, errors.New("persistence failed")
+}
+
+type revokeFleetNodeStore struct {
+	Store
+	pending *PendingEnrollment
+}
+
+func (s *revokeFleetNodeStore) LockFleetNodeByID(context.Context, int64, int64) (*FleetNode, error) {
+	return &FleetNode{ID: 42, OrgID: 7, Name: "test-node"}, nil
+}
+
+func (s *revokeFleetNodeStore) GetPendingEnrollmentByFleetNode(context.Context, int64, int64) (*PendingEnrollment, error) {
+	if s.pending == nil {
+		return nil, fleeterror.NewNotFoundError("pending enrollment not found")
+	}
+	return s.pending, nil
+}
+
+func (*revokeFleetNodeStore) SetFleetNodeEnrollmentStatus(context.Context, FleetNodeStatus, int64, int64) (int64, error) {
+	return 1, nil
+}
+
+func (*revokeFleetNodeStore) CancelEnrollmentForFleetNode(context.Context, int64, int64, time.Time) (int64, error) {
+	return 1, nil
+}
+
+func (*revokeFleetNodeStore) ListDeviceIDsForFleetNode(context.Context, int64, int64) ([]int64, error) {
+	return nil, nil
+}
+
+func (*revokeFleetNodeStore) DeleteMinerCredentialsForFleetNode(context.Context, int64, int64) (int64, error) {
+	return 0, nil
+}
+
+func (*revokeFleetNodeStore) DeletePairingsForFleetNode(context.Context, int64, int64) (int64, error) {
+	return 0, nil
+}
+
+func (*revokeFleetNodeStore) SoftDeleteFleetNode(context.Context, int64, int64, time.Time) (int64, error) {
+	return 1, nil
+}
+
+type revokeAPIKeyStore struct {
+	stores.ApiKeyStore
+}
+
+func (revokeAPIKeyStore) RevokeApiKeysByFleetNodeID(context.Context, int64, int64, time.Time) ([]string, error) {
+	return nil, nil
 }
 
 type registerFleetNodeStore struct {

--- a/server/internal/domain/stores/sqlstores/fleetnodeauth.go
+++ b/server/internal/domain/stores/sqlstores/fleetnodeauth.go
@@ -71,10 +71,11 @@ func (s *SQLFleetNodeAuthStore) GetSessionFleetNode(ctx context.Context, tokenHa
 		return nil, err
 	}
 	return &auth.ResolvedFleetNode{
-		FleetNodeID:    row.FleetNodeID,
-		OrgID:          row.OrgID,
-		Name:           row.Name,
-		IdentityPubkey: row.IdentityPubkey,
+		FleetNodeID:      row.FleetNodeID,
+		OrgID:            row.OrgID,
+		Name:             row.Name,
+		IdentityPubkey:   row.IdentityPubkey,
+		SessionExpiresAt: row.ExpiresAt,
 	}, nil
 }
 

--- a/server/internal/fleetnode/bootstrap/authclient.go
+++ b/server/internal/fleetnode/bootstrap/authclient.go
@@ -7,6 +7,7 @@ import (
 
 	"connectrpc.com/connect"
 
+	pb "github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1"
 	"github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1/fleetnodegatewayv1connect"
 )
 
@@ -18,11 +19,34 @@ func NewAuthenticatedGatewayClient(serverURL string, tokenSource func() string) 
 	if err != nil {
 		return nil, err
 	}
-	return fleetnodegatewayv1connect.NewFleetNodeGatewayServiceClient(
+	authOption := connect.WithInterceptors(bearerInterceptor(tokenSource))
+	connectClient := fleetnodegatewayv1connect.NewFleetNodeGatewayServiceClient(
 		httpClient,
 		serverURL,
-		connect.WithInterceptors(bearerInterceptor(tokenSource)),
-	), nil
+		authOption,
+	)
+	grpcClient := fleetnodegatewayv1connect.NewFleetNodeGatewayServiceClient(
+		httpClient,
+		serverURL,
+		authOption,
+		connect.WithGRPC(),
+	)
+	return &controlStreamGRPCClient{
+		FleetNodeGatewayServiceClient: connectClient,
+		controlStreamClient:           grpcClient,
+	}, nil
+}
+
+// controlStreamGRPCClient keeps the existing Connect protocol for every Fleet
+// Node RPC except the long-lived bidirectional ControlStream, which requires
+// native gRPC so NGINX can proxy it over HTTP/2 without changing the public URL.
+type controlStreamGRPCClient struct {
+	fleetnodegatewayv1connect.FleetNodeGatewayServiceClient
+	controlStreamClient fleetnodegatewayv1connect.FleetNodeGatewayServiceClient
+}
+
+func (c *controlStreamGRPCClient) ControlStream(ctx context.Context) *connect.BidiStreamForClient[pb.ControlStreamRequest, pb.ControlStreamResponse] {
+	return c.controlStreamClient.ControlStream(ctx)
 }
 
 func bearerInterceptor(tokenSource func() string) connect.Interceptor {

--- a/server/internal/fleetnode/bootstrap/authclient_test.go
+++ b/server/internal/fleetnode/bootstrap/authclient_test.go
@@ -2,6 +2,7 @@ package bootstrap
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"sync"
 	"testing"
@@ -20,15 +21,34 @@ import (
 type captureGateway struct {
 	fleetnodegatewayv1connect.UnimplementedFleetNodeGatewayServiceHandler
 
-	mu              sync.Mutex
-	authHeadersSeen []string
+	mu                 sync.Mutex
+	authHeadersSeen    []string
+	heartbeatProtocols []string
+	controlProtocols   []string
 }
 
 func (c *captureGateway) UploadHeartbeat(_ context.Context, req *connect.Request[pb.UploadHeartbeatRequest]) (*connect.Response[pb.UploadHeartbeatResponse], error) {
 	c.mu.Lock()
 	c.authHeadersSeen = append(c.authHeadersSeen, req.Header().Get("Authorization"))
+	c.heartbeatProtocols = append(c.heartbeatProtocols, req.Peer().Protocol)
 	c.mu.Unlock()
 	return connect.NewResponse(&pb.UploadHeartbeatResponse{ReceivedAt: timestamppb.Now()}), nil
+}
+
+func (c *captureGateway) ControlStream(_ context.Context, stream *connect.BidiStream[pb.ControlStreamRequest, pb.ControlStreamResponse]) error {
+	c.mu.Lock()
+	c.authHeadersSeen = append(c.authHeadersSeen, stream.RequestHeader().Get("Authorization"))
+	c.controlProtocols = append(c.controlProtocols, stream.Peer().Protocol)
+	c.mu.Unlock()
+	if _, err := stream.Receive(); err != nil {
+		return fmt.Errorf("receive control hello: %w", err)
+	}
+	if err := stream.Send(&pb.ControlStreamResponse{Kind: &pb.ControlStreamResponse_Accepted{
+		Accepted: &pb.ControlAccepted{ServerTime: timestamppb.Now()},
+	}}); err != nil {
+		return fmt.Errorf("send control accepted: %w", err)
+	}
+	return nil
 }
 
 func (c *captureGateway) headers() []string {
@@ -37,6 +57,12 @@ func (c *captureGateway) headers() []string {
 	out := make([]string, len(c.authHeadersSeen))
 	copy(out, c.authHeadersSeen)
 	return out
+}
+
+func (c *captureGateway) protocols() ([]string, []string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]string(nil), c.heartbeatProtocols...), append([]string(nil), c.controlProtocols...)
 }
 
 func TestAuthenticatedClient_AttachesBearerHeaderPerCall(t *testing.T) {
@@ -84,4 +110,33 @@ func TestAuthenticatedClient_RejectsEmptyToken(t *testing.T) {
 	// Assert
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+}
+
+func TestAuthenticatedClient_UsesGRPCOnlyForControlStream(t *testing.T) {
+	t.Parallel()
+
+	// Arrange
+	fake := &captureGateway{}
+	mux := http.NewServeMux()
+	path, h := fleetnodegatewayv1connect.NewFleetNodeGatewayServiceHandler(fake)
+	mux.Handle(path, h)
+	srv := testutil.NewH2CServer(t, mux)
+	client, err := NewAuthenticatedGatewayClient(srv.URL, func() string { return "session-token" })
+	require.NoError(t, err)
+
+	// Act: a representative unary RPC remains Connect, while ControlStream uses gRPC.
+	_, err = client.UploadHeartbeat(t.Context(), connect.NewRequest(&pb.UploadHeartbeatRequest{SentAt: timestamppb.Now()}))
+	require.NoError(t, err)
+	stream := client.ControlStream(t.Context())
+	require.NoError(t, stream.Send(&pb.ControlStreamRequest{Kind: &pb.ControlStreamRequest_Hello{Hello: &pb.ControlHello{}}}))
+	_, err = stream.Receive()
+	require.NoError(t, err)
+	require.NoError(t, stream.CloseRequest())
+	require.NoError(t, stream.CloseResponse())
+
+	// Assert
+	heartbeatProtocols, controlProtocols := fake.protocols()
+	require.Equal(t, []string{connect.ProtocolConnect}, heartbeatProtocols)
+	require.Equal(t, []string{connect.ProtocolGRPC}, controlProtocols)
+	require.Equal(t, []string{"Bearer session-token", "Bearer session-token"}, fake.headers())
 }

--- a/server/internal/fleetnode/bootstrap/client.go
+++ b/server/internal/fleetnode/bootstrap/client.go
@@ -15,6 +15,11 @@ import (
 	"github.com/block/proto-fleet/server/internal/transportguard"
 )
 
+const (
+	http2ReadIdleTimeout = 30 * time.Second
+	http2PingTimeout     = 10 * time.Second
+)
+
 // A shared AllowHTTP+DialTLSContext shim would silently downgrade https to
 // plaintext, defeating ValidateServerURL's https-required policy. The https
 // branch uses net/http's Transport so ALPN can negotiate H2 when available
@@ -29,7 +34,9 @@ func newGatewayHTTPClient(serverURL string) (*http.Client, error) {
 	switch u.Scheme {
 	case "http":
 		tr = &http2.Transport{
-			AllowHTTP: true,
+			AllowHTTP:       true,
+			ReadIdleTimeout: http2ReadIdleTimeout,
+			PingTimeout:     http2PingTimeout,
 			DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
 				var d net.Dialer
 				return d.DialContext(ctx, network, addr)
@@ -41,6 +48,10 @@ func newGatewayHTTPClient(serverURL string) (*http.Client, error) {
 			TLSHandshakeTimeout:   10 * time.Second,
 			ExpectContinueTimeout: 1 * time.Second,
 			ForceAttemptHTTP2:     true,
+			HTTP2: &http.HTTP2Config{
+				SendPingTimeout: http2ReadIdleTimeout,
+				PingTimeout:     http2PingTimeout,
+			},
 		}
 	default:
 		return nil, fmt.Errorf("server-url scheme must be http or https; got %q", u.Scheme)

--- a/server/internal/fleetnode/bootstrap/client_test.go
+++ b/server/internal/fleetnode/bootstrap/client_test.go
@@ -7,9 +7,11 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http2"
 
 	"github.com/block/proto-fleet/server/internal/testutil"
 )
@@ -117,4 +119,31 @@ func TestGatewayHTTPClient_RejectsRedirect(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGatewayHTTPClient_ConfiguresHTTP2ConnectionHealthChecks(t *testing.T) {
+	t.Parallel()
+
+	t.Run("h2c", func(t *testing.T) {
+		t.Parallel()
+
+		client, err := newGatewayHTTPClient("http://127.0.0.1:4000/api-proxy")
+		require.NoError(t, err)
+		transport, ok := client.Transport.(*http2.Transport)
+		require.True(t, ok)
+		assert.Equal(t, 30*time.Second, transport.ReadIdleTimeout)
+		assert.Equal(t, 10*time.Second, transport.PingTimeout)
+	})
+
+	t.Run("https", func(t *testing.T) {
+		t.Parallel()
+
+		client, err := newGatewayHTTPClient("https://fleet.example.com/api-proxy")
+		require.NoError(t, err)
+		transport, ok := client.Transport.(*http.Transport)
+		require.True(t, ok)
+		require.NotNil(t, transport.HTTP2)
+		assert.Equal(t, 30*time.Second, transport.HTTP2.SendPingTimeout)
+		assert.Equal(t, 10*time.Second, transport.HTTP2.PingTimeout)
+	})
 }

--- a/server/internal/handlers/fleetnode/gateway/handler.go
+++ b/server/internal/handlers/fleetnode/gateway/handler.go
@@ -18,6 +18,7 @@ import (
 	pb "github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1"
 	"github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1/fleetnodegatewayv1connect"
 	pairingpb "github.com/block/proto-fleet/server/generated/grpc/pairing/v1"
+	"github.com/block/proto-fleet/server/internal/admissionctx"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 	"github.com/block/proto-fleet/server/internal/domain/fleetnode/auth"
 	"github.com/block/proto-fleet/server/internal/domain/fleetnode/control"
@@ -727,7 +728,7 @@ func (h *Handler) ControlStream(ctx context.Context, stream *connect.BidiStream[
 	for {
 		select {
 		case <-ctx.Done():
-			return nil
+			return controlStreamContextError(ctx)
 		case <-regHandle.Done:
 			// Newest-wins eviction or Unregister fired; let the handler
 			// exit so connect-go closes the stream.
@@ -755,4 +756,12 @@ func (h *Handler) ControlStream(ctx context.Context, stream *connect.BidiStream[
 			}
 		}
 	}
+}
+
+func controlStreamContextError(ctx context.Context) error {
+	activeLifetime, admitted := admissionctx.ActiveLifetime(ctx)
+	if admitted && activeLifetime.Err() != nil {
+		return fleeterror.NewNotActiveError()
+	}
+	return nil
 }

--- a/server/internal/handlers/fleetnode/gateway/handler.go
+++ b/server/internal/handlers/fleetnode/gateway/handler.go
@@ -686,12 +686,12 @@ func (h *Handler) ControlStream(ctx context.Context, stream *connect.BidiStream[
 	var first *pb.ControlStreamRequest
 	select {
 	case <-helloTimer.C:
-		return fleeterror.NewFailedPreconditionErrorf("control stream Hello not received within %s", HelloTimeout)
+		return controlStreamHandshakeError(ctx, fleeterror.NewFailedPreconditionErrorf("control stream Hello not received within %s", HelloTimeout))
 	case <-ctx.Done():
-		return fleeterror.NewInternalErrorf("control stream closed before hello: %v", ctx.Err())
+		return controlStreamHandshakeError(ctx, fleeterror.NewInternalErrorf("control stream closed before hello: %v", ctx.Err()))
 	case r := <-helloCh:
 		if r.err != nil {
-			return fleeterror.NewInvalidArgumentErrorf("control stream closed before hello: %v", r.err)
+			return controlStreamHandshakeError(ctx, fleeterror.NewInvalidArgumentErrorf("control stream closed before hello: %v", r.err))
 		}
 		first = r.msg
 	}
@@ -702,10 +702,8 @@ func (h *Handler) ControlStream(ctx context.Context, stream *connect.BidiStream[
 	regHandle := h.registry.Register(subject.FleetNodeID)
 	defer regHandle.Unregister()
 
-	if sendErr := stream.Send(&pb.ControlStreamResponse{Kind: &pb.ControlStreamResponse_Accepted{
-		Accepted: &pb.ControlAccepted{ServerTime: timestamppb.New(time.Now().UTC())},
-	}}); sendErr != nil {
-		return fleeterror.NewInternalErrorf("send accepted: %v", sendErr)
+	if err := sendControlStreamAccepted(ctx, stream.Send); err != nil {
+		return err
 	}
 	// Side-goroutine bridges blocking stream.Receive into the select loop. Its
 	// send selects on regHandle.Done (closed by the deferred Unregister) so it
@@ -762,6 +760,22 @@ func controlStreamContextError(ctx context.Context) error {
 	activeLifetime, admitted := admissionctx.ActiveLifetime(ctx)
 	if admitted && activeLifetime.Err() != nil {
 		return fleeterror.NewNotActiveError()
+	}
+	return nil
+}
+
+func controlStreamHandshakeError(ctx context.Context, fallback error) error {
+	if err := controlStreamContextError(ctx); err != nil {
+		return err
+	}
+	return fallback
+}
+
+func sendControlStreamAccepted(ctx context.Context, send func(*pb.ControlStreamResponse) error) error {
+	if err := send(&pb.ControlStreamResponse{Kind: &pb.ControlStreamResponse_Accepted{
+		Accepted: &pb.ControlAccepted{ServerTime: timestamppb.New(time.Now().UTC())},
+	}}); err != nil {
+		return controlStreamHandshakeError(ctx, fleeterror.NewInternalErrorf("send accepted: %v", err))
 	}
 	return nil
 }

--- a/server/internal/handlers/fleetnode/gateway/handler.go
+++ b/server/internal/handlers/fleetnode/gateway/handler.go
@@ -50,10 +50,15 @@ type Handler struct {
 	fleetnodegatewayv1connect.UnimplementedFleetNodeGatewayServiceHandler
 
 	enrollment *enrollment.Service
-	auth       *auth.Service
+	auth       authService
 	pairing    *pairing.Service
 	registry   *control.Registry
 	files      *files.Service
+}
+
+type authService interface {
+	BeginHandshake(ctx context.Context, apiKeyPlaintext string, identityPubkey []byte) ([]byte, time.Time, error)
+	CompleteHandshake(ctx context.Context, challenge, signature []byte) (string, time.Time, int64, error)
 }
 
 var _ fleetnodegatewayv1connect.FleetNodeGatewayServiceHandler = &Handler{}
@@ -95,10 +100,11 @@ func (h *Handler) BeginAuthHandshake(ctx context.Context, req *connect.Request[p
 }
 
 func (h *Handler) CompleteAuthHandshake(ctx context.Context, req *connect.Request[pb.CompleteAuthHandshakeRequest]) (*connect.Response[pb.CompleteAuthHandshakeResponse], error) {
-	token, expiresAt, err := h.auth.CompleteHandshake(ctx, req.Msg.GetChallenge(), req.Msg.GetSignature())
+	token, expiresAt, fleetNodeID, err := h.auth.CompleteHandshake(ctx, req.Msg.GetChallenge(), req.Msg.GetSignature())
 	if err != nil {
 		return nil, err
 	}
+	h.registry.Disconnect(fleetNodeID)
 	return connect.NewResponse(&pb.CompleteAuthHandshakeResponse{
 		SessionToken: token,
 		ExpiresAt:    timestamppb.New(expiresAt),

--- a/server/internal/handlers/fleetnode/gateway/handler.go
+++ b/server/internal/handlers/fleetnode/gateway/handler.go
@@ -104,7 +104,7 @@ func (h *Handler) CompleteAuthHandshake(ctx context.Context, req *connect.Reques
 	if err != nil {
 		return nil, err
 	}
-	h.registry.Disconnect(fleetNodeID)
+	h.registry.ReplaceSession(fleetNodeID, auth.SessionFingerprint(token))
 	return connect.NewResponse(&pb.CompleteAuthHandshakeResponse{
 		SessionToken: token,
 		ExpiresAt:    timestamppb.New(expiresAt),
@@ -662,10 +662,16 @@ func toPairingDevice(d *pb.DiscoveredDeviceReport) *pairingpb.Device {
 	}
 }
 
-// HelloTimeout bounds the wait for the agent's first Hello, so a node that
-// opens the stream and never sends one can't pin a goroutine + HTTP/2 stream
-// indefinitely. Var so tests can shrink it.
-var HelloTimeout = 5 * time.Second
+var (
+	// HelloTimeout bounds the wait for the agent's first Hello, so a node that
+	// opens the stream and never sends one can't pin a goroutine + HTTP/2 stream
+	// indefinitely. Vars so tests can shrink them.
+	HelloTimeout = 5 * time.Second
+
+	// ControlStreamLivenessInterval keeps data moving across the fleetd-to-NGINX
+	// hop so NGINX can detect a stalled upstream within its read timeout.
+	ControlStreamLivenessInterval = 30 * time.Second
+)
 
 func (h *Handler) ControlStream(ctx context.Context, stream *connect.BidiStream[pb.ControlStreamRequest, pb.ControlStreamResponse]) error {
 	subject, err := auth.GetSubject(ctx)
@@ -705,12 +711,17 @@ func (h *Handler) ControlStream(ctx context.Context, stream *connect.BidiStream[
 		return controlStreamExitError(ctx, fleeterror.NewInvalidArgumentError("first ControlStreamRequest must be Hello"))
 	}
 
-	regHandle := h.registry.Register(subject.FleetNodeID)
+	regHandle, err := h.registry.RegisterAuthenticated(subject.FleetNodeID, subject.SessionFingerprint)
+	if err != nil {
+		return fleeterror.NewUnauthenticatedError("fleet node session was replaced or revoked")
+	}
 	defer regHandle.Unregister()
 
 	if err := sendControlStreamAccepted(ctx, stream.Send); err != nil {
 		return err
 	}
+	liveness := time.NewTicker(ControlStreamLivenessInterval)
+	defer liveness.Stop()
 	// Side-goroutine bridges blocking stream.Receive into the select loop. Its
 	// send selects on regHandle.Done (closed by the deferred Unregister) so it
 	// can't block forever on a full channel after the main loop exits.
@@ -737,6 +748,10 @@ func (h *Handler) ControlStream(ctx context.Context, stream *connect.BidiStream[
 			// Newest-wins eviction or Unregister fired; let the handler
 			// exit so connect-go closes the stream.
 			return controlStreamExitError(ctx, nil)
+		case <-liveness.C:
+			if err := sendControlStreamAccepted(ctx, stream.Send); err != nil {
+				return err
+			}
 		case cmd := <-regHandle.Outgoing:
 			if sendErr := stream.Send(&pb.ControlStreamResponse{Kind: &pb.ControlStreamResponse_Command{Command: cmd}}); sendErr != nil {
 				return controlStreamExitError(ctx, fleeterror.NewInternalErrorf("send command: %v", sendErr))

--- a/server/internal/handlers/fleetnode/gateway/handler.go
+++ b/server/internal/handlers/fleetnode/gateway/handler.go
@@ -54,6 +54,8 @@ type Handler struct {
 	pairing    *pairing.Service
 	registry   *control.Registry
 	files      *files.Service
+	// Keep the persisted session rotation and in-memory fence in the same order.
+	sessionRotationMu sync.Mutex
 }
 
 type authService interface {
@@ -100,6 +102,9 @@ func (h *Handler) BeginAuthHandshake(ctx context.Context, req *connect.Request[p
 }
 
 func (h *Handler) CompleteAuthHandshake(ctx context.Context, req *connect.Request[pb.CompleteAuthHandshakeRequest]) (*connect.Response[pb.CompleteAuthHandshakeResponse], error) {
+	h.sessionRotationMu.Lock()
+	defer h.sessionRotationMu.Unlock()
+
 	token, expiresAt, fleetNodeID, err := h.auth.CompleteHandshake(ctx, req.Msg.GetChallenge(), req.Msg.GetSignature())
 	if err != nil {
 		return nil, err

--- a/server/internal/handlers/fleetnode/gateway/handler.go
+++ b/server/internal/handlers/fleetnode/gateway/handler.go
@@ -686,17 +686,17 @@ func (h *Handler) ControlStream(ctx context.Context, stream *connect.BidiStream[
 	var first *pb.ControlStreamRequest
 	select {
 	case <-helloTimer.C:
-		return controlStreamHandshakeError(ctx, fleeterror.NewFailedPreconditionErrorf("control stream Hello not received within %s", HelloTimeout))
+		return controlStreamExitError(ctx, fleeterror.NewFailedPreconditionErrorf("control stream Hello not received within %s", HelloTimeout))
 	case <-ctx.Done():
-		return controlStreamHandshakeError(ctx, fleeterror.NewInternalErrorf("control stream closed before hello: %v", ctx.Err()))
+		return controlStreamExitError(ctx, fleeterror.NewInternalErrorf("control stream closed before hello: %v", ctx.Err()))
 	case r := <-helloCh:
 		if r.err != nil {
-			return controlStreamHandshakeError(ctx, fleeterror.NewInvalidArgumentErrorf("control stream closed before hello: %v", r.err))
+			return controlStreamExitError(ctx, fleeterror.NewInvalidArgumentErrorf("control stream closed before hello: %v", r.err))
 		}
 		first = r.msg
 	}
 	if first.GetHello() == nil {
-		return fleeterror.NewInvalidArgumentError("first ControlStreamRequest must be Hello")
+		return controlStreamExitError(ctx, fleeterror.NewInvalidArgumentError("first ControlStreamRequest must be Hello"))
 	}
 
 	regHandle := h.registry.Register(subject.FleetNodeID)
@@ -726,21 +726,21 @@ func (h *Handler) ControlStream(ctx context.Context, stream *connect.BidiStream[
 	for {
 		select {
 		case <-ctx.Done():
-			return controlStreamContextError(ctx)
+			return controlStreamExitError(ctx, nil)
 		case <-regHandle.Done:
 			// Newest-wins eviction or Unregister fired; let the handler
 			// exit so connect-go closes the stream.
-			return nil
+			return controlStreamExitError(ctx, nil)
 		case cmd := <-regHandle.Outgoing:
 			if sendErr := stream.Send(&pb.ControlStreamResponse{Kind: &pb.ControlStreamResponse_Command{Command: cmd}}); sendErr != nil {
-				return fleeterror.NewInternalErrorf("send command: %v", sendErr)
+				return controlStreamExitError(ctx, fleeterror.NewInternalErrorf("send command: %v", sendErr))
 			}
 		case r := <-incoming:
 			if r.err != nil {
 				if errors.Is(r.err, io.EOF) {
-					return nil
+					return controlStreamExitError(ctx, nil)
 				}
-				return fleeterror.NewInternalErrorf("control stream recv: %v", r.err)
+				return controlStreamExitError(ctx, fleeterror.NewInternalErrorf("control stream recv: %v", r.err))
 			}
 			if ack := r.msg.GetAck(); ack != nil {
 				// Trust boundary for node input: drop a malformed/oversized ack rather than
@@ -756,17 +756,10 @@ func (h *Handler) ControlStream(ctx context.Context, stream *connect.BidiStream[
 	}
 }
 
-func controlStreamContextError(ctx context.Context) error {
+func controlStreamExitError(ctx context.Context, fallback error) error {
 	activeLifetime, admitted := admissionctx.ActiveLifetime(ctx)
 	if admitted && activeLifetime.Err() != nil {
 		return fleeterror.NewNotActiveError()
-	}
-	return nil
-}
-
-func controlStreamHandshakeError(ctx context.Context, fallback error) error {
-	if err := controlStreamContextError(ctx); err != nil {
-		return err
 	}
 	return fallback
 }
@@ -775,7 +768,7 @@ func sendControlStreamAccepted(ctx context.Context, send func(*pb.ControlStreamR
 	if err := send(&pb.ControlStreamResponse{Kind: &pb.ControlStreamResponse_Accepted{
 		Accepted: &pb.ControlAccepted{ServerTime: timestamppb.New(time.Now().UTC())},
 	}}); err != nil {
-		return controlStreamHandshakeError(ctx, fleeterror.NewInternalErrorf("send accepted: %v", err))
+		return controlStreamExitError(ctx, fleeterror.NewInternalErrorf("send accepted: %v", err))
 	}
 	return nil
 }

--- a/server/internal/handlers/fleetnode/gateway/handler_artifact_internal_test.go
+++ b/server/internal/handlers/fleetnode/gateway/handler_artifact_internal_test.go
@@ -9,7 +9,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	commonpb "github.com/block/proto-fleet/server/generated/grpc/common/v1"
 	pb "github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1"
+	"github.com/block/proto-fleet/server/internal/admissionctx"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 	"github.com/block/proto-fleet/server/internal/domain/fleetnode/control"
 )
@@ -58,4 +60,32 @@ func TestCommandArtifactUploadReaderRejectsOversizedChunk(t *testing.T) {
 	var fleetErr fleeterror.FleetError
 	require.ErrorAs(t, err, &fleetErr)
 	assert.Equal(t, connect.CodeInvalidArgument, fleetErr.GRPCCode)
+}
+
+func TestControlStreamContextErrorDistinguishesDemotionFromClientCancellation(t *testing.T) {
+	t.Run("active lifetime ended", func(t *testing.T) {
+		activeCtx, cancelActive := context.WithCancel(t.Context())
+		requestCtx, cancelRequest := context.WithCancel(admissionctx.WithActiveLifetime(t.Context(), activeCtx))
+		cancelActive()
+		cancelRequest()
+
+		err := controlStreamContextError(requestCtx)
+
+		var fleetErr fleeterror.FleetError
+		require.ErrorAs(t, err, &fleetErr)
+		assert.Equal(t, connect.CodeUnavailable, fleetErr.GRPCCode)
+		assert.Equal(t, int32(commonpb.FleetErrorCode_FLEET_ERROR_CODE_NOT_ACTIVE), fleetErr.FleetErrorCode)
+	})
+
+	t.Run("client canceled while activation remains live", func(t *testing.T) {
+		activeCtx := context.Background()
+		requestCtx, cancelRequest := context.WithCancel(admissionctx.WithActiveLifetime(t.Context(), activeCtx))
+		cancelRequest()
+
+		assert.NoError(t, controlStreamContextError(requestCtx))
+	})
+
+	t.Run("normal stream replacement has no activation cancellation", func(t *testing.T) {
+		assert.NoError(t, controlStreamContextError(t.Context()))
+	})
 }

--- a/server/internal/handlers/fleetnode/gateway/handler_artifact_internal_test.go
+++ b/server/internal/handlers/fleetnode/gateway/handler_artifact_internal_test.go
@@ -62,14 +62,14 @@ func TestCommandArtifactUploadReaderRejectsOversizedChunk(t *testing.T) {
 	assert.Equal(t, connect.CodeInvalidArgument, fleetErr.GRPCCode)
 }
 
-func TestControlStreamContextErrorDistinguishesDemotionFromClientCancellation(t *testing.T) {
-	t.Run("active lifetime ended", func(t *testing.T) {
+func TestControlStreamExitErrorDistinguishesDemotionFromClientCancellation(t *testing.T) {
+	t.Run("nil fallback becomes not-active when active lifetime ended", func(t *testing.T) {
 		activeCtx, cancelActive := context.WithCancel(t.Context())
 		requestCtx, cancelRequest := context.WithCancel(admissionctx.WithActiveLifetime(t.Context(), activeCtx))
 		cancelActive()
 		cancelRequest()
 
-		err := controlStreamContextError(requestCtx)
+		err := controlStreamExitError(requestCtx, nil)
 
 		var fleetErr fleeterror.FleetError
 		require.ErrorAs(t, err, &fleetErr)
@@ -77,17 +77,41 @@ func TestControlStreamContextErrorDistinguishesDemotionFromClientCancellation(t 
 		assert.Equal(t, int32(commonpb.FleetErrorCode_FLEET_ERROR_CODE_NOT_ACTIVE), fleetErr.FleetErrorCode)
 	})
 
-	t.Run("client canceled while activation remains live", func(t *testing.T) {
+	t.Run("nil fallback remains nil while activation remains live", func(t *testing.T) {
 		activeCtx := context.Background()
 		requestCtx, cancelRequest := context.WithCancel(admissionctx.WithActiveLifetime(t.Context(), activeCtx))
 		cancelRequest()
 
-		assert.NoError(t, controlStreamContextError(requestCtx))
+		assert.NoError(t, controlStreamExitError(requestCtx, nil))
+	})
+
+	t.Run("stream failure while activation remains live", func(t *testing.T) {
+		fallback := fleeterror.NewInternalError("send command")
+		requestCtx := admissionctx.WithActiveLifetime(t.Context(), context.Background())
+
+		assert.Equal(t, fallback, controlStreamExitError(requestCtx, fallback))
 	})
 
 	t.Run("normal stream replacement has no activation cancellation", func(t *testing.T) {
-		assert.NoError(t, controlStreamContextError(t.Context()))
+		assert.NoError(t, controlStreamExitError(t.Context(), nil))
 	})
+}
+
+func TestControlStreamExitErrorPrefersDemotionOverConcurrentStreamFailure(t *testing.T) {
+	for _, name := range []string{"send command failure", "receive failure"} {
+		t.Run(name, func(t *testing.T) {
+			activeCtx, cancelActive := context.WithCancel(t.Context())
+			requestCtx := admissionctx.WithActiveLifetime(t.Context(), activeCtx)
+			cancelActive()
+
+			err := controlStreamExitError(requestCtx, fleeterror.NewInternalError(name))
+
+			var fleetErr fleeterror.FleetError
+			require.ErrorAs(t, err, &fleetErr)
+			assert.Equal(t, connect.CodeUnavailable, fleetErr.GRPCCode)
+			assert.Equal(t, int32(commonpb.FleetErrorCode_FLEET_ERROR_CODE_NOT_ACTIVE), fleetErr.FleetErrorCode)
+		})
+	}
 }
 
 func TestSendControlStreamAcceptedClassifiesDemotion(t *testing.T) {

--- a/server/internal/handlers/fleetnode/gateway/handler_artifact_internal_test.go
+++ b/server/internal/handlers/fleetnode/gateway/handler_artifact_internal_test.go
@@ -89,3 +89,19 @@ func TestControlStreamContextErrorDistinguishesDemotionFromClientCancellation(t 
 		assert.NoError(t, controlStreamContextError(t.Context()))
 	})
 }
+
+func TestSendControlStreamAcceptedClassifiesDemotion(t *testing.T) {
+	activeCtx, cancelActive := context.WithCancel(t.Context())
+	requestCtx := admissionctx.WithActiveLifetime(t.Context(), activeCtx)
+
+	err := sendControlStreamAccepted(requestCtx, func(response *pb.ControlStreamResponse) error {
+		require.NotNil(t, response.GetAccepted())
+		cancelActive()
+		return context.Canceled
+	})
+
+	var fleetErr fleeterror.FleetError
+	require.ErrorAs(t, err, &fleetErr)
+	assert.Equal(t, connect.CodeUnavailable, fleetErr.GRPCCode)
+	assert.Equal(t, int32(commonpb.FleetErrorCode_FLEET_ERROR_CODE_NOT_ACTIVE), fleetErr.FleetErrorCode)
+}

--- a/server/internal/handlers/fleetnode/gateway/handler_auth_test.go
+++ b/server/internal/handlers/fleetnode/gateway/handler_auth_test.go
@@ -1,0 +1,72 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/require"
+
+	pb "github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1"
+	"github.com/block/proto-fleet/server/internal/domain/fleetnode/control"
+)
+
+type stubAuthService struct {
+	token       string
+	expiresAt   time.Time
+	fleetNodeID int64
+	err         error
+}
+
+func (stubAuthService) BeginHandshake(context.Context, string, []byte) ([]byte, time.Time, error) {
+	panic("not used")
+}
+
+func (s stubAuthService) CompleteHandshake(context.Context, []byte, []byte) (string, time.Time, int64, error) {
+	return s.token, s.expiresAt, s.fleetNodeID, s.err
+}
+
+func TestCompleteAuthHandshakeDisconnectsReplacedSessionStream(t *testing.T) {
+	const fleetNodeID = 42
+	registry := control.NewRegistry()
+	oldStream := registry.Register(fleetNodeID)
+	expiresAt := time.Now().Add(time.Hour)
+	handler := &Handler{auth: stubAuthService{
+		token:       "replacement-token",
+		expiresAt:   expiresAt,
+		fleetNodeID: fleetNodeID,
+	}, registry: registry}
+
+	response, err := handler.CompleteAuthHandshake(t.Context(), connect.NewRequest(&pb.CompleteAuthHandshakeRequest{}))
+
+	require.NoError(t, err)
+	require.Equal(t, "replacement-token", response.Msg.GetSessionToken())
+	require.True(t, expiresAt.Equal(response.Msg.GetExpiresAt().AsTime()))
+	select {
+	case <-oldStream.Done:
+	default:
+		t.Fatal("replaced session's ControlStream remains connected")
+	}
+	require.Empty(t, registry.ConnectedFleetNodeIDs())
+}
+
+func TestCompleteAuthHandshakeFailureKeepsCurrentStream(t *testing.T) {
+	const fleetNodeID = 42
+	registry := control.NewRegistry()
+	oldStream := registry.Register(fleetNodeID)
+	handler := &Handler{auth: stubAuthService{
+		fleetNodeID: fleetNodeID,
+		err:         errors.New("handshake failed"),
+	}, registry: registry}
+
+	_, err := handler.CompleteAuthHandshake(t.Context(), connect.NewRequest(&pb.CompleteAuthHandshakeRequest{}))
+
+	require.EqualError(t, err, "handshake failed")
+	select {
+	case <-oldStream.Done:
+		t.Fatal("failed session replacement disconnected the current ControlStream")
+	default:
+	}
+}

--- a/server/internal/handlers/fleetnode/gateway/handler_auth_test.go
+++ b/server/internal/handlers/fleetnode/gateway/handler_auth_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	pb "github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1"
+	"github.com/block/proto-fleet/server/internal/domain/fleetnode/auth"
 	"github.com/block/proto-fleet/server/internal/domain/fleetnode/control"
 )
 
@@ -50,6 +51,11 @@ func TestCompleteAuthHandshakeDisconnectsReplacedSessionStream(t *testing.T) {
 		t.Fatal("replaced session's ControlStream remains connected")
 	}
 	require.Empty(t, registry.ConnectedFleetNodeIDs())
+	newStream, err := registry.RegisterAuthenticated(fleetNodeID, auth.SessionFingerprint("replacement-token"))
+	require.NoError(t, err)
+	newStream.Unregister()
+	_, err = registry.RegisterAuthenticated(fleetNodeID, auth.SessionFingerprint("old-token"))
+	require.Error(t, err)
 }
 
 func TestCompleteAuthHandshakeFailureKeepsCurrentStream(t *testing.T) {

--- a/server/internal/handlers/fleetnode/gateway/handler_auth_test.go
+++ b/server/internal/handlers/fleetnode/gateway/handler_auth_test.go
@@ -3,6 +3,7 @@ package gateway
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -19,6 +20,49 @@ type stubAuthService struct {
 	expiresAt   time.Time
 	fleetNodeID int64
 	err         error
+}
+
+type concurrentHandshakeAuthService struct {
+	firstStarted  chan struct{}
+	releaseFirst  chan struct{}
+	secondStarted chan struct{}
+
+	mu           sync.Mutex
+	callCount    int
+	currentToken string
+}
+
+func (s *concurrentHandshakeAuthService) BeginHandshake(context.Context, string, []byte) ([]byte, time.Time, error) {
+	panic("not used")
+}
+
+func (s *concurrentHandshakeAuthService) CompleteHandshake(context.Context, []byte, []byte) (string, time.Time, int64, error) {
+	s.mu.Lock()
+	s.callCount++
+	call := s.callCount
+	s.mu.Unlock()
+
+	if call == 1 {
+		close(s.firstStarted)
+		<-s.releaseFirst
+	} else {
+		close(s.secondStarted)
+	}
+
+	token := "old-token"
+	if call == 2 {
+		token = "new-token"
+	}
+	s.mu.Lock()
+	s.currentToken = token
+	s.mu.Unlock()
+	return token, time.Now().Add(time.Hour), 42, nil
+}
+
+func (s *concurrentHandshakeAuthService) CurrentToken() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.currentToken
 }
 
 func (stubAuthService) BeginHandshake(context.Context, string, []byte) ([]byte, time.Time, error) {
@@ -75,4 +119,49 @@ func TestCompleteAuthHandshakeFailureKeepsCurrentStream(t *testing.T) {
 		t.Fatal("failed session replacement disconnected the current ControlStream")
 	default:
 	}
+}
+
+func TestCompleteAuthHandshakeSerializesSessionPersistenceAndFence(t *testing.T) {
+	authService := &concurrentHandshakeAuthService{
+		firstStarted:  make(chan struct{}),
+		releaseFirst:  make(chan struct{}),
+		secondStarted: make(chan struct{}),
+	}
+	registry := control.NewRegistry()
+	handler := &Handler{auth: authService, registry: registry}
+
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := handler.CompleteAuthHandshake(t.Context(), connect.NewRequest(&pb.CompleteAuthHandshakeRequest{}))
+		firstDone <- err
+	}()
+	<-authService.firstStarted
+
+	secondRequestStarted := make(chan struct{})
+	secondDone := make(chan error, 1)
+	go func() {
+		close(secondRequestStarted)
+		_, err := handler.CompleteAuthHandshake(t.Context(), connect.NewRequest(&pb.CompleteAuthHandshakeRequest{}))
+		secondDone <- err
+	}()
+	<-secondRequestStarted
+	require.Never(t, func() bool {
+		select {
+		case <-authService.secondStarted:
+			return true
+		default:
+			return false
+		}
+	}, 50*time.Millisecond, time.Millisecond, "second persistence entered before the first fence update")
+
+	close(authService.releaseFirst)
+	require.NoError(t, <-firstDone)
+	require.NoError(t, <-secondDone)
+	require.Equal(t, "new-token", authService.CurrentToken())
+
+	currentStream, err := registry.RegisterAuthenticated(42, auth.SessionFingerprint(authService.CurrentToken()))
+	require.NoError(t, err)
+	currentStream.Unregister()
+	_, err = registry.RegisterAuthenticated(42, auth.SessionFingerprint("old-token"))
+	require.Error(t, err)
 }

--- a/server/internal/handlers/fleetnode/gateway/handler_controlstream_test.go
+++ b/server/internal/handlers/fleetnode/gateway/handler_controlstream_test.go
@@ -240,7 +240,10 @@ func TestControlStream_ReturnsStructuredNotActive(t *testing.T) {
 	t.Run("passive admission", func(t *testing.T) {
 		client := startControlServerWithAdmission(t, controlledAdmissionGate{reject: true})
 		stream := client.ControlStream(t.Context())
-		require.NoError(t, stream.Send(&pb.ControlStreamRequest{Kind: &pb.ControlStreamRequest_Hello{Hello: &pb.ControlHello{}}}))
+		// Admission can reject before the first client write completes. In that
+		// race Send returns EOF, while Receive still carries the structured RPC
+		// status this test is asserting.
+		_ = stream.Send(&pb.ControlStreamRequest{Kind: &pb.ControlStreamRequest_Hello{Hello: &pb.ControlHello{}}})
 
 		_, err := stream.Receive()
 

--- a/server/internal/handlers/fleetnode/gateway/handler_controlstream_test.go
+++ b/server/internal/handlers/fleetnode/gateway/handler_controlstream_test.go
@@ -247,6 +247,18 @@ func TestControlStream_ReturnsStructuredNotActive(t *testing.T) {
 		requireStructuredNotActive(t, err)
 	})
 
+	t.Run("demotion before hello", func(t *testing.T) {
+		activeCtx, cancelActive := context.WithCancel(t.Context())
+		client := startControlServerWithAdmission(t, controlledAdmissionGate{active: activeCtx})
+		stream := client.ControlStream(t.Context())
+		require.NoError(t, stream.Send(nil), "start the RPC without sending Hello")
+
+		cancelActive()
+		_, err := stream.Receive()
+
+		requireStructuredNotActive(t, err)
+	})
+
 	t.Run("accepted stream demotion", func(t *testing.T) {
 		activeCtx, cancelActive := context.WithCancel(t.Context())
 		client := startControlServerWithAdmission(t, controlledAdmissionGate{active: activeCtx})

--- a/server/internal/handlers/fleetnode/gateway/handler_controlstream_test.go
+++ b/server/internal/handlers/fleetnode/gateway/handler_controlstream_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"crypto/tls"
 	"database/sql"
+	"errors"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -20,8 +21,10 @@ import (
 	"golang.org/x/net/http2"
 	"golang.org/x/net/http2/h2c"
 
+	commonpb "github.com/block/proto-fleet/server/generated/grpc/common/v1"
 	pb "github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1"
 	"github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1/fleetnodegatewayv1connect"
+	"github.com/block/proto-fleet/server/internal/admissionctx"
 	"github.com/block/proto-fleet/server/internal/domain/apikey"
 	"github.com/block/proto-fleet/server/internal/domain/fleetnode/auth"
 	"github.com/block/proto-fleet/server/internal/domain/fleetnode/control"
@@ -214,6 +217,84 @@ func TestControlStream_RequiresHelloFirst(t *testing.T) {
 	var connErr *connect.Error
 	require.ErrorAs(t, err, &connErr)
 	assert.Equal(t, connect.CodeInvalidArgument, connErr.Code())
+}
+
+type controlledAdmissionGate struct {
+	active context.Context //nolint:containedctx // Test-owned activation lifetime.
+	reject bool
+}
+
+func (g controlledAdmissionGate) Admit(ctx context.Context) (context.Context, func(), error) {
+	if g.reject {
+		return nil, nil, errors.New("passive")
+	}
+	requestCtx, cancelRequest := context.WithCancel(admissionctx.WithActiveLifetime(ctx, g.active))
+	stop := context.AfterFunc(g.active, cancelRequest)
+	return requestCtx, func() {
+		stop()
+		cancelRequest()
+	}, nil
+}
+
+func TestControlStream_ReturnsStructuredNotActive(t *testing.T) {
+	t.Run("passive admission", func(t *testing.T) {
+		client := startControlServerWithAdmission(t, controlledAdmissionGate{reject: true})
+		stream := client.ControlStream(t.Context())
+		require.NoError(t, stream.Send(&pb.ControlStreamRequest{Kind: &pb.ControlStreamRequest_Hello{Hello: &pb.ControlHello{}}}))
+
+		_, err := stream.Receive()
+
+		requireStructuredNotActive(t, err)
+	})
+
+	t.Run("accepted stream demotion", func(t *testing.T) {
+		activeCtx, cancelActive := context.WithCancel(t.Context())
+		client := startControlServerWithAdmission(t, controlledAdmissionGate{active: activeCtx})
+		stream := client.ControlStream(t.Context())
+		require.NoError(t, stream.Send(&pb.ControlStreamRequest{Kind: &pb.ControlStreamRequest_Hello{Hello: &pb.ControlHello{}}}))
+		accepted, err := stream.Receive()
+		require.NoError(t, err)
+		require.NotNil(t, accepted.GetAccepted())
+
+		cancelActive()
+		_, err = stream.Receive()
+
+		requireStructuredNotActive(t, err)
+	})
+}
+
+func requireStructuredNotActive(t *testing.T, err error) {
+	t.Helper()
+	require.Error(t, err)
+	var connectErr *connect.Error
+	require.ErrorAs(t, err, &connectErr)
+	require.Equal(t, connect.CodeUnavailable, connectErr.Code())
+	for _, detail := range connectErr.Details() {
+		value, valueErr := detail.Value()
+		require.NoError(t, valueErr)
+		if fleetDetails, ok := value.(*commonpb.FleetErrorDetails); ok {
+			require.Equal(t, commonpb.FleetErrorCode_FLEET_ERROR_CODE_NOT_ACTIVE, fleetDetails.GetCommon())
+			return
+		}
+	}
+	t.Fatal("missing FleetErrorDetails")
+}
+
+func startControlServerWithAdmission(t *testing.T, gate controlledAdmissionGate) fleetnodegatewayv1connect.FleetNodeGatewayServiceClient {
+	t.Helper()
+	const fleetNodeID = 42
+	subject := &auth.Subject{FleetNodeID: fleetNodeID, OrgID: 1, Name: "agent-control"}
+	mux := http.NewServeMux()
+	mux.Handle(fleetnodegatewayv1connect.NewFleetNodeGatewayServiceHandler(
+		gateway.NewHandler(nil, nil, nil, control.NewRegistry(), nil),
+		connect.WithInterceptors(
+			interceptors.NewErrorMappingInterceptor(),
+			interceptors.NewActiveInterceptor(gate),
+			agentSubjectInjector{subject: subject},
+		),
+	))
+	srv := testutil.NewH2CServer(t, mux)
+	return fleetnodegatewayv1connect.NewFleetNodeGatewayServiceClient(testutil.NewH2CClient(), srv.URL, connect.WithGRPC())
 }
 
 func waitForSend(t *testing.T, r *control.Registry, fleetNodeID int64, commandID string, payload []byte) *control.Session {

--- a/server/internal/handlers/fleetnode/gateway/handler_controlstream_test.go
+++ b/server/internal/handlers/fleetnode/gateway/handler_controlstream_test.go
@@ -275,6 +275,26 @@ func TestControlStream_ReturnsStructuredNotActive(t *testing.T) {
 	})
 }
 
+func TestControlStream_SendsPeriodicLiveness(t *testing.T) {
+	previous := gateway.ControlStreamLivenessInterval
+	gateway.ControlStreamLivenessInterval = 20 * time.Millisecond
+	t.Cleanup(func() { gateway.ControlStreamLivenessInterval = previous })
+
+	activeCtx, cancelActive := context.WithCancel(t.Context())
+	defer cancelActive()
+	client := startControlServerWithAdmission(t, controlledAdmissionGate{active: activeCtx})
+	stream := client.ControlStream(t.Context())
+	t.Cleanup(func() { _ = stream.CloseRequest(); _ = stream.CloseResponse() })
+	require.NoError(t, stream.Send(&pb.ControlStreamRequest{Kind: &pb.ControlStreamRequest_Hello{Hello: &pb.ControlHello{}}}))
+
+	first, err := stream.Receive()
+	require.NoError(t, err)
+	require.NotNil(t, first.GetAccepted())
+	second, err := stream.Receive()
+	require.NoError(t, err)
+	require.NotNil(t, second.GetAccepted())
+}
+
 func requireStructuredNotActive(t *testing.T, err error) {
 	t.Helper()
 	require.Error(t, err)

--- a/server/internal/handlers/interceptors/fleetnode_authentication.go
+++ b/server/internal/handlers/interceptors/fleetnode_authentication.go
@@ -85,5 +85,6 @@ func (i *FleetNodeAuthInterceptor) authenticate(ctx context.Context, authHeader 
 		OrgID:               resolved.OrgID,
 		Name:                resolved.Name,
 		IdentityFingerprint: enrollment.IdentityFingerprint(resolved.IdentityPubkey),
+		SessionFingerprint:  resolved.SessionFingerprint,
 	}), resolved.SessionExpiresAt, nil
 }

--- a/server/internal/handlers/interceptors/fleetnode_authentication.go
+++ b/server/internal/handlers/interceptors/fleetnode_authentication.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"time"
 
 	"connectrpc.com/authn"
 	"connectrpc.com/connect"
@@ -38,7 +39,7 @@ func (i *FleetNodeAuthInterceptor) WrapUnary(next connect.UnaryFunc) connect.Una
 		if !i.appliesTo(req.Spec().Procedure) {
 			return next(ctx, req)
 		}
-		newCtx, err := i.authenticate(ctx, req.Header().Get("Authorization"))
+		newCtx, _, err := i.authenticate(ctx, req.Header().Get("Authorization"))
 		if err != nil {
 			return nil, err
 		}
@@ -55,32 +56,34 @@ func (i *FleetNodeAuthInterceptor) WrapStreamingHandler(next connect.StreamingHa
 		if !i.appliesTo(conn.Spec().Procedure) {
 			return next(ctx, conn)
 		}
-		newCtx, err := i.authenticate(ctx, conn.RequestHeader().Get("Authorization"))
+		newCtx, expiresAt, err := i.authenticate(ctx, conn.RequestHeader().Get("Authorization"))
 		if err != nil {
 			return err
 		}
-		return next(newCtx, conn)
+		sessionCtx, cancel := context.WithDeadline(newCtx, expiresAt)
+		defer cancel()
+		return next(sessionCtx, conn)
 	}
 }
 
-func (i *FleetNodeAuthInterceptor) authenticate(ctx context.Context, authHeader string) (context.Context, error) {
+func (i *FleetNodeAuthInterceptor) authenticate(ctx context.Context, authHeader string) (context.Context, time.Time, error) {
 	rawToken, ok := parseBearerToken(authHeader)
 	if !ok {
-		return ctx, fleeterror.NewUnauthenticatedError("invalid Authorization header format, expected: Bearer <session_token>")
+		return ctx, time.Time{}, fleeterror.NewUnauthenticatedError("invalid Authorization header format, expected: Bearer <session_token>")
 	}
 	resolved, err := i.auth.ResolveSession(ctx, rawToken)
 	if err != nil {
 		var fe fleeterror.FleetError
 		if errors.As(err, &fe) {
-			return ctx, err
+			return ctx, time.Time{}, err
 		}
 		slog.Error("fleet node auth: session lookup failed", "error", err)
-		return ctx, fleeterror.NewInternalError("fleet node authentication failed")
+		return ctx, time.Time{}, fleeterror.NewInternalError("fleet node authentication failed")
 	}
 	return authn.SetInfo(ctx, &auth.Subject{
 		FleetNodeID:         resolved.FleetNodeID,
 		OrgID:               resolved.OrgID,
 		Name:                resolved.Name,
 		IdentityFingerprint: enrollment.IdentityFingerprint(resolved.IdentityPubkey),
-	}), nil
+	}), resolved.SessionExpiresAt, nil
 }

--- a/server/internal/handlers/interceptors/fleetnode_authentication_test.go
+++ b/server/internal/handlers/interceptors/fleetnode_authentication_test.go
@@ -1,0 +1,81 @@
+package interceptors
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/proto-fleet/server/internal/domain/fleetnode/auth"
+)
+
+type fleetNodeSessionStore struct {
+	resolved *auth.ResolvedFleetNode
+}
+
+func (s fleetNodeSessionStore) UpsertChallenge(context.Context, []byte, int64, time.Time) error {
+	panic("not used")
+}
+
+func (s fleetNodeSessionStore) ConsumeChallenge(context.Context, []byte, time.Time) (int64, error) {
+	panic("not used")
+}
+
+func (s fleetNodeSessionStore) SweepExpiredChallenges(context.Context, time.Time) (int64, error) {
+	panic("not used")
+}
+
+func (s fleetNodeSessionStore) UpsertSession(context.Context, string, int64, time.Time) error {
+	panic("not used")
+}
+
+func (s fleetNodeSessionStore) GetSessionFleetNode(context.Context, string, time.Time) (*auth.ResolvedFleetNode, error) {
+	return s.resolved, nil
+}
+
+func (s fleetNodeSessionStore) SweepExpiredSessions(context.Context, time.Time) (int64, error) {
+	panic("not used")
+}
+
+type fleetNodeStreamingConn struct {
+	procedure string
+	header    http.Header
+}
+
+func (c fleetNodeStreamingConn) Spec() connect.Spec         { return connect.Spec{Procedure: c.procedure} }
+func (fleetNodeStreamingConn) Peer() connect.Peer           { return connect.Peer{} }
+func (fleetNodeStreamingConn) Receive(any) error            { panic("not used") }
+func (c fleetNodeStreamingConn) RequestHeader() http.Header { return c.header }
+func (fleetNodeStreamingConn) Send(any) error               { panic("not used") }
+func (fleetNodeStreamingConn) ResponseHeader() http.Header  { return http.Header{} }
+func (fleetNodeStreamingConn) ResponseTrailer() http.Header { return http.Header{} }
+
+func TestFleetNodeAuthInterceptorExpiresAuthenticatedStream(t *testing.T) {
+	const procedure = "/test.Service/ControlStream"
+	expiresAt := time.Now().Add(50 * time.Millisecond)
+	authService := auth.NewService(fleetNodeSessionStore{resolved: &auth.ResolvedFleetNode{
+		FleetNodeID:      42,
+		OrgID:            7,
+		Name:             "test-node",
+		SessionExpiresAt: expiresAt,
+	}}, nil, nil)
+	interceptor := NewFleetNodeAuthInterceptor(authService, []string{procedure})
+	header := http.Header{}
+	header.Set("Authorization", "Bearer session-token")
+	conn := fleetNodeStreamingConn{procedure: procedure, header: header}
+
+	wrapper := interceptor.WrapStreamingHandler(func(ctx context.Context, _ connect.StreamingHandlerConn) error {
+		deadline, ok := ctx.Deadline()
+		require.True(t, ok)
+		require.WithinDuration(t, expiresAt, deadline, time.Millisecond)
+		<-ctx.Done()
+		return ctx.Err()
+	})
+
+	err := wrapper(t.Context(), conn)
+
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}

--- a/server/internal/handlers/interceptors/fleetnode_authentication_test.go
+++ b/server/internal/handlers/interceptors/fleetnode_authentication_test.go
@@ -68,6 +68,9 @@ func TestFleetNodeAuthInterceptorExpiresAuthenticatedStream(t *testing.T) {
 	conn := fleetNodeStreamingConn{procedure: procedure, header: header}
 
 	wrapper := interceptor.WrapStreamingHandler(func(ctx context.Context, _ connect.StreamingHandlerConn) error {
+		subject, err := auth.GetSubject(ctx)
+		require.NoError(t, err)
+		require.Equal(t, auth.SessionFingerprint("session-token"), subject.SessionFingerprint)
 		deadline, ok := ctx.Deadline()
 		require.True(t, ok)
 		require.WithinDuration(t, expiresAt, deadline, time.Millisecond)


### PR DESCRIPTION
Reviewable diff: +224/-44 across 8 files (excludes generated, test, and story files).

## Summary

Fleet Nodes can now remain usable through Proto Fleet application-host failover while keeping the existing VIP, certificate, port 443, and `/api-proxy` URL. The authenticated ControlStream reconnects quickly after demotion without waiting for commands from the old session, while every other Fleet Node RPC stays on the Connect protocol. This extends the existing active/passive HA boundary to Fleet Node command delivery without adding a supervisor, persisted coordination state, operator command, or qualification automation.

## How it works

1. The Fleet Node sends ordinary authenticated RPCs through the existing Connect client. Its authenticated ControlStream alone uses native gRPC over the same HTTP client and public URL.
2. The client keeps HTTP/2 connections observable with a PING after 30 idle seconds and a 10-second response timeout. The settings apply to both HTTPS and h2c transports.
3. NGINX enables HTTP/2 and selects an exact ControlStream location. That location strips `/api-proxy`, forwards the request to the existing h2c Fleet server, disables upstream retry, and removes request-body limits that would terminate a long-lived stream. The generic proxy continues to serve all other RPCs.
4. A passive host rejects stream admission with `Unavailable` plus `FLEET_ERROR_CODE_NOT_ACTIVE`. An accepted stream returns the same structured error if its active lifetime ends. Client cancellation and normal newest-stream replacement still close without being labeled as demotion.
5. The Fleet Node recognizes the structured error and retries in an independent 1-1.5 second jitter window. Other transient failures retain the existing 1-30 second exponential backoff.
6. `RunCmd` owns process-wide command permits and worker accounting. Stream loss cancels the old command contexts, closes the old acknowledgement sender, and immediately starts reconnecting. Old workers retain their permits until exit, so a replacement stream returns `BUSY` instead of exceeding process capacity. Daemon shutdown waits at most 10 seconds for those workers before existing plugin cleanup continues.

## Diagrams

```mermaid
flowchart LR
    FN["Fleet Node daemon"] -->|"ControlStream: gRPC over HTTP/2"| VIP["Existing Fleet VIP :443/api-proxy"]
    FN -->|"Other RPCs: Connect"| VIP
    VIP --> NG["NGINX on selected application host"]
    NG -->|"Exact ControlStream route: grpc_pass"| GW["Fleet Node gateway on :4000"]
    NG -->|"Generic routes: proxy_pass"| GW
    GW --> ADM["Active admission lifetime"]
    ADM -->|"Active"| REG["Control session registry"]
    ADM -->|"Passive or demoted"| NA["Unavailable plus NOT_ACTIVE detail"]
    NA --> FN
```

```mermaid
sequenceDiagram
    participant FN as Fleet Node
    participant VIP as VIP and NGINX
    participant A as Active Fleet host
    participant W as Old command worker
    participant B as Replacement Fleet host

    FN->>VIP: Open authenticated gRPC ControlStream
    VIP->>A: Forward exact RPC path
    A-->>FN: Accepted
    A->>W: Start command
    A-->>FN: NOT_ACTIVE after demotion
    FN->>FN: Cancel old session and close old sender
    FN->>VIP: Reconnect after 1-1.5 second jitter
    VIP->>B: Forward to selected host
    B-->>FN: Accepted
    B-->>FN: BUSY while old permits remain occupied
    W-->>FN: Late acknowledgement rejected by closed old sender
    B-->>FN: Command accepted after one old permit is released
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/nginx.runner-protofleet.conf`, `deployment-files/client/nginx.*.conf` | Enabled HTTP/2 and added the exact, long-lived gRPC ControlStream route | Verify route specificity, timeout/body limits, retry behavior, and unchanged generic proxying |
| `server/internal/fleetnode/bootstrap` | Split authenticated protocol selection and configured HTTP/2 PING health checks | Verify only ControlStream uses gRPC and bearer authentication is preserved on both protocols |
| `server/internal/handlers/fleetnode/gateway` | Mapped accepted-stream demotion to the existing structured not-active error | Verify demotion remains distinct from client cancellation and stream replacement |
| `server/cmd/fleetnode/control.go` | Added structured retry classification and process-wide command capacity | Verify retry windows, permit ownership, sender isolation, and immediate reconnect ordering |
| `server/cmd/fleetnode/run.go` | Added bounded daemon-level worker drainage | Verify the 10-second shutdown boundary occurs before existing plugin cleanup |
| Fleet Node and gateway tests | Added protocol, demotion, retry, reconnect, capacity, acknowledgement, and shutdown coverage | Focus on cross-session concurrency behavior and race-detector coverage |

## Key technical decisions & trade-offs

- Use gRPC only for authenticated ControlStream instead of moving the full Fleet Node API; this keeps existing unary and streaming RPC behavior unchanged.
- Reuse `Unavailable` plus `FLEET_ERROR_CODE_NOT_ACTIVE` instead of adding a new protobuf or endpoint; clients can distinguish HA demotion without a contract migration.
- Keep permits on `RunCmd` instead of introducing a supervisor; reconnect stays immediate while work from prior sessions remains bounded at the process level.
- Close each session's acknowledgement sender instead of redirecting workers to the replacement stream; late results cannot be attributed to a new session.
- Disable NGINX retry for the stream and let the Fleet Node reconnect loop own host reselection; this avoids replaying a bidirectional stream inside the proxy.
- Server and NGINX must deploy before the updated Fleet Node. The exact proxy route remains compatible with the previous Connect ControlStream during rollout.

## Testing & validation

- Targeted Fleet Node, bootstrap transport, and gateway demotion tests pass under the Go race detector.
- All three NGINX configurations pass `nginx -t` in the repository's pinned `nginx:1.29.0-alpine` image.
- A disposable NGINX probe confirmed that the exact `grpc_pass` route preserves the prior Connect ControlStream protocol and bearer header during rollout.
- The existing HA deployment profile checks pass unchanged.
- Hermit-backed diff-scoped server lint, protobuf lint, and `git diff --check` pass.
- The full server lint baseline still reports the unrelated current-main `goconst` issue in `server/internal/domain/alerts/deliver.go`; this PR adds no new lint findings.
- The real two-host Fleet Node failover remains the requested post-merge check. No HA qualification section, RFC, qualification document, or qualification automation changed in this PR.

## Post-Deploy Monitoring & Validation

- **Owner/window:** The release operator runs the Fleet Node failover check after the server/NGINX rollout and again after the Fleet Node rollout.
- **Logs:** Search for `control stream disconnected; will reconnect`, structured `NOT_ACTIVE`, repeated `BUSY`, and `control command handlers still running; continuing daemon shutdown`.
- **Operational signals:** Keep `fleet-ha status` healthy and watch the existing `fleet_ha_failover_ready` Grafana signal while failing the active application host.
- **Healthy result:** A harmless command succeeds before failover, the node reconnects through the same VIP, and a second command succeeds within the existing 180-second RTO.
- **Failure/mitigation:** Repeated not-active responses, a missing command acknowledgement, or recovery beyond 180 seconds blocks rollout. Roll back the Fleet Node package first; the server and proxy remain compatible with the previous Connect ControlStream.
- **Recordkeeping:** Keep the result in the task or release notes. Open a corrective PR only if the check exposes a defect.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
