### PR TITLE
fix(ci): remove Codex fast service tier

### DIFF
--- a/.github/workflows/codex-security-review.yml
+++ b/.github/workflows/codex-security-review.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           model: ${{ env.CODEX_MODEL }}
-          codex-args: '["-c","model_reasoning_effort=${{ env.CODEX_REASONING_EFFORT }}","-c","service_tier=fast"]'
+          codex-args: '["-c","model_reasoning_effort=${{ env.CODEX_REASONING_EFFORT }}"]'
 
           safety-strategy: drop-sudo
           sandbox: read-only

--- a/.github/workflows/review-policy.yml
+++ b/.github/workflows/review-policy.yml
@@ -346,7 +346,7 @@ jobs:
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           model: ${{ env.CODEX_MODEL }}
-          codex-args: '["-c","model_reasoning_effort=${{ env.CODEX_REASONING_EFFORT }}","-c","service_tier=fast"]'
+          codex-args: '["-c","model_reasoning_effort=${{ env.CODEX_REASONING_EFFORT }}"]'
           safety-strategy: drop-sudo
           sandbox: read-only
           prompt: |


### PR DESCRIPTION
Reviewable diff: +2/-2 across 2 files (excludes generated, test, and story files).

## Summary

Removes the explicit Codex `fast` service tier from both AI-powered CI review paths. The security review and low-risk classifier retain their existing models and reasoning-effort settings while using the service default.

## How it works

Both workflows continue to invoke `openai/codex-action` with their configured model and reasoning effort. They no longer pass `service_tier=fast`, preventing removal of that tier from breaking review execution.

```mermaid
flowchart LR
    PR["Pull request update"] --> SR["Codex security review"]
    PR --> RP["Low-risk policy classifier"]
    SR --> DS["Default service tier"]
    RP --> DS
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `.github/workflows/codex-security-review.yml` | Removed the `service_tier=fast` Codex argument | Keeps the required security review compatible with the imminent tier removal |
| `.github/workflows/review-policy.yml` | Removed the same argument from the low-risk classifier | Keeps automated review-policy decisions running |

## Key technical decisions & trade-offs

- Preserve each workflow's model and reasoning effort rather than changing review behavior alongside the service-tier migration.
- Use the service default rather than pinning a replacement tier whose long-term availability is not guaranteed.

## Testing & validation

- `python3 .github/scripts/evaluate_review_policy_test.py` — 53 tests passed.
- `git diff --check` passed.
- Confirmed no `service_tier=fast` references remain under `.github/workflows/`.
