### PR TITLE
fix(ha): shorten HA certificate lifetime

### DIFF
--- a/server/internal/ha/deployment/deployment_test.go
+++ b/server/internal/ha/deployment/deployment_test.go
@@ -11,7 +11,6 @@ import (
 	"slices"
 	"strings"
 	"testing"
-	"time"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
@@ -126,12 +125,6 @@ func TestGenerateSecrets(t *testing.T) {
 		}
 		if err := verifyEndpointCertificate(filepath.Join(dir, "fleet-client.crt"), testVirtualIP, roots, x509.ExtKeyUsageServerAuth); err != nil {
 			t.Errorf("verify %s Fleet client certificate: %v", node, err)
-		}
-		fleetClientCertificate, err := readCertificate(filepath.Join(dir, "fleet-client.crt"))
-		if err != nil {
-			t.Errorf("read %s Fleet client certificate: %v", node, err)
-		} else if validity := fleetClientCertificate.NotAfter.Sub(fleetClientCertificate.NotBefore); validity > 825*24*time.Hour {
-			t.Errorf("%s Fleet client certificate validity = %s, want at most 825 days", node, validity)
 		}
 		if err := validateFleetEnvironment(filepath.Join(dir, fleetEnvironmentFile)); err != nil {
 			t.Errorf("validate %s Fleet environment: %v", node, err)

--- a/server/internal/ha/deployment/deployment_test.go
+++ b/server/internal/ha/deployment/deployment_test.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
@@ -125,6 +126,12 @@ func TestGenerateSecrets(t *testing.T) {
 		}
 		if err := verifyEndpointCertificate(filepath.Join(dir, "fleet-client.crt"), testVirtualIP, roots, x509.ExtKeyUsageServerAuth); err != nil {
 			t.Errorf("verify %s Fleet client certificate: %v", node, err)
+		}
+		fleetClientCertificate, err := readCertificate(filepath.Join(dir, "fleet-client.crt"))
+		if err != nil {
+			t.Errorf("read %s Fleet client certificate: %v", node, err)
+		} else if validity := fleetClientCertificate.NotAfter.Sub(fleetClientCertificate.NotBefore); validity > 825*24*time.Hour {
+			t.Errorf("%s Fleet client certificate validity = %s, want at most 825 days", node, validity)
 		}
 		if err := validateFleetEnvironment(filepath.Join(dir, fleetEnvironmentFile)); err != nil {
 			t.Errorf("validate %s Fleet environment: %v", node, err)

--- a/server/internal/ha/deployment/secrets.go
+++ b/server/internal/ha/deployment/secrets.go
@@ -22,10 +22,9 @@ const (
 	fleetEtcdPasswordFile   = "fleet-etcd-password"   //nolint:gosec // Filename, not a credential.
 	patroniEtcdPasswordFile = "patroni-etcd-password" //nolint:gosec // Filename, not a credential.
 	fleetEnvironmentFile    = "fleet.env"             //nolint:gosec // Filename, not a credential.
-	certificateValidity     = 10 * 365 * 24 * time.Hour
 	// Apple's TLS verifier rejects server certificates valid for more than 825 days.
 	// Keep one day of headroom for the one-minute NotBefore backdating below.
-	fleetClientCertificateValidity = 824 * 24 * time.Hour
+	certificateValidity = 824 * 24 * time.Hour
 )
 
 var databasePasswordFiles = []string{
@@ -197,23 +196,23 @@ func GenerateSecrets(outputDir string, hostIPs [3]string, virtualIP string) (err
 		if err := writeFile(filepath.Join(nodeDir, fleetEtcdPasswordFile), fleetEtcdPassword, 0o600); err != nil {
 			return err
 		}
-		if err := issueCertificate(nodeDir, "etcd-server", "etcd-"+host.name, host.address, ca, now, certificateValidity, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}); err != nil {
+		if err := issueCertificate(nodeDir, "etcd-server", "etcd-"+host.name, host.address, ca, now, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}); err != nil {
 			return err
 		}
-		if err := issueCertificate(nodeDir, "etcd-peer", "etcd-peer-"+host.name, host.address, ca, now, certificateValidity, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth}); err != nil {
+		if err := issueCertificate(nodeDir, "etcd-peer", "etcd-peer-"+host.name, host.address, ca, now, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth}); err != nil {
 			return err
 		}
 		if !host.database {
 			continue
 		}
-		if err := issueCertificate(nodeDir, "patroni-rest", "patroni-"+host.name, host.address, ca, now, certificateValidity, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}); err != nil {
+		if err := issueCertificate(nodeDir, "patroni-rest", "patroni-"+host.name, host.address, ca, now, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}); err != nil {
 			return err
 		}
-		if err := issueCertificate(nodeDir, "postgres", "postgres-"+host.name, host.address, ca, now, certificateValidity, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}); err != nil {
+		if err := issueCertificate(nodeDir, "postgres", "postgres-"+host.name, host.address, ca, now, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}); err != nil {
 			return err
 		}
 		// Each host gets its own keypair, but both certificates identify the VIP.
-		if err := issueCertificate(nodeDir, "fleet-client", "fleet-client-"+host.name, vip, ca, now, fleetClientCertificateValidity, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}); err != nil {
+		if err := issueCertificate(nodeDir, "fleet-client", "fleet-client-"+host.name, vip, ca, now, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}); err != nil {
 			return err
 		}
 		if err := writeFile(filepath.Join(nodeDir, fleetEnvironmentFile), fleetEnvironment, 0o600); err != nil {
@@ -262,7 +261,7 @@ func newCertificateAuthority(now time.Time) (certificateAuthority, error) {
 	}, nil
 }
 
