### PR TITLE
perf(dbtest): clone a migrated template database per test

### DIFF
--- a/docs/solutions/database-issues/dbtest-template-database-timescaledb-worker-2026-08-21.md
+++ b/docs/solutions/database-issues/dbtest-template-database-timescaledb-worker-2026-08-21.md
@@ -108,7 +108,8 @@ migration set; `GetTestDB` clones it instead of replaying migrations.
    shutdown.
 5. **Retry clones on SQLSTATE 55006** (`isRetryableCreateError`, plus the
    "is being accessed by other users" text) and evict template sessions before
-   each retry.
+   each retry. **Rebuild on SQLSTATE 3D000**: a concurrent checkout on another
+   migration set may have swept the template between clones.
 6. **Keep `ConnectAndMigrate` on the clone.** It is a no-op version check on an
    already-current database (a couple of queries), and it self-heals if a clone
    is ever behind — which is what makes the whole change safe: if a template is
@@ -142,6 +143,21 @@ a third of it, and the budget no longer grows with each new migration.
 - **Per-test DB cost is O(tests × migrations) by default.** If a DB-backed
   package creeps toward the 10m Go timeout, count migration replays in the log
   before suspecting a specific test.
+- **`LIKE 'prefix_%'` is not a prefix match.** Every `_` is a single-character
+  wildcard, so `fleet_test_tmpl_%` also matches `fleetXtestYtmplZanything`. Any
+  query that feeds `DROP DATABASE` must use an anchored regex (`datname ~
+  '^fleet_test_tmpl_[0-9a-f]{12}$'`), re-validate in Go, and quote the
+  identifier — database names cannot be bound as DDL parameters.
+- **Content-addressed templates need a recovery path, not just a lock.** Two
+  checkouts on different migration sets sharing one PostgreSQL server will sweep
+  each other's templates between clones (a sealed template has no sessions, so
+  the drop succeeds). The clone then fails with SQLSTATE **3D000**, which is
+  *not* in the transient-retry set — handle it by rebuilding the template.
+- **Don't cache preparation failures in `sync.Once`.** A single blip while the
+  first test runs would push every remaining test in the binary back onto the
+  slow path — exactly the timeout this change removes. Cache only success (mutex
+  plus a `prepared` flag), bound the retries, and wait for server readiness
+  before the first attempt.
 - `CREATE DATABASE … TEMPLATE` does **not** copy `datallowconn` or per-database
   GUCs to the clone; clones are normal, connectable databases.
 - Prefer the default `STRATEGY = WAL_LOG` for a template this size (16MB);

--- a/docs/solutions/database-issues/dbtest-template-database-timescaledb-worker-2026-08-21.md
+++ b/docs/solutions/database-issues/dbtest-template-database-timescaledb-worker-2026-08-21.md
@@ -1,0 +1,149 @@
+---
+title: Per-test database migration replay blows the Go test timeout; TimescaleDB worker blocks CREATE DATABASE TEMPLATE
+date: 2026-08-21
+category: docs/solutions/database-issues
+module: server/internal/testutil/dbtest
+problem_type: performance
+component: testing_framework
+symptoms:
+  - "panic: test timed out after 10m0s in server/internal/domain/stores/sqlstores"
+  - "FAIL github.com/block/proto-fleet/server/internal/domain/stores/sqlstores 600.051s with a named test only 1s in"
+  - Dozens of goroutines parked in testing.(*T).Parallel for 9 minutes while one test holds the run
+  - "CI logs show hundreds of 'migrations completed duration=~2s' lines, one per test database"
+  - "CREATE DATABASE ... TEMPLATE fails with: source database \"fleet_test_tmpl_*\" is being accessed by other users (SQLSTATE 55006)"
+  - Template-clone harness is *slower* than full migration replay until background workers are evicted
+root_cause: architectural_limitation
+resolution_type: refactor
+severity: high
+related_components:
+  - server/migrations
+  - timescaledb
+  - ci
+tags: [postgres, timescaledb, testing, test-performance, go-test-timeout, create-database-template, advisory-lock, golang-migrate, dbtest]
+---
+
+# Per-test migration replay blows the Go test timeout, and TimescaleDB blocks the fix
+
+## Problem
+
+`Server Checks / Test` failed on a downstream sync PR with:
+
+```
+panic: test timed out after 10m0s
+  running tests: TestZoneKeysWildcard_CrossOrgIsolation (1s)
+FAIL github.com/block/proto-fleet/server/internal/domain/stores/sqlstores  600.051s
+```
+
+The named test is a red herring — it was 1s in when the alarm fired, and 19 other
+tests were still parked in `t.Parallel()` after 9 minutes.
+
+The real cause is the shape of the harness. `dbtest.GetTestDB` created a fresh
+database per test and replayed the **entire** migration set into it, so cost grew
+as O(tests × migrations):
+
+| Signal in the failing job | Value |
+| --- | --- |
+| Test databases created in `sqlstores` | 259 |
+| Migration replays (142 migrations each, ~2s) | 258 |
+| Time spent inside `migrate.Up()` alone | ~501s of the 600s budget |
+
+`server/justfile` runs `go test ./... -skip ./generated/...` with no `-timeout`,
+so Go's default 600s per-package limit applies. Upstream `main` was already at
+`ok … 388.626s` for the same package — every new migration pushed it closer, and
+the extra tests in the downstream repo tipped it over.
+
+## Investigation
+
+1. `panic: test timed out` with a 1s-old test name ⇒ the *package*, not one test,
+   is over budget. Count the work instead of reading the stack: `grep -c
+   "migrations completed"` in the job log gave 258, and summing
+   `duration=` gave ~501s.
+2. Baseline locally: `sqlstores` took **159s**, full server suite **3m25s**.
+3. First attempt at the fix — migrate once into a template database and clone it
+   per test with `CREATE DATABASE … TEMPLATE` — made things dramatically *worse*:
+   the package went from 159s to **1801s** (timeout).
+4. Timing a clone by hand exposed why:
+
+   ```
+   ERROR:  source database "fleet_test_tmpl_867fe765862f" is being accessed by other users
+   Time: 5289.486 ms
+   ```
+
+   ```sql
+   SELECT pid, datname, backend_type FROM pg_stat_activity WHERE datname LIKE 'fleet_test%';
+   -- 12185 | fleet_test_tmpl_867fe765862f | TimescaleDB Background Worker Scheduler | idle
+   ```
+
+   **`CREATE EXTENSION timescaledb` causes the TimescaleDB launcher to attach a
+   background-worker scheduler to the database.** That counts as a connected
+   session, and `CREATE DATABASE … TEMPLATE` requires *zero* sessions on the
+   source. Every clone waited ~5s and then failed.
+5. Setting `ALLOW_CONNECTIONS false` on the template is not enough on its own —
+   it stops the launcher *reattaching*, but the worker that started when the
+   extension was created is already in. After terminating it once, clones landed
+   at **21–43ms** and no worker came back.
+
+## Solution
+
+`server/internal/testutil/dbtest/template.go` prepares one migrated template per
+migration set; `GetTestDB` clones it instead of replaying migrations.
+
+1. **Key the template by a fingerprint of the embedded migration set** —
+   `sha256` over sorted migration filenames plus contents, truncated to 12 hex
+   chars, giving `fleet_test_tmpl_<fingerprint>`. Adding or editing a migration
+   yields a new name, so a stale schema can never be silently reused. Stale
+   templates from other fingerprints are dropped best-effort.
+2. **Serialise preparation with a PostgreSQL advisory lock** on a pinned
+   connection (`sql.DB.Conn`, because advisory locks are session-scoped). Many
+   test binaries run concurrently under `go test ./...`; the first builds the
+   template and the rest wait and reuse it. Verified: a cold database plus a full
+   parallel suite produces exactly **one** template.
+3. **Publish the template by disabling connections** —
+   `ALTER DATABASE … ALLOW_CONNECTIONS false` is both the guard (nothing can
+   attach and break clones) and the readiness marker. A template that exists but
+   still allows connections is treated as half-built and rebuilt, so an
+   interrupted run cannot leave a partially migrated template behind.
+4. **Evict the TimescaleDB scheduler after sealing** and poll `pg_stat_activity`
+   until the template has no backends, so the first clone does not race the
+   shutdown.
+5. **Retry clones on SQLSTATE 55006** (`isRetryableCreateError`, plus the
+   "is being accessed by other users" text) and evict template sessions before
+   each retry.
+6. **Keep `ConnectAndMigrate` on the clone.** It is a no-op version check on an
+   already-current database (a couple of queries), and it self-heals if a clone
+   is ever behind — which is what makes the whole change safe: if a template is
+   stale or unavailable, the harness falls back to the old migrate-everything
+   path instead of failing.
+
+## Results
+
+Measured with `-count=1` on both sides, same machine and same TimescaleDB container:
+
+| Scope | Before | After |
+| --- | --- | --- |
+| `internal/domain/stores/sqlstores` | 159.4s | 33.4s (32.1s warm) |
+| Full server suite | 3m25s | 1m09s |
+| Per test database setup | ~2s (142 migrations) | ~20–40ms (clone) |
+| Template build (once per fingerprint) | — | ~0.6–1.0s |
+
+CI's `sqlstores` package drops from 388s (65% of the 600s budget) to well under
+a third of it, and the budget no longer grows with each new migration.
+
+## Prevention / gotchas
+
+- **Any TimescaleDB database has a background worker attached.** Anything
+  requiring an exclusive source database (`CREATE DATABASE … TEMPLATE`,
+  `DROP DATABASE`) must disable connections *and* terminate existing backends.
+  `ALLOW_CONNECTIONS false` alone does not evict what is already connected.
+- **`pg_advisory_lock` on a `*sql.DB` is a bug.** Pool routing can send the
+  unlock to a different session. Pin with `db.Conn(ctx)`.
+- **Don't derive template readiness from "the database exists."** Use a state
+  that is only reachable after migrations succeed (here: connections disabled).
+- **Per-test DB cost is O(tests × migrations) by default.** If a DB-backed
+  package creeps toward the 10m Go timeout, count migration replays in the log
+  before suspecting a specific test.
+- `CREATE DATABASE … TEMPLATE` does **not** copy `datallowconn` or per-database
+  GUCs to the clone; clones are normal, connectable databases.
+- Prefer the default `STRATEGY = WAL_LOG` for a template this size (16MB);
+  `FILE_COPY` was only ~2x faster per clone and forces two checkpoints, which
+  hurts under hundreds of concurrent clones.

