### PR TITLE
fix(ci): anchor review policy checkout to trusted ref

### DIFF
--- a/.github/scripts/evaluate_review_policy_test.py
+++ b/.github/scripts/evaluate_review_policy_test.py
@@ -58,12 +58,21 @@ class ReviewPolicyTest(unittest.TestCase):
         cancel_expression = workflow["concurrency"]["cancel-in-progress"]
 
         self.assertIn("format('ignored-{0}', github.run_id)", group_expression)
-        self.assertIn("github.event.pull_request.head.sha || github.event.workflow_run.head_sha", group_expression)
-        self.assertIn("github.event.check_run.app.slug == 'github-actions'", cancel_expression)
+        self.assertIn(
+            "github.event.pull_request.head.sha || github.event.workflow_run.head_sha",
+            group_expression,
+        )
+        self.assertIn(
+            "github.event.check_run.app.slug == 'github-actions'", cancel_expression
+        )
         self.assertIn("github.event.action == 'rerequested'", cancel_expression)
-        self.assertIn("github.event.check_suite.app.slug == 'github-actions'", cancel_expression)
+        self.assertIn(
+            "github.event.check_suite.app.slug == 'github-actions'", cancel_expression
+        )
         self.assertIn("github.event.context == 'Review Policy'", cancel_expression)
-        self.assertIn("github.event.context == 'Review Policy Advisory'", cancel_expression)
+        self.assertIn(
+            "github.event.context == 'Review Policy Advisory'", cancel_expression
+        )
         self.assertIn("github.event.review.state == 'commented'", cancel_expression)
 
     def test_workflow_publishes_pending_status_for_cancelled_evaluation(self):
@@ -72,12 +81,16 @@ class ReviewPolicyTest(unittest.TestCase):
         publish_step = publish_job["steps"][0]
         script = publish_step["with"]["script"]
 
-        self.assertEqual(publish_job["if"], "always() && needs.evaluate.outputs.found == 'true'")
+        self.assertEqual(
+            publish_job["if"], "always() && needs.evaluate.outputs.found == 'true'"
+        )
         self.assertEqual(
             publish_job["concurrency"]["group"],
             "review-policy-publish-${{ needs.evaluate.outputs.head_sha }}",
         )
-        self.assertEqual(publish_step["env"]["EVALUATE_RESULT"], "${{ needs.evaluate.result }}")
+        self.assertEqual(
+            publish_step["env"]["EVALUATE_RESULT"], "${{ needs.evaluate.result }}"
+        )
         self.assertIn("existingRunId > currentRunId", script)
         self.assertIn("evaluationCancelled ? 'pending'", script)
         self.assertIn(
@@ -97,7 +110,9 @@ class ReviewPolicyTest(unittest.TestCase):
             label_job["concurrency"]["group"],
             "review-policy-label-${{ needs.evaluate.outputs.head_sha }}",
         )
-        self.assertEqual(label_job["permissions"], {"issues": "write", "pull-requests": "write"})
+        self.assertEqual(
+            label_job["permissions"], {"issues": "write", "pull-requests": "write"}
+        )
 
     def test_workflow_uses_default_branch_policy_for_stacked_prs(self):
         workflow_text = read_workflow("review-policy.yml")
@@ -106,9 +121,7 @@ class ReviewPolicyTest(unittest.TestCase):
         evaluate_outputs = workflow["jobs"]["evaluate"]["outputs"]
         evaluate_steps = workflow["jobs"]["evaluate"]["steps"]
         classifier_step = next(
-            step
-            for step in evaluate_steps
-            if step.get("id") == "ai_classifier"
+            step for step in evaluate_steps if step.get("id") == "ai_classifier"
         )
         mode_index, mode_step = next(
             (index, step)
@@ -127,67 +140,144 @@ class ReviewPolicyTest(unittest.TestCase):
             if step.get("id") == "policy_config"
         )
 
-        self.assertIn("core.setOutput('default_branch', pr.base.repo.default_branch)", workflow_text)
+        self.assertIn(
+            "core.setOutput('default_branch', pr.base.repo.default_branch)",
+            workflow_text,
+        )
         self.assertNotIn("core.setOutput('trusted_base'", workflow_text)
         self.assertLess(mode_index, checkout_index)
         self.assertGreater(config_index, checkout_index)
         self.assertEqual(mode_step["if"], "steps.pr.outputs.found == 'true'")
         self.assertNotIn("POLICY_ROOT", mode_step["env"])
-        self.assertEqual(config_step["env"]["STACKED_ADVISORY"], "${{ steps.policy_mode.outputs.stacked_advisory || 'false' }}")
-        self.assertEqual(checkout_step["with"]["ref"], "${{ steps.pr.outputs.default_branch }}")
-        self.assertNotIn("Review policy only evaluates PRs based on the repository default branch", workflow_text)
-        self.assertIn("Using review policy code from the trusted default branch", workflow_text)
-        self.assertIn("REVIEW_BASE_SHA: ${{ steps.pr.outputs.base_sha }}", workflow_text)
-        self.assertIn("REVIEW_POLICY_ENFORCED: ${{ steps.policy_config.outputs.enforced || steps.policy_mode.outputs.enforced || 'true' }}", workflow_text)
+        self.assertEqual(
+            config_step["env"]["STACKED_ADVISORY"],
+            "${{ steps.policy_mode.outputs.stacked_advisory || 'false' }}",
+        )
+        self.assertEqual(
+            checkout_step["with"]["ref"],
+            "${{ github.event.repository.default_branch }}",
+        )
+        self.assertNotIn(
+            "Review policy only evaluates PRs based on the repository default branch",
+            workflow_text,
+        )
+        self.assertIn(
+            "Using review policy code from the trusted default branch", workflow_text
+        )
+        self.assertIn(
+            "REVIEW_BASE_SHA: ${{ steps.pr.outputs.base_sha }}", workflow_text
+        )
+        self.assertIn(
+            "REVIEW_POLICY_ENFORCED: ${{ steps.policy_config.outputs.enforced || steps.policy_mode.outputs.enforced || 'true' }}",
+            workflow_text,
+        )
         self.assertNotIn('--base-ref "$BASE_REF"', workflow_text)
         self.assertNotIn('--default-branch "$DEFAULT_BRANCH"', workflow_text)
         self.assertIn('enforced="${REVIEW_POLICY_ENFORCED}"', workflow_text)