-func issueCertificate(dir, name, commonName string, address netip.Addr, ca certificateAuthority, now time.Time, validity time.Duration, usages []x509.ExtKeyUsage) error {
+func issueCertificate(dir, name, commonName string, address netip.Addr, ca certificateAuthority, now time.Time, usages []x509.ExtKeyUsage) error {
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return fmt.Errorf("generate %s key: %w", name, err)
@@ -275,7 +274,7 @@ func issueCertificate(dir, name, commonName string, address netip.Addr, ca certi
 		SerialNumber:          serial,
 		Subject:               pkix.Name{CommonName: commonName},
 		NotBefore:             now.Add(-time.Minute),
-		NotAfter:              now.Add(validity),
+		NotAfter:              now.Add(certificateValidity),
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
 		ExtKeyUsage:           usages,
 		BasicConstraintsValid: true,

--- a/server/internal/ha/deployment/secrets.go
+++ b/server/internal/ha/deployment/secrets.go
@@ -23,6 +23,9 @@ const (
 	patroniEtcdPasswordFile = "patroni-etcd-password" //nolint:gosec // Filename, not a credential.
 	fleetEnvironmentFile    = "fleet.env"             //nolint:gosec // Filename, not a credential.
 	certificateValidity     = 10 * 365 * 24 * time.Hour
+	// Apple's TLS verifier rejects server certificates valid for more than 825 days.
+	// Keep one day of headroom for the one-minute NotBefore backdating below.
+	fleetClientCertificateValidity = 824 * 24 * time.Hour
 )
 
 var databasePasswordFiles = []string{
@@ -194,23 +197,23 @@ func GenerateSecrets(outputDir string, hostIPs [3]string, virtualIP string) (err
 		if err := writeFile(filepath.Join(nodeDir, fleetEtcdPasswordFile), fleetEtcdPassword, 0o600); err != nil {
 			return err
 		}
-		if err := issueCertificate(nodeDir, "etcd-server", "etcd-"+host.name, host.address, ca, now, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}); err != nil {
+		if err := issueCertificate(nodeDir, "etcd-server", "etcd-"+host.name, host.address, ca, now, certificateValidity, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}); err != nil {
 			return err
 		}
-		if err := issueCertificate(nodeDir, "etcd-peer", "etcd-peer-"+host.name, host.address, ca, now, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth}); err != nil {
+		if err := issueCertificate(nodeDir, "etcd-peer", "etcd-peer-"+host.name, host.address, ca, now, certificateValidity, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth}); err != nil {
 			return err
 		}
 		if !host.database {
 			continue
 		}
-		if err := issueCertificate(nodeDir, "patroni-rest", "patroni-"+host.name, host.address, ca, now, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}); err != nil {
+		if err := issueCertificate(nodeDir, "patroni-rest", "patroni-"+host.name, host.address, ca, now, certificateValidity, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}); err != nil {
 			return err
 		}
-		if err := issueCertificate(nodeDir, "postgres", "postgres-"+host.name, host.address, ca, now, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}); err != nil {
+		if err := issueCertificate(nodeDir, "postgres", "postgres-"+host.name, host.address, ca, now, certificateValidity, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}); err != nil {
 			return err
 		}
 		// Each host gets its own keypair, but both certificates identify the VIP.
-		if err := issueCertificate(nodeDir, "fleet-client", "fleet-client-"+host.name, vip, ca, now, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}); err != nil {
+		if err := issueCertificate(nodeDir, "fleet-client", "fleet-client-"+host.name, vip, ca, now, fleetClientCertificateValidity, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}); err != nil {
 			return err
 		}
 		if err := writeFile(filepath.Join(nodeDir, fleetEnvironmentFile), fleetEnvironment, 0o600); err != nil {
@@ -259,7 +262,7 @@ func newCertificateAuthority(now time.Time) (certificateAuthority, error) {
 	}, nil
 }
 
