### PR TITLE
alerts: rename channels & maintenance windows, updates

### DIFF
--- a/client/e2eTests/protoFleet/helpers/rbacTestSetup.ts
+++ b/client/e2eTests/protoFleet/helpers/rbacTestSetup.ts
@@ -459,7 +459,7 @@ async function cleanupRbacArtifacts(browser: Browser, testInfo: TestInfo, cleanu
         await page.goto("/settings/alerts");
         if (
           await page
-            .getByRole("button", { name: "Add channel", exact: true })
+            .getByRole("button", { name: "Add destination", exact: true })
             .isVisible()
             .catch(() => false)
         ) {

--- a/client/e2eTests/protoFleet/pages/alerts.ts
+++ b/client/e2eTests/protoFleet/pages/alerts.ts
@@ -7,7 +7,7 @@ import { ModalMinerSelectionList } from "./components/modalMinerSelectionList";
  *
  * The "Test" actions ask the server to have Grafana deliver a synthetic alert to
  * the destination, so the selectors here drive both the pre-save test (in the
- * Add channel modal) and the per-row test on a saved channel.
+ * Add destination modal) and the per-row test on a saved destination.
  */
 export class AlertsPage extends BasePage {
   constructor(page: Page, isMobile: boolean = false) {
@@ -20,11 +20,11 @@ export class AlertsPage extends BasePage {
   }
 
   async validateAddChannelHidden() {
-    await expect(this.page.getByRole("button", { name: "Add channel", exact: true })).toHaveCount(0);
+    await expect(this.page.getByRole("button", { name: "Add destination", exact: true })).toHaveCount(0);
   }
 
   async openAddChannelModal() {
-    await this.page.getByRole("button", { name: "Add channel" }).click();
+    await this.page.getByRole("button", { name: "Add destination" }).click();
     await this.validateModalIsOpen();
   }
 
@@ -38,7 +38,7 @@ export class AlertsPage extends BasePage {
   }
 
   async saveChannel() {
-    await this.clickIn("Save channel", "modal");
+    await this.clickIn("Save destination", "modal");
     await this.validateModalIsClosed();
   }
 
@@ -86,7 +86,7 @@ export class AlertsPage extends BasePage {
     await expect(this.channelRow(name)).toBeHidden();
   }
 
-  // Cleanup helper: remove every channel whose name carries the given test prefix.
+  // Cleanup helper: remove every destination whose name carries the given test prefix.
   async deleteChannelsByPrefix(prefix: string) {
     await this.deleteRowsByPrefix(prefix);
   }

--- a/client/src/protoFleet/features/alerts/api/useChannelSelection.ts
+++ b/client/src/protoFleet/features/alerts/api/useChannelSelection.ts
@@ -35,7 +35,7 @@ export function useChannelSelection(active: boolean): UseChannelSelectionResult 
         // one transient failure. Toggling back into the selected mode retries instead.
         sessionFetchedRef.current = false;
         pushToast({
-          message: getErrorMessage(error, "Failed to load channels"),
+          message: getErrorMessage(error, "Failed to load destinations"),
           status: STATUSES.error,
         });
       });

--- a/client/src/protoFleet/features/alerts/api/useDeliveryRouting.ts
+++ b/client/src/protoFleet/features/alerts/api/useDeliveryRouting.ts
@@ -41,7 +41,7 @@ export function useDeliveryRouting(): UseDeliveryRoutingResult {
 
   const validate = useCallback((): string | null => {
     if (mode === "custom" && selectedIds.size === 0) {
-      return "Pick at least one channel, or use All channels / In-app only";
+      return "Pick at least one destination, or use All destinations / In-app only";
     }
     return null;
   }, [mode, selectedIds]);

--- a/client/src/protoFleet/features/alerts/components/AddChannelModal.tsx
+++ b/client/src/protoFleet/features/alerts/components/AddChannelModal.tsx
@@ -50,7 +50,7 @@ const AddChannelModal = ({ open, onDismiss, onCreate }: AddChannelModalProps) =>
   } | null => {
     const trimmedName = name.trim();
     if (!trimmedName) {
-      setErrorMsg("Add a name for this channel");
+      setErrorMsg("Add a name for this destination");
       return null;
     }
     let webhook: WebhookConfig | null = null;
@@ -107,7 +107,7 @@ const AddChannelModal = ({ open, onDismiss, onCreate }: AddChannelModalProps) =>
       onDismiss();
     } catch (error) {
       pushToast({
-        message: getErrorMessage(error, "Failed to save channel"),
+        message: getErrorMessage(error, "Failed to save destination"),
         status: STATUSES.error,
       });
       setSaving(false);
@@ -120,8 +120,8 @@ const AddChannelModal = ({ open, onDismiss, onCreate }: AddChannelModalProps) =>
     <Modal
       open={open}
       onDismiss={onDismiss}
-      title="Add channel"
-      description="Pick a destination. Test the channel before saving so you don't ship a dead receiver into the live config."
+      title="Add destination"
+      description="Choose a destination. Test it before saving so you don't ship a dead receiver into the live config."
       buttons={[
         ...(canTest
           ? [
@@ -137,7 +137,7 @@ const AddChannelModal = ({ open, onDismiss, onCreate }: AddChannelModalProps) =>
             ]
           : []),
         {
-          text: saving ? "Saving…" : "Save channel",
+          text: saving ? "Saving…" : "Save destination",
           onClick: () => {
             void handleSave();
           },

--- a/client/src/protoFleet/features/alerts/components/AddMaintenanceWindowModal.tsx
+++ b/client/src/protoFleet/features/alerts/components/AddMaintenanceWindowModal.tsx
@@ -228,7 +228,7 @@ const AddMaintenanceWindowModal = ({
       return;
     }
     if (ruleMode === "all" && channelMode === "all" && !confirmedAllAlertingMute) {
-      setErrorMsg("Confirm that no alerts will be delivered during this window");
+      setErrorMsg("Confirm that no alerts will be delivered during this quiet period");
       return;
     }
     if (ruleMode === "selected" && liveRuleIds.size === 0) {

--- a/client/src/protoFleet/features/alerts/components/AddMaintenanceWindowModal.tsx
+++ b/client/src/protoFleet/features/alerts/components/AddMaintenanceWindowModal.tsx
@@ -224,7 +224,7 @@ const AddMaintenanceWindowModal = ({
       return;
     }
     if (new Date(ends).getTime() - new Date(starts).getTime() > MAX_MAINTENANCE_WINDOW_DURATION_MS) {
-      setErrorMsg("Maintenance windows cannot exceed 30 days");
+      setErrorMsg("Quiet periods cannot exceed 30 days");
       return;
     }
     if (ruleMode === "all" && channelMode === "all" && !confirmedAllAlertingMute) {
@@ -236,7 +236,7 @@ const AddMaintenanceWindowModal = ({
       return;
     }
     if (channelMode === "selected" && liveChannelIds.size === 0) {
-      setErrorMsg("Pick at least one channel, or use All channels");
+      setErrorMsg("Pick at least one destination, or use All destinations");
       return;
     }
 
@@ -252,15 +252,15 @@ const AddMaintenanceWindowModal = ({
     try {
       if (isEditing && editingMaintenanceWindow) {
         await updateMaintenanceWindow({ id: editingMaintenanceWindow.id, ...payload });
-        pushToast({ message: "Maintenance window updated", status: STATUSES.success });
+        pushToast({ message: "Quiet period updated", status: STATUSES.success });
       } else {
         await createMaintenanceWindow(payload);
-        pushToast({ message: "Maintenance window saved", status: STATUSES.success });
+        pushToast({ message: "Quiet period saved", status: STATUSES.success });
       }
       onDismiss();
     } catch (error) {
       pushToast({
-        message: getErrorMessage(error, "Failed to save maintenance window"),
+        message: getErrorMessage(error, "Failed to save quiet period"),
         status: STATUSES.error,
       });
       setSaving(false);
@@ -285,11 +285,11 @@ const AddMaintenanceWindowModal = ({
     <Modal
       open={open}
       onDismiss={onDismiss}
-      title={isEditing ? "Edit maintenance window" : "Add maintenance window"}
+      title={isEditing ? "Edit quiet period" : "Add quiet period"}
       description="Mute alert delivery during planned work. Alerts still show up in history."
       buttons={[
         {
-          text: saving ? "Saving…" : "Save maintenance window",
+          text: saving ? "Saving…" : "Save quiet period",
           onClick: () => {
             void handleSave();
           },
@@ -325,8 +325,8 @@ const AddMaintenanceWindowModal = ({
         <TargetPicker
           key={`channels-${syncKey ?? ""}`}
           segments={[
-            { key: "all", title: "All channels" },
-            { key: "selected", title: "Selected channels" },
+            { key: "all", title: "All destinations" },
+            { key: "selected", title: "Selected destinations" },
           ]}
           mode={channelMode}
           onModeChange={(mode) => {
@@ -334,10 +334,12 @@ const AddMaintenanceWindowModal = ({
             setConfirmedAllAlertingMute(false);
             clearError();
           }}
-          allHint="Delivery is muted on every channel, including channels added later."
+          allHint="Delivery is muted on every destination, including destinations added later."
           options={channelOptions}
           emptyMessage={
-            channelsLoaded ? "No channels yet — add one in the Channels section first." : "Loading channels…"
+            channelsLoaded
+              ? "No destinations yet — add one in the Destinations section first."
+              : "Loading destinations…"
           }
           selectedIds={liveChannelIds}
           onToggle={toggleChannel}
@@ -349,7 +351,7 @@ const AddMaintenanceWindowModal = ({
               intent="warning"
               prefixIcon={<Alert />}
               title="This mutes all alerting"
-              subtitle="No alert reaches any channel while this window is active."
+              subtitle="No alert reaches any destination while this quiet period is active."
             />
             <label className="flex cursor-pointer items-center gap-3 text-300 text-text-primary">
               <Checkbox
@@ -359,14 +361,14 @@ const AddMaintenanceWindowModal = ({
                   clearError();
                 }}
               />
-              I understand that no alerts will be delivered during this window.
+              I understand that no alerts will be delivered during this quiet period.
             </label>
           </div>
         ) : null}
 
         <SinglePickerField
           id="maintenance-window-quick"
-          label="Quick window"
+          label="Quick period"
           options={MAINTENANCE_WINDOW_QUICK_OPTIONS}
           value={quick}
           placeholder="Custom"

--- a/client/src/protoFleet/features/alerts/components/ChannelsSection.tsx
+++ b/client/src/protoFleet/features/alerts/components/ChannelsSection.tsx
@@ -63,7 +63,7 @@ const ChannelsSection = () => {
         pushToast({ message: `Renamed: ${next}`, status: STATUSES.success });
       } catch (error) {
         pushToast({
-          message: getErrorMessage(error, "Failed to rename channel"),
+          message: getErrorMessage(error, "Failed to rename destination"),
           status: STATUSES.error,
         });
       }
@@ -147,20 +147,20 @@ const ChannelsSection = () => {
         await removeChannel(channel.id);
       } catch (error) {
         pushToast({
-          message: getErrorMessage(error, "Failed to delete channel"),
+          message: getErrorMessage(error, "Failed to delete destination"),
           status: STATUSES.error,
         });
         return;
       }
 
-      pushToast({ message: `Deleted channel "${channel.name}"`, status: STATUSES.success });
+      pushToast({ message: `Deleted destination "${channel.name}"`, status: STATUSES.success });
       try {
         // ListRules filters soft-deleted channel ids from custom routes. Refreshing here keeps
         // the rule's Muted/Active badge aligned with the delivery path after a channel delete.
         await refreshAlerts();
       } catch (error) {
         pushToast({
-          message: getErrorMessage(error, "Channel deleted, but alert rules could not be refreshed"),
+          message: getErrorMessage(error, "Destination deleted, but alert rules could not be refreshed"),
           status: STATUSES.error,
         });
       }
@@ -234,18 +234,18 @@ const ChannelsSection = () => {
   return (
     <section className="flex flex-col gap-4 rounded-xl border border-border-5 p-6">
       <div className="flex items-center justify-between">
-        <Header title="Channels" titleSize="text-heading-200" />
+        <Header title="Destinations" titleSize="text-heading-200" />
         {canManage ? (
           <Button
             variant={variants.secondary}
             size={sizes.compact}
-            text="Add channel"
+            text="Add destination"
             onClick={() => setShowAddModal(true)}
           />
         ) : null}
       </div>
       <p className="text-300 text-text-primary-50">
-        Webhook and Slack destinations for alert delivery. Every rule delivers to every channel unless it has custom
+        Webhook and Slack destinations for alert delivery. Every rule delivers to every destination unless it has custom
         delivery set in the Rules section above. "Test" sends a synthetic alert directly to the destination.
       </p>
 
@@ -256,10 +256,10 @@ const ChannelsSection = () => {
         colTitles={colTitles}
         colConfig={colConfig}
         total={channels.length}
-        itemName={{ singular: "channel", plural: "channels" }}
+        itemName={{ singular: "destination", plural: "destinations" }}
         noDataElement={
           <div className="py-10 text-center text-text-primary-50">
-            No channels yet — add a webhook or Slack URL to start getting alerts.
+            No destinations yet — add a webhook or Slack URL to start getting alerts.
           </div>
         }
         actions={canManage ? actions : []}

--- a/client/src/protoFleet/features/alerts/components/DeliveryPicker.tsx
+++ b/client/src/protoFleet/features/alerts/components/DeliveryPicker.tsx
@@ -3,8 +3,8 @@ import Checkbox from "@/shared/components/Checkbox";
 import SegmentedControl from "@/shared/components/SegmentedControl";
 
 const MODE_SEGMENTS: { key: RoutingMode; title: string }[] = [
-  { key: "default", title: "All channels" },
-  { key: "custom", title: "Selected channels" },
+  { key: "default", title: "All destinations" },
+  { key: "custom", title: "Selected destinations" },
   { key: "none", title: "In-app only" },
 ];
 
@@ -52,15 +52,15 @@ const DeliveryPicker = ({
         ))}
         {channelsLoaded && channels.length === 0 ? (
           <p className="py-4 text-center text-text-primary-50">
-            No channels yet — add one in the Channels section first.
+            No destinations yet — add one in the Destinations section first.
           </p>
         ) : null}
       </div>
     ) : (
       <p className="text-200 text-text-primary-50">
         {mode === "default"
-          ? "Alerts from this rule are delivered to every channel, including ones added later."
-          : "Alerts from this rule show up in the in-app history only; no channel is notified."}
+          ? "Alerts from this rule are delivered to every destination, including ones added later."
+          : "Alerts from this rule show up in the in-app history only; no destination is notified."}
       </p>
     )}
   </div>

--- a/client/src/protoFleet/features/alerts/components/MaintenanceWindowsSection.tsx
+++ b/client/src/protoFleet/features/alerts/components/MaintenanceWindowsSection.tsx
@@ -18,24 +18,34 @@ type MaintenanceWindowColumns = "alerts" | "channels" | "window" | "reason";
 
 const colTitles: ColTitles<MaintenanceWindowColumns> = {
   alerts: "Alerts",
-  channels: "Channels",
-  window: "Window",
+  channels: "Destinations",
+  window: "Period",
   reason: "Reason",
 };
 
 const activeCols: MaintenanceWindowColumns[] = ["alerts", "channels", "window", "reason"];
 
+const periodDateTimeOptions: Intl.DateTimeFormatOptions = {
+  year: "numeric",
+  month: "numeric",
+  day: "numeric",
+  hour: "numeric",
+  minute: "2-digit",
+};
+
 const formatWindow = (maintenanceWindow: MaintenanceWindowWithActive): string => {
-  const start = new Date(maintenanceWindow.starts_at).toLocaleString();
-  const end = maintenanceWindow.ends_at ? new Date(maintenanceWindow.ends_at).toLocaleString() : "—";
+  const start = new Date(maintenanceWindow.starts_at).toLocaleString(undefined, periodDateTimeOptions);
+  const end = maintenanceWindow.ends_at
+    ? new Date(maintenanceWindow.ends_at).toLocaleString(undefined, periodDateTimeOptions)
+    : "—";
   return `${start} → ${end}`;
 };
 
 // Channel names live in a separate lazily-loaded list; a count keeps this column dependency-free.
 const formatChannels = (maintenanceWindow: MaintenanceWindowWithActive): string =>
   maintenanceWindow.channel_ids.length === 0
-    ? "All channels"
-    : countLabel(maintenanceWindow.channel_ids.length, "channel");
+    ? "All destinations"
+    : countLabel(maintenanceWindow.channel_ids.length, "destination");
 
 const MaintenanceWindowsSection = () => {
   const { maintenanceWindows, rules, removeMaintenanceWindow } = useAlertsContext();
@@ -78,10 +88,10 @@ const MaintenanceWindowsSection = () => {
     async (maintenanceWindow: MaintenanceWindowWithActive) => {
       try {
         await removeMaintenanceWindow(maintenanceWindow.id);
-        pushToast({ message: "Maintenance window lifted", status: STATUSES.success });
+        pushToast({ message: "Quiet period lifted", status: STATUSES.success });
       } catch (error) {
         pushToast({
-          message: getErrorMessage(error, "Failed to lift maintenance window"),
+          message: getErrorMessage(error, "Failed to lift quiet period"),
           status: STATUSES.error,
         });
       }
@@ -97,7 +107,7 @@ const MaintenanceWindowsSection = () => {
         actionHandler: handleEdit,
       },
       {
-        title: "Lift maintenance window",
+        title: "Lift quiet period",
         icon: <Stop />,
         variant: "destructive",
         actionHandler: (maintenanceWindow) => {
@@ -157,9 +167,9 @@ const MaintenanceWindowsSection = () => {
   return (
     <section className="flex flex-col gap-4 rounded-xl border border-border-5 p-6">
       <div className="flex items-center justify-between">
-        <Header title="Maintenance Windows" titleSize="text-heading-200" />
+        <Header title="Quiet Periods" titleSize="text-heading-200" />
         {canManage ? (
-          <Button variant={variants.secondary} size={sizes.compact} text="Add maintenance window" onClick={openAdd} />
+          <Button variant={variants.secondary} size={sizes.compact} text="Add quiet period" onClick={openAdd} />
         ) : null}
       </div>
       <p className="text-300 text-text-primary-50">
@@ -173,10 +183,10 @@ const MaintenanceWindowsSection = () => {
         colTitles={colTitles}
         colConfig={colConfig}
         total={sortedMaintenanceWindows.length}
-        itemName={{ singular: "maintenance window", plural: "maintenance windows" }}
+        itemName={{ singular: "quiet period", plural: "quiet periods" }}
         noDataElement={
           <div className="py-10 text-center text-text-primary-50">
-            No maintenance windows right now — click Add maintenance window to mute during planned work.
+            No quiet periods right now — click Add quiet period to mute during planned work.
           </div>
         }
         actions={canManage ? actions : []}

--- a/client/src/protoFleet/features/alerts/components/RulesSection.tsx
+++ b/client/src/protoFleet/features/alerts/components/RulesSection.tsx
@@ -60,11 +60,13 @@ const formatRuleScope = (rule: Rule): string => {
 const formatRuleDelivery = (rule: Rule): string => {
   switch (rule.routing?.mode) {
     case "custom":
-      return rule.routing.channel_ids.length === 1 ? "1 channel" : `${rule.routing.channel_ids.length} channels`;
+      return rule.routing.channel_ids.length === 1
+        ? "1 destination"
+        : `${rule.routing.channel_ids.length} destinations`;
     case "none":
       return "In-app only";
     case "default":
-      return "All channels";
+      return "All destinations";
     default:
       return "—";
   }
@@ -142,12 +144,12 @@ const RulesSection = () => {
           // Lift every active window for the rule so it isn't left muted by an overlapping one.
           await Promise.all(activeIds.map((id) => removeMaintenanceWindow(id)));
           pushToast({
-            message: activeIds.length > 1 ? "Maintenance windows lifted" : "Maintenance window lifted",
+            message: activeIds.length > 1 ? "Quiet periods lifted" : "Quiet period lifted",
             status: STATUSES.success,
           });
         } catch (error) {
           pushToast({
-            message: getErrorMessage(error, "Failed to lift maintenance window"),
+            message: getErrorMessage(error, "Failed to lift quiet period"),
             status: STATUSES.error,
           });
         }
@@ -204,7 +206,7 @@ const RulesSection = () => {
         },
       },
       {
-        title: (rule) => (liftableWindowIdsByRule.has(rule.id) ? "Lift maintenance window" : "Maintenance window"),
+        title: (rule) => (liftableWindowIdsByRule.has(rule.id) ? "Lift quiet period" : "Quiet period"),
         icon: <Stop />,
         actionHandler: (rule) => {
           void handleMaintenanceWindowOrLift(rule);
@@ -289,8 +291,7 @@ const RulesSection = () => {
         </div>
         <p className="text-300 text-text-primary-50">
           Conditions that decide when an alert fires. Add your own rule on a fleet metric, or work with the provisioned
-          defaults — pause one to silence it indefinitely, or attach a maintenance window to mute it for a finite
-          period.
+          defaults — pause one to silence it indefinitely, or attach a quiet period to mute it for a finite period.
         </p>
       </div>
 

--- a/client/src/protoFleet/features/alerts/pages/Alerts.tsx
+++ b/client/src/protoFleet/features/alerts/pages/Alerts.tsx
@@ -8,7 +8,7 @@ import RulesSection from "@/protoFleet/features/alerts/components/RulesSection";
 import SettingsPageHeader from "@/protoFleet/features/settings/components/SettingsPageHeader";
 import { pushToast, STATUSES } from "@/shared/features/toaster";
 
-const ALERTS_PAGE_DESCRIPTION = "Configure alert rules, notification channels, and maintenance windows.";
+const ALERTS_PAGE_DESCRIPTION = "Configure alert rules, notification destinations, and quiet periods.";
 
 const Alerts = () => {
   const alerts = useAlerts();

--- a/server/generated/sqlc/notification_history.sql.go
+++ b/server/generated/sqlc/notification_history.sql.go
@@ -479,6 +479,7 @@ LEFT JOIN device d
     AND d.deleted_at IS NULL
 LEFT JOIN discovered_device dd ON dd.id = d.discovered_device_id
 WHERE nh.organization_id = $1
+  AND nh.status <> 'resolved'
   AND ($2::bigint IS NULL OR nh.id < $2)
 ORDER BY nh.id DESC
 LIMIT $3
@@ -508,6 +509,8 @@ type ListNotificationHistoryRow struct {
 	EndsAt         sql.NullTime
 }
 
+// Resolution rows remain stored so the notification_active trigger can close firing alerts,
+// but the activity feed records only the alert firing event.
 func (q *Queries) ListNotificationHistory(ctx context.Context, arg ListNotificationHistoryParams) ([]ListNotificationHistoryRow, error) {
 	rows, err := q.query(ctx, q.listNotificationHistoryStmt, listNotificationHistory, arg.OrganizationID, arg.BeforeID, arg.PageLimit)
 	if err != nil {

--- a/server/generated/sqlc/querier.go
+++ b/server/generated/sqlc/querier.go
@@ -1064,6 +1064,8 @@ type Querier interface {
 	// System-scope (no org filter); reconciler is a singleton driving all orgs.
 	// Order by id keeps per-tick processing deterministic.
 	ListNonTerminalCurtailmentEvents(ctx context.Context) ([]CurtailmentEvent, error)
+	// Resolution rows remain stored so the notification_active trigger can close firing alerts,
+	// but the activity feed records only the alert firing event.
 	ListNotificationHistory(ctx context.Context, arg ListNotificationHistoryParams) ([]ListNotificationHistoryRow, error)
 	ListOrganizations(ctx context.Context) ([]Organization, error)
 	ListPermissions(ctx context.Context) ([]Permission, error)

--- a/server/internal/domain/alerts/deliver.go
+++ b/server/internal/domain/alerts/deliver.go
@@ -23,6 +23,8 @@ const perSendTimeout = 10 * time.Second
 // maxDeliveryConcurrency bounds in-flight sends per org so one slow channel can't starve the rest.
 const maxDeliveryConcurrency = 8
 
+const alertStatusResolved = "resolved"
+
 // Alert is one alert instance from a Grafana webhook batch, reduced to what delivery needs.
 type Alert struct {
 	Status      string
@@ -240,7 +242,7 @@ func dropMutedAlerts(alerts []Alert, muted map[string]bool, muteAll bool) []Aler
 		return alerts
 	}
 	isMuted := func(a Alert) bool {
-		if a.Status == "resolved" {
+		if a.Status == alertStatusResolved {
 			return false
 		}
 		return muteAll || (a.RuleUID != "" && muted[a.RuleUID])
@@ -461,7 +463,7 @@ func (d *Deliverer) post(ctx context.Context, rawURL, bearer string, body []byte
 // firing/resolved partition, stable by alertname then device for a deterministic message.
 func partitionAlerts(alerts []Alert) (firing, resolved []Alert) {
 	for _, a := range alerts {
-		if a.Status == "resolved" {
+		if a.Status == alertStatusResolved {
 			resolved = append(resolved, a)
 		} else {
 			firing = append(firing, a)

--- a/server/internal/domain/alerts/render.go
+++ b/server/internal/domain/alerts/render.go
@@ -12,7 +12,7 @@ import (
 // Slack limits: section text ≤3000, ≤50 blocks per message.
 const (
 	slackSectionMaxRunes = 2900
-	// Cap alert sections so title + heading + overflow line stay under Slack's 50-block limit.
+	// Cap alert sections so the title and overflow line stay under Slack's 50-block limit.
 	slackMaxAlertSections = 40
 	// Keep the instance name from crowding the alert counts out of the truncated title.
 	slackInstanceMaxRunes = 50
@@ -40,22 +40,17 @@ func renderSlack(publicURL string, alerts []Alert, identities map[string]DeviceI
 
 	blocks := []map[string]any{mrkdwnSection("*" + slackTitle(linked, firingGroups, firingDevices) + "*")}
 	remaining := slackMaxAlertSections
-	appendGroups := func(groups []alertGroup) {
+	appendGroups := func(groups []alertGroup, resolved bool) {
 		for _, g := range groups {
 			if remaining <= 0 {
 				return
 			}
-			blocks = append(blocks, mrkdwnSection(groupLine(g, identities)))
+			blocks = append(blocks, mrkdwnSection(groupLine(g, identities, resolved)))
 			remaining--
 		}
 	}
-	// Firing groups need no heading — the title already says how many are firing — but resolved ones do,
-	// since nothing else separates them from the alerts still up.
-	appendGroups(firingGroups)
-	if len(resolvedGroups) > 0 && remaining > 0 {
-		blocks = append(blocks, mrkdwnSection("*Resolved*"))
-		appendGroups(resolvedGroups)
-	}
+	appendGroups(firingGroups, false)
+	appendGroups(resolvedGroups, true)
 	if overflow := len(firingGroups) + len(resolvedGroups) - slackMaxAlertSections; overflow > 0 {
 		blocks = append(blocks, mrkdwnSection(fmt.Sprintf("_…and %d more — open Proto Fleet for the full list._", overflow)))
 	}
@@ -113,10 +108,14 @@ func slackTitle(instance string, firing []alertGroup, firingDevices int) string 
 
 // groupLine renders one rule's rollup for Slack: the alert, its blast radius, and enough miner names to act on.
 // Labels are escaped here, not in the rollup, so a non-Slack renderer formats the same group its own way.
-func groupLine(g alertGroup, identities map[string]DeviceIdentity) string {
+func groupLine(g alertGroup, identities map[string]DeviceIdentity, resolved bool) string {
 	var b strings.Builder
-	b.WriteString("*" + escapeMrkdwn(g.Name) + "*")
-	if g.Severity != "" {
+	if resolved {
+		b.WriteString("*Resolved: " + escapeMrkdwn(g.Name) + "*")
+	} else {
+		b.WriteString("*" + escapeMrkdwn(g.Name) + "*")
+	}
+	if !resolved && g.Severity != "" {
 		b.WriteString(" _(" + escapeMrkdwn(g.Severity) + ")_")
 	}
 	switch {
@@ -140,11 +139,15 @@ func groupLine(g alertGroup, identities map[string]DeviceIdentity) string {
 			b.WriteString(fmt.Sprintf(" and %d more", more))
 		}
 	}
-	for _, summary := range g.Summaries {
-		b.WriteString("\n" + escapeMrkdwn(summary))
-	}
-	if more := g.SummaryCount - len(g.Summaries); more > 0 {
-		b.WriteString(fmt.Sprintf("\n_…and %d more_", more))
+	// Miner-backed resolutions are identifiable from their miner labels and stay terse. Device-less alerts
+	// often identify their source or host only in the summary, so retain those summaries on resolution.
+	if !resolved || g.DeviceCount == 0 {
+		for _, summary := range g.Summaries {
+			b.WriteString("\n" + escapeMrkdwn(summary))
+		}
+		if more := g.SummaryCount - len(g.Summaries); more > 0 {
+			b.WriteString(fmt.Sprintf("\n_…and %d more_", more))
+		}
 	}
 	return b.String()
 }
@@ -171,7 +174,7 @@ func mrkdwnSection(text string) map[string]any {
 // Miners named inline per alert before the "+N more" tail; the app holds the full list.
 const groupSampleDevices = 3
 
-// Distinct summaries named inline before the "+N more" tail, for rules that interpolate the firing instance.
+// Distinct summaries named inline before the "+N more" tail, for rules that interpolate the alert instance.
 const groupSampleSummaries = 3
 
 // alertGroup is one rule's rollup within a delivery batch. Every outward-facing renderer groups through it, so
@@ -348,11 +351,11 @@ func renderWebhook(orgID int64, alerts []Alert, identities map[string]DeviceIden
 		return out
 	}
 	return map[string]any{
-		"organization_id": orgID,
-		"firing":          convert(firing),
-		"resolved":        convert(resolved),
-		"firing_groups":   convertGroups(firing),
-		"resolved_groups": convertGroups(resolved),
+		"organization_id":   orgID,
+		"firing":            convert(firing),
+		alertStatusResolved: convert(resolved),
+		"firing_groups":     convertGroups(firing),
+		"resolved_groups":   convertGroups(resolved),
 	}
 }
 

--- a/server/internal/domain/alerts/render_test.go
+++ b/server/internal/domain/alerts/render_test.go
@@ -66,12 +66,15 @@ func TestRenderSlackTitleLinksTheInstanceName(t *testing.T) {
 		sectionText(t, blocks[0]))
 
 	body := mustJSON(t, msg)
-	// Firing alerts need no heading — the title counts them — but the resolved ones must stay separable.
+	// Firing alerts need no heading — the title counts them — and resolved rows carry their status in the name.
 	assert.NotContains(t, body, "*Firing*")
-	assert.Contains(t, body, "*Resolved*")
+	assert.NotContains(t, body, "*Resolved*")
 	assert.Contains(t, body, "*Device Temperature High* _(warning)_ — miner-02 (`11:22:33:44:55:66`)")
 	assert.Contains(t, body, "Max sensor temperature is above 90C.")
-	assert.Contains(t, body, "*Device Offline* _(warning)_ — miner-01 (`aa:bb:cc:dd:ee:ff`)")
+	resolvedText := sectionText(t, blocks[len(blocks)-1])
+	assert.Equal(t, "*Resolved: Device Offline* — miner-01 (`aa:bb:cc:dd:ee:ff`)", resolvedText)
+	assert.NotContains(t, resolvedText, "warning")
+	assert.NotContains(t, resolvedText, "Device is offline for at least five minutes.")
 }
 
 func TestRenderSlackOmitsLinkWhenNoPublicURL(t *testing.T) {
@@ -241,6 +244,22 @@ func TestRenderSlackCountsInstancesForDevicelessAlerts(t *testing.T) {
 	text := allSectionText(t, renderSlack("", []Alert{source("maestro-a"), source("maestro-b")}, nil))
 	assert.Contains(t, text, "*Curtailment Source Unreachable* _(critical)_ — 2 instances")
 	// The rule interpolates the source into summary, so naming only one would leave the other unreported.
+	assert.Contains(t, text, "Curtailment source maestro-a is unreachable; cannot curtail.")
+	assert.Contains(t, text, "Curtailment source maestro-b is unreachable; cannot curtail.")
+}
+
+func TestRenderSlackResolvedDevicelessAlertsKeepIdentifyingSummaries(t *testing.T) {
+	source := func(kind string) Alert {
+		return Alert{
+			Status:      "resolved",
+			Labels:      map[string]string{"alertname": "Curtailment Source Unreachable", "severity": "critical"},
+			Annotations: map[string]string{"summary": "Curtailment source " + kind + " is unreachable; cannot curtail."},
+		}
+	}
+	text := allSectionText(t, renderSlack("", []Alert{source("maestro-a"), source("maestro-b")}, nil))
+
+	assert.Contains(t, text, "*Resolved: Curtailment Source Unreachable* — 2 instances")
+	assert.NotContains(t, text, "_(critical)_", "resolved alerts omit severity")
 	assert.Contains(t, text, "Curtailment source maestro-a is unreachable; cannot curtail.")
 	assert.Contains(t, text, "Curtailment source maestro-b is unreachable; cannot curtail.")
 }

--- a/server/internal/domain/alerts/routing.go
+++ b/server/internal/domain/alerts/routing.go
@@ -100,14 +100,14 @@ func (s *Service) resolveRoutePolicy(ctx context.Context, orgID int64, mode Rout
 	switch mode {
 	case RouteModeDefault, RouteModeNone:
 		if len(channelIDs) > 0 {
-			return nil, fleeterror.NewInvalidArgumentErrorf("channel_ids must be empty for %s routing", mode)
+			return nil, fleeterror.NewInvalidArgumentErrorf("destinations must be empty for %s routing", mode)
 		}
 	case RouteModeCustom:
 		if len(channelIDs) == 0 {
-			return nil, fleeterror.NewInvalidArgumentError("custom routing requires at least one channel")
+			return nil, fleeterror.NewInvalidArgumentError("custom routing requires at least one destination")
 		}
 		if len(channelIDs) > maxRouteChannels {
-			return nil, fleeterror.NewInvalidArgumentErrorf("too many channels: %d (max %d)", len(channelIDs), maxRouteChannels)
+			return nil, fleeterror.NewInvalidArgumentErrorf("too many destinations: %d (max %d)", len(channelIDs), maxRouteChannels)
 		}
 	default:
 		return nil, fleeterror.NewInvalidArgumentErrorf("unknown routing mode: %q", mode)
@@ -141,7 +141,7 @@ func (s *Service) resolveOrgChannelIDs(ctx context.Context, orgID int64, channel
 	for _, raw := range channelIDs {
 		id, err := parseRowID(raw)
 		if err != nil || !owned[id] {
-			return nil, fleeterror.NewInvalidArgumentErrorf("unknown channel id: %q", raw)
+			return nil, fleeterror.NewInvalidArgumentErrorf("unknown destination id: %q", raw)
 		}
 		if seen[id] {
 			continue

--- a/server/internal/domain/alerts/routing_test.go
+++ b/server/internal/domain/alerts/routing_test.go
@@ -124,6 +124,9 @@ func TestSetRuleRoutingValidation(t *testing.T) {
 	// Custom requires at least one channel.
 	_, err := svc.SetRuleRouting(ctx, 7, "pfu-mine", RouteModeCustom, nil)
 	assert.True(t, fleeterror.IsInvalidArgumentError(err))
+	var fleetErr fleeterror.FleetError
+	require.ErrorAs(t, err, &fleetErr)
+	assert.Equal(t, "custom routing requires at least one destination", fleetErr.DebugMessage)
 
 	// Default/none reject channel ids.
 	_, err = svc.SetRuleRouting(ctx, 7, "pfu-mine", RouteModeNone, []string{"1"})

--- a/server/internal/domain/alerts/service.go
+++ b/server/internal/domain/alerts/service.go
@@ -193,7 +193,7 @@ func (s *Service) CreateChannel(ctx context.Context, orgID int64, c Channel) (*C
 	}
 	// Reject a duplicate name up front (the live-rows unique index would reject it anyway).
 	if _, err := s.channels.GetByName(ctx, orgID, c.Name); err == nil {
-		return nil, fleeterror.NewAlreadyExistsErrorf("a channel named %q already exists", c.Name)
+		return nil, fleeterror.NewAlreadyExistsErrorf("a destination named %q already exists", c.Name)
 	} else if !errors.Is(err, ErrNotFound) {
 		return nil, err
 	}
@@ -243,7 +243,7 @@ func (s *Service) UpdateChannel(ctx context.Context, orgID int64, c Channel) (*C
 	// Reject a rename onto another live channel's name (the unique index would reject it too).
 	if c.Name != rec.Name {
 		if other, err := s.channels.GetByName(ctx, orgID, c.Name); err == nil && other.ID != id {
-			return nil, fleeterror.NewAlreadyExistsErrorf("a channel named %q already exists", c.Name)
+			return nil, fleeterror.NewAlreadyExistsErrorf("a destination named %q already exists", c.Name)
 		} else if err != nil && !errors.Is(err, ErrNotFound) {
 			return nil, err
 		}
@@ -386,7 +386,7 @@ func testStatusCode(ok bool) int {
 // Rejects names matching the transient test-receiver pattern so a saved channel can never be misclassified as transient and dropped from routing.
 func validateChannelName(name string) error {
 	if transientReceiverName.MatchString(name) {
-		return fleeterror.NewInvalidArgumentError("channel name may not match the reserved transient test-receiver pattern")
+		return fleeterror.NewInvalidArgumentError("destination name may not match the reserved transient test-receiver pattern")
 	}
 	return nil
 }
@@ -890,7 +890,7 @@ func (s *Service) UpdateMaintenanceWindow(ctx context.Context, orgID int64, w Ma
 
 func maintenanceWindowLimitError() error {
 	return fleeterror.NewFailedPreconditionErrorf(
-		"maintenance window limit reached (%d active or scheduled); delete one first", maxMaintenanceWindowsPerOrg)
+		"quiet period limit reached (%d active or scheduled); delete one first", maxMaintenanceWindowsPerOrg)
 }
 
 func (s *Service) DeleteMaintenanceWindow(ctx context.Context, orgID int64, id string) error {
@@ -974,7 +974,7 @@ func (s *Service) resolveWindowChannelIDs(ctx context.Context, orgID int64, chan
 		return nil, nil
 	}
 	if len(channelIDs) > maxMaintenanceWindowTargets {
-		return nil, fleeterror.NewInvalidArgumentErrorf("too many channel_ids: %d (max %d)", len(channelIDs), maxMaintenanceWindowTargets)
+		return nil, fleeterror.NewInvalidArgumentErrorf("too many destinations: %d (max %d)", len(channelIDs), maxMaintenanceWindowTargets)
 	}
 	return s.resolveOrgChannelIDs(ctx, orgID, channelIDs)
 }
@@ -1006,19 +1006,19 @@ func maintenanceWindowFromRecord(rec MaintenanceWindowRecord, now time.Time) Mai
 // by deleting it.
 func validateMaintenanceWindowTimes(startsAt, endsAt, now time.Time) error {
 	if startsAt.IsZero() {
-		return fleeterror.NewInvalidArgumentError("starts_at is required for a maintenance window")
+		return fleeterror.NewInvalidArgumentError("starts_at is required for a quiet period")
 	}
 	if endsAt.IsZero() {
-		return fleeterror.NewInvalidArgumentError("ends_at is required for a maintenance window")
+		return fleeterror.NewInvalidArgumentError("ends_at is required for a quiet period")
 	}
 	if !endsAt.After(startsAt) {
 		return fleeterror.NewInvalidArgumentError("ends_at must be after starts_at")
 	}
 	if endsAt.Sub(startsAt) > maxMaintenanceWindowDuration {
-		return fleeterror.NewInvalidArgumentError("maintenance window duration cannot exceed 30 days")
+		return fleeterror.NewInvalidArgumentError("quiet period duration cannot exceed 30 days")
 	}
 	if !endsAt.After(now) {
-		return fleeterror.NewInvalidArgumentError("ends_at must be in the future; to end a window early, delete it")
+		return fleeterror.NewInvalidArgumentError("ends_at must be in the future; to end a quiet period early, delete it")
 	}
 	return nil
 }

--- a/server/internal/domain/alerts/service_test.go
+++ b/server/internal/domain/alerts/service_test.go
@@ -135,6 +135,9 @@ func TestValidateChannelNameRejectsTransientPattern(t *testing.T) {
 	err := validateChannelName("test-550e8400-e29b-41d4-a716-446655440000")
 	require.Error(t, err)
 	assert.True(t, fleeterror.IsInvalidArgumentError(err))
+	var fleetErr fleeterror.FleetError
+	require.ErrorAs(t, err, &fleetErr)
+	assert.Equal(t, "destination name may not match the reserved transient test-receiver pattern", fleetErr.DebugMessage)
 }
 
 func TestRedactWebhookURL(t *testing.T) {
@@ -400,6 +403,9 @@ func TestMaintenanceWindowRejectsUnknownChannel(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.True(t, fleeterror.IsInvalidArgumentError(err), "want InvalidArgument, got %v", err)
+	var fleetErr fleeterror.FleetError
+	require.ErrorAs(t, err, &fleetErr)
+	assert.Equal(t, `unknown destination id: "999"`, fleetErr.DebugMessage)
 	assert.Empty(t, windows.rows, "window with an unknown channel must not persist")
 }
 

--- a/server/internal/domain/stores/sqlstores/notification_history_test.go
+++ b/server/internal/domain/stores/sqlstores/notification_history_test.go
@@ -86,6 +86,31 @@ func TestNotificationHistoryStore_InsertBatch_Chunks(t *testing.T) {
 	assert.Equal(t, "device-0", gotLabel, "labels jsonb round-trips")
 }
 
+func TestNotificationHistoryStore_ListExcludesResolvedRows(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test in short mode")
+	}
+
+	testContext := testutil.InitializeDBServiceInfrastructure(t)
+	db := testContext.DatabaseService.DB
+	orgID := testContext.DatabaseService.CreateSuperAdminUser().OrganizationID
+	store := sqlstores.NewSQLNotificationHistoryStore(db)
+	now := time.Now()
+
+	insertNotification(t, db, orgID, "firing-alert", "firing", now.Add(-time.Minute))
+	insertNotification(t, db, orgID, "resolved-alert", "resolved", now)
+
+	history, err := store.List(t.Context(), orgID, nil, 50)
+	require.NoError(t, err)
+	require.Len(t, history, 1)
+	assert.Equal(t, "firing-alert", history[0].Fingerprint)
+
+	var storedRows int
+	require.NoError(t, db.QueryRowContext(t.Context(),
+		`SELECT COUNT(*) FROM notification_history WHERE organization_id = $1`, orgID).Scan(&storedRows))
+	assert.Equal(t, 2, storedRows, "resolution rows remain stored for active-alert lifecycle state")
+}
+
 func TestNotificationHistoryStore_ListActive_FreshnessGate(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping database integration test in short mode")

--- a/server/internal/handlers/alerts/handler.go
+++ b/server/internal/handlers/alerts/handler.go
@@ -776,7 +776,7 @@ func protoToMaintenanceWindow(id string, scope *alertsv1.MaintenanceWindowScope,
 	if err := validateMaintenanceWindowTargetSelection("rules", scope.GetAllRules(), scope.GetRuleIds()); err != nil {
 		return alerts.MaintenanceWindow{}, err
 	}
-	if err := validateMaintenanceWindowTargetSelection("channels", scope.GetAllChannels(), scope.GetChannelIds()); err != nil {
+	if err := validateMaintenanceWindowTargetSelection("destinations", scope.GetAllChannels(), scope.GetChannelIds()); err != nil {
 		return alerts.MaintenanceWindow{}, err
 	}
 	if startsAt == nil {
@@ -882,7 +882,7 @@ func protoToChannelKind(k alertsv1.ChannelKind) (alerts.ChannelKind, error) {
 	// SMTP is not offered in this slice; it ships in the SMTP channel slice.
 	case alertsv1.ChannelKind_CHANNEL_KIND_UNSPECIFIED, alertsv1.ChannelKind_CHANNEL_KIND_SMTP:
 	}
-	return "", fleeterror.NewInvalidArgumentErrorf("unknown channel kind: %s", k)
+	return "", fleeterror.NewInvalidArgumentErrorf("unknown destination kind: %s", k)
 }
 
 func httpStatusToInt32(code int) int32 {

--- a/server/migrations/000141_notification_history_unresolved_index.down.sql
+++ b/server/migrations/000141_notification_history_unresolved_index.down.sql
@@ -1,0 +1,2 @@
+-- CONCURRENTLY avoids blocking alert ingestion and must remain the sole statement in this migration.
+DROP INDEX CONCURRENTLY IF EXISTS idx_notification_history_org_unresolved_id;

--- a/server/migrations/000141_notification_history_unresolved_index.up.sql
+++ b/server/migrations/000141_notification_history_unresolved_index.up.sql
@@ -1,0 +1,6 @@
+-- Keeps activity-history pagination on unresolved rows after a large recovery batch. The key order matches
+-- the organization filter and descending id keyset scan in ListNotificationHistory.
+-- CONCURRENTLY avoids blocking alert ingestion and must remain the sole statement in this migration.
+CREATE INDEX CONCURRENTLY idx_notification_history_org_unresolved_id
+    ON notification_history (organization_id, id DESC)
+    WHERE status <> 'resolved';

--- a/server/sqlc/queries/notification_history.sql
+++ b/server/sqlc/queries/notification_history.sql
@@ -77,6 +77,8 @@ FROM jsonb_to_recordset(sqlc.arg('rows_jsonb')::JSONB) AS r(
 );
 
 -- name: ListNotificationHistory :many
+-- Resolution rows remain stored so the notification_active trigger can close firing alerts,
+-- but the activity feed records only the alert firing event.
 SELECT
     nh.id,
     nh.received_at,
@@ -106,6 +108,7 @@ LEFT JOIN device d
     AND d.deleted_at IS NULL
 LEFT JOIN discovered_device dd ON dd.id = d.discovered_device_id
 WHERE nh.organization_id = sqlc.arg('organization_id')
+  AND nh.status <> 'resolved'
   AND (sqlc.narg('before_id')::bigint IS NULL OR nh.id < sqlc.narg('before_id'))
 ORDER BY nh.id DESC
 LIMIT sqlc.arg('page_limit');


### PR DESCRIPTION
Reviewable diff: +133/-104 across 19 files (excludes generated, test, and story files).

## Summary

This PR updates the alerting interface to call notification channels “Destinations” and maintenance windows “Quiet Periods,” including minute-precision period timestamps. Slack recovery messages now identify each alert as `Resolved: <alert name>` without a separate heading, severity, or non-identifying miner summary, while preserving the summary for device-less alerts whose source would otherwise be ambiguous. Resolved events continue to close active alert state but no longer appear as separate activity-log rows, and a partial index keeps that filtered feed efficient after large recovery batches.

## How it works

1. The alerts settings UI and user-facing validation errors use the new terminology while retaining the existing channel and maintenance-window API fields.
2. Alertmanager webhook processing continues to persist both firing and resolved events. The existing database trigger uses the resolved row to close the corresponding active alert.
3. Activity history reads filter out rows whose status is `resolved`, so the lifecycle state remains correct without showing recovery entries in the feed. A concurrent partial index matches the organization, status, and descending keyset-pagination predicates.
4. Slack rendering partitions firing and resolved alerts, groups them by alert name, and prefixes resolved group names inline. Miner-backed resolutions omit severity and summary; device-less resolutions retain identifying summaries such as a source or host name.

## Diagrams

```mermaid
flowchart LR
    operator["Operator"]
    ui["Alerts settings UI"]
    api["Existing alerts API contracts"]
    grafana["Grafana Alertmanager"]
    handler["Alert webhook handler"]
    history["Notification history"]
    active["Active alert state"]
    feed["Activity history query"]
    deliverer["Alert deliverer"]
    renderer["Slack renderer"]
    destination["Slack destination"]

    operator --> ui
    ui --> api
    grafana --> handler
    handler --> history
    history --> active
    history --> feed
    handler --> deliverer
    deliverer --> renderer
    renderer --> destination
```

```mermaid
sequenceDiagram
    participant G as Grafana Alertmanager
    participant H as Webhook handler
    participant N as Notification history
    participant A as Active alert state
    participant S as Slack destination
    participant U as Activity UI
    G->>H: Send resolved alert
    H->>N: Insert resolved row
    N->>A: Close active alert
    H->>S: Send resolved notification
    U->>N: Request activity history
    N-->>U: Return firing rows only
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/src/protoFleet/features/alerts/` | Renamed visible channel/window copy and formatted quiet-period timestamps without seconds | Review terminology coverage and locale-aware period display |
| `client/e2eTests/protoFleet/` | Updated alert page helpers and RBAC selectors for renamed controls | Keeps E2E automation aligned with the UI copy |
| `server/internal/domain/alerts/` | Changed Slack recovery rendering and user-facing service/routing errors; added focused regressions | Review the device-backed versus device-less resolution detail policy |
| `server/internal/handlers/alerts/` | Updated request-validation terminology | Ensures API errors shown in the UI use the same vocabulary |
| `server/sqlc/queries/notification_history.sql` | Excluded resolved rows from activity-history reads while retaining persisted rows | Review the separation between lifecycle persistence and feed presentation |
| `server/migrations/000141_notification_history_unresolved_index.*.sql` | Added a concurrent partial index for unresolved activity-history rows | Review the predicate, key order, and non-blocking rollout/rollback behavior |
| `server/generated/sqlc/` | Regenerated sqlc bindings — generated, skip | Confirms generated output matches the query source |

## Key technical decisions & trade-offs

- Keep channel and maintenance-window names in internal/API contracts, changing only user-facing language instead of introducing a schema and wire-format rename.
- Filter resolved rows when reading activity history instead of suppressing their inserts, preserving the trigger that closes active alerts.
- Add a concurrent partial index for the filtered keyset query instead of relying on the broader organization/id index to skip potentially large resolved batches.
- Omit summary and severity for miner-backed Slack resolutions, but retain summaries for device-less rules because they can carry the only source identity.
- Use locale-aware date formatting with explicit year-through-minute fields instead of slicing formatted strings or forcing a single timezone/locale.

## Testing & validation

- `just gen` (sqlc output regenerated; only expected generated bindings changed)
- `just lint`
- `go test ./internal/domain/alerts ./internal/handlers/alerts`
- `DB_PASSWORD=fleet go test ./internal/handlers/alertmanagerwebhook`
- `DB_PASSWORD=fleet go test ./internal/domain/stores/sqlstores -run TestNotificationHistoryStore_ListExcludesResolvedRows -count=1`
- `EXPLAIN (ANALYZE, BUFFERS)` with 100 firing rows followed by 100,000 resolved rows: matching partial index-only scan, 0.023 ms execution in the synthetic plan check
- `npm test -- --run src/protoFleet/features/alerts/api/useChannelSelection.test.ts`
- Pre-commit hooks: protected-branch guard, Go imports, and client formatting
- Pre-push hooks: client typecheck and server lint
- Not run locally: ProtoFleet Playwright E2E; the touched helpers require the full docker-compose application environment.