-        self.assertEqual(evaluate_outputs["enforced"], "${{ steps.evaluate_policy.outputs.enforced || steps.policy_config.outputs.enforced || steps.bootstrap_policy.outputs.enforced || steps.policy_mode.outputs.enforced || 'true' }}")
-        self.assertEqual(evaluate_outputs["stacked_advisory"], "${{ steps.policy_mode.outputs.stacked_advisory || 'false' }}")
-        self.assertEqual(evaluate_outputs["config_enforced"], "${{ steps.policy_config.outputs.config_enforced || 'true' }}")
-        self.assertEqual(evaluate_outputs["policy_source_available"], "${{ steps.policy_source.outputs.available || 'false' }}")
+        self.assertEqual(
+            evaluate_outputs["enforced"],
+            "${{ steps.evaluate_policy.outputs.enforced || steps.policy_config.outputs.enforced || steps.bootstrap_policy.outputs.enforced || steps.policy_mode.outputs.enforced || 'true' }}",
+        )
+        self.assertEqual(
+            evaluate_outputs["stacked_advisory"],
+            "${{ steps.policy_mode.outputs.stacked_advisory || 'false' }}",
+        )
+        self.assertEqual(
+            evaluate_outputs["config_enforced"],
+            "${{ steps.policy_config.outputs.config_enforced || 'true' }}",
+        )
+        self.assertEqual(
+            evaluate_outputs["policy_source_available"],
+            "${{ steps.policy_source.outputs.available || 'false' }}",
+        )
         self.assertIn("stacked_advisory=true", workflow_text)
-        self.assertEqual(publish_env["DECISION"], "${{ needs.evaluate.outputs.decision || 'needs-human-review' }}")
-        self.assertEqual(publish_env["PASSED"], "${{ needs.evaluate.outputs.passed || 'false' }}")
-        self.assertEqual(publish_env["ENFORCED"], "${{ needs.evaluate.outputs.enforced || 'true' }}")
+        self.assertEqual(
+            publish_env["DECISION"],
+            "${{ needs.evaluate.outputs.decision || 'needs-human-review' }}",
+        )
+        self.assertEqual(
+            publish_env["PASSED"], "${{ needs.evaluate.outputs.passed || 'false' }}"
+        )
+        self.assertEqual(
+            publish_env["ENFORCED"], "${{ needs.evaluate.outputs.enforced || 'true' }}"
+        )
         self.assertEqual(classifier_step["timeout-minutes"], 10)
-        self.assertIn("Tiny non-sensitive server utility changes are eligible", classifier_step["with"]["prompt"])
+        self.assertIn(
+            "Tiny non-sensitive server utility changes are eligible",
+            classifier_step["with"]["prompt"],
+        )
 
     def test_workflow_invalidates_enforced_status_for_enforced_stacked_advisory(self):
         workflow_text = read_workflow("review-policy.yml")
         workflow = load_workflow("review-policy.yml")
         publish_env = workflow["jobs"]["publish-status"]["steps"][0]["env"]
 
-        self.assertEqual(publish_env["CONFIG_ENFORCED"], "${{ needs.evaluate.outputs.config_enforced || 'true' }}")
-        self.assertEqual(publish_env["STACKED_ADVISORY"], "${{ needs.evaluate.outputs.stacked_advisory || 'false' }}")
-        self.assertEqual(publish_env["POLICY_SOURCE_AVAILABLE"], "${{ needs.evaluate.outputs.policy_source_available || 'false' }}")
+        self.assertEqual(
+            publish_env["CONFIG_ENFORCED"],
+            "${{ needs.evaluate.outputs.config_enforced || 'true' }}",
+        )
+        self.assertEqual(
+            publish_env["STACKED_ADVISORY"],
+            "${{ needs.evaluate.outputs.stacked_advisory || 'false' }}",
+        )
+        self.assertEqual(
+            publish_env["POLICY_SOURCE_AVAILABLE"],
+            "${{ needs.evaluate.outputs.policy_source_available || 'false' }}",
+        )
         self.assertIn("function hasNewerStatusRun(contextName)", workflow_text)
         self.assertIn("if (!hasNewerStatusRun('Review Policy'))", workflow_text)
         self.assertIn("context: 'Review Policy'", workflow_text)
         self.assertIn("state: enforcedAdvisoryState", workflow_text)
-        self.assertIn("Stacked PR result is advisory; default-branch PR must pass Review Policy.", workflow_text)
-        self.assertIn("enforcedAdvisoryState = stackedAdvisory ? 'pending' : 'failure'", workflow_text)
-        self.assertIn("Stacked PR policy source unavailable; default-branch PR must pass Review Policy.", workflow_text)
-        self.assertIn("Review Policy is advisory; see Review Policy Advisory.", workflow_text)
-        self.assertIn("Trusted Review Policy source unavailable; human review required.", workflow_text)
+        self.assertIn(
+            "Stacked PR result is advisory; default-branch PR must pass Review Policy.",
+            workflow_text,
+        )
+        self.assertIn(
+            "enforcedAdvisoryState = stackedAdvisory ? 'pending' : 'failure'",
+            workflow_text,
+        )
+        self.assertIn(
+            "Stacked PR policy source unavailable; default-branch PR must pass Review Policy.",
+            workflow_text,
+        )
+        self.assertIn(
+            "Review Policy is advisory; see Review Policy Advisory.", workflow_text
+        )
+        self.assertIn(
+            "Trusted Review Policy source unavailable; human review required.",
+            workflow_text,
+        )
 
     def test_workflow_label_sync_is_bound_to_base_and_head(self):
         workflow_text = read_workflow("review-policy.yml")
         workflow = load_workflow("review-policy.yml")
         label_env = workflow["jobs"]["sync-label"]["steps"][0]["env"]
 
-        self.assertEqual(label_env["BASE_SHA"], "${{ needs.evaluate.outputs.base_sha }}")
-        self.assertEqual(label_env["HEAD_SHA"], "${{ needs.evaluate.outputs.head_sha }}")
-        self.assertIn("Missing evaluated base SHA for review policy label sync", workflow_text)
-        self.assertIn("pr.head.sha !== headSha || pr.base.sha !== baseSha", workflow_text)
-        self.assertIn("Skipping stale Review Policy label sync for ${baseSha}...${headSha}", workflow_text)
+        self.assertEqual(
+            label_env["BASE_SHA"], "${{ needs.evaluate.outputs.base_sha }}"
+        )
+        self.assertEqual(
+            label_env["HEAD_SHA"], "${{ needs.evaluate.outputs.head_sha }}"
+        )
+        self.assertIn(
+            "Missing evaluated base SHA for review policy label sync", workflow_text
+        )
+        self.assertIn(
+            "pr.head.sha !== headSha || pr.base.sha !== baseSha", workflow_text
+        )
+        self.assertIn(
+            "Skipping stale Review Policy label sync for ${baseSha}...${headSha}",
+            workflow_text,
+        )
 
     def test_path_matches_double_star_root_file(self):
         self.assertTrue(policy.path_matches("package.json", "**/package.json"))
         self.assertTrue(policy.path_matches("client/package.json", "**/package.json"))
 
     def test_path_matches_directory_prefix(self):
