### PR TITLE
chore(ci): update pinned GitHub Actions

### DIFF
--- a/.github/workflows/codex-security-review.yml
+++ b/.github/workflows/codex-security-review.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Run Codex Security Review
         id: run_codex
         if: ${{ env.OPENAI_API_KEY_PRESENT == 'true' }}
-        uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1.11
+        uses: openai/codex-action@86365089eb2b84e0a8fb0717b304f8bdcb13b20e # v1.12
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           model: ${{ env.CODEX_MODEL }}

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Detect changed areas
         id: filter
         if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         with:
           filters: .github/path-filters.yml
 

--- a/.github/workflows/proto-fleet-artifact-build.yml
+++ b/.github/workflows/proto-fleet-artifact-build.yml
@@ -202,7 +202,7 @@ jobs:
           chmod +x server/proto-plugin-* server/antminer-plugin-* server/virtual-plugin-*
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Build asicrs plugin binary
         run: |
@@ -370,7 +370,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Build TimescaleDB images
         run: |

--- a/.github/workflows/protofleet-contract-checks.yml
+++ b/.github/workflows/protofleet-contract-checks.yml
@@ -42,7 +42,7 @@ jobs:
         uses: ./.github/actions/go-cache-setup
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       # buildx's type=gha cache backend reads ACTIONS_RUNTIME_TOKEN and
       # ACTIONS_CACHE_URL (aka ACTIONS_RESULTS_URL) from the environment. These

--- a/.github/workflows/protofleet-e2e-tests.yml
+++ b/.github/workflows/protofleet-e2e-tests.yml
@@ -116,7 +116,7 @@ jobs:
           npm run build:protoFleet
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       # Docker cache is computed before the plugin build so the gitignored
       # `server/plugins/*` binaries (not a Docker build input) don't enter

--- a/.github/workflows/protofleet-server-checks.yml
+++ b/.github/workflows/protofleet-server-checks.yml
@@ -69,7 +69,7 @@ jobs:
       # the step). Cache the built image (same approach as the E2E build job)
       # and load it first so `docker compose up` finds it and skips the build.
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       # Rotate the cache weekly (ISO year-week) so a cache hit still rebuilds
       # against fresh upstream base images and packages (ubuntu, PostgreSQL,

--- a/.github/workflows/review-policy.yml
+++ b/.github/workflows/review-policy.yml
@@ -344,7 +344,7 @@ jobs:
           steps.preflight.outputs.eligible == 'true'
         continue-on-error: true
         timeout-minutes: 10
-        uses: openai/codex-action@52fe01ec70a42f454c9d2ebd47598f9fd6893d56 # v1.11
+        uses: openai/codex-action@86365089eb2b84e0a8fb0717b304f8bdcb13b20e # v1.12
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           model: ${{ env.CODEX_MODEL }}


### PR DESCRIPTION
Reviewable diff: +8/-8 across 7 files (excludes generated, test, and story files).

## Summary

Updates every stale GitHub Action dependency while preserving the repository's immutable SHA-pin convention. Buildx, Codex review, and PR path filtering now use their latest stable releases without changing workflow inputs or job behavior.

## How it works

GitHub Actions continues to resolve each external action by an immutable commit SHA, with a version comment for maintainability. Build workflows use Buildx v4.3.0, security-review workflows use Codex Action v1.12, and the PR gate uses paths-filter v4.0.3.

## Diagrams

```mermaid
flowchart LR
  A["Workflow trigger"] --> B["Immutable action SHA"]
  B --> C["Existing workflow inputs"]
  C --> D["Existing build, review, or filter job"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| Build and test workflows | Buildx v4.3.0 pin | Confirm Docker build and cache setup remains compatible |
| Security-review workflows | Codex Action v1.12 pin | Confirm existing model, prompt, and credential inputs are unchanged |
| PR gate | paths-filter v4.0.3 pin | Includes upstream filename-handling security fixes while retaining current filters |

## Key technical decisions & trade-offs

- Keep immutable commit SHAs instead of mutable version tags; comments retain the human-readable release version.
- Update only stale actions instead of rewriting workflow structure; this minimizes CI behavior risk.
- Preserve all existing action inputs because these stable updates require no input migration.

## Testing & validation

- Parsed all 28 workflow files successfully as YAML.
- Verified each new commit SHA against its upstream stable tag through the GitHub API.
- Confirmed all other external action pins already match their latest stable tags.
- `git diff --check` passed.
- Pre-commit and pre-push hooks passed; code-specific hooks correctly skipped this workflow-only diff.
- Code review: skipped (mechanical diff) — immutable dependency-pin updates only.

## Post-Deploy Monitoring & Validation

No additional production monitoring is required because this changes CI dependencies only. The PR author will validate the first PR and default-branch workflow runs; healthy signals are successful action setup and unchanged job outcomes. Any action initialization or input-compatibility failure should trigger a revert of this pin update.