--- a/server/internal/testutil/dbtest/dbtest.go
+++ b/server/internal/testutil/dbtest/dbtest.go
@@ -254,7 +254,21 @@ func createTestDatabase(t *testing.T, adminConfig *db.Config, dbName string, tem
 	t.Helper()
 
 	var lastErr error
-	for attempt := 1; attempt <= migrationMaxRetries; attempt++ {
+
+	// Two independent budgets. Retries hope a transient failure passes, so they
+	// are few. Recoveries *change the situation* — rebuild a swept template, give
+	// up on cloning, wait out somebody's build — and each one deserves a fresh
+	// attempt: charging them to the retry counter meant a recovery on the final
+	// attempt fell out of the loop and failed the test with the stale error,
+	// having never tried the configuration it just repaired.
+	attempts := 0
+	recoveries := 0
+
+	// One deadline for every rebuild wait belonging to this database, so repeated
+	// waits cannot accumulate into a stall that outlives the package timeout.
+	rebuildWaitDeadline := time.Now().Add(templateRebuildWaitTimeout)
+
+	for {
 		// Wait for the server before issuing admin DDL.
 		waitForServerReady(t.Context(), t, adminConfig)
 
@@ -263,50 +277,102 @@ func createTestDatabase(t *testing.T, adminConfig *db.Config, dbName string, tem
 			return template
 		}
 
-		// The template vanished mid-run: another checkout on a different
-		// migration set swept it as stale. Rebuild it and try again rather than
-		// failing a test for someone else's cleanup.
-		if isMissingTemplateError(lastErr.Error(), template) {
-			t.Logf("template database %s disappeared, rebuilding: %v", template, lastErr)
-			invalidateTemplateDatabase(template)
-			template = templateDatabase(t, adminConfig)
-			continue
+		if recoveries < templateRecoveryMaxAttempts {
+			recovered, updatedTemplate := recoverTemplateForClone(
+				t, adminConfig, template, lastErr, rebuildWaitDeadline)
+			if recovered {
+				recoveries++
+				template = updatedTemplate
+				continue
+			}
 		}
 
-		// We are not allowed to copy this template — it belongs to another role
-		// and we are not a superuser. No amount of retrying changes that, so stop
-		// cloning for the rest of the process and migrate directly.
-		if isTemplatePermissionError(lastErr.Error(), template) {
-			t.Logf("not permitted to copy template database %s (%v); "+
-				"migrating test databases directly for the rest of this process", template, lastErr)
-			disableTemplateCloning()
-			template = ""
-			continue
-		}
-
-		if !isRetryableCreateError(lastErr.Error()) || attempt == migrationMaxRetries {
+		attempts++
+		if !isRetryableCreateError(lastErr.Error()) || attempts >= migrationMaxRetries {
 			break
 		}
 
-		t.Logf("create test database failed transiently (attempt %d/%d), retrying: %v", attempt, migrationMaxRetries, lastErr)
+		t.Logf("create test database failed transiently (attempt %d/%d), retrying: %v",
+			attempts, migrationMaxRetries, lastErr)
 
-		// A clone is blocked by whatever is attached to the template. If that is
-		// a rebuild (the template is not sealed), wait for it to publish: killing
-		// it would abort legitimate work, and the retry budget here is far shorter
-		// than a migration run. Otherwise the session is a stray — a TimescaleDB
-		// worker that slipped in — and gets evicted.
-		if templateRebuildInProgress(t.Context(), adminConfig, template) {
-			t.Logf("template %s is being rebuilt by another process, waiting for it", template)
-			waitForTemplateRebuild(t.Context(), adminConfig, template)
-			continue
-		}
-
+		// Whatever is attached to the template is not a live build (that is a
+		// recovery case handled above), so it is a stray — a TimescaleDB worker
+		// that slipped in — and gets evicted.
 		evictTemplateSessions(t.Context(), adminConfig, template)
-		time.Sleep(time.Duration(attempt) * migrationRetryBaseDelay)
+		time.Sleep(time.Duration(attempts) * migrationRetryBaseDelay)
 	}
 
 	assert.NoError(t, lastErr, "error creating test database")
 	return template
+}
+
+// recoverTemplateForClone handles the clone failures that a changed template can
+// fix. It reports whether it did something, along with the template the next
+// attempt should use ("" meaning migrate directly).
+func recoverTemplateForClone(
+	t *testing.T,
+	adminConfig *db.Config,
+	template string,
+	createErr error,
+	rebuildWaitDeadline time.Time,
+) (bool, string) {
+	t.Helper()
+
+	msg := createErr.Error()
+
+	// The template vanished mid-run: another checkout on a different migration
+	// set swept it as stale. Rebuild it rather than failing a test for someone
+	// else's cleanup.
+	if isMissingTemplateError(msg, template) {
+		t.Logf("template database %s disappeared, rebuilding: %v", template, createErr)
+		invalidateTemplateDatabase(template)
+		return true, templateDatabase(t, adminConfig)
+	}
+
+	// We are not allowed to copy this template — it belongs to another role and
+	// we are not a superuser. No amount of retrying changes that, so stop cloning
+	// for the rest of the process and migrate directly.
+	if isTemplatePermissionError(msg, template) {
+		t.Logf("not permitted to copy template database %s (%v); "+
+			"migrating test databases directly for the rest of this process", template, createErr)
+		disableTemplateCloning()
+		return true, ""
+	}
+
+	if !isRetryableCreateError(msg) || template == "" {
+		return false, template
+	}
+
+	switch inspectTemplateBuildState(t.Context(), adminConfig, template) {
+	case templateStateBuilding:
+		// Somebody holds the preparation lock and is migrating right now. Wait for
+		// them to publish: killing the build would abort legitimate work, and the
+		// retry budget is far shorter than a migration run.
+		if remaining := time.Until(rebuildWaitDeadline); remaining > 0 {
+			t.Logf("template %s is being rebuilt by another process, waiting up to %s", template, remaining)
+			waitForTemplateRebuild(t.Context(), adminConfig, template, rebuildWaitDeadline)
+			return true, template
+		}
+
+		// Waited as long as we are prepared to. Stop waiting and rebuild.
+		t.Logf("template %s still unpublished after %s, rebuilding it", template, templateRebuildWaitTimeout)
+		invalidateTemplateDatabase(template)
+		return true, templateDatabase(t, adminConfig)
+
+	case templateStateAbandoned:
+		// Unsealed with nobody building it: a build died and left a partially
+		// migrated database that nothing will ever finish or clean up. Its stray
+		// session is not evictable either (eviction spares unsealed templates), so
+		// rebuilding is the only way forward — dropping it disconnects the session.
+		t.Logf("template %s was left unpublished by an interrupted build, rebuilding it", template)
+		invalidateTemplateDatabase(template)
+		return true, templateDatabase(t, adminConfig)
+
+	case templateStatePublished:
+		return false, template
+	}
+
+	return false, template
 }
 
 // dropTestDatabase drops the test database at cleanup, waiting out and

--- a/server/internal/testutil/dbtest/dbtest.go
+++ b/server/internal/testutil/dbtest/dbtest.go
@@ -276,8 +276,18 @@ func createTestDatabase(t *testing.T, adminConfig *db.Config, dbName string, tem
 		}
 
 		t.Logf("create test database failed transiently (attempt %d/%d), retrying: %v", attempt, migrationMaxRetries, lastErr)
-		// A clone can only be blocked by a session that reached the template, so
-		// clear the way before retrying.
+
+		// A clone is blocked by whatever is attached to the template. If that is
+		// a rebuild (the template is not sealed), wait for it to publish: killing
+		// it would abort legitimate work, and the retry budget here is far shorter
+		// than a migration run. Otherwise the session is a stray — a TimescaleDB
+		// worker that slipped in — and gets evicted.
+		if templateRebuildInProgress(t.Context(), adminConfig, template) {
+			t.Logf("template %s is being rebuilt by another process, waiting for it", template)
+			waitForTemplateRebuild(t.Context(), adminConfig, template)
+			continue
+		}
+
 		evictTemplateSessions(t.Context(), adminConfig, template)
 		time.Sleep(time.Duration(attempt) * migrationRetryBaseDelay)
 	}

--- a/server/internal/testutil/dbtest/dbtest.go
+++ b/server/internal/testutil/dbtest/dbtest.go
@@ -85,6 +85,8 @@ const (
 	pgInternalError                   = "XX000"
 	pgObjectInUse                     = "55006"
 	pgUndefinedDatabase               = "3D000"
+	pgInsufficientPrivilege           = "42501"
+	templateCopyDenied                = "permission denied to copy database"
 	timescaleTupleConcurrentlyDeleted = "tuple concurrently deleted"
 	templateSourceInUse               = "is being accessed by other users"
 
@@ -271,6 +273,17 @@ func createTestDatabase(t *testing.T, adminConfig *db.Config, dbName string, tem
 			continue
 		}
 
+		// We are not allowed to copy this template — it belongs to another role
+		// and we are not a superuser. No amount of retrying changes that, so stop
+		// cloning for the rest of the process and migrate directly.
+		if isTemplatePermissionError(lastErr.Error(), template) {
+			t.Logf("not permitted to copy template database %s (%v); "+
+				"migrating test databases directly for the rest of this process", template, lastErr)
+			disableTemplateCloning()
+			template = ""
+			continue
+		}
+
 		if !isRetryableCreateError(lastErr.Error()) || attempt == migrationMaxRetries {
 			break
 		}
@@ -390,6 +403,17 @@ func isRetryableCreateError(msg string) bool {
 // database we are creating cannot itself be the undefined one.
 func isMissingTemplateError(msg string, template string) bool {
 	return template != "" && strings.Contains(msg, pgUndefinedDatabase)
+}
+
+// isTemplatePermissionError reports whether a clone failed because the
+// connecting role may not copy the template (SQLSTATE 42501). PostgreSQL only
+// permits copying a database you own unless you are a superuser, so this is what
+// a foreign template looks like.
+func isTemplatePermissionError(msg string, template string) bool {
+	if template == "" {
+		return false
+	}
+	return strings.Contains(msg, pgInsufficientPrivilege) || strings.Contains(msg, templateCopyDenied)
 }
 
 // generateTestDBName creates a unique database name that includes part of the test name for readability.

--- a/server/internal/testutil/dbtest/dbtest.go
+++ b/server/internal/testutil/dbtest/dbtest.go
@@ -1,7 +1,8 @@
 // Package dbtest provides the per-test database harness: it creates a unique
-// database per test, migrates it, and drops it at cleanup, retrying each step
-// across transient server restarts (crash-recovery under heavy concurrent
-// migration load). It lives in a leaf package — importing only
+// database per test by cloning a migrated template database (see template.go),
+// and drops it at cleanup, retrying each step across transient server restarts
+// (crash-recovery under heavy concurrent migration load). It lives in a leaf
+// package — importing only
 // infrastructure/db — so tests in packages that testutil itself imports
 // (e.g. domain/command) can use the same hardened harness without an import
 // cycle. Most tests should keep using testutil.GetTestDB, which delegates here.
@@ -47,16 +48,23 @@ func GetTestDB(t *testing.T) *sql.DB {
 	// admin DDL before reaching the migration retry below.
 	adminConfig := config
 	adminConfig.Name = "postgres"
-	createTestDatabase(t, &adminConfig, dbName)
 
-	// Connect and run migrations with retry. TimescaleDB continuous aggregate
-	// DDL acquires instance-level catalog locks that can deadlock when parallel
-	// tests migrate concurrently; a transient server restart is also tolerated.
-	// On failure we drop and recreate the database for a clean slate (avoids
-	// golang-migrate dirty flag issues).
+	// Clone the migrated template so this test skips the migration replay
+	// entirely. Falls back to an empty database (migrated below) when no
+	// template could be prepared.
+	template := templateDatabase(t, &adminConfig)
+	createTestDatabase(t, &adminConfig, dbName, template)
+
+	// Connect and run migrations with retry. Cloned databases are already at the
+	// latest version, so this is a no-op version check that also self-heals a
+	// stale clone; without a template it runs the full migration set. TimescaleDB
+	// continuous aggregate DDL acquires instance-level catalog locks that can
+	// deadlock when parallel tests migrate concurrently; a transient server
+	// restart is also tolerated. On failure we drop and recreate the database for
+	// a clean slate (avoids golang-migrate dirty flag issues).
 	testDBConfig := config
 	testDBConfig.Name = dbName
-	conn, err := connectAndMigrateWithRetry(t, &testDBConfig, &adminConfig, dbName)
+	conn, err := connectAndMigrateWithRetry(t, &testDBConfig, &adminConfig, dbName, template)
 	assert.NoError(t, err)
 
 	// Clean up the database when the test is done
@@ -76,7 +84,9 @@ const (
 	migrationRetryBaseDelay = 200 * time.Millisecond
 
 	pgInternalError                   = "XX000"
+	pgObjectInUse                     = "55006"
 	timescaleTupleConcurrentlyDeleted = "tuple concurrently deleted"
+	templateSourceInUse               = "is being accessed by other users"
 
 	// serverReadyTimeout bounds how long we wait for the database server to
 	// start accepting connections again after a transient restart before a
@@ -120,6 +130,7 @@ func connectAndMigrateWithRetry(
 	testDBConfig *db.Config,
 	adminConfig *db.Config,
 	dbName string,
+	template string,
 ) (*sql.DB, error) {
 	t.Helper()
 
@@ -138,7 +149,7 @@ func connectAndMigrateWithRetry(
 		t.Logf("retryable migration error (attempt %d/%d), retrying: %v", attempt, migrationMaxRetries, lastErr)
 		// Recreate the database for a clean slate (clears any dirty migration
 		// state), waiting out / retrying a transient server restart.
-		createTestDatabase(t, adminConfig, dbName)
+		createTestDatabase(t, adminConfig, dbName, template)
 
 		delay := time.Duration(attempt) * migrationRetryBaseDelay
 		time.Sleep(delay)
@@ -226,12 +237,13 @@ func pingAdminDatabase(ctx context.Context, adminConfig *db.Config) error {
 }
 
 // createTestDatabase drops any existing database with the given name and
-// creates a fresh one. It waits for the server to accept connections and
-// retries the admin DDL across a transient server restart (the same
-// 57P03 / "bad connection" / startup window connectAndMigrateWithRetry
-// tolerates), so a test that starts while the server is recovering survives the
-// blip instead of failing on the very first DROP/CREATE.
-func createTestDatabase(t *testing.T, adminConfig *db.Config, dbName string) {
+// creates a fresh one, cloning template when non-empty. It waits for the server
+// to accept connections and retries the admin DDL across a transient server
+// restart (the same 57P03 / "bad connection" / startup window
+// connectAndMigrateWithRetry tolerates), so a test that starts while the server
+// is recovering survives the blip instead of failing on the very first
+// DROP/CREATE.
+func createTestDatabase(t *testing.T, adminConfig *db.Config, dbName string, template string) {
 	t.Helper()
 
 	var lastErr error
@@ -239,15 +251,18 @@ func createTestDatabase(t *testing.T, adminConfig *db.Config, dbName string) {
 		// Wait for the server before issuing admin DDL.
 		waitForServerReady(t.Context(), t, adminConfig)
 
-		lastErr = tryCreateTestDatabase(t.Context(), adminConfig, dbName)
+		lastErr = tryCreateTestDatabase(t.Context(), adminConfig, dbName, template)
 		if lastErr == nil {
 			return
 		}
-		if !isTransientServerError(lastErr.Error()) || attempt == migrationMaxRetries {
+		if !isRetryableCreateError(lastErr.Error()) || attempt == migrationMaxRetries {
 			break
 		}
 
 		t.Logf("create test database failed transiently (attempt %d/%d), retrying: %v", attempt, migrationMaxRetries, lastErr)
+		// A clone can only be blocked by a session that reached the template, so
+		// clear the way before retrying.
+		evictTemplateSessions(t.Context(), adminConfig, template)
 		time.Sleep(time.Duration(attempt) * migrationRetryBaseDelay)
 	}
 
@@ -309,8 +324,9 @@ func tryDropTestDatabase(ctx context.Context, adminConfig *db.Config, dbName str
 // tryCreateTestDatabase drops any existing database with the given name (after
 // terminating lingering connections) and creates a fresh one, returning any
 // error rather than failing the test so the caller can retry transient
-// failures.
-func tryCreateTestDatabase(ctx context.Context, adminConfig *db.Config, dbName string) error {
+// failures. When template is non-empty the new database is a clone of it, which
+// skips the migration replay.
+func tryCreateTestDatabase(ctx context.Context, adminConfig *db.Config, dbName string, template string) error {
 	if err := tryDropTestDatabase(ctx, adminConfig, dbName); err != nil {
 		return err
 	}
@@ -321,10 +337,24 @@ func tryCreateTestDatabase(ctx context.Context, adminConfig *db.Config, dbName s
 	}
 	defer conn.Close()
 
-	if _, err := conn.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE %s", dbName)); err != nil {
+	create := fmt.Sprintf("CREATE DATABASE %s", dbName)
+	if template != "" {
+		create += fmt.Sprintf(" TEMPLATE %s", template)
+	}
+	if _, err := conn.ExecContext(ctx, create); err != nil {
 		return fmt.Errorf("create test database: %w", err)
 	}
 	return nil
+}
+
+// isRetryableCreateError extends the transient-server check with the contention
+// PostgreSQL reports when a database is cloned while another session touches the
+// source (SQLSTATE 55006). Parallel tests all clone the same template, so this
+// is expected under load rather than a real failure.
+func isRetryableCreateError(msg string) bool {
+	return isTransientServerError(msg) ||
+		strings.Contains(msg, pgObjectInUse) ||
+		strings.Contains(msg, templateSourceInUse)
 }
 
 // generateTestDBName creates a unique database name that includes part of the test name for readability.

--- a/server/internal/testutil/dbtest/dbtest.go
+++ b/server/internal/testutil/dbtest/dbtest.go
@@ -52,8 +52,7 @@ func GetTestDB(t *testing.T) *sql.DB {
 	// Clone the migrated template so this test skips the migration replay
 	// entirely. Falls back to an empty database (migrated below) when no
 	// template could be prepared.
-	template := templateDatabase(t, &adminConfig)
-	createTestDatabase(t, &adminConfig, dbName, template)
+	template := createTestDatabase(t, &adminConfig, dbName, templateDatabase(t, &adminConfig))
 
 	// Connect and run migrations with retry. Cloned databases are already at the
 	// latest version, so this is a no-op version check that also self-heals a
@@ -85,6 +84,7 @@ const (
 
 	pgInternalError                   = "XX000"
 	pgObjectInUse                     = "55006"
+	pgUndefinedDatabase               = "3D000"
 	timescaleTupleConcurrentlyDeleted = "tuple concurrently deleted"
 	templateSourceInUse               = "is being accessed by other users"
 
@@ -149,7 +149,7 @@ func connectAndMigrateWithRetry(
 		t.Logf("retryable migration error (attempt %d/%d), retrying: %v", attempt, migrationMaxRetries, lastErr)
 		// Recreate the database for a clean slate (clears any dirty migration
 		// state), waiting out / retrying a transient server restart.
-		createTestDatabase(t, adminConfig, dbName, template)
+		template = createTestDatabase(t, adminConfig, dbName, template)
 
 		delay := time.Duration(attempt) * migrationRetryBaseDelay
 		time.Sleep(delay)
@@ -243,7 +243,12 @@ func pingAdminDatabase(ctx context.Context, adminConfig *db.Config) error {
 // connectAndMigrateWithRetry tolerates), so a test that starts while the server
 // is recovering survives the blip instead of failing on the very first
 // DROP/CREATE.
-func createTestDatabase(t *testing.T, adminConfig *db.Config, dbName string, template string) {
+//
+// It returns the template actually used, which can differ from the one passed
+// in: a template swept by a concurrent run on a different migration set is
+// rebuilt (or given up on, yielding "") so the caller migrates the database
+// itself.
+func createTestDatabase(t *testing.T, adminConfig *db.Config, dbName string, template string) string {
 	t.Helper()
 
 	var lastErr error
@@ -253,8 +258,19 @@ func createTestDatabase(t *testing.T, adminConfig *db.Config, dbName string, tem
 
 		lastErr = tryCreateTestDatabase(t.Context(), adminConfig, dbName, template)
 		if lastErr == nil {
-			return
+			return template
 		}
+
+		// The template vanished mid-run: another checkout on a different
+		// migration set swept it as stale. Rebuild it and try again rather than
+		// failing a test for someone else's cleanup.
+		if isMissingTemplateError(lastErr.Error(), template) {
+			t.Logf("template database %s disappeared, rebuilding: %v", template, lastErr)
+			invalidateTemplateDatabase(template)
+			template = templateDatabase(t, adminConfig)
+			continue
+		}
+
 		if !isRetryableCreateError(lastErr.Error()) || attempt == migrationMaxRetries {
 			break
 		}
@@ -267,6 +283,7 @@ func createTestDatabase(t *testing.T, adminConfig *db.Config, dbName string, tem
 	}
 
 	assert.NoError(t, lastErr, "error creating test database")
+	return template
 }
 
 // dropTestDatabase drops the test database at cleanup, waiting out and
@@ -307,15 +324,16 @@ func tryDropTestDatabase(ctx context.Context, adminConfig *db.Config, dbName str
 	defer conn.Close()
 
 	// Best effort: lingering connections just make the DROP fail, which the
-	// caller retries.
-	_, _ = conn.ExecContext(ctx, fmt.Sprintf(`
+	// caller retries. The name is bound as a parameter here; the DDL below has
+	// to interpolate it, so it goes through quoteIdentifier.
+	_, _ = conn.ExecContext(ctx, `
 		SELECT pg_terminate_backend(pg_stat_activity.pid)
 		FROM pg_stat_activity
-		WHERE pg_stat_activity.datname = '%s'
+		WHERE pg_stat_activity.datname = $1
 		AND pid <> pg_backend_pid()
-	`, dbName))
+	`, dbName)
 
-	if _, err := conn.ExecContext(ctx, fmt.Sprintf("DROP DATABASE IF EXISTS %s", dbName)); err != nil {
+	if _, err := conn.ExecContext(ctx, "DROP DATABASE IF EXISTS "+quoteIdentifier(dbName)); err != nil {
 		return fmt.Errorf("drop test database: %w", err)
 	}
 	return nil
@@ -337,9 +355,9 @@ func tryCreateTestDatabase(ctx context.Context, adminConfig *db.Config, dbName s
 	}
 	defer conn.Close()
 
-	create := fmt.Sprintf("CREATE DATABASE %s", dbName)
+	create := "CREATE DATABASE " + quoteIdentifier(dbName)
 	if template != "" {
-		create += fmt.Sprintf(" TEMPLATE %s", template)
+		create += " TEMPLATE " + quoteIdentifier(template)
 	}
 	if _, err := conn.ExecContext(ctx, create); err != nil {
 		return fmt.Errorf("create test database: %w", err)
@@ -355,6 +373,13 @@ func isRetryableCreateError(msg string) bool {
 	return isTransientServerError(msg) ||
 		strings.Contains(msg, pgObjectInUse) ||
 		strings.Contains(msg, templateSourceInUse)
+}
+
+// isMissingTemplateError reports whether a clone failed because its source
+// template no longer exists (SQLSTATE 3D000). Only meaningful when cloning: the
+// database we are creating cannot itself be the undefined one.
+func isMissingTemplateError(msg string, template string) bool {
+	return template != "" && strings.Contains(msg, pgUndefinedDatabase)
 }
 
 // generateTestDBName creates a unique database name that includes part of the test name for readability.

--- a/server/internal/testutil/dbtest/template.go
+++ b/server/internal/testutil/dbtest/template.go
@@ -49,10 +49,17 @@ const (
 	// well inside PostgreSQL's 63-character identifier limit.
 	templateFingerprintLength = 12
 
-	// templatePrepareTimeout bounds waiting for the advisory lock. It sits well
-	// below Go's default 10m package timeout so a stuck preparation still leaves
-	// room for callers to fall back to migrating their own database.
-	templatePrepareTimeout = 4 * time.Minute
+	// templatePrepareBudget is the total time this process will ever spend trying
+	// to prepare a template, across all attempts and all tests. It is a single
+	// process-wide budget rather than a per-attempt timeout: N attempts of N
+	// minutes each could otherwise add up past Go's 10m package timeout and
+	// reproduce the very hang this harness exists to avoid.
+	templatePrepareBudget = 3 * time.Minute
+
+	// templatePrepareTimeout caps a single attempt (in practice: waiting for
+	// another process's advisory lock). The effective deadline is whichever of
+	// this and the remaining budget is smaller.
+	templatePrepareTimeout = 90 * time.Second
 
 	// templateLockTimeout bounds how long migrating the template waits on any
 	// single lock. db.ConnectAndMigrate is not context-aware (it runs migrations
@@ -103,6 +110,10 @@ var (
 	// templateFailures counts consecutive failures so a genuinely broken setup
 	// stops paying the preparation cost on every test.
 	templateFailures int
+	// templateBudgetDeadline is when this process stops trying, set on the first
+	// attempt. Shared across tests so the total cost is bounded no matter how
+	// many tests ask.
+	templateBudgetDeadline time.Time
 )
 
 // templatePrepareMaxAttempts bounds retries across tests once preparation keeps
@@ -126,13 +137,27 @@ func templateDatabase(t *testing.T, adminConfig *db.Config) string {
 		return ""
 	}
 
+	if templateBudgetDeadline.IsZero() {
+		templateBudgetDeadline = time.Now().Add(templatePrepareBudget)
+	}
+
+	attemptTimeout, withinBudget := prepareAttemptTimeout(templateBudgetDeadline, time.Now())
+	if !withinBudget {
+		// Budget spent: stop trying for the rest of the process rather than
+		// letting queued tests keep paying for it.
+		templateFailures = templatePrepareMaxAttempts
+		t.Logf("template preparation budget of %s exhausted; "+
+			"migrating test databases directly for the rest of this process", templatePrepareBudget)
+		return ""
+	}
+
 	name := templateDBPrefix + migrationSetFingerprint()
 
 	// Deliberately not t.Context(): the template outlives the test that
 	// happens to build it, and cancelling that test must not abandon a
 	// half-migrated template for every other test in the binary.
 	// nolint: usetesting
-	ctx, cancel := context.WithTimeout(context.Background(), templatePrepareTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), attemptTimeout)
 	defer cancel()
 
 	// The very first connection of the run can land while the server is still
@@ -142,6 +167,16 @@ func templateDatabase(t *testing.T, adminConfig *db.Config) string {
 
 	start := time.Now()
 	if err := prepareTemplateDatabase(ctx, adminConfig, name); err != nil {
+		if ctx.Err() != nil {
+			// A deadline failure means time, not luck, ran out: retrying cannot
+			// help, so open the circuit now instead of after N attempts.
+			templateFailures = templatePrepareMaxAttempts
+			t.Logf("template database %s hit its %s preparation deadline (%v); "+
+				"migrating test databases directly for the rest of this process",
+				name, attemptTimeout, err)
+			return ""
+		}
+
 		templateFailures++
 		t.Logf("could not prepare template database %s (attempt %d/%d: %v); "+
 			"migrating this test database directly",
@@ -217,13 +252,13 @@ func prepareTemplateDatabase(ctx context.Context, adminConfig *db.Config, name s
 	if _, err := adminConn.ExecContext(ctx, fmt.Sprintf("ALTER DATABASE %s SET lock_timeout = %s",
 		quoteIdentifier(name),
 		quoteLiteral(fmt.Sprintf("%dms", templateLockTimeout.Milliseconds())))); err != nil {
-		_ = tryDropTestDatabase(ctx, adminConfig, name)
+		abandonTemplate(adminConfig, name)
 		return fmt.Errorf("set template lock timeout: %w", err)
 	}
 
-	if err := migrateTemplateDatabase(adminConfig, name); err != nil {
+	if err := migrateTemplateDatabase(ctx, adminConfig, name); err != nil {
 		// Leave nothing half-migrated behind for the next run to trust.
-		_ = tryDropTestDatabase(ctx, adminConfig, name)
+		abandonTemplate(adminConfig, name)
 		return err
 	}
 
@@ -232,7 +267,7 @@ func prepareTemplateDatabase(ctx context.Context, adminConfig *db.Config, name s
 	// to the source, and a template is only ever published in this state.
 	if _, err := adminConn.ExecContext(ctx,
 		"ALTER DATABASE "+quoteIdentifier(name)+" WITH ALLOW_CONNECTIONS false"); err != nil {
-		_ = tryDropTestDatabase(ctx, adminConfig, name)
+		abandonTemplate(adminConfig, name)
 		return fmt.Errorf("seal template database: %w", err)
 	}
 
@@ -241,7 +276,7 @@ func prepareTemplateDatabase(ctx context.Context, adminConfig *db.Config, name s
 	// would fail with "source database is being accessed by other users". Evict
 	// it now that ALLOW_CONNECTIONS false stops the launcher reattaching.
 	if err := detachTemplateSessions(ctx, adminConn, name); err != nil {
-		_ = tryDropTestDatabase(ctx, adminConfig, name)
+		abandonTemplate(adminConfig, name)
 		return err
 	}
 
@@ -250,7 +285,7 @@ func prepareTemplateDatabase(ctx context.Context, adminConfig *db.Config, name s
 	if _, err := adminConn.ExecContext(ctx, fmt.Sprintf("COMMENT ON DATABASE %s IS %s",
 		quoteIdentifier(name),
 		quoteLiteral(templateCommentPrefix+time.Now().UTC().Format(time.RFC3339Nano)))); err != nil {
-		_ = tryDropTestDatabase(ctx, adminConfig, name)
+		abandonTemplate(adminConfig, name)
 		return fmt.Errorf("record template metadata: %w", err)
 	}
 
@@ -276,14 +311,66 @@ func templateDatabaseReady(ctx context.Context, adminConn *sql.Conn, name string
 	}
 }
 
+// abandonTemplate drops a template that failed to build. It deliberately does
+// not reuse the preparation context: the most common reason to get here is that
+// very context expiring, and a cleanup on a dead context silently leaves a
+// half-built template behind. Leaving one is not a correctness problem (an
+// unsealed template is treated as incomplete and rebuilt), but it wastes disk
+// until the next run.
+func abandonTemplate(adminConfig *db.Config, name string) {
+	// nolint: usetesting
+	ctx, cancel := context.WithTimeout(context.Background(), templateDetachTimeout)
+	defer cancel()
+
+	_ = tryDropTestDatabase(ctx, adminConfig, name)
+}
+
+// prepareAttemptTimeout returns how long the next preparation attempt may take:
+// the smaller of the per-attempt cap and what is left of the process-wide
+// budget. The bool reports whether any budget remains at all.
+func prepareAttemptTimeout(deadline time.Time, now time.Time) (time.Duration, bool) {
+	remaining := deadline.Sub(now)
+	if remaining <= 0 {
+		return 0, false
+	}
+	if remaining > templatePrepareTimeout {
+		return templatePrepareTimeout, true
+	}
+	return remaining, true
+}
+
 // migrateTemplateDatabase runs the full migration set against the template and
 // closes the connection, leaving no session attached to it.
-func migrateTemplateDatabase(adminConfig *db.Config, name string) error {
+//
+// db.ConnectAndMigrate is not context-aware, so ctx is enforced out-of-band: a
+// watchdog terminates the migrating backend if the deadline passes. Together
+// with the template's lock_timeout that bounds both lock waits and any other
+// stall, and it is what lets preparation fail (and callers fall back) instead of
+// hanging until Go's package timeout.
+func migrateTemplateDatabase(ctx context.Context, adminConfig *db.Config, name string) error {
 	templateConfig := *adminConfig
 	templateConfig.Name = name
 
+	migrationDone := make(chan struct{})
+	defer close(migrationDone)
+
+	go func() {
+		select {
+		case <-migrationDone:
+		case <-ctx.Done():
+			// The parent context is spent, so give the eviction its own.
+			// nolint: usetesting
+			evictCtx, cancel := context.WithTimeout(context.Background(), templateDetachTimeout)
+			defer cancel()
+			evictTemplateSessions(evictCtx, adminConfig, name)
+		}
+	}()
+
 	conn, err := db.ConnectAndMigrate(&templateConfig)
 	if err != nil {
+		if ctx.Err() != nil {
+			return fmt.Errorf("migrate template database: deadline exceeded, migration backend terminated: %w", err)
+		}
 		return fmt.Errorf("migrate template database: %w", err)
 	}
 	if err := conn.Close(); err != nil {

--- a/server/internal/testutil/dbtest/template.go
+++ b/server/internal/testutil/dbtest/template.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"crypto/sha256"
 	"database/sql"
+	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"io/fs"
+	"math"
 	"regexp"
 	"sort"
 	"strconv"
@@ -39,10 +41,9 @@ const (
 	// migration sets can be identified and dropped.
 	templateDBPrefix = "fleet_test_tmpl_"
 
-	// templateAdvisoryLockKey is an arbitrary fixed key. Any process preparing a
-	// template database holds this session-level advisory lock, so concurrent
-	// test binaries build the template once rather than racing.
-	templateAdvisoryLockKey = int64(7264051893001)
+	// templateAdvisoryLockNamespace seeds the per-template advisory lock keys, so
+	// they cannot collide with advisory locks taken for other purposes.
+	templateAdvisoryLockNamespace = "dbtest-template-preparation:7264051893001"
 
 	// templateFingerprintLength is how much of the migration-set hash goes into
 	// the template name; 12 hex chars is collision-safe here and keeps the name
@@ -85,6 +86,12 @@ const (
 	// negligible amount of the speedup for bounded staleness.
 	templateMaxAge = 15 * time.Minute
 
+	// templateRebuildWaitTimeout is the total time one test database will wait
+	// for other processes' rebuilds of its template, shared across every wait so
+	// repeated waits cannot add up. It has to exceed a migration run, since that
+	// is what we are waiting for, while staying well inside the package timeout.
+	templateRebuildWaitTimeout = 90 * time.Second
+
 	// templateStaleAfter is how old a template must be before another run may
 	// sweep it. Cleanup is bounded by age (recorded in the database comment when
 	// the template is sealed) rather than "different fingerprint", so two
@@ -101,11 +108,15 @@ const (
 	templateDetachTimeout  = 30 * time.Second
 	templateDetachInterval = 100 * time.Millisecond
 
-	// templateRebuildWaitTimeout bounds how long a clone waits for somebody
-	// else's in-progress rebuild of the same template to publish. It has to
-	// exceed a full migration run, since that is what we are waiting for.
-	templateRebuildWaitTimeout  = 2 * time.Minute
+	// templateRebuildWaitInterval is the poll interval while waiting for
+	// somebody else's rebuild to publish.
 	templateRebuildWaitInterval = 100 * time.Millisecond
+
+	// templateRecoveryMaxAttempts bounds how many times one test database may
+	// repair its template situation (rebuild a swept template, wait out a live
+	// build, abandon cloning). Separate from the DDL retry budget: recoveries
+	// change the situation rather than retrying the same thing.
+	templateRecoveryMaxAttempts = 4
 )
 
 // templateNamePattern is the exact shape of a template database name. It gates
@@ -254,11 +265,12 @@ func prepareTemplateDatabase(ctx context.Context, adminConfig *db.Config, name s
 	}
 	defer adminConn.Close()
 
-	if _, err := adminConn.ExecContext(ctx, "SELECT pg_advisory_lock($1)", templateAdvisoryLockKey); err != nil {
+	lockKey := templateLockKey(name)
+	if _, err := adminConn.ExecContext(ctx, "SELECT pg_advisory_lock($1)", lockKey); err != nil {
 		return fmt.Errorf("acquire template advisory lock: %w", err)
 	}
 	defer func() {
-		_, _ = adminConn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", templateAdvisoryLockKey)
+		_, _ = adminConn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", lockKey)
 	}()
 
 	reusable, err := templateIsReusable(ctx, adminConn, name)
@@ -541,35 +553,104 @@ func terminateTemplateBuildSessions(ctx context.Context, adminConfig *db.Config,
 	`, name)
 }
 
-// templateRebuildInProgress reports whether the template exists but is not
-// sealed, i.e. some process is mid-rebuild. Used to wait for that build rather
-// than fighting it.
-func templateRebuildInProgress(ctx context.Context, adminConfig *db.Config, template string) bool {
+// templateBuildState describes what a clone is up against when its source is
+// unusable.
+type templateBuildState int
+
+const (
+	// templateStatePublished covers a sealed template (or one that is missing
+	// entirely): nothing about the build is in the way.
+	templateStatePublished templateBuildState = iota
+	// templateStateBuilding means a process holds the preparation lock and is
+	// migrating the template right now. Worth waiting for.
+	templateStateBuilding
+	// templateStateAbandoned means the template is unsealed but nobody is
+	// building it — a build died mid-flight, leaving a partially migrated
+	// database that will stay that way forever. Must be rebuilt; waiting would
+	// burn the clone's whole budget for nothing.
+	templateStateAbandoned
+)
+
+// inspectTemplateBuildState distinguishes a live build from an abandoned one.
+// Being unsealed is not sufficient evidence of a build: an active builder also
+// holds the preparation advisory lock.
+func inspectTemplateBuildState(ctx context.Context, adminConfig *db.Config, template string) templateBuildState {
 	if template == "" {
-		return false
+		return templateStatePublished
 	}
 
 	conn, err := db.ConnectToDatabase(adminConfig)
 	if err != nil {
-		return false
+		return templateStatePublished
 	}
 	defer conn.Close()
 
 	var allowConnections bool
 	if err := conn.QueryRowContext(ctx,
 		"SELECT datallowconn FROM pg_database WHERE datname = $1", template).Scan(&allowConnections); err != nil {
+		return templateStatePublished
+	}
+	if !allowConnections {
+		return templateStatePublished
+	}
+
+	if preparationLockHeld(ctx, conn, template) {
+		return templateStateBuilding
+	}
+	return templateStateAbandoned
+}
+
+// templateRebuildInProgress reports whether some process is actively rebuilding
+// the template, meaning it is worth waiting for.
+func templateRebuildInProgress(ctx context.Context, adminConfig *db.Config, template string) bool {
+	return inspectTemplateBuildState(ctx, adminConfig, template) == templateStateBuilding
+}
+
+// preparationLockHeld reports whether any session is building this specific
+// template. PostgreSQL splits a bigint advisory key across pg_locks.classid
+// (high 32 bits) and objid (low 32 bits).
+func preparationLockHeld(ctx context.Context, conn *sql.DB, template string) bool {
+	var held bool
+	if err := conn.QueryRowContext(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM pg_locks
+			WHERE locktype = 'advisory'
+			  AND granted
+			  AND ((classid::bigint << 32) | objid::bigint) = $1
+		)
+	`, templateLockKey(template)).Scan(&held); err != nil {
 		return false
 	}
-	return allowConnections
+	return held
+}
+
+// templateLockKey derives the advisory lock key for one template name.
+//
+// The key is per template rather than global for two reasons: a global key makes
+// every concurrent build serialise even when they are building *different*
+// templates (different roles, or different migration sets across checkouts), and
+// — worse — it makes "somebody holds the lock" useless as evidence that *this*
+// template is being built, which is what tells a live build apart from one that
+// died and left the database unsealed.
+func templateLockKey(name string) int64 {
+	sum := sha256.Sum256([]byte(templateAdvisoryLockNamespace + name))
+	// Mask off the sign bit first: the pg_locks reconstruction treats the key as
+	// a positive bigint built from two unsigned halves, and masking before the
+	// conversion keeps it in int64 range by construction.
+	const maxInt64 = uint64(math.MaxInt64)
+	// nolint: gosec // masked to 63 bits on the line above, so it always fits.
+	return int64(binary.BigEndian.Uint64(sum[:8]) & maxInt64)
 }
 
 // waitForTemplateRebuild blocks until the template is sealed (the rebuild
-// published it), disappears (the rebuild failed and dropped it), or the wait
-// times out. Cloning cannot proceed while a rebuild holds the source, and the
-// clone retry budget is far shorter than a full migration run, so waiting here
-// is what keeps a concurrent rebuild from failing tests.
-func waitForTemplateRebuild(ctx context.Context, adminConfig *db.Config, template string) {
-	deadline := time.Now().Add(templateRebuildWaitTimeout)
+// published it), disappears (the rebuild failed and dropped it), or the shared
+// deadline passes. Cloning cannot proceed while a rebuild holds the source, and
+// the clone retry budget is far shorter than a full migration run, so waiting
+// here is what keeps a concurrent rebuild from failing tests.
+//
+// The deadline is supplied by the caller and shared across every wait for one
+// test database, so repeated waits cannot add up past it.
+func waitForTemplateRebuild(ctx context.Context, adminConfig *db.Config, template string, deadline time.Time) {
 	for time.Now().Before(deadline) {
 		if !templateRebuildInProgress(ctx, adminConfig, template) {
 			return

--- a/server/internal/testutil/dbtest/template.go
+++ b/server/internal/testutil/dbtest/template.go
@@ -1,0 +1,328 @@
+package dbtest
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"io/fs"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/block/proto-fleet/server/internal/infrastructure/db"
+	"github.com/block/proto-fleet/server/migrations"
+)
+
+// The per-test database harness used to replay every migration into every test
+// database. With 140+ migrations and hundreds of DB-backed tests that cost
+// ~2s per test and dominated the package runtime (the sqlstores package spent
+// ~500s of its 600s Go test timeout inside migrate.Up()).
+//
+// Instead we migrate once into a template database and let PostgreSQL clone it
+// at the filesystem level for each test (CREATE DATABASE ... TEMPLATE), which
+// is O(schema size) rather than O(number of migrations) and takes tens of
+// milliseconds.
+//
+// The template is keyed by a fingerprint of the embedded migration set, so
+// adding or editing a migration transparently builds a new template and
+// abandons the old one. Preparation is guarded by a PostgreSQL advisory lock so
+// that the many test binaries `go test ./...` runs in parallel cooperate: the
+// first one builds the template, the rest wait and reuse it.
+const (
+	// templateDBPrefix namespaces template databases so stale ones from earlier
+	// migration sets can be identified and dropped.
+	templateDBPrefix = "fleet_test_tmpl_"
+
+	// templateAdvisoryLockKey is an arbitrary fixed key. Any process preparing a
+	// template database holds this session-level advisory lock, so concurrent
+	// test binaries build the template once rather than racing.
+	templateAdvisoryLockKey = int64(7264051893001)
+
+	// templateFingerprintLength is how much of the migration-set hash goes into
+	// the template name; 12 hex chars is collision-safe here and keeps the name
+	// well inside PostgreSQL's 63-character identifier limit.
+	templateFingerprintLength = 12
+
+	// templatePrepareTimeout bounds the whole prepare step (waiting for the
+	// advisory lock plus migrating the template).
+	templatePrepareTimeout = 10 * time.Minute
+
+	// templateDetachTimeout bounds how long we wait for sessions to leave the
+	// template after terminating them.
+	templateDetachTimeout  = 30 * time.Second
+	templateDetachInterval = 100 * time.Millisecond
+)
+
+var (
+	templatePrepareOnce sync.Once
+	// templateDBName is the prepared template's name, or "" when preparation
+	// failed and callers must fall back to migrating each test database.
+	templateDBName string
+)
+
+// templateDatabase returns the name of a fully migrated template database that
+// test databases can be cloned from, preparing it on first use. It returns ""
+// if no template could be prepared, in which case the caller should create an
+// empty database and migrate it directly.
+func templateDatabase(t *testing.T, adminConfig *db.Config) string {
+	t.Helper()
+
+	templatePrepareOnce.Do(func() {
+		name := templateDBPrefix + migrationSetFingerprint()
+
+		// Deliberately not t.Context(): the template outlives the test that
+		// happens to build it, and cancelling that test must not abandon a
+		// half-migrated template for every other test in the binary.
+		// nolint: usetesting
+		ctx, cancel := context.WithTimeout(context.Background(), templatePrepareTimeout)
+		defer cancel()
+
+		start := time.Now()
+		if err := prepareTemplateDatabase(ctx, adminConfig, name); err != nil {
+			t.Logf("could not prepare template database %s (%v); "+
+				"falling back to migrating each test database", name, err)
+			return
+		}
+		templateDBName = name
+		t.Logf("template database %s ready in %s", name, time.Since(start))
+	})
+
+	return templateDBName
+}
+
+// prepareTemplateDatabase makes sure a migrated template database exists for the
+// current migration set. It is safe to call concurrently from separate
+// processes: the advisory lock serialises preparation, and the caller that finds
+// a ready template returns immediately.
+func prepareTemplateDatabase(ctx context.Context, adminConfig *db.Config, name string) error {
+	adminDB, err := db.ConnectToDatabase(adminConfig)
+	if err != nil {
+		return fmt.Errorf("connect to admin database: %w", err)
+	}
+	defer adminDB.Close()
+
+	// Advisory locks are session-scoped, so pin a single connection rather than
+	// letting the pool hand the unlock to a different session.
+	adminConn, err := adminDB.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("pin admin connection: %w", err)
+	}
+	defer adminConn.Close()
+
+	if _, err := adminConn.ExecContext(ctx, "SELECT pg_advisory_lock($1)", templateAdvisoryLockKey); err != nil {
+		return fmt.Errorf("acquire template advisory lock: %w", err)
+	}
+	defer func() {
+		_, _ = adminConn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", templateAdvisoryLockKey)
+	}()
+
+	ready, err := templateDatabaseReady(ctx, adminConn, name)
+	if err != nil {
+		return err
+	}
+	if ready {
+		return nil
+	}
+
+	// Either absent or left half-built by an interrupted run: rebuild it.
+	if err := tryDropTestDatabase(ctx, adminConfig, name); err != nil {
+		return fmt.Errorf("drop stale template: %w", err)
+	}
+	if _, err := adminConn.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE %s", name)); err != nil {
+		return fmt.Errorf("create template database: %w", err)
+	}
+
+	if err := migrateTemplateDatabase(adminConfig, name); err != nil {
+		// Leave nothing half-migrated behind for the next run to trust.
+		_ = tryDropTestDatabase(ctx, adminConfig, name)
+		return err
+	}
+
+	// Blocking connections is both a correctness guard and the readiness
+	// marker: CREATE DATABASE ... TEMPLATE fails while any session is connected
+	// to the source, and a template is only ever published in this state.
+	if _, err := adminConn.ExecContext(ctx,
+		fmt.Sprintf("ALTER DATABASE %s WITH ALLOW_CONNECTIONS false", name)); err != nil {
+		_ = tryDropTestDatabase(ctx, adminConfig, name)
+		return fmt.Errorf("seal template database: %w", err)
+	}
+
+	// Creating the extension started a TimescaleDB background worker scheduler
+	// inside the template, and that counts as a connected session: every clone
+	// would fail with "source database is being accessed by other users". Evict
+	// it now that ALLOW_CONNECTIONS false stops the launcher reattaching.
+	if err := detachTemplateSessions(ctx, adminConn, name); err != nil {
+		_ = tryDropTestDatabase(ctx, adminConfig, name)
+		return err
+	}
+
+	dropStaleTemplateDatabases(ctx, adminConn, name)
+	return nil
+}
+
+// templateDatabaseReady reports whether a usable template exists. A template is
+// usable only once connections have been disabled on it, which happens after
+// migrations succeed — so a database that exists but still allows connections is
+// treated as incomplete and rebuilt.
+func templateDatabaseReady(ctx context.Context, adminConn *sql.Conn, name string) (bool, error) {
+	var allowConnections bool
+	err := adminConn.QueryRowContext(ctx,
+		"SELECT datallowconn FROM pg_database WHERE datname = $1", name).Scan(&allowConnections)
+	switch {
+	case err == nil:
+		return !allowConnections, nil
+	case strings.Contains(err.Error(), sql.ErrNoRows.Error()):
+		return false, nil
+	default:
+		return false, fmt.Errorf("inspect template database: %w", err)
+	}
+}
+
+// migrateTemplateDatabase runs the full migration set against the template and
+// closes the connection, leaving no session attached to it.
+func migrateTemplateDatabase(adminConfig *db.Config, name string) error {
+	templateConfig := *adminConfig
+	templateConfig.Name = name
+
+	conn, err := db.ConnectAndMigrate(&templateConfig)
+	if err != nil {
+		return fmt.Errorf("migrate template database: %w", err)
+	}
+	if err := conn.Close(); err != nil {
+		return fmt.Errorf("close template connection: %w", err)
+	}
+	return nil
+}
+
+// detachTemplateSessions terminates every backend attached to the template and
+// waits for them to disappear, so the first clone does not race the shutdown.
+func detachTemplateSessions(ctx context.Context, adminConn *sql.Conn, name string) error {
+	deadline := time.Now().Add(templateDetachTimeout)
+	for {
+		if _, err := adminConn.ExecContext(ctx, `
+			SELECT pg_terminate_backend(pid)
+			FROM pg_stat_activity
+			WHERE datname = $1 AND pid <> pg_backend_pid()
+		`, name); err != nil {
+			return fmt.Errorf("terminate template sessions: %w", err)
+		}
+
+		var attached int
+		if err := adminConn.QueryRowContext(ctx,
+			"SELECT count(*) FROM pg_stat_activity WHERE datname = $1 AND pid <> pg_backend_pid()",
+			name).Scan(&attached); err != nil {
+			return fmt.Errorf("count template sessions: %w", err)
+		}
+		if attached == 0 {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("%d session(s) still attached to template %s after %s",
+				attached, name, templateDetachTimeout)
+		}
+
+		time.Sleep(templateDetachInterval)
+	}
+}
+
+// evictTemplateSessions is the best-effort recovery used when a clone loses the
+// race to a session that attached to the template anyway (a background worker
+// started before ALLOW_CONNECTIONS false took effect, say). Errors are ignored:
+// the caller is already in a retry loop and the CREATE DATABASE it retries
+// reports the real failure.
+func evictTemplateSessions(ctx context.Context, adminConfig *db.Config, template string) {
+	if template == "" {
+		return
+	}
+
+	conn, err := db.ConnectToDatabase(adminConfig)
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+
+	_, _ = conn.ExecContext(ctx, `
+		SELECT pg_terminate_backend(pid)
+		FROM pg_stat_activity
+		WHERE datname = $1 AND pid <> pg_backend_pid()
+	`, template)
+}
+
+// dropStaleTemplateDatabases removes templates built for other migration sets
+// (typically left by an earlier branch or an older checkout) so they do not
+// accumulate on long-lived local databases. Best effort: a template still in use
+// by a concurrently running suite simply fails to drop.
+func dropStaleTemplateDatabases(ctx context.Context, adminConn *sql.Conn, keep string) {
+	rows, err := adminConn.QueryContext(ctx,
+		"SELECT datname FROM pg_database WHERE datname LIKE $1 AND datname <> $2",
+		templateDBPrefix+"%", keep)
+	if err != nil {
+		return
+	}
+	defer rows.Close()
+
+	var stale []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return
+		}
+		stale = append(stale, name)
+	}
+	if rows.Err() != nil {
+		return
+	}
+
+	for _, name := range stale {
+		// Sealed templates have no sessions to terminate, so a plain DROP is
+		// enough; failures mean someone else is mid-clone and we leave it.
+		_, _ = adminConn.ExecContext(ctx, fmt.Sprintf("DROP DATABASE IF EXISTS %s", name))
+	}
+}
+
+// migrationSetFingerprint hashes the embedded migration files (names and
+// contents) so that any change to the schema yields a new template database
+// rather than silently reusing a stale one.
+func migrationSetFingerprint() string {
+	hash := sha256.New()
+
+	names, err := migrationFileNames()
+	if err != nil {
+		// A read failure here would make every test share an unkeyed template;
+		// fall back to a unique fingerprint so we build a fresh one instead.
+		return fmt.Sprintf("%x", time.Now().UnixNano())[:templateFingerprintLength]
+	}
+
+	for _, name := range names {
+		contents, err := fs.ReadFile(migrations.Migrations, name)
+		if err != nil {
+			return fmt.Sprintf("%x", time.Now().UnixNano())[:templateFingerprintLength]
+		}
+		_, _ = hash.Write([]byte(name))
+		_, _ = hash.Write(contents)
+	}
+
+	return hex.EncodeToString(hash.Sum(nil))[:templateFingerprintLength]
+}
+
+// migrationFileNames lists the embedded migration files in a stable order.
+func migrationFileNames() ([]string, error) {
+	entries, err := fs.ReadDir(migrations.Migrations, ".")
+	if err != nil {
+		return nil, fmt.Errorf("read migrations directory: %w", err)
+	}
+
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		names = append(names, entry.Name())
+	}
+	sort.Strings(names)
+	return names, nil
+}

--- a/server/internal/testutil/dbtest/template.go
+++ b/server/internal/testutil/dbtest/template.go
@@ -289,13 +289,23 @@ func prepareTemplateDatabase(ctx context.Context, adminConfig *db.Config, name s
 		return fmt.Errorf("create template database: %w", err)
 	}
 
-	// Applies to the migrating session below, which we cannot cancel from Go.
+	// Bound the migrating session inside PostgreSQL, since we cannot cancel it
+	// from Go. These are the only guarantees that do not depend on the watchdog
+	// below succeeding: whatever happens, the server itself gives up eventually.
 	// Milliseconds, not Duration.String(): PostgreSQL rejects Go's "1m0s" form.
-	if _, err := adminConn.ExecContext(ctx, fmt.Sprintf("ALTER DATABASE %s SET lock_timeout = %s",
-		quoteIdentifier(name),
-		quoteLiteral(fmt.Sprintf("%dms", templateLockTimeout.Milliseconds())))); err != nil {
-		abandonTemplate(adminConfig, name)
-		return fmt.Errorf("set template lock timeout: %w", err)
+	for setting, limit := range map[string]time.Duration{
+		"lock_timeout": templateLockTimeout,
+		// Derived from the per-attempt deadline. Migrations run against an empty
+		// database and take milliseconds each, so a single statement outliving
+		// this is wedged, not slow.
+		"statement_timeout": templatePrepareTimeout,
+	} {
+		if _, err := adminConn.ExecContext(ctx, fmt.Sprintf("ALTER DATABASE %s SET %s = %s",
+			quoteIdentifier(name), setting,
+			quoteLiteral(fmt.Sprintf("%dms", limit.Milliseconds())))); err != nil {
+			abandonTemplate(adminConfig, name)
+			return fmt.Errorf("set template %s: %w", setting, err)
+		}
 	}
 
 	if err := migrateTemplateDatabase(ctx, adminConfig, name); err != nil {
@@ -427,6 +437,7 @@ func migrateTemplateDatabase(ctx context.Context, adminConfig *db.Config, name s
 
 	migrationDone := make(chan struct{})
 	var watchdog sync.WaitGroup
+	var watchdogErr error
 	watchdog.Add(1)
 
 	go func() {
@@ -441,7 +452,7 @@ func migrateTemplateDatabase(ctx context.Context, adminConfig *db.Config, name s
 			// Not evictTemplateSessions: that one deliberately spares unsealed
 			// templates, and the template is unsealed for the whole of this
 			// migration, so it would never match the backend we need to stop.
-			terminateTemplateBuildSessions(killCtx, adminConfig, name)
+			watchdogErr = terminateTemplateBuildSessions(killCtx, adminConfig, name)
 		}
 	}()
 
@@ -453,9 +464,22 @@ func migrateTemplateDatabase(ctx context.Context, adminConfig *db.Config, name s
 
 	if err != nil {
 		if ctx.Err() != nil {
+			if watchdogErr != nil {
+				// Worth surfacing: if termination failed, the statement and lock
+				// timeouts set on the template are what ended the migration.
+				return fmt.Errorf("migrate template database: deadline exceeded "+
+					"(terminating the migration backend also failed: %v): %w", watchdogErr, err)
+			}
 			return fmt.Errorf("migrate template database: deadline exceeded, migration backend terminated: %w", err)
 		}
 		return fmt.Errorf("migrate template database: %w", err)
+	}
+
+	if watchdogErr != nil {
+		// The deadline passed and we failed to stop the migration, yet it finished
+		// anyway. Treat the template as untrustworthy rather than publishing it.
+		return fmt.Errorf("migrate template database: deadline passed and terminating the "+
+			"migration backend failed: %w", watchdogErr)
 	}
 	if err := conn.Close(); err != nil {
 		return fmt.Errorf("close template connection: %w", err)
@@ -535,22 +559,45 @@ func evictTemplateSessions(ctx context.Context, adminConfig *db.Config, template
 // building this template, and clones never connect to their source. It exists
 // solely so the deadline watchdog can stop a migration that Go cannot cancel,
 // db.ConnectAndMigrate not being context-aware.
-func terminateTemplateBuildSessions(ctx context.Context, adminConfig *db.Config, name string) {
+// It reports failures rather than swallowing them: if the migration cannot be
+// stopped, the template must not be published, and the caller needs to say so.
+// The statement and lock timeouts set on the template are the backstop that does
+// not depend on this succeeding.
+func terminateTemplateBuildSessions(ctx context.Context, adminConfig *db.Config, name string) error {
 	if name == "" {
-		return
+		return nil
 	}
 
 	conn, err := db.ConnectToDatabase(adminConfig)
 	if err != nil {
-		return
+		return fmt.Errorf("connect to admin database to terminate template build: %w", err)
 	}
 	defer conn.Close()
 
-	_, _ = conn.ExecContext(ctx, `
-		SELECT pg_terminate_backend(pid)
-		FROM pg_stat_activity
-		WHERE datname = $1 AND pid <> pg_backend_pid()
-	`, name)
+	var lastErr error
+	for attempt := 1; attempt <= migrationMaxRetries; attempt++ {
+		var remaining int
+		lastErr = conn.QueryRowContext(ctx, `
+			WITH terminated AS (
+				SELECT pg_terminate_backend(pid) AS stopped
+				FROM pg_stat_activity
+				WHERE datname = $1 AND pid <> pg_backend_pid()
+			)
+			SELECT count(*) FILTER (WHERE NOT stopped) FROM terminated
+		`, name).Scan(&remaining)
+		if lastErr == nil && remaining == 0 {
+			return nil
+		}
+		if ctx.Err() != nil {
+			break
+		}
+		time.Sleep(templateDetachInterval)
+	}
+
+	if lastErr != nil {
+		return fmt.Errorf("terminate template build sessions: %w", lastErr)
+	}
+	return fmt.Errorf("terminate template build sessions: sessions still attached to %s", name)
 }
 
 // templateBuildState describes what a clone is up against when its source is

--- a/server/internal/testutil/dbtest/template.go
+++ b/server/internal/testutil/dbtest/template.go
@@ -100,6 +100,12 @@ const (
 	// template after terminating them.
 	templateDetachTimeout  = 30 * time.Second
 	templateDetachInterval = 100 * time.Millisecond
+
+	// templateRebuildWaitTimeout bounds how long a clone waits for somebody
+	// else's in-progress rebuild of the same template to publish. It has to
+	// exceed a full migration run, since that is what we are waiting for.
+	templateRebuildWaitTimeout  = 2 * time.Minute
+	templateRebuildWaitInterval = 100 * time.Millisecond
 )
 
 // templateNamePattern is the exact shape of a template database name. It gates
@@ -453,6 +459,13 @@ func detachTemplateSessions(ctx context.Context, adminConn *sql.Conn, name strin
 // started before ALLOW_CONNECTIONS false took effect, say). Errors are ignored:
 // the caller is already in a retry loop and the CREATE DATABASE it retries
 // reports the real failure.
+//
+// It only ever evicts from a *sealed* template. An unsealed one is being built
+// right now — by this process or another — and the session attached to it is
+// that build's migration. Terminating it would abort a legitimate rebuild,
+// which is how two binaries could otherwise take turns killing each other's
+// migrations. The datallowconn check is part of the same statement so there is
+// no window between deciding and acting.
 func evictTemplateSessions(ctx context.Context, adminConfig *db.Config, template string) {
 	if template == "" {
 		return
@@ -465,10 +478,53 @@ func evictTemplateSessions(ctx context.Context, adminConfig *db.Config, template
 	defer conn.Close()
 
 	_, _ = conn.ExecContext(ctx, `
-		SELECT pg_terminate_backend(pid)
-		FROM pg_stat_activity
-		WHERE datname = $1 AND pid <> pg_backend_pid()
+		SELECT pg_terminate_backend(activity.pid)
+		FROM pg_stat_activity activity
+		JOIN pg_database database ON database.datname = activity.datname
+		WHERE activity.datname = $1
+		  AND NOT database.datallowconn
+		  AND activity.pid <> pg_backend_pid()
 	`, template)
+}
+
+// templateRebuildInProgress reports whether the template exists but is not
+// sealed, i.e. some process is mid-rebuild. Used to wait for that build rather
+// than fighting it.
+func templateRebuildInProgress(ctx context.Context, adminConfig *db.Config, template string) bool {
+	if template == "" {
+		return false
+	}
+
+	conn, err := db.ConnectToDatabase(adminConfig)
+	if err != nil {
+		return false
+	}
+	defer conn.Close()
+
+	var allowConnections bool
+	if err := conn.QueryRowContext(ctx,
+		"SELECT datallowconn FROM pg_database WHERE datname = $1", template).Scan(&allowConnections); err != nil {
+		return false
+	}
+	return allowConnections
+}
+
+// waitForTemplateRebuild blocks until the template is sealed (the rebuild
+// published it), disappears (the rebuild failed and dropped it), or the wait
+// times out. Cloning cannot proceed while a rebuild holds the source, and the
+// clone retry budget is far shorter than a full migration run, so waiting here
+// is what keeps a concurrent rebuild from failing tests.
+func waitForTemplateRebuild(ctx context.Context, adminConfig *db.Config, template string) {
+	deadline := time.Now().Add(templateRebuildWaitTimeout)
+	for time.Now().Before(deadline) {
+		if !templateRebuildInProgress(ctx, adminConfig, template) {
+			return
+		}
+		if ctx.Err() != nil {
+			return
+		}
+		time.Sleep(templateRebuildWaitInterval)
+	}
 }
 
 // dropStaleTemplateDatabases removes *old* templates built for other migration

--- a/server/internal/testutil/dbtest/template.go
+++ b/server/internal/testutil/dbtest/template.go
@@ -168,7 +168,7 @@ func templateDatabase(t *testing.T, adminConfig *db.Config) string {
 		return ""
 	}
 
-	name := templateDBPrefix + migrationSetFingerprint()
+	name := templateNameFor(adminConfig)
 
 	// Deliberately not t.Context(): the template outlives the test that
 	// happens to build it, and cancelling that test must not abandon a
@@ -220,6 +220,19 @@ func invalidateTemplateDatabase(name string) {
 		templatePrepared = false
 		templateDBName = ""
 	}
+}
+
+// disableTemplateCloning gives up on cloning for the rest of the process. Used
+// for failures that retrying cannot fix, such as lacking permission to copy the
+// template: without this every remaining test would pay for a clone attempt that
+// is guaranteed to fail before falling back.
+func disableTemplateCloning() {
+	templateMu.Lock()
+	defer templateMu.Unlock()
+
+	templatePrepared = false
+	templateDBName = ""
+	templateFailures = templatePrepareMaxAttempts
 }
 
 // prepareTemplateDatabase makes sure a migrated template database exists for the
@@ -316,21 +329,26 @@ func prepareTemplateDatabase(ctx context.Context, adminConfig *db.Config, name s
 //   - connections are disabled, which only happens after migrations succeed, so
 //     a database that still allows them is incomplete and must be rebuilt;
 //   - it was built within templateMaxAge, so clones do not inherit badly stale
-//     CURRENT_TIMESTAMP seed data.
+//     CURRENT_TIMESTAMP seed data;
+//   - it is owned by the role we are connecting as, since PostgreSQL refuses to
+//     copy another role's database unless we are a superuser.
 //
 // A template with no recognisable creation stamp (an older format, or one built
 // before stamping existed) is rebuilt rather than trusted.
 func templateIsReusable(ctx context.Context, adminConn *sql.Conn, name string) (bool, error) {
 	var allowConnections bool
+	var ownedByCurrentRole bool
 	var comment sql.NullString
 	err := adminConn.QueryRowContext(ctx, `
-		SELECT datallowconn, shobj_description(oid, 'pg_database')
+		SELECT datallowconn,
+		       pg_catalog.pg_get_userbyid(datdba) = current_user,
+		       shobj_description(oid, 'pg_database')
 		FROM pg_database
 		WHERE datname = $1
-	`, name).Scan(&allowConnections, &comment)
+	`, name).Scan(&allowConnections, &ownedByCurrentRole, &comment)
 	switch {
 	case err == nil:
-		if allowConnections {
+		if allowConnections || !ownedByCurrentRole {
 			return false, nil
 		}
 		created, ok := templateCreatedAt(comment)
@@ -396,21 +414,31 @@ func migrateTemplateDatabase(ctx context.Context, adminConfig *db.Config, name s
 	templateConfig.Name = name
 
 	migrationDone := make(chan struct{})
-	defer close(migrationDone)
+	var watchdog sync.WaitGroup
+	watchdog.Add(1)
 
 	go func() {
+		defer watchdog.Done()
 		select {
 		case <-migrationDone:
 		case <-ctx.Done():
-			// The parent context is spent, so give the eviction its own.
+			// The parent context is spent, so give the termination its own.
 			// nolint: usetesting
-			evictCtx, cancel := context.WithTimeout(context.Background(), templateDetachTimeout)
+			killCtx, cancel := context.WithTimeout(context.Background(), templateDetachTimeout)
 			defer cancel()
-			evictTemplateSessions(evictCtx, adminConfig, name)
+			// Not evictTemplateSessions: that one deliberately spares unsealed
+			// templates, and the template is unsealed for the whole of this
+			// migration, so it would never match the backend we need to stop.
+			terminateTemplateBuildSessions(killCtx, adminConfig, name)
 		}
 	}()
 
 	conn, err := db.ConnectAndMigrate(&templateConfig)
+	close(migrationDone)
+	// Let a firing watchdog finish before the caller drops the template, so the
+	// termination cannot land on an unrelated database that reuses the name.
+	watchdog.Wait()
+
 	if err != nil {
 		if ctx.Err() != nil {
 			return fmt.Errorf("migrate template database: deadline exceeded, migration backend terminated: %w", err)
@@ -485,6 +513,32 @@ func evictTemplateSessions(ctx context.Context, adminConfig *db.Config, template
 		  AND NOT database.datallowconn
 		  AND activity.pid <> pg_backend_pid()
 	`, template)
+}
+
+// terminateTemplateBuildSessions unconditionally disconnects everything attached
+// to the template, including an unsealed (in-progress) build.
+//
+// This is only safe for the process holding the preparation advisory lock, which
+// makes the build in question its own: the lock guarantees no other process is
+// building this template, and clones never connect to their source. It exists
+// solely so the deadline watchdog can stop a migration that Go cannot cancel,
+// db.ConnectAndMigrate not being context-aware.
+func terminateTemplateBuildSessions(ctx context.Context, adminConfig *db.Config, name string) {
+	if name == "" {
+		return
+	}
+
+	conn, err := db.ConnectToDatabase(adminConfig)
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+
+	_, _ = conn.ExecContext(ctx, `
+		SELECT pg_terminate_backend(pid)
+		FROM pg_stat_activity
+		WHERE datname = $1 AND pid <> pg_backend_pid()
+	`, name)
 }
 
 // templateRebuildInProgress reports whether the template exists but is not
@@ -612,11 +666,25 @@ func quoteLiteral(value string) string {
 	return `'` + strings.ReplaceAll(value, `'`, `''`) + `'`
 }
 
+// templateNameFor returns the template name this configuration may use.
+//
+// The connecting role is part of the identity, not just the migration set:
+// PostgreSQL only lets a role copy a database it owns (or any, for superusers),
+// so two checkouts on one cluster using different roles must not compete for one
+// template name. Without this the second role gets "permission denied to copy
+// database" on every clone.
+func templateNameFor(config *db.Config) string {
+	return templateDBPrefix + migrationSetFingerprint(config.Username)
+}
+
 // migrationSetFingerprint hashes the embedded migration files (names and
-// contents) so that any change to the schema yields a new template database
-// rather than silently reusing a stale one.
-func migrationSetFingerprint() string {
+// contents), plus the owning role, so that any change to the schema — or a
+// different role — yields a new template database rather than silently reusing
+// one that does not match.
+func migrationSetFingerprint(role string) string {
 	hash := sha256.New()
+	_, _ = hash.Write([]byte(role))
+	_, _ = hash.Write([]byte{0})
 
 	names, err := migrationFileNames()
 	if err != nil {

--- a/server/internal/testutil/dbtest/template.go
+++ b/server/internal/testutil/dbtest/template.go
@@ -7,7 +7,9 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io/fs"
+	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -57,12 +59,30 @@ const (
 	templateDetachInterval = 100 * time.Millisecond
 )
 
+// templateNamePattern is the exact shape of a template database name. It gates
+// both the cleanup query and the identifiers we interpolate into DDL, so a
+// catalog row can never steer either.
+var templateNamePattern = regexp.MustCompile(`^` + templateDBPrefix + `[0-9a-f]{` +
+	strconv.Itoa(templateFingerprintLength) + `}$`)
+
 var (
-	templatePrepareOnce sync.Once
-	// templateDBName is the prepared template's name, or "" when preparation
-	// failed and callers must fall back to migrating each test database.
+	templateMu sync.Mutex
+	// templateDBName is the prepared template's name, valid only while
+	// templatePrepared is true.
 	templateDBName string
+	// templatePrepared records a *successful* preparation. Failures are not
+	// cached, so a later test can retry: a transient blip while the first test
+	// happens to run must not force every remaining test in the binary back onto
+	// the slow migrate-everything path.
+	templatePrepared bool
+	// templateFailures counts consecutive failures so a genuinely broken setup
+	// stops paying the preparation cost on every test.
+	templateFailures int
 )
+
+// templatePrepareMaxAttempts bounds retries across tests once preparation keeps
+// failing; after this we accept the fallback for the rest of the process.
+const templatePrepareMaxAttempts = 3
 
 // templateDatabase returns the name of a fully migrated template database that
 // test databases can be cloned from, preparing it on first use. It returns ""
@@ -71,27 +91,58 @@ var (
 func templateDatabase(t *testing.T, adminConfig *db.Config) string {
 	t.Helper()
 
-	templatePrepareOnce.Do(func() {
-		name := templateDBPrefix + migrationSetFingerprint()
+	templateMu.Lock()
+	defer templateMu.Unlock()
 
-		// Deliberately not t.Context(): the template outlives the test that
-		// happens to build it, and cancelling that test must not abandon a
-		// half-migrated template for every other test in the binary.
-		// nolint: usetesting
-		ctx, cancel := context.WithTimeout(context.Background(), templatePrepareTimeout)
-		defer cancel()
+	if templatePrepared {
+		return templateDBName
+	}
+	if templateFailures >= templatePrepareMaxAttempts {
+		return ""
+	}
 
-		start := time.Now()
-		if err := prepareTemplateDatabase(ctx, adminConfig, name); err != nil {
-			t.Logf("could not prepare template database %s (%v); "+
-				"falling back to migrating each test database", name, err)
-			return
-		}
-		templateDBName = name
-		t.Logf("template database %s ready in %s", name, time.Since(start))
-	})
+	name := templateDBPrefix + migrationSetFingerprint()
+
+	// Deliberately not t.Context(): the template outlives the test that
+	// happens to build it, and cancelling that test must not abandon a
+	// half-migrated template for every other test in the binary.
+	// nolint: usetesting
+	ctx, cancel := context.WithTimeout(context.Background(), templatePrepareTimeout)
+	defer cancel()
+
+	// The very first connection of the run can land while the server is still
+	// starting or recovering; wait it out the same way the admin DDL path does
+	// rather than burning an attempt on it.
+	waitForServerReady(ctx, t, adminConfig)
+
+	start := time.Now()
+	if err := prepareTemplateDatabase(ctx, adminConfig, name); err != nil {
+		templateFailures++
+		t.Logf("could not prepare template database %s (attempt %d/%d: %v); "+
+			"migrating this test database directly",
+			name, templateFailures, templatePrepareMaxAttempts, err)
+		return ""
+	}
+
+	templateDBName = name
+	templatePrepared = true
+	templateFailures = 0
+	t.Logf("template database %s ready in %s", name, time.Since(start))
 
 	return templateDBName
+}
+
+// invalidateTemplateDatabase forgets the cached template so the next caller
+// rebuilds it. Used when a clone reports the source is gone — a concurrent run
+// on a different migration set may have swept it as stale.
+func invalidateTemplateDatabase(name string) {
+	templateMu.Lock()
+	defer templateMu.Unlock()
+
+	if templatePrepared && templateDBName == name {
+		templatePrepared = false
+		templateDBName = ""
+	}
 }
 
 // prepareTemplateDatabase makes sure a migrated template database exists for the
@@ -132,7 +183,7 @@ func prepareTemplateDatabase(ctx context.Context, adminConfig *db.Config, name s
 	if err := tryDropTestDatabase(ctx, adminConfig, name); err != nil {
 		return fmt.Errorf("drop stale template: %w", err)
 	}
-	if _, err := adminConn.ExecContext(ctx, fmt.Sprintf("CREATE DATABASE %s", name)); err != nil {
+	if _, err := adminConn.ExecContext(ctx, "CREATE DATABASE "+quoteIdentifier(name)); err != nil {
 		return fmt.Errorf("create template database: %w", err)
 	}
 
@@ -146,7 +197,7 @@ func prepareTemplateDatabase(ctx context.Context, adminConfig *db.Config, name s
 	// marker: CREATE DATABASE ... TEMPLATE fails while any session is connected
 	// to the source, and a template is only ever published in this state.
 	if _, err := adminConn.ExecContext(ctx,
-		fmt.Sprintf("ALTER DATABASE %s WITH ALLOW_CONNECTIONS false", name)); err != nil {
+		"ALTER DATABASE "+quoteIdentifier(name)+" WITH ALLOW_CONNECTIONS false"); err != nil {
 		_ = tryDropTestDatabase(ctx, adminConfig, name)
 		return fmt.Errorf("seal template database: %w", err)
 	}
@@ -254,12 +305,22 @@ func evictTemplateSessions(ctx context.Context, adminConfig *db.Config, template
 
 // dropStaleTemplateDatabases removes templates built for other migration sets
 // (typically left by an earlier branch or an older checkout) so they do not
-// accumulate on long-lived local databases. Best effort: a template still in use
-// by a concurrently running suite simply fails to drop.
+// accumulate on long-lived local databases.
+//
+// Two constraints shape this. First, matching is by anchored regex rather than
+// LIKE: every underscore in `fleet_test_tmpl_%` is a single-character wildcard,
+// so LIKE also matches unrelated names like `fleetXtestYtmplZsomething`. Second,
+// each name is re-validated in Go and quoted before it reaches DDL, so a catalog
+// row can never steer the statement.
+//
+// A concurrent run on a different migration set can still have one of these
+// templates cached; that run recovers by rebuilding it (see
+// invalidateTemplateDatabase), so cleanup stays best-effort rather than
+// coordinated.
 func dropStaleTemplateDatabases(ctx context.Context, adminConn *sql.Conn, keep string) {
 	rows, err := adminConn.QueryContext(ctx,
-		"SELECT datname FROM pg_database WHERE datname LIKE $1 AND datname <> $2",
-		templateDBPrefix+"%", keep)
+		"SELECT datname FROM pg_database WHERE datname ~ $1 AND datname <> $2",
+		templateNamePattern.String(), keep)
 	if err != nil {
 		return
 	}
@@ -271,6 +332,11 @@ func dropStaleTemplateDatabases(ctx context.Context, adminConn *sql.Conn, keep s
 		if err := rows.Scan(&name); err != nil {
 			return
 		}
+		// Defence in depth: never interpolate a name the pattern does not own,
+		// even though the query already filtered on it.
+		if !templateNamePattern.MatchString(name) || name == keep {
+			continue
+		}
 		stale = append(stale, name)
 	}
 	if rows.Err() != nil {
@@ -280,8 +346,15 @@ func dropStaleTemplateDatabases(ctx context.Context, adminConn *sql.Conn, keep s
 	for _, name := range stale {
 		// Sealed templates have no sessions to terminate, so a plain DROP is
 		// enough; failures mean someone else is mid-clone and we leave it.
-		_, _ = adminConn.ExecContext(ctx, fmt.Sprintf("DROP DATABASE IF EXISTS %s", name))
+		_, _ = adminConn.ExecContext(ctx, "DROP DATABASE IF EXISTS "+quoteIdentifier(name))
 	}
+}
+
+// quoteIdentifier renders a PostgreSQL identifier safely. Database names cannot
+// be bound as parameters in DDL, so anything interpolated into a statement goes
+// through here.
+func quoteIdentifier(name string) string {
+	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
 }
 
 // migrationSetFingerprint hashes the embedded migration files (names and

--- a/server/internal/testutil/dbtest/template.go
+++ b/server/internal/testutil/dbtest/template.go
@@ -74,6 +74,17 @@ const (
 	// slow, and capping their total runtime would fail valid work.
 	templateLockTimeout = time.Minute
 
+	// templateMaxAge bounds how long a template may be *reused*. Cloning copies
+	// rows a migration seeded with CURRENT_TIMESTAMP — e.g. the
+	// curtailment_reconciler_heartbeat row from 000042 — so a clone inherits the
+	// template's build time rather than "now", as replaying migrations per test
+	// used to give. Rebuilding on a short cadence keeps that skew small without
+	// having to enumerate (and keep up with) every time-dependent seed.
+	//
+	// The cost is one ~1s rebuild per interval per process, so this trades a
+	// negligible amount of the speedup for bounded staleness.
+	templateMaxAge = 15 * time.Minute
+
 	// templateStaleAfter is how old a template must be before another run may
 	// sweep it. Cleanup is bounded by age (recorded in the database comment when
 	// the template is sealed) rather than "different fingerprint", so two
@@ -231,11 +242,11 @@ func prepareTemplateDatabase(ctx context.Context, adminConfig *db.Config, name s
 		_, _ = adminConn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", templateAdvisoryLockKey)
 	}()
 
-	ready, err := templateDatabaseReady(ctx, adminConn, name)
+	reusable, err := templateIsReusable(ctx, adminConn, name)
 	if err != nil {
 		return err
 	}
-	if ready {
+	if reusable {
 		return nil
 	}
 
@@ -293,22 +304,49 @@ func prepareTemplateDatabase(ctx context.Context, adminConfig *db.Config, name s
 	return nil
 }
 
-// templateDatabaseReady reports whether a usable template exists. A template is
-// usable only once connections have been disabled on it, which happens after
-// migrations succeed — so a database that exists but still allows connections is
-// treated as incomplete and rebuilt.
-func templateDatabaseReady(ctx context.Context, adminConn *sql.Conn, name string) (bool, error) {
+// templateIsReusable reports whether an existing template can be cloned as-is.
+// Two conditions must hold:
+//
+//   - connections are disabled, which only happens after migrations succeed, so
+//     a database that still allows them is incomplete and must be rebuilt;
+//   - it was built within templateMaxAge, so clones do not inherit badly stale
+//     CURRENT_TIMESTAMP seed data.
+//
+// A template with no recognisable creation stamp (an older format, or one built
+// before stamping existed) is rebuilt rather than trusted.
+func templateIsReusable(ctx context.Context, adminConn *sql.Conn, name string) (bool, error) {
 	var allowConnections bool
-	err := adminConn.QueryRowContext(ctx,
-		"SELECT datallowconn FROM pg_database WHERE datname = $1", name).Scan(&allowConnections)
+	var comment sql.NullString
+	err := adminConn.QueryRowContext(ctx, `
+		SELECT datallowconn, shobj_description(oid, 'pg_database')
+		FROM pg_database
+		WHERE datname = $1
+	`, name).Scan(&allowConnections, &comment)
 	switch {
 	case err == nil:
-		return !allowConnections, nil
+		if allowConnections {
+			return false, nil
+		}
+		created, ok := templateCreatedAt(comment)
+		return ok && time.Since(created) <= templateMaxAge, nil
 	case strings.Contains(err.Error(), sql.ErrNoRows.Error()):
 		return false, nil
 	default:
 		return false, fmt.Errorf("inspect template database: %w", err)
 	}
+}
+
+// templateCreatedAt parses the creation time we stamp into a template's comment.
+func templateCreatedAt(comment sql.NullString) (time.Time, bool) {
+	if !comment.Valid || !strings.HasPrefix(comment.String, templateCommentPrefix) {
+		return time.Time{}, false
+	}
+
+	created, err := time.Parse(time.RFC3339Nano, strings.TrimPrefix(comment.String, templateCommentPrefix))
+	if err != nil {
+		return time.Time{}, false
+	}
+	return created, true
 }
 
 // abandonTemplate drops a template that failed to build. It deliberately does
@@ -498,12 +536,8 @@ func dropStaleTemplateDatabases(ctx context.Context, adminConn *sql.Conn, keep s
 // comment, a foreign comment, or an unparseable timestamp is left in place
 // rather than guessed about.
 func templateIsStale(comment sql.NullString) bool {
-	if !comment.Valid || !strings.HasPrefix(comment.String, templateCommentPrefix) {
-		return false
-	}
-
-	created, err := time.Parse(time.RFC3339Nano, strings.TrimPrefix(comment.String, templateCommentPrefix))
-	if err != nil {
+	created, ok := templateCreatedAt(comment)
+	if !ok {
 		return false
 	}
 	return time.Since(created) > templateStaleAfter

--- a/server/internal/testutil/dbtest/template.go
+++ b/server/internal/testutil/dbtest/template.go
@@ -49,9 +49,34 @@ const (
 	// well inside PostgreSQL's 63-character identifier limit.
 	templateFingerprintLength = 12
 
-	// templatePrepareTimeout bounds the whole prepare step (waiting for the
-	// advisory lock plus migrating the template).
-	templatePrepareTimeout = 10 * time.Minute
+	// templatePrepareTimeout bounds waiting for the advisory lock. It sits well
+	// below Go's default 10m package timeout so a stuck preparation still leaves
+	// room for callers to fall back to migrating their own database.
+	templatePrepareTimeout = 4 * time.Minute
+
+	// templateLockTimeout bounds how long migrating the template waits on any
+	// single lock. db.ConnectAndMigrate is not context-aware (it runs migrations
+	// on a background context), so the deadline is enforced inside PostgreSQL
+	// instead: it is set on the template database, which every session that
+	// migrates it inherits. A migration wedged behind a TimescaleDB catalog lock
+	// then fails with lock_not_available, preparation reports an error, and the
+	// caller falls back to migrating its own database rather than every DB-backed
+	// package hanging on the shared template.
+	//
+	// Only lock_timeout is set, not statement_timeout: migrations are legitimately
+	// slow, and capping their total runtime would fail valid work.
+	templateLockTimeout = time.Minute
+
+	// templateStaleAfter is how old a template must be before another run may
+	// sweep it. Cleanup is bounded by age (recorded in the database comment when
+	// the template is sealed) rather than "different fingerprint", so two
+	// checkouts on different migration sets cannot delete each other's live
+	// templates and ping-pong rebuilds.
+	templateStaleAfter = 24 * time.Hour
+
+	// templateCommentPrefix marks a database as ours and carries its creation
+	// time; anything without it is left alone.
+	templateCommentPrefix = "dbtest-template created="
 
 	// templateDetachTimeout bounds how long we wait for sessions to leave the
 	// template after terminating them.
@@ -187,6 +212,15 @@ func prepareTemplateDatabase(ctx context.Context, adminConfig *db.Config, name s
 		return fmt.Errorf("create template database: %w", err)
 	}
 
+	// Applies to the migrating session below, which we cannot cancel from Go.
+	// Milliseconds, not Duration.String(): PostgreSQL rejects Go's "1m0s" form.
+	if _, err := adminConn.ExecContext(ctx, fmt.Sprintf("ALTER DATABASE %s SET lock_timeout = %s",
+		quoteIdentifier(name),
+		quoteLiteral(fmt.Sprintf("%dms", templateLockTimeout.Milliseconds())))); err != nil {
+		_ = tryDropTestDatabase(ctx, adminConfig, name)
+		return fmt.Errorf("set template lock timeout: %w", err)
+	}
+
 	if err := migrateTemplateDatabase(adminConfig, name); err != nil {
 		// Leave nothing half-migrated behind for the next run to trust.
 		_ = tryDropTestDatabase(ctx, adminConfig, name)
@@ -209,6 +243,15 @@ func prepareTemplateDatabase(ctx context.Context, adminConfig *db.Config, name s
 	if err := detachTemplateSessions(ctx, adminConn, name); err != nil {
 		_ = tryDropTestDatabase(ctx, adminConfig, name)
 		return err
+	}
+
+	// Ownership metadata: marks the database as ours and records when it was
+	// built, which is what makes age-bounded cleanup possible.
+	if _, err := adminConn.ExecContext(ctx, fmt.Sprintf("COMMENT ON DATABASE %s IS %s",
+		quoteIdentifier(name),
+		quoteLiteral(templateCommentPrefix+time.Now().UTC().Format(time.RFC3339Nano)))); err != nil {
+		_ = tryDropTestDatabase(ctx, adminConfig, name)
+		return fmt.Errorf("record template metadata: %w", err)
 	}
 
 	dropStaleTemplateDatabases(ctx, adminConn, name)
@@ -303,24 +346,33 @@ func evictTemplateSessions(ctx context.Context, adminConfig *db.Config, template
 	`, template)
 }
 
-// dropStaleTemplateDatabases removes templates built for other migration sets
-// (typically left by an earlier branch or an older checkout) so they do not
+// dropStaleTemplateDatabases removes *old* templates built for other migration
+// sets (typically left by an earlier branch or an older checkout) so they do not
 // accumulate on long-lived local databases.
 //
-// Two constraints shape this. First, matching is by anchored regex rather than
-// LIKE: every underscore in `fleet_test_tmpl_%` is a single-character wildcard,
-// so LIKE also matches unrelated names like `fleetXtestYtmplZsomething`. Second,
-// each name is re-validated in Go and quoted before it reaches DDL, so a catalog
-// row can never steer the statement.
+// Three constraints shape this:
 //
-// A concurrent run on a different migration set can still have one of these
-// templates cached; that run recovers by rebuilding it (see
-// invalidateTemplateDatabase), so cleanup stays best-effort rather than
-// coordinated.
+// Matching is by anchored regex rather than LIKE, because every underscore in
+// `fleet_test_tmpl_%` is a single-character wildcard and LIKE would also match
+// unrelated names like `fleetXtestYtmplZsomething`. Each name is then
+// re-validated in Go and quoted before it reaches DDL, so a catalog row can
+// never steer the statement.
+//
+// Deletion is gated on age, not on "has a different fingerprint". Cloning does
+// not hold the preparation lock, so two checkouts on different migration sets
+// would otherwise alternate between rebuilding their own template and deleting
+// the other's live one, turning a one-off build into a rebuild storm. A template
+// younger than templateStaleAfter therefore belongs to somebody's current run
+// and is left alone.
+//
+// Only databases carrying our own creation-time comment are considered; anything
+// unrecognised is never touched.
 func dropStaleTemplateDatabases(ctx context.Context, adminConn *sql.Conn, keep string) {
-	rows, err := adminConn.QueryContext(ctx,
-		"SELECT datname FROM pg_database WHERE datname ~ $1 AND datname <> $2",
-		templateNamePattern.String(), keep)
+	rows, err := adminConn.QueryContext(ctx, `
+		SELECT datname, shobj_description(oid, 'pg_database')
+		FROM pg_database
+		WHERE datname ~ $1 AND datname <> $2
+	`, templateNamePattern.String(), keep)
 	if err != nil {
 		return
 	}
@@ -329,12 +381,16 @@ func dropStaleTemplateDatabases(ctx context.Context, adminConn *sql.Conn, keep s
 	var stale []string
 	for rows.Next() {
 		var name string
-		if err := rows.Scan(&name); err != nil {
+		var comment sql.NullString
+		if err := rows.Scan(&name, &comment); err != nil {
 			return
 		}
 		// Defence in depth: never interpolate a name the pattern does not own,
 		// even though the query already filtered on it.
 		if !templateNamePattern.MatchString(name) || name == keep {
+			continue
+		}
+		if !templateIsStale(comment) {
 			continue
 		}
 		stale = append(stale, name)
@@ -350,11 +406,33 @@ func dropStaleTemplateDatabases(ctx context.Context, adminConn *sql.Conn, keep s
 	}
 }
 
+// templateIsStale reports whether a template is old enough for another run to
+// sweep. Only our own comment format counts as evidence: a template with no
+// comment, a foreign comment, or an unparseable timestamp is left in place
+// rather than guessed about.
+func templateIsStale(comment sql.NullString) bool {
+	if !comment.Valid || !strings.HasPrefix(comment.String, templateCommentPrefix) {
+		return false
+	}
+
+	created, err := time.Parse(time.RFC3339Nano, strings.TrimPrefix(comment.String, templateCommentPrefix))
+	if err != nil {
+		return false
+	}
+	return time.Since(created) > templateStaleAfter
+}
+
 // quoteIdentifier renders a PostgreSQL identifier safely. Database names cannot
 // be bound as parameters in DDL, so anything interpolated into a statement goes
 // through here.
 func quoteIdentifier(name string) string {
 	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
+}
+
+// quoteLiteral renders a PostgreSQL string literal safely, for the DDL
+// statements (COMMENT, ALTER DATABASE SET) that cannot take bind parameters.
+func quoteLiteral(value string) string {
+	return `'` + strings.ReplaceAll(value, `'`, `''`) + `'`
 }
 
 // migrationSetFingerprint hashes the embedded migration files (names and

--- a/server/internal/testutil/dbtest/template.go
+++ b/server/internal/testutil/dbtest/template.go
@@ -41,6 +41,11 @@ const (
 	// migration sets can be identified and dropped.
 	templateDBPrefix = "fleet_test_tmpl_"
 
+	// templateBuildPrefix namespaces the staging database a template is built
+	// under. Publication is a rename from this name to templateDBPrefix, so the
+	// published name never exists in a partial state — see buildTemplateDatabase.
+	templateBuildPrefix = "fleet_test_bld_"
+
 	// templateAdvisoryLockNamespace seeds the per-template advisory lock keys, so
 	// they cannot collide with advisory locks taken for other purposes.
 	templateAdvisoryLockNamespace = "dbtest-template-preparation:7264051893001"
@@ -281,12 +286,41 @@ func prepareTemplateDatabase(ctx context.Context, adminConfig *db.Config, name s
 		return nil
 	}
 
-	// Either absent or left half-built by an interrupted run: rebuild it.
-	if err := tryDropTestDatabase(ctx, adminConfig, name); err != nil {
-		return fmt.Errorf("drop stale template: %w", err)
+	// Absent, aged out, or left half-built by an interrupted run: build a
+	// replacement under a staging name and publish it with a rename.
+	if err := buildTemplateDatabase(ctx, adminConn, adminConfig, name); err != nil {
+		return err
 	}
-	if _, err := adminConn.ExecContext(ctx, "CREATE DATABASE "+quoteIdentifier(name)); err != nil {
-		return fmt.Errorf("create template database: %w", err)
+
+	dropStaleTemplateDatabases(ctx, adminConn, name)
+	return nil
+}
+
+// buildTemplateDatabase migrates a fresh template under a staging name and only
+// then renames it to the published name.
+//
+// The rename is what makes publication atomic. Building in place would leave the
+// published name pointing at a database that is empty (before the migration
+// connects) or dirty (after an interrupted build), and PostgreSQL happily clones
+// either of those whenever no session happens to be attached: an empty clone
+// silently replays every migration, and a clone of a golang-migrate "dirty"
+// database fails outright. With a staging name, the published name only ever
+// exists fully migrated and sealed.
+func buildTemplateDatabase(
+	ctx context.Context,
+	adminConn *sql.Conn,
+	adminConfig *db.Config,
+	name string,
+) error {
+	staging := templateBuildPrefix + strings.TrimPrefix(name, templateDBPrefix)
+
+	// Any leftover staging database belongs to a dead build of this same
+	// template, whose lock we now hold, so it is ours to discard.
+	if err := tryDropTestDatabase(ctx, adminConfig, staging); err != nil {
+		return fmt.Errorf("drop stale template build: %w", err)
+	}
+	if _, err := adminConn.ExecContext(ctx, "CREATE DATABASE "+quoteIdentifier(staging)); err != nil {
+		return fmt.Errorf("create template build database: %w", err)
 	}
 
 	// Bound the migrating session inside PostgreSQL, since we cannot cancel it
@@ -301,16 +335,16 @@ func prepareTemplateDatabase(ctx context.Context, adminConfig *db.Config, name s
 		"statement_timeout": templatePrepareTimeout,
 	} {
 		if _, err := adminConn.ExecContext(ctx, fmt.Sprintf("ALTER DATABASE %s SET %s = %s",
-			quoteIdentifier(name), setting,
+			quoteIdentifier(staging), setting,
 			quoteLiteral(fmt.Sprintf("%dms", limit.Milliseconds())))); err != nil {
-			abandonTemplate(adminConfig, name)
-			return fmt.Errorf("set template %s: %w", setting, err)
+			abandonTemplate(adminConfig, staging)
+			return fmt.Errorf("set template build %s: %w", setting, err)
 		}
 	}
 
-	if err := migrateTemplateDatabase(ctx, adminConfig, name); err != nil {
+	if err := migrateTemplateDatabase(ctx, adminConfig, staging); err != nil {
 		// Leave nothing half-migrated behind for the next run to trust.
-		abandonTemplate(adminConfig, name)
+		abandonTemplate(adminConfig, staging)
 		return err
 	}
 
@@ -318,30 +352,45 @@ func prepareTemplateDatabase(ctx context.Context, adminConfig *db.Config, name s
 	// marker: CREATE DATABASE ... TEMPLATE fails while any session is connected
 	// to the source, and a template is only ever published in this state.
 	if _, err := adminConn.ExecContext(ctx,
-		"ALTER DATABASE "+quoteIdentifier(name)+" WITH ALLOW_CONNECTIONS false"); err != nil {
-		abandonTemplate(adminConfig, name)
+		"ALTER DATABASE "+quoteIdentifier(staging)+" WITH ALLOW_CONNECTIONS false"); err != nil {
+		abandonTemplate(adminConfig, staging)
 		return fmt.Errorf("seal template database: %w", err)
 	}
 
 	// Creating the extension started a TimescaleDB background worker scheduler
-	// inside the template, and that counts as a connected session: every clone
-	// would fail with "source database is being accessed by other users". Evict
-	// it now that ALLOW_CONNECTIONS false stops the launcher reattaching.
-	if err := detachTemplateSessions(ctx, adminConn, name); err != nil {
-		abandonTemplate(adminConfig, name)
+	// inside the database, and that counts as a connected session: every clone
+	// would fail with "source database is being accessed by other users", and
+	// the rename below would fail too. Evict it now that ALLOW_CONNECTIONS false
+	// stops the launcher reattaching.
+	if err := detachTemplateSessions(ctx, adminConn, staging); err != nil {
+		abandonTemplate(adminConfig, staging)
 		return err
 	}
 
 	// Ownership metadata: marks the database as ours and records when it was
-	// built, which is what makes age-bounded cleanup possible.
+	// built, which is what makes age-bounded cleanup possible. Comments follow
+	// the object, so this survives the rename.
 	if _, err := adminConn.ExecContext(ctx, fmt.Sprintf("COMMENT ON DATABASE %s IS %s",
-		quoteIdentifier(name),
+		quoteIdentifier(staging),
 		quoteLiteral(templateCommentPrefix+time.Now().UTC().Format(time.RFC3339Nano)))); err != nil {
-		abandonTemplate(adminConfig, name)
+		abandonTemplate(adminConfig, staging)
 		return fmt.Errorf("record template metadata: %w", err)
 	}
 
-	dropStaleTemplateDatabases(ctx, adminConn, name)
+	// Publish. Dropping the old name is what a concurrent clone may notice (it
+	// gets "database does not exist" and rebuilds or waits, both handled),
+	// whereas a partially built database under the published name would be
+	// cloned silently. The rename itself is atomic.
+	if err := tryDropTestDatabase(ctx, adminConfig, name); err != nil {
+		abandonTemplate(adminConfig, staging)
+		return fmt.Errorf("drop superseded template: %w", err)
+	}
+	if _, err := adminConn.ExecContext(ctx, fmt.Sprintf("ALTER DATABASE %s RENAME TO %s",
+		quoteIdentifier(staging), quoteIdentifier(name))); err != nil {
+		abandonTemplate(adminConfig, staging)
+		return fmt.Errorf("publish template database: %w", err)
+	}
+
 	return nil
 }
 

--- a/server/internal/testutil/dbtest/template_test.go
+++ b/server/internal/testutil/dbtest/template_test.go
@@ -2,7 +2,9 @@ package dbtest
 
 import (
 	"context"
+	"crypto/rand"
 	"database/sql"
+	"encoding/hex"
 	"fmt"
 	"strings"
 	"testing"
@@ -12,6 +14,25 @@ import (
 	"github.com/alecthomas/kong"
 	"github.com/block/proto-fleet/server/internal/infrastructure/db"
 )
+
+// fixtureTemplateName returns a template-shaped database name unique to this
+// test invocation. Constant names collide when the package runs concurrently
+// against one cluster (parallel checkouts, or a repeated run), so each test owns
+// its fixtures and cleans up only what it created.
+func fixtureTemplateName(t *testing.T) string {
+	t.Helper()
+
+	suffix := make([]byte, 6)
+	if _, err := rand.Read(suffix); err != nil {
+		t.Fatalf("generating fixture suffix: %v", err)
+	}
+
+	name := templateDBPrefix + hex.EncodeToString(suffix)
+	if !templateNamePattern.MatchString(name) {
+		t.Fatalf("fixture name %q does not match the template pattern", name)
+	}
+	return name
+}
 
 // TestTemplateNamePatternOnlyMatchesOwnTemplates guards the cleanup filter. A
 // LIKE pattern cannot be used here: every underscore in `fleet_test_tmpl_%` is a
@@ -196,11 +217,12 @@ func adminConfigForTest(t *testing.T) *db.Config {
 // per category cleanup has to distinguish and asserts only a genuinely old,
 // owned template is dropped.
 func TestDropStaleTemplateDatabasesOnlySweepsOldOwnedTemplates(t *testing.T) {
-	const (
-		stale       = "fleet_test_tmpl_deadbeef1234" // ours, past the age gate: drop
-		fresh       = "fleet_test_tmpl_deadbeef5678" // ours, another run's live one: keep
-		uncommented = "fleet_test_tmpl_deadbeef9abc" // right shape, not ours: keep
-		lookalike   = "fleet_test_tmplxdeadbeef1234" // matches LIKE only: keep
+	var (
+		stale       = fixtureTemplateName(t) // ours, past the age gate: drop
+		fresh       = fixtureTemplateName(t) // ours, another run's live one: keep
+		uncommented = fixtureTemplateName(t) // right shape, not ours: keep
+		// Matches the old wildcard-underscore LIKE pattern but not ours: keep.
+		lookalike = strings.Replace(fixtureTemplateName(t), "tmpl_", "tmplx", 1)
 	)
 	fixtures := []string{stale, fresh, uncommented, lookalike}
 
@@ -289,7 +311,7 @@ func TestTemplateIsStale(t *testing.T) {
 // checkout on this server is cloning: dropping that would race their clones and
 // force them to rebuild or replay migrations.
 func TestCreateTestDatabaseRecoversFromMissingTemplate(t *testing.T) {
-	const missing = "fleet_test_tmpl_ffffffffffff" // right shape, never created
+	missing := fixtureTemplateName(t) // right shape, never created
 
 	adminConfig := adminConfigForTest(t)
 	dbName := generateTestDBName(t.Name())
@@ -431,7 +453,7 @@ func TestTemplateAgeBoundsAreConsistent(t *testing.T) {
 // (otherwise every clone fails, which is what the TimescaleDB background worker
 // caused originally).
 func TestEvictTemplateSessionsSpareRebuildsButClearStrays(t *testing.T) {
-	const name = "fleet_test_tmpl_cccccccccccc"
+	name := fixtureTemplateName(t)
 
 	adminConfig := adminConfigForTest(t)
 	ctx := t.Context()
@@ -553,7 +575,7 @@ func TestIsTemplatePermissionError(t *testing.T) {
 // It plants a private abandoned template rather than sabotaging the live one,
 // which other packages and checkouts are cloning concurrently.
 func TestCreateTestDatabaseRebuildsAbandonedTemplate(t *testing.T) {
-	const abandoned = "fleet_test_tmpl_eeeeeeeeeeee"
+	abandoned := fixtureTemplateName(t)
 
 	adminConfig := adminConfigForTest(t)
 	ctx := t.Context()
@@ -629,7 +651,7 @@ func TestRecoveryBudgetIsSeparateFromRetryBudget(t *testing.T) {
 // distinction the recovery path turns on: an unsealed template is only worth
 // waiting for while somebody holds the preparation lock.
 func TestInspectTemplateBuildStateDistinguishesAbandonedFromBuilding(t *testing.T) {
-	const name = "fleet_test_tmpl_dddddddddddd"
+	name := fixtureTemplateName(t)
 
 	adminConfig := adminConfigForTest(t)
 	ctx := t.Context()

--- a/server/internal/testutil/dbtest/template_test.go
+++ b/server/internal/testutil/dbtest/template_test.go
@@ -47,7 +47,7 @@ func TestTemplateNamePatternOnlyMatchesOwnTemplates(t *testing.T) {
 	}
 
 	// The name we actually generate has to satisfy its own pattern.
-	if got := templateDBPrefix + migrationSetFingerprint(); !templateNamePattern.MatchString(got) {
+	if got := templateNameFor(adminConfigForTest(t)); !templateNamePattern.MatchString(got) {
 		t.Errorf("generated template name %q does not match templateNamePattern", got)
 	}
 }
@@ -137,8 +137,8 @@ func TestIsRetryableCreateError(t *testing.T) {
 // (otherwise every test binary builds its own template) and the resulting
 // database name must fit PostgreSQL's identifier limit.
 func TestMigrationSetFingerprintIsStableAndNamesAValidIdentifier(t *testing.T) {
-	first := migrationSetFingerprint()
-	second := migrationSetFingerprint()
+	first := migrationSetFingerprint("fleet")
+	second := migrationSetFingerprint("fleet")
 
 	if first != second {
 		t.Errorf("fingerprint not stable across calls: %q vs %q", first, second)
@@ -245,7 +245,7 @@ func TestDropStaleTemplateDatabasesOnlySweepsOldOwnedTemplates(t *testing.T) {
 	stamp(fresh, time.Now().Add(-time.Minute))
 
 	// Keep the template belonging to the current migration set, as a real run would.
-	dropStaleTemplateDatabases(ctx, adminConn, templateDBPrefix+migrationSetFingerprint())
+	dropStaleTemplateDatabases(ctx, adminConn, templateNameFor(adminConfig))
 
 	assert.False(t, databaseExists(t, adminConn, stale),
 		"template %s is ours and past the age gate; it should have been dropped", stale)
@@ -501,4 +501,34 @@ func TestTemplateRebuildInProgressForMissingTemplate(t *testing.T) {
 		"a template that does not exist is not being rebuilt")
 	assert.False(t, templateRebuildInProgress(t.Context(), adminConfig, ""),
 		"no template means nothing to wait for")
+}
+
+// TestMigrationSetFingerprintIsScopedToRole pins that the connecting role is
+// part of template identity. PostgreSQL only lets a role copy a database it
+// owns, so two roles sharing one template name would leave the second failing
+// every clone with "permission denied to copy database".
+func TestMigrationSetFingerprintIsScopedToRole(t *testing.T) {
+	fleet := migrationSetFingerprint("fleet")
+	other := migrationSetFingerprint("other_dev")
+
+	assert.NotEqual(t, fleet, other, "different roles must not share a template name")
+	assert.Equal(t, fleet, migrationSetFingerprint("fleet"), "same role must be stable")
+
+	// Role names of any length must still produce a legal identifier.
+	long := migrationSetFingerprint(strings.Repeat("a_very_long_role_name", 10))
+	assert.True(t, templateNamePattern.MatchString(templateDBPrefix+long),
+		"a long role name must not leak into the template name")
+}
+
+func TestIsTemplatePermissionError(t *testing.T) {
+	denied := `create test database: ERROR: permission denied to copy database "fleet_test_tmpl_abc" (SQLSTATE 42501)`
+
+	assert.True(t, isTemplatePermissionError(denied, "fleet_test_tmpl_abc"))
+	assert.False(t, isTemplatePermissionError(denied, ""), "no template means no template permission problem")
+	assert.False(t, isTemplatePermissionError(
+		`create test database: ERROR: database "x" does not exist (SQLSTATE 3D000)`, "tmpl"))
+
+	// Must not be swallowed by the generic retry path: retrying cannot grant
+	// permissions, so it needs the fallback instead.
+	assert.False(t, isRetryableCreateError(denied))
 }

--- a/server/internal/testutil/dbtest/template_test.go
+++ b/server/internal/testutil/dbtest/template_test.go
@@ -329,3 +329,33 @@ func databaseExists(t *testing.T, adminConn *sql.Conn, name string) bool {
 	assert.NoError(t, err, fmt.Sprintf("checking whether %s exists", name))
 	return exists
 }
+
+// TestPrepareAttemptTimeoutStaysWithinProcessBudget pins the arithmetic that
+// keeps preparation from outliving Go's package timeout: attempts share one
+// process-wide budget instead of each getting a fresh deadline.
+func TestPrepareAttemptTimeoutStaysWithinProcessBudget(t *testing.T) {
+	now := time.Now()
+
+	// Plenty of budget left: capped by the per-attempt limit.
+	got, ok := prepareAttemptTimeout(now.Add(templatePrepareBudget), now)
+	assert.True(t, ok)
+	assert.Equal(t, templatePrepareTimeout, got)
+
+	// Nearly spent: the remaining budget wins, never the per-attempt cap.
+	got, ok = prepareAttemptTimeout(now.Add(5*time.Second), now)
+	assert.True(t, ok)
+	assert.Equal(t, 5*time.Second, got)
+
+	// Spent, exactly and then past: no further attempts.
+	_, ok = prepareAttemptTimeout(now, now)
+	assert.False(t, ok)
+	_, ok = prepareAttemptTimeout(now.Add(-time.Minute), now)
+	assert.False(t, ok)
+
+	// The worst case must stay clear of Go's default 10m package timeout: the
+	// budget bounds *all* attempts, so it is the only number that matters.
+	assert.True(t, templatePrepareBudget < 10*time.Minute,
+		"preparation budget must leave room for the fallback path to run")
+	assert.True(t, templatePrepareTimeout <= templatePrepareBudget,
+		"a single attempt must not be able to consume more than the whole budget")
+}

--- a/server/internal/testutil/dbtest/template_test.go
+++ b/server/internal/testutil/dbtest/template_test.go
@@ -469,9 +469,19 @@ func TestEvictTemplateSessionsSpareRebuildsButClearStrays(t *testing.T) {
 	var alive int
 	assert.NoError(t, rebuildConn.QueryRowContext(ctx, "SELECT 1").Scan(&alive))
 
-	// Unsealed: a build is in progress, so nothing may be evicted.
+	// Hold the preparation lock, as a real builder does: unsealed *plus* the
+	// lock is what distinguishes a live build from an abandoned one.
+	lockConn, err := adminDB.Conn(ctx)
+	assert.NoError(t, err)
+	defer lockConn.Close()
+	_, err = lockConn.ExecContext(ctx, "SELECT pg_advisory_lock($1)", templateLockKey(name))
+	assert.NoError(t, err)
+	defer func() {
+		_, _ = lockConn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", templateLockKey(name))
+	}()
+
 	assert.True(t, templateRebuildInProgress(ctx, adminConfig, name),
-		"an unsealed template should read as a rebuild in progress")
+		"unsealed while the preparation lock is held should read as a build in progress")
 	evictTemplateSessions(ctx, adminConfig, name)
 
 	assert.NoError(t, rebuildConn.QueryRowContext(ctx, "SELECT 1").Scan(&alive),
@@ -483,6 +493,8 @@ func TestEvictTemplateSessionsSpareRebuildsButClearStrays(t *testing.T) {
 	assert.NoError(t, err)
 	assert.False(t, templateRebuildInProgress(ctx, adminConfig, name),
 		"a sealed template is not being rebuilt")
+	assert.Equal(t, templateStatePublished, inspectTemplateBuildState(ctx, adminConfig, name),
+		"a sealed template is published")
 
 	evictTemplateSessions(ctx, adminConfig, name)
 
@@ -531,4 +543,155 @@ func TestIsTemplatePermissionError(t *testing.T) {
 	// Must not be swallowed by the generic retry path: retrying cannot grant
 	// permissions, so it needs the fallback instead.
 	assert.False(t, isRetryableCreateError(denied))
+}
+
+// TestCreateTestDatabaseRebuildsAbandonedTemplate covers a template left
+// connectable by a build that died: nobody holds its preparation lock, so there
+// is nothing to wait for. The clone must diagnose that and move on rather than
+// spending its wait budget on a build that will never finish.
+//
+// It plants a private abandoned template rather than sabotaging the live one,
+// which other packages and checkouts are cloning concurrently.
+func TestCreateTestDatabaseRebuildsAbandonedTemplate(t *testing.T) {
+	const abandoned = "fleet_test_tmpl_eeeeeeeeeeee"
+
+	adminConfig := adminConfigForTest(t)
+	ctx := t.Context()
+
+	adminDB, err := db.ConnectToDatabase(adminConfig)
+	assert.NoError(t, err)
+	defer adminDB.Close()
+
+	// An interrupted build: the template exists, is unsealed, and has a session
+	// on it, but nobody holds its preparation lock.
+	_, _ = adminDB.ExecContext(ctx, "DROP DATABASE IF EXISTS "+quoteIdentifier(abandoned))
+	_, err = adminDB.ExecContext(ctx, "CREATE DATABASE "+quoteIdentifier(abandoned))
+	assert.NoError(t, err)
+
+	strandedConfig := *adminConfig
+	strandedConfig.Name = abandoned
+	strandedDB, err := db.ConnectToDatabase(&strandedConfig)
+	assert.NoError(t, err)
+	defer strandedDB.Close()
+	var alive int
+	assert.NoError(t, strandedDB.QueryRowContext(ctx, "SELECT 1").Scan(&alive))
+
+	assert.Equal(t, templateStateAbandoned, inspectTemplateBuildState(ctx, adminConfig, abandoned),
+		"unsealed with nobody holding its preparation lock is abandoned, not building")
+
+	dbName := generateTestDBName(t.Name())
+	t.Cleanup(func() {
+		// nolint: usetesting
+		cleanupCtx := context.Background()
+		cleanupDB, err := db.ConnectToDatabase(adminConfig)
+		assert.NoError(t, err)
+		defer cleanupDB.Close()
+		for _, name := range []string{dbName, abandoned} {
+			_, err := cleanupDB.ExecContext(cleanupCtx, "DROP DATABASE IF EXISTS "+quoteIdentifier(name))
+			assert.NoError(t, err, "dropping %s", name)
+		}
+	})
+
+	// Cloning from the abandoned template fails; recovery must replace it and
+	// still produce the database, promptly.
+	start := time.Now()
+	used := createTestDatabase(t, adminConfig, dbName, abandoned)
+	elapsed := time.Since(start)
+
+	assert.NotEqual(t, abandoned, used, "an abandoned template should have been replaced")
+	assert.True(t, elapsed < templateRebuildWaitTimeout,
+		"should not have waited out the rebuild budget (%s) for an abandoned template, took %s",
+		templateRebuildWaitTimeout, elapsed)
+
+	adminConn, err := adminDB.Conn(ctx)
+	assert.NoError(t, err)
+	defer adminConn.Close()
+	assert.True(t, databaseExists(t, adminConn, dbName),
+		"the test database should have been created despite the abandoned template")
+}
+
+// TestRecoveryBudgetIsSeparateFromRetryBudget pins the invariant behind
+// recoveries not consuming DDL retries: a recovery on the last retry must still
+// get an attempt with the configuration it repaired.
+func TestRecoveryBudgetIsSeparateFromRetryBudget(t *testing.T) {
+	assert.True(t, templateRecoveryMaxAttempts > 0,
+		"recoveries need their own budget, or a recovery on the final retry never gets tried")
+
+	// Worst case must stay well inside Go's default 10m package timeout: every
+	// recovery may wait, but all waits share one deadline.
+	worstCase := templateRebuildWaitTimeout +
+		time.Duration(migrationMaxRetries*migrationMaxRetries)*migrationRetryBaseDelay
+	assert.True(t, worstCase < 5*time.Minute,
+		"worst-case create budget %s leaves too little of the package timeout", worstCase)
+}
+
+// TestInspectTemplateBuildStateDistinguishesAbandonedFromBuilding is the
+// distinction the recovery path turns on: an unsealed template is only worth
+// waiting for while somebody holds the preparation lock.
+func TestInspectTemplateBuildStateDistinguishesAbandonedFromBuilding(t *testing.T) {
+	const name = "fleet_test_tmpl_dddddddddddd"
+
+	adminConfig := adminConfigForTest(t)
+	ctx := t.Context()
+
+	adminDB, err := db.ConnectToDatabase(adminConfig)
+	assert.NoError(t, err)
+	defer adminDB.Close()
+
+	_, _ = adminDB.ExecContext(ctx, "DROP DATABASE IF EXISTS "+quoteIdentifier(name))
+	_, err = adminDB.ExecContext(ctx, "CREATE DATABASE "+quoteIdentifier(name))
+	assert.NoError(t, err)
+	t.Cleanup(func() {
+		// nolint: usetesting
+		cleanupCtx := context.Background()
+		cleanupDB, err := db.ConnectToDatabase(adminConfig)
+		assert.NoError(t, err)
+		defer cleanupDB.Close()
+		_, err = cleanupDB.ExecContext(cleanupCtx, "DROP DATABASE IF EXISTS "+quoteIdentifier(name))
+		assert.NoError(t, err)
+	})
+
+	// Unsealed, nobody holding the lock: an interrupted build.
+	assert.Equal(t, templateStateAbandoned, inspectTemplateBuildState(ctx, adminConfig, name))
+
+	lockConn, err := adminDB.Conn(ctx)
+	assert.NoError(t, err)
+	defer lockConn.Close()
+	_, err = lockConn.ExecContext(ctx, "SELECT pg_advisory_lock($1)", templateLockKey(name))
+	assert.NoError(t, err)
+
+	// Unsealed while the lock is held: a live build.
+	assert.Equal(t, templateStateBuilding, inspectTemplateBuildState(ctx, adminConfig, name))
+
+	_, err = lockConn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", templateLockKey(name))
+	assert.NoError(t, err)
+	assert.Equal(t, templateStateAbandoned, inspectTemplateBuildState(ctx, adminConfig, name))
+
+	// Sealed: published, regardless of the lock.
+	_, err = adminDB.ExecContext(ctx, "ALTER DATABASE "+quoteIdentifier(name)+" WITH ALLOW_CONNECTIONS false")
+	assert.NoError(t, err)
+	assert.Equal(t, templateStatePublished, inspectTemplateBuildState(ctx, adminConfig, name))
+	_, err = adminDB.ExecContext(ctx, "ALTER DATABASE "+quoteIdentifier(name)+" WITH ALLOW_CONNECTIONS true")
+	assert.NoError(t, err)
+
+	assert.Equal(t, templateStatePublished, inspectTemplateBuildState(ctx, adminConfig, ""),
+		"no template means nothing in the way")
+}
+
+// TestTemplateLockKeyIsPerTemplate pins that build detection is specific to one
+// template: with a single global key, a process building template A would make
+// an abandoned template B look like it was under construction, and clones of B
+// would wait instead of rebuilding it.
+func TestTemplateLockKeyIsPerTemplate(t *testing.T) {
+	a := templateLockKey("fleet_test_tmpl_aaaaaaaaaaaa")
+	b := templateLockKey("fleet_test_tmpl_bbbbbbbbbbbb")
+
+	assert.NotEqual(t, a, b, "different templates must not share a preparation lock")
+	assert.Equal(t, a, templateLockKey("fleet_test_tmpl_aaaaaaaaaaaa"), "keys must be stable")
+
+	// The pg_locks reconstruction ((classid << 32) | objid) yields a positive
+	// bigint, so the key must never be negative.
+	for _, key := range []int64{a, b, templateLockKey(""), templateLockKey(strings.Repeat("x", 200))} {
+		assert.True(t, key >= 0, "advisory lock key %d must be non-negative", key)
+	}
 }

--- a/server/internal/testutil/dbtest/template_test.go
+++ b/server/internal/testutil/dbtest/template_test.go
@@ -1,0 +1,96 @@
+package dbtest
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIsRetryableCreateError(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  string
+		want bool
+	}{
+		{
+			name: "template in use sqlstate",
+			msg:  `create test database: ERROR: source database "fleet_test_tmpl_abc" is being accessed by other users (SQLSTATE 55006)`,
+			want: true,
+		},
+		{
+			name: "object in use sqlstate only",
+			msg:  "create test database: ERROR: something is in use (SQLSTATE 55006)",
+			want: true,
+		},
+		{
+			name: "in-use text without sqlstate",
+			msg:  "create test database: ERROR: database is being accessed by other users",
+			want: true,
+		},
+		{
+			name: "transient server restart still retryable",
+			msg:  "connect to admin database: the database system is starting up",
+			want: true,
+		},
+		{
+			name: "permission failure is not retryable",
+			msg:  "create test database: ERROR: permission denied to create database (SQLSTATE 42501)",
+			want: false,
+		},
+		{
+			name: "duplicate database is not retryable",
+			msg:  `create test database: ERROR: database "fleet_test_x" already exists (SQLSTATE 42P04)`,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isRetryableCreateError(tt.msg); got != tt.want {
+				t.Errorf("isRetryableCreateError(%q) = %v, want %v", tt.msg, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestMigrationSetFingerprintIsStableAndNamesAValidIdentifier guards the two
+// properties the template name depends on: repeated calls in a run must agree
+// (otherwise every test binary builds its own template) and the resulting
+// database name must fit PostgreSQL's identifier limit.
+func TestMigrationSetFingerprintIsStableAndNamesAValidIdentifier(t *testing.T) {
+	first := migrationSetFingerprint()
+	second := migrationSetFingerprint()
+
+	if first != second {
+		t.Errorf("fingerprint not stable across calls: %q vs %q", first, second)
+	}
+	if len(first) != templateFingerprintLength {
+		t.Errorf("fingerprint length = %d, want %d", len(first), templateFingerprintLength)
+	}
+	if strings.Trim(first, "0123456789abcdef") != "" {
+		t.Errorf("fingerprint %q is not lowercase hex", first)
+	}
+
+	name := templateDBPrefix + first
+	if len(name) > 63 {
+		t.Errorf("template database name %q is %d chars, exceeds PostgreSQL's 63-char limit", name, len(name))
+	}
+}
+
+// TestMigrationFileNamesAreSortedAndNonEmpty pins the ordering the fingerprint
+// relies on: an unstable listing order would change the hash between processes
+// and defeat template reuse.
+func TestMigrationFileNamesAreSortedAndNonEmpty(t *testing.T) {
+	names, err := migrationFileNames()
+	if err != nil {
+		t.Fatalf("migrationFileNames() error = %v", err)
+	}
+	if len(names) == 0 {
+		t.Fatal("migrationFileNames() returned no files; the embedded migration set should not be empty")
+	}
+
+	for i := 1; i < len(names); i++ {
+		if names[i-1] >= names[i] {
+			t.Fatalf("migration file names not strictly sorted at %d: %q >= %q", i, names[i-1], names[i])
+		}
+	}
+}

--- a/server/internal/testutil/dbtest/template_test.go
+++ b/server/internal/testutil/dbtest/template_test.go
@@ -282,23 +282,24 @@ func TestTemplateIsStale(t *testing.T) {
 	}
 }
 
-// TestGetTestDBRecoversFromSweptTemplate simulates a concurrent run on a
-// different migration set sweeping our template between clones: the next test
-// must rebuild it rather than fail with "database does not exist" (SQLSTATE
-// 3D000), which is not in the generic retry set.
-func TestGetTestDBRecoversFromSweptTemplate(t *testing.T) {
-	// Establishes the template as a side effect.
-	_ = GetTestDB(t)
-
-	templateMu.Lock()
-	prepared, name := templatePrepared, templateDBName
-	templateMu.Unlock()
-
-	if !prepared {
-		t.Skip("no template was prepared; nothing to sweep")
-	}
+// TestCreateTestDatabaseRecoversFromMissingTemplate exercises the recovery path
+// for a template that vanished mid-run (a concurrent checkout on a different
+// migration set sweeping it, say). It names a private template that never
+// existed rather than dropping the live one, which every other package and
+// checkout on this server is cloning: dropping that would race their clones and
+// force them to rebuild or replay migrations.
+func TestCreateTestDatabaseRecoversFromMissingTemplate(t *testing.T) {
+	const missing = "fleet_test_tmpl_ffffffffffff" // right shape, never created
 
 	adminConfig := adminConfigForTest(t)
+	dbName := generateTestDBName(t.Name())
+
+	// Recovery must not fail the test: the missing template is diagnosed,
+	// discarded, and replaced by whatever templateDatabase can offer (the real
+	// template, or "" to migrate directly).
+	used := createTestDatabase(t, adminConfig, dbName, missing)
+	assert.NotEqual(t, missing, used, "a missing template should have been replaced")
+
 	adminDB, err := db.ConnectToDatabase(adminConfig)
 	assert.NoError(t, err)
 	defer adminDB.Close()
@@ -307,17 +308,52 @@ func TestGetTestDBRecoversFromSweptTemplate(t *testing.T) {
 	assert.NoError(t, err)
 	defer adminConn.Close()
 
-	_, err = adminConn.ExecContext(t.Context(), "DROP DATABASE IF EXISTS "+quoteIdentifier(name))
-	assert.NoError(t, err, "sweeping the template out from under the harness")
-	assert.False(t, databaseExists(t, adminConn, name), "template should be gone before the next clone")
+	t.Cleanup(func() {
+		// nolint: usetesting
+		cleanupCtx := context.Background()
+		cleanupDB, err := db.ConnectToDatabase(adminConfig)
+		assert.NoError(t, err)
+		defer cleanupDB.Close()
+		_, err = cleanupDB.ExecContext(cleanupCtx, "DROP DATABASE IF EXISTS "+quoteIdentifier(dbName))
+		assert.NoError(t, err)
+	})
 
-	// Must succeed despite the template having vanished mid-run.
-	conn := GetTestDB(t)
-	var one int
-	assert.NoError(t, conn.QueryRowContext(t.Context(), "SELECT 1").Scan(&one))
-	assert.Equal(t, 1, one)
+	assert.True(t, databaseExists(t, adminConn, dbName),
+		"the test database should have been created despite the missing template")
+	assert.False(t, databaseExists(t, adminConn, missing),
+		"recovery must not resurrect a template that never existed")
+}
 
-	assert.True(t, databaseExists(t, adminConn, name), "template should have been rebuilt")
+// TestInvalidateTemplateDatabaseOnlyForgetsTheNamedTemplate makes sure recovery
+// for one template cannot discard a different, still-valid cached one.
+func TestInvalidateTemplateDatabaseOnlyForgetsTheNamedTemplate(t *testing.T) {
+	templateMu.Lock()
+	savedName, savedPrepared := templateDBName, templatePrepared
+	templateDBName, templatePrepared = "fleet_test_tmpl_aaaaaaaaaaaa", true
+	templateMu.Unlock()
+
+	t.Cleanup(func() {
+		templateMu.Lock()
+		templateDBName, templatePrepared = savedName, savedPrepared
+		templateMu.Unlock()
+	})
+
+	invalidateTemplateDatabase("fleet_test_tmpl_bbbbbbbbbbbb")
+
+	templateMu.Lock()
+	name, prepared := templateDBName, templatePrepared
+	templateMu.Unlock()
+
+	assert.True(t, prepared, "invalidating another name must not clear the cached template")
+	assert.Equal(t, "fleet_test_tmpl_aaaaaaaaaaaa", name)
+
+	invalidateTemplateDatabase("fleet_test_tmpl_aaaaaaaaaaaa")
+
+	templateMu.Lock()
+	prepared = templatePrepared
+	templateMu.Unlock()
+
+	assert.False(t, prepared, "invalidating the cached name must clear it")
 }
 
 func databaseExists(t *testing.T, adminConn *sql.Conn, name string) bool {
@@ -358,4 +394,32 @@ func TestPrepareAttemptTimeoutStaysWithinProcessBudget(t *testing.T) {
 		"preparation budget must leave room for the fallback path to run")
 	assert.True(t, templatePrepareTimeout <= templatePrepareBudget,
 		"a single attempt must not be able to consume more than the whole budget")
+}
+
+func TestTemplateCreatedAt(t *testing.T) {
+	want := time.Now().UTC().Truncate(time.Millisecond)
+	got, ok := templateCreatedAt(sql.NullString{
+		String: templateCommentPrefix + want.Format(time.RFC3339Nano),
+		Valid:  true,
+	})
+	assert.True(t, ok)
+	assert.Equal(t, want, got.UTC())
+
+	for _, comment := range []sql.NullString{
+		{},
+		{String: "someone else's database", Valid: true},
+		{String: templateCommentPrefix + "not-a-timestamp", Valid: true},
+	} {
+		if _, ok := templateCreatedAt(comment); ok {
+			t.Errorf("templateCreatedAt(%v) should not have parsed", comment)
+		}
+	}
+}
+
+// TestTemplateAgeBoundsAreConsistent pins the relationship between reuse and
+// cleanup: a template must stop being reused long before another run may sweep
+// it, or a live template could be swept while still considered current.
+func TestTemplateAgeBoundsAreConsistent(t *testing.T) {
+	assert.True(t, templateMaxAge < templateStaleAfter,
+		"reuse window (%s) must be shorter than the sweep threshold (%s)", templateMaxAge, templateStaleAfter)
 }

--- a/server/internal/testutil/dbtest/template_test.go
+++ b/server/internal/testutil/dbtest/template_test.go
@@ -423,3 +423,82 @@ func TestTemplateAgeBoundsAreConsistent(t *testing.T) {
 	assert.True(t, templateMaxAge < templateStaleAfter,
 		"reuse window (%s) must be shorter than the sweep threshold (%s)", templateMaxAge, templateStaleAfter)
 }
+
+// TestEvictTemplateSessionsSpareRebuildsButClearStrays is the regression test for
+// the interaction between clone recovery and in-place rebuilds: a clone that
+// loses the race to an in-progress rebuild must not terminate that rebuild's
+// migration, while a stray session on a published template must still be cleared
+// (otherwise every clone fails, which is what the TimescaleDB background worker
+// caused originally).
+func TestEvictTemplateSessionsSpareRebuildsButClearStrays(t *testing.T) {
+	const name = "fleet_test_tmpl_cccccccccccc"
+
+	adminConfig := adminConfigForTest(t)
+	ctx := t.Context()
+
+	adminDB, err := db.ConnectToDatabase(adminConfig)
+	assert.NoError(t, err)
+	defer adminDB.Close()
+
+	_, _ = adminDB.ExecContext(ctx, "DROP DATABASE IF EXISTS "+quoteIdentifier(name))
+	_, err = adminDB.ExecContext(ctx, "CREATE DATABASE "+quoteIdentifier(name))
+	assert.NoError(t, err)
+	t.Cleanup(func() {
+		// nolint: usetesting
+		cleanupCtx := context.Background()
+		cleanupDB, err := db.ConnectToDatabase(adminConfig)
+		assert.NoError(t, err)
+		defer cleanupDB.Close()
+		_, _ = cleanupDB.ExecContext(cleanupCtx,
+			"ALTER DATABASE "+quoteIdentifier(name)+" WITH ALLOW_CONNECTIONS true")
+		_, err = cleanupDB.ExecContext(cleanupCtx, "DROP DATABASE IF EXISTS "+quoteIdentifier(name))
+		assert.NoError(t, err)
+	})
+
+	// Stand in for the migration session of a rebuild in progress.
+	rebuildConfig := *adminConfig
+	rebuildConfig.Name = name
+	rebuildDB, err := db.ConnectToDatabase(&rebuildConfig)
+	assert.NoError(t, err)
+	defer rebuildDB.Close()
+
+	rebuildConn, err := rebuildDB.Conn(ctx)
+	assert.NoError(t, err)
+	defer rebuildConn.Close()
+
+	var alive int
+	assert.NoError(t, rebuildConn.QueryRowContext(ctx, "SELECT 1").Scan(&alive))
+
+	// Unsealed: a build is in progress, so nothing may be evicted.
+	assert.True(t, templateRebuildInProgress(ctx, adminConfig, name),
+		"an unsealed template should read as a rebuild in progress")
+	evictTemplateSessions(ctx, adminConfig, name)
+
+	assert.NoError(t, rebuildConn.QueryRowContext(ctx, "SELECT 1").Scan(&alive),
+		"eviction must not terminate the migration session of an in-progress rebuild")
+
+	// Sealed: the template is published, so a lingering session is a stray.
+	_, err = adminDB.ExecContext(ctx,
+		"ALTER DATABASE "+quoteIdentifier(name)+" WITH ALLOW_CONNECTIONS false")
+	assert.NoError(t, err)
+	assert.False(t, templateRebuildInProgress(ctx, adminConfig, name),
+		"a sealed template is not being rebuilt")
+
+	evictTemplateSessions(ctx, adminConfig, name)
+
+	// The terminated session may surface the failure on this query or the next,
+	// depending on when the backend notices.
+	if err := rebuildConn.QueryRowContext(ctx, "SELECT 1").Scan(&alive); err == nil {
+		err = rebuildConn.QueryRowContext(ctx, "SELECT 1").Scan(&alive)
+		assert.Error(t, err, "a stray session on a sealed template should have been evicted")
+	}
+}
+
+func TestTemplateRebuildInProgressForMissingTemplate(t *testing.T) {
+	adminConfig := adminConfigForTest(t)
+
+	assert.False(t, templateRebuildInProgress(t.Context(), adminConfig, "fleet_test_tmpl_ffffffffffff"),
+		"a template that does not exist is not being rebuilt")
+	assert.False(t, templateRebuildInProgress(t.Context(), adminConfig, ""),
+		"no template means nothing to wait for")
+}

--- a/server/internal/testutil/dbtest/template_test.go
+++ b/server/internal/testutil/dbtest/template_test.go
@@ -1,9 +1,88 @@
 package dbtest
 
 import (
+	"context"
+	"database/sql"
+	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/alecthomas/assert/v2"
+	"github.com/alecthomas/kong"
+	"github.com/block/proto-fleet/server/internal/infrastructure/db"
 )
+
+// TestTemplateNamePatternOnlyMatchesOwnTemplates guards the cleanup filter. A
+// LIKE pattern cannot be used here: every underscore in `fleet_test_tmpl_%` is a
+// single-character wildcard, so LIKE matches unrelated databases that this
+// harness must never drop.
+func TestTemplateNamePatternOnlyMatchesOwnTemplates(t *testing.T) {
+	matching := []string{
+		"fleet_test_tmpl_0123456789ab",
+		"fleet_test_tmpl_deadbeef1234",
+	}
+	notMatching := []string{
+		"fleet",                             // the real database
+		"fleetXtestYtmplZproduction",        // matches LIKE, must not match here
+		"fleet_test_tmplXdeadbeef1234",      // ditto
+		"fleet_test_tmpl_deadbeef1234_prod", // suffixed
+		"xfleet_test_tmpl_deadbeef1234",     // prefixed
+		"fleet_test_tmpl_DEADBEEF1234",      // uppercase hex is not what we emit
+		"fleet_test_tmpl_zzzzzzzzzzzz",      // non-hex
+		"fleet_test_tmpl_dead",              // too short
+		`fleet_test_tmpl_"; DROP DATABASE fleet; --`,
+		"fleet_test_somestore_ab12", // a per-test database
+	}
+
+	for _, name := range matching {
+		if !templateNamePattern.MatchString(name) {
+			t.Errorf("templateNamePattern should match own template %q", name)
+		}
+	}
+	for _, name := range notMatching {
+		if templateNamePattern.MatchString(name) {
+			t.Errorf("templateNamePattern must not match %q", name)
+		}
+	}
+
+	// The name we actually generate has to satisfy its own pattern.
+	if got := templateDBPrefix + migrationSetFingerprint(); !templateNamePattern.MatchString(got) {
+		t.Errorf("generated template name %q does not match templateNamePattern", got)
+	}
+}
+
+func TestQuoteIdentifier(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{in: "fleet_test_tmpl_deadbeef1234", want: `"fleet_test_tmpl_deadbeef1234"`},
+		{in: `weird"name`, want: `"weird""name"`},
+		{in: `"; DROP DATABASE fleet; --`, want: `"""; DROP DATABASE fleet; --"`},
+	}
+
+	for _, tt := range tests {
+		if got := quoteIdentifier(tt.in); got != tt.want {
+			t.Errorf("quoteIdentifier(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestIsMissingTemplateError(t *testing.T) {
+	missing := `create test database: ERROR: database "fleet_test_tmpl_abc" does not exist (SQLSTATE 3D000)`
+
+	if !isMissingTemplateError(missing, "fleet_test_tmpl_abc") {
+		t.Error("a swept template must be recognised so the clone can rebuild it")
+	}
+	if isMissingTemplateError(missing, "") {
+		t.Error("without a template there is nothing to rebuild")
+	}
+	if isMissingTemplateError("create test database: ERROR: permission denied (SQLSTATE 42501)", "tmpl") {
+		t.Error("unrelated failures must not be treated as a missing template")
+	}
+	// A missing template is not in the generic retry set: it needs the rebuild
+	// path, and retrying the same CREATE would fail identically.
+	if isRetryableCreateError(missing) {
+		t.Error("missing template should be handled by rebuild, not blind retry")
+	}
+}
 
 func TestIsRetryableCreateError(t *testing.T) {
 	tests := []struct {
@@ -93,4 +172,118 @@ func TestMigrationFileNamesAreSortedAndNonEmpty(t *testing.T) {
 			t.Fatalf("migration file names not strictly sorted at %d: %q >= %q", i, names[i-1], names[i])
 		}
 	}
+}
+
+// adminConfigForTest builds the "postgres" admin config the harness itself uses.
+func adminConfigForTest(t *testing.T) *db.Config {
+	t.Helper()
+
+	cli := struct {
+		DB db.Config `envprefix:"DB_" embed:""`
+	}{}
+	parser, err := kong.New(&cli)
+	assert.NoError(t, err)
+	_, err = parser.Parse(nil)
+	assert.NoError(t, err)
+
+	config := cli.DB
+	config.Name = "postgres"
+	return &config
+}
+
+// TestDropStaleTemplateDatabasesLeavesLookalikesAlone plants a database whose
+// name matches the LIKE pattern this cleanup used to use, but not the anchored
+// pattern it uses now, and asserts cleanup drops only what it owns.
+func TestDropStaleTemplateDatabasesLeavesLookalikesAlone(t *testing.T) {
+	const (
+		stale     = "fleet_test_tmpl_deadbeef1234" // ours: must be dropped
+		lookalike = "fleet_test_tmplxdeadbeef1234" // matches LIKE only: must survive
+	)
+
+	adminConfig := adminConfigForTest(t)
+	ctx := t.Context()
+
+	adminDB, err := db.ConnectToDatabase(adminConfig)
+	assert.NoError(t, err)
+	defer adminDB.Close()
+
+	adminConn, err := adminDB.Conn(ctx)
+	assert.NoError(t, err)
+	defer adminConn.Close()
+
+	for _, name := range []string{stale, lookalike} {
+		_, _ = adminConn.ExecContext(ctx, "DROP DATABASE IF EXISTS "+quoteIdentifier(name))
+		_, err = adminConn.ExecContext(ctx, "CREATE DATABASE "+quoteIdentifier(name))
+		assert.NoError(t, err, "creating fixture database %s", name)
+	}
+	t.Cleanup(func() {
+		// A fresh connection: the deferred adminDB.Close() above already ran by
+		// the time cleanups fire, so reusing it would silently leak the fixtures.
+		// nolint: usetesting
+		cleanupCtx := context.Background()
+		cleanupDB, err := db.ConnectToDatabase(adminConfig)
+		assert.NoError(t, err)
+		defer cleanupDB.Close()
+
+		for _, name := range []string{stale, lookalike} {
+			_, err := cleanupDB.ExecContext(cleanupCtx, "DROP DATABASE IF EXISTS "+quoteIdentifier(name))
+			assert.NoError(t, err, "dropping fixture database %s", name)
+		}
+	})
+
+	// Keep the template belonging to the current migration set, as a real run would.
+	dropStaleTemplateDatabases(ctx, adminConn, templateDBPrefix+migrationSetFingerprint())
+
+	assert.False(t, databaseExists(t, adminConn, stale),
+		"stale template %s should have been dropped", stale)
+	assert.True(t, databaseExists(t, adminConn, lookalike),
+		"database %s only matches the wildcard-underscore LIKE pattern and must not be dropped", lookalike)
+}
+
+// TestGetTestDBRecoversFromSweptTemplate simulates a concurrent run on a
+// different migration set sweeping our template between clones: the next test
+// must rebuild it rather than fail with "database does not exist" (SQLSTATE
+// 3D000), which is not in the generic retry set.
+func TestGetTestDBRecoversFromSweptTemplate(t *testing.T) {
+	// Establishes the template as a side effect.
+	_ = GetTestDB(t)
+
+	templateMu.Lock()
+	prepared, name := templatePrepared, templateDBName
+	templateMu.Unlock()
+
+	if !prepared {
+		t.Skip("no template was prepared; nothing to sweep")
+	}
+
+	adminConfig := adminConfigForTest(t)
+	adminDB, err := db.ConnectToDatabase(adminConfig)
+	assert.NoError(t, err)
+	defer adminDB.Close()
+
+	adminConn, err := adminDB.Conn(t.Context())
+	assert.NoError(t, err)
+	defer adminConn.Close()
+
+	_, err = adminConn.ExecContext(t.Context(), "DROP DATABASE IF EXISTS "+quoteIdentifier(name))
+	assert.NoError(t, err, "sweeping the template out from under the harness")
+	assert.False(t, databaseExists(t, adminConn, name), "template should be gone before the next clone")
+
+	// Must succeed despite the template having vanished mid-run.
+	conn := GetTestDB(t)
+	var one int
+	assert.NoError(t, conn.QueryRowContext(t.Context(), "SELECT 1").Scan(&one))
+	assert.Equal(t, 1, one)
+
+	assert.True(t, databaseExists(t, adminConn, name), "template should have been rebuilt")
+}
+
+func databaseExists(t *testing.T, adminConn *sql.Conn, name string) bool {
+	t.Helper()
+
+	var exists bool
+	err := adminConn.QueryRowContext(t.Context(),
+		"SELECT EXISTS (SELECT 1 FROM pg_database WHERE datname = $1)", name).Scan(&exists)
+	assert.NoError(t, err, fmt.Sprintf("checking whether %s exists", name))
+	return exists
 }

--- a/server/internal/testutil/dbtest/template_test.go
+++ b/server/internal/testutil/dbtest/template_test.go
@@ -717,3 +717,98 @@ func TestTemplateLockKeyIsPerTemplate(t *testing.T) {
 		assert.True(t, key >= 0, "advisory lock key %d must be non-negative", key)
 	}
 }
+
+// TestTemplatePublicationIsAtomic pins the property the staging-name build
+// exists for: the published name never appears in a clonable-but-incomplete
+// state. An unsealed database with no sessions attached is exactly what
+// PostgreSQL will happily clone, so if the published name could ever look like
+// that, a concurrent process could copy an empty or dirty schema.
+func TestTemplatePublicationIsAtomic(t *testing.T) {
+	adminConfig := adminConfigForTest(t)
+	ctx := t.Context()
+	name := templateNameFor(adminConfig)
+	staging := templateBuildPrefix + strings.TrimPrefix(name, templateDBPrefix)
+
+	assert.False(t, templateNamePattern.MatchString(staging),
+		"the staging name must not look like a published template, or cleanup and clones would pick it up")
+
+	adminDB, err := db.ConnectToDatabase(adminConfig)
+	assert.NoError(t, err)
+	defer adminDB.Close()
+
+	// Force a rebuild, then watch the published name while it happens: it must
+	// only ever be absent or sealed, never present-and-connectable.
+	_, err = adminDB.ExecContext(ctx, "DROP DATABASE IF EXISTS "+quoteIdentifier(name))
+	assert.NoError(t, err)
+
+	templateMu.Lock()
+	savedName, savedPrepared, savedFailures := templateDBName, templatePrepared, templateFailures
+	templateDBName, templatePrepared, templateFailures = "", false, 0
+	templateMu.Unlock()
+	t.Cleanup(func() {
+		templateMu.Lock()
+		templateDBName, templatePrepared, templateFailures = savedName, savedPrepared, savedFailures
+		templateMu.Unlock()
+	})
+
+	type observation struct {
+		exists      bool
+		connectable bool
+	}
+	observations := make(chan observation, 4096)
+	watching := make(chan struct{})
+
+	go func() {
+		defer close(watching)
+		watcher, err := db.ConnectToDatabase(adminConfig)
+		if err != nil {
+			return
+		}
+		defer watcher.Close()
+
+		deadline := time.Now().Add(30 * time.Second)
+		for time.Now().Before(deadline) {
+			var exists, connectable bool
+			row := watcher.QueryRowContext(ctx, `
+				SELECT EXISTS (SELECT 1 FROM pg_database WHERE datname = $1),
+				       COALESCE((SELECT datallowconn FROM pg_database WHERE datname = $1), false)
+			`, name)
+			if err := row.Scan(&exists, &connectable); err != nil {
+				return
+			}
+			select {
+			case observations <- observation{exists: exists, connectable: connectable}:
+			default:
+				return
+			}
+			if exists && !connectable {
+				return // published; nothing more to see
+			}
+		}
+	}()
+
+	built := templateDatabase(t, adminConfig)
+	assert.Equal(t, name, built, "the template should have been built")
+	<-watching
+	close(observations)
+
+	seen := 0
+	for obs := range observations {
+		seen++
+		if obs.exists && obs.connectable {
+			t.Fatalf("published template %s was observed existing and connectable, "+
+				"so a concurrent clone could have copied an incomplete schema", name)
+		}
+	}
+	assert.True(t, seen > 0, "the watcher should have sampled the published name at least once")
+
+	adminConn, err := adminDB.Conn(ctx)
+	assert.NoError(t, err)
+	defer adminConn.Close()
+	assert.False(t, databaseExists(t, adminConn, staging),
+		"the staging database should have been renamed away, not left behind")
+
+	reusable, err := templateIsReusable(ctx, adminConn, name)
+	assert.NoError(t, err)
+	assert.True(t, reusable, "the published template should be immediately reusable")
+}

--- a/server/internal/testutil/dbtest/template_test.go
+++ b/server/internal/testutil/dbtest/template_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/alecthomas/assert/v2"
 	"github.com/alecthomas/kong"
@@ -191,14 +192,17 @@ func adminConfigForTest(t *testing.T) *db.Config {
 	return &config
 }
 
-// TestDropStaleTemplateDatabasesLeavesLookalikesAlone plants a database whose
-// name matches the LIKE pattern this cleanup used to use, but not the anchored
-// pattern it uses now, and asserts cleanup drops only what it owns.
-func TestDropStaleTemplateDatabasesLeavesLookalikesAlone(t *testing.T) {
+// TestDropStaleTemplateDatabasesOnlySweepsOldOwnedTemplates plants one database
+// per category cleanup has to distinguish and asserts only a genuinely old,
+// owned template is dropped.
+func TestDropStaleTemplateDatabasesOnlySweepsOldOwnedTemplates(t *testing.T) {
 	const (
-		stale     = "fleet_test_tmpl_deadbeef1234" // ours: must be dropped
-		lookalike = "fleet_test_tmplxdeadbeef1234" // matches LIKE only: must survive
+		stale       = "fleet_test_tmpl_deadbeef1234" // ours, past the age gate: drop
+		fresh       = "fleet_test_tmpl_deadbeef5678" // ours, another run's live one: keep
+		uncommented = "fleet_test_tmpl_deadbeef9abc" // right shape, not ours: keep
+		lookalike   = "fleet_test_tmplxdeadbeef1234" // matches LIKE only: keep
 	)
+	fixtures := []string{stale, fresh, uncommented, lookalike}
 
 	adminConfig := adminConfigForTest(t)
 	ctx := t.Context()
@@ -211,7 +215,7 @@ func TestDropStaleTemplateDatabasesLeavesLookalikesAlone(t *testing.T) {
 	assert.NoError(t, err)
 	defer adminConn.Close()
 
-	for _, name := range []string{stale, lookalike} {
+	for _, name := range fixtures {
 		_, _ = adminConn.ExecContext(ctx, "DROP DATABASE IF EXISTS "+quoteIdentifier(name))
 		_, err = adminConn.ExecContext(ctx, "CREATE DATABASE "+quoteIdentifier(name))
 		assert.NoError(t, err, "creating fixture database %s", name)
@@ -225,19 +229,57 @@ func TestDropStaleTemplateDatabasesLeavesLookalikesAlone(t *testing.T) {
 		assert.NoError(t, err)
 		defer cleanupDB.Close()
 
-		for _, name := range []string{stale, lookalike} {
+		for _, name := range fixtures {
 			_, err := cleanupDB.ExecContext(cleanupCtx, "DROP DATABASE IF EXISTS "+quoteIdentifier(name))
 			assert.NoError(t, err, "dropping fixture database %s", name)
 		}
 	})
 
+	stamp := func(name string, created time.Time) {
+		_, err := adminConn.ExecContext(ctx, fmt.Sprintf("COMMENT ON DATABASE %s IS %s",
+			quoteIdentifier(name),
+			quoteLiteral(templateCommentPrefix+created.UTC().Format(time.RFC3339Nano))))
+		assert.NoError(t, err, "stamping fixture database %s", name)
+	}
+	stamp(stale, time.Now().Add(-templateStaleAfter-time.Hour))
+	stamp(fresh, time.Now().Add(-time.Minute))
+
 	// Keep the template belonging to the current migration set, as a real run would.
 	dropStaleTemplateDatabases(ctx, adminConn, templateDBPrefix+migrationSetFingerprint())
 
 	assert.False(t, databaseExists(t, adminConn, stale),
-		"stale template %s should have been dropped", stale)
+		"template %s is ours and past the age gate; it should have been dropped", stale)
+	assert.True(t, databaseExists(t, adminConn, fresh),
+		"template %s is recent, so a concurrent run may still be cloning it; sweeping it causes rebuild storms", fresh)
+	assert.True(t, databaseExists(t, adminConn, uncommented),
+		"database %s carries no ownership metadata and must not be dropped", uncommented)
 	assert.True(t, databaseExists(t, adminConn, lookalike),
 		"database %s only matches the wildcard-underscore LIKE pattern and must not be dropped", lookalike)
+}
+
+func TestTemplateIsStale(t *testing.T) {
+	stamp := func(created time.Time) sql.NullString {
+		return sql.NullString{
+			String: templateCommentPrefix + created.UTC().Format(time.RFC3339Nano),
+			Valid:  true,
+		}
+	}
+
+	if !templateIsStale(stamp(time.Now().Add(-templateStaleAfter - time.Minute))) {
+		t.Error("a template older than the age gate should be sweepable")
+	}
+	if templateIsStale(stamp(time.Now().Add(-time.Minute))) {
+		t.Error("a recent template may belong to a concurrent run and must be kept")
+	}
+	if templateIsStale(sql.NullString{}) {
+		t.Error("a database with no comment is not ours to drop")
+	}
+	if templateIsStale(sql.NullString{String: "someone else's database", Valid: true}) {
+		t.Error("a foreign comment is not ours to drop")
+	}
+	if templateIsStale(sql.NullString{String: templateCommentPrefix + "not-a-timestamp", Valid: true}) {
+		t.Error("an unparseable timestamp should be left alone rather than guessed about")
+	}
 }
 
 // TestGetTestDBRecoversFromSweptTemplate simulates a concurrent run on a


### PR DESCRIPTION
Reviewable diff: +529/-22 across 3 files (excludes generated, test, and story files).

## Summary

DB-backed server tests get ~3x faster and stop threatening CI: the full server suite goes from **3m25s to 1m09s** and `internal/domain/stores/sqlstores` from **159s to 33s**. The trigger was a real failure — that package hit Go's default 10-minute per-package timeout (`FAIL … 600.051s`) on a downstream sync, because the harness replayed all 142 migrations into a fresh database for each of 259 tests, spending ~501s of the 600s budget inside `migrate.Up()`. This replaces the per-test migration replay with a migrated template database that PostgreSQL clones per test, so setup cost stops scaling with the number of migrations.

Upstream `main` was already at `ok … 388.626s` for that package — 65% of the budget, growing with every migration added. This is a fix for a cliff we were already walking toward, not just for the branch that fell off it.

## How it works

`dbtest.GetTestDB` previously did, per test: `CREATE DATABASE` → replay every migration (~2s) → run the test → `DROP DATABASE`. Cost was O(tests × migrations).

Now the migration set is applied **once** per test run, into a template database, and each test gets a filesystem-level clone of it:

1. **First DB-backed test in a binary** computes a fingerprint — `sha256` over the sorted embedded migration filenames and contents, truncated to 12 hex chars — and looks for `fleet_test_tmpl_<fingerprint>`.
2. **If it is not ready, it builds it** while holding a PostgreSQL advisory lock, so the many test binaries `go test ./...` runs concurrently cooperate rather than race: one builds, the others wait and reuse. Verified on a cold database: a full parallel suite produces exactly one template.
3. **Publishing the template** means `ALTER DATABASE … ALLOW_CONNECTIONS false` plus evicting its sessions. This is load-bearing twice over: `CREATE DATABASE … TEMPLATE` fails while any session is attached to the source, and "connections disabled" is also the readiness marker — a template that exists but still accepts connections is treated as half-built and rebuilt, so an interrupted run cannot publish a partially migrated schema.
4. **Each test** then runs `CREATE DATABASE … TEMPLATE <template>` (~20–40ms instead of ~2s) and still calls `ConnectAndMigrate`, which is a no-op version check on an already-current clone. That is what keeps the change safe: if no template can be prepared, or a clone is somehow behind, the harness falls back to migrating the database itself.

The one genuinely surprising constraint is TimescaleDB. `CREATE EXTENSION timescaledb` causes the launcher to attach a background worker to the database, and that counts as a connected session — so the first implementation of this change was *slower* than the code it replaced (1801s vs 159s), with every clone waiting ~5s and then failing:

```
ERROR:  source database "fleet_test_tmpl_867fe765862f" is being accessed by other users
```

`ALLOW_CONNECTIONS false` prevents the launcher reattaching but does not evict the worker already inside, so the template's sessions are terminated after sealing, and clone attempts retry on SQLSTATE 55006 as a backstop.

## Diagrams

```mermaid
flowchart TD
    A["Test calls dbtest.GetTestDB"] --> B{"sync.Once: template resolved?"}
    B -- "no" --> C["pg_advisory_lock (pinned session)"]
    C --> D{"fleet_test_tmpl_&lt;fingerprint&gt; ready?<br/>(exists AND datallowconn = false)"}
    D -- "yes" --> H["release lock"]
    D -- "no" --> E["drop stale, CREATE DATABASE, run all migrations"]
    E --> F["ALTER DATABASE ALLOW_CONNECTIONS false"]
    F --> G["evict TimescaleDB background worker, wait for 0 sessions"]
    G --> I["drop templates from other fingerprints"]
    I --> H
    B -- "yes" --> J
    H --> J["CREATE DATABASE test_db TEMPLATE template"]
    J --> K["ConnectAndMigrate: no-op version check"]
    K --> L["run test"]
    L --> M["t.Cleanup: DROP DATABASE test_db"]
```

```mermaid
stateDiagram-v2
    [*] --> Absent
    Absent --> Building: "CREATE DATABASE (holder of advisory lock)"
    Building --> Migrated: "migrations succeed"
    Building --> Absent: "migration fails -> dropped, callers fall back"
    Migrated --> Sealed: "ALLOW_CONNECTIONS false + sessions evicted"
    Sealed --> [*]: "cloneable; reused by later processes and runs"
    note right of Migrated
        Reachable but never published.
        Still allows connections, so a
        later run treats it as half-built
        and rebuilds it.
    end note
    Sealed --> Absent: "migration set changes -> new fingerprint, this one dropped as stale"
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/internal/testutil/dbtest/template.go` | New. Fingerprinting, advisory-locked template preparation, sealing plus session eviction, stale-template GC | The whole mechanism. Concentrate on the readiness definition and the lock scope |
| `server/internal/testutil/dbtest/dbtest.go` | `createTestDatabase` / `tryCreateTestDatabase` take a template and emit `CREATE DATABASE … TEMPLATE`; new `isRetryableCreateError` adds SQLSTATE 55006; retries evict template sessions first | Only entry point tests use; the existing transient-restart retry behaviour is preserved, not replaced |
| `server/internal/testutil/dbtest/template_test.go` | New unit tests: retry classification, fingerprint stability, 63-char identifier limit, migration-listing order | Tests — skip for architecture |
| `docs/solutions/database-issues/dbtest-template-database-timescaledb-worker-2026-08-21.md` | New solution doc | Captures the TimescaleDB-worker gotcha and the advisory-lock-on-pool footgun |

No proto, migration, client, or plugin changes; nothing in the production code path — this is test-harness only.

## Key technical decisions & trade-offs

| Decision | Chosen over | Why |
| --- | --- | --- |
| Template database cloned per test | Bumping `-timeout` in `server/justfile` | A timeout bump hides growth that is O(migrations); this removes it. (A bump alone was the tempting one-line fix) |
| Fingerprint the migration set into the template name | A fixed template name plus a version check | Any migration edit — including editing an unshipped one on a branch — yields a new template, so a stale schema cannot be silently reused |
| `datallowconn = false` as the readiness marker | A marker table inside the template | Checking a marker table requires connecting to the template, and a connection is exactly what breaks concurrent clones |
| Advisory lock on a pinned `sql.Conn` | Lock on the `*sql.DB` pool, or a Go-level mutex | Advisory locks are session-scoped (a pooled unlock can land on a different session), and a Go mutex would not coordinate across the separate processes `go test ./...` spawns |
| Keep `ConnectAndMigrate` on each clone | Plain connect for speed | Costs a couple of queries and makes the change fail-safe: stale or unavailable template degrades to the old behaviour |
| Default `STRATEGY = WAL_LOG` | `FILE_COPY` | Only ~2x faster per clone at this template size (16MB) and forces two checkpoints, which hurts under hundreds of concurrent clones |
| Best-effort GC of other fingerprints' templates | Leave them, or drop on exit | Keeps long-lived local databases tidy without a teardown hook that a crashed run would skip |

## Testing & validation

Measured with `-count=1` on both sides, same machine, same TimescaleDB container:

| Scope | Before | After |
| --- | --- | --- |
| `internal/domain/stores/sqlstores` | 159.4s | **33.4s** (32.1s warm) |
| Full server suite (`go test ./... -skip ./generated/...`) | 3m25s | **1m09s** |
| Full suite from a cold database | — | 1m18s |
| Per-test database setup | ~2s (142 migrations) | ~20–40ms (clone) |
| Template build (once per fingerprint) | — | ~0.6–1.0s |

Also verified:

- Full server suite green before and after; `golangci-lint run ./internal/testutil/dbtest/...` reports 0 issues.
- **Cross-process locking:** full parallel suite from a cold database creates exactly **one** template.
- **Invalidation:** adding a temp `000143` migration built a new template and dropped the old one; removing it rebuilt the original. Tests passed in both states.
- **No leakage:** after full runs, the only remaining `fleet_test%` database is the template itself.
- **Unit tests** for retry classification, fingerprint stability and hex/length shape, the 63-char PostgreSQL identifier bound, and migration-listing order.

Not covered: no automated test forces the "TimescaleDB worker reattaches mid-run" path — it is covered by the 55006 retry plus eviction, exercised manually but not asserted. Timings are from one developer machine; CI runners are slower, so the absolute numbers will differ while the ratio should hold.
