### PR TITLE
Enable fixed-kW building, rack, and group curtailments

### DIFF
--- a/client/src/protoFleet/api/curtailmentScopes.test.ts
+++ b/client/src/protoFleet/api/curtailmentScopes.test.ts
@@ -6,6 +6,7 @@ import {
   type CurtailmentTerminalScope,
   getCurtailmentScopeFormFields,
   getCurtailmentScopeSummary,
+  isCurtailmentTopologyScopeType,
   parseCurtailmentTargetId,
   parseCurtailmentTerminalScopes,
 } from "@/protoFleet/api/curtailmentScopes";
@@ -111,6 +112,23 @@ describe("parseCurtailmentTerminalScopes", () => {
     );
 
     expect(parseCurtailmentTerminalScopes(scopes)).toEqual({ type: "group", groupIds: ["7", "8"] });
+  });
+});
+
+describe("isCurtailmentTopologyScopeType", () => {
+  const cases = [
+    ["building", true],
+    ["rack", true],
+    ["group", true],
+    ["site", false],
+    ["explicitMiners", false],
+    ["deviceIdentifiers", false],
+    ["wholeOrg", false],
+    [undefined, false],
+  ] as const;
+
+  it.each(cases)("classifies %s", (scopeType, expected) => {
+    expect(isCurtailmentTopologyScopeType(scopeType)).toBe(expected);
   });
 });
 

--- a/client/src/protoFleet/api/curtailmentScopes.ts
+++ b/client/src/protoFleet/api/curtailmentScopes.ts
@@ -105,6 +105,12 @@ export function getCurtailmentTerminalScope(
   }
 }
 
+export function isCurtailmentTopologyScopeType(
+  scopeType: CurtailmentTerminalScopeType | CurtailmentTerminalScope["type"] | undefined,
+): boolean {
+  return scopeType === "building" || scopeType === "rack" || scopeType === "group";
+}
+
 function formatScopeCount(count: number, singular: string): string {
   return `${count} ${count === 1 ? singular : `${singular}s`}`;
 }

--- a/client/src/protoFleet/api/useCurtailmentApi.test.ts
+++ b/client/src/protoFleet/api/useCurtailmentApi.test.ts
@@ -2746,6 +2746,59 @@ describe("useCurtailmentApi", () => {
     );
   });
 
+  it.each([
+    {
+      scopeType: "building" as const,
+      targetIds: { buildingTargetIds: ["7", "8"] },
+      protoCase: "building",
+      expectedIds: [7n, 8n],
+    },
+    {
+      scopeType: "rack" as const,
+      targetIds: { rackTargetIds: ["9", "10"] },
+      protoCase: "rack",
+      expectedIds: [9n, 10n],
+    },
+    {
+      scopeType: "group" as const,
+      targetIds: { groupTargetIds: ["11", "12"] },
+      protoCase: "group",
+      expectedIds: [11n, 12n],
+    },
+  ])("starts a frozen fixed-kW $scopeType scope with its typed selectors", async (testCase) => {
+    const startedEvent = curtailmentEvent();
+    mockStartCurtailment.mockResolvedValueOnce({ event: startedEvent });
+    mockListActiveCurtailments.mockResolvedValue({ event: startedEvent });
+    mockListCurtailmentEvents.mockResolvedValue({ events: [startedEvent], nextPageToken: "" });
+    const { result } = renderHook(() => useCurtailmentApi());
+
+    await act(async () => {
+      await result.current.startCurtailment({
+        ...baseSubmitValues,
+        scopeType: testCase.scopeType,
+        ...testCase.targetIds,
+      });
+    });
+
+    const request = mockStartCurtailment.mock.calls[0]?.[0];
+    expect(request).toEqual(
+      expect.objectContaining({
+        mode: CurtailmentMode.FIXED_KW,
+        scopeSchemaVersion: 1,
+      }),
+    );
+    expect(request.scopes.map((scope: { scope: { case?: string } }) => scope.scope.case)).toEqual([
+      testCase.protoCase,
+      testCase.protoCase,
+    ]);
+    expect(
+      request.scopes.map((scope: { scope: { value: { buildingId?: bigint; rackId?: bigint; groupId?: bigint } } }) => {
+        const value = scope.scope.value;
+        return value.buildingId ?? value.rackId ?? value.groupId;
+      }),
+    ).toEqual(testCase.expectedIds);
+  });
+
   it("updates active curtailment fields and refreshes listeners", async () => {
     const changedListener = vi.fn();
     window.addEventListener(CURTAILMENT_CHANGED_EVENT, changedListener);

--- a/client/src/protoFleet/api/useCurtailmentResponseProfiles.test.tsx
+++ b/client/src/protoFleet/api/useCurtailmentResponseProfiles.test.tsx
@@ -297,7 +297,7 @@ describe("useCurtailmentResponseProfiles", () => {
     expect(result.current.responseProfiles[0]).toMatchObject({
       scope: "2 buildings",
       isReadOnly: false,
-      isExecutionReady: false,
+      isAutomationReady: false,
       formValues: expect.objectContaining({ scopeType: "building", buildingTargetIds: ["7", "8"] }),
     });
   });
@@ -767,21 +767,21 @@ describe("useCurtailmentResponseProfiles", () => {
           name: "Buildings",
           scope: "2 buildings",
           isReadOnly: false,
-          isExecutionReady: false,
+          isAutomationReady: false,
           formValues: expect.objectContaining({ scopeType: "building", buildingTargetIds: ["7", "8"] }),
         }),
         expect.objectContaining({
           name: "Rack",
           scope: "1 rack",
           isReadOnly: false,
-          isExecutionReady: false,
+          isAutomationReady: false,
           formValues: expect.objectContaining({ scopeType: "rack", rackTargetIds: ["9"] }),
         }),
         expect.objectContaining({
           name: "Groups",
           scope: "2 groups",
           isReadOnly: false,
-          isExecutionReady: false,
+          isAutomationReady: false,
           formValues: expect.objectContaining({ scopeType: "group", groupTargetIds: ["10", "11"] }),
         }),
       ]),

--- a/client/src/protoFleet/api/useCurtailmentResponseProfiles.ts
+++ b/client/src/protoFleet/api/useCurtailmentResponseProfiles.ts
@@ -33,7 +33,7 @@ import {
   parseOptionalUint32Field,
 } from "@/protoFleet/features/energy/curtailmentNumericFields";
 import {
-  isResponseProfileScopeExecutionReady,
+  isResponseProfileAutomationReady,
   type ResponseProfile,
   type ResponseProfileFormValues,
 } from "@/protoFleet/features/settings/components/Curtailment/types";
@@ -279,7 +279,7 @@ function mapApiResponseProfile(profile: ApiCurtailmentResponseProfile, siteNameB
     deadlineSummary: responseDeadlineMinutes === "1" ? "Within 1 min" : `Within ${responseDeadlineMinutes} min`,
     formValues: readOnlyScopeSummary ? undefined : mergedFormValues,
     isReadOnly: Boolean(readOnlyScopeSummary),
-    isExecutionReady: isResponseProfileScopeExecutionReady(scopeFormValues.scopeType),
+    isAutomationReady: isResponseProfileAutomationReady(scopeFormValues.scopeType),
   };
 }
 