-        self.assertTrue(policy.path_matches(".github/workflows/review-policy.yml", ".github/**"))
+        self.assertTrue(
+            policy.path_matches(".github/workflows/review-policy.yml", ".github/**")
+        )
         self.assertTrue(policy.path_matches("server", "server/**"))
         self.assertTrue(policy.path_matches("server/main.go", "server/**"))
 
@@ -262,7 +352,12 @@ class ReviewPolicyTest(unittest.TestCase):
             {"filename": "deployment-files/ha/QUALIFICATION.md"},
         ]
 
-        self.assertEqual(policy.denied_paths(files, low_risk["deny_paths"], low_risk["deny_path_exceptions"]), [])
+        self.assertEqual(
+            policy.denied_paths(
+                files, low_risk["deny_paths"], low_risk["deny_path_exceptions"]
+            ),
+            [],
+        )
 
     def test_low_risk_config_keeps_deployment_runtime_files_denied(self):
         low_risk = load_policy_config()["low_risk"]
@@ -272,8 +367,13 @@ class ReviewPolicyTest(unittest.TestCase):
         ]
 
         self.assertEqual(
-            policy.denied_paths(files, low_risk["deny_paths"], low_risk["deny_path_exceptions"]),
-            ["deployment-files/docker-compose.yaml", "deployment-files/ha/scripts/install.sh"],
+            policy.denied_paths(
+                files, low_risk["deny_paths"], low_risk["deny_path_exceptions"]
+            ),
+            [
+                "deployment-files/docker-compose.yaml",
+                "deployment-files/ha/scripts/install.sh",
+            ],
         )
 
     def test_low_risk_config_keeps_sensitive_server_paths_denied(self):
@@ -360,10 +460,14 @@ class ReviewPolicyTest(unittest.TestCase):
 
     def test_classifier_rejects_embedded_json(self):
         with self.assertRaisesRegex(policy.PolicyError, "exactly one JSON object"):
-            policy.load_classifier('warning\n{"risk":"low","confidence":0.9,"requires_human_review":false,"reasons":[]}')
+            policy.load_classifier(
+                'warning\n{"risk":"low","confidence":0.9,"requires_human_review":false,"reasons":[]}'
+            )
 
     def test_classifier_rejects_non_finite_confidence(self):
-        classifier = policy.load_classifier('{"risk":"low","confidence":NaN,"requires_human_review":false,"reasons":[]}')
+        classifier = policy.load_classifier(
+            '{"risk":"low","confidence":NaN,"requires_human_review":false,"reasons":[]}'
+        )
         allowed, reasons = policy.classifier_allows_low_risk(classifier, 0.85)
         self.assertFalse(allowed)
         self.assertIn("AI classifier confidence must be a finite number", reasons)
@@ -401,9 +505,18 @@ class ReviewPolicyTest(unittest.TestCase):
             },
         )
 
-        self.assertIn("client/src/foo.ts has 81 changed lines, exceeds per-file limit 80", blockers)
-        self.assertIn("client/src/foo.ts adds blocked content: adds process execution or shell-out code", blockers)
-        self.assertIn("client/src/opaque.bin diff content is unavailable for deterministic content checks", blockers)
+        self.assertIn(
+            "client/src/foo.ts has 81 changed lines, exceeds per-file limit 80",
+            blockers,
+        )
+        self.assertIn(
+            "client/src/foo.ts adds blocked content: adds process execution or shell-out code",
+            blockers,
+        )
+        self.assertIn(
+            "client/src/opaque.bin diff content is unavailable for deterministic content checks",
+            blockers,
+        )
         self.assertEqual(len(blockers), 3)
 
     def test_deterministic_content_blockers_allows_larger_test_files(self):
@@ -457,7 +570,9 @@ class ReviewPolicyTest(unittest.TestCase):
 
         self.assertEqual(
             blockers,
-            ["server/internal/domain/alerts/grafana_client.go has 95 changed lines, exceeds per-file limit 80"],
+            [
+                "server/internal/domain/alerts/grafana_client.go has 95 changed lines, exceeds per-file limit 80"
+            ],
         )
 
     def test_low_risk_preflight_blocks_before_classifier(self):
@@ -465,14 +580,29 @@ class ReviewPolicyTest(unittest.TestCase):
         original_request = policy.github_request
         original_trusted_author_reasons = policy.trusted_author_reasons
         try:
+
             def fake_paginate(path, token):
                 if path.endswith("/files"):
                     return [
-                        {"filename": ".github/workflows/review-policy.yml", "additions": 2, "deletions": 1},
-                        {"filename": "docs/readme.md", "additions": 300, "deletions": 0},
+                        {
+                            "filename": ".github/workflows/review-policy.yml",
+                            "additions": 2,
+                            "deletions": 1,
+                        },
+                        {
+                            "filename": "docs/readme.md",
+                            "additions": 300,
+                            "deletions": 0,
+                        },
                     ]
                 if path.endswith("/commits"):
-                    return [{"sha": "abc123", "author": {"login": "author"}, "committer": {"login": "author"}}]
+                    return [
+                        {
+                            "sha": "abc123",
+                            "author": {"login": "author"},
+                            "committer": {"login": "author"},
+                        }
+                    ]
                 if path.endswith("/commits/abc123/pulls"):
                     return [{"number": 123, "state": "open", "head": {"sha": "abc123"}}]
                 return []
@@ -482,9 +612,11 @@ class ReviewPolicyTest(unittest.TestCase):
                 "state": "open",
                 "head": {"sha": "abc123"},
             }
