### PR TITLE
fix(ci): restrict workflow token permissions

### DIFF
--- a/.github/workflows/generated-code-check.yml
+++ b/.github/workflows/generated-code-check.yml
@@ -7,6 +7,9 @@ on:
   workflow_dispatch:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   generated-code-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/protofleet-client-checks.yml
+++ b/.github/workflows/protofleet-client-checks.yml
@@ -13,6 +13,9 @@ on:
   workflow_dispatch:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   # Fast checks (lint, format, typecheck) run in a single job to reduce overhead
   quality:

--- a/.github/workflows/protofleet-e2e-real-miners-manual.yml
+++ b/.github/workflows/protofleet-e2e-real-miners-manual.yml
@@ -8,6 +8,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 concurrency:
   group: protofleet-e2e-real-miners
   cancel-in-progress: false

--- a/.github/workflows/protofleet-e2e-tests.yml
+++ b/.github/workflows/protofleet-e2e-tests.yml
@@ -22,6 +22,9 @@ on:
         default: smoke
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   detect-specs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Reviewable diff: +12/-0 across 4 files (excludes generated, test, and story files).

## Summary

GitHub Actions jobs now run with an explicit read-only repository token instead of inheriting the repository's default token scope. This closes six medium code-scanning findings while preserving the checkout, cache, artifact, build, test, manual, and reusable-workflow paths.

## How it works

Each affected workflow sets `contents: read` at workflow scope. GitHub denies every unspecified token permission, while all jobs retain the repository-read capability required by checkout and local actions.

```mermaid
flowchart LR
  Trigger["Push, schedule, dispatch, or reusable call"] --> Workflow["Affected workflow"]
  Workflow --> Token["GITHUB_TOKEN: contents read"]
  Token --> Jobs["Checkout, build, test, cache, and artifacts"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `.github/workflows/generated-code-check.yml` | Read-only workflow token | Generation checks only need repository contents |
| `.github/workflows/protofleet-client-checks.yml` | Read-only workflow token | Covers lint, test, and build jobs |
| `.github/workflows/protofleet-e2e-tests.yml` | Read-only workflow token | Covers spec detection and preserves existing job restrictions |
| `.github/workflows/protofleet-e2e-real-miners-manual.yml` | Read-only workflow token | Narrows the self-hosted manual workflow |

## Key technical decisions & trade-offs

- Use one workflow-level permission block over repeated job blocks so every current and future job inherits the same least-privilege ceiling.
- Grant only `contents: read`; no reviewed step uses checks, pull-request, package, or OIDC writes.
- Keep the real-miner workflow in this PR despite its manual validation surface because its token requirement is identical.

## Testing & validation

- Ruby YAML loading succeeded for all four workflows.
- `git diff --check`, Lefthook pre-commit, and Lefthook pre-push passed.
- Static correctness, testing, security, and repository-standards reviews found no actionable issues.
- Not covered locally: a real-miner manual dispatch and post-push GitHub-hosted workflow execution.

## Post-Deploy Monitoring & Validation

- Watch the next code-scanning analysis for alerts 80-86 to close.
- Confirm the PR Gate's generated-code, client, and ProtoFleet E2E reusable workflows start without token-permission errors.
- Healthy signal: checkouts and artifact/cache operations succeed with no `Resource not accessible by integration` errors.
- Failure trigger: any affected job reports a token-permission denial; revert this PR and add only the specific missing read permission.
- Validation window and owner: first full PR Gate run after merge, owned by the PR author.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