--- a/client/src/protoFleet/features/energy/CurtailmentManagementPanel.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentManagementPanel.test.tsx
@@ -252,6 +252,9 @@ vi.mock("@/protoFleet/features/energy/CurtailmentStartModal", () => ({
       <div data-testid="modal-initial-reason">{initialValues?.reason ?? ""}</div>
       <div data-testid="modal-response-profiles">{responseProfiles?.map((profile) => profile.label).join(",")}</div>
       <div data-testid="modal-response-profile-values">{JSON.stringify(responseProfiles?.[0]?.values ?? {})}</div>
+      <div data-testid="modal-response-profile-all-values">
+        {JSON.stringify(responseProfiles?.map((profile) => profile.values) ?? [])}
+      </div>
       <div data-testid="modal-site-options">{siteOptions?.map((siteOption) => siteOption.name).join(",")}</div>
       <div data-testid="modal-infrastructure-count">{infrastructureDevices?.length ?? 0}</div>
       <div data-testid="modal-infrastructure-loading">{isLoadingInfrastructureDevices ? "loading" : "idle"}</div>
@@ -595,9 +598,9 @@ describe("CurtailmentManagementPanel", () => {
           deadlineSummary: "Within 15 min",
           formValues: {
             name: "Building shed",
-            actionType: "fullFleet",
+            actionType: "fixedKwReduction",
             scopeType: "building",
-            targetKw: "",
+            targetKw: "100",
             buildingTargetIds: ["7", "8"],
             rackTargetIds: [],
             groupTargetIds: [],
@@ -644,6 +647,9 @@ describe("CurtailmentManagementPanel", () => {
       '"deviceIdentifiers":["miner-1","miner-2","miner-3"]',
     );
     expect(screen.getByTestId("modal-response-profile-values")).toHaveTextContent('"targetKw":"50"');
+    expect(screen.getByTestId("modal-response-profile-all-values")).toHaveTextContent('"scopeType":"building"');
+    expect(screen.getByTestId("modal-response-profile-all-values")).toHaveTextContent('"buildingTargetIds":["7","8"]');
+    expect(screen.getByTestId("modal-response-profile-all-values")).toHaveTextContent('"scopeId":"2 buildings"');
   });
 
   it("passes miner-scoped response profiles to the plan modal", async () => {

--- a/client/src/protoFleet/features/energy/CurtailmentManagementPanel.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentManagementPanel.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import clsx from "clsx";
 import { Code, ConnectError } from "@connectrpc/connect";
 
+import { getCurtailmentScopeSummary, getCurtailmentTerminalScope } from "@/protoFleet/api/curtailmentScopes";
 import type { SiteWithCounts } from "@/protoFleet/api/generated/sites/v1/sites_pb";
 import { getErrorCause } from "@/protoFleet/api/requestErrors";
 import { buildSiteNameById } from "@/protoFleet/api/siteNames";
@@ -281,31 +282,42 @@ function createCurtailmentResponseProfileOption(profile: ResponseProfile): Curta
       : siteIds.length > 0
         ? "site"
         : "none";
+  const terminalScope = getCurtailmentTerminalScope(values);
+  const scopeType = hasAllMinersSelected
+    ? "wholeOrg"
+    : terminalScope?.type === "deviceIdentifiers"
+      ? "explicitMiners"
+      : (terminalScope?.type ??
+        (deviceIdentifiers.length > 0 ? "explicitMiners" : siteIds.length > 0 ? "site" : "wholeOrg"));
+  const scopeId =
+    scopeType === "wholeOrg"
+      ? "whole-org"
+      : siteIds.length > 0
+        ? siteIds.length === 1
+          ? siteName
+          : `${siteIds.length} sites`
+        : scopeType === "explicitMiners"
+          ? undefined
+          : terminalScope
+            ? getCurtailmentScopeSummary(terminalScope, {
+                fallbackLabel: "Whole organization",
+                getSiteLabel: (id) => siteNamesById[id],
+              })
+            : undefined;
 
   return {
     id: profile.id,
     label: profile.name,
     values: {
-      scopeType: hasAllMinersSelected
-        ? "wholeOrg"
-        : deviceIdentifiers.length > 0
-          ? "explicitMiners"
-          : siteIds.length > 0
-            ? "site"
-            : "wholeOrg",
-      scopeId: hasAllMinersSelected
-        ? "whole-org"
-        : siteIds.length > 0
-          ? siteIds.length === 1
-            ? siteName
-            : `${siteIds.length} sites`
-          : deviceIdentifiers.length > 0
-            ? undefined
-            : "whole-org",
+      scopeType,
+      scopeId,
       siteSelection,
       siteId,
       siteIds,
       siteNamesById,
+      buildingTargetIds: [...(values.buildingTargetIds ?? [])],
+      rackTargetIds: [...(values.rackTargetIds ?? [])],
+      groupTargetIds: [...(values.groupTargetIds ?? [])],
       deviceSetIds: [],
       deviceIdentifiers,
       minerSelectionMode: hasAllMinersSelected ? "all" : "subset",

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.test.tsx
@@ -584,7 +584,7 @@ describe("CurtailmentStartModal", () => {
     );
   });
 
-  it("rehydrates a topology-scoped response profile without widening or running its terminal scope", async () => {
+  it("rehydrates and runs a fixed-kW topology-scoped response profile without widening its terminal scope", async () => {
     const user = userEvent.setup();
     const { onSubmit } = renderModal({
       initialValues: { ...configuredValues, includeMaintenance: false },
@@ -609,17 +609,26 @@ describe("CurtailmentStartModal", () => {
     expect(screen.getByRole("button", { name: /Sites\s+Select/ })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Miners\s+Select/ })).toBeInTheDocument();
 
-    expect(screen.getByRole("button", { name: "Run curtailment" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Run curtailment" })).toBeEnabled();
+    await user.click(screen.getByRole("button", { name: "Run curtailment" }));
     expect(
       screen.getByText(
-        "This topology target can be previewed, but it cannot be run until topology execution is enabled.",
+        "This will curtail miners in 2 buildings immediately. Schedules stay suppressed until miners are restored.",
       ),
     ).toBeInTheDocument();
-    expect(onSubmit).not.toHaveBeenCalled();
+    await confirmCurtailment(user);
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scopeType: "building",
+        buildingTargetIds: ["7", "8"],
+      }),
+    );
   });
 
-  it("saves a topology-scoped response profile while keeping its test action disabled", async () => {
+  it("saves and tests a fixed-kW topology-scoped response profile", async () => {
     const user = userEvent.setup();
+    const onTestCurtailment = vi.fn();
     const { onSubmit } = renderModal({
       variant: "responseProfile",
       initialValues: {
@@ -628,22 +637,50 @@ describe("CurtailmentStartModal", () => {
         buildingTargetIds: ["7", "8"],
         includeMaintenance: false,
       },
-      onTestCurtailment: vi.fn(),
+      onTestCurtailment,
     });
 
-    expect(screen.getByRole("button", { name: "Run curtailment" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Run curtailment" })).toBeEnabled();
     expect(screen.getByRole("button", { name: "Save profile" })).toBeEnabled();
+
+    await user.click(screen.getByRole("button", { name: "Run curtailment" }));
     expect(
       screen.getByText(
-        "This topology target can be previewed and saved. Running it will be available when topology execution is enabled.",
+        "This will save the profile, then trigger curtailment for miners in 2 buildings. Schedules stay suppressed until miners are restored.",
       ),
     ).toBeInTheDocument();
+    await confirmCurtailment(user);
+
+    expect(onTestCurtailment).toHaveBeenCalledWith(
+      expect.objectContaining({ scopeType: "building", buildingTargetIds: ["7", "8"] }),
+    );
 
     await user.click(screen.getByRole("button", { name: "Save profile" }));
 
     expect(onSubmit).toHaveBeenCalledWith(
       expect.objectContaining({ scopeType: "building", buildingTargetIds: ["7", "8"] }),
     );
+  });
+
+  it("keeps topology-following full-fleet execution disabled", () => {
+    const { onSubmit } = renderModal({
+      initialValues: {
+        ...configuredValues,
+        curtailmentMode: "fullFleet",
+        targetKw: "",
+        scopeType: "building",
+        buildingTargetIds: ["7", "8"],
+        includeMaintenance: false,
+      },
+    });
+
+    expect(screen.getByRole("button", { name: "Run curtailment" })).toBeDisabled();
+    expect(
+      screen.getByText(
+        "This full-fleet topology target can be previewed, but it cannot be run until topology-following execution is enabled.",
+      ),
+    ).toBeInTheDocument();
+    expect(onSubmit).not.toHaveBeenCalled();
   });
 
   it("preserves site scope from response profiles in live curtailment create mode", async () => {

--- a/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
+++ b/client/src/protoFleet/features/energy/CurtailmentStartModal.tsx
@@ -4,6 +4,7 @@ import { create } from "@bufbuild/protobuf";
 import {
   type CurtailmentTerminalScopeType,
   getCurtailmentTerminalScope,
+  isCurtailmentTopologyScopeType,
   parseCurtailmentTargetId,
 } from "@/protoFleet/api/curtailmentScopes";
 import { MinerListFilterSchema } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
@@ -1457,11 +1458,12 @@ function CurtailmentStartModalContent({
   const isSubmitDisabled = isBusy || hasBlockingSubmitPreviewState || hasExternalFormError || !hasEditableChanges;
   const displayedPreviewState = isResponseProfileVariant ? responseProfilePreviewState(previewState) : previewState;
   const terminalScope = getCurtailmentTerminalScope(effectiveValues);
-  const isTopologyExecutionUnavailable =
-    terminalScope?.type === "building" || terminalScope?.type === "rack" || terminalScope?.type === "group";
-  const isPrimarySubmitDisabled = isSubmitDisabled || (!isResponseProfileVariant && isTopologyExecutionUnavailable);
+  const isTopologyFullFleetExecutionUnavailable =
+    effectiveValues.curtailmentMode === "fullFleet" && isCurtailmentTopologyScopeType(terminalScope?.type);
+  const isPrimarySubmitDisabled =
+    isSubmitDisabled || (!isResponseProfileVariant && isTopologyFullFleetExecutionUnavailable);
   const isRunCurtailmentDisabled =
-    isBusy || hasBlockingRunPreviewState || hasExternalFormError || isTopologyExecutionUnavailable;
+    isBusy || hasBlockingRunPreviewState || hasExternalFormError || isTopologyFullFleetExecutionUnavailable;
   const selectedMinerIds = getSelectedMinerIds(effectiveValues);
   const minerApplyToTarget = getMinerApplyToTarget(effectiveValues);
   const targetPathSiteValues = {
@@ -2131,10 +2133,10 @@ function CurtailmentStartModalContent({
               title="Apply to"
               subtext={
                 facilityFanSelectionDisabledReason ??
-                (isTopologyExecutionUnavailable
+                (isTopologyFullFleetExecutionUnavailable
                   ? isResponseProfileVariant
-                    ? "This topology target can be previewed and saved. Running it will be available when topology execution is enabled."
-                    : "This topology target can be previewed, but it cannot be run until topology execution is enabled."
+                    ? "This full-fleet topology target can be previewed and saved. Running it will be available when topology-following execution is enabled."
+                    : "This full-fleet topology target can be previewed, but it cannot be run until topology-following execution is enabled."
                   : "Choose a site-to-miner path and any infrastructure included in this curtailment.")
               }
             >

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentAutomations.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentAutomations.test.tsx
@@ -52,7 +52,7 @@ const testResponseProfiles: ResponseProfile[] = [
     selectionStrategy: "Least efficient first",
     restoreBehavior: "Restore in batches",
     deadlineSummary: "Within 15 min",
-    isExecutionReady: true,
+    isAutomationReady: true,
   },
   {
     id: "partial-reduction",
@@ -62,7 +62,7 @@ const testResponseProfiles: ResponseProfile[] = [
     selectionStrategy: "Least efficient first",
     restoreBehavior: "Restore immediately",
     deadlineSummary: "Within 10 min",
-    isExecutionReady: true,
+    isAutomationReady: true,
   },
 ];
 
@@ -173,12 +173,12 @@ describe("CurtailmentAutomationsContent", () => {
     expect(responseProfileSelect).toHaveTextContent("Facility fan shed");
   });
 
-  it("excludes profiles whose target scope is not ready for execution", () => {
+  it("excludes profiles whose target scope is not ready for automation", () => {
     const topologyProfile: ResponseProfile = {
       ...testResponseProfiles[0],
       id: "building-shed",
       name: "Building shed",
-      isExecutionReady: false,
+      isAutomationReady: false,
     };
     render(
       <CurtailmentAutomationsContent
@@ -194,12 +194,12 @@ describe("CurtailmentAutomationsContent", () => {
     expect(responseProfileSelect).not.toHaveTextContent("Building shed");
   });
 
-  it("prevents enabling an automation whose response profile is not ready for execution", () => {
+  it("prevents enabling an automation whose response profile is not automation-ready", () => {
     const topologyProfile: ResponseProfile = {
       ...testResponseProfiles[0],
       id: "building-shed",
       name: "Building shed",
-      isExecutionReady: false,
+      isAutomationReady: false,
     };
     const topologyRule: AutomationRule = {
       ...testAutomationRules[0],

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentAutomations.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentAutomations.tsx
@@ -74,7 +74,7 @@ const emptyResponseProfiles: ResponseProfile[] = [];
 
 type AutomationRuleWithDetails = AutomationRule & {
   responseProfileName: string;
-  isResponseProfileExecutionReady: boolean;
+  isResponseProfileAutomationReady: boolean;
 };
 
 type AutomationModalProps = {
@@ -513,7 +513,7 @@ function createAutomationColConfig(
           <Switch
             checked={rule.enabled}
             setChecked={() => onToggle(rule.id)}
-            disabled={updatingRuleIds.has(rule.id) || (!rule.enabled && !rule.isResponseProfileExecutionReady)}
+            disabled={updatingRuleIds.has(rule.id) || (!rule.enabled && !rule.isResponseProfileAutomationReady)}
           />
         </div>
       ),
@@ -533,7 +533,7 @@ function mapAutomationRules(
     return {
       ...rule,
       responseProfileName: responseProfile?.name ?? rule.responseProfileName ?? "Unknown profile",
-      isResponseProfileExecutionReady: responseProfile?.isExecutionReady === true,
+      isResponseProfileAutomationReady: responseProfile?.isAutomationReady === true,
     };
   });
 }
@@ -576,13 +576,13 @@ export function CurtailmentAutomationsContent({
   const [isAutomationModalOpen, setIsAutomationModalOpen] = useState(false);
   const [editingAutomationRule, setEditingAutomationRule] = useState<AutomationRule | null>(null);
   const automationRules = controlledAutomationRules ?? localAutomationRules;
-  const executionReadyResponseProfiles = useMemo(
-    () => responseProfiles.filter((profile) => profile.isExecutionReady),
+  const automationReadyResponseProfiles = useMemo(
+    () => responseProfiles.filter((profile) => profile.isAutomationReady),
     [responseProfiles],
   );
-  const executionReadyResponseProfileIds = useMemo(
-    () => new Set(executionReadyResponseProfiles.map((profile) => profile.id)),
-    [executionReadyResponseProfiles],
+  const automationReadyResponseProfileIds = useMemo(
+    () => new Set(automationReadyResponseProfiles.map((profile) => profile.id)),
+    [automationReadyResponseProfiles],
   );
 
   const rulesWithDetails = useMemo(
@@ -591,8 +591,8 @@ export function CurtailmentAutomationsContent({
   );
   const automationModalMode = editingAutomationRule ? "edit" : "create";
   const automationModalInitialValues = useMemo(
-    () => getAutomationFormValuesFromRule(editingAutomationRule, sources, executionReadyResponseProfiles),
-    [editingAutomationRule, executionReadyResponseProfiles, sources],
+    () => getAutomationFormValuesFromRule(editingAutomationRule, sources, automationReadyResponseProfiles),
+    [automationReadyResponseProfiles, editingAutomationRule, sources],
   );
 
   const openCreateAutomationModal = useCallback(() => {
@@ -616,7 +616,7 @@ export function CurtailmentAutomationsContent({
       if (
         !rule ||
         updatingRuleIds.has(ruleId) ||
-        (!rule.enabled && !executionReadyResponseProfileIds.has(rule.responseProfileId))
+        (!rule.enabled && !automationReadyResponseProfileIds.has(rule.responseProfileId))
       ) {
         return;
       }
@@ -633,7 +633,7 @@ export function CurtailmentAutomationsContent({
         ),
       );
     },
-    [automationRules, executionReadyResponseProfileIds, onToggleAutomation, updatingRuleIds],
+    [automationReadyResponseProfileIds, automationRules, onToggleAutomation, updatingRuleIds],
   );
 
   const automationColConfig = useMemo(
@@ -750,7 +750,7 @@ export function CurtailmentAutomationsContent({
         hideTotal
         itemName={{ singular: "automation", plural: "automations" }}
         stickyFirstColumn={false}
-        isRowDisabled={(rule) => !rule.enabled || !rule.isResponseProfileExecutionReady}
+        isRowDisabled={(rule) => !rule.enabled || !rule.isResponseProfileAutomationReady}
         columnsExemptFromDisabledStyling={automationColumnsExemptFromDisabledStyling}
         tableClassName={automationTableClassName}
         noDataElement={automationsNoDataElement}
@@ -768,7 +768,7 @@ export function CurtailmentAutomationsContent({
         mode={automationModalMode}
         initialValues={automationModalInitialValues}
         sources={sources}
-        responseProfiles={executionReadyResponseProfiles}
+        responseProfiles={automationReadyResponseProfiles}
         isLoadingSources={isLoadingSources}
         loadSourcesError={loadSourcesError}
         isLoadingResponseProfiles={isLoadingResponseProfiles}

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.stories.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.stories.tsx
@@ -85,7 +85,7 @@ const storyResponseProfiles: ResponseProfile[] = [
     selectionStrategy: "Least efficient first",
     restoreBehavior: "Restore in batches",
     deadlineSummary: "Within 15 min",
-    isExecutionReady: true,
+    isAutomationReady: true,
   },
   {
     id: "emergency-shed",
@@ -95,7 +95,7 @@ const storyResponseProfiles: ResponseProfile[] = [
     selectionStrategy: "Least efficient first",
     restoreBehavior: "Restore immediately",
     deadlineSummary: "Within 15 min",
-    isExecutionReady: true,
+    isAutomationReady: true,
     formValues: {
       name: "Emergency shed",
       actionType: "fullFleet",
@@ -127,7 +127,7 @@ const storyResponseProfiles: ResponseProfile[] = [
     selectionStrategy: "Least efficient first",
     restoreBehavior: "Restore in batches",
     deadlineSummary: "Within 15 min",
-    isExecutionReady: true,
+    isAutomationReady: true,
     formValues: {
       name: "Partial reduction",
       actionType: "fixedKwReduction",
@@ -159,7 +159,7 @@ const storyResponseProfiles: ResponseProfile[] = [
     selectionStrategy: "Least efficient first",
     restoreBehavior: "Restore in batches",
     deadlineSummary: "Within 15 min",
-    isExecutionReady: true,
+    isAutomationReady: true,
     formValues: {
       name: "Staged reduction",
       actionType: "fixedKwReduction",

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.test.tsx
@@ -191,7 +191,7 @@ const testResponseProfiles: ResponseProfile[] = [
     selectionStrategy: "Least efficient first",
     restoreBehavior: "Restore in batches",
     deadlineSummary: "Within 5 min",
-    isExecutionReady: true,
+    isAutomationReady: true,
     formValues: {
       name: "Emergency full shed",
       actionType: "fullFleet",
@@ -223,7 +223,7 @@ const testResponseProfiles: ResponseProfile[] = [
     selectionStrategy: "Least efficient first",
     restoreBehavior: "Restore immediately",
     deadlineSummary: "Within 15 min",
-    isExecutionReady: true,
+    isAutomationReady: true,
     formValues: {
       name: "Site Alpha 500 kW",
       actionType: "fixedKwReduction",
@@ -257,7 +257,7 @@ const targetedMinersResponseProfile: ResponseProfile = {
   selectionStrategy: "Least efficient first",
   restoreBehavior: "Restore in batches",
   deadlineSummary: "Within 15 min",
-  isExecutionReady: true,
+  isAutomationReady: true,
   formValues: {
     name: "Targeted miners",
     actionType: "fixedKwReduction",
@@ -290,7 +290,7 @@ const siteScopedResponseProfile: ResponseProfile = {
   selectionStrategy: "Least efficient first",
   restoreBehavior: "Restore immediately",
   deadlineSummary: "Within 15 min",
-  isExecutionReady: true,
+  isAutomationReady: true,
   formValues: {
     name: "Site scoped profile",
     actionType: "fixedKwReduction",
@@ -1332,7 +1332,7 @@ describe("CurtailmentSettingsPage", () => {
         siteIds: [],
       },
       isReadOnly: false,
-      isExecutionReady: false,
+      isAutomationReady: false,
     };
 
     render(<CurtailmentSettingsContent initialResponseProfiles={[topologyProfile]} />);

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.tsx
@@ -31,7 +31,7 @@ import {
   type CurtailmentSource,
   type CurtailmentSourceFormValues,
   DEFAULT_SOURCE_STALENESS_THRESHOLD_SEC,
-  isResponseProfileScopeExecutionReady,
+  isResponseProfileAutomationReady,
   MAX_SOURCE_STALENESS_THRESHOLD_SEC,
   type ResponseProfile,
   type ResponseProfileFormValues,
@@ -390,7 +390,7 @@ function createResponseProfileFromFormValues(
     restoreBehavior: responseProfileRestoreBehaviorLabel[normalizedValues.restoreBehavior],
     deadlineSummary: getResponseProfileDeadlineSummary(normalizedValues),
     formValues: normalizedValues,
-    isExecutionReady: isResponseProfileScopeExecutionReady(normalizedValues.scopeType),
+    isAutomationReady: isResponseProfileAutomationReady(normalizedValues.scopeType),
   };
 }
 

--- a/client/src/protoFleet/features/settings/components/Curtailment/types.ts
+++ b/client/src/protoFleet/features/settings/components/Curtailment/types.ts
@@ -1,4 +1,4 @@
-import type { CurtailmentTerminalScopeType } from "@/protoFleet/api/curtailmentScopes";
+import { type CurtailmentTerminalScopeType, isCurtailmentTopologyScopeType } from "@/protoFleet/api/curtailmentScopes";
 
 export type CurtailmentHealth = "connected" | "waitingForSignal" | "noSignal" | "offline";
 export type AutomationTriggerType = "MQTT";
@@ -44,8 +44,8 @@ export type ResponseProfileRestoreBehavior = "automaticBatchRestore" | "automati
 export type ResponseProfileSiteSelection = "none" | "allSites" | "site";
 export type ResponseProfileScopeType = CurtailmentTerminalScopeType;
 
-export function isResponseProfileScopeExecutionReady(scopeType: ResponseProfileScopeType | undefined): boolean {
-  return scopeType !== undefined && scopeType !== "building" && scopeType !== "rack" && scopeType !== "group";
+export function isResponseProfileAutomationReady(scopeType: ResponseProfileScopeType | undefined): boolean {
+  return scopeType !== undefined && !isCurtailmentTopologyScopeType(scopeType);
 }
 
 export type ResponseProfileFormValues = {
@@ -89,7 +89,7 @@ export type ResponseProfile = {
   deadlineSummary: string;
   formValues?: ResponseProfileFormValues;
   isReadOnly?: boolean;
-  isExecutionReady: boolean;
+  isAutomationReady: boolean;
 };
 
 export type AutomationConditionType = "mqttTriggerTargetOff" | "marketPriceAbove" | "hashpriceBelow" | "capacityAbove";

--- a/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
+++ b/docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
@@ -130,10 +130,11 @@ When an owned miner leaves scope or becomes unpaired:
 - During that staged rollout, topology-scoped profiles remain visible but
   read-only in Settings and are excluded from the New curtailment profile
   selector until the UI can rehydrate their terminal selector. Once the UI
-  lands, operators may preview and save topology scopes, but Run, Test, and
-  automation remain disabled until topology execution and lifecycle support
-  land. No intermediate adapter may synthesize Whole organization for an
-  unsupported typed scope.
+  lands, operators may preview and save topology scopes. Fixed-kW Run and Test
+  become available with frozen topology execution; FULL_FLEET Run/Test and
+  automation remain disabled until topology-following lifecycle support lands.
+  No intermediate adapter may synthesize Whole organization for an unsupported
+  typed scope.
 
 ### 2. Add the shared drill-down target builder
 

--- a/server/cmd/fleetd/main.go
+++ b/server/cmd/fleetd/main.go
@@ -553,6 +553,7 @@ func start(config *Config) (result error) {
 		curtailmentReconciler.WithMetrics(curtailmentMetrics),
 		curtailmentReconciler.WithFacilityFanController(facilityFanController),
 		curtailmentReconciler.WithFacilityFanAlertEmitter(metricsProvider),
+		curtailmentReconciler.WithDispatchPermissionResolver(permissionResolver),
 		// The confirmation fast path samples device metrics through the
 		// telemetry service's read-only seam (shared worker pool, no
 		// persistence side effects).

--- a/server/generated/sqlc/curtailment.sql.go
+++ b/server/generated/sqlc/curtailment.sql.go
@@ -3369,7 +3369,7 @@ func (q *Queries) RecordCurtailPendingDispatch(ctx context.Context, arg RecordCu
 	return result.RowsAffected()
 }
 
-const releaseUndispatchedAllPairedTargetsForRestore = `-- name: ReleaseUndispatchedAllPairedTargetsForRestore :execrows
+const releaseUndispatchedTargetsForRestore = `-- name: ReleaseUndispatchedTargetsForRestore :execrows
 UPDATE curtailment_target
 SET state              = 'released',
     last_error         = COALESCE(last_error, 'released without restore: no curtail command dispatched'),
@@ -3378,16 +3378,27 @@ SET state              = 'released',
     curtail_last_error = COALESCE(curtail_last_error, last_error, 'released without restore: no curtail command dispatched')
 WHERE curtailment_event_id = $1
   AND desired_state = 'curtailed'
-  AND state IN ('pending', 'unavailable')
+  AND (
+      state IN ('pending', 'unavailable')
+      OR (
+          state = 'dispatching'
+          AND device_identifier = ANY($2::TEXT[])
+      )
+  )
   AND last_dispatched_at IS NULL
   AND curtail_dispatched_at IS NULL
   AND retry_count = 0
   AND restore_started_at IS NULL
 `
 
-// All-paired policy targets that never received a Curtail command do not need
-// Uncurtail. Release them before the restore reset so graceful Stop does not
-// enqueue no-op restore work for offline/auth-needed miners.
+type ReleaseUndispatchedTargetsForRestoreParams struct {
+	CurtailmentEventID           int64
+	KnownUnsentDeviceIdentifiers []string
+}
+
+// Targets that never received a Curtail command do not need Uncurtail. Release
+// them before the restore reset so graceful Stop does not enqueue commands
+// that could wake miners this event never curtailed.
 //
 // "Never attempted" is retry_count = 0 plus NULL dispatch timestamps: every
 // dispatch attempt/failure bumps retry_count and every successful enqueue
@@ -3402,8 +3413,8 @@ WHERE curtailment_event_id = $1
 // stamp survives that reset — any row that ever entered a restore cycle had
 // a real dispatch in its past and must route through the restore queue, not
 // be terminally released.
-func (q *Queries) ReleaseUndispatchedAllPairedTargetsForRestore(ctx context.Context, curtailmentEventID int64) (int64, error) {
-	result, err := q.exec(ctx, q.releaseUndispatchedAllPairedTargetsForRestoreStmt, releaseUndispatchedAllPairedTargetsForRestore, curtailmentEventID)
+func (q *Queries) ReleaseUndispatchedTargetsForRestore(ctx context.Context, arg ReleaseUndispatchedTargetsForRestoreParams) (int64, error) {
+	result, err := q.exec(ctx, q.releaseUndispatchedTargetsForRestoreStmt, releaseUndispatchedTargetsForRestore, arg.CurtailmentEventID, pq.Array(arg.KnownUnsentDeviceIdentifiers))
 	if err != nil {
 		return 0, err
 	}

--- a/server/generated/sqlc/curtailment.sql.go
+++ b/server/generated/sqlc/curtailment.sql.go
@@ -3578,7 +3578,7 @@ WITH selected_resources AS MATERIALIZED (
               FROM device_set_membership dsm
               WHERE dsm.org_id = $1
                 AND dsm.device_id = d.id
-                AND dsm.device_set_type = sr.selector_type
+                AND dsm.device_set_type::TEXT = sr.selector_type
                 AND dsm.device_set_id = sr.selector_id
           ))
      )

--- a/server/generated/sqlc/curtailment.sql.go
+++ b/server/generated/sqlc/curtailment.sql.go
@@ -3555,8 +3555,6 @@ WITH selected_resources AS MATERIALIZED (
       AND ds.id = ANY($4::BIGINT[])
 ), members AS MATERIALIZED (
     SELECT DISTINCT
-           sr.selector_type,
-           sr.selector_id,
            d.id AS device_id,
            d.device_identifier,
            d.site_id
@@ -3593,6 +3591,8 @@ WITH selected_resources AS MATERIALIZED (
                 AND dsm.device_set_id = sr.selector_id
           ))
      )
+    ORDER BY d.id
+    LIMIT 10001
 ), selector_rollup AS (
     SELECT
         COALESCE(array_agg(sr.selector_id ORDER BY sr.selector_id), '{}')::BIGINT[] AS existing_selector_ids,
@@ -3615,9 +3615,15 @@ WITH selected_resources AS MATERIALIZED (
             array_agg(sr.selector_id ORDER BY sr.selector_id)
                 FILTER (WHERE sr.selector_type = 'group'
                         AND NOT EXISTS (
-                            SELECT 1 FROM members m
-                            WHERE m.selector_type = sr.selector_type
-                              AND m.selector_id = sr.selector_id
+                            SELECT 1
+                            FROM device_set_membership dsm
+                            JOIN device d
+                              ON d.id = dsm.device_id
+                             AND d.org_id = dsm.org_id
+                             AND d.deleted_at IS NULL
+                            WHERE dsm.org_id = $1
+                              AND dsm.device_set_type = 'group'
+                              AND dsm.device_set_id = sr.selector_id
                         )),
             '{}'
         )::BIGINT[] AS empty_group_ids

--- a/server/generated/sqlc/curtailment.sql.go
+++ b/server/generated/sqlc/curtailment.sql.go
@@ -3300,7 +3300,7 @@ WHERE d.org_id = $1
   )
 ORDER BY d.id
 LIMIT 10001
-FOR UPDATE
+FOR NO KEY UPDATE
 `
 
 type LockCurtailmentTopologyMemberDeviceSitesByOrgParams struct {
@@ -3319,6 +3319,8 @@ type LockCurtailmentTopologyMemberDeviceSitesByOrgRow struct {
 // event targets/profile row are persisted. The query mirrors the executable
 // topology selector predicates and locks in device.id order, matching the
 // canonical device-reassignment lock order used by site/building/rack writes.
+// Topology writes still conflict with this lock, while command queue inserts
+// can take the foreign-key KEY SHARE lock on device without self-deadlocking.
 func (q *Queries) LockCurtailmentTopologyMemberDeviceSitesByOrg(ctx context.Context, arg LockCurtailmentTopologyMemberDeviceSitesByOrgParams) ([]LockCurtailmentTopologyMemberDeviceSitesByOrgRow, error) {
 	rows, err := q.query(ctx, q.lockCurtailmentTopologyMemberDeviceSitesByOrgStmt, lockCurtailmentTopologyMemberDeviceSitesByOrg,
 		arg.OrgID,

--- a/server/generated/sqlc/curtailment.sql.go
+++ b/server/generated/sqlc/curtailment.sql.go
@@ -3498,6 +3498,196 @@ func (q *Queries) ResetCurtailmentTargetsForRestore(ctx context.Context, curtail
 	return err
 }
 
+const resolveCurtailmentTopologyDispatch = `-- name: ResolveCurtailmentTopologyDispatch :one
+WITH selected_resources AS MATERIALIZED (
+    SELECT 'building'::TEXT AS selector_type,
+           b.id AS selector_id,
+           b.site_id AS resource_site_id,
+           NULL::BIGINT AS building_id,
+           NULL::BIGINT AS building_site_id
+    FROM building b
+    WHERE b.org_id = $1
+      AND b.deleted_at IS NULL
+      AND b.id = ANY($2::BIGINT[])
+
+    UNION ALL
+
+    SELECT 'rack'::TEXT AS selector_type,
+           ds.id AS selector_id,
+           dsr.site_id AS resource_site_id,
+           dsr.building_id,
+           b.site_id AS building_site_id
+    FROM device_set ds
+    JOIN device_set_rack dsr
+      ON dsr.device_set_id = ds.id
+     AND dsr.org_id = ds.org_id
+    LEFT JOIN building b
+      ON b.id = dsr.building_id
+     AND b.org_id = dsr.org_id
+     AND b.deleted_at IS NULL
+    WHERE ds.org_id = $1
+      AND ds.type = 'rack'
+      AND ds.deleted_at IS NULL
+      AND ds.id = ANY($3::BIGINT[])
+
+    UNION ALL
+
+    SELECT 'group'::TEXT AS selector_type,
+           ds.id AS selector_id,
+           NULL::BIGINT AS resource_site_id,
+           NULL::BIGINT AS building_id,
+           NULL::BIGINT AS building_site_id
+    FROM device_set ds
+    WHERE ds.org_id = $1
+      AND ds.type = 'group'
+      AND ds.deleted_at IS NULL
+      AND ds.id = ANY($4::BIGINT[])
+), members AS MATERIALIZED (
+    SELECT DISTINCT
+           sr.selector_type,
+           sr.selector_id,
+           d.id AS device_id,
+           d.device_identifier,
+           d.site_id
+    FROM selected_resources sr
+    JOIN device d
+      ON d.org_id = $1
+     AND d.deleted_at IS NULL
+     AND (
+          (sr.selector_type = 'building' AND (
+              d.building_id = sr.selector_id
+              OR EXISTS (
+                  SELECT 1
+                  FROM device_set_membership dsm
+                  JOIN device_set ds
+                    ON ds.id = dsm.device_set_id
+                   AND ds.org_id = dsm.org_id
+                   AND ds.type = 'rack'
+                   AND ds.deleted_at IS NULL
+                  JOIN device_set_rack dsr
+                    ON dsr.device_set_id = ds.id
+                   AND dsr.org_id = ds.org_id
+                  WHERE dsm.org_id = $1
+                    AND dsm.device_id = d.id
+                    AND dsm.device_set_type = 'rack'
+                    AND dsr.building_id = sr.selector_id
+              )
+          ))
+          OR (sr.selector_type IN ('rack', 'group') AND EXISTS (
+              SELECT 1
+              FROM device_set_membership dsm
+              WHERE dsm.org_id = $1
+                AND dsm.device_id = d.id
+                AND dsm.device_set_type = sr.selector_type
+                AND dsm.device_set_id = sr.selector_id
+          ))
+     )
+), selector_rollup AS (
+    SELECT
+        COALESCE(array_agg(sr.selector_id ORDER BY sr.selector_id), '{}')::BIGINT[] AS existing_selector_ids,
+        COALESCE(
+            array_agg(DISTINCT sr.resource_site_id ORDER BY sr.resource_site_id)
+                FILTER (WHERE sr.resource_site_id IS NOT NULL),
+            '{}'
+        )::BIGINT[] AS selected_resource_site_ids,
+        COALESCE(bool_or(sr.selector_type <> 'group' AND sr.resource_site_id IS NULL), FALSE)::BOOLEAN AS has_unassigned_resource,
+        COALESCE(
+            array_agg(sr.selector_id ORDER BY sr.selector_id)
+                FILTER (WHERE sr.selector_type = 'rack'
+                        AND sr.building_id IS NOT NULL
+                        AND sr.resource_site_id IS NOT NULL
+                        AND sr.building_site_id IS NOT NULL
+                        AND sr.resource_site_id <> sr.building_site_id),
+            '{}'
+        )::BIGINT[] AS mismatched_rack_ids,
+        COALESCE(
+            array_agg(sr.selector_id ORDER BY sr.selector_id)
+                FILTER (WHERE sr.selector_type = 'group'
+                        AND NOT EXISTS (
+                            SELECT 1 FROM members m
+                            WHERE m.selector_type = sr.selector_type
+                              AND m.selector_id = sr.selector_id
+                        )),
+            '{}'
+        )::BIGINT[] AS empty_group_ids
+    FROM selected_resources sr
+), member_rollup AS (
+    SELECT
+        COUNT(DISTINCT m.device_id)::BIGINT AS member_count,
+        COALESCE(
+            array_agg(DISTINCT m.site_id ORDER BY m.site_id)
+                FILTER (WHERE m.site_id IS NOT NULL),
+            '{}'
+        )::BIGINT[] AS current_member_site_ids,
+        COALESCE(bool_or(m.device_id IS NOT NULL AND m.site_id IS NULL), FALSE)::BOOLEAN AS has_unassigned_member,
+        COALESCE(
+            array_agg(DISTINCT m.device_identifier ORDER BY m.device_identifier)
+                FILTER (WHERE m.device_identifier = ANY($5::TEXT[])),
+            '{}'
+        )::TEXT[] AS dispatch_member_device_identifiers
+    FROM members m
+)
+SELECT
+    sr.existing_selector_ids,
+    sr.selected_resource_site_ids,
+    sr.has_unassigned_resource,
+    sr.mismatched_rack_ids,
+    sr.empty_group_ids,
+    mr.member_count,
+    mr.current_member_site_ids,
+    mr.has_unassigned_member,
+    mr.dispatch_member_device_identifiers
+FROM selector_rollup sr
+CROSS JOIN member_rollup mr
+`
+
+type ResolveCurtailmentTopologyDispatchParams struct {
+	OrgID                     int64
+	BuildingIds               []int64
+	RackIds                   []int64
+	GroupIds                  []int64
+	DispatchDeviceIdentifiers []string
+}
+
+type ResolveCurtailmentTopologyDispatchRow struct {
+	ExistingSelectorIds             []int64
+	SelectedResourceSiteIds         []int64
+	HasUnassignedResource           bool
+	MismatchedRackIds               []int64
+	EmptyGroupIds                   []int64
+	MemberCount                     int64
+	CurrentMemberSiteIds            []int64
+	HasUnassignedMember             bool
+	DispatchMemberDeviceIdentifiers []string
+}
+
+// Returns authorization coverage for the full live selector plus membership
+// only for the devices in the pending dispatch batch. Both are derived by one
+// statement snapshot so a concurrent placement change cannot mix old coverage
+// with new membership. The reconciler validates selector shape before calling.
+func (q *Queries) ResolveCurtailmentTopologyDispatch(ctx context.Context, arg ResolveCurtailmentTopologyDispatchParams) (ResolveCurtailmentTopologyDispatchRow, error) {
+	row := q.queryRow(ctx, q.resolveCurtailmentTopologyDispatchStmt, resolveCurtailmentTopologyDispatch,
+		arg.OrgID,
+		pq.Array(arg.BuildingIds),
+		pq.Array(arg.RackIds),
+		pq.Array(arg.GroupIds),
+		pq.Array(arg.DispatchDeviceIdentifiers),
+	)
+	var i ResolveCurtailmentTopologyDispatchRow
+	err := row.Scan(
+		pq.Array(&i.ExistingSelectorIds),
+		pq.Array(&i.SelectedResourceSiteIds),
+		&i.HasUnassignedResource,
+		pq.Array(&i.MismatchedRackIds),
+		pq.Array(&i.EmptyGroupIds),
+		&i.MemberCount,
+		pq.Array(&i.CurrentMemberSiteIds),
+		&i.HasUnassignedMember,
+		pq.Array(&i.DispatchMemberDeviceIdentifiers),
+	)
+	return i, err
+}
+
 const resumeCurtailmentFromRestoring = `-- name: ResumeCurtailmentFromRestoring :one
 UPDATE curtailment_event
 SET state = 'pending',

--- a/server/generated/sqlc/db.go
+++ b/server/generated/sqlc/db.go
@@ -1275,8 +1275,8 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.refreshOpenErrorsLastSeenByDeviceStmt, err = db.PrepareContext(ctx, refreshOpenErrorsLastSeenByDevice); err != nil {
 		return nil, fmt.Errorf("error preparing query RefreshOpenErrorsLastSeenByDevice: %w", err)
 	}
-	if q.releaseUndispatchedAllPairedTargetsForRestoreStmt, err = db.PrepareContext(ctx, releaseUndispatchedAllPairedTargetsForRestore); err != nil {
-		return nil, fmt.Errorf("error preparing query ReleaseUndispatchedAllPairedTargetsForRestore: %w", err)
+	if q.releaseUndispatchedTargetsForRestoreStmt, err = db.PrepareContext(ctx, releaseUndispatchedTargetsForRestore); err != nil {
+		return nil, fmt.Errorf("error preparing query ReleaseUndispatchedTargetsForRestore: %w", err)
 	}
 	if q.removeAllDevicesFromDeviceSetStmt, err = db.PrepareContext(ctx, removeAllDevicesFromDeviceSet); err != nil {
 		return nil, fmt.Errorf("error preparing query RemoveAllDevicesFromDeviceSet: %w", err)
@@ -3773,9 +3773,9 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing refreshOpenErrorsLastSeenByDeviceStmt: %w", cerr)
 		}
 	}
-	if q.releaseUndispatchedAllPairedTargetsForRestoreStmt != nil {
-		if cerr := q.releaseUndispatchedAllPairedTargetsForRestoreStmt.Close(); cerr != nil {
-			err = fmt.Errorf("error closing releaseUndispatchedAllPairedTargetsForRestoreStmt: %w", cerr)
+	if q.releaseUndispatchedTargetsForRestoreStmt != nil {
+		if cerr := q.releaseUndispatchedTargetsForRestoreStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing releaseUndispatchedTargetsForRestoreStmt: %w", cerr)
 		}
 	}
 	if q.removeAllDevicesFromDeviceSetStmt != nil {
@@ -4909,7 +4909,7 @@ type Queries struct {
 	reconcileDefaultPasswordPairingStatusByIdentifierStmt        *sql.Stmt
 	recordCurtailPendingDispatchStmt                             *sql.Stmt
 	refreshOpenErrorsLastSeenByDeviceStmt                        *sql.Stmt
-	releaseUndispatchedAllPairedTargetsForRestoreStmt            *sql.Stmt
+	releaseUndispatchedTargetsForRestoreStmt                     *sql.Stmt
 	removeAllDevicesFromDeviceSetStmt                            *sql.Stmt
 	removeDevicesFromAnyRackStmt                                 *sql.Stmt
 	removeDevicesFromDeviceSetStmt                               *sql.Stmt
@@ -5468,7 +5468,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		reconcileDefaultPasswordPairingStatusByIdentifierStmt:        q.reconcileDefaultPasswordPairingStatusByIdentifierStmt,
 		recordCurtailPendingDispatchStmt:                             q.recordCurtailPendingDispatchStmt,
 		refreshOpenErrorsLastSeenByDeviceStmt:                        q.refreshOpenErrorsLastSeenByDeviceStmt,
-		releaseUndispatchedAllPairedTargetsForRestoreStmt:            q.releaseUndispatchedAllPairedTargetsForRestoreStmt,
+		releaseUndispatchedTargetsForRestoreStmt:                     q.releaseUndispatchedTargetsForRestoreStmt,
 		removeAllDevicesFromDeviceSetStmt:                            q.removeAllDevicesFromDeviceSetStmt,
 		removeDevicesFromAnyRackStmt:                                 q.removeDevicesFromAnyRackStmt,
 		removeDevicesFromDeviceSetStmt:                               q.removeDevicesFromDeviceSetStmt,

--- a/server/generated/sqlc/db.go
+++ b/server/generated/sqlc/db.go
@@ -1305,6 +1305,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.resetReapedFirmwareStatusesStmt, err = db.PrepareContext(ctx, resetReapedFirmwareStatuses); err != nil {
 		return nil, fmt.Errorf("error preparing query ResetReapedFirmwareStatuses: %w", err)
 	}
+	if q.resolveCurtailmentTopologyDispatchStmt, err = db.PrepareContext(ctx, resolveCurtailmentTopologyDispatch); err != nil {
+		return nil, fmt.Errorf("error preparing query ResolveCurtailmentTopologyDispatch: %w", err)
+	}
 	if q.resumeCurtailmentFromRestoringStmt, err = db.PrepareContext(ctx, resumeCurtailmentFromRestoring); err != nil {
 		return nil, fmt.Errorf("error preparing query ResumeCurtailmentFromRestoring: %w", err)
 	}
@@ -3820,6 +3823,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing resetReapedFirmwareStatusesStmt: %w", cerr)
 		}
 	}
+	if q.resolveCurtailmentTopologyDispatchStmt != nil {
+		if cerr := q.resolveCurtailmentTopologyDispatchStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing resolveCurtailmentTopologyDispatchStmt: %w", cerr)
+		}
+	}
 	if q.resumeCurtailmentFromRestoringStmt != nil {
 		if cerr := q.resumeCurtailmentFromRestoringStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing resumeCurtailmentFromRestoringStmt: %w", cerr)
@@ -4911,6 +4919,7 @@ type Queries struct {
 	resetCurtailmentTargetsForRecurtailStmt                      *sql.Stmt
 	resetCurtailmentTargetsForRestoreStmt                        *sql.Stmt
 	resetReapedFirmwareStatusesStmt                              *sql.Stmt
+	resolveCurtailmentTopologyDispatchStmt                       *sql.Stmt
 	resumeCurtailmentFromRestoringStmt                           *sql.Stmt
 	resumePausedScheduleStmt                                     *sql.Stmt
 	retryRigConfigReconciliationStmt                             *sql.Stmt
@@ -5469,6 +5478,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		resetCurtailmentTargetsForRecurtailStmt:                      q.resetCurtailmentTargetsForRecurtailStmt,
 		resetCurtailmentTargetsForRestoreStmt:                        q.resetCurtailmentTargetsForRestoreStmt,
 		resetReapedFirmwareStatusesStmt:                              q.resetReapedFirmwareStatusesStmt,
+		resolveCurtailmentTopologyDispatchStmt:                       q.resolveCurtailmentTopologyDispatchStmt,
 		resumeCurtailmentFromRestoringStmt:                           q.resumeCurtailmentFromRestoringStmt,
 		resumePausedScheduleStmt:                                     q.resumePausedScheduleStmt,
 		retryRigConfigReconciliationStmt:                             q.retryRigConfigReconciliationStmt,

--- a/server/generated/sqlc/querier.go
+++ b/server/generated/sqlc/querier.go
@@ -1329,9 +1329,9 @@ type Querier interface {
 	// Refreshes open errors for a device after an incomplete diagnostics poll.
 	// Uses GREATEST so a delayed partial poll cannot move newer observations backward.
 	RefreshOpenErrorsLastSeenByDevice(ctx context.Context, arg RefreshOpenErrorsLastSeenByDeviceParams) (sql.Result, error)
-	// All-paired policy targets that never received a Curtail command do not need
-	// Uncurtail. Release them before the restore reset so graceful Stop does not
-	// enqueue no-op restore work for offline/auth-needed miners.
+	// Targets that never received a Curtail command do not need Uncurtail. Release
+	// them before the restore reset so graceful Stop does not enqueue commands
+	// that could wake miners this event never curtailed.
 	//
 	// "Never attempted" is retry_count = 0 plus NULL dispatch timestamps: every
 	// dispatch attempt/failure bumps retry_count and every successful enqueue
@@ -1346,7 +1346,7 @@ type Querier interface {
 	// stamp survives that reset — any row that ever entered a restore cycle had
 	// a real dispatch in its past and must route through the restore queue, not
 	// be terminally released.
-	ReleaseUndispatchedAllPairedTargetsForRestore(ctx context.Context, curtailmentEventID int64) (int64, error)
+	ReleaseUndispatchedTargetsForRestore(ctx context.Context, arg ReleaseUndispatchedTargetsForRestoreParams) (int64, error)
 	RemoveAllDevicesFromDeviceSet(ctx context.Context, arg RemoveAllDevicesFromDeviceSetParams) (int64, error)
 	// Removes the given devices from whatever rack they're currently in,
 	// EXCEPT the target rack (@target_rack_id). AssignDevicesToRack uses

--- a/server/generated/sqlc/querier.go
+++ b/server/generated/sqlc/querier.go
@@ -1378,6 +1378,11 @@ type Querier interface {
 	// has an unambiguous queue. Terminal states are untouched.
 	ResetCurtailmentTargetsForRestore(ctx context.Context, curtailmentEventID int64) error
 	ResetReapedFirmwareStatuses(ctx context.Context, deviceIds []int64) error
+	// Returns authorization coverage for the full live selector plus membership
+	// only for the devices in the pending dispatch batch. Both are derived by one
+	// statement snapshot so a concurrent placement change cannot mix old coverage
+	// with new membership. The reconciler validates selector shape before calling.
+	ResolveCurtailmentTopologyDispatch(ctx context.Context, arg ResolveCurtailmentTopologyDispatchParams) (ResolveCurtailmentTopologyDispatchRow, error)
 	// Restore reversal: go back through pending so the curtail dispatcher picks
 	// up reset targets. Preserve fan_off_sent_at and fan_last_error until the
 	// active reconciler has positively reopened airflow; clearing them here can

--- a/server/generated/sqlc/querier.go
+++ b/server/generated/sqlc/querier.go
@@ -981,7 +981,7 @@ type Querier interface {
 	ListEffectivePermissionsForUser(ctx context.Context, arg ListEffectivePermissionsForUserParams) ([]ListEffectivePermissionsForUserRow, error)
 	// Race-safety variant of ListEffectivePermissionsForUser. Same join
 	// shape, same row order, same narrowing semantics — but takes
-	// FOR UPDATE on every row whose mutation can revoke the caller's
+	// FOR NO KEY UPDATE on every row whose mutation can revoke the caller's
 	// effective permissions: the assignment row (uor), the caller's user
 	// row (u), and the caller's role row (r). Concurrent:
 	//
@@ -995,7 +995,7 @@ type Querier interface {
 	//       can't interleave between our recheck and our commit
 	//
 	// The LEFT JOIN sides (role_permission, permission) cannot participate
-	// in FOR UPDATE because they may have no matching row for a
+	// in row locking because they may have no matching row for a
 	// zero-permission assignment. We accept that role_permission edits
 	// via paths other than UpdateCustomRole (none exist today) would race
 	// this check; the practical lock graph through the existing surfaces
@@ -1198,6 +1198,8 @@ type Querier interface {
 	// event targets/profile row are persisted. The query mirrors the executable
 	// topology selector predicates and locks in device.id order, matching the
 	// canonical device-reassignment lock order used by site/building/rack writes.
+	// Topology writes still conflict with this lock, while command queue inserts
+	// can take the foreign-key KEY SHARE lock on device without self-deadlocking.
 	LockCurtailmentTopologyMemberDeviceSitesByOrg(ctx context.Context, arg LockCurtailmentTopologyMemberDeviceSitesByOrgParams) ([]LockCurtailmentTopologyMemberDeviceSitesByOrgRow, error)
 	// Takes a row lock on each device row for the duration of the
 	// surrounding transaction so the conflict check and the UPDATE are

--- a/server/generated/sqlc/retrying_querier.gen.go
+++ b/server/generated/sqlc/retrying_querier.gen.go
@@ -4812,10 +4812,10 @@ func (q *retryingQuerier) RefreshOpenErrorsLastSeenByDevice(ctx context.Context,
 	return result, err
 }
 
-func (q *retryingQuerier) ReleaseUndispatchedAllPairedTargetsForRestore(ctx context.Context, curtailmentEventID int64) (int64, error) {
+func (q *retryingQuerier) ReleaseUndispatchedTargetsForRestore(ctx context.Context, arg ReleaseUndispatchedTargetsForRestoreParams) (int64, error) {
 	var result int64
-	err := q.retrier.RetryQuery(ctx, "ReleaseUndispatchedAllPairedTargetsForRestore", func() error {
-		callResult, callErr := q.next.ReleaseUndispatchedAllPairedTargetsForRestore(ctx, curtailmentEventID)
+	err := q.retrier.RetryQuery(ctx, "ReleaseUndispatchedTargetsForRestore", func() error {
+		callResult, callErr := q.next.ReleaseUndispatchedTargetsForRestore(ctx, arg)
 		if callErr == nil {
 			result = callResult
 		}

--- a/server/generated/sqlc/retrying_querier.gen.go
+++ b/server/generated/sqlc/retrying_querier.gen.go
@@ -4908,6 +4908,18 @@ func (q *retryingQuerier) ResetReapedFirmwareStatuses(ctx context.Context, devic
 	})
 }
 
+func (q *retryingQuerier) ResolveCurtailmentTopologyDispatch(ctx context.Context, arg ResolveCurtailmentTopologyDispatchParams) (ResolveCurtailmentTopologyDispatchRow, error) {
+	var result ResolveCurtailmentTopologyDispatchRow
+	err := q.retrier.RetryQuery(ctx, "ResolveCurtailmentTopologyDispatch", func() error {
+		callResult, callErr := q.next.ResolveCurtailmentTopologyDispatch(ctx, arg)
+		if callErr == nil {
+			result = callResult
+		}
+		return callErr
+	})
+	return result, err
+}
+
 func (q *retryingQuerier) ResumeCurtailmentFromRestoring(ctx context.Context, id int64) (CurtailmentEvent, error) {
 	var result CurtailmentEvent
 	err := q.retrier.RetryQuery(ctx, "ResumeCurtailmentFromRestoring", func() error {

--- a/server/generated/sqlc/user_organization_role.sql.go
+++ b/server/generated/sqlc/user_organization_role.sql.go
@@ -393,7 +393,7 @@ WHERE uor.user_id = $1
   AND r.deleted_at IS NULL
   AND u.deleted_at IS NULL
 ORDER BY uor.id, p.key NULLS FIRST
-FOR UPDATE OF uor, u, r
+FOR NO KEY UPDATE OF uor, u, r
 `
 
 type ListEffectivePermissionsForUserForUpdateParams struct {
@@ -411,7 +411,7 @@ type ListEffectivePermissionsForUserForUpdateRow struct {
 
 // Race-safety variant of ListEffectivePermissionsForUser. Same join
 // shape, same row order, same narrowing semantics — but takes
-// FOR UPDATE on every row whose mutation can revoke the caller's
+// FOR NO KEY UPDATE on every row whose mutation can revoke the caller's
 // effective permissions: the assignment row (uor), the caller's user
 // row (u), and the caller's role row (r). Concurrent:
 //
@@ -425,7 +425,7 @@ type ListEffectivePermissionsForUserForUpdateRow struct {
 //     can't interleave between our recheck and our commit
 //
 // The LEFT JOIN sides (role_permission, permission) cannot participate
-// in FOR UPDATE because they may have no matching row for a
+// in row locking because they may have no matching row for a
 // zero-permission assignment. We accept that role_permission edits
 // via paths other than UpdateCustomRole (none exist today) would race
 // this check; the practical lock graph through the existing surfaces

--- a/server/internal/domain/curtailment/automation_test.go
+++ b/server/internal/domain/curtailment/automation_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/block/proto-fleet/server/internal/domain/curtailment/models"
 	"github.com/block/proto-fleet/server/internal/domain/curtailment/mqttingest"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
+	"github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
 )
 
 func TestAutomationService_CreateValidatesSourceAndProfile(t *testing.T) {
@@ -499,6 +500,36 @@ func TestAutomationService_HandleMQTTSignal_OffStartsCurtailmentFromResponseProf
 	require.NotNil(t, h.rule.ActiveEventUUID)
 	assert.Equal(t, *h.rule.ActiveEventUUID, h.rules.lastActiveEvent)
 	assert.Equal(t, receivedAt, h.rules.lastActiveAt)
+}
+
+func TestAutomationService_HandleMQTTSignal_OffRejectsStaleTopologyProfileBinding(t *testing.T) {
+	t.Parallel()
+
+	h := newAutomationHarness(t)
+	h.profile.Mode = models.ModeFixedKw
+	targetKW := 5.0
+	h.profile.TargetKW = &targetKW
+	h.profile.SiteID = nil
+	h.profile.ScopeJSON = []byte(`{"scope_schema_version":1,"building_ids":[7]}`)
+	h.curtailments.orgConfigByOrg[h.orgID] = defaultOrgConfig(h.orgID)
+	h.curtailments.topologyCoverage = interfaces.CurtailmentTopologyScopeCoverage{
+		SelectedResourceSiteIDs: []int64{7},
+		CurrentMemberSiteIDs:    []int64{7},
+	}
+	h.curtailments.candidatesByBuilding[h.orgID] = map[int64][]*models.Candidate{
+		7: {minerWithEff("miner-a", 3000, 100, 50)},
+	}
+
+	err := h.automation.HandleMQTTSignal(t.Context(), mqttingest.SignalEdge{
+		Source: h.source,
+		Target: mqttingest.TargetOff,
+	})
+
+	require.Error(t, err)
+	assert.True(t, fleeterror.IsFailedPreconditionError(err))
+	assert.Contains(t, err.Error(), "topology-scoped Start is not available for automation")
+	assert.Equal(t, 0, h.curtailments.insertEventCalls)
+	assert.Equal(t, 0, h.rules.setActiveCalls)
 }
 
 func TestAutomationService_HandleMQTTSignal_OffSnapshotsExplicitMinerSites(t *testing.T) {

--- a/server/internal/domain/curtailment/reconciler/dispatch_authorization.go
+++ b/server/internal/domain/curtailment/reconciler/dispatch_authorization.go
@@ -24,6 +24,7 @@ func (r *Reconciler) authorizeTopologyCurtailDispatch(
 	ctx context.Context,
 	ev *models.Event,
 	targets []*models.Target,
+	knownUnsentDeviceIdentifiers []string,
 ) bool {
 	if ev.ScopeType != models.ScopeTypeMixed {
 		return true
@@ -39,7 +40,9 @@ func (r *Reconciler) authorizeTopologyCurtailDispatch(
 			ctx,
 			ev.OrgID,
 			ev.EventUUID,
-			interfaces.BeginRestoreTransitionParams{},
+			interfaces.BeginRestoreTransitionParams{
+				KnownUnsentDeviceIdentifiers: knownUnsentDeviceIdentifiers,
+			},
 		); restoreErr != nil {
 			slog.Error("curtailment reconciler: failed to restore after topology dispatch authorization failure",
 				"event_id", ev.ID, "event_uuid", ev.EventUUID, "error", restoreErr)

--- a/server/internal/domain/curtailment/reconciler/dispatch_authorization.go
+++ b/server/internal/domain/curtailment/reconciler/dispatch_authorization.go
@@ -31,19 +31,23 @@ func (r *Reconciler) authorizeTopologyCurtailDispatch(
 	if ev.ScopeType != models.ScopeTypeMixed {
 		return false, true
 	}
-	reject := func(reason string, cause error) bool {
-		r.topologyDispatchRejects.Store(ev.EventUUID, reason)
-		attrs := []any{"event_id", ev.ID, "event_uuid", ev.EventUUID, "reason", reason}
+	reject := func(rejection topologyDispatchRejection, cause error) bool {
+		r.topologyDispatchRejects.Store(ev.EventUUID, rejection)
+		attrs := []any{"event_id", ev.ID, "event_uuid", ev.EventUUID, "reason", rejection.reason}
 		if cause != nil {
 			attrs = append(attrs, "error", cause)
 		}
 		slog.Error("curtailment reconciler: topology dispatch authorization failed", attrs...)
+		releaseUnsent := knownUnsentDeviceIdentifiers
+		if rejection.preserveRestoreOwnership {
+			releaseUnsent = nil
+		}
 		if _, restoreErr := r.store.BeginRestoreTransition(
 			ctx,
 			ev.OrgID,
 			ev.EventUUID,
 			interfaces.BeginRestoreTransitionParams{
-				KnownUnsentDeviceIdentifiers: knownUnsentDeviceIdentifiers,
+				KnownUnsentDeviceIdentifiers: releaseUnsent,
 			},
 		); restoreErr != nil {
 			slog.Error("curtailment reconciler: failed to restore after topology dispatch authorization failure",
@@ -53,28 +57,34 @@ func (r *Reconciler) authorizeTopologyCurtailDispatch(
 		}
 		return false
 	}
-	if rejectedReason, rejected := r.topologyDispatchRejects.Load(ev.EventUUID); rejected {
-		reason, ok := rejectedReason.(string)
+	rejectBeforeCommand := func(reason string, cause error) (bool, bool) {
+		return true, reject(topologyDispatchRejection{reason: reason}, cause)
+	}
+	if rejectedValue, rejected := r.topologyDispatchRejects.Load(ev.EventUUID); rejected {
+		rejection, ok := rejectedValue.(topologyDispatchRejection)
 		if !ok {
-			reason = "previous topology dispatch authorization failure"
+			rejection = topologyDispatchRejection{
+				reason:                   "previous topology dispatch authorization failure",
+				preserveRestoreOwnership: true,
+			}
 		}
-		return true, reject(reason, nil)
+		return true, reject(rejection, nil)
 	}
 	scope, hasScope, err := curtailment.ScopeFromJSON(ev.ScopeJSON)
 	if err != nil || !hasScope {
-		return true, reject("parse persisted mixed scope", err)
+		return rejectBeforeCommand("parse persisted mixed scope", err)
 	}
 	if !curtailment.IsTopologyScope(scope) {
 		return false, true
 	}
 	filter, err := curtailment.ListCandidatesParamsForScope(scope)
 	if err != nil {
-		return true, reject("parse persisted topology selector", err)
+		return rejectBeforeCommand("parse persisted topology selector", err)
 	}
 	filter.OrgID = ev.OrgID
 	fenceStore, ok := r.store.(interfaces.CurtailmentTopologyDispatchFenceStore)
 	if !ok {
-		return true, reject("topology dispatch fence is not configured", nil)
+		return rejectBeforeCommand("topology dispatch fence is not configured", nil)
 	}
 	dispatchDeviceIdentifiers := make([]string, 0, len(targets))
 	for _, target := range targets {
@@ -84,6 +94,7 @@ func (r *Reconciler) authorizeTopologyCurtailDispatch(
 	}
 	var rejectionReason string
 	var rejectionCause error
+	commandAttempted := false
 	rejectFence := func(reason string, cause error) error {
 		rejectionReason = reason
 		rejectionCause = cause
@@ -130,23 +141,32 @@ func (r *Reconciler) authorizeTopologyCurtailDispatch(
 			if !authorizationEnvelopeAllowsDispatch(effective, envelope, coverage) {
 				return rejectFence("event creator no longer has required permissions", nil)
 			}
+			commandAttempted = true
 			command()
 			return nil
 		},
 	)
 	if rejectionReason != "" {
-		return true, reject(rejectionReason, rejectionCause)
+		return rejectBeforeCommand(rejectionReason, rejectionCause)
 	}
 	if errors.Is(err, interfaces.ErrCurtailmentEventStateRaceLoss) {
 		return true, false
 	}
 	if err != nil {
-		return true, reject("acquire topology dispatch fence", err)
+		return true, reject(topologyDispatchRejection{
+			reason:                   "acquire topology dispatch fence",
+			preserveRestoreOwnership: commandAttempted,
+		}, err)
 	}
 	return true, true
 }
 
 var errTopologyDispatchRejected = errors.New("topology dispatch rejected")
+
+type topologyDispatchRejection struct {
+	reason                   string
+	preserveRestoreOwnership bool
+}
 
 func topologyCoverageWithinEnvelope(
 	coverage interfaces.CurtailmentTopologyScopeCoverage,

--- a/server/internal/domain/curtailment/reconciler/dispatch_authorization.go
+++ b/server/internal/domain/curtailment/reconciler/dispatch_authorization.go
@@ -1,0 +1,183 @@
+package reconciler
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/block/proto-fleet/server/internal/domain/authz"
+	"github.com/block/proto-fleet/server/internal/domain/curtailment"
+	"github.com/block/proto-fleet/server/internal/domain/curtailment/models"
+	"github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
+)
+
+// DispatchPermissionResolver reloads the event creator's live permissions
+// immediately before a topology-scoped Curtail command is sent.
+type DispatchPermissionResolver interface {
+	LoadEffective(ctx context.Context, userID, organizationID int64) (*authz.EffectivePermissions, error)
+}
+
+func WithDispatchPermissionResolver(resolver DispatchPermissionResolver) Option {
+	return func(r *Reconciler) { r.permissions = resolver }
+}
+
+func (r *Reconciler) authorizeTopologyCurtailDispatch(
+	ctx context.Context,
+	ev *models.Event,
+	targets []*models.Target,
+) bool {
+	if ev.ScopeType != models.ScopeTypeMixed {
+		return true
+	}
+	reject := func(reason string, cause error) bool {
+		attrs := []any{"event_id", ev.ID, "event_uuid", ev.EventUUID, "reason", reason}
+		if cause != nil {
+			attrs = append(attrs, "error", cause)
+		}
+		slog.Error("curtailment reconciler: topology dispatch authorization failed", attrs...)
+		if _, restoreErr := r.store.BeginRestoreTransition(
+			ctx,
+			ev.OrgID,
+			ev.EventUUID,
+			interfaces.BeginRestoreTransitionParams{},
+		); restoreErr != nil {
+			slog.Error("curtailment reconciler: failed to restore after topology dispatch authorization failure",
+				"event_id", ev.ID, "event_uuid", ev.EventUUID, "error", restoreErr)
+		}
+		return false
+	}
+	scope, hasScope, err := curtailment.ScopeFromJSON(ev.ScopeJSON)
+	if err != nil || !hasScope {
+		return reject("parse persisted mixed scope", err)
+	}
+	if !curtailment.IsTopologyScope(scope) {
+		return true
+	}
+
+	latest, err := r.store.GetEventByUUID(ctx, ev.OrgID, ev.EventUUID)
+	if err != nil {
+		return reject("reload persisted event", err)
+	}
+	if latest == nil || latest.State != ev.State || latest.State.IsTerminal() {
+		return reject("event is no longer dispatchable", nil)
+	}
+	latestScope, hasScope, err := curtailment.ScopeFromJSON(latest.ScopeJSON)
+	if err != nil || !hasScope || !curtailment.IsTopologyScope(latestScope) {
+		return reject("reload persisted topology scope", err)
+	}
+	envelope, err := curtailment.AuthorizationEnvelopeFromJSON(latest.AuthorizationEnvelopeJSON)
+	if err != nil {
+		return reject("parse persisted authorization envelope", err)
+	}
+	filter, err := curtailment.ListCandidatesParamsForScope(latestScope)
+	if err != nil {
+		return reject("parse persisted topology selector", err)
+	}
+	filter.OrgID = latest.OrgID
+	topologyStore, ok := r.store.(interfaces.CurtailmentTopologyScopeStore)
+	if !ok {
+		return reject("topology scope resolver is not configured", nil)
+	}
+	coverage, err := topologyStore.ResolveCurtailmentTopologyScope(ctx, filter)
+	if err != nil {
+		return reject("reload topology coverage", err)
+	}
+	if !topologyCoverageWithinEnvelope(coverage, envelope) {
+		return reject("current topology exceeds the persisted authorization envelope", nil)
+	}
+	candidates, err := r.store.ListCandidates(ctx, filter)
+	if err != nil {
+		return reject("reload topology members", err)
+	}
+	currentMembers := make(map[string]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		if candidate != nil {
+			currentMembers[candidate.DeviceIdentifier] = struct{}{}
+		}
+	}
+	for _, target := range targets {
+		if target == nil {
+			continue
+		}
+		if _, ok := currentMembers[target.DeviceIdentifier]; !ok {
+			return reject("claimed miner is no longer in the persisted topology scope", nil)
+		}
+	}
+
+	if r.permissions == nil {
+		return reject("dispatch permission resolver is not configured", nil)
+	}
+	effective, err := r.permissions.LoadEffective(ctx, latest.CreatedByUserID, latest.OrgID)
+	if err != nil {
+		return reject("reload event creator permissions", err)
+	}
+	if !authorizationEnvelopeAllowsDispatch(effective, envelope, coverage) {
+		return reject("event creator no longer has required permissions", nil)
+	}
+	return true
+}
+
+func topologyCoverageWithinEnvelope(
+	coverage interfaces.CurtailmentTopologyScopeCoverage,
+	envelope models.AuthorizationEnvelope,
+) bool {
+	if envelope.MinerScopeUnbounded {
+		return true
+	}
+	if coverage.RequireOrgWide {
+		return false
+	}
+	return siteIDsWithinEnvelope(coverage.SelectedResourceSiteIDs, envelope.SelectedResourceSiteIDs) &&
+		siteIDsWithinEnvelope(coverage.CurrentMemberSiteIDs, envelope.CurrentMemberSiteIDs)
+}
+
+func siteIDsWithinEnvelope(current, persisted []int64) bool {
+	allowed := make(map[int64]struct{}, len(persisted))
+	for _, siteID := range persisted {
+		allowed[siteID] = struct{}{}
+	}
+	for _, siteID := range current {
+		if _, ok := allowed[siteID]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func authorizationEnvelopeAllowsDispatch(
+	effective *authz.EffectivePermissions,
+	envelope models.AuthorizationEnvelope,
+	coverage interfaces.CurtailmentTopologyScopeCoverage,
+) bool {
+	requireOrgWideManage := envelope.MinerScopeUnbounded || envelope.FacilityFanScopeUnbounded || coverage.RequireOrgWide
+	if requireOrgWideManage && !effective.HasOrgWide(authz.PermCurtailmentManage) {
+		return false
+	}
+	manageSites := make(map[int64]struct{})
+	for _, sites := range [][]int64{
+		envelope.SelectedResourceSiteIDs,
+		envelope.CurrentMemberSiteIDs,
+		envelope.FacilityFanSiteIDs,
+		coverage.SelectedResourceSiteIDs,
+		coverage.CurrentMemberSiteIDs,
+	} {
+		for _, siteID := range sites {
+			manageSites[siteID] = struct{}{}
+		}
+	}
+	for siteID := range manageSites {
+		id := siteID
+		if !effective.Has(authz.PermCurtailmentManage, authz.ResourceContext{SiteID: &id}) {
+			return false
+		}
+	}
+	if envelope.FacilityFanScopeUnbounded && !effective.HasOrgWide(authz.PermSiteRead) {
+		return false
+	}
+	for _, siteID := range envelope.FacilityFanSiteIDs {
+		id := siteID
+		if !effective.Has(authz.PermSiteRead, authz.ResourceContext{SiteID: &id}) {
+			return false
+		}
+	}
+	return true
+}

--- a/server/internal/domain/curtailment/reconciler/dispatch_authorization.go
+++ b/server/internal/domain/curtailment/reconciler/dispatch_authorization.go
@@ -2,6 +2,7 @@ package reconciler
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 
 	"github.com/block/proto-fleet/server/internal/domain/authz"
@@ -25,9 +26,10 @@ func (r *Reconciler) authorizeTopologyCurtailDispatch(
 	ev *models.Event,
 	targets []*models.Target,
 	knownUnsentDeviceIdentifiers []string,
-) bool {
+	command func(),
+) (bool, bool) {
 	if ev.ScopeType != models.ScopeTypeMixed {
-		return true
+		return false, true
 	}
 	reject := func(reason string, cause error) bool {
 		r.topologyDispatchRejects.Store(ev.EventUUID, reason)
@@ -56,39 +58,23 @@ func (r *Reconciler) authorizeTopologyCurtailDispatch(
 		if !ok {
 			reason = "previous topology dispatch authorization failure"
 		}
-		return reject(reason, nil)
+		return true, reject(reason, nil)
 	}
 	scope, hasScope, err := curtailment.ScopeFromJSON(ev.ScopeJSON)
 	if err != nil || !hasScope {
-		return reject("parse persisted mixed scope", err)
+		return true, reject("parse persisted mixed scope", err)
 	}
 	if !curtailment.IsTopologyScope(scope) {
-		return true
+		return false, true
 	}
-
-	latest, err := r.store.GetEventByUUID(ctx, ev.OrgID, ev.EventUUID)
+	filter, err := curtailment.ListCandidatesParamsForScope(scope)
 	if err != nil {
-		return reject("reload persisted event", err)
+		return true, reject("parse persisted topology selector", err)
 	}
-	if latest == nil || latest.State != ev.State || latest.State.IsTerminal() {
-		return reject("event is no longer dispatchable", nil)
-	}
-	latestScope, hasScope, err := curtailment.ScopeFromJSON(latest.ScopeJSON)
-	if err != nil || !hasScope || !curtailment.IsTopologyScope(latestScope) {
-		return reject("reload persisted topology scope", err)
-	}
-	envelope, err := curtailment.AuthorizationEnvelopeFromJSON(latest.AuthorizationEnvelopeJSON)
-	if err != nil {
-		return reject("parse persisted authorization envelope", err)
-	}
-	filter, err := curtailment.ListCandidatesParamsForScope(latestScope)
-	if err != nil {
-		return reject("parse persisted topology selector", err)
-	}
-	filter.OrgID = latest.OrgID
-	topologyStore, ok := r.store.(interfaces.CurtailmentTopologyDispatchStore)
+	filter.OrgID = ev.OrgID
+	fenceStore, ok := r.store.(interfaces.CurtailmentTopologyDispatchFenceStore)
 	if !ok {
-		return reject("topology dispatch resolver is not configured", nil)
+		return true, reject("topology dispatch fence is not configured", nil)
 	}
 	dispatchDeviceIdentifiers := make([]string, 0, len(targets))
 	for _, target := range targets {
@@ -96,39 +82,71 @@ func (r *Reconciler) authorizeTopologyCurtailDispatch(
 			dispatchDeviceIdentifiers = append(dispatchDeviceIdentifiers, target.DeviceIdentifier)
 		}
 	}
-	snapshot, err := topologyStore.ResolveCurtailmentTopologyDispatch(ctx, filter, dispatchDeviceIdentifiers)
+	var rejectionReason string
+	var rejectionCause error
+	rejectFence := func(reason string, cause error) error {
+		rejectionReason = reason
+		rejectionCause = cause
+		return errTopologyDispatchRejected
+	}
+	err = fenceStore.WithCurtailmentTopologyDispatchFence(
+		ctx,
+		ev,
+		filter,
+		dispatchDeviceIdentifiers,
+		func(fenced interfaces.CurtailmentTopologyDispatchFenceSnapshot) error {
+			latest := fenced.Event
+			latestScope, hasScope, err := curtailment.ScopeFromJSON(latest.ScopeJSON)
+			if err != nil || !hasScope || !curtailment.IsTopologyScope(latestScope) {
+				return rejectFence("reload persisted topology scope", err)
+			}
+			envelope, err := curtailment.AuthorizationEnvelopeFromJSON(latest.AuthorizationEnvelopeJSON)
+			if err != nil {
+				return rejectFence("parse persisted authorization envelope", err)
+			}
+			coverage := fenced.Topology.Coverage
+			if !topologyCoverageWithinEnvelope(coverage, envelope) {
+				return rejectFence("current topology exceeds the persisted authorization envelope", nil)
+			}
+			currentMembers := make(map[string]struct{}, len(fenced.Topology.DispatchMemberDeviceIdentifiers))
+			for _, deviceIdentifier := range fenced.Topology.DispatchMemberDeviceIdentifiers {
+				currentMembers[deviceIdentifier] = struct{}{}
+			}
+			for _, target := range targets {
+				if target == nil {
+					continue
+				}
+				if _, ok := currentMembers[target.DeviceIdentifier]; !ok {
+					return rejectFence("claimed miner is no longer in the persisted topology scope", nil)
+				}
+			}
+			if r.permissions == nil {
+				return rejectFence("dispatch permission resolver is not configured", nil)
+			}
+			effective, err := r.permissions.LoadEffective(ctx, latest.CreatedByUserID, latest.OrgID)
+			if err != nil {
+				return rejectFence("reload event creator permissions", err)
+			}
+			if !authorizationEnvelopeAllowsDispatch(effective, envelope, coverage) {
+				return rejectFence("event creator no longer has required permissions", nil)
+			}
+			command()
+			return nil
+		},
+	)
+	if rejectionReason != "" {
+		return true, reject(rejectionReason, rejectionCause)
+	}
+	if errors.Is(err, interfaces.ErrCurtailmentEventStateRaceLoss) {
+		return true, false
+	}
 	if err != nil {
-		return reject("reload topology dispatch snapshot", err)
+		return true, reject("acquire topology dispatch fence", err)
 	}
-	coverage := snapshot.Coverage
-	if !topologyCoverageWithinEnvelope(coverage, envelope) {
-		return reject("current topology exceeds the persisted authorization envelope", nil)
-	}
-	currentMembers := make(map[string]struct{}, len(snapshot.DispatchMemberDeviceIdentifiers))
-	for _, deviceIdentifier := range snapshot.DispatchMemberDeviceIdentifiers {
-		currentMembers[deviceIdentifier] = struct{}{}
-	}
-	for _, target := range targets {
-		if target == nil {
-			continue
-		}
-		if _, ok := currentMembers[target.DeviceIdentifier]; !ok {
-			return reject("claimed miner is no longer in the persisted topology scope", nil)
-		}
-	}
-
-	if r.permissions == nil {
-		return reject("dispatch permission resolver is not configured", nil)
-	}
-	effective, err := r.permissions.LoadEffective(ctx, latest.CreatedByUserID, latest.OrgID)
-	if err != nil {
-		return reject("reload event creator permissions", err)
-	}
-	if !authorizationEnvelopeAllowsDispatch(effective, envelope, coverage) {
-		return reject("event creator no longer has required permissions", nil)
-	}
-	return true
+	return true, true
 }
+
+var errTopologyDispatchRejected = errors.New("topology dispatch rejected")
 
 func topologyCoverageWithinEnvelope(
 	coverage interfaces.CurtailmentTopologyScopeCoverage,

--- a/server/internal/domain/curtailment/reconciler/dispatch_authorization.go
+++ b/server/internal/domain/curtailment/reconciler/dispatch_authorization.go
@@ -29,6 +29,7 @@ func (r *Reconciler) authorizeTopologyCurtailDispatch(
 		return true
 	}
 	reject := func(reason string, cause error) bool {
+		r.topologyDispatchRejects.Store(ev.EventUUID, reason)
 		attrs := []any{"event_id", ev.ID, "event_uuid", ev.EventUUID, "reason", reason}
 		if cause != nil {
 			attrs = append(attrs, "error", cause)
@@ -42,8 +43,17 @@ func (r *Reconciler) authorizeTopologyCurtailDispatch(
 		); restoreErr != nil {
 			slog.Error("curtailment reconciler: failed to restore after topology dispatch authorization failure",
 				"event_id", ev.ID, "event_uuid", ev.EventUUID, "error", restoreErr)
+		} else {
+			r.topologyDispatchRejects.Delete(ev.EventUUID)
 		}
 		return false
+	}
+	if rejectedReason, rejected := r.topologyDispatchRejects.Load(ev.EventUUID); rejected {
+		reason, ok := rejectedReason.(string)
+		if !ok {
+			reason = "previous topology dispatch authorization failure"
+		}
+		return reject(reason, nil)
 	}
 	scope, hasScope, err := curtailment.ScopeFromJSON(ev.ScopeJSON)
 	if err != nil || !hasScope {
@@ -73,26 +83,27 @@ func (r *Reconciler) authorizeTopologyCurtailDispatch(
 		return reject("parse persisted topology selector", err)
 	}
 	filter.OrgID = latest.OrgID
-	topologyStore, ok := r.store.(interfaces.CurtailmentTopologyScopeStore)
+	topologyStore, ok := r.store.(interfaces.CurtailmentTopologyDispatchStore)
 	if !ok {
-		return reject("topology scope resolver is not configured", nil)
+		return reject("topology dispatch resolver is not configured", nil)
 	}
-	coverage, err := topologyStore.ResolveCurtailmentTopologyScope(ctx, filter)
+	dispatchDeviceIdentifiers := make([]string, 0, len(targets))
+	for _, target := range targets {
+		if target != nil {
+			dispatchDeviceIdentifiers = append(dispatchDeviceIdentifiers, target.DeviceIdentifier)
+		}
+	}
+	snapshot, err := topologyStore.ResolveCurtailmentTopologyDispatch(ctx, filter, dispatchDeviceIdentifiers)
 	if err != nil {
-		return reject("reload topology coverage", err)
+		return reject("reload topology dispatch snapshot", err)
 	}
+	coverage := snapshot.Coverage
 	if !topologyCoverageWithinEnvelope(coverage, envelope) {
 		return reject("current topology exceeds the persisted authorization envelope", nil)
 	}
-	candidates, err := r.store.ListCandidates(ctx, filter)
-	if err != nil {
-		return reject("reload topology members", err)
-	}
-	currentMembers := make(map[string]struct{}, len(candidates))
-	for _, candidate := range candidates {
-		if candidate != nil {
-			currentMembers[candidate.DeviceIdentifier] = struct{}{}
-		}
+	currentMembers := make(map[string]struct{}, len(snapshot.DispatchMemberDeviceIdentifiers))
+	for _, deviceIdentifier := range snapshot.DispatchMemberDeviceIdentifiers {
+		currentMembers[deviceIdentifier] = struct{}{}
 	}
 	for _, target := range targets {
 		if target == nil {

--- a/server/internal/domain/curtailment/reconciler/reconciler.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler.go
@@ -101,14 +101,15 @@ func (c Config) withDefaults() Config {
 // Each tick reads non-terminal events, dispatches/observes per event with
 // per-event panic isolation, then upserts the heartbeat.
 type Reconciler struct {
-	cfg      Config
-	store    interfaces.CurtailmentStore
-	fanStore interfaces.CurtailmentFanStateStore
-	cmd      CommandDispatcher
-	metrics  curtailment.Metrics
-	fans     curtailment.FacilityFanController
-	fanAlert FacilityFanAlertEmitter
-	now      func() time.Time
+	cfg         Config
+	store       interfaces.CurtailmentStore
+	fanStore    interfaces.CurtailmentFanStateStore
+	cmd         CommandDispatcher
+	permissions DispatchPermissionResolver
+	metrics     curtailment.Metrics
+	fans        curtailment.FacilityFanController
+	fanAlert    FacilityFanAlertEmitter
+	now         func() time.Time
 
 	// sampler backs the confirmation fast path (see
 	// confirmation_fast_path.go); required only when
@@ -702,6 +703,9 @@ func (r *Reconciler) dispatchCurtailBatch(ctx context.Context, ev *models.Event,
 		return true
 	}
 	if !r.eventStillDispatchable(ctx, ev) {
+		return false
+	}
+	if !r.authorizeTopologyCurtailDispatch(ctx, ev, dispatchSet) {
 		return false
 	}
 

--- a/server/internal/domain/curtailment/reconciler/reconciler.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler.go
@@ -684,7 +684,11 @@ func (r *Reconciler) dispatchCurtailBatch(ctx context.Context, ev *models.Event,
 	// last_dispatched_at is *not* stamped here — only successful enqueues
 	// advance it (used by the restore-batch interval gate).
 	dispatchSet := make([]*models.Target, 0, len(claim))
+	knownUnsentDeviceIdentifiers := make([]string, 0, len(claim))
 	for _, t := range claim {
+		if t.State == models.TargetStatePending {
+			knownUnsentDeviceIdentifiers = append(knownUnsentDeviceIdentifiers, t.DeviceIdentifier)
+		}
 		dispatchingParams := interfaces.UpdateCurtailmentTargetStateParams{
 			State: models.TargetStateDispatching,
 		}
@@ -709,7 +713,7 @@ func (r *Reconciler) dispatchCurtailBatch(ctx context.Context, ev *models.Event,
 	if !r.eventStillDispatchable(ctx, ev) {
 		return false
 	}
-	if !r.authorizeTopologyCurtailDispatch(ctx, ev, dispatchSet) {
+	if !r.authorizeTopologyCurtailDispatch(ctx, ev, dispatchSet, knownUnsentDeviceIdentifiers) {
 		return false
 	}
 	if !r.eventStillDispatchable(ctx, ev) {

--- a/server/internal/domain/curtailment/reconciler/reconciler.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler.go
@@ -713,13 +713,6 @@ func (r *Reconciler) dispatchCurtailBatch(ctx context.Context, ev *models.Event,
 	if !r.eventStillDispatchable(ctx, ev) {
 		return false
 	}
-	if !r.authorizeTopologyCurtailDispatch(ctx, ev, dispatchSet, knownUnsentDeviceIdentifiers) {
-		return false
-	}
-	if !r.eventStillDispatchable(ctx, ev) {
-		return false
-	}
-
 	deviceIDs := make([]string, 0, len(dispatchSet))
 	for _, t := range dispatchSet {
 		deviceIDs = append(deviceIDs, t.DeviceIdentifier)
@@ -731,7 +724,25 @@ func (r *Reconciler) dispatchCurtailBatch(ctx context.Context, ev *models.Event,
 			},
 		},
 	}
-	result, dispatchErr := r.cmd.Curtail(ctx, selector, sdk.CurtailLevelFull)
+	var result *command.CommandResult
+	var dispatchErr error
+	topologyHandled, topologyAllowed := r.authorizeTopologyCurtailDispatch(
+		ctx,
+		ev,
+		dispatchSet,
+		knownUnsentDeviceIdentifiers,
+		func() { result, dispatchErr = r.cmd.Curtail(ctx, selector, sdk.CurtailLevelFull) },
+	)
+	if topologyHandled {
+		if !topologyAllowed {
+			return false
+		}
+	} else {
+		if !r.eventStillDispatchable(ctx, ev) {
+			return false
+		}
+		result, dispatchErr = r.cmd.Curtail(ctx, selector, sdk.CurtailLevelFull)
+	}
 	if dispatchErr != nil {
 		errMsg := dispatchErr.Error()
 		slog.Error("curtailment reconciler: curtail batch dispatch failed",

--- a/server/internal/domain/curtailment/reconciler/reconciler.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler.go
@@ -131,6 +131,10 @@ type Reconciler struct {
 	// eligibility read advances it even when no target promotes, preventing
 	// a nonconfirming page from monopolizing the active pulse.
 	confirmationCursor interfaces.ConfirmationPageCursor
+	// topologyDispatchRejects latches a failed dispatch authorization until
+	// the durable restoring transition succeeds. This prevents a transient
+	// transition failure from letting a later tick resume Curtail commands.
+	topologyDispatchRejects sync.Map
 
 	loopCancel  context.CancelFunc
 	workCancel  context.CancelFunc
@@ -706,6 +710,9 @@ func (r *Reconciler) dispatchCurtailBatch(ctx context.Context, ev *models.Event,
 		return false
 	}
 	if !r.authorizeTopologyCurtailDispatch(ctx, ev, dispatchSet) {
+		return false
+	}
+	if !r.eventStillDispatchable(ctx, ev) {
 		return false
 	}
 

--- a/server/internal/domain/curtailment/reconciler/reconciler_test.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	pb "github.com/block/proto-fleet/server/generated/grpc/minercommand/v1"
+	"github.com/block/proto-fleet/server/internal/domain/authz"
 	"github.com/block/proto-fleet/server/internal/domain/command"
 	"github.com/block/proto-fleet/server/internal/domain/curtailment"
 	"github.com/block/proto-fleet/server/internal/domain/curtailment/models"
@@ -83,6 +84,8 @@ type fakeStore struct {
 	lastListCandidatesSiteIDs []int64
 	lastListCandidatesFilter  []string
 	listCandidatesFilters     [][]string
+	topologyCoverage          interfaces.CurtailmentTopologyScopeCoverage
+	topologyCoverageErr       error
 
 	// BeginRestoreTransition captures, exercised by max_duration tests.
 	beginRestoreCalls       int
@@ -358,6 +361,13 @@ func (f *fakeStore) ListCandidates(_ context.Context, params interfaces.ListCand
 		}
 	}
 	return out, nil
+}
+
+func (f *fakeStore) ResolveCurtailmentTopologyScope(
+	_ context.Context,
+	_ interfaces.ListCandidatesParams,
+) (interfaces.CurtailmentTopologyScopeCoverage, error) {
+	return f.topologyCoverage, f.topologyCoverageErr
 }
 
 func (f *fakeStore) ListEvents(context.Context, interfaces.ListEventsParams) ([]*models.Event, string, error) {
@@ -859,6 +869,19 @@ func newReconcilerWithFanAlertForTest(
 
 func ptrFloat64(v float64) *float64 { return &v }
 
+type staticDispatchPermissionResolver struct {
+	effective *authz.EffectivePermissions
+	err       error
+}
+
+func (r staticDispatchPermissionResolver) LoadEffective(
+	context.Context,
+	int64,
+	int64,
+) (*authz.EffectivePermissions, error) {
+	return r.effective, r.err
+}
+
 // --- tests ---
 
 func TestReconciler_PendingDispatchesCurtail(t *testing.T) {
@@ -897,6 +920,113 @@ func TestReconciler_PendingDispatchesCurtail(t *testing.T) {
 	// Heartbeat upserted once.
 	assert.Equal(t, 1, store.heartbeatCalls)
 	assert.Equal(t, int32(1), store.lastHeartbeatActive)
+}
+
+func TestReconciler_TopologyDispatchRevalidatesMembershipAndCreatorPermission(t *testing.T) {
+	t.Parallel()
+
+	const siteID = int64(7)
+	allowed := authz.NewEffectivePermissions([]authz.Assignment{{
+		AssignmentID: 1,
+		ScopeType:    authz.ScopeOrg,
+		Permissions:  []string{authz.PermCurtailmentManage},
+	}})
+	tests := []struct {
+		name       string
+		candidates []*models.Candidate
+		effective  *authz.EffectivePermissions
+		wantSend   bool
+	}{
+		{
+			name:       "authorized member dispatches",
+			candidates: []*models.Candidate{{DeviceIdentifier: "miner-1"}},
+			effective:  allowed,
+			wantSend:   true,
+		},
+		{
+			name:       "member left scope restores without dispatch",
+			candidates: nil,
+			effective:  allowed,
+		},
+		{
+			name:       "creator permission revoked restores without dispatch",
+			candidates: []*models.Candidate{{DeviceIdentifier: "miner-1"}},
+			effective:  authz.NewEffectivePermissions(nil),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := newFakeStore()
+			dispatcher := &fakeDispatcher{}
+			eventID := int64(10)
+			eventUUID := uuid.New()
+			store.events = []*models.Event{{
+				ID:                        eventID,
+				EventUUID:                 eventUUID,
+				OrgID:                     1,
+				State:                     models.EventStatePending,
+				Mode:                      models.ModeFixedKw,
+				LoopType:                  models.LoopTypeOpen,
+				ScopeType:                 models.ScopeTypeMixed,
+				ScopeJSON:                 []byte(`{"scope_schema_version":1,"building_ids":[11]}`),
+				AuthorizationEnvelopeJSON: []byte(`{"schema_version":1,"selected_resource_site_ids":[7],"current_member_site_ids":[7],"miner_scope_unbounded":false,"facility_fan_site_ids":[],"facility_fan_scope_unbounded":false}`),
+				CreatedByUserID:           99,
+			}}
+			store.targetsByEventID[eventID] = []*models.Target{{
+				CurtailmentEventID: eventID,
+				DeviceIdentifier:   "miner-1",
+				State:              models.TargetStatePending,
+				DesiredState:       models.DesiredStateCurtailed,
+				BaselinePowerW:     ptrFloat64(3000),
+			}}
+			store.candidates = tt.candidates
+			store.topologyCoverage = interfaces.CurtailmentTopologyScopeCoverage{
+				SelectedResourceSiteIDs: []int64{siteID},
+				CurrentMemberSiteIDs:    []int64{siteID},
+			}
+			reconciler := New(
+				Config{TickInterval: time.Hour},
+				store,
+				dispatcher,
+				WithDispatchPermissionResolver(staticDispatchPermissionResolver{effective: tt.effective}),
+			)
+
+			reconciler.runTick(t.Context())
+
+			if tt.wantSend {
+				assert.Equal(t, 1, dispatcher.curtailCalls)
+				assert.Equal(t, 0, store.beginRestoreCalls)
+				return
+			}
+			assert.Equal(t, 0, dispatcher.curtailCalls)
+			assert.Equal(t, 1, store.beginRestoreCalls)
+			assert.Equal(t, models.EventStateRestoring, store.events[0].State)
+		})
+	}
+}
+
+func TestTopologyCoverageWithinEnvelope(t *testing.T) {
+	t.Parallel()
+
+	envelope := models.AuthorizationEnvelope{
+		SelectedResourceSiteIDs: []int64{7},
+		CurrentMemberSiteIDs:    []int64{8},
+	}
+	assert.True(t, topologyCoverageWithinEnvelope(interfaces.CurtailmentTopologyScopeCoverage{
+		SelectedResourceSiteIDs: []int64{7},
+		CurrentMemberSiteIDs:    []int64{8},
+	}, envelope))
+	assert.False(t, topologyCoverageWithinEnvelope(interfaces.CurtailmentTopologyScopeCoverage{
+		SelectedResourceSiteIDs: []int64{8},
+		CurrentMemberSiteIDs:    []int64{8},
+	}, envelope), "a resource move must not borrow authority from member-site coverage")
+	assert.False(t, topologyCoverageWithinEnvelope(interfaces.CurtailmentTopologyScopeCoverage{
+		SelectedResourceSiteIDs: []int64{7},
+		CurrentMemberSiteIDs:    []int64{8, 9},
+	}, envelope), "new member sites must remain inside the persisted member-site envelope")
 }
 
 func TestReconciler_PendingDispatchesAllTargetsInEffectiveBatches(t *testing.T) {

--- a/server/internal/domain/curtailment/reconciler/reconciler_test.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler_test.go
@@ -86,6 +86,11 @@ type fakeStore struct {
 	listCandidatesFilters     [][]string
 	topologyCoverage          interfaces.CurtailmentTopologyScopeCoverage
 	topologyCoverageErr       error
+	topologyDispatchErr       error
+	topologyDispatchCalls     int
+	getEventErr               error
+	getEventCalls             int
+	getEventHook              func(call int, event *models.Event)
 
 	// BeginRestoreTransition captures, exercised by max_duration tests.
 	beginRestoreCalls       int
@@ -141,8 +146,17 @@ func (f *fakeStore) SiteBelongsToOrg(context.Context, int64, int64) (bool, error
 	panic("SiteBelongsToOrg not exercised")
 }
 func (f *fakeStore) GetEventByUUID(_ context.Context, orgID int64, eventUUID uuid.UUID) (*models.Event, error) {
+	f.getEventCalls++
+	if f.getEventErr != nil {
+		return nil, f.getEventErr
+	}
 	for _, ev := range f.events {
 		if ev.OrgID == orgID && ev.EventUUID == eventUUID {
+			if f.getEventHook != nil {
+				latest := *ev
+				f.getEventHook(f.getEventCalls, &latest)
+				return &latest, nil
+			}
 			return ev, nil
 		}
 	}
@@ -368,6 +382,33 @@ func (f *fakeStore) ResolveCurtailmentTopologyScope(
 	_ interfaces.ListCandidatesParams,
 ) (interfaces.CurtailmentTopologyScopeCoverage, error) {
 	return f.topologyCoverage, f.topologyCoverageErr
+}
+
+func (f *fakeStore) ResolveCurtailmentTopologyDispatch(
+	_ context.Context,
+	_ interfaces.ListCandidatesParams,
+	dispatchDeviceIdentifiers []string,
+) (interfaces.CurtailmentTopologyDispatchSnapshot, error) {
+	f.topologyDispatchCalls++
+	if f.topologyDispatchErr != nil {
+		return interfaces.CurtailmentTopologyDispatchSnapshot{}, f.topologyDispatchErr
+	}
+	members := make(map[string]struct{}, len(f.candidates))
+	for _, candidate := range f.candidates {
+		if candidate != nil {
+			members[candidate.DeviceIdentifier] = struct{}{}
+		}
+	}
+	dispatchMembers := make([]string, 0, len(dispatchDeviceIdentifiers))
+	for _, deviceIdentifier := range dispatchDeviceIdentifiers {
+		if _, ok := members[deviceIdentifier]; ok {
+			dispatchMembers = append(dispatchMembers, deviceIdentifier)
+		}
+	}
+	return interfaces.CurtailmentTopologyDispatchSnapshot{
+		Coverage:                        f.topologyCoverage,
+		DispatchMemberDeviceIdentifiers: dispatchMembers,
+	}, nil
 }
 
 func (f *fakeStore) ListEvents(context.Context, interfaces.ListEventsParams) ([]*models.Event, string, error) {
@@ -995,6 +1036,11 @@ func TestReconciler_TopologyDispatchRevalidatesMembershipAndCreatorPermission(t 
 			)
 
 			reconciler.runTick(t.Context())
+			assert.Equal(t, 1, store.topologyDispatchCalls)
+			for _, filter := range store.listCandidatesFilters {
+				assert.NotEmpty(t, filter,
+					"dispatch authorization must not re-expand the full topology selector")
+			}
 
 			if tt.wantSend {
 				assert.Equal(t, 1, dispatcher.curtailCalls)
@@ -1006,6 +1052,174 @@ func TestReconciler_TopologyDispatchRevalidatesMembershipAndCreatorPermission(t 
 			assert.Equal(t, models.EventStateRestoring, store.events[0].State)
 		})
 	}
+}
+
+func TestReconciler_TopologyDispatchAuthorizationErrorsFailClosed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		configure func(*fakeStore, *models.Event) DispatchPermissionResolver
+	}{
+		{
+			name: "persisted scope parse error",
+			configure: func(_ *fakeStore, event *models.Event) DispatchPermissionResolver {
+				event.ScopeJSON = []byte(`{`)
+				return staticDispatchPermissionResolver{effective: topologyDispatchManagePermission()}
+			},
+		},
+		{
+			name: "event reload error",
+			configure: func(store *fakeStore, _ *models.Event) DispatchPermissionResolver {
+				store.getEventErr = errors.New("reload failed")
+				return staticDispatchPermissionResolver{effective: topologyDispatchManagePermission()}
+			},
+		},
+		{
+			name: "reloaded scope parse error",
+			configure: func(store *fakeStore, _ *models.Event) DispatchPermissionResolver {
+				store.getEventHook = func(_ int, latest *models.Event) { latest.ScopeJSON = []byte(`{`) }
+				return staticDispatchPermissionResolver{effective: topologyDispatchManagePermission()}
+			},
+		},
+		{
+			name: "authorization envelope parse error",
+			configure: func(_ *fakeStore, event *models.Event) DispatchPermissionResolver {
+				event.AuthorizationEnvelopeJSON = []byte(`{`)
+				return staticDispatchPermissionResolver{effective: topologyDispatchManagePermission()}
+			},
+		},
+		{
+			name: "topology snapshot error",
+			configure: func(store *fakeStore, _ *models.Event) DispatchPermissionResolver {
+				store.topologyDispatchErr = errors.New("snapshot failed")
+				return staticDispatchPermissionResolver{effective: topologyDispatchManagePermission()}
+			},
+		},
+		{
+			name: "permission reload error",
+			configure: func(_ *fakeStore, _ *models.Event) DispatchPermissionResolver {
+				return staticDispatchPermissionResolver{err: errors.New("permission read failed")}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			store, event, target := topologyDispatchFixture()
+			dispatcher := &fakeDispatcher{}
+			reconciler := New(
+				Config{TickInterval: time.Hour},
+				store,
+				dispatcher,
+				WithDispatchPermissionResolver(tt.configure(store, event)),
+			)
+
+			assert.False(t, reconciler.authorizeTopologyCurtailDispatch(t.Context(), event, []*models.Target{target}))
+			assert.Equal(t, 0, dispatcher.curtailCalls)
+			assert.Equal(t, 1, store.beginRestoreCalls)
+			assert.Equal(t, models.EventStateRestoring, store.events[0].State)
+		})
+	}
+}
+
+func TestReconciler_TopologyDispatchRejectionStaysLatchedUntilRestoreStarts(t *testing.T) {
+	t.Parallel()
+
+	store, event, target := topologyDispatchFixture()
+	store.beginRestoreErr = errors.New("restore transition failed")
+	reconciler := New(
+		Config{TickInterval: time.Hour},
+		store,
+		&fakeDispatcher{},
+		WithDispatchPermissionResolver(staticDispatchPermissionResolver{
+			effective: authz.NewEffectivePermissions(nil),
+		}),
+	)
+
+	assert.False(t, reconciler.authorizeTopologyCurtailDispatch(t.Context(), event, []*models.Target{target}))
+	assert.Equal(t, models.EventStatePending, event.State)
+
+	store.beginRestoreErr = nil
+	reconciler.permissions = staticDispatchPermissionResolver{effective: topologyDispatchManagePermission()}
+	assert.False(t, reconciler.authorizeTopologyCurtailDispatch(t.Context(), event, []*models.Target{target}),
+		"a cleared rejection condition must not resume curtail dispatch")
+	assert.Equal(t, 2, store.beginRestoreCalls)
+	assert.Equal(t, models.EventStateRestoring, event.State)
+}
+
+func TestReconciler_TopologyDispatchRechecksEventAtCommandBoundary(t *testing.T) {
+	t.Parallel()
+
+	store, event, target := topologyDispatchFixture()
+	dispatcher := &fakeDispatcher{}
+	store.getEventHook = func(call int, latest *models.Event) {
+		if call == 4 {
+			latest.State = models.EventStateRestoring
+		}
+	}
+	reconciler := New(
+		Config{TickInterval: time.Hour},
+		store,
+		dispatcher,
+		WithDispatchPermissionResolver(staticDispatchPermissionResolver{
+			effective: topologyDispatchManagePermission(),
+		}),
+	)
+
+	dispatched := reconciler.dispatchCurtailBatch(
+		t.Context(),
+		event,
+		[]*models.Target{target},
+		models.TargetStatePending,
+		skipPendingDispatchClock,
+	)
+
+	assert.False(t, dispatched)
+	assert.Equal(t, 4, store.getEventCalls)
+	assert.Equal(t, 0, dispatcher.curtailCalls)
+}
+
+func topologyDispatchFixture() (*fakeStore, *models.Event, *models.Target) {
+	const siteID = int64(7)
+	eventID := int64(10)
+	event := &models.Event{
+		ID:                        eventID,
+		EventUUID:                 uuid.New(),
+		OrgID:                     1,
+		State:                     models.EventStatePending,
+		Mode:                      models.ModeFixedKw,
+		LoopType:                  models.LoopTypeOpen,
+		ScopeType:                 models.ScopeTypeMixed,
+		ScopeJSON:                 []byte(`{"scope_schema_version":1,"building_ids":[11]}`),
+		AuthorizationEnvelopeJSON: []byte(`{"schema_version":1,"selected_resource_site_ids":[7],"current_member_site_ids":[7],"miner_scope_unbounded":false,"facility_fan_site_ids":[],"facility_fan_scope_unbounded":false}`),
+		CreatedByUserID:           99,
+	}
+	target := &models.Target{
+		CurtailmentEventID: eventID,
+		DeviceIdentifier:   "miner-1",
+		State:              models.TargetStatePending,
+		DesiredState:       models.DesiredStateCurtailed,
+		BaselinePowerW:     ptrFloat64(3000),
+	}
+	store := newFakeStore()
+	store.events = []*models.Event{event}
+	store.targetsByEventID[eventID] = []*models.Target{target}
+	store.candidates = []*models.Candidate{{DeviceIdentifier: target.DeviceIdentifier}}
+	store.topologyCoverage = interfaces.CurtailmentTopologyScopeCoverage{
+		SelectedResourceSiteIDs: []int64{siteID},
+		CurrentMemberSiteIDs:    []int64{siteID},
+	}
+	return store, event, target
+}
+
+func topologyDispatchManagePermission() *authz.EffectivePermissions {
+	return authz.NewEffectivePermissions([]authz.Assignment{{
+		AssignmentID: 1,
+		ScopeType:    authz.ScopeOrg,
+		Permissions:  []string{authz.PermCurtailmentManage},
+	}})
 }
 
 func TestTopologyCoverageWithinEnvelope(t *testing.T) {

--- a/server/internal/domain/curtailment/reconciler/reconciler_test.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler_test.go
@@ -88,6 +88,9 @@ type fakeStore struct {
 	topologyCoverageErr       error
 	topologyDispatchErr       error
 	topologyDispatchCalls     int
+	topologyFenceErr          error
+	topologyFenceActive       bool
+	topologyFenceHook         func(event *models.Event)
 	getEventErr               error
 	getEventCalls             int
 	getEventHook              func(call int, event *models.Event)
@@ -409,6 +412,43 @@ func (f *fakeStore) ResolveCurtailmentTopologyDispatch(
 		Coverage:                        f.topologyCoverage,
 		DispatchMemberDeviceIdentifiers: dispatchMembers,
 	}, nil
+}
+
+func (f *fakeStore) WithCurtailmentTopologyDispatchFence(
+	ctx context.Context,
+	event *models.Event,
+	params interfaces.ListCandidatesParams,
+	dispatchDeviceIdentifiers []string,
+	command func(interfaces.CurtailmentTopologyDispatchFenceSnapshot) error,
+) error {
+	if f.topologyFenceErr != nil {
+		return f.topologyFenceErr
+	}
+	latest, err := f.GetEventByUUID(ctx, event.OrgID, event.EventUUID)
+	if err != nil {
+		return err
+	}
+	if latest == nil || latest.ID != event.ID || latest.State != event.State || latest.State.IsTerminal() {
+		return interfaces.ErrCurtailmentEventStateRaceLoss
+	}
+	latestCopy := *latest
+	latest = &latestCopy
+	if f.topologyFenceHook != nil {
+		f.topologyFenceHook(latest)
+	}
+	if latest.State != event.State || latest.State.IsTerminal() {
+		return interfaces.ErrCurtailmentEventStateRaceLoss
+	}
+	topology, err := f.ResolveCurtailmentTopologyDispatch(ctx, params, dispatchDeviceIdentifiers)
+	if err != nil {
+		return err
+	}
+	f.topologyFenceActive = true
+	defer func() { f.topologyFenceActive = false }()
+	return command(interfaces.CurtailmentTopologyDispatchFenceSnapshot{
+		Event:    latest,
+		Topology: topology,
+	})
 }
 
 func (f *fakeStore) ListEvents(context.Context, interfaces.ListEventsParams) ([]*models.Event, string, error) {
@@ -1131,9 +1171,11 @@ func TestReconciler_TopologyDispatchAuthorizationErrorsFailClosed(t *testing.T) 
 				WithDispatchPermissionResolver(tt.configure(store, event)),
 			)
 
-			assert.False(t, reconciler.authorizeTopologyCurtailDispatch(
-				t.Context(), event, []*models.Target{target}, []string{target.DeviceIdentifier},
-			))
+			handled, allowed := reconciler.authorizeTopologyCurtailDispatch(
+				t.Context(), event, []*models.Target{target}, []string{target.DeviceIdentifier}, func() {},
+			)
+			assert.True(t, handled)
+			assert.False(t, allowed)
 			assert.Equal(t, 0, dispatcher.curtailCalls)
 			assert.Equal(t, 1, store.beginRestoreCalls)
 			assert.Equal(t, models.EventStateRestoring, store.events[0].State)
@@ -1156,16 +1198,20 @@ func TestReconciler_TopologyDispatchRejectionStaysLatchedUntilRestoreStarts(t *t
 		}),
 	)
 
-	assert.False(t, reconciler.authorizeTopologyCurtailDispatch(
-		t.Context(), event, []*models.Target{target}, []string{target.DeviceIdentifier},
-	))
+	handled, allowed := reconciler.authorizeTopologyCurtailDispatch(
+		t.Context(), event, []*models.Target{target}, []string{target.DeviceIdentifier}, func() {},
+	)
+	assert.True(t, handled)
+	assert.False(t, allowed)
 	assert.Equal(t, models.EventStatePending, event.State)
 
 	store.beginRestoreErr = nil
 	reconciler.permissions = staticDispatchPermissionResolver{effective: topologyDispatchManagePermission()}
-	assert.False(t, reconciler.authorizeTopologyCurtailDispatch(
-		t.Context(), event, []*models.Target{target}, []string{target.DeviceIdentifier},
-	),
+	handled, allowed = reconciler.authorizeTopologyCurtailDispatch(
+		t.Context(), event, []*models.Target{target}, []string{target.DeviceIdentifier}, func() {},
+	)
+	assert.True(t, handled)
+	assert.False(t, allowed,
 		"a cleared rejection condition must not resume curtail dispatch")
 	assert.Equal(t, 2, store.beginRestoreCalls)
 	assert.Equal(t, models.EventStateRestoring, event.State)
@@ -1177,10 +1223,8 @@ func TestReconciler_TopologyDispatchRechecksEventAtCommandBoundary(t *testing.T)
 
 	store, event, target := topologyDispatchFixture()
 	dispatcher := &fakeDispatcher{}
-	store.getEventHook = func(call int, latest *models.Event) {
-		if call == 4 {
-			latest.State = models.EventStateRestoring
-		}
+	store.topologyFenceHook = func(latest *models.Event) {
+		latest.State = models.EventStateRestoring
 	}
 	reconciler := New(
 		Config{TickInterval: time.Hour},
@@ -1200,8 +1244,38 @@ func TestReconciler_TopologyDispatchRechecksEventAtCommandBoundary(t *testing.T)
 	)
 
 	assert.False(t, dispatched)
-	assert.Equal(t, 4, store.getEventCalls)
+	assert.Equal(t, 3, store.getEventCalls)
 	assert.Equal(t, 0, dispatcher.curtailCalls)
+}
+
+func TestReconciler_TopologyDispatchHoldsFenceThroughCommand(t *testing.T) {
+	t.Parallel()
+
+	store, event, target := topologyDispatchFixture()
+	dispatcher := &fakeDispatcher{}
+	dispatcher.curtailHook = func(_ []string) {
+		assert.True(t, store.topologyFenceActive)
+	}
+	reconciler := New(
+		Config{TickInterval: time.Hour},
+		store,
+		dispatcher,
+		WithDispatchPermissionResolver(staticDispatchPermissionResolver{
+			effective: topologyDispatchManagePermission(),
+		}),
+	)
+
+	dispatched := reconciler.dispatchCurtailBatch(
+		t.Context(),
+		event,
+		[]*models.Target{target},
+		models.TargetStatePending,
+		skipPendingDispatchClock,
+	)
+
+	assert.True(t, dispatched)
+	assert.Equal(t, 1, dispatcher.curtailCalls)
+	assert.False(t, store.topologyFenceActive)
 }
 
 func topologyDispatchFixture() (*fakeStore, *models.Event, *models.Target) {

--- a/server/internal/domain/curtailment/reconciler/reconciler_test.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler_test.go
@@ -78,22 +78,23 @@ type fakeStore struct {
 	lastCooldownFilter     []string
 	lastCooldownSiteIDs    []int64
 
-	heartbeatCalls            int
-	lastHeartbeatActive       int32
-	lastHeartbeatTickUUID     uuid.UUID
-	lastListCandidatesSiteIDs []int64
-	lastListCandidatesFilter  []string
-	listCandidatesFilters     [][]string
-	topologyCoverage          interfaces.CurtailmentTopologyScopeCoverage
-	topologyCoverageErr       error
-	topologyDispatchErr       error
-	topologyDispatchCalls     int
-	topologyFenceErr          error
-	topologyFenceActive       bool
-	topologyFenceHook         func(event *models.Event)
-	getEventErr               error
-	getEventCalls             int
-	getEventHook              func(call int, event *models.Event)
+	heartbeatCalls               int
+	lastHeartbeatActive          int32
+	lastHeartbeatTickUUID        uuid.UUID
+	lastListCandidatesSiteIDs    []int64
+	lastListCandidatesFilter     []string
+	listCandidatesFilters        [][]string
+	topologyCoverage             interfaces.CurtailmentTopologyScopeCoverage
+	topologyCoverageErr          error
+	topologyDispatchErr          error
+	topologyDispatchCalls        int
+	topologyFenceErr             error
+	topologyFenceAfterCommandErr error
+	topologyFenceActive          bool
+	topologyFenceHook            func(event *models.Event)
+	getEventErr                  error
+	getEventCalls                int
+	getEventHook                 func(call int, event *models.Event)
 
 	// BeginRestoreTransition captures, exercised by max_duration tests.
 	beginRestoreCalls       int
@@ -445,10 +446,13 @@ func (f *fakeStore) WithCurtailmentTopologyDispatchFence(
 	}
 	f.topologyFenceActive = true
 	defer func() { f.topologyFenceActive = false }()
-	return command(interfaces.CurtailmentTopologyDispatchFenceSnapshot{
+	if err := command(interfaces.CurtailmentTopologyDispatchFenceSnapshot{
 		Event:    latest,
 		Topology: topology,
-	})
+	}); err != nil {
+		return err
+	}
+	return f.topologyFenceAfterCommandErr
 }
 
 func (f *fakeStore) ListEvents(context.Context, interfaces.ListEventsParams) ([]*models.Event, string, error) {
@@ -1276,6 +1280,52 @@ func TestReconciler_TopologyDispatchHoldsFenceThroughCommand(t *testing.T) {
 	assert.True(t, dispatched)
 	assert.Equal(t, 1, dispatcher.curtailCalls)
 	assert.False(t, store.topologyFenceActive)
+}
+
+func TestReconciler_TopologyDispatchFenceFailurePreservesRestoreOwnership(t *testing.T) {
+	t.Parallel()
+
+	store, event, target := topologyDispatchFixture()
+	store.topologyFenceAfterCommandErr = errors.New("commit failed")
+	store.beginRestoreErr = errors.New("restore transition failed")
+	dispatcher := &fakeDispatcher{}
+	reconciler := New(
+		Config{TickInterval: time.Hour},
+		store,
+		dispatcher,
+		WithDispatchPermissionResolver(staticDispatchPermissionResolver{
+			effective: topologyDispatchManagePermission(),
+		}),
+	)
+
+	dispatched := reconciler.dispatchCurtailBatch(
+		t.Context(),
+		event,
+		[]*models.Target{target},
+		models.TargetStatePending,
+		skipPendingDispatchClock,
+	)
+	assert.False(t, dispatched)
+	assert.Equal(t, 1, dispatcher.curtailCalls)
+	assert.Equal(t, models.TargetStateDispatching, target.State)
+
+	store.beginRestoreErr = nil
+	commandCalls := 0
+	handled, allowed := reconciler.authorizeTopologyCurtailDispatch(
+		t.Context(),
+		event,
+		[]*models.Target{target},
+		[]string{target.DeviceIdentifier},
+		func() { commandCalls++ },
+	)
+	assert.True(t, handled)
+	assert.False(t, allowed)
+	assert.Zero(t, commandCalls)
+	assert.Equal(t, 2, store.beginRestoreCalls)
+	assert.Equal(t, models.DesiredStateActive, target.DesiredState)
+	assert.Equal(t, models.TargetStatePending, target.State)
+	assert.NotNil(t, target.RestorePhase,
+		"a command-attempted target must remain owned by restore after a fence commit error")
 }
 
 func topologyDispatchFixture() (*fakeStore, *models.Event, *models.Target) {

--- a/server/internal/domain/curtailment/reconciler/reconciler_test.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler_test.go
@@ -635,7 +635,7 @@ func (f *fakeStore) UpsertHeartbeat(_ context.Context, params interfaces.UpsertC
 // assert the call happened and the event row flips to restoring in-place
 // (mirroring SQL store semantics — the reconciler reads ev again on the next
 // tick). effective_batch_size was stamped at Start; this fake does not touch it.
-func (f *fakeStore) BeginRestoreTransition(_ context.Context, _ int64, eventUUID uuid.UUID, _ interfaces.BeginRestoreTransitionParams) (*models.Event, error) {
+func (f *fakeStore) BeginRestoreTransition(_ context.Context, _ int64, eventUUID uuid.UUID, params interfaces.BeginRestoreTransitionParams) (*models.Event, error) {
 	f.beginRestoreCalls++
 	f.beginRestoreLastEventID = eventUUID
 	if f.beginRestoreErr != nil {
@@ -645,10 +645,23 @@ func (f *fakeStore) BeginRestoreTransition(_ context.Context, _ int64, eventUUID
 		if ev.EventUUID == eventUUID {
 			ev.State = models.EventStateRestoring
 			now := time.Now()
+			knownUnsent := make(map[string]struct{}, len(params.KnownUnsentDeviceIdentifiers))
+			for _, deviceIdentifier := range params.KnownUnsentDeviceIdentifiers {
+				knownUnsent[deviceIdentifier] = struct{}{}
+			}
 			for _, t := range f.targetsByEventID[ev.ID] {
 				if t.State == models.TargetStateResolved ||
 					t.State == models.TargetStateRestoreFailed ||
 					t.State == models.TargetStateReleased {
+					continue
+				}
+				_, explicitlyUnsent := knownUnsent[t.DeviceIdentifier]
+				if t.DesiredState == models.DesiredStateCurtailed &&
+					(t.State == models.TargetStatePending || t.State == models.TargetStateUnavailable ||
+						(t.State == models.TargetStateDispatching && explicitlyUnsent)) &&
+					t.LastDispatchedAt == nil && t.CurtailPhase.DispatchedAt == nil &&
+					t.RetryCount == 0 && t.RestorePhase == nil {
+					t.State = models.TargetStateReleased
 					continue
 				}
 				t.DesiredState = models.DesiredStateActive
@@ -1050,6 +1063,8 @@ func TestReconciler_TopologyDispatchRevalidatesMembershipAndCreatorPermission(t 
 			assert.Equal(t, 0, dispatcher.curtailCalls)
 			assert.Equal(t, 1, store.beginRestoreCalls)
 			assert.Equal(t, models.EventStateRestoring, store.events[0].State)
+			assert.Equal(t, models.TargetStateReleased, store.targetsByEventID[eventID][0].State,
+				"a target rejected before its first Curtail must not enter the Uncurtail queue")
 		})
 	}
 }
@@ -1116,10 +1131,13 @@ func TestReconciler_TopologyDispatchAuthorizationErrorsFailClosed(t *testing.T) 
 				WithDispatchPermissionResolver(tt.configure(store, event)),
 			)
 
-			assert.False(t, reconciler.authorizeTopologyCurtailDispatch(t.Context(), event, []*models.Target{target}))
+			assert.False(t, reconciler.authorizeTopologyCurtailDispatch(
+				t.Context(), event, []*models.Target{target}, []string{target.DeviceIdentifier},
+			))
 			assert.Equal(t, 0, dispatcher.curtailCalls)
 			assert.Equal(t, 1, store.beginRestoreCalls)
 			assert.Equal(t, models.EventStateRestoring, store.events[0].State)
+			assert.Equal(t, models.TargetStateReleased, target.State)
 		})
 	}
 }
@@ -1138,15 +1156,20 @@ func TestReconciler_TopologyDispatchRejectionStaysLatchedUntilRestoreStarts(t *t
 		}),
 	)
 
-	assert.False(t, reconciler.authorizeTopologyCurtailDispatch(t.Context(), event, []*models.Target{target}))
+	assert.False(t, reconciler.authorizeTopologyCurtailDispatch(
+		t.Context(), event, []*models.Target{target}, []string{target.DeviceIdentifier},
+	))
 	assert.Equal(t, models.EventStatePending, event.State)
 
 	store.beginRestoreErr = nil
 	reconciler.permissions = staticDispatchPermissionResolver{effective: topologyDispatchManagePermission()}
-	assert.False(t, reconciler.authorizeTopologyCurtailDispatch(t.Context(), event, []*models.Target{target}),
+	assert.False(t, reconciler.authorizeTopologyCurtailDispatch(
+		t.Context(), event, []*models.Target{target}, []string{target.DeviceIdentifier},
+	),
 		"a cleared rejection condition must not resume curtail dispatch")
 	assert.Equal(t, 2, store.beginRestoreCalls)
 	assert.Equal(t, models.EventStateRestoring, event.State)
+	assert.Equal(t, models.TargetStateReleased, target.State)
 }
 
 func TestReconciler_TopologyDispatchRechecksEventAtCommandBoundary(t *testing.T) {

--- a/server/internal/domain/curtailment/service.go
+++ b/server/internal/domain/curtailment/service.go
@@ -197,6 +197,11 @@ func (s *Service) Start(ctx context.Context, req StartRequest) (*Plan, error) {
 	if err := validateStartRequest(req); err != nil {
 		return nil, err
 	}
+	if hasTopologySelectors(req.Scope) && req.SourceActorType == models.SourceActorAutomation {
+		return nil, fleeterror.NewFailedPreconditionError(
+			"topology-scoped Start is not available for automation",
+		)
+	}
 	if hasTopologySelectors(req.Scope) && req.Mode == models.ModeFullFleet {
 		return nil, fleeterror.NewUnimplementedError(
 			"topology-scoped FULL_FLEET Start requires topology-following lifecycle support",
@@ -1781,6 +1786,17 @@ func normalizeScope(s Scope) Scope {
 
 func hasTopologySelectors(s Scope) bool {
 	return len(s.BuildingIDs) > 0 || len(s.RackIDs) > 0 || len(s.GroupIDs) > 0
+}
+
+// IsTopologyScope reports whether scope targets buildings, racks, or groups.
+func IsTopologyScope(s Scope) bool {
+	return hasTopologySelectors(s)
+}
+
+// ListCandidatesParamsForScope returns the canonical candidate filter for a
+// validated scope. Callers must set OrgID before querying a store.
+func ListCandidatesParamsForScope(s Scope) (interfaces.ListCandidatesParams, error) {
+	return resolveScope(s)
 }
 
 func validateScopeContract(s Scope) error {

--- a/server/internal/domain/curtailment/service.go
+++ b/server/internal/domain/curtailment/service.go
@@ -197,9 +197,9 @@ func (s *Service) Start(ctx context.Context, req StartRequest) (*Plan, error) {
 	if err := validateStartRequest(req); err != nil {
 		return nil, err
 	}
-	if hasTopologySelectors(req.Scope) {
+	if hasTopologySelectors(req.Scope) && req.Mode == models.ModeFullFleet {
 		return nil, fleeterror.NewUnimplementedError(
-			"topology-scoped Start requires durable authorization and lifecycle support",
+			"topology-scoped FULL_FLEET Start requires topology-following lifecycle support",
 		)
 	}
 	req.PostEventCooldownSec = effectivePostEventCooldownSec(req.PreviewRequest)

--- a/server/internal/domain/curtailment/service_start_test.go
+++ b/server/internal/domain/curtailment/service_start_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/block/proto-fleet/server/internal/domain/curtailment/models"
 	"github.com/block/proto-fleet/server/internal/domain/curtailment/modes"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
+	"github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
 )
 
 // validStartRequest builds a valid StartRequest pointing at orgID. Callers
@@ -53,7 +54,76 @@ func TestService_Start_RejectsEmptyReason(t *testing.T) {
 	}
 }
 
-func TestService_Start_RejectsTopologyScopeUntilAuthorizationLifecycleLands(t *testing.T) {
+func TestService_Start_TopologyScopesFreezeSelectedTargets(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name      string
+		scope     Scope
+		seed      func(*fakeStore, int64, *models.Candidate)
+		wantScope string
+	}{
+		{
+			name:  "building",
+			scope: Scope{SchemaVersion: ScopeSchemaVersionCurrent, BuildingIDs: []int64{7}},
+			seed: func(store *fakeStore, orgID int64, candidate *models.Candidate) {
+				store.candidatesByBuilding[orgID] = map[int64][]*models.Candidate{7: {candidate}}
+			},
+			wantScope: `{"building_ids":[7],"scope_schema_version":1}`,
+		},
+		{
+			name:  "rack",
+			scope: Scope{SchemaVersion: ScopeSchemaVersionCurrent, RackIDs: []int64{8}},
+			seed: func(store *fakeStore, orgID int64, candidate *models.Candidate) {
+				store.candidatesByRack[orgID] = map[int64][]*models.Candidate{8: {candidate}}
+			},
+			wantScope: `{"rack_ids":[8],"scope_schema_version":1}`,
+		},
+		{
+			name:  "group",
+			scope: Scope{SchemaVersion: ScopeSchemaVersionCurrent, GroupIDs: []int64{9}},
+			seed: func(store *fakeStore, orgID int64, candidate *models.Candidate) {
+				store.candidatesByGroup[orgID] = map[int64][]*models.Candidate{9: {candidate}}
+			},
+			wantScope: `{"group_ids":[9],"scope_schema_version":1}`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			const orgID = int64(1)
+			candidate := minerWithEff(tc.name+"-miner", 3000, 100, 30)
+			store := newFakeStore()
+			store.orgConfigByOrg[orgID] = defaultOrgConfig(orgID)
+			store.topologyCoverage = interfaces.CurtailmentTopologyScopeCoverage{SiteIDs: []int64{42}}
+			tc.seed(store, orgID, candidate)
+			svc := NewService(store)
+			req := validStartRequest(orgID)
+			req.Scope = tc.scope
+			req.TargetKW = 2
+
+			plan, err := svc.Start(t.Context(), req)
+
+			require.NoError(t, err)
+			require.Len(t, plan.Selected, 1)
+			assert.Equal(t, tc.name+"-miner", plan.Selected[0].DeviceIdentifier)
+			assert.Equal(t, tc.scope.BuildingIDs, store.lastTopologyFilter.BuildingIDs)
+			assert.Equal(t, tc.scope.RackIDs, store.lastTopologyFilter.RackIDs)
+			assert.Equal(t, tc.scope.GroupIDs, store.lastTopologyFilter.GroupIDs)
+			assert.Equal(t, tc.scope.BuildingIDs, store.lastListCandidateBuildings)
+			assert.Equal(t, tc.scope.RackIDs, store.lastListCandidateRacks)
+			assert.Equal(t, tc.scope.GroupIDs, store.lastListCandidateGroups)
+			assert.Equal(t, models.ScopeTypeMixed, store.lastInsertEvent.ScopeType)
+			assert.Equal(t, models.LoopTypeOpen, store.lastInsertEvent.LoopType)
+			assert.Equal(t, models.EventStatePending, store.lastInsertEvent.State)
+			assert.JSONEq(t, tc.wantScope, string(store.lastInsertEvent.ScopeJSON))
+			require.Len(t, store.lastInsertTargets, 1)
+			assert.Equal(t, tc.name+"-miner", store.lastInsertTargets[0].DeviceIdentifier)
+		})
+	}
+}
+
+func TestService_Start_RejectsTopologyFullFleetUntilLifecycleLands(t *testing.T) {
 	t.Parallel()
 
 	store := newFakeStore()
@@ -63,13 +133,37 @@ func TestService_Start_RejectsTopologyScopeUntilAuthorizationLifecycleLands(t *t
 		SchemaVersion: ScopeSchemaVersionCurrent,
 		BuildingIDs:   []int64{7},
 	}
+	req.Mode = models.ModeFullFleet
+	req.TargetKW = 0
 
 	_, err := svc.Start(t.Context(), req)
 
 	require.Error(t, err)
 	assert.True(t, fleeterror.IsUnimplementedError(err))
-	assert.Contains(t, err.Error(), "durable authorization and lifecycle")
+	assert.Contains(t, err.Error(), "topology-following lifecycle")
 	assert.Zero(t, store.listCandidatesCalls)
+}
+
+func TestService_Start_EmptyTopologyScopeReturnsInsufficientLoadWithoutPersisting(t *testing.T) {
+	t.Parallel()
+
+	const orgID = int64(1)
+	store := newFakeStore()
+	store.orgConfigByOrg[orgID] = defaultOrgConfig(orgID)
+	store.topologyCoverage = interfaces.CurtailmentTopologyScopeCoverage{SiteIDs: []int64{42}}
+	svc := NewService(store)
+	req := validStartRequest(orgID)
+	req.Scope = Scope{
+		SchemaVersion: ScopeSchemaVersionCurrent,
+		GroupIDs:      []int64{9},
+	}
+
+	plan, err := svc.Start(t.Context(), req)
+
+	require.NoError(t, err)
+	require.NotNil(t, plan.InsufficientLoadDetail)
+	assert.Equal(t, modes.OutcomeInsufficientLoad, plan.Outcome)
+	assert.Zero(t, store.insertEventCalls)
 }
 
 func TestService_Start_RejectsAllowUnboundedWithMaxDuration(t *testing.T) {

--- a/server/internal/domain/stores/interfaces/curtailment.go
+++ b/server/internal/domain/stores/interfaces/curtailment.go
@@ -143,6 +143,9 @@ type UpsertCurtailmentHeartbeatParams struct {
 
 type BeginRestoreTransitionParams struct {
 	AutomationDemandGuard *AutomationDemandGuard
+	// KnownUnsentDeviceIdentifiers identifies DISPATCHING rows for which the
+	// caller knows the physical command boundary was never crossed.
+	KnownUnsentDeviceIdentifiers []string
 }
 
 type AutomationDemandGuard struct {

--- a/server/internal/domain/stores/interfaces/curtailment.go
+++ b/server/internal/domain/stores/interfaces/curtailment.go
@@ -284,7 +284,8 @@ type CurtailmentTopologyDispatchFenceSnapshot struct {
 
 // CurtailmentTopologyDispatchFenceStore serializes event transitions,
 // topology mutations, and creator permission revocations through the physical
-// Curtail command callback.
+// Curtail command callback. Implementations must keep referenced user/device
+// rows compatible with the foreign-key locks acquired by command enqueueing.
 type CurtailmentTopologyDispatchFenceStore interface {
 	WithCurtailmentTopologyDispatchFence(
 		ctx context.Context,

--- a/server/internal/domain/stores/interfaces/curtailment.go
+++ b/server/internal/domain/stores/interfaces/curtailment.go
@@ -252,6 +252,26 @@ type CurtailmentTopologyScopeStore interface {
 	) (CurtailmentTopologyScopeCoverage, error)
 }
 
+// CurtailmentTopologyDispatchSnapshot is one database snapshot of both the
+// selector's authorization coverage and the subset of the dispatch batch that
+// is still a member. Keeping these reads together prevents a placement change
+// from being authorized against coverage from a different point in time.
+type CurtailmentTopologyDispatchSnapshot struct {
+	Coverage                        CurtailmentTopologyScopeCoverage
+	DispatchMemberDeviceIdentifiers []string
+}
+
+// CurtailmentTopologyDispatchStore performs the live topology check used at
+// the physical command boundary. It is separate from the start-time topology
+// resolver because only the reconciler needs batch membership in the result.
+type CurtailmentTopologyDispatchStore interface {
+	ResolveCurtailmentTopologyDispatch(
+		ctx context.Context,
+		params ListCandidatesParams,
+		dispatchDeviceIdentifiers []string,
+	) (CurtailmentTopologyDispatchSnapshot, error)
+}
+
 // UpdateOperatorFieldsParams carries the optional patch fields for a
 // partial event update. nil values preserve the column via COALESCE.
 // effective_batch_size is not on this surface — recomputing mid-event

--- a/server/internal/domain/stores/interfaces/curtailment.go
+++ b/server/internal/domain/stores/interfaces/curtailment.go
@@ -275,6 +275,26 @@ type CurtailmentTopologyDispatchStore interface {
 	) (CurtailmentTopologyDispatchSnapshot, error)
 }
 
+// CurtailmentTopologyDispatchFenceSnapshot is the event and topology state
+// protected by the dispatch fence for the duration of its callback.
+type CurtailmentTopologyDispatchFenceSnapshot struct {
+	Event    *models.Event
+	Topology CurtailmentTopologyDispatchSnapshot
+}
+
+// CurtailmentTopologyDispatchFenceStore serializes event transitions,
+// topology mutations, and creator permission revocations through the physical
+// Curtail command callback.
+type CurtailmentTopologyDispatchFenceStore interface {
+	WithCurtailmentTopologyDispatchFence(
+		ctx context.Context,
+		event *models.Event,
+		params ListCandidatesParams,
+		dispatchDeviceIdentifiers []string,
+		command func(CurtailmentTopologyDispatchFenceSnapshot) error,
+	) error
+}
+
 // UpdateOperatorFieldsParams carries the optional patch fields for a
 // partial event update. nil values preserve the column via COALESCE.
 // effective_batch_size is not on this surface — recomputing mid-event

--- a/server/internal/domain/stores/sqlstores/curtailment.go
+++ b/server/internal/domain/stores/sqlstores/curtailment.go
@@ -2076,11 +2076,76 @@ func (s *SQLCurtailmentStore) ResolveCurtailmentTopologyScope(
 	return resolveCurtailmentTopologyScope(ctx, s.GetQueries(ctx), params)
 }
 
-func resolveCurtailmentTopologyScope(
+func (s *SQLCurtailmentStore) ResolveCurtailmentTopologyDispatch(
 	ctx context.Context,
-	q sqlc.Querier,
 	params interfaces.ListCandidatesParams,
-) (interfaces.CurtailmentTopologyScopeCoverage, error) {
+	dispatchDeviceIdentifiers []string,
+) (interfaces.CurtailmentTopologyDispatchSnapshot, error) {
+	requestedIDs, selectorLabel, err := topologySelector(params)
+	if err != nil {
+		return interfaces.CurtailmentTopologyDispatchSnapshot{}, err
+	}
+	row, err := s.GetQueries(ctx).ResolveCurtailmentTopologyDispatch(
+		ctx,
+		sqlc.ResolveCurtailmentTopologyDispatchParams{
+			OrgID:                     params.OrgID,
+			BuildingIds:               params.BuildingIDs,
+			RackIds:                   params.RackIDs,
+			GroupIds:                  params.GroupIDs,
+			DispatchDeviceIdentifiers: dispatchDeviceIdentifiers,
+		},
+	)
+	if err != nil {
+		return interfaces.CurtailmentTopologyDispatchSnapshot{}, fleeterror.NewInternalErrorf(
+			"failed to resolve curtailment topology dispatch: %v",
+			err,
+		)
+	}
+
+	existing := make(map[int64]struct{}, len(row.ExistingSelectorIds))
+	for _, id := range row.ExistingSelectorIds {
+		existing[id] = struct{}{}
+	}
+	missingIDs := make([]int64, 0)
+	for _, id := range requestedIDs {
+		if _, ok := existing[id]; !ok {
+			missingIDs = append(missingIDs, id)
+		}
+	}
+	if len(missingIDs) > 0 {
+		return interfaces.CurtailmentTopologyDispatchSnapshot{}, fleeterror.NewNotFoundErrorf(
+			"%s not found in caller's org: %v",
+			selectorLabel,
+			missingIDs,
+		)
+	}
+	if len(row.MismatchedRackIds) > 0 {
+		return interfaces.CurtailmentTopologyDispatchSnapshot{}, fleeterror.NewFailedPreconditionErrorf(
+			"rack %d site does not match its building site",
+			row.MismatchedRackIds[0],
+		)
+	}
+	if row.MemberCount > interfaces.CurtailmentResolvedMinerMax {
+		return interfaces.CurtailmentTopologyDispatchSnapshot{}, fleeterror.NewResourceExhaustedErrorf(
+			"scope resolves to more than %d miners",
+			interfaces.CurtailmentResolvedMinerMax,
+		)
+	}
+
+	selectedSites := uniqueSortedInt64s(row.SelectedResourceSiteIds)
+	memberSites := uniqueSortedInt64s(row.CurrentMemberSiteIds)
+	return interfaces.CurtailmentTopologyDispatchSnapshot{
+		Coverage: interfaces.CurtailmentTopologyScopeCoverage{
+			SiteIDs:                 uniqueSortedInt64s(append(append([]int64(nil), selectedSites...), memberSites...)),
+			SelectedResourceSiteIDs: selectedSites,
+			CurrentMemberSiteIDs:    memberSites,
+			RequireOrgWide:          row.HasUnassignedResource || row.HasUnassignedMember || len(row.EmptyGroupIds) > 0,
+		},
+		DispatchMemberDeviceIdentifiers: append([]string(nil), row.DispatchMemberDeviceIdentifiers...),
+	}, nil
+}
+
+func topologySelector(params interfaces.ListCandidatesParams) ([]int64, string, error) {
 	selectedTypeCount := 0
 	for _, ids := range [][]int64{params.BuildingIDs, params.RackIDs, params.GroupIDs} {
 		if len(ids) > 0 {
@@ -2088,9 +2153,27 @@ func resolveCurtailmentTopologyScope(
 		}
 	}
 	if selectedTypeCount != 1 {
-		return interfaces.CurtailmentTopologyScopeCoverage{}, fleeterror.NewInvalidArgumentError(
+		return nil, "", fleeterror.NewInvalidArgumentError(
 			"topology scope must contain exactly one selector type",
 		)
+	}
+	switch {
+	case len(params.BuildingIDs) > 0:
+		return uniqueSortedInt64s(params.BuildingIDs), "buildings", nil
+	case len(params.RackIDs) > 0:
+		return uniqueSortedInt64s(params.RackIDs), "racks", nil
+	default:
+		return uniqueSortedInt64s(params.GroupIDs), "groups", nil
+	}
+}
+
+func resolveCurtailmentTopologyScope(
+	ctx context.Context,
+	q sqlc.Querier,
+	params interfaces.ListCandidatesParams,
+) (interfaces.CurtailmentTopologyScopeCoverage, error) {
+	if _, _, err := topologySelector(params); err != nil {
+		return interfaces.CurtailmentTopologyScopeCoverage{}, err
 	}
 
 	switch {

--- a/server/internal/domain/stores/sqlstores/curtailment.go
+++ b/server/internal/domain/stores/sqlstores/curtailment.go
@@ -2879,10 +2879,11 @@ func (s *SQLCurtailmentStore) BeginRestoreTransition(
 			return convertEventRow(updated), nil
 		}
 
-		if current.ForceIncludeAllPairedMiners {
-			if _, err := q.ReleaseUndispatchedAllPairedTargetsForRestore(ctx, current.ID); err != nil {
-				return nil, fleeterror.NewInternalErrorf("failed to release undispatched all-paired targets for restore: %v", err)
-			}
+		if _, err := q.ReleaseUndispatchedTargetsForRestore(ctx, sqlc.ReleaseUndispatchedTargetsForRestoreParams{
+			CurtailmentEventID:           current.ID,
+			KnownUnsentDeviceIdentifiers: params.KnownUnsentDeviceIdentifiers,
+		}); err != nil {
+			return nil, fleeterror.NewInternalErrorf("failed to release undispatched targets for restore: %v", err)
 		}
 
 		if err := q.ResetCurtailmentTargetsForRestore(ctx, current.ID); err != nil {

--- a/server/internal/domain/stores/sqlstores/curtailment.go
+++ b/server/internal/domain/stores/sqlstores/curtailment.go
@@ -60,6 +60,7 @@ func mapOrgConfigError(err error, orgID int64) error {
 
 var _ interfaces.CurtailmentStore = &SQLCurtailmentStore{}
 var _ interfaces.CurtailmentTopologyScopeStore = &SQLCurtailmentStore{}
+var _ interfaces.CurtailmentTopologyDispatchFenceStore = &SQLCurtailmentStore{}
 var _ interfaces.ResponseProfileStore = &SQLCurtailmentStore{}
 var _ interfaces.AutomationStore = &SQLCurtailmentStore{}
 var _ interfaces.CurtailmentFanStateStore = &SQLCurtailmentStore{}
@@ -2081,11 +2082,25 @@ func (s *SQLCurtailmentStore) ResolveCurtailmentTopologyDispatch(
 	params interfaces.ListCandidatesParams,
 	dispatchDeviceIdentifiers []string,
 ) (interfaces.CurtailmentTopologyDispatchSnapshot, error) {
+	return resolveCurtailmentTopologyDispatch(
+		ctx,
+		s.GetQueries(ctx),
+		params,
+		dispatchDeviceIdentifiers,
+	)
+}
+
+func resolveCurtailmentTopologyDispatch(
+	ctx context.Context,
+	q sqlc.Querier,
+	params interfaces.ListCandidatesParams,
+	dispatchDeviceIdentifiers []string,
+) (interfaces.CurtailmentTopologyDispatchSnapshot, error) {
 	requestedIDs, selectorLabel, err := topologySelector(params)
 	if err != nil {
 		return interfaces.CurtailmentTopologyDispatchSnapshot{}, err
 	}
-	row, err := s.GetQueries(ctx).ResolveCurtailmentTopologyDispatch(
+	row, err := q.ResolveCurtailmentTopologyDispatch(
 		ctx,
 		sqlc.ResolveCurtailmentTopologyDispatchParams{
 			OrgID:                     params.OrgID,
@@ -2143,6 +2158,53 @@ func (s *SQLCurtailmentStore) ResolveCurtailmentTopologyDispatch(
 		},
 		DispatchMemberDeviceIdentifiers: append([]string(nil), row.DispatchMemberDeviceIdentifiers...),
 	}, nil
+}
+
+func (s *SQLCurtailmentStore) WithCurtailmentTopologyDispatchFence(
+	ctx context.Context,
+	event *models.Event,
+	params interfaces.ListCandidatesParams,
+	dispatchDeviceIdentifiers []string,
+	command func(interfaces.CurtailmentTopologyDispatchFenceSnapshot) error,
+) error {
+	if event == nil || command == nil {
+		return fleeterror.NewInvalidArgumentError("topology dispatch fence requires an event and command")
+	}
+	return db.WithTransactionNoRetryNoResult(ctx, s.conn.DB, func(q sqlc.Querier) error {
+		locked, err := q.LockCurtailmentEventByUUIDForWrite(ctx, sqlc.LockCurtailmentEventByUUIDForWriteParams{
+			EventUuid: event.EventUUID,
+			OrgID:     event.OrgID,
+		})
+		if errors.Is(err, sql.ErrNoRows) {
+			return interfaces.ErrCurtailmentEventStateRaceLoss
+		}
+		if err != nil {
+			return fleeterror.NewInternalErrorf("failed to lock curtailment event for topology dispatch: %v", err)
+		}
+		if locked.ID != event.ID || models.EventState(locked.State) != event.State || models.EventState(locked.State).IsTerminal() {
+			return interfaces.ErrCurtailmentEventStateRaceLoss
+		}
+		if _, err := q.ListEffectivePermissionsForUserForUpdate(
+			ctx,
+			sqlc.ListEffectivePermissionsForUserForUpdateParams{
+				UserID:         locked.CreatedByUserID,
+				OrganizationID: locked.OrgID,
+			},
+		); err != nil {
+			return fleeterror.NewInternalErrorf("failed to lock event creator permissions for topology dispatch: %v", err)
+		}
+		if _, _, err := lockTopologyScopeCoverage(ctx, q, params, dispatchDeviceIdentifiers); err != nil {
+			return err
+		}
+		topology, err := resolveCurtailmentTopologyDispatch(ctx, q, params, dispatchDeviceIdentifiers)
+		if err != nil {
+			return err
+		}
+		return command(interfaces.CurtailmentTopologyDispatchFenceSnapshot{
+			Event:    convertEventRow(locked),
+			Topology: topology,
+		})
+	})
 }
 
 func topologySelector(params interfaces.ListCandidatesParams) ([]int64, string, error) {

--- a/server/internal/domain/stores/sqlstores/curtailment_authorization_envelope.go
+++ b/server/internal/domain/stores/sqlstores/curtailment_authorization_envelope.go
@@ -203,6 +203,12 @@ func lockTopologyScopeCoverage(
 	if err != nil {
 		return nil, false, fleeterror.NewInternalErrorf("failed to lock curtailment topology members: %v", err)
 	}
+	if len(rows) > interfaces.CurtailmentResolvedMinerMax {
+		return nil, false, fleeterror.NewResourceExhaustedErrorf(
+			"scope resolves to more than %d miners",
+			interfaces.CurtailmentResolvedMinerMax,
+		)
+	}
 	memberSites := make([]int64, 0, len(rows))
 	members := make(map[string]struct{}, len(rows))
 	unbounded := false

--- a/server/internal/domain/stores/sqlstores/curtailment_topology_start_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/curtailment_topology_start_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -82,8 +83,49 @@ func TestSQLCurtailmentStore_FrozenTopologyStartPersistsEnvelopeAndRejectsMember
 	require.Len(t, targets, 1)
 	assert.Equal(t, device.ID, targets[0].DeviceIdentifier)
 
-	_, err = buildingStore.AssignDevicesToBuilding(ctx, orgID, nil, deviceIdentifiers)
-	require.NoError(t, err)
+	fenceSnapshot := make(chan interfaces.CurtailmentTopologyDispatchFenceSnapshot, 1)
+	releaseFence := make(chan struct{})
+	fenceDone := make(chan error, 1)
+	go func() {
+		fenceDone <- store.WithCurtailmentTopologyDispatchFence(
+			ctx,
+			persisted,
+			interfaces.ListCandidatesParams{OrgID: orgID, BuildingIDs: []int64{building.ID}},
+			[]string{device.ID},
+			func(snapshot interfaces.CurtailmentTopologyDispatchFenceSnapshot) error {
+				fenceSnapshot <- snapshot
+				<-releaseFence
+				return nil
+			},
+		)
+	}()
+	select {
+	case snapshot := <-fenceSnapshot:
+		assert.Equal(t, []string{device.ID}, snapshot.Topology.DispatchMemberDeviceIdentifiers)
+	case fenceErr := <-fenceDone:
+		require.NoError(t, fenceErr)
+		t.Fatal("dispatch fence exited before invoking its callback")
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for dispatch fence callback")
+	}
+	mutationStarted := make(chan struct{})
+	mutationDone := make(chan error, 1)
+	go func() {
+		close(mutationStarted)
+		_, mutationErr := buildingStore.AssignDevicesToBuilding(ctx, orgID, nil, deviceIdentifiers)
+		mutationDone <- mutationErr
+	}()
+	<-mutationStarted
+	select {
+	case mutationErr := <-mutationDone:
+		require.NoError(t, mutationErr)
+		t.Fatal("topology mutation completed while the dispatch fence was held")
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(releaseFence)
+	require.NoError(t, <-fenceDone)
+	require.NoError(t, <-mutationDone)
+
 	dispatchSnapshot, err = store.ResolveCurtailmentTopologyDispatch(
 		ctx,
 		interfaces.ListCandidatesParams{OrgID: orgID, BuildingIDs: []int64{building.ID}},

--- a/server/internal/domain/stores/sqlstores/curtailment_topology_start_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/curtailment_topology_start_integration_test.go
@@ -1,0 +1,89 @@
+package sqlstores_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	buildingsmodels "github.com/block/proto-fleet/server/internal/domain/buildings/models"
+	"github.com/block/proto-fleet/server/internal/domain/curtailment/models"
+	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
+	sitesmodels "github.com/block/proto-fleet/server/internal/domain/sites/models"
+	"github.com/block/proto-fleet/server/internal/domain/stores/sqlstores"
+	"github.com/block/proto-fleet/server/internal/testutil"
+)
+
+func TestSQLCurtailmentStore_FrozenTopologyStartPersistsEnvelopeAndRejectsMembershipDrift(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping database integration test in short mode")
+	}
+
+	testContext := testutil.InitializeDBServiceInfrastructure(t)
+	user := testContext.DatabaseService.CreateSuperAdminUser()
+	ctx := t.Context()
+	database := testContext.DatabaseService.DB
+	store := sqlstores.NewSQLCurtailmentStore(database)
+	buildingStore := sqlstores.NewSQLBuildingStore(database)
+	orgID := user.OrganizationID
+
+	site, err := sqlstores.NewSQLSiteStore(database).CreateSite(ctx, sitesmodels.CreateSiteParams{
+		OrgID: orgID,
+		Name:  "Frozen topology start site",
+	})
+	require.NoError(t, err)
+	building, err := buildingStore.CreateBuilding(ctx, buildingsmodels.CreateParams{
+		OrgID:  orgID,
+		SiteID: &site.ID,
+		Name:   "Frozen topology start building",
+	})
+	require.NoError(t, err)
+	device := testContext.DatabaseService.CreateDevice(orgID, "proto")
+	deviceIdentifiers := []string{device.ID}
+	_, err = buildingStore.AssignDevicesToBuilding(ctx, orgID, &building.ID, deviceIdentifiers)
+	require.NoError(t, err)
+	_, err = buildingStore.CascadeDevicesSiteForBuilding(ctx, orgID, deviceIdentifiers, &site.ID)
+	require.NoError(t, err)
+
+	eventUUID := uuid.New()
+	event := curtailmentStoreTestEvent(orgID, user.DatabaseID, eventUUID, models.EventStatePending, "frozen-topology-start")
+	event.ScopeType = models.ScopeTypeMixed
+	event.ScopeJSON = []byte(fmt.Sprintf(`{"scope_schema_version":1,"building_ids":[%d]}`, building.ID))
+	target := curtailmentStoreTestTarget(device.ID, models.TargetStatePending, models.DesiredStateCurtailed)
+
+	inserted, err := store.InsertEventWithTargets(ctx, event, []models.InsertTargetParams{target})
+	require.NoError(t, err)
+	require.NotNil(t, inserted)
+
+	persisted, err := store.GetEventByUUID(ctx, orgID, eventUUID)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(event.ScopeJSON), string(persisted.ScopeJSON))
+	var envelope models.AuthorizationEnvelope
+	require.NoError(t, json.Unmarshal(persisted.AuthorizationEnvelopeJSON, &envelope))
+	assert.Equal(t, []int64{site.ID}, envelope.SelectedResourceSiteIDs)
+	assert.Equal(t, []int64{site.ID}, envelope.CurrentMemberSiteIDs)
+	assert.False(t, envelope.MinerScopeUnbounded)
+
+	targets, err := store.ListTargetsByEvent(ctx, orgID, eventUUID)
+	require.NoError(t, err)
+	require.Len(t, targets, 1)
+	assert.Equal(t, device.ID, targets[0].DeviceIdentifier)
+
+	_, err = buildingStore.AssignDevicesToBuilding(ctx, orgID, nil, deviceIdentifiers)
+	require.NoError(t, err)
+
+	driftedUUID := uuid.New()
+	drifted := event
+	drifted.EventUUID = driftedUUID
+	_, err = store.InsertEventWithTargets(ctx, drifted, []models.InsertTargetParams{target})
+	require.Error(t, err)
+	assert.True(t, fleeterror.IsFailedPreconditionError(err))
+	assert.Contains(t, err.Error(), "topology changed before save")
+
+	_, err = store.GetEventByUUID(ctx, orgID, driftedUUID)
+	require.Error(t, err)
+	assert.True(t, fleeterror.IsNotFoundError(err), "failed topology validation must roll back the event insert")
+}

--- a/server/internal/domain/stores/sqlstores/curtailment_topology_start_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/curtailment_topology_start_integration_test.go
@@ -1,6 +1,7 @@
 package sqlstores_test
 
 import (
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -10,12 +11,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/block/proto-fleet/server/generated/sqlc"
 	buildingsmodels "github.com/block/proto-fleet/server/internal/domain/buildings/models"
 	"github.com/block/proto-fleet/server/internal/domain/curtailment/models"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 	sitesmodels "github.com/block/proto-fleet/server/internal/domain/sites/models"
 	"github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
 	"github.com/block/proto-fleet/server/internal/domain/stores/sqlstores"
+	dbinfra "github.com/block/proto-fleet/server/internal/infrastructure/db"
 	"github.com/block/proto-fleet/server/internal/testutil"
 )
 
@@ -93,6 +96,28 @@ func TestSQLCurtailmentStore_FrozenTopologyStartPersistsEnvelopeAndRejectsMember
 			interfaces.ListCandidatesParams{OrgID: orgID, BuildingIDs: []int64{building.ID}},
 			[]string{device.ID},
 			func(snapshot interfaces.CurtailmentTopologyDispatchFenceSnapshot) error {
+				batchUUID := uuid.NewString()
+				if commandErr := dbinfra.WithTransactionNoResult(ctx, database, func(q sqlc.Querier) error {
+					if _, err := q.CreateCommandBatchLog(ctx, sqlc.CreateCommandBatchLogParams{
+						Uuid:           batchUUID,
+						Type:           "CURTAIL",
+						CreatedBy:      user.DatabaseID,
+						CreatedAt:      time.Now(),
+						Status:         sqlc.BatchStatusEnumPENDING,
+						DevicesCount:   1,
+						OrganizationID: sql.NullInt64{Int64: orgID, Valid: true},
+					}); err != nil {
+						return err
+					}
+					return q.CreateQueueMessage(ctx, sqlc.CreateQueueMessageParams{
+						CommandBatchLogUuid: batchUUID,
+						CommandType:         "CURTAIL",
+						DeviceID:            device.DatabaseID,
+						Status:              sqlc.QueueStatusEnumPENDING,
+					})
+				}); commandErr != nil {
+					return commandErr
+				}
 				fenceSnapshot <- snapshot
 				<-releaseFence
 				return nil

--- a/server/internal/domain/stores/sqlstores/curtailment_topology_start_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/curtailment_topology_start_integration_test.go
@@ -105,4 +105,14 @@ func TestSQLCurtailmentStore_FrozenTopologyStartPersistsEnvelopeAndRejectsMember
 	_, err = store.GetEventByUUID(ctx, orgID, driftedUUID)
 	require.Error(t, err)
 	assert.True(t, fleeterror.IsNotFoundError(err), "failed topology validation must roll back the event insert")
+
+	_, err = store.BeginRestoreTransition(ctx, orgID, eventUUID, interfaces.BeginRestoreTransitionParams{
+		KnownUnsentDeviceIdentifiers: []string{device.ID},
+	})
+	require.NoError(t, err)
+	targets, err = store.ListTargetsByEvent(ctx, orgID, eventUUID)
+	require.NoError(t, err)
+	require.Len(t, targets, 1)
+	assert.Equal(t, models.TargetStateReleased, targets[0].State,
+		"a dispatch rejection must not queue Uncurtail for a miner that never received Curtail")
 }

--- a/server/internal/domain/stores/sqlstores/curtailment_topology_start_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/curtailment_topology_start_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/block/proto-fleet/server/internal/domain/curtailment/models"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 	sitesmodels "github.com/block/proto-fleet/server/internal/domain/sites/models"
+	"github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
 	"github.com/block/proto-fleet/server/internal/domain/stores/sqlstores"
 	"github.com/block/proto-fleet/server/internal/testutil"
 )
@@ -47,6 +48,15 @@ func TestSQLCurtailmentStore_FrozenTopologyStartPersistsEnvelopeAndRejectsMember
 	require.NoError(t, err)
 	_, err = buildingStore.CascadeDevicesSiteForBuilding(ctx, orgID, deviceIdentifiers, &site.ID)
 	require.NoError(t, err)
+	dispatchSnapshot, err := store.ResolveCurtailmentTopologyDispatch(
+		ctx,
+		interfaces.ListCandidatesParams{OrgID: orgID, BuildingIDs: []int64{building.ID}},
+		[]string{device.ID, "not-a-member"},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, []int64{site.ID}, dispatchSnapshot.Coverage.SelectedResourceSiteIDs)
+	assert.Equal(t, []int64{site.ID}, dispatchSnapshot.Coverage.CurrentMemberSiteIDs)
+	assert.Equal(t, []string{device.ID}, dispatchSnapshot.DispatchMemberDeviceIdentifiers)
 
 	eventUUID := uuid.New()
 	event := curtailmentStoreTestEvent(orgID, user.DatabaseID, eventUUID, models.EventStatePending, "frozen-topology-start")
@@ -74,6 +84,15 @@ func TestSQLCurtailmentStore_FrozenTopologyStartPersistsEnvelopeAndRejectsMember
 
 	_, err = buildingStore.AssignDevicesToBuilding(ctx, orgID, nil, deviceIdentifiers)
 	require.NoError(t, err)
+	dispatchSnapshot, err = store.ResolveCurtailmentTopologyDispatch(
+		ctx,
+		interfaces.ListCandidatesParams{OrgID: orgID, BuildingIDs: []int64{building.ID}},
+		[]string{device.ID},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, []int64{site.ID}, dispatchSnapshot.Coverage.SelectedResourceSiteIDs)
+	assert.Empty(t, dispatchSnapshot.Coverage.CurrentMemberSiteIDs)
+	assert.Empty(t, dispatchSnapshot.DispatchMemberDeviceIdentifiers)
 
 	driftedUUID := uuid.New()
 	drifted := event

--- a/server/internal/handlers/curtailment/handler_start_test.go
+++ b/server/internal/handlers/curtailment/handler_start_test.go
@@ -78,6 +78,13 @@ func (s *startStubStore) ListCandidates(_ context.Context, _ interfaces.ListCand
 	return s.candidates, nil
 }
 
+func (s *startStubStore) ResolveCurtailmentTopologyScope(
+	context.Context,
+	interfaces.ListCandidatesParams,
+) (interfaces.CurtailmentTopologyScopeCoverage, error) {
+	return interfaces.CurtailmentTopologyScopeCoverage{SiteIDs: []int64{42}}, nil
+}
+
 func (s *startStubStore) InsertEventWithTargets(
 	_ context.Context,
 	event models.InsertEventParams,
@@ -359,6 +366,93 @@ func TestHandler_StartCurtailment_HappyPath(t *testing.T) {
 	// echoed in the Start response. Two selected candidates with no caller
 	// preference means immediate restore of the full pending set.
 	assert.Equal(t, uint32(2), ev.EffectiveBatchSize)
+}
+
+func TestHandler_StartCurtailment_FrozenTopologyScope(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name      string
+		scopes    []*pb.CurtailmentScope
+		wantScope string
+	}{
+		{
+			name: "building",
+			scopes: []*pb.CurtailmentScope{{Scope: &pb.CurtailmentScope_Building{
+				Building: &pb.ScopeBuilding{BuildingId: 7},
+			}}},
+			wantScope: `{"building_ids":[7],"scope_schema_version":1}`,
+		},
+		{
+			name: "rack",
+			scopes: []*pb.CurtailmentScope{{Scope: &pb.CurtailmentScope_Rack{
+				Rack: &pb.ScopeRack{RackId: 8},
+			}}},
+			wantScope: `{"rack_ids":[8],"scope_schema_version":1}`,
+		},
+		{
+			name: "group",
+			scopes: []*pb.CurtailmentScope{{Scope: &pb.CurtailmentScope_Group{
+				Group: &pb.ScopeGroup{GroupId: 9},
+			}}},
+			wantScope: `{"group_ids":[9],"scope_schema_version":1}`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := newStartStubStore()
+			store.candidates = []*models.Candidate{
+				miner(tc.name+"-miner", "ACTIVE", "PAIRED", 3000, 100, 40),
+			}
+			h := NewHandler(curtailment.NewService(store))
+			ctx := startSessionCtxWithPerms(t, 42, "OPERATOR", authz.PermCurtailmentManage)
+			req := validStartRequestBuilder()
+			req.Scope = nil
+			req.Scopes = tc.scopes
+			req.ScopeSchemaVersion = curtailment.ScopeSchemaVersionCurrent
+			req.ModeParams = &pb.StartCurtailmentRequest_FixedKw{
+				FixedKw: &pb.FixedKwParams{TargetKw: 2},
+			}
+
+			resp, err := h.StartCurtailment(ctx, connect.NewRequest(req))
+
+			require.NoError(t, err)
+			require.NotNil(t, resp.Msg.Event)
+			assert.Equal(t, pb.CurtailmentEventState_CURTAILMENT_EVENT_STATE_PENDING, resp.Msg.Event.State)
+			assert.JSONEq(t, tc.wantScope, string(store.lastEvent.ScopeJSON))
+			require.Len(t, store.lastTargets, 1)
+			assert.Equal(t, tc.name+"-miner", store.lastTargets[0].DeviceIdentifier)
+		})
+	}
+}
+
+func TestHandler_StartCurtailment_FrozenTopologyScopeRequiresOrgWideManage(t *testing.T) {
+	t.Parallel()
+
+	store := newStartStubStore()
+	h := NewHandler(curtailment.NewService(store))
+	req := validStartRequestBuilder()
+	req.Scope = nil
+	req.Scopes = []*pb.CurtailmentScope{{Scope: &pb.CurtailmentScope_Building{
+		Building: &pb.ScopeBuilding{BuildingId: 7},
+	}}}
+	req.ScopeSchemaVersion = curtailment.ScopeSchemaVersionCurrent
+	ctx := testSessionCtxWithAssignments(t, &session.Info{
+		AuthMethod:     session.AuthMethodSession,
+		OrganizationID: 42,
+		UserID:         9,
+		Role:           "OPERATOR",
+		SessionID:      "sess-topology-site-only",
+	}, testSiteAssignment(42, authz.PermCurtailmentManage))
+
+	_, err := h.StartCurtailment(ctx, connect.NewRequest(req))
+
+	require.Error(t, err)
+	var fleetErr fleeterror.FleetError
+	require.ErrorAs(t, err, &fleetErr)
+	assert.Equal(t, connect.CodePermissionDenied, fleetErr.GRPCCode)
+	assert.Zero(t, store.lastEvent.OrgID, "org-wide gate must fail before persistence")
 }
 
 func TestHandler_StartCurtailment_AllPairedPolicyReturnsBoundedTargetRollup(t *testing.T) {

--- a/server/internal/infrastructure/db/with_transaction.go
+++ b/server/internal/infrastructure/db/with_transaction.go
@@ -100,6 +100,15 @@ func WithTransactionNoResult(ctx context.Context, db *sql.DB, action func(q sqlc
 	return withTransactionNoResultWithRetry(ctx, db, action, DefaultRetryConfig, firstTxOpts(opts))
 }
 
+// WithTransactionNoRetryNoResult runs action exactly once. Use it only when
+// action performs an external side effect that cannot safely be replayed.
+func WithTransactionNoRetryNoResult(ctx context.Context, db *sql.DB, action func(q sqlc.Querier) error, opts ...*sql.TxOptions) error {
+	_, err := executeTransaction(ctx, db, func(q sqlc.Querier) (struct{}, error) {
+		return struct{}{}, action(q)
+	}, firstTxOpts(opts))
+	return err
+}
+
 // WithTransactionTimeout bounds the complete operation, including retries, and
 // applies the same limit inside each transaction.
 func WithTransactionTimeout[T any](ctx context.Context, db *sql.DB, timeout time.Duration, action func(q sqlc.Querier) (T, error)) (T, error) {

--- a/server/sqlc/queries/curtailment.sql
+++ b/server/sqlc/queries/curtailment.sql
@@ -1858,8 +1858,6 @@ WITH selected_resources AS MATERIALIZED (
       AND ds.id = ANY(sqlc.arg('group_ids')::BIGINT[])
 ), members AS MATERIALIZED (
     SELECT DISTINCT
-           sr.selector_type,
-           sr.selector_id,
            d.id AS device_id,
            d.device_identifier,
            d.site_id
@@ -1896,6 +1894,8 @@ WITH selected_resources AS MATERIALIZED (
                 AND dsm.device_set_id = sr.selector_id
           ))
      )
+    ORDER BY d.id
+    LIMIT 10001
 ), selector_rollup AS (
     SELECT
         COALESCE(array_agg(sr.selector_id ORDER BY sr.selector_id), '{}')::BIGINT[] AS existing_selector_ids,
@@ -1918,9 +1918,15 @@ WITH selected_resources AS MATERIALIZED (
             array_agg(sr.selector_id ORDER BY sr.selector_id)
                 FILTER (WHERE sr.selector_type = 'group'
                         AND NOT EXISTS (
-                            SELECT 1 FROM members m
-                            WHERE m.selector_type = sr.selector_type
-                              AND m.selector_id = sr.selector_id
+                            SELECT 1
+                            FROM device_set_membership dsm
+                            JOIN device d
+                              ON d.id = dsm.device_id
+                             AND d.org_id = dsm.org_id
+                             AND d.deleted_at IS NULL
+                            WHERE dsm.org_id = sqlc.arg('org_id')
+                              AND dsm.device_set_type = 'group'
+                              AND dsm.device_set_id = sr.selector_id
                         )),
             '{}'
         )::BIGINT[] AS empty_group_ids

--- a/server/sqlc/queries/curtailment.sql
+++ b/server/sqlc/queries/curtailment.sql
@@ -1208,10 +1208,10 @@ SET desired_state      = 'active',
 WHERE curtailment_event_id = sqlc.arg('curtailment_event_id')
   AND state NOT IN ('resolved', 'restore_failed', 'released');
 
--- name: ReleaseUndispatchedAllPairedTargetsForRestore :execrows
--- All-paired policy targets that never received a Curtail command do not need
--- Uncurtail. Release them before the restore reset so graceful Stop does not
--- enqueue no-op restore work for offline/auth-needed miners.
+-- name: ReleaseUndispatchedTargetsForRestore :execrows
+-- Targets that never received a Curtail command do not need Uncurtail. Release
+-- them before the restore reset so graceful Stop does not enqueue commands
+-- that could wake miners this event never curtailed.
 --
 -- "Never attempted" is retry_count = 0 plus NULL dispatch timestamps: every
 -- dispatch attempt/failure bumps retry_count and every successful enqueue
@@ -1234,7 +1234,13 @@ SET state              = 'released',
     curtail_last_error = COALESCE(curtail_last_error, last_error, 'released without restore: no curtail command dispatched')
 WHERE curtailment_event_id = sqlc.arg('curtailment_event_id')
   AND desired_state = 'curtailed'
-  AND state IN ('pending', 'unavailable')
+  AND (
+      state IN ('pending', 'unavailable')
+      OR (
+          state = 'dispatching'
+          AND device_identifier = ANY(sqlc.arg('known_unsent_device_identifiers')::TEXT[])
+      )
+  )
   AND last_dispatched_at IS NULL
   AND curtail_dispatched_at IS NULL
   AND retry_count = 0

--- a/server/sqlc/queries/curtailment.sql
+++ b/server/sqlc/queries/curtailment.sql
@@ -1886,7 +1886,7 @@ WITH selected_resources AS MATERIALIZED (
               FROM device_set_membership dsm
               WHERE dsm.org_id = sqlc.arg('org_id')
                 AND dsm.device_id = d.id
-                AND dsm.device_set_type = sr.selector_type
+                AND dsm.device_set_type::TEXT = sr.selector_type
                 AND dsm.device_set_id = sr.selector_id
           ))
      )

--- a/server/sqlc/queries/curtailment.sql
+++ b/server/sqlc/queries/curtailment.sql
@@ -1696,7 +1696,9 @@ WHERE d.org_id = sqlc.arg('org_id')
   )
 ORDER BY d.id
 LIMIT 10001
-FOR UPDATE;
+-- Topology writes still conflict with this lock, while command queue inserts
+-- can take the foreign-key KEY SHARE lock on device without self-deadlocking.
+FOR NO KEY UPDATE;
 
 -- name: LockCurtailmentGroupsForWrite :many
 -- Serializes group membership changes with topology target/envelope writes.

--- a/server/sqlc/queries/curtailment.sql
+++ b/server/sqlc/queries/curtailment.sql
@@ -1801,3 +1801,149 @@ SELECT 0 AS selector_id,
        m.device_id AS member_device_id
 FROM members m
 ORDER BY selector_id, member_device_id;
+
+-- name: ResolveCurtailmentTopologyDispatch :one
+-- Returns authorization coverage for the full live selector plus membership
+-- only for the devices in the pending dispatch batch. Both are derived by one
+-- statement snapshot so a concurrent placement change cannot mix old coverage
+-- with new membership. The reconciler validates selector shape before calling.
+WITH selected_resources AS MATERIALIZED (
+    SELECT 'building'::TEXT AS selector_type,
+           b.id AS selector_id,
+           b.site_id AS resource_site_id,
+           NULL::BIGINT AS building_id,
+           NULL::BIGINT AS building_site_id
+    FROM building b
+    WHERE b.org_id = sqlc.arg('org_id')
+      AND b.deleted_at IS NULL
+      AND b.id = ANY(sqlc.arg('building_ids')::BIGINT[])
+
+    UNION ALL
+
+    SELECT 'rack'::TEXT AS selector_type,
+           ds.id AS selector_id,
+           dsr.site_id AS resource_site_id,
+           dsr.building_id,
+           b.site_id AS building_site_id
+    FROM device_set ds
+    JOIN device_set_rack dsr
+      ON dsr.device_set_id = ds.id
+     AND dsr.org_id = ds.org_id
+    LEFT JOIN building b
+      ON b.id = dsr.building_id
+     AND b.org_id = dsr.org_id
+     AND b.deleted_at IS NULL
+    WHERE ds.org_id = sqlc.arg('org_id')
+      AND ds.type = 'rack'
+      AND ds.deleted_at IS NULL
+      AND ds.id = ANY(sqlc.arg('rack_ids')::BIGINT[])
+
+    UNION ALL
+
+    SELECT 'group'::TEXT AS selector_type,
+           ds.id AS selector_id,
+           NULL::BIGINT AS resource_site_id,
+           NULL::BIGINT AS building_id,
+           NULL::BIGINT AS building_site_id
+    FROM device_set ds
+    WHERE ds.org_id = sqlc.arg('org_id')
+      AND ds.type = 'group'
+      AND ds.deleted_at IS NULL
+      AND ds.id = ANY(sqlc.arg('group_ids')::BIGINT[])
+), members AS MATERIALIZED (
+    SELECT DISTINCT
+           sr.selector_type,
+           sr.selector_id,
+           d.id AS device_id,
+           d.device_identifier,
+           d.site_id
+    FROM selected_resources sr
+    JOIN device d
+      ON d.org_id = sqlc.arg('org_id')
+     AND d.deleted_at IS NULL
+     AND (
+          (sr.selector_type = 'building' AND (
+              d.building_id = sr.selector_id
+              OR EXISTS (
+                  SELECT 1
+                  FROM device_set_membership dsm
+                  JOIN device_set ds
+                    ON ds.id = dsm.device_set_id
+                   AND ds.org_id = dsm.org_id
+                   AND ds.type = 'rack'
+                   AND ds.deleted_at IS NULL
+                  JOIN device_set_rack dsr
+                    ON dsr.device_set_id = ds.id
+                   AND dsr.org_id = ds.org_id
+                  WHERE dsm.org_id = sqlc.arg('org_id')
+                    AND dsm.device_id = d.id
+                    AND dsm.device_set_type = 'rack'
+                    AND dsr.building_id = sr.selector_id
+              )
+          ))
+          OR (sr.selector_type IN ('rack', 'group') AND EXISTS (
+              SELECT 1
+              FROM device_set_membership dsm
+              WHERE dsm.org_id = sqlc.arg('org_id')
+                AND dsm.device_id = d.id
+                AND dsm.device_set_type = sr.selector_type
+                AND dsm.device_set_id = sr.selector_id
+          ))
+     )
+), selector_rollup AS (
+    SELECT
+        COALESCE(array_agg(sr.selector_id ORDER BY sr.selector_id), '{}')::BIGINT[] AS existing_selector_ids,
+        COALESCE(
+            array_agg(DISTINCT sr.resource_site_id ORDER BY sr.resource_site_id)
+                FILTER (WHERE sr.resource_site_id IS NOT NULL),
+            '{}'
+        )::BIGINT[] AS selected_resource_site_ids,
+        COALESCE(bool_or(sr.selector_type <> 'group' AND sr.resource_site_id IS NULL), FALSE)::BOOLEAN AS has_unassigned_resource,
+        COALESCE(
+            array_agg(sr.selector_id ORDER BY sr.selector_id)
+                FILTER (WHERE sr.selector_type = 'rack'
+                        AND sr.building_id IS NOT NULL
+                        AND sr.resource_site_id IS NOT NULL
+                        AND sr.building_site_id IS NOT NULL
+                        AND sr.resource_site_id <> sr.building_site_id),
+            '{}'
+        )::BIGINT[] AS mismatched_rack_ids,
+        COALESCE(
+            array_agg(sr.selector_id ORDER BY sr.selector_id)
+                FILTER (WHERE sr.selector_type = 'group'
+                        AND NOT EXISTS (
+                            SELECT 1 FROM members m
+                            WHERE m.selector_type = sr.selector_type
+                              AND m.selector_id = sr.selector_id
+                        )),
+            '{}'
+        )::BIGINT[] AS empty_group_ids
+    FROM selected_resources sr
+), member_rollup AS (
+    SELECT
+        COUNT(DISTINCT m.device_id)::BIGINT AS member_count,
+        COALESCE(
+            array_agg(DISTINCT m.site_id ORDER BY m.site_id)
+                FILTER (WHERE m.site_id IS NOT NULL),
+            '{}'
+        )::BIGINT[] AS current_member_site_ids,
+        COALESCE(bool_or(m.device_id IS NOT NULL AND m.site_id IS NULL), FALSE)::BOOLEAN AS has_unassigned_member,
+        COALESCE(
+            array_agg(DISTINCT m.device_identifier ORDER BY m.device_identifier)
+                FILTER (WHERE m.device_identifier = ANY(sqlc.arg('dispatch_device_identifiers')::TEXT[])),
+            '{}'
+        )::TEXT[] AS dispatch_member_device_identifiers
+    FROM members m
+)
+SELECT
+    sr.existing_selector_ids,
+    sr.selected_resource_site_ids,
+    sr.has_unassigned_resource,
+    sr.mismatched_rack_ids,
+    sr.empty_group_ids,
+    mr.member_count,
+    mr.current_member_site_ids,
+    mr.has_unassigned_member,
+    mr.dispatch_member_device_identifiers
+FROM selector_rollup sr
+CROSS JOIN member_rollup mr;

--- a/server/sqlc/queries/user_organization_role.sql
+++ b/server/sqlc/queries/user_organization_role.sql
@@ -108,7 +108,7 @@ WHERE uor.role_id = $1
 -- name: ListEffectivePermissionsForUserForUpdate :many
 -- Race-safety variant of ListEffectivePermissionsForUser. Same join
 -- shape, same row order, same narrowing semantics — but takes
--- FOR UPDATE on every row whose mutation can revoke the caller's
+-- FOR NO KEY UPDATE on every row whose mutation can revoke the caller's
 -- effective permissions: the assignment row (uor), the caller's user
 -- row (u), and the caller's role row (r). Concurrent:
 --
@@ -122,7 +122,7 @@ WHERE uor.role_id = $1
 --       can't interleave between our recheck and our commit
 --
 -- The LEFT JOIN sides (role_permission, permission) cannot participate
--- in FOR UPDATE because they may have no matching row for a
+-- in row locking because they may have no matching row for a
 -- zero-permission assignment. We accept that role_permission edits
 -- via paths other than UpdateCustomRole (none exist today) would race
 -- this check; the practical lock graph through the existing surfaces
@@ -147,7 +147,7 @@ WHERE uor.user_id = $1
   AND r.deleted_at IS NULL
   AND u.deleted_at IS NULL
 ORDER BY uor.id, p.key NULLS FIRST
-FOR UPDATE OF uor, u, r;
+FOR NO KEY UPDATE OF uor, u, r;
 
 -- name: ListEffectivePermissionsForUser :many
 -- Single-query resolver source: one row per (assignment, permission)


### PR DESCRIPTION
Reviewable diff: +44/-35 across 8 files (excludes generated, test, and story files).

## Summary

Operators can now run and test fixed-kW curtailments against Buildings, Racks, and Groups. These starts resolve the selected topology once, freeze the selected miners as concrete targets, and use the existing open-loop curtailment lifecycle. Full-fleet topology execution and topology-backed automation remain disabled while their topology-following lifecycle work continues under #909.

## How it works

The New curtailment and response-profile modals classify the terminal scope through the shared curtailment scope model. Fixed-kW topology scopes can proceed through Run or Test, while the modal still blocks full-fleet topology execution and the automation UI continues to exclude topology-scoped profiles.

The client submits the existing typed Building, Rack, or Group selectors. The handler requires organization-wide `curtailment:manage`, then the domain selector resolves eligible miners and freezes the selected identifiers. During persistence, the SQL store locks and re-resolves the topology, verifies every frozen target is still a member, creates the authorization envelope, and writes the event and targets atomically. The existing reconciler then dispatches those concrete targets without treating the event as a topology-following watcher.

## Diagrams

```mermaid
flowchart TD
  A["New curtailment or profile Test"] --> B["Canonical Building, Rack, or Group scope"]
  B --> C{"Curtailment mode"}
  C --> D["Fixed kW"]
  C --> E["Full fleet"]
  E --> F["Blocked until topology-following lifecycle lands"]
  D --> G["Start RPC and organization-wide authorization"]
  G --> H["Resolve and freeze selected miners"]
  H --> I["Transactionally revalidate topology and persist envelope, event, and targets"]
  I --> J["Existing open-loop reconciler dispatch"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/src/protoFleet/api/curtailmentScopes.ts` | Centralizes Building/Rack/Group scope classification. | Keeps manual execution and automation policy aligned on the same scope vocabulary. |
| `client/src/protoFleet/features/energy/CurtailmentStartModal.tsx` | Enables fixed-kW topology Run/Test while retaining the full-fleet gate and mode-specific copy. | Defines the operator-facing rollout boundary. |
| `client/src/protoFleet/features/settings/components/Curtailment/` | Renames profile readiness to automation readiness and keeps topology profiles out of automation. | Separates newly supported manual execution from unsupported automated execution. |
| `server/internal/domain/curtailment/service.go` | Allows topology Start for non-full-fleet modes and continues rejecting full-fleet topology starts. | Establishes frozen versus topology-following lifecycle behavior at the domain boundary. |
| `server/internal/domain/stores/sqlstores/curtailment_topology_start_integration_test.go` | Covers transactional topology-envelope persistence and membership-drift rejection. | Verifies a topology change cannot widen or persist a stale frozen start. |
| `docs/plans/2026-08-11-curtailment-building-rack-and-group-targets-plan.md` | Records the staged fixed-kW Run/Test rollout. | Keeps the implementation boundary and remaining #909 work explicit. |

## Key technical decisions & trade-offs

- Enable only fixed-kW topology execution, which can freeze concrete targets, instead of exposing full-fleet scopes before topology-following ownership and restoration exist.
- Continue requiring organization-wide `curtailment:manage` for topology starts until dispatch-time scoped reauthorization is implemented.
- Revalidate topology inside the event-and-target transaction instead of trusting the earlier selector result, so membership drift fails closed.
- Model profile readiness specifically as automation readiness instead of using one flag for both manual and automated execution.

## Testing & validation

- Built the ProtoFleet production client with `npm run build:protoFleet`.
- Passed TypeScript typechecking and targeted ESLint/Prettier checks for the changed client code.
- Passed 266 tests across the six affected frontend suites; re-ran the 125 directly affected tests after consolidating topology classification.
- Passed the changed curtailment domain and handler topology Start tests.
- Compiled the curtailment domain, handler, reconciler, and SQL-store Go packages.
- The new SQL integration test compiles but was not executed locally because the configured test Postgres rejected the local credentials; CI will run it with the repository test database.

Refs #909