-            policy.trusted_author_reasons = lambda author, trusted_authors, owner, token: (
-                False,
-                [f"author @{author} is not in trusted_authors"],
+            policy.trusted_author_reasons = (
+                lambda author, trusted_authors, owner, token: (
+                    False,
+                    [f"author @{author} is not in trusted_authors"],
+                )
             )
             result = policy.evaluate_low_risk_preflight(
                 config={
@@ -510,7 +642,10 @@ class ReviewPolicyTest(unittest.TestCase):
         self.assertFalse(result["eligible"])
         self.assertIn("author @author is not in trusted_authors", result["blockers"])
         self.assertIn("303 changed lines exceeds limit 200", result["blockers"])
-        self.assertIn("denied paths changed: .github/workflows/review-policy.yml", result["blockers"])
+        self.assertIn(
+            "denied paths changed: .github/workflows/review-policy.yml",
+            result["blockers"],
+        )
 
     def test_shared_head_pr_blockers_fail_closed_for_multiple_open_prs(self):
         original = policy.github_paginate
@@ -520,27 +655,39 @@ class ReviewPolicyTest(unittest.TestCase):
                 {"number": 456, "state": "open", "head": {"sha": "abc123"}},
                 {"number": 789, "state": "closed", "head": {"sha": "abc123"}},
             ]
-            blockers = policy.shared_head_pr_blockers("block", "proto-fleet", 123, "abc123", "token")
+            blockers = policy.shared_head_pr_blockers(
+                "block", "proto-fleet", 123, "abc123", "token"
+            )
         finally:
             policy.github_paginate = original
 
-        self.assertEqual(blockers, ["current head SHA is shared by multiple open PRs: #123, #456"])
+        self.assertEqual(
+            blockers, ["current head SHA is shared by multiple open PRs: #123, #456"]
+        )
 
     def test_trusted_author_reasons_accepts_team_membership(self):
         original = policy.is_team_member
         try:
             policy.is_team_member = lambda owner, team_slug, username, token: (
-                owner == "block" and team_slug == "proto-fleet-dev" and username == "member"
+                owner == "block"
+                and team_slug == "proto-fleet-dev"
+                and username == "member"
             )
-            trusted, reasons = policy.trusted_author_reasons("member", ["@block/proto-fleet-dev"], "block", "token")
+            trusted, reasons = policy.trusted_author_reasons(
+                "member", ["@block/proto-fleet-dev"], "block", "token"
+            )
         finally:
             policy.is_team_member = original
 
         self.assertTrue(trusted)
-        self.assertEqual(reasons, ["author @member is a member of @block/proto-fleet-dev"])
+        self.assertEqual(
+            reasons, ["author @member is a member of @block/proto-fleet-dev"]
+        )
 
     def test_trusted_author_reasons_accepts_case_insensitive_login(self):
-        trusted, reasons = policy.trusted_author_reasons("AnkitGoswami", ["ankitgoswami"], "block", "token")
+        trusted, reasons = policy.trusted_author_reasons(
+            "AnkitGoswami", ["ankitgoswami"], "block", "token"
+        )
 
         self.assertTrue(trusted)
         self.assertEqual(reasons, ["author @AnkitGoswami is explicitly trusted"])
@@ -548,13 +695,21 @@ class ReviewPolicyTest(unittest.TestCase):
     def test_trusted_head_contributor_reasons_blocks_untrusted_committers(self):
         original = policy.trusted_author_reasons
         try:
-            policy.trusted_author_reasons = lambda author, trusted_authors, owner, token: (
-                author == "trusted",
-                [f"author @{author} is explicitly trusted"] if author == "trusted" else [f"author @{author} is not in trusted_authors"],
+            policy.trusted_author_reasons = (
+                lambda author, trusted_authors, owner, token: (
+                    author == "trusted",
+                    [f"author @{author} is explicitly trusted"]
+                    if author == "trusted"
+                    else [f"author @{author} is not in trusted_authors"],
+                )
             )
             ok, reasons, blockers = policy.trusted_head_contributor_reasons(
                 [
-                    {"sha": "abc123", "author": {"login": "trusted"}, "committer": {"login": "untrusted"}},
+                    {
+                        "sha": "abc123",
+                        "author": {"login": "trusted"},
+                        "committer": {"login": "untrusted"},
+                    },
                     {"sha": "def456", "author": None, "committer": None},
                 ],
                 ["trusted"],
@@ -567,7 +722,10 @@ class ReviewPolicyTest(unittest.TestCase):
         self.assertFalse(ok)
         self.assertEqual(reasons, ["head contributor @trusted is trusted"])
         self.assertIn("head contributor @untrusted is not in trusted_authors", blockers)
-        self.assertIn("current head has commits without GitHub-linked authors or committers: def456", blockers)
+        self.assertIn(
+            "current head has commits without GitHub-linked authors or committers: def456",
+            blockers,
+        )
 
     def test_trusted_workflow_actor_reasons_requires_trusted_authenticated_actor(self):
         original_workflow_runs = policy.latest_workflow_runs
@@ -576,16 +734,21 @@ class ReviewPolicyTest(unittest.TestCase):
             policy.latest_workflow_runs = lambda owner, repo, head_sha, event, token: {
                 ".github/workflows/pr-gate.yml": {"actor": {"login": "untrusted"}},
             }
-            policy.trusted_author_reasons = lambda author, trusted_authors, owner, token: (
-                author == "trusted",
-                [f"author @{author} trust checked"],
+            policy.trusted_author_reasons = (
+                lambda author, trusted_authors, owner, token: (
+                    author == "trusted",
+                    [f"author @{author} trust checked"],
+                )
             )
             ok, reasons, blockers = policy.trusted_workflow_actor_reasons(
                 "block",
                 "proto-fleet",
                 "abc123",
                 ["trusted"],
-                {"workflow_path": ".github/workflows/pr-gate.yml", "event": "pull_request"},
+                {
+                    "workflow_path": ".github/workflows/pr-gate.yml",
+                    "event": "pull_request",
+                },
                 "token",
             )
         finally:
@@ -594,14 +757,27 @@ class ReviewPolicyTest(unittest.TestCase):
 
         self.assertFalse(ok)
         self.assertEqual(reasons, [])
-        self.assertEqual(blockers, ["authenticated workflow actor @untrusted is not in trusted_authors"])
+        self.assertEqual(
+            blockers,
+            ["authenticated workflow actor @untrusted is not in trusted_authors"],
+        )
 
     def test_latest_check_runs_tie_breaks_on_id(self):
         original = policy.github_paginate_key
         try:
             policy.github_paginate_key = lambda path, token, key: [
-                {"name": "Gate", "started_at": "2026-01-01T00:00:00Z", "id": 1, "conclusion": "failure"},
-                {"name": "Gate", "started_at": "2026-01-01T00:00:00Z", "id": 2, "conclusion": "success"},
+                {
+                    "name": "Gate",
+                    "started_at": "2026-01-01T00:00:00Z",
+                    "id": 1,
+                    "conclusion": "failure",
+                },
+                {
+                    "name": "Gate",
+                    "started_at": "2026-01-01T00:00:00Z",
+                    "id": 2,
+                    "conclusion": "success",
+                },
             ]
             latest = policy.latest_check_runs("block", "proto-fleet", "abc123", "token")
         finally:
@@ -673,7 +849,11 @@ class ReviewPolicyTest(unittest.TestCase):
         original_statuses = policy.latest_commit_statuses
         try:
             policy.latest_check_runs = lambda owner, repo, head_sha, token: {
-                "DCO Check": {"status": "completed", "conclusion": "success", "app": {"slug": "block-dco-check"}},
+                "DCO Check": {
+                    "status": "completed",
+                    "conclusion": "success",
+                    "app": {"slug": "block-dco-check"},
+                },
             }
             policy.latest_commit_statuses = lambda owner, repo, head_sha, token: {
                 "Legacy": {"state": "success", "creator": {"login": "trusted-bot"}},
@@ -684,9 +864,21 @@ class ReviewPolicyTest(unittest.TestCase):
                 "proto-fleet",
                 "abc123",
                 [
-                    {"name": "DCO Check", "type": "check_run", "app_slug": "block-dco-check"},
-                    {"name": "Legacy", "type": "commit_status", "creator": "trusted-bot"},
-                    {"name": "External", "type": "commit_status", "creator": "external-ci"},
+                    {
+                        "name": "DCO Check",
+                        "type": "check_run",
+                        "app_slug": "block-dco-check",
+                    },
+                    {
+                        "name": "Legacy",
+                        "type": "commit_status",
+                        "creator": "trusted-bot",
+                    },
+                    {
+                        "name": "External",
+                        "type": "commit_status",
+                        "creator": "external-ci",
+                    },
                 ],
                 "token",
             )
@@ -777,7 +969,10 @@ class ReviewPolicyTest(unittest.TestCase):
             policy.latest_workflow_runs = original_workflow_runs
 
         self.assertFalse(ok)
-        self.assertIn("required workflow 'PR Gate' name is 'Attacker Gate', expected 'PR Gate'", blockers)
+        self.assertIn(
+            "required workflow 'PR Gate' name is 'Attacker Gate', expected 'PR Gate'",
+            blockers,
+        )
 
     def test_latest_workflow_runs_tie_breaks_on_id(self):
         original = policy.github_paginate_key
@@ -808,7 +1003,9 @@ class ReviewPolicyTest(unittest.TestCase):
                     "conclusion": "success",
                 },
             ]
-            latest = policy.latest_workflow_runs("block", "proto-fleet", "abc123", "pull_request", "token")
+            latest = policy.latest_workflow_runs(
+                "block", "proto-fleet", "abc123", "pull_request", "token"
+            )
         finally:
             policy.github_paginate_key = original
 
@@ -819,7 +1016,11 @@ class ReviewPolicyTest(unittest.TestCase):
         original_statuses = policy.latest_commit_statuses
         try:
             policy.latest_check_runs = lambda owner, repo, head_sha, token: {
-                "DCO Check": {"status": "completed", "conclusion": "success", "app": {"slug": "block-dco-check"}},
+                "DCO Check": {
+                    "status": "completed",
+                    "conclusion": "success",
+                    "app": {"slug": "block-dco-check"},
+                },
             }
             policy.latest_commit_statuses = lambda owner, repo, head_sha, token: {
                 "Legacy": {"state": "success", "creator": {"login": "trusted-bot"}},
@@ -831,7 +1032,11 @@ class ReviewPolicyTest(unittest.TestCase):
                 [
                     "Gate",
                     {"name": "DCO Check", "type": "check_run"},
-                    {"name": "security-review", "type": "github_actions", "event": "pull_request"},
+                    {
+                        "name": "security-review",
+                        "type": "github_actions",
+                        "event": "pull_request",
+                    },
                     {
                         "name": "PR Gate",
                         "type": "github_actions_workflow",
@@ -847,8 +1052,13 @@ class ReviewPolicyTest(unittest.TestCase):
 
         self.assertFalse(ok)
         self.assertIn("required check 'Gate' uses legacy unvalidated config", blockers)
-        self.assertIn("required check 'DCO Check' is missing trusted app_slug", blockers)
-        self.assertIn("required check 'security-review' is missing trusted workflow_path", blockers)
+        self.assertIn(
+            "required check 'DCO Check' is missing trusted app_slug", blockers
+        )
+        self.assertIn(
+            "required check 'security-review' is missing trusted workflow_path",
+            blockers,
+        )
         self.assertIn("required workflow 'PR Gate' is missing trusted event", blockers)
         self.assertIn("required status 'Legacy' is missing trusted creator", blockers)
 
@@ -856,10 +1066,22 @@ class ReviewPolicyTest(unittest.TestCase):
         original = policy.github_paginate
         try:
             policy.github_paginate = lambda path, token: [
-                {"context": "DCO Check", "created_at": "2026-01-01T00:00:00Z", "id": 1, "state": "failure"},
-                {"context": "DCO Check", "created_at": "2026-01-01T00:00:00Z", "id": 2, "state": "success"},
+                {
+                    "context": "DCO Check",
+                    "created_at": "2026-01-01T00:00:00Z",
+                    "id": 1,
+                    "state": "failure",
+                },
+                {
+                    "context": "DCO Check",
+                    "created_at": "2026-01-01T00:00:00Z",
+                    "id": 2,
+                    "state": "success",
+                },
             ]
-            latest = policy.latest_commit_statuses("block", "proto-fleet", "abc123", "token")
+            latest = policy.latest_commit_statuses(
+                "block", "proto-fleet", "abc123", "token"
+            )
         finally:
             policy.github_paginate = original
 
@@ -867,10 +1089,14 @@ class ReviewPolicyTest(unittest.TestCase):
 
     def test_extract_run_id(self):
         self.assertEqual(
-            policy.extract_run_id("https://github.com/block/proto-fleet/actions/runs/123/job/456"),
+            policy.extract_run_id(
+                "https://github.com/block/proto-fleet/actions/runs/123/job/456"
+            ),
             "123",
         )
-        self.assertIsNone(policy.extract_run_id("https://github.com/block/proto-fleet/runs/123"))
+        self.assertIsNone(
+            policy.extract_run_id("https://github.com/block/proto-fleet/runs/123")
+        )
 
     def test_extract_security_risk_validates_workflow_run_identity(self):
         original_paginate_key = policy.github_paginate_key
@@ -880,14 +1106,17 @@ class ReviewPolicyTest(unittest.TestCase):
         with zipfile.ZipFile(archive_bytes, "w") as archive:
             archive.writestr(
                 "codex-security-review-result.json",
-                json.dumps({
-                    "head_sha": "abc123",
-                    "commit_range": "base123...abc123",
-                    "run_id": "123",
-                    "overall_risk": "LOW",
-                }),
+                json.dumps(
+                    {
+                        "head_sha": "abc123",
+                        "commit_range": "base123...abc123",
+                        "run_id": "123",
+                        "overall_risk": "LOW",
+                    }
+                ),
             )
         try:
+
             def fake_paginate_key(path, token, key):
                 if "/commits/" in path:
                     return [
@@ -898,7 +1127,13 @@ class ReviewPolicyTest(unittest.TestCase):
                         }
                     ]
                 if "/actions/runs/123/artifacts" in path:
-                    return [{"id": 999, "name": "codex-security-review-result", "expired": False}]
+                    return [
+                        {
+                            "id": 999,
+                            "name": "codex-security-review-result",
+                            "expired": False,
+                        }
+                    ]
                 return []
 
             policy.github_paginate_key = fake_paginate_key
@@ -934,14 +1169,17 @@ class ReviewPolicyTest(unittest.TestCase):
         with zipfile.ZipFile(archive_bytes, "w") as archive:
             archive.writestr(
                 "codex-security-review-result.json",
-                json.dumps({
-                    "head_sha": "abc123",
-                    "commit_range": "oldbase...abc123",
-                    "run_id": "123",
-                    "overall_risk": "LOW",
-                }),
+                json.dumps(
+                    {
+                        "head_sha": "abc123",
+                        "commit_range": "oldbase...abc123",
+                        "run_id": "123",
+                        "overall_risk": "LOW",
+                    }
+                ),
             )
         try:
+
             def fake_paginate_key(path, token, key):
                 if "/commits/" in path:
                     return [
@@ -952,7 +1190,13 @@ class ReviewPolicyTest(unittest.TestCase):
                         }
                     ]
                 if "/actions/runs/123/artifacts" in path:
-                    return [{"id": 999, "name": "codex-security-review-result", "expired": False}]
+                    return [
+                        {
+                            "id": 999,
+                            "name": "codex-security-review-result",
+                            "expired": False,
+                        }
+                    ]
                 return []
 
             policy.github_paginate_key = fake_paginate_key
@@ -978,7 +1222,10 @@ class ReviewPolicyTest(unittest.TestCase):
             policy.github_download = original_download
 
         self.assertIsNone(risk)
-        self.assertIn("Codex security-review result artifact is stale for this PR base/head range", blockers)
+        self.assertIn(
+            "Codex security-review result artifact is stale for this PR base/head range",
+            blockers,
+        )
 
     def test_extract_security_risk_rejects_non_string_risk(self):
         original_paginate_key = policy.github_paginate_key
@@ -988,14 +1235,17 @@ class ReviewPolicyTest(unittest.TestCase):
         with zipfile.ZipFile(archive_bytes, "w") as archive:
             archive.writestr(
                 "codex-security-review-result.json",
-                json.dumps({
-                    "head_sha": "abc123",
-                    "commit_range": "base123...abc123",
-                    "run_id": "123",
-                    "overall_risk": None,
-                }),
+                json.dumps(
+                    {
+                        "head_sha": "abc123",
+                        "commit_range": "base123...abc123",
+                        "run_id": "123",
+                        "overall_risk": None,
+                    }
+                ),
             )
         try:
+
             def fake_paginate_key(path, token, key):
                 if "/commits/" in path:
                     return [
@@ -1006,7 +1256,13 @@ class ReviewPolicyTest(unittest.TestCase):
                         }
                     ]
                 if "/actions/runs/123/artifacts" in path:
-                    return [{"id": 999, "name": "codex-security-review-result", "expired": False}]
+                    return [
+                        {
+                            "id": 999,
+                            "name": "codex-security-review-result",
+                            "expired": False,
+                        }
+                    ]
                 return []
 
             policy.github_paginate_key = fake_paginate_key
@@ -1032,12 +1288,16 @@ class ReviewPolicyTest(unittest.TestCase):
             policy.github_download = original_download
 
         self.assertIsNone(risk)
-        self.assertIn("Codex security-review result artifact is missing or invalid overall_risk", blockers)
+        self.assertIn(
+            "Codex security-review result artifact is missing or invalid overall_risk",
+            blockers,
+        )
 
     def test_extract_security_risk_rejects_forged_workflow_run(self):
         original_paginate_key = policy.github_paginate_key
         original_request = policy.github_request
         try:
+
             def fake_paginate_key(path, token, key):
                 if "/commits/" in path:
                     return [
@@ -1084,6 +1344,7 @@ class ReviewPolicyTest(unittest.TestCase):
         original_latest_check_runs = policy.latest_check_runs
         original_workflow_runs = policy.latest_workflow_runs
         try:
+
             def fake_paginate(path, token):
                 if path.endswith("/commits/abc123/pulls"):
                     return [{"number": 123, "state": "open", "head": {"sha": "abc123"}}]
@@ -1097,7 +1358,13 @@ class ReviewPolicyTest(unittest.TestCase):
                         }
                     ]
                 if path.endswith("/commits"):
-                    return [{"sha": "abc123", "author": {"login": "author"}, "committer": {"login": "author"}}]
+                    return [
+                        {
+                            "sha": "abc123",
+                            "author": {"login": "author"},
+                            "committer": {"login": "author"},
+                        }
+                    ]
                 if path.endswith("/reviews"):
                     return []
                 return []
@@ -1108,14 +1375,23 @@ class ReviewPolicyTest(unittest.TestCase):
                 "head": {"sha": "abc123"},
                 "base": {"sha": "base123"},
             }
-            policy.trusted_author_reasons = lambda author, trusted_authors, owner, token: (
-                True,
-                [f"author @{author} is explicitly trusted"],
+            policy.trusted_author_reasons = (
+                lambda author, trusted_authors, owner, token: (
+                    True,
+                    [f"author @{author} is explicitly trusted"],
+                )
             )
-            policy.check_statuses = lambda owner, repo, head_sha, required_checks, token, latest_by_name=None: (True, [])
-            policy.extract_security_risk = lambda owner, repo, base_sha, head_sha, token, check_name, workflow_path, artifact_name, latest_by_name=None: (
-                "LOW",
-                [],
+            policy.check_statuses = (
+                lambda owner, repo, head_sha, required_checks, token, latest_by_name=None: (
+                    True,
+                    [],
+                )
+            )
+            policy.extract_security_risk = (
+                lambda owner, repo, base_sha, head_sha, token, check_name, workflow_path, artifact_name, latest_by_name=None: (
+                    "LOW",
+                    [],
+                )
             )
             policy.latest_check_runs = lambda owner, repo, head_sha, token: {}
             policy.latest_workflow_runs = lambda owner, repo, head_sha, event, token: {
@@ -1175,6 +1451,7 @@ class ReviewPolicyTest(unittest.TestCase):
         original_latest_check_runs = policy.latest_check_runs
         original_workflow_runs = policy.latest_workflow_runs
         try:
+
             def fake_paginate(path, token):
                 if path.endswith("/commits/abc123/pulls"):
                     return [{"number": 123, "state": "open", "head": {"sha": "abc123"}}]
@@ -1188,7 +1465,13 @@ class ReviewPolicyTest(unittest.TestCase):
                         }
                     ]
                 if path.endswith("/commits"):
-                    return [{"sha": "abc123", "author": {"login": "author"}, "committer": {"login": "author"}}]
+                    return [
+                        {
+                            "sha": "abc123",
+                            "author": {"login": "author"},
+                            "committer": {"login": "author"},
+                        }
+                    ]
                 if path.endswith("/reviews"):
                     return [
                         {
@@ -1207,14 +1490,23 @@ class ReviewPolicyTest(unittest.TestCase):
                 "base": {"sha": "base123"},
             }
             policy.reviewer_has_authority = lambda owner, repo, username, token: True
-            policy.trusted_author_reasons = lambda author, trusted_authors, owner, token: (
-                True,
-                [f"author @{author} is explicitly trusted"],
+            policy.trusted_author_reasons = (
+                lambda author, trusted_authors, owner, token: (
+                    True,
+                    [f"author @{author} is explicitly trusted"],
+                )
             )
-            policy.check_statuses = lambda owner, repo, head_sha, required_checks, token, latest_by_name=None: (True, [])
-            policy.extract_security_risk = lambda owner, repo, base_sha, head_sha, token, check_name, workflow_path, artifact_name, latest_by_name=None: (
-                "LOW",
-                [],
+            policy.check_statuses = (
+                lambda owner, repo, head_sha, required_checks, token, latest_by_name=None: (
+                    True,
+                    [],
+                )
+            )
+            policy.extract_security_risk = (
+                lambda owner, repo, base_sha, head_sha, token, check_name, workflow_path, artifact_name, latest_by_name=None: (
+                    "LOW",
+                    [],
+                )
             )
             policy.latest_check_runs = lambda owner, repo, head_sha, token: {}
             policy.latest_workflow_runs = lambda owner, repo, head_sha, event, token: {
@@ -1263,7 +1555,9 @@ class ReviewPolicyTest(unittest.TestCase):
 
         self.assertTrue(result.passed)
         self.assertEqual(result.decision, "trusted-author-low-risk")
-        self.assertIn("current authorized human approvals: reviewer", result.human_review_reasons)
+        self.assertIn(
+            "current authorized human approvals: reviewer", result.human_review_reasons
+        )
 
     def test_evaluate_policy_blocks_human_approval_with_unknown_commit_identity(self):
         original_paginate = policy.github_paginate
@@ -1275,11 +1569,19 @@ class ReviewPolicyTest(unittest.TestCase):
         original_latest_check_runs = policy.latest_check_runs
         original_workflow_runs = policy.latest_workflow_runs
         try:
+
             def fake_paginate(path, token):
                 if path.endswith("/commits/abc123/pulls"):
                     return [{"number": 123, "state": "open", "head": {"sha": "abc123"}}]
                 if path.endswith("/files"):
-                    return [{"filename": "client/src/foo.ts", "additions": 1, "deletions": 0, "patch": "@@\n+const x = 1"}]
+                    return [
+                        {
+                            "filename": "client/src/foo.ts",
+                            "additions": 1,
+                            "deletions": 0,
+                            "patch": "@@\n+const x = 1",
+                        }
+                    ]
                 if path.endswith("/commits"):
                     return [{"sha": "def456", "author": None, "committer": None}]
                 if path.endswith("/reviews"):
@@ -1301,14 +1603,23 @@ class ReviewPolicyTest(unittest.TestCase):
                 "base": {"sha": "base123"},
             }
             policy.reviewer_has_authority = lambda owner, repo, username, token: True
-            policy.trusted_author_reasons = lambda author, trusted_authors, owner, token: (
-                True,
-                [f"author @{author} is explicitly trusted"],
+            policy.trusted_author_reasons = (
+                lambda author, trusted_authors, owner, token: (
+                    True,
+                    [f"author @{author} is explicitly trusted"],
+                )
             )
-            policy.check_statuses = lambda owner, repo, head_sha, required_checks, token, latest_by_name=None: (True, [])
-            policy.extract_security_risk = lambda owner, repo, base_sha, head_sha, token, check_name, workflow_path, artifact_name, latest_by_name=None: (
-                "LOW",
-                [],
+            policy.check_statuses = (
+                lambda owner, repo, head_sha, required_checks, token, latest_by_name=None: (
+                    True,
+                    [],
+                )
+            )
+            policy.extract_security_risk = (
+                lambda owner, repo, base_sha, head_sha, token, check_name, workflow_path, artifact_name, latest_by_name=None: (
+                    "LOW",
+                    [],
+                )
             )
             policy.latest_check_runs = lambda owner, repo, head_sha, token: {}
             policy.latest_workflow_runs = lambda owner, repo, head_sha, event, token: {
@@ -1357,7 +1668,10 @@ class ReviewPolicyTest(unittest.TestCase):
 
         self.assertFalse(result.passed)
         self.assertEqual(result.decision, "needs-human-review")
-        self.assertIn("current head has commits without GitHub-linked authors or committers: def456", result.reasons)
+        self.assertIn(
+            "current head has commits without GitHub-linked authors or committers: def456",
+            result.reasons,
+        )
 
     def test_evaluate_policy_blocks_stale_pr_head(self):
         original_request = policy.github_request
@@ -1400,7 +1714,9 @@ class ReviewPolicyTest(unittest.TestCase):
 
         self.assertFalse(result.passed)
         self.assertEqual(result.decision, "needs-human-review")
-        self.assertEqual(result.reasons, ["pull request #123 head is newhead, expected abc123"])
+        self.assertEqual(
+            result.reasons, ["pull request #123 head is newhead, expected abc123"]
+        )
 
     def test_evaluate_policy_ignores_authenticated_actor_approval(self):
         original_paginate = policy.github_paginate
@@ -1412,13 +1728,27 @@ class ReviewPolicyTest(unittest.TestCase):
         original_latest_check_runs = policy.latest_check_runs
         original_workflow_runs = policy.latest_workflow_runs
         try:
+
             def fake_paginate(path, token):
                 if path.endswith("/commits/abc123/pulls"):
                     return [{"number": 123, "state": "open", "head": {"sha": "abc123"}}]
                 if path.endswith("/files"):
-                    return [{"filename": "client/src/foo.ts", "additions": 1, "deletions": 0, "patch": "@@\n+const x = 1"}]
+                    return [
+                        {
+                            "filename": "client/src/foo.ts",
+                            "additions": 1,
+                            "deletions": 0,
+                            "patch": "@@\n+const x = 1",
+                        }
+                    ]
                 if path.endswith("/commits"):
-                    return [{"sha": "abc123", "author": {"login": "author"}, "committer": {"login": "author"}}]
+                    return [
+                        {
+                            "sha": "abc123",
+                            "author": {"login": "author"},
+                            "committer": {"login": "author"},
+                        }
+                    ]
                 if path.endswith("/reviews"):
                     return [
                         {
@@ -1438,14 +1768,23 @@ class ReviewPolicyTest(unittest.TestCase):
                 "base": {"sha": "base123"},
             }
             policy.reviewer_has_authority = lambda owner, repo, username, token: True
-            policy.trusted_author_reasons = lambda author, trusted_authors, owner, token: (
-                True,
-                [f"author @{author} is explicitly trusted"],
+            policy.trusted_author_reasons = (
+                lambda author, trusted_authors, owner, token: (
+                    True,
+                    [f"author @{author} is explicitly trusted"],
+                )
             )
-            policy.check_statuses = lambda owner, repo, head_sha, required_checks, token, latest_by_name=None: (True, [])
-            policy.extract_security_risk = lambda owner, repo, base_sha, head_sha, token, check_name, workflow_path, artifact_name, latest_by_name=None: (
-                "LOW",
-                [],
+            policy.check_statuses = (
+                lambda owner, repo, head_sha, required_checks, token, latest_by_name=None: (
+                    True,
+                    [],
+                )
+            )
+            policy.extract_security_risk = (
+                lambda owner, repo, base_sha, head_sha, token, check_name, workflow_path, artifact_name, latest_by_name=None: (
+                    "LOW",
+                    [],
+                )
             )
             policy.latest_check_runs = lambda owner, repo, head_sha, token: {}
             policy.latest_workflow_runs = lambda owner, repo, head_sha, event, token: {
@@ -1495,12 +1834,17 @@ class ReviewPolicyTest(unittest.TestCase):
         self.assertFalse(result.passed)
         self.assertEqual(result.decision, "needs-human-review")
         self.assertIn("0 current human approval(s), need 1", result.reasons)
-        self.assertIn("ignored approvals from PR contributors: pusher", result.human_review_reasons)
+        self.assertIn(
+            "ignored approvals from PR contributors: pusher",
+            result.human_review_reasons,
+        )
 
     def test_human_review_state_ignores_unauthorized_approvals(self):
         original = policy.reviewer_has_authority
         try:
-            policy.reviewer_has_authority = lambda owner, repo, username, token: username == "member"
+            policy.reviewer_has_authority = lambda owner, repo, username, token: (
+                username == "member"
+            )
             reviews = [
                 {
                     "user": {"login": "outsider", "type": "User"},
@@ -1603,6 +1947,7 @@ class ReviewPolicyTest(unittest.TestCase):
         original = policy.reviewer_has_authority
         calls = []
         try:
+
             def fake_reviewer_has_authority(owner, repo, username, token):
                 calls.append(username)
                 return True
@@ -1665,11 +2010,27 @@ class ReviewPolicyTest(unittest.TestCase):
                     "submitted_at": "2026-01-01T00:00:01Z",
                 },
             ]
-            approved_ok, _approved_reasons, approved_blockers = policy.human_review_state(
-                approved_reviews, "abc123", "author", 1, "block", "proto-fleet", "token"
+            approved_ok, _approved_reasons, approved_blockers = (
+                policy.human_review_state(
+                    approved_reviews,
+                    "abc123",
+                    "author",
+                    1,
+                    "block",
+                    "proto-fleet",
+                    "token",
+                )
             )
-            dismissed_ok, _dismissed_reasons, dismissed_blockers = policy.human_review_state(
-                dismissed_reviews, "abc123", "author", 1, "block", "proto-fleet", "token"
+            dismissed_ok, _dismissed_reasons, dismissed_blockers = (
+                policy.human_review_state(
+                    dismissed_reviews,
+                    "abc123",
+                    "author",
+                    1,
+                    "block",
+                    "proto-fleet",
+                    "token",
+                )
             )
         finally:
             policy.reviewer_has_authority = original

--- a/.github/workflows/review-policy.yml
+++ b/.github/workflows/review-policy.yml
@@ -205,7 +205,9 @@ jobs:
         if: steps.pr.outputs.found == 'true'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ steps.pr.outputs.default_branch }}
+          # Keep executable policy code anchored to trusted repository metadata,
+          # never a ref derived from the pull request being evaluated.
+          ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 0
           persist-credentials: false
 


### PR DESCRIPTION
Reviewable diff: +3/-1 across 1 file (excludes generated, test, and story files).

## Summary

The secret-backed Review Policy workflow now anchors executable policy code to trusted repository metadata instead of a pull-request-derived step output. This preserves default-branch-only execution while addressing the critical untrusted-checkout code-scanning finding.

## How it works

The workflow resolves the repository's default branch directly from `github.event.repository.default_branch` for checkout. PR metadata still controls stacked-PR advisory behavior and the fetched diff SHAs, but it cannot choose the ref containing executable policy code.

```mermaid
flowchart LR
  Event["Workflow, check, status, or PR event"] --> TrustedRef["Repository default-branch metadata"]
  TrustedRef --> Checkout["Checkout trusted policy code"]
  Event --> PRData["Resolve current PR metadata"]
  PRData --> Diff["Fetch base and head objects; write diff"]
  Checkout --> Evaluate["Run policy and optional classifier"]
  Diff --> Evaluate
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `.github/workflows/review-policy.yml` | Checkout ref now comes from trusted event repository metadata | This is the privileged execution boundary |
| `.github/scripts/evaluate_review_policy_test.py` | Structural assertion follows the trusted ref; Ruff formatted the touched test file | Test-only; review the assertion, not formatting churn |

## Key technical decisions & trade-offs

- Use event repository metadata over PR API output for the executable checkout ref; both identify the same base repository branch, but the former gives CodeQL a direct trust boundary.
- Keep `persist-credentials: false` and fetch PR SHAs as Git objects only; fetched PR content is diffed, never checked out or executed.
- Preserve the existing PR-derived default branch output for stacked-PR mode selection and status messaging, where it is data rather than executable code.

## Testing & validation

- Updated the structural assertion first and observed the expected failure against the old checkout expression.
- All 53 review-policy tests pass after the workflow change.
- Ruff check/format, Ruby YAML loading, `git diff --check`, Lefthook pre-commit, and Lefthook pre-push passed.
- Correctness, testing, security, adversarial, and repository-standards reviews found no actionable issues.
- Not covered locally: live GitHub expression evaluation for every webhook payload and the next CodeQL analysis.

## Post-Deploy Monitoring & Validation

- Watch code-scanning alert 87 and the first Review Policy runs triggered by `workflow_run`, PR review, and status events.
- Healthy signal: alert 87 closes, the trusted checkout succeeds, and Review Policy publishes the expected enforced or advisory status.
- Failure trigger: checkout cannot resolve the default branch or Review Policy stops publishing; revert this PR while preserving the existing fail-closed behavior.
- Validation window and owner: first representative Review Policy runs after merge, owned by the PR author.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
