### PR TITLE
fix(driver): build the sim miner image once and keep it

### DIFF
--- a/plugin/proto/go.mod
+++ b/plugin/proto/go.mod
@@ -4,6 +4,7 @@ go 1.26
 
 require (
 	github.com/block/proto-fleet/server v0.0.0-20260803122651-c989687a8036
+	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-plugin v1.8.0
 	github.com/moby/moby/api v1.55.0
 	github.com/moby/moby/client v0.5.1
@@ -36,7 +37,6 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/yamux v0.1.2 // indirect
 	github.com/klauspost/compress v1.19.1 // indirect

--- a/plugin/proto/internal/driver/discovery_test.go
+++ b/plugin/proto/internal/driver/discovery_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/moby/moby/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -49,8 +50,11 @@ var (
 // a Docker daemon (parallel packages, or a public and a downstream checkout on
 // one machine) would otherwise retag the same name and start containers from
 // each other's revision.
+//
+// The suffix is random rather than the PID, because binaries in separate PID
+// namespaces can share a daemon through a mounted socket and collide.
 func simMinerImageTag() string {
-	return fmt.Sprintf("driver-tests-%d", os.Getpid())
+	return "driver-tests-" + uuid.NewString()
 }
 
 // simMinerImage builds the fake-proto-rig image on first use and returns the

--- a/plugin/proto/internal/driver/discovery_test.go
+++ b/plugin/proto/internal/driver/discovery_test.go
@@ -38,7 +38,11 @@ type simMinerContainer struct {
 // still in flight, and container creation fails with:
 //
 //	failed to get digest sha256:...: open /var/lib/docker/image/overlay2/imagedb/content/sha256/...: no such file or directory
-const simMinerImageRepo = "proto-fleet-fake-proto-rig"
+//
+// The localhost registry qualifier marks this as a local image and prevents
+// TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX from rewriting the tag between the
+// direct BuildImage call and GenericContainer.
+const simMinerImageRepo = "localhost:5000/proto-fleet-fake-proto-rig"
 
 var (
 	simMinerImageOnce sync.Once
@@ -98,10 +102,21 @@ func TestMain(m *testing.M) {
 	code := m.Run()
 
 	if simMinerImageRef != "" {
-		if provider, err := testcontainers.NewDockerProvider(); err == nil {
-			_, _ = provider.Client().ImageRemove(context.Background(), simMinerImageRef, client.ImageRemoveOptions{})
+		// The test timeout alarm no longer protects cleanup after m.Run, and the
+		// Docker client has no default HTTP timeout. Keep cleanup best-effort: a
+		// daemon disappearing after successful tests should warn, not fail them.
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+
+		provider, err := testcontainers.NewDockerProvider()
+		if err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "warning: create Docker provider for sim miner image cleanup: %v\n", err)
+		} else {
+			if _, err := provider.Client().ImageRemove(ctx, simMinerImageRef, client.ImageRemoveOptions{}); err != nil {
+				_, _ = fmt.Fprintf(os.Stderr, "warning: remove retained sim miner image %s: %v\n", simMinerImageRef, err)
+			}
 			_ = provider.Close()
 		}
+		cancel()
 	}
 
 	os.Exit(code)

--- a/plugin/proto/internal/driver/discovery_test.go
+++ b/plugin/proto/internal/driver/discovery_test.go
@@ -2,7 +2,9 @@ package driver
 
 import (
 	"context"
+	"fmt"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -21,17 +23,73 @@ type simMinerContainer struct {
 	mappedPort string
 }
 
+// The sim miner image is built once per test binary and reused by every
+// container, under a fixed tag that Terminate must not delete.
+//
+// Building per container is unsafe here. Every build uses the same context and
+// Dockerfile, so the cache resolves them all to a single image digest, and
+// testcontainers tags each one with a fresh UUID by default. Terminate removes
+// a built image unless KeepImage is set, and it removes it by ID, so tearing
+// down one container deletes the digest the others still reference. A later
+// build then resolves to that same digest while the removal is still in
+// flight, and container creation fails with:
+//
+//	failed to get digest sha256:...: open /var/lib/docker/image/overlay2/imagedb/content/sha256/...: no such file or directory
+const (
+	simMinerImageRepo = "proto-fleet-fake-proto-rig"
+	simMinerImageTag  = "driver-tests"
+)
+
+var (
+	simMinerImageOnce sync.Once
+	simMinerImageRef  string
+	simMinerImageErr  error
+)
+
+// simMinerImage builds the fake-proto-rig image on first use and returns the
+// tag every sim miner container should run from.
+func simMinerImage(ctx context.Context) (string, error) {
+	simMinerImageOnce.Do(func() {
+		provider, err := testcontainers.NewDockerProvider()
+		if err != nil {
+			simMinerImageErr = fmt.Errorf("create docker provider: %w", err)
+			return
+		}
+		defer provider.Close()
+
+		req := testcontainers.ContainerRequest{
+			FromDockerfile: testcontainers.FromDockerfile{
+				Context:    "../../../..",
+				Dockerfile: "server/fake-proto-rig/Dockerfile",
+				Repo:       simMinerImageRepo,
+				Tag:        simMinerImageTag,
+				KeepImage:  true,
+			},
+		}
+
+		tag, err := provider.BuildImage(ctx, &req)
+		if err != nil {
+			simMinerImageErr = fmt.Errorf("build sim miner image: %w", err)
+			return
+		}
+
+		simMinerImageRef = tag
+	})
+
+	return simMinerImageRef, simMinerImageErr
+}
+
 // startSimMiner starts a sim miner container and returns connection details
 func startSimMiner(ctx context.Context, t *testing.T) *simMinerContainer {
 	if testing.Short() {
 		t.Skip("Skipping sim miner tests in short mode")
 	}
 
+	image, err := simMinerImage(ctx)
+	require.NoError(t, err, "Failed to build sim miner image")
+
 	req := testcontainers.ContainerRequest{
-		FromDockerfile: testcontainers.FromDockerfile{
-			Context:    "../../../..",
-			Dockerfile: "server/fake-proto-rig/Dockerfile",
-		},
+		Image:        image,
 		ExposedPorts: []string{"8080/tcp"},
 		WaitingFor:   wait.ForHTTP("/health").WithPort("8080/tcp").WithStartupTimeout(2 * time.Minute),
 	}

--- a/plugin/proto/internal/driver/discovery_test.go
+++ b/plugin/proto/internal/driver/discovery_test.go
@@ -3,11 +3,13 @@ package driver
 import (
 	"context"
 	"fmt"
+	"os"
 	"strconv"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/moby/moby/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
@@ -24,27 +26,32 @@ type simMinerContainer struct {
 }
 
 // The sim miner image is built once per test binary and reused by every
-// container, under a fixed tag that Terminate must not delete.
+// container, under a tag that Terminate must not delete.
 //
 // Building per container is unsafe here. Every build uses the same context and
 // Dockerfile, so the cache resolves them all to a single image digest, and
-// testcontainers tags each one with a fresh UUID by default. Terminate removes
-// a built image unless KeepImage is set, and it removes it by ID, so tearing
-// down one container deletes the digest the others still reference. A later
-// build then resolves to that same digest while the removal is still in
-// flight, and container creation fails with:
+// testcontainers tags each one with a fresh UUID by default. Terminate then
+// removes that tag with force and PruneChildren unless KeepImage is set, and
+// because the throwaway tag was the digest's only reference, the digest itself
+// is deleted. A later build resolves to that same digest while the removal is
+// still in flight, and container creation fails with:
 //
 //	failed to get digest sha256:...: open /var/lib/docker/image/overlay2/imagedb/content/sha256/...: no such file or directory
-const (
-	simMinerImageRepo = "proto-fleet-fake-proto-rig"
-	simMinerImageTag  = "driver-tests"
-)
+const simMinerImageRepo = "proto-fleet-fake-proto-rig"
 
 var (
 	simMinerImageOnce sync.Once
 	simMinerImageRef  string
 	simMinerImageErr  error
 )
+
+// simMinerImageTag scopes the tag to this test binary. Two invocations sharing
+// a Docker daemon (parallel packages, or a public and a downstream checkout on
+// one machine) would otherwise retag the same name and start containers from
+// each other's revision.
+func simMinerImageTag() string {
+	return fmt.Sprintf("driver-tests-%d", os.Getpid())
+}
 
 // simMinerImage builds the fake-proto-rig image on first use and returns the
 // tag every sim miner container should run from.
@@ -62,7 +69,7 @@ func simMinerImage(ctx context.Context) (string, error) {
 				Context:    "../../../..",
 				Dockerfile: "server/fake-proto-rig/Dockerfile",
 				Repo:       simMinerImageRepo,
-				Tag:        simMinerImageTag,
+				Tag:        simMinerImageTag(),
 				KeepImage:  true,
 			},
 		}
@@ -77,6 +84,23 @@ func simMinerImage(ctx context.Context) (string, error) {
 	})
 
 	return simMinerImageRef, simMinerImageErr
+}
+
+// TestMain drops the retained image once every test in the binary is done.
+// Nothing else deletes it, since KeepImage suppresses Terminate's cleanup.
+// Removing by tag only untags when another tag shares the digest, so this
+// cannot pull the image out from under a concurrent test binary.
+func TestMain(m *testing.M) {
+	code := m.Run()
+
+	if simMinerImageRef != "" {
+		if provider, err := testcontainers.NewDockerProvider(); err == nil {
+			_, _ = provider.Client().ImageRemove(context.Background(), simMinerImageRef, client.ImageRemoveOptions{})
+			_ = provider.Close()
+		}
+	}
+
+	os.Exit(code)
 }
 
 // startSimMiner starts a sim miner container and returns connection details


### PR DESCRIPTION
## Summary

`TestDiscoverDevice_MultipleSimMiners` fails intermittently while building the sim miner container:

```
create container: build image: failed to get digest sha256:...:
open /var/lib/docker/image/overlay2/imagedb/content/sha256/...: no such file or directory
```

The digest is different on every occurrence, because it tracks the current build cache rather than a fixed image.

## Cause

`startSimMiner` built from the Dockerfile on every call. Three things combine:

1. Every build uses the same context and Dockerfile, so the build cache resolves all of them to **one image digest**.
2. testcontainers tags each build with a fresh UUID when `Repo`/`Tag` are unset (`container.go:302` `GetRepo`), so several tags point at that single digest.
3. `Terminate` removes a built image unless `KeepImage` is set, and removes it **by ID** (`docker.go:318`), so tearing down one container deletes the digest its siblings still reference.

`TestDiscoverDevice_WithSimMiner` and `TestDiscoverDevice_SchemeNegotiation` run first and each defer a `Terminate`. `TestDiscoverDevice_MultipleSimMiners` then builds twice in a loop; the builds are pure cache hits onto that same digest, and when an earlier removal is still in flight the imagedb entry disappears between build resolution and container create.

## Fix

Build the image once per test binary under a fixed tag with `KeepImage: true`, and start every container from that tag. No production code changes.

## Why now

The race is timing-dependent, so identical code passes here and fails elsewhere. On `main` the package runs ~167s on this repo's runners and passes; on a downstream repo running the same commit on slower runners it took ~185s and failed 4 out of 4 times. This repo is winning the race by margin, not by correctness. Grepping confirms no `KeepImage` anywhere in the tree today.

## Verification

`plugin/proto/internal/driver` passes locally against Docker (60s), `golangci-lint` reports 0 issues, and the built image survives the run:

```
$ docker images proto-fleet-fake-proto-rig --format "{{.Repository}}:{{.Tag}} {{.Size}}"
proto-fleet-fake-proto-rig:driver-tests 21MB
```

Note `plugin/proto/tests` fails locally for me with `read unix ->docker.sock: use of closed network connection`; that reproduces on unmodified `main` (it uses the BuildKit builder over a Docker Desktop socket) and is unrelated to this change. CI covers that package.