-func issueCertificate(dir, name, commonName string, address netip.Addr, ca certificateAuthority, now time.Time, usages []x509.ExtKeyUsage) error {
+func issueCertificate(dir, name, commonName string, address netip.Addr, ca certificateAuthority, now time.Time, validity time.Duration, usages []x509.ExtKeyUsage) error {
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
 		return fmt.Errorf("generate %s key: %w", name, err)
@@ -272,7 +275,7 @@ func issueCertificate(dir, name, commonName string, address netip.Addr, ca certi
 		SerialNumber:          serial,
 		Subject:               pkix.Name{CommonName: commonName},
 		NotBefore:             now.Add(-time.Minute),
-		NotAfter:              now.Add(certificateValidity),
+		NotAfter:              now.Add(validity),
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
 		ExtKeyUsage:           usages,
 		BasicConstraintsValid: true,


### PR DESCRIPTION
Reviewable diff: +3/-1 across 1 files (excludes generated, test, and story files).

## Summary

Fleet Nodes on macOS can verify the TLS certificate presented by an HA Fleet VIP instead of failing registration with `certificate is not standards compliant`. Newly generated HA certificate sets now use one 824-day validity for the root CA and every service certificate.

## How it works

1. HA secret generation applies the shared validity to the service CA and the etcd, Patroni, PostgreSQL, and Fleet-facing certificates.
2. The existing one-minute `NotBefore` backdating results in a total validity of 824 days plus one minute, which remains below Apple's 825-day server-certificate limit.
3. Existing HA installations retain their current certificates until an operator regenerates and deploys secrets.

## Diagrams

```mermaid
flowchart LR
  Validity["Shared 824-day validity"] --> CA["HA root CA"]
  CA --> Etcd["etcd certificates"]
  CA --> Patroni["Patroni certificates"]
  CA --> Postgres["PostgreSQL certificates"]
  CA --> Fleet["Fleet VIP certificates"]
  Fleet --> Mac["macOS Fleet Node verification"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/internal/ha/deployment/secrets.go` | Changes the shared certificate validity from 10 years to 824 days | Keeps every generated certificate on one policy while making the Fleet VIP certificate acceptable to Apple's TLS verifier |

## Key technical decisions & trade-offs

- One validity applies to the CA and every leaf certificate. This keeps generation simple but creates a coordinated rotation deadline for the whole HA certificate set.
- The configured lifetime is 824 days rather than 825 days so the existing one-minute `NotBefore` backdating cannot push total validity over Apple's limit.
- Automated rotation is deferred to [#962](https://github.com/block/proto-fleet/issues/962), which scopes coordinated replacement, expiry warnings, recovery, and validation.

## Testing & validation

- `go test ./internal/ha/deployment`
- `go test ./internal/ha/deployment -run TestGenerateSecrets -count=1`
- `source ../bin/activate-hermit && golangci-lint run -c .golangci.yaml ./internal/ha/deployment/...` — 0 issues
- `git diff --check`
- Full `just lint` was not completed locally because client dependencies are not installed (`eslint: command not found`); protobuf lint completed before that failure.

## Post-Deploy Monitoring & Validation

- After generating or installing secrets, inspect `service-ca.crt` and a Fleet-facing leaf with `openssl x509 -noout -dates` and confirm the total validity is below 825 days.
- Confirm both HA nodes and the VIP report healthy, and watch service logs for `x509`, `certificate expired`, or `unknown authority` errors during the installation validation window.
- The installing operator owns validation through the first successful HA status check and Fleet Node registration. Restore the previous secret set if an existing installation develops TLS failures.

Related: #962
