### PR TITLE
Enforce persisted curtailment authorization envelopes

### DIFF
--- a/server/generated/sqlc/curtailment_response_profile.sql.go
+++ b/server/generated/sqlc/curtailment_response_profile.sql.go
@@ -19,19 +19,21 @@ WHERE id = $1
   AND org_id = $2
   AND site_id IS NOT DISTINCT FROM $3
   AND scope_json = $4::jsonb
-  AND facility_fan_device_ids = $5::bigint[]
-  AND fan_off_delay_sec = $6
-  AND fan_restore_delay_sec = $7
+  AND authorization_envelope_jsonb = $5::jsonb
+  AND facility_fan_device_ids = $6::bigint[]
+  AND fan_off_delay_sec = $7
+  AND fan_restore_delay_sec = $8
 `
 
 type DeleteCurtailmentResponseProfileByOrgParams struct {
-	ID                           int64
-	OrgID                        int64
-	ExpectedSiteID               sql.NullInt64
-	ExpectedScopeJson            json.RawMessage
-	ExpectedFacilityFanDeviceIds []int64
-	ExpectedFanOffDelaySec       int32
-	ExpectedFanRestoreDelaySec   int32
+	ID                                int64
+	OrgID                             int64
+	ExpectedSiteID                    sql.NullInt64
+	ExpectedScopeJson                 json.RawMessage
+	ExpectedAuthorizationEnvelopeJson json.RawMessage
+	ExpectedFacilityFanDeviceIds      []int64
+	ExpectedFanOffDelaySec            int32
+	ExpectedFanRestoreDelaySec        int32
 }
 
 func (q *Queries) DeleteCurtailmentResponseProfileByOrg(ctx context.Context, arg DeleteCurtailmentResponseProfileByOrgParams) (int64, error) {
@@ -40,6 +42,7 @@ func (q *Queries) DeleteCurtailmentResponseProfileByOrg(ctx context.Context, arg
 		arg.OrgID,
 		arg.ExpectedSiteID,
 		arg.ExpectedScopeJson,
+		arg.ExpectedAuthorizationEnvelopeJson,
 		pq.Array(arg.ExpectedFacilityFanDeviceIds),
 		arg.ExpectedFanOffDelaySec,
 		arg.ExpectedFanRestoreDelaySec,

--- a/server/internal/domain/curtailment/authorization_envelope.go
+++ b/server/internal/domain/curtailment/authorization_envelope.go
@@ -1,6 +1,7 @@
 package curtailment
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 
@@ -37,6 +38,11 @@ func AuthorizationEnvelopeFromJSON(raw []byte) (models.AuthorizationEnvelope, er
 	for _, field := range authorizationEnvelopeFields {
 		if _, ok := fields[field]; !ok {
 			return models.AuthorizationEnvelope{}, invalidAuthorizationEnvelope("is missing %q", field)
+		}
+	}
+	for _, field := range [...]string{"miner_scope_unbounded", "facility_fan_scope_unbounded"} {
+		if bytes.Equal(bytes.TrimSpace(fields[field]), []byte("null")) {
+			return models.AuthorizationEnvelope{}, invalidAuthorizationEnvelope("%s must be a boolean", field)
 		}
 	}
 

--- a/server/internal/domain/curtailment/authorization_envelope.go
+++ b/server/internal/domain/curtailment/authorization_envelope.go
@@ -1,0 +1,85 @@
+package curtailment
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/block/proto-fleet/server/internal/domain/curtailment/models"
+	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
+)
+
+var authorizationEnvelopeFields = [...]string{
+	"schema_version",
+	"selected_resource_site_ids",
+	"current_member_site_ids",
+	"miner_scope_unbounded",
+	"facility_fan_site_ids",
+	"facility_fan_scope_unbounded",
+}
+
+// AuthorizationEnvelopeFromJSON parses the persisted authorization snapshot.
+// It is intentionally stricter than the database shape checks so every caller
+// fails closed on missing, unknown, null, or invalid coverage.
+func AuthorizationEnvelopeFromJSON(raw []byte) (models.AuthorizationEnvelope, error) {
+	var fields map[string]json.RawMessage
+	if len(raw) == 0 {
+		return models.AuthorizationEnvelope{}, invalidAuthorizationEnvelope("must be set")
+	}
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return models.AuthorizationEnvelope{}, invalidAuthorizationEnvelope("must be a JSON object: %v", err)
+	}
+	if fields == nil {
+		return models.AuthorizationEnvelope{}, invalidAuthorizationEnvelope("must be a JSON object")
+	}
+	if len(fields) != len(authorizationEnvelopeFields) {
+		return models.AuthorizationEnvelope{}, invalidAuthorizationEnvelope("must contain exactly the supported fields")
+	}
+	for _, field := range authorizationEnvelopeFields {
+		if _, ok := fields[field]; !ok {
+			return models.AuthorizationEnvelope{}, invalidAuthorizationEnvelope("is missing %q", field)
+		}
+	}
+
+	var envelope models.AuthorizationEnvelope
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return models.AuthorizationEnvelope{}, invalidAuthorizationEnvelope("contains an invalid field: %v", err)
+	}
+	if envelope.SchemaVersion != models.AuthorizationEnvelopeSchemaVersion {
+		return models.AuthorizationEnvelope{}, invalidAuthorizationEnvelope(
+			"has unsupported schema_version %d", envelope.SchemaVersion,
+		)
+	}
+	if envelope.SelectedResourceSiteIDs == nil ||
+		envelope.CurrentMemberSiteIDs == nil ||
+		envelope.FacilityFanSiteIDs == nil {
+		return models.AuthorizationEnvelope{}, invalidAuthorizationEnvelope("site ID fields must be arrays")
+	}
+	if err := validateAuthorizationEnvelopeSiteIDs(envelope.SelectedResourceSiteIDs, "selected_resource_site_ids"); err != nil {
+		return models.AuthorizationEnvelope{}, err
+	}
+	if err := validateAuthorizationEnvelopeSiteIDs(envelope.CurrentMemberSiteIDs, "current_member_site_ids"); err != nil {
+		return models.AuthorizationEnvelope{}, err
+	}
+	if err := validateAuthorizationEnvelopeSiteIDs(envelope.FacilityFanSiteIDs, "facility_fan_site_ids"); err != nil {
+		return models.AuthorizationEnvelope{}, err
+	}
+	if !envelope.MinerScopeUnbounded &&
+		len(envelope.SelectedResourceSiteIDs) == 0 &&
+		len(envelope.CurrentMemberSiteIDs) == 0 {
+		return models.AuthorizationEnvelope{}, invalidAuthorizationEnvelope("has no bounded miner coverage")
+	}
+	return envelope, nil
+}
+
+func validateAuthorizationEnvelopeSiteIDs(siteIDs []int64, field string) error {
+	for _, siteID := range siteIDs {
+		if siteID <= 0 {
+			return invalidAuthorizationEnvelope("%s must contain only positive IDs", field)
+		}
+	}
+	return nil
+}
+
+func invalidAuthorizationEnvelope(format string, args ...any) error {
+	return fleeterror.NewInvalidArgumentError(fmt.Sprintf("curtailment authorization envelope "+format, args...))
+}

--- a/server/internal/domain/curtailment/authorization_envelope_test.go
+++ b/server/internal/domain/curtailment/authorization_envelope_test.go
@@ -55,3 +55,21 @@ func TestAuthorizationEnvelopeFromJSONRejectsInvalidCoverage(t *testing.T) {
 		})
 	}
 }
+
+func TestAuthorizationEnvelopeFromJSONRejectsNullBooleanFields(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"miner_scope_unbounded":        `{"schema_version":1,"selected_resource_site_ids":[7],"current_member_site_ids":[],"miner_scope_unbounded":null,"facility_fan_site_ids":[],"facility_fan_scope_unbounded":false}`,
+		"facility_fan_scope_unbounded": `{"schema_version":1,"selected_resource_site_ids":[7],"current_member_site_ids":[],"miner_scope_unbounded":false,"facility_fan_site_ids":[],"facility_fan_scope_unbounded":null}`,
+	}
+
+	for field, raw := range tests {
+		t.Run(field, func(t *testing.T) {
+			t.Parallel()
+			_, err := AuthorizationEnvelopeFromJSON([]byte(raw))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), field+" must be a boolean")
+		})
+	}
+}

--- a/server/internal/domain/curtailment/authorization_envelope_test.go
+++ b/server/internal/domain/curtailment/authorization_envelope_test.go
@@ -1,0 +1,57 @@
+package curtailment
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/proto-fleet/server/internal/domain/curtailment/models"
+)
+
+func TestAuthorizationEnvelopeFromJSON(t *testing.T) {
+	t.Parallel()
+
+	valid := `{
+		"schema_version":1,
+		"selected_resource_site_ids":[7],
+		"current_member_site_ids":[8],
+		"miner_scope_unbounded":false,
+		"facility_fan_site_ids":[9],
+		"facility_fan_scope_unbounded":false
+	}`
+
+	envelope, err := AuthorizationEnvelopeFromJSON([]byte(valid))
+	require.NoError(t, err)
+	assert.Equal(t, models.AuthorizationEnvelope{
+		SchemaVersion:           1,
+		SelectedResourceSiteIDs: []int64{7},
+		CurrentMemberSiteIDs:    []int64{8},
+		FacilityFanSiteIDs:      []int64{9},
+	}, envelope)
+}
+
+func TestAuthorizationEnvelopeFromJSONRejectsInvalidCoverage(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"missing envelope":       ``,
+		"null envelope":          `null`,
+		"unknown field":          `{"schema_version":1,"selected_resource_site_ids":[7],"current_member_site_ids":[],"miner_scope_unbounded":false,"facility_fan_site_ids":[],"facility_fan_scope_unbounded":false,"extra":true}`,
+		"missing field":          `{"schema_version":1,"selected_resource_site_ids":[7],"current_member_site_ids":[],"miner_scope_unbounded":false,"facility_fan_site_ids":[]}`,
+		"unsupported version":    `{"schema_version":2,"selected_resource_site_ids":[7],"current_member_site_ids":[],"miner_scope_unbounded":false,"facility_fan_site_ids":[],"facility_fan_scope_unbounded":false}`,
+		"null site IDs":          `{"schema_version":1,"selected_resource_site_ids":null,"current_member_site_ids":[],"miner_scope_unbounded":false,"facility_fan_site_ids":[],"facility_fan_scope_unbounded":false}`,
+		"non-positive site ID":   `{"schema_version":1,"selected_resource_site_ids":[0],"current_member_site_ids":[],"miner_scope_unbounded":false,"facility_fan_site_ids":[],"facility_fan_scope_unbounded":false}`,
+		"missing miner coverage": `{"schema_version":1,"selected_resource_site_ids":[],"current_member_site_ids":[],"miner_scope_unbounded":false,"facility_fan_site_ids":[],"facility_fan_scope_unbounded":false}`,
+		"invalid boolean":        `{"schema_version":1,"selected_resource_site_ids":[],"current_member_site_ids":[],"miner_scope_unbounded":"true","facility_fan_site_ids":[],"facility_fan_scope_unbounded":false}`,
+	}
+
+	for name, raw := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			_, err := AuthorizationEnvelopeFromJSON([]byte(raw))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "curtailment authorization envelope")
+		})
+	}
+}

--- a/server/internal/domain/curtailment/response_profile.go
+++ b/server/internal/domain/curtailment/response_profile.go
@@ -187,6 +187,7 @@ func (s *ResponseProfileService) Delete(
 	profileID int64,
 	expectedSiteID *int64,
 	expectedScopeJSON []byte,
+	expectedAuthorizationEnvelopeJSON []byte,
 	expectedFacilityFanSettings models.ResponseProfileFanSettings,
 ) error {
 	if s == nil || s.store == nil {
@@ -213,6 +214,7 @@ func (s *ResponseProfileService) Delete(
 		profileID,
 		expectedSiteID,
 		expectedScopeJSON,
+		expectedAuthorizationEnvelopeJSON,
 		expectedFacilityFanSettings,
 	)
 }

--- a/server/internal/domain/curtailment/response_profile_test.go
+++ b/server/internal/domain/curtailment/response_profile_test.go
@@ -866,7 +866,7 @@ func TestResponseProfileService_DeleteRejectsReferencedProfile(t *testing.T) {
 	store.automationRuleCount = 1
 	svc := NewResponseProfileService(store)
 
-	err := svc.Delete(t.Context(), 42, 101, nil, nil, models.ResponseProfileFanSettings{})
+	err := svc.Delete(t.Context(), 42, 101, nil, nil, nil, models.ResponseProfileFanSettings{})
 
 	require.Error(t, err)
 	assert.True(t, fleeterror.IsFailedPreconditionError(err))
@@ -956,7 +956,7 @@ func (s *responseProfileFakeStore) UpdateResponseProfile(_ context.Context, prof
 	return &profile, nil
 }
 
-func (s *responseProfileFakeStore) DeleteResponseProfile(context.Context, int64, int64, *int64, []byte, models.ResponseProfileFanSettings) error {
+func (s *responseProfileFakeStore) DeleteResponseProfile(context.Context, int64, int64, *int64, []byte, []byte, models.ResponseProfileFanSettings) error {
 	s.deleteCalls++
 	return nil
 }

--- a/server/internal/domain/curtailment/service.go
+++ b/server/internal/domain/curtailment/service.go
@@ -330,6 +330,25 @@ func (s *Service) Start(ctx context.Context, req StartRequest) (*Plan, error) {
 	return plan, nil
 }
 
+// LookupStartReplay returns the persisted event matched by a Start request's
+// idempotency handles. It intentionally does not hydrate targets so handlers
+// can authorize the immutable event envelope before loading response data.
+func (s *Service) LookupStartReplay(ctx context.Context, req StartRequest) (*models.Event, error) {
+	if err := validateStartRequest(req); err != nil {
+		return nil, err
+	}
+	return s.lookupIdempotentReplay(ctx, req)
+}
+
+// RenderStartReplay builds the bounded Start response from an already
+// authorized persisted event.
+func (s *Service) RenderStartReplay(ctx context.Context, orgID int64, event *models.Event) (*Plan, error) {
+	if event == nil || event.OrgID != orgID {
+		return nil, fleeterror.NewNotFoundError("curtailment event not found")
+	}
+	return s.replayPlanFromPersistedEvent(ctx, orgID, event)
+}
+
 // ListActive returns every non-terminal event for the org, most-recent first.
 // Multiple can be active when they target disjoint device scopes (e.g. one per
 // site).

--- a/server/internal/domain/stores/interfaces/curtailment.go
+++ b/server/internal/domain/stores/interfaces/curtailment.go
@@ -178,7 +178,7 @@ type ResponseProfileStore interface {
 	ListResponseProfileInfrastructureDevices(ctx context.Context, orgID int64, infrastructureDeviceIDs []int64) (map[int64]models.ResponseProfileInfrastructureDevice, error)
 	CreateResponseProfile(ctx context.Context, profile models.ResponseProfile, expectedDeviceSites map[string]*int64, expectedInfrastructureDevices map[int64]models.ResponseProfileInfrastructureDevice) (*models.ResponseProfile, error)
 	UpdateResponseProfile(ctx context.Context, profile models.ResponseProfile, expectedDeviceSites map[string]*int64, expectedInfrastructureDevices map[int64]models.ResponseProfileInfrastructureDevice, expectedSiteID *int64, expectedScopeJSON []byte, expectedFacilityFanSettings models.ResponseProfileFanSettings) (*models.ResponseProfile, error)
-	DeleteResponseProfile(ctx context.Context, orgID, profileID int64, expectedSiteID *int64, expectedScopeJSON []byte, expectedFacilityFanSettings models.ResponseProfileFanSettings) error
+	DeleteResponseProfile(ctx context.Context, orgID, profileID int64, expectedSiteID *int64, expectedScopeJSON, expectedAuthorizationEnvelopeJSON []byte, expectedFacilityFanSettings models.ResponseProfileFanSettings) error
 	CountAutomationRulesByResponseProfile(ctx context.Context, orgID, profileID int64) (int64, error)
 	SiteBelongsToOrg(ctx context.Context, orgID, siteID int64) (bool, error)
 }

--- a/server/internal/domain/stores/sqlstores/curtailment.go
+++ b/server/internal/domain/stores/sqlstores/curtailment.go
@@ -341,6 +341,7 @@ func (s *SQLCurtailmentStore) DeleteResponseProfile(
 	profileID int64,
 	expectedSiteID *int64,
 	expectedScopeJSON []byte,
+	expectedAuthorizationEnvelopeJSON []byte,
 	expectedFacilityFanSettings models.ResponseProfileFanSettings,
 ) error {
 	count, err := s.CountAutomationRulesByResponseProfile(ctx, orgID, profileID)
@@ -351,13 +352,14 @@ func (s *SQLCurtailmentStore) DeleteResponseProfile(
 		return fleeterror.NewFailedPreconditionError("curtailment response profile is referenced by an automation rule")
 	}
 	rows, err := s.GetQueries(ctx).DeleteCurtailmentResponseProfileByOrg(ctx, sqlc.DeleteCurtailmentResponseProfileByOrgParams{
-		ID:                           profileID,
-		OrgID:                        orgID,
-		ExpectedSiteID:               ptrToNullInt64(expectedSiteID),
-		ExpectedScopeJson:            normalizedResponseProfileScopeJSON(expectedScopeJSON),
-		ExpectedFacilityFanDeviceIds: append([]int64{}, expectedFacilityFanSettings.FacilityFanDeviceIDs...),
-		ExpectedFanOffDelaySec:       expectedFacilityFanSettings.FanOffDelaySec,
-		ExpectedFanRestoreDelaySec:   expectedFacilityFanSettings.FanRestoreDelaySec,
+		ID:                                profileID,
+		OrgID:                             orgID,
+		ExpectedSiteID:                    ptrToNullInt64(expectedSiteID),
+		ExpectedScopeJson:                 normalizedResponseProfileScopeJSON(expectedScopeJSON),
+		ExpectedAuthorizationEnvelopeJson: append([]byte(nil), expectedAuthorizationEnvelopeJSON...),
+		ExpectedFacilityFanDeviceIds:      append([]int64{}, expectedFacilityFanSettings.FacilityFanDeviceIDs...),
+		ExpectedFanOffDelaySec:            expectedFacilityFanSettings.FanOffDelaySec,
+		ExpectedFanRestoreDelaySec:        expectedFacilityFanSettings.FanRestoreDelaySec,
 	})
 	if err != nil {
 		return fleeterror.NewInternalErrorf("failed to delete curtailment response profile: %v", err)

--- a/server/internal/domain/stores/sqlstores/response_profile_facility_fans_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/response_profile_facility_fans_integration_test.go
@@ -143,7 +143,22 @@ func TestSQLCurtailmentStore_ResponseProfileFacilityFanSettings(t *testing.T) {
 		created.ID,
 		updated.SiteID,
 		updated.ScopeJSON,
+		updated.AuthorizationEnvelopeJSON,
 		responseProfileFanSettings(updated),
+	)
+	require.Error(t, err)
+	assert.True(t, fleeterror.IsFailedPreconditionError(err))
+	_, err = service.Get(ctx, orgID, created.ID)
+	require.NoError(t, err)
+
+	err = service.Delete(
+		ctx,
+		orgID,
+		created.ID,
+		replacement.SiteID,
+		replacement.ScopeJSON,
+		updated.AuthorizationEnvelopeJSON,
+		responseProfileFanSettings(replacement),
 	)
 	require.Error(t, err)
 	assert.True(t, fleeterror.IsFailedPreconditionError(err))

--- a/server/internal/domain/stores/sqlstores/response_profile_facility_fans_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/response_profile_facility_fans_integration_test.go
@@ -165,6 +165,20 @@ func TestSQLCurtailmentStore_ResponseProfileFacilityFanSettings(t *testing.T) {
 	_, err = service.Get(ctx, orgID, created.ID)
 	require.NoError(t, err)
 
+	err = service.Delete(
+		ctx,
+		orgID,
+		created.ID,
+		replacement.SiteID,
+		replacement.ScopeJSON,
+		replacement.AuthorizationEnvelopeJSON,
+		responseProfileFanSettings(replacement),
+	)
+	require.NoError(t, err)
+	_, err = service.Get(ctx, orgID, created.ID)
+	require.Error(t, err)
+	assert.True(t, fleeterror.IsNotFoundError(err))
+
 	otherSiteProfile, err := service.Create(ctx, domainCurtailment.SaveResponseProfileRequest{
 		Profile: models.ResponseProfile{
 			OrgID:                orgID,

--- a/server/internal/handlers/curtailment/automation.go
+++ b/server/internal/handlers/curtailment/automation.go
@@ -61,10 +61,8 @@ func (h *Handler) ListCurtailmentAutomationRules(ctx context.Context, _ *connect
 	if err != nil {
 		return nil, err
 	}
-	siteAllowed := make(map[int64]bool)
+	permissionCache := newResourceContextPermissionCache()
 	facilityFanSiteAllowed := make(map[int64]bool)
-	orgWideAllowed := false
-	orgWideChecked := false
 	for _, rule := range rules {
 		requirements, err := h.automationRuleProfileResourceContextRequirements(ctx, info.OrganizationID, rule, deviceSites)
 		if err != nil {
@@ -74,9 +72,7 @@ func (h *Handler) ListCurtailmentAutomationRules(ctx context.Context, _ *connect
 			ctx,
 			authz.PermCurtailmentManage,
 			requirements,
-			siteAllowed,
-			&orgWideAllowed,
-			&orgWideChecked,
+			&permissionCache,
 		)
 		if err != nil {
 			return nil, err

--- a/server/internal/handlers/curtailment/handler.go
+++ b/server/internal/handlers/curtailment/handler.go
@@ -3,8 +3,6 @@ package curtailment
 
 import (
 	"context"
-	"encoding/json"
-	"strings"
 
 	"connectrpc.com/connect"
 	"github.com/google/uuid"
@@ -26,7 +24,6 @@ import (
 const actionSupplyOverrideFields = "supply curtailment override fields"
 const actionAdminTerminateEvents = "admin terminate curtailment events"
 const actionManageMqttSources = "manage MaestroOS curtailment sources"
-const incompleteTargetSiteContextMessage = "curtailment target site context is incomplete"
 const listCurtailmentEventsDefaultPageSize int32 = 50
 const listCurtailmentEventsMaxPageSize int32 = 200
 const listCurtailmentEventsMaxPermissionScanPages = 3
@@ -79,7 +76,7 @@ func NewHandlerWithAutomation(
 }
 
 func (h *Handler) PreviewCurtailmentPlan(ctx context.Context, req *connect.Request[pb.PreviewCurtailmentPlanRequest]) (*connect.Response[pb.PreviewCurtailmentPlanResponse], error) {
-	info, err := middleware.RequirePermission(ctx, authz.PermCurtailmentManage, authz.ResourceContext{})
+	info, err := requireScopedPermissionCapability(ctx, authz.PermCurtailmentManage)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +115,7 @@ func (h *Handler) PreviewCurtailmentPlan(ctx context.Context, req *connect.Reque
 }
 
 func (h *Handler) StartCurtailment(ctx context.Context, req *connect.Request[pb.StartCurtailmentRequest]) (*connect.Response[pb.StartCurtailmentResponse], error) {
-	info, err := middleware.RequirePermission(ctx, authz.PermCurtailmentManage, authz.ResourceContext{})
+	info, err := requireScopedPermissionCapability(ctx, authz.PermCurtailmentManage)
 	if err != nil {
 		return nil, err
 	}
@@ -254,7 +251,7 @@ func (h *Handler) ListActiveCurtailments(ctx context.Context, _ *connect.Request
 	if h.service == nil {
 		return nil, errCurtailmentNotImplemented("ListActiveCurtailments")
 	}
-	info, err := middleware.RequirePermission(ctx, authz.PermCurtailmentRead, authz.ResourceContext{})
+	info, err := requireScopedPermissionCapability(ctx, authz.PermCurtailmentRead)
 	if err != nil {
 		return nil, err
 	}
@@ -266,11 +263,12 @@ func (h *Handler) ListActiveCurtailments(ctx context.Context, _ *connect.Request
 	if err != nil {
 		return nil, err
 	}
-	// Whole-org events stay visible on the plain org grant so narrowed
-	// operators still learn their sites are curtailed, but their live rollup
-	// aggregates target counts across every site — including narrowed ones —
-	// so it requires the same unnarrowed org-wide read that whole-org writes
-	// and incomplete-coverage reads already demand.
+	if err := h.hydrateTargetSiteCoverageByEvents(ctx, info.OrganizationID, events); err != nil {
+		return nil, err
+	}
+	// Envelope filtering removes whole-org events for narrowed callers. Keep the
+	// renderer gate as defense in depth because their live rollups aggregate
+	// target counts across every site.
 	orgWideRead, err := hasOrgWidePermission(ctx, authz.PermCurtailmentRead)
 	if err != nil {
 		return nil, err
@@ -295,7 +293,7 @@ func (h *Handler) ListCurtailmentEvents(ctx context.Context, req *connect.Reques
 	if h.service == nil {
 		return nil, errCurtailmentNotImplemented("ListCurtailmentEvents")
 	}
-	info, err := middleware.RequirePermission(ctx, authz.PermCurtailmentRead, authz.ResourceContext{})
+	info, err := requireScopedPermissionCapability(ctx, authz.PermCurtailmentRead)
 	if err != nil {
 		return nil, err
 	}
@@ -305,6 +303,9 @@ func (h *Handler) ListCurtailmentEvents(ctx context.Context, req *connect.Reques
 	}
 	events, nextToken, err := h.listPermittedEvents(ctx, listReq)
 	if err != nil {
+		return nil, err
+	}
+	if err := h.hydrateTargetSiteCoverageByEvents(ctx, info.OrganizationID, events); err != nil {
 		return nil, err
 	}
 	return connect.NewResponse(toListEventsResponse(events, nextToken)), nil
@@ -382,10 +383,10 @@ func (h *Handler) AdminTerminateEvent(ctx context.Context, req *connect.Request[
 
 // ForceReleaseCurtailmentOwnership is an admin recovery path that releases
 // curtailment ownership immediately. It intentionally checks org-level manage
-// permission before loading event site contexts so incomplete target-site
-// coverage cannot block recovery.
+// capability before loading the event envelope so recovery remains scoped to
+// the durable authorization snapshot.
 func (h *Handler) ForceReleaseCurtailmentOwnership(ctx context.Context, req *connect.Request[pb.ForceReleaseCurtailmentOwnershipRequest]) (*connect.Response[pb.ForceReleaseCurtailmentOwnershipResponse], error) {
-	info, err := middleware.RequirePermission(ctx, authz.PermCurtailmentManage, authz.ResourceContext{})
+	info, err := requireScopedPermissionCapability(ctx, authz.PermCurtailmentManage)
 	if err != nil {
 		return nil, err
 	}
@@ -441,6 +442,84 @@ type scopeResourceContextRequirements struct {
 	siteContexts   []authz.ResourceContext
 	requireOrgWide bool
 	deviceSites    map[string]*int64
+}
+
+type authorizationEnvelopeRequirements struct {
+	resource        scopeResourceContextRequirements
+	facilityFanRead scopeResourceContextRequirements
+}
+
+type authorizationEnvelopePermissionCache struct {
+	resource        resourceContextPermissionCache
+	facilityFanRead resourceContextPermissionCache
+}
+
+func newAuthorizationEnvelopePermissionCache() *authorizationEnvelopePermissionCache {
+	return &authorizationEnvelopePermissionCache{
+		resource:        newResourceContextPermissionCache(),
+		facilityFanRead: newResourceContextPermissionCache(),
+	}
+}
+
+func authorizationEnvelopeResourceContextRequirements(raw []byte) (authorizationEnvelopeRequirements, error) {
+	envelope, err := curtailment.AuthorizationEnvelopeFromJSON(raw)
+	if err != nil {
+		return authorizationEnvelopeRequirements{}, fleeterror.NewInternalErrorf(
+			"invalid persisted curtailment authorization envelope: %v", err,
+		)
+	}
+	minerSiteIDs := append([]int64(nil), envelope.SelectedResourceSiteIDs...)
+	minerSiteIDs = append(minerSiteIDs, envelope.CurrentMemberSiteIDs...)
+	minerContexts := siteResourceContextsForScope(curtailment.Scope{SiteIDs: minerSiteIDs})
+	fanContexts := siteResourceContextsForScope(curtailment.Scope{SiteIDs: envelope.FacilityFanSiteIDs})
+	return authorizationEnvelopeRequirements{
+		resource: scopeResourceContextRequirements{
+			siteContexts:   mergeSiteResourceContexts(minerContexts, fanContexts),
+			requireOrgWide: envelope.MinerScopeUnbounded || envelope.FacilityFanScopeUnbounded,
+		},
+		facilityFanRead: scopeResourceContextRequirements{
+			siteContexts:   fanContexts,
+			requireOrgWide: envelope.FacilityFanScopeUnbounded,
+		},
+	}, nil
+}
+
+func requireAuthorizationEnvelopePermissions(ctx context.Context, permission string, raw []byte) error {
+	requirements, err := authorizationEnvelopeResourceContextRequirements(raw)
+	if err != nil {
+		return err
+	}
+	if err := requireResourceContextPermissions(ctx, permission, requirements.resource); err != nil {
+		return err
+	}
+	return requireResourceContextPermissions(ctx, authz.PermSiteRead, requirements.facilityFanRead)
+}
+
+func authorizationEnvelopeAccessAllowed(
+	ctx context.Context,
+	permission string,
+	raw []byte,
+	cache *authorizationEnvelopePermissionCache,
+) (bool, error) {
+	requirements, err := authorizationEnvelopeResourceContextRequirements(raw)
+	if err != nil {
+		return false, err
+	}
+	allowed, err := resourceContextRequirementsAllowed(
+		ctx,
+		permission,
+		requirements.resource,
+		&cache.resource,
+	)
+	if err != nil || !allowed {
+		return allowed, err
+	}
+	return resourceContextRequirementsAllowed(
+		ctx,
+		authz.PermSiteRead,
+		requirements.facilityFanRead,
+		&cache.facilityFanRead,
+	)
 }
 
 func (h *Handler) previewResourceContextRequirements(
@@ -514,10 +593,9 @@ func (h *Handler) scopeResourceContextRequirements(
 		return out, nil
 	}
 	if len(scope.BuildingIDs) > 0 || len(scope.RackIDs) > 0 || len(scope.GroupIDs) > 0 {
-		// Scoped topology authorization must be bound to the same snapshot used
-		// for candidate resolution. Until the durable authorization envelope and
-		// dispatch-time recheck land, require org-wide permission so membership
-		// changes cannot broaden a site-scoped request after authorization.
+		// The persisted envelope secures later reads and recovery. Live topology
+		// starts still require org-wide access until dispatch-time reauthorization
+		// can bind the resolved membership to every physical command.
 		out.requireOrgWide = true
 		return out, nil
 	}
@@ -602,24 +680,6 @@ func mergeSiteResourceContexts(groups ...[]authz.ResourceContext) []authz.Resour
 	return siteResourceContextsForScope(curtailment.Scope{SiteIDs: siteIDs})
 }
 
-func requireOrgPermissionWithOptionalSiteContexts(ctx context.Context, permission string, siteContexts []authz.ResourceContext) (*session.Info, error) {
-	info, err := middleware.RequirePermission(ctx, permission, authz.ResourceContext{})
-	if err != nil {
-		return nil, err
-	}
-	for _, rc := range siteContexts {
-		if rc.SiteID == nil {
-			continue
-		}
-		checkedInfo, err := middleware.RequirePermission(ctx, permission, rc)
-		if err != nil {
-			return nil, err
-		}
-		info = checkedInfo
-	}
-	return info, nil
-}
-
 func requireScopeResourceContextPermissions(
 	ctx context.Context,
 	permission string,
@@ -646,6 +706,23 @@ func requireScopeResourceContextPermissions(
 	return info, nil
 }
 
+func requireScopedPermissionCapability(ctx context.Context, permission string) (*session.Info, error) {
+	info, err := session.GetInfo(ctx)
+	if err != nil {
+		return nil, fleeterror.NewUnauthenticatedError("authentication required")
+	}
+	orgWide, siteIDs, err := middleware.SiteScopeForPermission(ctx, permission)
+	if err != nil {
+		return nil, err
+	}
+	if orgWide || len(siteIDs) > 0 {
+		return info, nil
+	}
+	// Preserve the middleware's structured permission-denied response when the
+	// caller has no grant for this capability at any supported scope.
+	return middleware.RequirePermission(ctx, permission, authz.ResourceContext{})
+}
+
 func requireResourceContextPermissions(ctx context.Context, permission string, requirements scopeResourceContextRequirements) error {
 	_, err := requireScopeResourceContextPermissions(ctx, permission, requirements, nil)
 	return err
@@ -662,7 +739,7 @@ func parseEventUUID(raw string) (uuid.UUID, error) {
 }
 
 func (h *Handler) requireEventPermission(ctx context.Context, permission string, eventUUID uuid.UUID) (*session.Info, *models.Event, error) {
-	info, err := middleware.RequirePermission(ctx, permission, authz.ResourceContext{})
+	info, err := requireScopedPermissionCapability(ctx, permission)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -670,19 +747,10 @@ func (h *Handler) requireEventPermission(ctx context.Context, permission string,
 	if err != nil {
 		return nil, nil, err
 	}
-	requirements, err := h.eventResourceContextRequirements(ctx, info.OrganizationID, event)
-	if err != nil {
-		if isIncompleteTargetSiteContextError(err) {
-			info, err = middleware.RequireOrgWidePermission(ctx, permission)
-			if err != nil {
-				return nil, nil, err
-			}
-			return info, event, nil
-		}
+	if err := requireAuthorizationEnvelopePermissions(ctx, permission, event.AuthorizationEnvelopeJSON); err != nil {
 		return nil, nil, err
 	}
-	info, err = requireScopeResourceContextPermissions(ctx, permission, requirements, info)
-	if err != nil {
+	if err := h.hydrateTargetSiteCoverageByEvent(ctx, info.OrganizationID, event); err != nil {
 		return nil, nil, err
 	}
 	return info, event, nil
@@ -702,15 +770,13 @@ func (h *Handler) requireForceReleasePermission(ctx context.Context, orgID int64
 }
 
 func (h *Handler) requirePersistedEventPermission(ctx context.Context, orgID int64, permission string, event *models.Event) error {
-	requirements, err := h.eventResourceContextRequirements(ctx, orgID, event)
-	if err != nil {
-		if isIncompleteTargetSiteContextError(err) {
-			_, err := middleware.RequireOrgWidePermission(ctx, permission)
-			return err
-		}
+	if event == nil || event.OrgID != orgID {
+		return fleeterror.NewNotFoundError("curtailment event not found")
+	}
+	if err := requireAuthorizationEnvelopePermissions(ctx, permission, event.AuthorizationEnvelopeJSON); err != nil {
 		return err
 	}
-	return requireResourceContextPermissions(ctx, permission, requirements)
+	return h.hydrateTargetSiteCoverageByEvent(ctx, orgID, event)
 }
 
 func (h *Handler) filterEventsByPermission(
@@ -719,41 +785,15 @@ func (h *Handler) filterEventsByPermission(
 	permission string,
 	events []*models.Event,
 ) ([]*models.Event, error) {
-	if err := h.hydrateTargetSiteCoverageByEvents(ctx, orgID, events); err != nil {
-		return nil, err
-	}
-	fanDeviceSites, err := h.facilityFanDeviceSitesForEvents(ctx, orgID, events)
-	if err != nil {
-		return nil, err
-	}
 	filtered := make([]*models.Event, 0, len(events))
+	cache := newAuthorizationEnvelopePermissionCache()
 	for _, event := range events {
-		requirements, err := h.eventResourceContextRequirementsWithFanSites(ctx, orgID, event, fanDeviceSites)
-		if err != nil {
-			if isIncompleteTargetSiteContextError(err) {
-				if _, orgWideErr := middleware.RequireOrgWidePermission(ctx, permission); orgWideErr != nil {
-					if fleeterror.IsForbiddenError(orgWideErr) {
-						continue
-					}
-					return nil, orgWideErr
-				}
-				filtered = append(filtered, event)
-				continue
-			}
-			if fleeterror.IsForbiddenError(err) {
-				continue
-			}
-			return nil, err
+		if event == nil || event.OrgID != orgID {
+			continue
 		}
-		permitted := true
-		for _, rc := range requirements.siteContexts {
-			if _, err := middleware.RequirePermission(ctx, permission, rc); err != nil {
-				if fleeterror.IsForbiddenError(err) {
-					permitted = false
-					break
-				}
-				return nil, err
-			}
+		permitted, err := authorizationEnvelopeAccessAllowed(ctx, permission, event.AuthorizationEnvelopeJSON, cache)
+		if err != nil {
+			return nil, err
 		}
 		if permitted {
 			filtered = append(filtered, event)
@@ -762,76 +802,11 @@ func (h *Handler) filterEventsByPermission(
 	return filtered, nil
 }
 
-func (h *Handler) facilityFanDeviceSitesForEvents(
-	ctx context.Context,
-	orgID int64,
-	events []*models.Event,
-) (map[int64]int64, error) {
-	seen := make(map[int64]struct{})
-	deviceIDs := make([]int64, 0)
-	for _, event := range events {
-		if event == nil {
-			continue
-		}
-		if len(event.FacilityFanDeviceIDs) == len(event.FacilityFanSiteIDs) {
-			continue
-		}
-		for _, deviceID := range event.FacilityFanDeviceIDs {
-			if _, ok := seen[deviceID]; ok {
-				continue
-			}
-			seen[deviceID] = struct{}{}
-			deviceIDs = append(deviceIDs, deviceID)
-		}
-	}
-	deviceSites := make(map[int64]int64, len(deviceIDs))
-	if len(deviceIDs) == 0 {
-		return deviceSites, nil
-	}
-	if h.responseProfiles == nil {
-		return nil, errCurtailmentNotImplemented("facility fan event authorization")
-	}
-	if err := h.resolveFacilityFanDeviceSites(ctx, orgID, deviceIDs, deviceSites); err != nil {
-		return nil, err
-	}
-	return deviceSites, nil
-}
-
-// resolveFacilityFanDeviceSites batches the normal list path. If a historical
-// event references a deleted fan, split only the failed batch so other events
-// retain their precise site authorization while the missing reference falls
-// back to the existing org-wide incomplete-context policy.
-func (h *Handler) resolveFacilityFanDeviceSites(
-	ctx context.Context,
-	orgID int64,
-	deviceIDs []int64,
-	out map[int64]int64,
-) error {
-	deviceSites, err := h.responseProfiles.FacilityFanDeviceSites(ctx, orgID, deviceIDs)
-	if err == nil {
-		for deviceID, siteID := range deviceSites {
-			out[deviceID] = siteID
-		}
-		return nil
-	}
-	if !fleeterror.IsNotFoundError(err) {
-		return err
-	}
-	if len(deviceIDs) == 1 {
-		return nil
-	}
-	mid := len(deviceIDs) / 2
-	if err := h.resolveFacilityFanDeviceSites(ctx, orgID, deviceIDs[:mid], out); err != nil {
-		return err
-	}
-	return h.resolveFacilityFanDeviceSites(ctx, orgID, deviceIDs[mid:], out)
-}
-
 func (h *Handler) hydrateTargetSiteCoverageByEvents(ctx context.Context, orgID int64, events []*models.Event) error {
 	eventUUIDs := make([]uuid.UUID, 0, len(events))
 	seen := make(map[uuid.UUID]struct{}, len(events))
 	for _, event := range events {
-		if !shouldBatchHydrateTargetSiteCoverage(event) {
+		if !shouldHydrateTargetSiteCoverage(event) {
 			continue
 		}
 		if _, ok := seen[event.EventUUID]; ok {
@@ -851,16 +826,26 @@ func (h *Handler) hydrateTargetSiteCoverageByEvents(ctx context.Context, orgID i
 		if event == nil {
 			continue
 		}
-		coverage, ok := coverageByEvent[event.EventUUID]
-		if !ok {
-			continue
+		if coverage, ok := coverageByEvent[event.EventUUID]; ok {
+			event.TargetSiteCoverage = &coverage
 		}
-		event.TargetSiteCoverage = &coverage
 	}
 	return nil
 }
 
-func shouldBatchHydrateTargetSiteCoverage(event *models.Event) bool {
+func (h *Handler) hydrateTargetSiteCoverageByEvent(ctx context.Context, orgID int64, event *models.Event) error {
+	if !shouldHydrateTargetSiteCoverage(event) {
+		return nil
+	}
+	coverage, err := h.service.ListTargetSiteCoverageByEvent(ctx, orgID, event.EventUUID)
+	if err != nil {
+		return err
+	}
+	event.TargetSiteCoverage = &coverage
+	return nil
+}
+
+func shouldHydrateTargetSiteCoverage(event *models.Event) bool {
 	if event == nil || event.TargetSiteCoverage != nil {
 		return false
 	}
@@ -868,13 +853,12 @@ func shouldBatchHydrateTargetSiteCoverage(event *models.Event) bool {
 	case models.ScopeTypeDeviceList:
 		return true
 	case models.ScopeTypeMixed:
-		_, handled, err := mixedSiteOnlyEventResourceContexts(event)
-		return !handled && err == nil
-	case models.ScopeTypeWholeOrg, models.ScopeTypeSite:
-		return false
-	default:
+		scope, hasScope, err := curtailment.ScopeFromJSON(event.ScopeJSON)
+		return err == nil && (!hasScope || !curtailment.IsSiteOnlyScope(scope))
+	case models.ScopeTypeWholeOrg, models.ScopeTypeSite, "":
 		return false
 	}
+	return false
 }
 
 func (h *Handler) listPermittedEvents(
@@ -924,200 +908,6 @@ func remainingListCurtailmentEventsPageSize(pageSize int32, filteredCount int) i
 		return listCurtailmentEventsMaxPageSize
 	}
 	return int32(remaining) // #nosec G115 -- page size is clamped to <= 200 above.
-}
-
-func requireOrgPermissionWithOptionalSiteContext(ctx context.Context, permission string, rc authz.ResourceContext) (*session.Info, error) {
-	return requireOrgPermissionWithOptionalSiteContexts(ctx, permission, []authz.ResourceContext{rc})
-}
-
-func eventResourceContext(event *models.Event) (authz.ResourceContext, error) {
-	if event == nil || event.ScopeType != models.ScopeTypeSite {
-		return authz.ResourceContext{}, nil
-	}
-	var payload struct {
-		SiteID int64 `json:"site_id"`
-	}
-	if err := json.Unmarshal(event.ScopeJSON, &payload); err != nil {
-		return authz.ResourceContext{}, fleeterror.NewInternalErrorf(
-			"failed to decode site-scoped curtailment event scope: %v", err,
-		)
-	}
-	if payload.SiteID <= 0 {
-		return authz.ResourceContext{}, fleeterror.NewInternalError(
-			"site-scoped curtailment event has invalid site_id",
-		)
-	}
-	return authz.ResourceContext{SiteID: &payload.SiteID}, nil
-}
-
-func (h *Handler) eventResourceContextRequirements(
-	ctx context.Context,
-	orgID int64,
-	event *models.Event,
-) (scopeResourceContextRequirements, error) {
-	return h.eventResourceContextRequirementsWithFanSites(ctx, orgID, event, nil)
-}
-
-func (h *Handler) eventResourceContextRequirementsWithFanSites(
-	ctx context.Context,
-	orgID int64,
-	event *models.Event,
-	fanDeviceSites map[int64]int64,
-) (scopeResourceContextRequirements, error) {
-	targetContexts, err := h.eventTargetSiteResourceContexts(ctx, orgID, event)
-	if err != nil {
-		return scopeResourceContextRequirements{}, err
-	}
-	fanContexts, err := h.eventFacilityFanResourceContexts(ctx, orgID, event, fanDeviceSites)
-	if err != nil {
-		return scopeResourceContextRequirements{}, err
-	}
-	siteContexts := mergeSiteResourceContexts(targetContexts, fanContexts)
-	return scopeResourceContextRequirements{
-		siteContexts: siteContexts,
-		requireOrgWide: event == nil ||
-			event.ScopeType == "" ||
-			event.ScopeType == models.ScopeTypeWholeOrg ||
-			len(siteContexts) == 0,
-	}, nil
-}
-
-func (h *Handler) eventTargetSiteResourceContexts(
-	ctx context.Context,
-	orgID int64,
-	event *models.Event,
-) ([]authz.ResourceContext, error) {
-	rc, err := eventResourceContext(event)
-	if err != nil {
-		return nil, err
-	}
-	if rc.SiteID != nil {
-		return []authz.ResourceContext{rc}, nil
-	}
-	if event == nil || event.ScopeType == "" || event.ScopeType == models.ScopeTypeWholeOrg {
-		return nil, nil
-	}
-	if contexts, handled, err := mixedSiteOnlyEventResourceContexts(event); handled || err != nil {
-		return contexts, err
-	}
-	var coverage models.TargetSiteCoverage
-	if event.TargetSiteCoverage != nil {
-		coverage = *event.TargetSiteCoverage
-	} else {
-		var err error
-		coverage, err = h.service.ListTargetSiteCoverageByEvent(ctx, orgID, event.EventUUID)
-		if err != nil {
-			return nil, err
-		}
-		event.TargetSiteCoverage = &coverage
-	}
-	if !coverage.Complete {
-		return nil, fleeterror.NewForbiddenError(incompleteTargetSiteContextMessage)
-	}
-	if len(coverage.SiteIDs) == 0 {
-		if contexts, handled, err := h.scopeJSONEventResourceContexts(ctx, orgID, event); handled || err != nil {
-			return contexts, err
-		}
-	}
-	contexts := make([]authz.ResourceContext, 0, len(coverage.SiteIDs))
-	for _, siteID := range coverage.SiteIDs {
-		contexts = append(contexts, authz.ResourceContext{SiteID: &siteID})
-	}
-	return contexts, nil
-}
-
-func (h *Handler) eventFacilityFanResourceContexts(
-	ctx context.Context,
-	orgID int64,
-	event *models.Event,
-	deviceSites map[int64]int64,
-) ([]authz.ResourceContext, error) {
-	if event == nil || len(event.FacilityFanDeviceIDs) == 0 {
-		return nil, nil
-	}
-	if len(event.FacilityFanDeviceIDs) == len(event.FacilityFanSiteIDs) {
-		for _, siteID := range event.FacilityFanSiteIDs {
-			if siteID <= 0 {
-				return nil, fleeterror.NewForbiddenError(incompleteTargetSiteContextMessage)
-			}
-		}
-		return siteResourceContextsForScope(curtailment.Scope{
-			SiteIDs: append([]int64(nil), event.FacilityFanSiteIDs...),
-		}), nil
-	}
-	if deviceSites == nil {
-		if h.responseProfiles == nil {
-			return nil, errCurtailmentNotImplemented("facility fan event authorization")
-		}
-		var err error
-		deviceSites, err = h.responseProfiles.FacilityFanDeviceSites(ctx, orgID, event.FacilityFanDeviceIDs)
-		if err != nil {
-			if fleeterror.IsNotFoundError(err) {
-				return nil, fleeterror.NewForbiddenError(incompleteTargetSiteContextMessage)
-			}
-			return nil, err
-		}
-	}
-	siteIDs := make([]int64, 0, len(event.FacilityFanDeviceIDs))
-	for _, deviceID := range event.FacilityFanDeviceIDs {
-		siteID, ok := deviceSites[deviceID]
-		if !ok {
-			return nil, fleeterror.NewForbiddenError(incompleteTargetSiteContextMessage)
-		}
-		siteIDs = append(siteIDs, siteID)
-	}
-	return siteResourceContextsForScope(curtailment.Scope{SiteIDs: siteIDs}), nil
-}
-
-func mixedSiteOnlyEventResourceContexts(event *models.Event) ([]authz.ResourceContext, bool, error) {
-	if event == nil || event.ScopeType != models.ScopeTypeMixed {
-		return nil, false, nil
-	}
-	scope, hasScope, err := curtailment.ScopeFromJSON(event.ScopeJSON)
-	if err != nil {
-		return nil, true, fleeterror.NewInternalErrorf(
-			"failed to decode mixed curtailment event scope: %v", err,
-		)
-	}
-	if !hasScope || !curtailment.IsSiteOnlyScope(scope) {
-		return nil, false, nil
-	}
-	contexts := siteResourceContextsForScope(scope)
-	if len(contexts) == 0 {
-		return nil, true, fleeterror.NewInternalError("mixed site-only curtailment event has no site_ids")
-	}
-	return contexts, true, nil
-}
-
-func (h *Handler) scopeJSONEventResourceContexts(
-	ctx context.Context,
-	orgID int64,
-	event *models.Event,
-) ([]authz.ResourceContext, bool, error) {
-	if event == nil || len(event.ScopeJSON) == 0 {
-		return nil, false, nil
-	}
-	scope, hasScope, err := curtailment.ScopeFromJSON(event.ScopeJSON)
-	if err != nil {
-		return nil, true, fleeterror.NewInternalErrorf(
-			"failed to decode curtailment event scope: %v", err,
-		)
-	}
-	if !hasScope {
-		return nil, false, nil
-	}
-	requirements, err := h.scopeResourceContextRequirements(ctx, orgID, scope, nil, false)
-	if err != nil {
-		return nil, true, err
-	}
-	if requirements.requireOrgWide {
-		return nil, true, fleeterror.NewForbiddenError(incompleteTargetSiteContextMessage)
-	}
-	return requirements.siteContexts, true, nil
-}
-
-func isIncompleteTargetSiteContextError(err error) bool {
-	return fleeterror.IsForbiddenError(err) && strings.Contains(err.Error(), incompleteTargetSiteContextMessage)
 }
 
 // requireAdminFromContext returns Forbidden unless the caller has Admin

--- a/server/internal/handlers/curtailment/handler.go
+++ b/server/internal/handlers/curtailment/handler.go
@@ -119,6 +119,28 @@ func (h *Handler) StartCurtailment(ctx context.Context, req *connect.Request[pb.
 	if err != nil {
 		return nil, err
 	}
+	startReq, err := toStartRequest(req.Msg, info)
+	if err != nil {
+		return nil, err
+	}
+	if h.service != nil {
+		replayEvent, err := h.service.LookupStartReplay(ctx, startReq)
+		if err != nil {
+			return nil, err
+		}
+		if replayEvent != nil {
+			if err := h.requirePersistedEventPermission(ctx, info.OrganizationID, authz.PermCurtailmentManage, replayEvent); err != nil {
+				return nil, err
+			}
+			plan, err := h.service.RenderStartReplay(ctx, info.OrganizationID, replayEvent)
+			if err != nil {
+				return nil, err
+			}
+			return connect.NewResponse(&pb.StartCurtailmentResponse{
+				Event: toEventProtoWithTargets(plan.ReplayEvent, plan.ReplayTargets),
+			}), nil
+		}
+	}
 	requirements, err := h.startResourceContextRequirements(ctx, info.OrganizationID, req.Msg)
 	if err != nil {
 		return nil, err
@@ -145,10 +167,6 @@ func (h *Handler) StartCurtailment(ctx context.Context, req *connect.Request[pb.
 		return nil, errCurtailmentNotImplemented("StartCurtailment")
 	}
 
-	startReq, err := toStartRequest(req.Msg, info)
-	if err != nil {
-		return nil, err
-	}
 	startReq.AuthorizedDeviceSites = requirements.deviceSites
 	startReq.AuthorizedFanSites = make(map[int64]int64, len(authorizedFans))
 	for deviceID, device := range authorizedFans {
@@ -321,6 +339,9 @@ func (h *Handler) GetCurtailmentEvent(ctx context.Context, req *connect.Request[
 	}
 	info, permissionEvent, err := h.requireEventPermission(ctx, authz.PermCurtailmentRead, eventUUID)
 	if err != nil {
+		return nil, err
+	}
+	if err := h.hydrateTargetSiteCoverageByEvent(ctx, info.OrganizationID, permissionEvent); err != nil {
 		return nil, err
 	}
 	event, targets, nextTargetPageToken, err := h.service.GetEventWithTargets(ctx, curtailment.GetEventWithTargetsRequest{
@@ -750,9 +771,6 @@ func (h *Handler) requireEventPermission(ctx context.Context, permission string,
 	if err := requireAuthorizationEnvelopePermissions(ctx, permission, event.AuthorizationEnvelopeJSON); err != nil {
 		return nil, nil, err
 	}
-	if err := h.hydrateTargetSiteCoverageByEvent(ctx, info.OrganizationID, event); err != nil {
-		return nil, nil, err
-	}
 	return info, event, nil
 }
 
@@ -773,10 +791,7 @@ func (h *Handler) requirePersistedEventPermission(ctx context.Context, orgID int
 	if event == nil || event.OrgID != orgID {
 		return fleeterror.NewNotFoundError("curtailment event not found")
 	}
-	if err := requireAuthorizationEnvelopePermissions(ctx, permission, event.AuthorizationEnvelopeJSON); err != nil {
-		return err
-	}
-	return h.hydrateTargetSiteCoverageByEvent(ctx, orgID, event)
+	return requireAuthorizationEnvelopePermissions(ctx, permission, event.AuthorizationEnvelopeJSON)
 }
 
 func (h *Handler) filterEventsByPermission(

--- a/server/internal/handlers/curtailment/handler_admin_terminate_test.go
+++ b/server/internal/handlers/curtailment/handler_admin_terminate_test.go
@@ -136,10 +136,10 @@ func (s *adminTerminateStubStore) BulkRefreshAllPairedTargetReadiness(
 }
 func (s *adminTerminateStubStore) GetEventByUUID(_ context.Context, _ int64, eventUUID uuid.UUID) (*models.Event, error) {
 	if s.authEvent != nil {
-		return s.authEvent, nil
+		return ensureTestEventAuthorizationEnvelope(s.authEvent, s.targetSiteIDs, s.targetSitesComplete), nil
 	}
 	if s.result != nil && s.result.EventUUID == eventUUID {
-		return s.result, nil
+		return ensureTestEventAuthorizationEnvelope(s.result, s.targetSiteIDs, s.targetSitesComplete), nil
 	}
 	return nil, fleeterror.NewNotFoundErrorf("curtailment event not found: %s", eventUUID)
 }
@@ -591,14 +591,21 @@ func TestHandler_ForceReleaseCurtailmentOwnership_RejectsWholeOrgWithFanWhenOrgG
 	assert.Equal(t, 0, store.forceReleaseCalls)
 }
 
-func TestHandler_ForceReleaseCurtailmentOwnership_RejectsSiteOnlyManage(t *testing.T) {
+func TestHandler_ForceReleaseCurtailmentOwnership_AllowsMatchingSiteOnlyManage(t *testing.T) {
 	t.Parallel()
 	const (
 		orgID  = int64(42)
 		siteID = int64(7)
 	)
 	eventUUID := uuid.New()
-	store := &adminTerminateStubStore{}
+	store := &adminTerminateStubStore{result: &models.Event{
+		ID:        99,
+		EventUUID: eventUUID,
+		OrgID:     orgID,
+		State:     models.EventStateCancelled,
+		ScopeType: models.ScopeTypeSite,
+		ScopeJSON: siteScopeJSON(t, siteID),
+	}}
 	h := NewHandler(domainCurtailment.NewService(store))
 	ctx := testSessionCtxWithAssignments(t, &session.Info{
 		AuthMethod:     session.AuthMethodSession,
@@ -612,11 +619,8 @@ func TestHandler_ForceReleaseCurtailmentOwnership_RejectsSiteOnlyManage(t *testi
 		Reason:    "operator release",
 	}))
 
-	require.Error(t, err)
-	var fleetErr fleeterror.FleetError
-	require.ErrorAs(t, err, &fleetErr)
-	assert.Equal(t, connect.CodePermissionDenied, fleetErr.GRPCCode)
-	assert.Equal(t, 0, store.forceReleaseCalls)
+	require.NoError(t, err)
+	assert.Equal(t, 1, store.forceReleaseCalls)
 }
 
 func TestHandler_ForceReleaseCurtailmentOwnership_RejectsNonAdmin(t *testing.T) {
@@ -849,7 +853,7 @@ func TestHandler_AdminTerminateEvent_UsesSiteScopedEventPermission(t *testing.T)
 	}{
 		{"org permission without site narrowing allows terminate", []authz.Assignment{testOrgAssignment(authz.PermCurtailmentManage)}, 0, 1},
 		{"matching site narrowing allows terminate", []authz.Assignment{testOrgAssignment(authz.PermCurtailmentManage), testSiteAssignment(allowedSite, authz.PermCurtailmentManage)}, 0, 1},
-		{"site-only permission denies terminate", []authz.Assignment{testSiteAssignment(allowedSite, authz.PermCurtailmentManage)}, connect.CodePermissionDenied, 0},
+		{"site-only permission allows matching terminate", []authz.Assignment{testSiteAssignment(allowedSite, authz.PermCurtailmentManage)}, 0, 1},
 		{"site narrowing without manage denies terminate", []authz.Assignment{testOrgAssignment(authz.PermCurtailmentManage), testSiteAssignment(allowedSite)}, connect.CodePermissionDenied, 0},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/server/internal/handlers/curtailment/handler_admin_terminate_test.go
+++ b/server/internal/handlers/curtailment/handler_admin_terminate_test.go
@@ -45,11 +45,13 @@ type adminTerminateStubStore struct {
 	forceReleaseErr                error
 	// Targets returned by ListTargetsByEvent; admin-terminate fetches them
 	// post-terminate so the response shape mirrors the read endpoints.
-	targets             []*models.Target
-	targetsErr          error
-	listTargetsCalls    int
-	targetSiteIDs       []int64
-	targetSitesComplete bool
+	targets                 []*models.Target
+	targetsErr              error
+	listTargetsCalls        int
+	targetSiteIDs           []int64
+	targetSitesComplete     bool
+	targetSiteCoverageErr   error
+	targetSiteCoverageCalls int
 }
 
 func (s *adminTerminateStubStore) AdminTerminateEvent(_ context.Context, orgID int64, eventUUID uuid.UUID, targetState models.EventState, reason string) (*models.Event, bool, error) {
@@ -157,6 +159,10 @@ func (s *adminTerminateStubStore) ListTargetsByEventPage(context.Context, interf
 	panic("ListTargetsByEventPage not exercised by AdminTerminate handler tests")
 }
 func (s *adminTerminateStubStore) ListTargetSiteCoverageByEvent(context.Context, int64, uuid.UUID) (models.TargetSiteCoverage, error) {
+	s.targetSiteCoverageCalls++
+	if s.targetSiteCoverageErr != nil {
+		return models.TargetSiteCoverage{}, s.targetSiteCoverageErr
+	}
 	siteIDs := append([]int64(nil), s.targetSiteIDs...)
 	mappedTargetCount := int64(len(siteIDs))
 	targetCount := mappedTargetCount
@@ -273,6 +279,42 @@ func TestHandler_AdminTerminateEvent_HappyPath(t *testing.T) {
 	assert.Equal(t, "operator escalation", store.lastReason)
 }
 
+func TestHandler_AdminTerminateEvent_DoesNotHydrateDisplayCoverageBeforeControl(t *testing.T) {
+	t.Parallel()
+	eventUUID := uuid.New()
+	store := &adminTerminateStubStore{
+		authEvent: &models.Event{
+			ID:        99,
+			EventUUID: eventUUID,
+			OrgID:     42,
+			State:     models.EventStateActive,
+			ScopeType: models.ScopeTypeDeviceList,
+		},
+		result: &models.Event{
+			ID:        99,
+			EventUUID: eventUUID,
+			OrgID:     42,
+			State:     models.EventStateCancelled,
+			ScopeType: models.ScopeTypeDeviceList,
+		},
+		targetSiteCoverageErr: assert.AnError,
+	}
+	h := NewHandler(domainCurtailment.NewService(store))
+
+	_, err := h.AdminTerminateEvent(
+		adminTerminateSessionCtx(42, "ADMIN"),
+		connect.NewRequest(&pb.AdminTerminateEventRequest{
+			EventUuid:   eventUUID.String(),
+			TargetState: pb.CurtailmentEventState_CURTAILMENT_EVENT_STATE_CANCELLED,
+			Reason:      "operator escalation",
+		}),
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, store.calls)
+	assert.Zero(t, store.targetSiteCoverageCalls)
+}
+
 func TestHandler_ForceReleaseCurtailmentOwnership_HappyPath(t *testing.T) {
 	t.Parallel()
 	eventUUID := uuid.New()
@@ -377,6 +419,76 @@ func TestHandler_ForceReleaseCurtailmentOwnership_BypassesIncompleteTargetSiteCo
 
 	require.NoError(t, err)
 	assert.Equal(t, 1, store.forceReleaseCalls)
+}
+
+func TestHandler_ForceReleaseCurtailmentOwnership_DoesNotHydrateDisplayCoverageBeforeRecovery(t *testing.T) {
+	t.Parallel()
+	eventUUID := uuid.New()
+	store := &adminTerminateStubStore{
+		authEvent: &models.Event{
+			ID:        99,
+			EventUUID: eventUUID,
+			OrgID:     42,
+			State:     models.EventStateActive,
+			ScopeType: models.ScopeTypeDeviceList,
+		},
+		result: &models.Event{
+			ID:        99,
+			EventUUID: eventUUID,
+			OrgID:     42,
+			State:     models.EventStateCancelled,
+			ScopeType: models.ScopeTypeDeviceList,
+		},
+		targetSiteCoverageErr: assert.AnError,
+	}
+	h := NewHandler(domainCurtailment.NewService(store))
+
+	_, err := h.ForceReleaseCurtailmentOwnership(
+		adminTerminateSessionCtx(42, "ADMIN"),
+		connect.NewRequest(&pb.ForceReleaseCurtailmentOwnershipRequest{
+			EventUuid: eventUUID.String(),
+			Reason:    "operator release",
+		}),
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, store.forceReleaseCalls)
+	assert.Zero(t, store.targetSiteCoverageCalls)
+}
+
+func TestHandler_ForceReleaseCurtailmentOwnership_FailsClosedForMalformedPersistedEnvelope(t *testing.T) {
+	t.Parallel()
+	eventUUID := uuid.New()
+	store := &adminTerminateStubStore{
+		authEvent: &models.Event{
+			ID:                        99,
+			EventUUID:                 eventUUID,
+			OrgID:                     42,
+			State:                     models.EventStateActive,
+			AuthorizationEnvelopeJSON: []byte(`{"schema_version":`),
+		},
+		result: &models.Event{
+			ID:        99,
+			EventUUID: eventUUID,
+			OrgID:     42,
+			State:     models.EventStateCancelled,
+		},
+	}
+	h := NewHandler(domainCurtailment.NewService(store))
+
+	_, err := h.ForceReleaseCurtailmentOwnership(
+		adminTerminateSessionCtx(42, "ADMIN"),
+		connect.NewRequest(&pb.ForceReleaseCurtailmentOwnershipRequest{
+			EventUuid: eventUUID.String(),
+			Reason:    "operator release",
+		}),
+	)
+
+	require.Error(t, err)
+	var fleetErr fleeterror.FleetError
+	require.ErrorAs(t, err, &fleetErr)
+	assert.Equal(t, connect.CodeInternal, fleetErr.GRPCCode)
+	assert.Zero(t, store.forceReleaseCalls)
 }
 
 func TestHandler_ForceReleaseCurtailmentOwnership_RejectsSiteNarrowedKnownSite(t *testing.T) {

--- a/server/internal/handlers/curtailment/handler_list_test.go
+++ b/server/internal/handlers/curtailment/handler_list_test.go
@@ -738,6 +738,105 @@ func TestHandler_ListCurtailmentEvents_FiltersEventsByPersistedFacilityFanSite(t
 	assert.Zero(t, profileStore.infrastructureDeviceListCalls, "persisted envelopes must not re-resolve facility fans")
 }
 
+func TestHandler_ListCurtailmentEvents_FailsClosedForMalformedPersistedEnvelope(t *testing.T) {
+	t.Parallel()
+	const orgID = int64(42)
+	store := &listStubStore{events: []*models.Event{{
+		ID:                        5,
+		EventUUID:                 uuid.New(),
+		OrgID:                     orgID,
+		State:                     models.EventStateCompleted,
+		ScopeType:                 models.ScopeTypeSite,
+		AuthorizationEnvelopeJSON: []byte(`{"schema_version":`),
+	}}}
+	h := NewHandler(domainCurtailment.NewService(store))
+
+	_, err := h.ListCurtailmentEvents(
+		sessionCtx(orgID),
+		connect.NewRequest(&pb.ListCurtailmentEventsRequest{}),
+	)
+
+	require.Error(t, err)
+	var fleetErr fleeterror.FleetError
+	require.ErrorAs(t, err, &fleetErr)
+	assert.Equal(t, connect.CodeInternal, fleetErr.GRPCCode)
+}
+
+func TestHandler_ListCurtailmentEvents_RequiresIndependentFacilityFanSiteRead(t *testing.T) {
+	t.Parallel()
+	const (
+		orgID     = int64(42)
+		minerSite = int64(7)
+		fanSite   = int64(8)
+	)
+
+	for _, test := range []struct {
+		name              string
+		fanScopeUnbounded bool
+		assignments       []authz.Assignment
+		wantEvents        int
+	}{
+		{
+			name: "bounded fan site without site read is filtered",
+			assignments: []authz.Assignment{
+				testSiteAssignment(minerSite, authz.PermCurtailmentRead),
+				testSiteAssignment(fanSite, authz.PermCurtailmentRead),
+			},
+		},
+		{
+			name: "bounded fan site with site read is visible",
+			assignments: []authz.Assignment{
+				testSiteAssignment(minerSite, authz.PermCurtailmentRead),
+				testSiteAssignment(fanSite, authz.PermCurtailmentRead, authz.PermSiteRead),
+			},
+			wantEvents: 1,
+		},
+		{
+			name:              "unbounded fan scope requires org-wide site read",
+			fanScopeUnbounded: true,
+			assignments: []authz.Assignment{
+				testOrgAssignment(authz.PermCurtailmentRead),
+				testSiteAssignment(fanSite, authz.PermSiteRead),
+			},
+		},
+		{
+			name:              "unbounded fan scope with org-wide site read is visible",
+			fanScopeUnbounded: true,
+			assignments: []authz.Assignment{
+				testOrgAssignment(authz.PermCurtailmentRead, authz.PermSiteRead),
+			},
+			wantEvents: 1,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			event := &models.Event{
+				ID:        5,
+				EventUUID: uuid.New(),
+				OrgID:     orgID,
+				State:     models.EventStateCompleted,
+				ScopeType: models.ScopeTypeSite,
+				AuthorizationEnvelopeJSON: testAuthorizationEnvelopeJSON(
+					[]int64{minerSite}, nil, false, []int64{fanSite}, test.fanScopeUnbounded,
+				),
+			}
+			store := &listStubStore{events: []*models.Event{event}}
+			h := NewHandler(domainCurtailment.NewService(store))
+			ctx := testSessionCtxWithAssignments(t, &session.Info{
+				AuthMethod:     session.AuthMethodSession,
+				OrganizationID: orgID,
+				UserID:         9,
+				Role:           "OPERATOR",
+			}, test.assignments...)
+
+			resp, err := h.ListCurtailmentEvents(ctx, connect.NewRequest(&pb.ListCurtailmentEventsRequest{}))
+
+			require.NoError(t, err)
+			assert.Len(t, resp.Msg.Events, test.wantEvents)
+		})
+	}
+}
+
 func TestHandler_ListCurtailmentEvents_UsesPersistedFacilityFanSiteSnapshot(t *testing.T) {
 	t.Parallel()
 	const (

--- a/server/internal/handlers/curtailment/handler_list_test.go
+++ b/server/internal/handlers/curtailment/handler_list_test.go
@@ -62,9 +62,20 @@ func (s *listStubStore) ListEvents(_ context.Context, params interfaces.ListEven
 		return nil, "", s.err
 	}
 	if s.eventsByPageToken != nil {
-		return s.eventsByPageToken[params.PageToken], s.nextByPageToken[params.PageToken], nil
+		return s.withAuthorizationEnvelopes(s.eventsByPageToken[params.PageToken]), s.nextByPageToken[params.PageToken], nil
 	}
-	return s.events, s.nextPageToken, nil
+	return s.withAuthorizationEnvelopes(s.events), s.nextPageToken, nil
+}
+
+func (s *listStubStore) withAuthorizationEnvelopes(events []*models.Event) []*models.Event {
+	for _, event := range events {
+		if event == nil {
+			continue
+		}
+		sites, hasCoverage := s.targetSiteIDsByUUID[event.EventUUID]
+		ensureTestEventAuthorizationEnvelope(event, sites, hasCoverage && !s.incompleteTargetSite[event.EventUUID])
+	}
+	return events
 }
 
 func (s *listStubStore) GetOrgConfig(context.Context, int64) (*models.OrgConfig, error) {
@@ -125,7 +136,8 @@ func (s *listStubStore) GetEventByUUID(_ context.Context, orgID int64, eventUUID
 	if !ok {
 		return nil, fleeterror.NewNotFoundErrorf("curtailment event not found: %s", eventUUID)
 	}
-	return ev, nil
+	sites, hasCoverage := s.targetSiteIDsByUUID[eventUUID]
+	return ensureTestEventAuthorizationEnvelope(ev, sites, hasCoverage && !s.incompleteTargetSite[eventUUID]), nil
 }
 func (s *listStubStore) GetEventDetailByUUID(ctx context.Context, orgID int64, eventUUID uuid.UUID) (*models.Event, error) {
 	s.lastGetOrgID = orgID
@@ -137,10 +149,11 @@ func (s *listStubStore) GetEventDetailByUUID(ctx context.Context, orgID int64, e
 	if !ok {
 		return nil, fleeterror.NewNotFoundErrorf("curtailment event not found: %s", eventUUID)
 	}
-	return ev, nil
+	sites, hasCoverage := s.targetSiteIDsByUUID[eventUUID]
+	return ensureTestEventAuthorizationEnvelope(ev, sites, hasCoverage && !s.incompleteTargetSite[eventUUID]), nil
 }
 func (s *listStubStore) ListActiveEvents(context.Context, int64) ([]*models.Event, error) {
-	return s.activeEvents, nil
+	return s.withAuthorizationEnvelopes(s.activeEvents), nil
 }
 func (s *listStubStore) ListTargetsByEvent(_ context.Context, _ int64, eventUUID uuid.UUID) ([]*models.Target, error) {
 	if s.targetsByUUID == nil {
@@ -414,7 +427,7 @@ func TestHandler_ListActiveCurtailments_ReturnsActiveEvents(t *testing.T) {
 // aggregates target counts across every site — including sites the caller's
 // read grant is narrowed away from — so the rollup requires unnarrowed
 // org-wide read. Site-scoped events at permitted sites keep their rollups.
-func TestHandler_ListActiveCurtailments_OmitsWholeOrgRollupForNarrowedRead(t *testing.T) {
+func TestHandler_ListActiveCurtailments_FiltersWholeOrgEventsForNarrowedRead(t *testing.T) {
 	t.Parallel()
 	const (
 		orgID       = int64(42)
@@ -470,14 +483,10 @@ func TestHandler_ListActiveCurtailments_OmitsWholeOrgRollupForNarrowedRead(t *te
 
 	resp, err := h.ListActiveCurtailments(narrowedCtx, connect.NewRequest(&pb.ListActiveCurtailmentsRequest{}))
 	require.NoError(t, err)
-	require.Len(t, resp.Msg.Events, 2)
-	assert.Equal(t, wholeOrgUUID.String(), resp.Msg.Events[0].EventUuid,
-		"whole-org events stay visible so narrowed operators learn their sites are curtailed")
-	assert.Nil(t, resp.Msg.Events[0].TargetRollup,
-		"whole-org rollup aggregates narrowed sites; it must not ship without org-wide read")
-	require.NotNil(t, resp.Msg.Events[1].TargetRollup,
-		"site-scoped rollups at permitted sites are unaffected by narrowing elsewhere")
-	assert.Equal(t, int32(3), resp.Msg.Events[1].TargetRollup.Total)
+	require.Len(t, resp.Msg.Events, 1)
+	assert.Equal(t, allowedSiteUUID.String(), resp.Msg.Events[0].EventUuid)
+	require.NotNil(t, resp.Msg.Events[0].TargetRollup)
+	assert.Equal(t, int32(3), resp.Msg.Events[0].TargetRollup.Total)
 
 	orgWideCtx := testSessionCtxWithAssignments(t, &session.Info{
 		AuthMethod:     session.AuthMethodSession,
@@ -564,9 +573,8 @@ func TestHandler_ListActiveCurtailments_FiltersSiteScopedEvents(t *testing.T) {
 	resp, err := h.ListActiveCurtailments(ctx, connect.NewRequest(&pb.ListActiveCurtailmentsRequest{}))
 	require.NoError(t, err)
 
-	require.Len(t, resp.Msg.Events, 2)
-	assert.Equal(t, orgScopedUUID.String(), resp.Msg.Events[0].EventUuid)
-	assert.Equal(t, allowedSiteUUID.String(), resp.Msg.Events[1].EventUuid)
+	require.Len(t, resp.Msg.Events, 1)
+	assert.Equal(t, allowedSiteUUID.String(), resp.Msg.Events[0].EventUuid)
 }
 
 func TestHandler_ListCurtailmentEvents_FiltersSiteScopedEventsAcrossPages(t *testing.T) {
@@ -664,7 +672,7 @@ func TestHandler_ListCurtailmentEvents_CapsPermissionFilteringScan(t *testing.T)
 	assert.Equal(t, []string{"", "page-2", "page-3"}, store.listPageTokens)
 }
 
-func TestHandler_ListCurtailmentEvents_FiltersEventsByFacilityFanSite(t *testing.T) {
+func TestHandler_ListCurtailmentEvents_FiltersEventsByPersistedFacilityFanSite(t *testing.T) {
 	t.Parallel()
 	const (
 		orgID       = int64(42)
@@ -683,6 +691,9 @@ func TestHandler_ListCurtailmentEvents_FiltersEventsByFacilityFanSite(t *testing
 				ScopeType:            models.ScopeTypeSite,
 				ScopeJSON:            siteScopeJSON(t, allowedSite),
 				FacilityFanDeviceIDs: []int64{firstFanID},
+				AuthorizationEnvelopeJSON: testAuthorizationEnvelopeJSON(
+					[]int64{allowedSite}, nil, false, []int64{deniedSite}, false,
+				),
 			},
 			{
 				ID:                   4,
@@ -692,6 +703,9 @@ func TestHandler_ListCurtailmentEvents_FiltersEventsByFacilityFanSite(t *testing
 				ScopeType:            models.ScopeTypeSite,
 				ScopeJSON:            siteScopeJSON(t, allowedSite),
 				FacilityFanDeviceIDs: []int64{secondFanID},
+				AuthorizationEnvelopeJSON: testAuthorizationEnvelopeJSON(
+					[]int64{allowedSite}, nil, false, []int64{deniedSite}, false,
+				),
 			},
 		},
 	}
@@ -721,7 +735,7 @@ func TestHandler_ListCurtailmentEvents_FiltersEventsByFacilityFanSite(t *testing
 	require.NoError(t, err)
 
 	assert.Empty(t, resp.Msg.Events)
-	assert.Equal(t, 1, profileStore.infrastructureDeviceListCalls, "fan sites should be resolved once per event page")
+	assert.Zero(t, profileStore.infrastructureDeviceListCalls, "persisted envelopes must not re-resolve facility fans")
 }
 
 func TestHandler_ListCurtailmentEvents_UsesPersistedFacilityFanSiteSnapshot(t *testing.T) {
@@ -747,7 +761,8 @@ func TestHandler_ListCurtailmentEvents_UsesPersistedFacilityFanSiteSnapshot(t *t
 		OrganizationID: orgID,
 		UserID:         9,
 		Role:           "OPERATOR",
-	}, testOrgAssignment(authz.PermCurtailmentRead), testSiteAssignment(allowedSite, authz.PermCurtailmentRead))
+	}, testOrgAssignment(authz.PermCurtailmentRead, authz.PermSiteRead),
+		testSiteAssignment(allowedSite, authz.PermCurtailmentRead, authz.PermSiteRead))
 
 	resp, err := h.ListCurtailmentEvents(ctx, connect.NewRequest(&pb.ListCurtailmentEventsRequest{}))
 
@@ -776,14 +791,14 @@ func TestHandler_ListCurtailmentEvents_MissingFacilityFanRequiresOrgWideRead(t *
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			ctx := sessionCtx(orgID)
+			ctx := sessionCtxWithPerms(orgID, authz.PermCurtailmentRead, authz.PermSiteRead)
 			if !test.orgWide {
 				ctx = testSessionCtxWithAssignments(t, &session.Info{
 					AuthMethod:     session.AuthMethodSession,
 					OrganizationID: orgID,
 					UserID:         9,
 					Role:           "OPERATOR",
-				}, testOrgAssignment(authz.PermCurtailmentRead), testSiteAssignment(narrowedSite))
+				}, testOrgAssignment(authz.PermCurtailmentRead, authz.PermSiteRead), testSiteAssignment(narrowedSite))
 			}
 			store := &listStubStore{events: []*models.Event{{
 				ID:                   5,
@@ -802,7 +817,7 @@ func TestHandler_ListCurtailmentEvents_MissingFacilityFanRequiresOrgWideRead(t *
 			resp, err := h.ListCurtailmentEvents(ctx, connect.NewRequest(&pb.ListCurtailmentEventsRequest{}))
 			require.NoError(t, err)
 			assert.Len(t, resp.Msg.Events, test.wantEvents)
-			assert.Equal(t, 1, profileStore.infrastructureDeviceListCalls)
+			assert.Zero(t, profileStore.infrastructureDeviceListCalls)
 		})
 	}
 }
@@ -1041,6 +1056,9 @@ func TestHandler_ListCurtailmentEvents_UsesTargetlessDeviceScopeJSON(t *testing.
 				ScopeType: models.ScopeTypeDeviceList,
 				ScopeJSON: []byte(`{"device_identifiers":["allowed-miner"]}`),
 				Reason:    "targetless allowed device scope",
+				AuthorizationEnvelopeJSON: testAuthorizationEnvelopeJSON(
+					nil, []int64{allowedSite}, false, nil, false,
+				),
 			},
 			{
 				ID:        2,
@@ -1050,6 +1068,9 @@ func TestHandler_ListCurtailmentEvents_UsesTargetlessDeviceScopeJSON(t *testing.
 				ScopeType: models.ScopeTypeDeviceList,
 				ScopeJSON: []byte(`{"device_identifiers":["denied-miner"]}`),
 				Reason:    "targetless denied device scope",
+				AuthorizationEnvelopeJSON: testAuthorizationEnvelopeJSON(
+					nil, []int64{deniedSite}, false, nil, false,
+				),
 			},
 		},
 		targetSiteIDsByUUID: map[uuid.UUID][]int64{},
@@ -1075,6 +1096,13 @@ func TestHandler_ListCurtailmentEvents_UsesTargetlessDeviceScopeJSON(t *testing.
 
 	require.Len(t, resp.Msg.Events, 1)
 	assert.Equal(t, allowedUUID.String(), resp.Msg.Events[0].EventUuid)
+	coverage := resp.Msg.Events[0].GetTargetSiteCoverage()
+	require.NotNil(t, coverage)
+	assert.True(t, coverage.GetComplete())
+	assert.Zero(t, coverage.GetTargetCount())
+	assert.Equal(t, 1, store.coverageBatchCalls)
+	assert.Equal(t, []uuid.UUID{allowedUUID}, store.lastCoverageBatch)
+	assert.Zero(t, profileStore.infrastructureDeviceListCalls)
 }
 
 func TestHandler_GetCurtailmentEvent_AllowsTargetlessDeviceListScope(t *testing.T) {
@@ -1339,7 +1367,7 @@ func TestHandler_GetCurtailmentEvent_UsesSiteScopedEventPermission(t *testing.T)
 	}{
 		{"org permission without site narrowing allows read", []authz.Assignment{testOrgAssignment(authz.PermCurtailmentRead)}, 0},
 		{"matching site narrowing allows read", []authz.Assignment{testOrgAssignment(authz.PermCurtailmentRead), testSiteAssignment(allowedSite, authz.PermCurtailmentRead)}, 0},
-		{"site-only permission denies read", []authz.Assignment{testSiteAssignment(allowedSite, authz.PermCurtailmentRead)}, connect.CodePermissionDenied},
+		{"site-only permission allows matching read", []authz.Assignment{testSiteAssignment(allowedSite, authz.PermCurtailmentRead)}, 0},
 		{"site narrowing without read denies read", []authz.Assignment{testOrgAssignment(authz.PermCurtailmentRead), testSiteAssignment(allowedSite)}, connect.CodePermissionDenied},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/server/internal/handlers/curtailment/handler_response_profiles_test.go
+++ b/server/internal/handlers/curtailment/handler_response_profiles_test.go
@@ -488,7 +488,7 @@ func TestHandler_GetCurtailmentResponseProfileChecksStoredSite(t *testing.T) {
 	assert.Equal(t, connect.CodePermissionDenied, fleetErr.GRPCCode)
 }
 
-func TestHandler_GetCurtailmentResponseProfileMasksInaccessibleFacilityFans(t *testing.T) {
+func TestHandler_GetCurtailmentResponseProfileChecksPersistedFacilityFanSites(t *testing.T) {
 	t.Parallel()
 
 	profileSiteID := int64(7)
@@ -515,7 +515,8 @@ func TestHandler_GetCurtailmentResponseProfileMasksInaccessibleFacilityFans(t *t
 	require.Error(t, err)
 	var fleetErr fleeterror.FleetError
 	require.ErrorAs(t, err, &fleetErr)
-	assert.Equal(t, connect.CodeNotFound, fleetErr.GRPCCode)
+	assert.Equal(t, connect.CodePermissionDenied, fleetErr.GRPCCode)
+	assert.Zero(t, store.infrastructureDeviceListCalls, "persisted envelopes must not re-resolve facility fans")
 }
 
 func TestHandler_GetCurtailmentResponseProfileChecksStoredCompositeSites(t *testing.T) {
@@ -896,6 +897,7 @@ func TestHandler_DeleteCurtailmentResponseProfile(t *testing.T) {
 	require.NotNil(t, store.deleteExpectedSiteID)
 	assert.Equal(t, siteID, *store.deleteExpectedSiteID)
 	assert.JSONEq(t, `{"site_id":7}`, string(store.deleteExpectedScopeJSON))
+	assert.JSONEq(t, string(store.profiles[0].AuthorizationEnvelopeJSON), string(store.deleteExpectedAuthorizationEnvelopeJSON))
 	assert.Equal(t, []int64{31}, store.deleteExpectedFanSettings.FacilityFanDeviceIDs)
 	assert.Equal(t, int32(45), store.deleteExpectedFanSettings.FanOffDelaySec)
 	assert.Equal(t, int32(90), store.deleteExpectedFanSettings.FanRestoreDelaySec)
@@ -1023,23 +1025,24 @@ func TestHandler_ResponseProfileAdminCanCreateAllPairedPolicy(t *testing.T) {
 }
 
 type handlerResponseProfileStore struct {
-	siteBelongs                   bool
-	siteCheckCount                int
-	created                       *models.ResponseProfile
-	createdDeviceSites            map[string]*int64
-	updated                       *models.ResponseProfile
-	updateExpectedSiteID          *int64
-	updateExpectedScopeJSON       []byte
-	updateExpectedFanSettings     models.ResponseProfileFanSettings
-	deletedProfileID              int64
-	deleteExpectedSiteID          *int64
-	deleteExpectedScopeJSON       []byte
-	deleteExpectedFanSettings     models.ResponseProfileFanSettings
-	profiles                      []*models.ResponseProfile
-	deviceSites                   map[string]*int64
-	infrastructureDevices         map[int64]models.ResponseProfileInfrastructureDevice
-	infrastructureDeviceListCalls int
-	createdInfrastructureDevices  map[int64]models.ResponseProfileInfrastructureDevice
+	siteBelongs                             bool
+	siteCheckCount                          int
+	created                                 *models.ResponseProfile
+	createdDeviceSites                      map[string]*int64
+	updated                                 *models.ResponseProfile
+	updateExpectedSiteID                    *int64
+	updateExpectedScopeJSON                 []byte
+	updateExpectedFanSettings               models.ResponseProfileFanSettings
+	deletedProfileID                        int64
+	deleteExpectedSiteID                    *int64
+	deleteExpectedScopeJSON                 []byte
+	deleteExpectedAuthorizationEnvelopeJSON []byte
+	deleteExpectedFanSettings               models.ResponseProfileFanSettings
+	profiles                                []*models.ResponseProfile
+	deviceSites                             map[string]*int64
+	infrastructureDevices                   map[int64]models.ResponseProfileInfrastructureDevice
+	infrastructureDeviceListCalls           int
+	createdInfrastructureDevices            map[int64]models.ResponseProfileInfrastructureDevice
 }
 
 func newHandlerResponseProfileStore() *handlerResponseProfileStore {
@@ -1050,16 +1053,76 @@ func newHandlerResponseProfileStore() *handlerResponseProfileStore {
 }
 
 func (s *handlerResponseProfileStore) ListResponseProfiles(context.Context, int64) ([]*models.ResponseProfile, error) {
+	for _, profile := range s.profiles {
+		s.ensureAuthorizationEnvelope(profile)
+	}
 	return s.profiles, nil
 }
 
 func (s *handlerResponseProfileStore) GetResponseProfile(_ context.Context, _ int64, profileID int64) (*models.ResponseProfile, error) {
 	for _, profile := range s.profiles {
 		if profile.ID == profileID {
+			s.ensureAuthorizationEnvelope(profile)
 			return profile, nil
 		}
 	}
 	return nil, fleeterror.NewNotFoundErrorf("curtailment response profile not found: %d", profileID)
+}
+
+func (s *handlerResponseProfileStore) ensureAuthorizationEnvelope(profile *models.ResponseProfile) {
+	if profile == nil || len(profile.AuthorizationEnvelopeJSON) > 0 {
+		return
+	}
+	scope, err := domainCurtailment.ResponseProfileScope(*profile)
+	if err != nil {
+		panic(err)
+	}
+	var selectedSiteIDs []int64
+	var currentMemberSiteIDs []int64
+	minerScopeUnbounded := false
+	switch scope.Type {
+	case models.ScopeTypeWholeOrg:
+		minerScopeUnbounded = true
+	case models.ScopeTypeSite:
+		selectedSiteIDs = []int64{scope.SiteID}
+	case models.ScopeTypeMixed:
+		if domainCurtailment.IsSiteOnlyScope(scope) {
+			selectedSiteIDs = append([]int64(nil), scope.SiteIDs...)
+		} else {
+			minerScopeUnbounded = true
+		}
+	case models.ScopeTypeDeviceList:
+		for _, identifier := range scope.DeviceIdentifiers {
+			siteID, ok := s.deviceSites[identifier]
+			if !ok || siteID == nil {
+				minerScopeUnbounded = true
+				continue
+			}
+			currentMemberSiteIDs = append(currentMemberSiteIDs, *siteID)
+		}
+		if len(currentMemberSiteIDs) == 0 {
+			minerScopeUnbounded = true
+		}
+	default:
+		minerScopeUnbounded = true
+	}
+	var fanSiteIDs []int64
+	fanScopeUnbounded := false
+	for _, deviceID := range profile.FacilityFanDeviceIDs {
+		device, ok := s.infrastructureDevices[deviceID]
+		if !ok {
+			fanScopeUnbounded = true
+			continue
+		}
+		fanSiteIDs = append(fanSiteIDs, device.SiteID)
+	}
+	profile.AuthorizationEnvelopeJSON = testAuthorizationEnvelopeJSON(
+		selectedSiteIDs,
+		currentMemberSiteIDs,
+		minerScopeUnbounded,
+		fanSiteIDs,
+		fanScopeUnbounded,
+	)
 }
 
 func (*handlerResponseProfileStore) ListCandidates(
@@ -1112,10 +1175,11 @@ func (s *handlerResponseProfileStore) UpdateResponseProfile(_ context.Context, p
 	return &profile, nil
 }
 
-func (s *handlerResponseProfileStore) DeleteResponseProfile(_ context.Context, _ int64, profileID int64, expectedSiteID *int64, expectedScopeJSON []byte, expectedFanSettings models.ResponseProfileFanSettings) error {
+func (s *handlerResponseProfileStore) DeleteResponseProfile(_ context.Context, _ int64, profileID int64, expectedSiteID *int64, expectedScopeJSON, expectedAuthorizationEnvelopeJSON []byte, expectedFanSettings models.ResponseProfileFanSettings) error {
 	s.deletedProfileID = profileID
 	s.deleteExpectedSiteID = cloneInt64Ptr(expectedSiteID)
 	s.deleteExpectedScopeJSON = cloneBytes(expectedScopeJSON)
+	s.deleteExpectedAuthorizationEnvelopeJSON = cloneBytes(expectedAuthorizationEnvelopeJSON)
 	s.deleteExpectedFanSettings = models.ResponseProfileFanSettings{
 		FacilityFanDeviceIDs: append([]int64(nil), expectedFanSettings.FacilityFanDeviceIDs...),
 		FanOffDelaySec:       expectedFanSettings.FanOffDelaySec,

--- a/server/internal/handlers/curtailment/handler_start_test.go
+++ b/server/internal/handlers/curtailment/handler_start_test.go
@@ -767,6 +767,65 @@ func TestHandler_StartCurtailment_IdempotentReplayRequiresPersistedEventPermissi
 	assert.Empty(t, store.lastTargets, "replay denial must not persist a second event")
 }
 
+func TestHandler_StartCurtailment_IdempotentReplayUsesPersistedEnvelopeBeforeLiveScopeAndFanChecks(t *testing.T) {
+	t.Parallel()
+
+	const (
+		requestSite = int64(7)
+		replaySite  = int64(8)
+		fanID       = int64(31)
+	)
+	eventUUID := uuid.New()
+	store := newStartStubStore()
+	store.replayByKey = map[string]*models.Event{
+		"retry-key": {
+			ID:        7,
+			EventUUID: eventUUID,
+			OrgID:     42,
+			State:     models.EventStateActive,
+			Mode:      models.ModeFixedKw,
+			Strategy:  models.StrategyLeastEfficientFirst,
+			Level:     models.LevelFull,
+			Priority:  models.PriorityNormal,
+			ScopeType: models.ScopeTypeSite,
+			ScopeJSON: siteScopeJSON(t, replaySite),
+			AuthorizationEnvelopeJSON: testAuthorizationEnvelopeJSON(
+				[]int64{replaySite}, nil, false, nil, false,
+			),
+			RestoreBatchSize:        10,
+			RestoreBatchIntervalSec: 60,
+			Reason:                  "original persisted reason",
+			CreatedAt:               time.Date(2026, 5, 22, 1, 0, 0, 0, time.UTC),
+			UpdatedAt:               time.Date(2026, 5, 22, 1, 0, 0, 0, time.UTC),
+			CreatedByUserID:         9,
+		},
+	}
+	profileStore := newHandlerResponseProfileStore()
+	h := NewHandlerWithResponseProfiles(
+		curtailment.NewService(store),
+		curtailment.NewResponseProfileService(profileStore),
+	)
+	ctx := testSessionCtxWithAssignments(t, &session.Info{
+		AuthMethod:     session.AuthMethodSession,
+		OrganizationID: 42,
+		UserID:         9,
+		Role:           "OPERATOR",
+		SessionID:      "sess-replay-before-live-auth",
+	}, testSiteAssignment(replaySite, authz.PermCurtailmentManage))
+	req := validStartRequestBuilder()
+	req.Scope = &pb.StartCurtailmentRequest_Site{Site: &pb.ScopeSite{SiteId: requestSite}}
+	req.FacilityFanDeviceIds = []int64{fanID}
+	req.IdempotencyKey = "retry-key"
+
+	resp, err := h.StartCurtailment(ctx, connect.NewRequest(req))
+
+	require.NoError(t, err)
+	require.NotNil(t, resp.Msg.Event)
+	assert.Equal(t, eventUUID.String(), resp.Msg.Event.EventUuid)
+	assert.Zero(t, profileStore.infrastructureDeviceListCalls, "replay must not resolve fans from the retry body")
+	assert.Empty(t, store.lastTargets, "replay must not execute the live selector")
+}
+
 // TestHandler_StartCurtailment_APIKeyDerivesAPIKeyActor pins the audit
 // attribution: an API-key authenticated session must persist
 // source_actor_type='api_key' even though the override fields aren't

--- a/server/internal/handlers/curtailment/handler_start_test.go
+++ b/server/internal/handlers/curtailment/handler_start_test.go
@@ -146,7 +146,7 @@ func (s *startStubStore) GetEventByIdempotencyKey(_ context.Context, _ int64, ke
 	// Default to "no prior match" so Start tests that pass an idempotency
 	// key fall through to the normal insert path. Replay-specific tests
 	// override with a field on the stub.
-	return s.replayByKey[key], nil
+	return ensureTestEventAuthorizationEnvelope(s.replayByKey[key], nil, false), nil
 }
 func (s *startStubStore) GetEventByExternalReference(context.Context, int64, string, string) (*models.Event, error) {
 	// Default to "no prior match" so Start tests that pass an external

--- a/server/internal/handlers/curtailment/handler_stop_test.go
+++ b/server/internal/handlers/curtailment/handler_stop_test.go
@@ -29,12 +29,14 @@ type stopStubStore struct {
 	event   *models.Event
 	targets []*models.Target
 
-	getEventErr           error
-	listTargetsErr        error
-	beginRestoreErr       error
-	beginRestoreCalls     int
-	targetSiteIDs         []int64
-	targetSiteIDsComplete bool
+	getEventErr             error
+	listTargetsErr          error
+	beginRestoreErr         error
+	beginRestoreCalls       int
+	targetSiteIDs           []int64
+	targetSiteIDsComplete   bool
+	targetSiteCoverageErr   error
+	targetSiteCoverageCalls int
 }
 
 func (s *stopStubStore) GetOrgConfig(context.Context, int64) (*models.OrgConfig, error) {
@@ -107,6 +109,10 @@ func (s *stopStubStore) ListTargetsByEventPage(context.Context, interfaces.ListT
 	panic("ListTargetsByEventPage not exercised by Stop handler tests")
 }
 func (s *stopStubStore) ListTargetSiteCoverageByEvent(context.Context, int64, uuid.UUID) (models.TargetSiteCoverage, error) {
+	s.targetSiteCoverageCalls++
+	if s.targetSiteCoverageErr != nil {
+		return models.TargetSiteCoverage{}, s.targetSiteCoverageErr
+	}
 	siteIDs := append([]int64(nil), s.targetSiteIDs...)
 	mappedTargetCount := int64(len(siteIDs))
 	targetCount := mappedTargetCount
@@ -245,6 +251,24 @@ func TestHandler_StopCurtailment_HappyPath(t *testing.T) {
 	assert.Equal(t, int32(2), resp.Msg.Event.TargetRollup.Pending)
 	assert.Equal(t, int32(2), resp.Msg.Event.TargetRollup.Total)
 	assert.Equal(t, 1, store.beginRestoreCalls)
+}
+
+func TestHandler_StopCurtailment_DoesNotHydrateDisplayCoverageBeforeControl(t *testing.T) {
+	t.Parallel()
+
+	store := newStopStubStore()
+	store.event.ScopeType = models.ScopeTypeDeviceList
+	store.targetSiteCoverageErr = assert.AnError
+	h := NewHandler(curtailment.NewService(store))
+
+	_, err := h.StopCurtailment(
+		stopSessionCtxWithPerms(t, 42, "OPERATOR", authz.PermCurtailmentManage),
+		connect.NewRequest(&pb.StopCurtailmentRequest{EventUuid: store.event.EventUUID.String()}),
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, store.beginRestoreCalls)
+	assert.Zero(t, store.targetSiteCoverageCalls)
 }
 
 func TestHandler_StopCurtailment_RequiresCurtailmentManage(t *testing.T) {

--- a/server/internal/handlers/curtailment/handler_stop_test.go
+++ b/server/internal/handlers/curtailment/handler_stop_test.go
@@ -89,7 +89,7 @@ func (s *stopStubStore) GetEventByUUID(_ context.Context, _ int64, _ uuid.UUID) 
 	if s.getEventErr != nil {
 		return nil, s.getEventErr
 	}
-	return s.event, nil
+	return ensureTestEventAuthorizationEnvelope(s.event, s.targetSiteIDs, s.targetSiteIDsComplete), nil
 }
 func (s *stopStubStore) GetEventDetailByUUID(context.Context, int64, uuid.UUID) (*models.Event, error) {
 	panic("GetEventDetailByUUID not exercised by Stop handler tests")
@@ -291,7 +291,7 @@ func TestHandler_StopCurtailment_UsesSiteScopedEventPermission(t *testing.T) {
 	}{
 		{"org permission without site narrowing allows stop", []authz.Assignment{testOrgAssignment(authz.PermCurtailmentManage)}, 0, 1},
 		{"matching site narrowing allows stop", []authz.Assignment{testOrgAssignment(authz.PermCurtailmentManage), testSiteAssignment(allowedSite, authz.PermCurtailmentManage)}, 0, 1},
-		{"site-only permission denies stop", []authz.Assignment{testSiteAssignment(allowedSite, authz.PermCurtailmentManage)}, connect.CodePermissionDenied, 0},
+		{"site-only permission allows matching stop", []authz.Assignment{testSiteAssignment(allowedSite, authz.PermCurtailmentManage)}, 0, 1},
 		{"site narrowing without manage denies stop", []authz.Assignment{testOrgAssignment(authz.PermCurtailmentManage), testSiteAssignment(allowedSite)}, connect.CodePermissionDenied, 0},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/server/internal/handlers/curtailment/handler_test.go
+++ b/server/internal/handlers/curtailment/handler_test.go
@@ -19,6 +19,7 @@ import (
 	domainAuth "github.com/block/proto-fleet/server/internal/domain/auth"
 	"github.com/block/proto-fleet/server/internal/domain/authz"
 	domainCurtailment "github.com/block/proto-fleet/server/internal/domain/curtailment"
+	"github.com/block/proto-fleet/server/internal/domain/curtailment/models"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 	"github.com/block/proto-fleet/server/internal/domain/session"
 	"github.com/block/proto-fleet/server/internal/handlers/interceptors"
@@ -60,6 +61,33 @@ func TestScopeResourceContextRequirementsTopologyRequiresOrgWide(t *testing.T) {
 	}
 }
 
+func TestAuthorizationEnvelopeResourceContextRequirements(t *testing.T) {
+	t.Parallel()
+
+	requirements, err := authorizationEnvelopeResourceContextRequirements(testAuthorizationEnvelopeJSON(
+		[]int64{7},
+		[]int64{8},
+		false,
+		[]int64{9},
+		false,
+	))
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []int64{7, 8, 9}, siteIDsFromResourceContexts(requirements.resource.siteContexts))
+	assert.False(t, requirements.resource.requireOrgWide)
+	assert.Equal(t, []int64{9}, siteIDsFromResourceContexts(requirements.facilityFanRead.siteContexts))
+	assert.False(t, requirements.facilityFanRead.requireOrgWide)
+}
+
+func TestAuthorizationEnvelopeResourceContextRequirementsFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	_, err := authorizationEnvelopeResourceContextRequirements(nil)
+	require.Error(t, err)
+	var fleetErr fleeterror.FleetError
+	require.ErrorAs(t, err, &fleetErr)
+	assert.Equal(t, connect.CodeInternal, fleetErr.GRPCCode)
+}
+
 func testSiteAssignment(siteID int64, perms ...string) authz.Assignment {
 	return authz.Assignment{
 		AssignmentID: 2,
@@ -74,6 +102,61 @@ func siteScopeJSON(t *testing.T, siteID int64) []byte {
 	out, err := json.Marshal(map[string]int64{"site_id": siteID})
 	require.NoError(t, err)
 	return out
+}
+
+func testAuthorizationEnvelopeJSON(
+	selectedSiteIDs []int64,
+	currentMemberSiteIDs []int64,
+	minerScopeUnbounded bool,
+	facilityFanSiteIDs []int64,
+	facilityFanScopeUnbounded bool,
+) []byte {
+	out, err := json.Marshal(models.AuthorizationEnvelope{
+		SchemaVersion:             models.AuthorizationEnvelopeSchemaVersion,
+		SelectedResourceSiteIDs:   append([]int64{}, selectedSiteIDs...),
+		CurrentMemberSiteIDs:      append([]int64{}, currentMemberSiteIDs...),
+		MinerScopeUnbounded:       minerScopeUnbounded,
+		FacilityFanSiteIDs:        append([]int64{}, facilityFanSiteIDs...),
+		FacilityFanScopeUnbounded: facilityFanScopeUnbounded,
+	})
+	if err != nil {
+		panic(err)
+	}
+	return out
+}
+
+func ensureTestEventAuthorizationEnvelope(event *models.Event, currentMemberSiteIDs []int64, coverageComplete bool) *models.Event {
+	if event == nil || len(event.AuthorizationEnvelopeJSON) > 0 {
+		return event
+	}
+	var selectedSiteIDs []int64
+	minerScopeUnbounded := false
+	scope, hasScope, err := domainCurtailment.ScopeFromJSON(event.ScopeJSON)
+	if err != nil {
+		panic(err)
+	}
+	switch {
+	case event.ScopeType == models.ScopeTypeWholeOrg || event.ScopeType == "" && !hasScope:
+		minerScopeUnbounded = true
+	case hasScope && scope.Type == models.ScopeTypeSite:
+		selectedSiteIDs = []int64{scope.SiteID}
+	case hasScope && domainCurtailment.IsSiteOnlyScope(scope):
+		selectedSiteIDs = append([]int64(nil), scope.SiteIDs...)
+	case coverageComplete && len(currentMemberSiteIDs) > 0:
+		currentMemberSiteIDs = append([]int64(nil), currentMemberSiteIDs...)
+	default:
+		minerScopeUnbounded = true
+	}
+	fanSiteIDs := append([]int64(nil), event.FacilityFanSiteIDs...)
+	fanScopeUnbounded := len(event.FacilityFanDeviceIDs) > 0 && len(fanSiteIDs) != len(event.FacilityFanDeviceIDs)
+	event.AuthorizationEnvelopeJSON = testAuthorizationEnvelopeJSON(
+		selectedSiteIDs,
+		currentMemberSiteIDs,
+		minerScopeUnbounded,
+		fanSiteIDs,
+		fanScopeUnbounded,
+	)
+	return event
 }
 
 func TestRequestReadLimitOptionRejectsOversizedBody(t *testing.T) {
@@ -715,7 +798,7 @@ func TestHandler_PublicPlanStartStopRequireCurtailmentManage(t *testing.T) {
 	}
 }
 
-func TestHandler_PreviewAndStartRequireOrgPermissionAndSiteContext(t *testing.T) {
+func TestHandler_PreviewAndStartRequireScopedPermissionCapability(t *testing.T) {
 	t.Parallel()
 
 	h := NewHandler(nil)
@@ -749,11 +832,11 @@ func TestHandler_PreviewAndStartRequireOrgPermissionAndSiteContext(t *testing.T)
 	}{
 		{"preview org permission without site narrowing reaches service", previewForSite, []authz.Assignment{testOrgAssignment(authz.PermCurtailmentManage)}, connect.CodeUnimplemented},
 		{"preview matching site narrowing reaches service", previewForSite, []authz.Assignment{testOrgAssignment(authz.PermCurtailmentManage), testSiteAssignment(allowedSite, authz.PermCurtailmentManage)}, connect.CodeUnimplemented},
-		{"preview site-only permission fails org gate", previewForSite, []authz.Assignment{testSiteAssignment(allowedSite, authz.PermCurtailmentManage)}, connect.CodePermissionDenied},
+		{"preview site-only permission reaches service", previewForSite, []authz.Assignment{testSiteAssignment(allowedSite, authz.PermCurtailmentManage)}, connect.CodeUnimplemented},
 		{"preview site narrowing without manage fails site gate", previewForSite, []authz.Assignment{testOrgAssignment(authz.PermCurtailmentManage), testSiteAssignment(allowedSite)}, connect.CodePermissionDenied},
 		{"start org permission without site narrowing reaches service", startForSite, []authz.Assignment{testOrgAssignment(authz.PermCurtailmentManage)}, connect.CodeUnimplemented},
 		{"start matching site narrowing reaches service", startForSite, []authz.Assignment{testOrgAssignment(authz.PermCurtailmentManage), testSiteAssignment(allowedSite, authz.PermCurtailmentManage)}, connect.CodeUnimplemented},
-		{"start site-only permission fails org gate", startForSite, []authz.Assignment{testSiteAssignment(allowedSite, authz.PermCurtailmentManage)}, connect.CodePermissionDenied},
+		{"start site-only permission reaches service", startForSite, []authz.Assignment{testSiteAssignment(allowedSite, authz.PermCurtailmentManage)}, connect.CodeUnimplemented},
 		{"start site narrowing without manage fails site gate", startForSite, []authz.Assignment{testOrgAssignment(authz.PermCurtailmentManage), testSiteAssignment(allowedSite)}, connect.CodePermissionDenied},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/server/internal/handlers/curtailment/handler_update_test.go
+++ b/server/internal/handlers/curtailment/handler_update_test.go
@@ -57,6 +57,9 @@ func newUpdateStubStore(state models.EventState) *updateStubStore {
 			RestoreBatchSize:        10,
 			RestoreBatchIntervalSec: 120,
 			Reason:                  "initial reason",
+			AuthorizationEnvelopeJSON: testAuthorizationEnvelopeJSON(
+				nil, nil, true, nil, false,
+			),
 		},
 	}
 }
@@ -354,7 +357,7 @@ func TestHandler_UpdateCurtailmentEvent_UsesSiteScopedEventPermission(t *testing
 	}{
 		{"org permission without site narrowing allows update", []authz.Assignment{testOrgAssignment(authz.PermCurtailmentManage)}, 0, 1},
 		{"matching site narrowing allows update", []authz.Assignment{testOrgAssignment(authz.PermCurtailmentManage), testSiteAssignment(allowedSite, authz.PermCurtailmentManage)}, 0, 1},
-		{"site-only permission denies update", []authz.Assignment{testSiteAssignment(allowedSite, authz.PermCurtailmentManage)}, connect.CodePermissionDenied, 0},
+		{"site-only permission allows matching update", []authz.Assignment{testSiteAssignment(allowedSite, authz.PermCurtailmentManage)}, 0, 1},
 		{"site narrowing without manage denies update", []authz.Assignment{testOrgAssignment(authz.PermCurtailmentManage), testSiteAssignment(allowedSite)}, connect.CodePermissionDenied, 0},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -362,6 +365,9 @@ func TestHandler_UpdateCurtailmentEvent_UsesSiteScopedEventPermission(t *testing
 			store := newUpdateStubStore(models.EventStateActive)
 			store.event.ScopeType = models.ScopeTypeSite
 			store.event.ScopeJSON = siteScopeJSON(t, allowedSite)
+			store.event.AuthorizationEnvelopeJSON = testAuthorizationEnvelopeJSON(
+				[]int64{allowedSite}, nil, false, nil, false,
+			)
 			h := NewHandler(domainCurtailment.NewService(store))
 
 			ctx := testSessionCtxWithAssignments(t, &session.Info{

--- a/server/internal/handlers/curtailment/response_profiles.go
+++ b/server/internal/handlers/curtailment/response_profiles.go
@@ -16,7 +16,7 @@ import (
 )
 
 func (h *Handler) ListCurtailmentResponseProfiles(ctx context.Context, _ *connect.Request[pb.ListCurtailmentResponseProfilesRequest]) (*connect.Response[pb.ListCurtailmentResponseProfilesResponse], error) {
-	info, err := middleware.RequirePermission(ctx, authz.PermCurtailmentManage, authz.ResourceContext{})
+	info, err := requireScopedPermissionCapability(ctx, authz.PermCurtailmentManage)
 	if err != nil {
 		return nil, err
 	}
@@ -28,42 +28,16 @@ func (h *Handler) ListCurtailmentResponseProfiles(ctx context.Context, _ *connec
 		return nil, err
 	}
 	out := make([]*pb.CurtailmentResponseProfile, 0, len(profiles))
-	deviceSites, err := h.responseProfileDeviceSitesForProfiles(ctx, info.OrganizationID, profiles)
-	if err != nil {
-		return nil, err
-	}
-	facilityFanDeviceSites, err := h.responseProfileFacilityFanDeviceSitesForProfiles(ctx, info.OrganizationID, profiles)
-	if err != nil {
-		return nil, err
-	}
-	siteAllowed := make(map[int64]bool)
-	facilityFanSiteAllowed := make(map[int64]bool)
-	orgWideAllowed := false
-	orgWideChecked := false
+	cache := newAuthorizationEnvelopePermissionCache()
 	for _, profile := range profiles {
-		requirements, err := h.responseProfileResourceContextRequirements(ctx, info.OrganizationID, profile, deviceSites, false)
-		if err != nil {
-			return nil, err
-		}
-		allowed, err := resourceContextRequirementsAllowed(
-			ctx,
-			authz.PermCurtailmentManage,
-			requirements,
-			siteAllowed,
-			&orgWideAllowed,
-			&orgWideChecked,
-		)
-		if err != nil {
-			return nil, err
-		}
-		if !allowed {
+		if profile == nil || profile.OrgID != info.OrganizationID {
 			continue
 		}
-		allowed, err = facilityFanSiteAccessAllowed(
+		allowed, err := authorizationEnvelopeAccessAllowed(
 			ctx,
-			profile.FacilityFanDeviceIDs,
-			facilityFanDeviceSites,
-			facilityFanSiteAllowed,
+			authz.PermCurtailmentManage,
+			profile.AuthorizationEnvelopeJSON,
+			cache,
 		)
 		if err != nil {
 			return nil, err
@@ -77,14 +51,14 @@ func (h *Handler) ListCurtailmentResponseProfiles(ctx context.Context, _ *connec
 }
 
 func (h *Handler) GetCurtailmentResponseProfile(ctx context.Context, req *connect.Request[pb.GetCurtailmentResponseProfileRequest]) (*connect.Response[pb.GetCurtailmentResponseProfileResponse], error) {
-	info, err := middleware.RequirePermission(ctx, authz.PermCurtailmentManage, authz.ResourceContext{})
+	info, err := requireScopedPermissionCapability(ctx, authz.PermCurtailmentManage)
 	if err != nil {
 		return nil, err
 	}
 	if h.responseProfiles == nil {
 		return nil, errCurtailmentNotImplemented("GetCurtailmentResponseProfile")
 	}
-	profile, err := h.getResponseProfileWithSitePermission(ctx, info.OrganizationID, req.Msg.GetProfileId())
+	profile, err := h.getResponseProfileWithPersistedPermission(ctx, info.OrganizationID, req.Msg.GetProfileId())
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +66,7 @@ func (h *Handler) GetCurtailmentResponseProfile(ctx context.Context, req *connec
 }
 
 func (h *Handler) CreateCurtailmentResponseProfile(ctx context.Context, req *connect.Request[pb.CreateCurtailmentResponseProfileRequest]) (*connect.Response[pb.CreateCurtailmentResponseProfileResponse], error) {
-	info, err := middleware.RequirePermission(ctx, authz.PermCurtailmentManage, authz.ResourceContext{})
+	info, err := requireScopedPermissionCapability(ctx, authz.PermCurtailmentManage)
 	if err != nil {
 		return nil, err
 	}
@@ -127,14 +101,14 @@ func (h *Handler) CreateCurtailmentResponseProfile(ctx context.Context, req *con
 }
 
 func (h *Handler) UpdateCurtailmentResponseProfile(ctx context.Context, req *connect.Request[pb.UpdateCurtailmentResponseProfileRequest]) (*connect.Response[pb.UpdateCurtailmentResponseProfileResponse], error) {
-	info, err := middleware.RequirePermission(ctx, authz.PermCurtailmentManage, authz.ResourceContext{})
+	info, err := requireScopedPermissionCapability(ctx, authz.PermCurtailmentManage)
 	if err != nil {
 		return nil, err
 	}
 	if h.responseProfiles == nil {
 		return nil, errCurtailmentNotImplemented("UpdateCurtailmentResponseProfile")
 	}
-	existing, err := h.getResponseProfileWithSitePermission(ctx, info.OrganizationID, req.Msg.GetProfileId())
+	existing, err := h.getResponseProfileWithPersistedPermission(ctx, info.OrganizationID, req.Msg.GetProfileId())
 	if err != nil {
 		return nil, err
 	}
@@ -174,14 +148,14 @@ func (h *Handler) UpdateCurtailmentResponseProfile(ctx context.Context, req *con
 }
 
 func (h *Handler) DeleteCurtailmentResponseProfile(ctx context.Context, req *connect.Request[pb.DeleteCurtailmentResponseProfileRequest]) (*connect.Response[pb.DeleteCurtailmentResponseProfileResponse], error) {
-	info, err := middleware.RequirePermission(ctx, authz.PermCurtailmentManage, authz.ResourceContext{})
+	info, err := requireScopedPermissionCapability(ctx, authz.PermCurtailmentManage)
 	if err != nil {
 		return nil, err
 	}
 	if h.responseProfiles == nil {
 		return nil, errCurtailmentNotImplemented("DeleteCurtailmentResponseProfile")
 	}
-	profile, err := h.getResponseProfileWithSitePermission(ctx, info.OrganizationID, req.Msg.GetProfileId())
+	profile, err := h.getResponseProfileWithPersistedPermission(ctx, info.OrganizationID, req.Msg.GetProfileId())
 	if err != nil {
 		return nil, err
 	}
@@ -191,6 +165,7 @@ func (h *Handler) DeleteCurtailmentResponseProfile(ctx context.Context, req *con
 		req.Msg.GetProfileId(),
 		cloneInt64Ptr(profile.SiteID),
 		cloneBytes(profile.ScopeJSON),
+		cloneBytes(profile.AuthorizationEnvelopeJSON),
 		responseProfileFanSettings(profile),
 	); err != nil {
 		return nil, err
@@ -215,6 +190,24 @@ func (h *Handler) getResponseProfileWithSitePermission(ctx context.Context, orgI
 		return nil, err
 	}
 	if err := h.requireFacilityFanSitePermissions(ctx, orgID, profile.FacilityFanDeviceIDs); err != nil {
+		return nil, err
+	}
+	return profile, nil
+}
+
+func (h *Handler) getResponseProfileWithPersistedPermission(ctx context.Context, orgID, profileID int64) (*models.ResponseProfile, error) {
+	profile, err := h.responseProfiles.Get(ctx, orgID, profileID)
+	if err != nil {
+		return nil, err
+	}
+	if profile == nil || profile.OrgID != orgID {
+		return nil, fleeterror.NewNotFoundErrorf("curtailment response profile not found: %d", profileID)
+	}
+	if err := requireAuthorizationEnvelopePermissions(
+		ctx,
+		authz.PermCurtailmentManage,
+		profile.AuthorizationEnvelopeJSON,
+	); err != nil {
 		return nil, err
 	}
 	return profile, nil
@@ -296,32 +289,6 @@ func (h *Handler) authorizeFacilityFanDevices(
 	return devices, nil
 }
 
-func (h *Handler) responseProfileDeviceSitesForProfiles(
-	ctx context.Context,
-	orgID int64,
-	profiles []*models.ResponseProfile,
-) (map[string]*int64, error) {
-	var deviceIdentifiers []string
-	for _, profile := range profiles {
-		if profile == nil {
-			continue
-		}
-		scope, err := domainCurtailment.ResponseProfileScope(*profile)
-		if err != nil {
-			return nil, err
-		}
-		deviceIdentifiers = append(deviceIdentifiers, scope.DeviceIdentifiers...)
-	}
-	deviceIdentifiers = uniqueResponseProfileDeviceIdentifiers(deviceIdentifiers)
-	if len(deviceIdentifiers) == 0 {
-		return map[string]*int64{}, nil
-	}
-	if h.responseProfiles == nil {
-		return nil, nil
-	}
-	return h.responseProfiles.ListDeviceSites(ctx, orgID, deviceIdentifiers)
-}
-
 func (h *Handler) responseProfileFacilityFanDeviceSitesForProfiles(
 	ctx context.Context,
 	orgID int64,
@@ -397,28 +364,36 @@ func (h *Handler) responseProfileResourceContextRequirements(
 	return h.scopeResourceContextRequirements(ctx, orgID, scope, deviceSites, requireKnownDevices)
 }
 
+type resourceContextPermissionCache struct {
+	siteAllowed    map[int64]bool
+	orgWideAllowed bool
+	orgWideChecked bool
+}
+
+func newResourceContextPermissionCache() resourceContextPermissionCache {
+	return resourceContextPermissionCache{siteAllowed: make(map[int64]bool)}
+}
+
 func resourceContextRequirementsAllowed(
 	ctx context.Context,
 	permission string,
 	requirements scopeResourceContextRequirements,
-	siteAllowed map[int64]bool,
-	orgWideAllowed *bool,
-	orgWideChecked *bool,
+	cache *resourceContextPermissionCache,
 ) (bool, error) {
 	if requirements.requireOrgWide {
-		if !*orgWideChecked {
-			*orgWideChecked = true
+		if !cache.orgWideChecked {
+			cache.orgWideChecked = true
 			if _, err := middleware.RequireOrgWidePermission(ctx, permission); err != nil {
 				if fleeterror.IsForbiddenError(err) {
-					*orgWideAllowed = false
+					cache.orgWideAllowed = false
 				} else {
 					return false, err
 				}
 			} else {
-				*orgWideAllowed = true
+				cache.orgWideAllowed = true
 			}
 		}
-		if !*orgWideAllowed {
+		if !cache.orgWideAllowed {
 			return false, nil
 		}
 	}
@@ -426,17 +401,17 @@ func resourceContextRequirementsAllowed(
 		if siteContext.SiteID == nil {
 			continue
 		}
-		siteAllowedValue, ok := siteAllowed[*siteContext.SiteID]
+		siteAllowedValue, ok := cache.siteAllowed[*siteContext.SiteID]
 		if !ok {
 			if _, err := middleware.RequirePermission(ctx, permission, siteContext); err != nil {
 				if fleeterror.IsForbiddenError(err) {
-					siteAllowed[*siteContext.SiteID] = false
+					cache.siteAllowed[*siteContext.SiteID] = false
 					return false, nil
 				}
 				return false, err
 			}
 			siteAllowedValue = true
-			siteAllowed[*siteContext.SiteID] = true
+			cache.siteAllowed[*siteContext.SiteID] = true
 		}
 		if !siteAllowedValue {
 			return false, nil

--- a/server/sqlc/queries/curtailment_response_profile.sql
+++ b/server/sqlc/queries/curtailment_response_profile.sql
@@ -138,6 +138,7 @@ WHERE id = sqlc.arg('id')
   AND org_id = sqlc.arg('org_id')
   AND site_id IS NOT DISTINCT FROM sqlc.narg('expected_site_id')
   AND scope_json = sqlc.arg('expected_scope_json')::jsonb
+  AND authorization_envelope_jsonb = sqlc.arg('expected_authorization_envelope_json')::jsonb
   AND facility_fan_device_ids = sqlc.arg('expected_facility_fan_device_ids')::bigint[]
   AND fan_off_delay_sec = sqlc.arg('expected_fan_off_delay_sec')
   AND fan_restore_delay_sec = sqlc.arg('expected_fan_restore_delay_sec');


### PR DESCRIPTION
Reviewable diff: +299/-448 across 8 files (excludes generated, test, and story files).

## Summary

Curtailment events and response profiles now authorize reads, mutations, and recovery operations from the durable authorization envelope captured when each record is written. This lets site-scoped operators retain access to the records they were authorized to create even if topology membership changes later, while malformed or incomplete persisted envelopes fail closed. This is the next backend slice of issue #909; topology execution and the remaining lifecycle work stay tracked there.

## How it works

Handlers first require that the caller has the relevant curtailment capability at some supported scope, load the organization-owned event or profile, and strictly parse its persisted authorization envelope. Miner and facility-fan coverage are converted into site resource contexts; unbounded coverage requires an organization-wide grant, and facility-fan sites additionally require `site:read`.

Single-record operations enforce every required context before returning or mutating the record. List operations apply the same checks with per-request permission caches, filter unauthorized records, and only then hydrate display-oriented target coverage. Response-profile deletion also includes the authorized envelope in its SQL optimistic predicate, so a concurrent envelope change cannot invalidate the permission decision before deletion.

## Diagrams

```mermaid
flowchart TD
    A["Event or profile RPC"] --> B["Require scoped curtailment capability"]
    B --> C["Load organization-owned record"]
    C --> D["Strictly parse persisted authorization envelope"]
    D --> E["Check curtailment permission for miner and fan coverage"]
    E --> F["Check site:read for facility-fan coverage"]
    F --> G["Filter or continue the lifecycle operation"]
    G --> H["Hydrate display-only target coverage"]
```

```mermaid
sequenceDiagram
    participant H as Handler
    participant S as Response profile service
    participant DB as PostgreSQL
    H->>S: Delete with authorized selector, fan, and envelope snapshots
    S->>DB: DELETE where every expected snapshot still matches
    DB-->>S: One row or zero rows
    S-->>H: Success or FailedPrecondition
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/internal/domain/curtailment/` | Added strict authorization-envelope parsing and validation | Establishes the fail-closed trust boundary for persisted coverage |
| `server/internal/handlers/curtailment/handler.go` | Replaced live topology reconstruction with envelope-based event authorization and cached list filtering | Controls event visibility and lifecycle/recovery authority |
| `server/internal/handlers/curtailment/response_profiles.go` | Applies the same persisted checks to profile get/list/update/delete flows | Keeps profile behavior aligned with event authorization |
| `server/internal/domain/stores/` and `server/sqlc/queries/` | Threads the expected envelope through response-profile deletion | Makes authorization and deletion atomic with respect to concurrent changes |
| `server/generated/sqlc/` | Regenerated query bindings | Generated — skip |
| Curtailment domain, handler, and SQL-store tests | Covers strict parsing, site-scoped access, filtering, recovery, and stale-envelope deletion | Verifies the authorization boundary and regression scenarios |

## Key technical decisions & trade-offs

- Persisted envelopes are the authority for record reads and recovery; current topology is used only for display hydration, avoiding authorization drift after moves or deletions.
- The parser requires the exact supported schema and fields; invalid stored data surfaces as an internal error instead of widening access.
- Facility fans require both the curtailment grant and `site:read` for every captured fan site.
- List endpoints cache organization-wide and per-site decisions for the request rather than repeating middleware checks per record.
- Automation entry points remain organization-scoped until immutable automation bindings have equivalent persisted authorization coverage.
- Response-profile deletion compares the envelope alongside the selector and fan snapshots, preferring a failed precondition over a stale authorization decision.

## Testing & validation

- `just gen`
- `cd server && just lint`
- `cd server && go test ./internal/domain/curtailment ./internal/handlers/curtailment -count=1`
- `cd server && go test ./internal/domain/stores/sqlstores -run '^(TestBuildAuthorizationEnvelopeJSON|TestLockTopologyScopeCoverage)' -count=1`
- `git diff --check origin/main...HEAD`
- The full database-backed SQL-store suite was not runnable locally because the configured local Postgres rejected the `fleet` password; focused in-memory SQL-store authorization tests passed, and CI remains responsible for the database integration run.

Refs #909
