### PR TITLE
Add topology curtailment store primitives (1/2)

### DIFF
--- a/server/generated/sqlc/curtailment.sql.go
+++ b/server/generated/sqlc/curtailment.sql.go
@@ -325,7 +325,7 @@ WHERE $3::INT <= 0
             AND (
                 cooldown_event.state IN ('pending', 'active', 'restoring')
                 OR cooldown_event.ended_at >= CURRENT_TIMESTAMP - ($3::INT * INTERVAL '1 second')
-            )
+      )
     )
 `
 
@@ -427,15 +427,17 @@ SET state              = t.state,
     END
 FROM locked_event
 JOIN jsonb_to_recordset($1::JSONB) AS t(
-    device_identifier TEXT,
-    expected_state    TEXT,
-    state             TEXT,
-    last_error        TEXT,
-    baseline_power_w  NUMERIC(12,3)
+    device_identifier      TEXT,
+    expected_state         TEXT,
+    expected_desired_state TEXT,
+    state                  TEXT,
+    last_error             TEXT,
+    baseline_power_w       NUMERIC(12,3)
 ) ON TRUE
 WHERE target.curtailment_event_id = locked_event.id
   AND target.device_identifier = t.device_identifier
   AND target.state = t.expected_state
+  AND target.desired_state = t.expected_desired_state
   AND (
       target.state <> 'restore_failed'
       OR NOT EXISTS (
@@ -3441,6 +3443,54 @@ func (q *Queries) ListEarlierCurtailmentReservationDevices(ctx context.Context, 
 			return nil, err
 		}
 		items = append(items, device_identifier)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listEarlierCurtailmentTopologyReservationScopes = `-- name: ListEarlierCurtailmentTopologyReservationScopes :many
+SELECT older.scope_jsonb
+FROM curtailment_event older
+WHERE older.org_id = $1
+  AND (
+      $2::BIGINT = 0
+      OR older.id < $2::BIGINT
+  )
+  AND older.state IN ('pending', 'active', 'restoring')
+  AND older.mode = 'FULL_FLEET'
+  AND older.loop_type = 'closed'
+  AND older.scope_type = 'mixed'
+  AND older.scope_jsonb ?| ARRAY['building_ids', 'rack_ids', 'group_ids']
+ORDER BY older.id
+`
+
+type ListEarlierCurtailmentTopologyReservationScopesParams struct {
+	OrgID              int64
+	CurtailmentEventID int64
+}
+
+// Returns topology selector envelopes for older logical reservations. Dynamic
+// admission locks these resources before locking candidate devices and
+// re-reading ListEarlierCurtailmentReservationDevices, so membership changes
+// cannot commit between reservation classification and target claim.
+func (q *Queries) ListEarlierCurtailmentTopologyReservationScopes(ctx context.Context, arg ListEarlierCurtailmentTopologyReservationScopesParams) ([]json.RawMessage, error) {
+	rows, err := q.query(ctx, q.listEarlierCurtailmentTopologyReservationScopesStmt, listEarlierCurtailmentTopologyReservationScopes, arg.OrgID, arg.CurtailmentEventID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []json.RawMessage
+	for rows.Next() {
+		var scope_jsonb json.RawMessage
+		if err := rows.Scan(&scope_jsonb); err != nil {
+			return nil, err
+		}
+		items = append(items, scope_jsonb)
 	}
 	if err := rows.Close(); err != nil {
 		return nil, err

--- a/server/generated/sqlc/curtailment.sql.go
+++ b/server/generated/sqlc/curtailment.sql.go
@@ -184,7 +184,7 @@ WITH locked_event AS MATERIALIZED (
 )
 UPDATE curtailment_target target
 SET desired_state = CASE
-        WHEN target.state IN ('pending', 'unavailable')
+        WHEN target.state IN ('pending', 'unavailable', 'dispatching')
          AND target.last_dispatched_at IS NULL
          AND target.curtail_dispatched_at IS NULL
          AND target.retry_count = 0
@@ -193,7 +193,7 @@ SET desired_state = CASE
         ELSE 'active'
     END,
     state = CASE
-        WHEN target.state IN ('pending', 'unavailable')
+        WHEN target.state IN ('pending', 'unavailable', 'dispatching')
          AND target.last_dispatched_at IS NULL
          AND target.curtail_dispatched_at IS NULL
          AND target.retry_count = 0
@@ -206,7 +206,7 @@ SET desired_state = CASE
     last_batch_uuid = NULL,
     confirmed_at = NULL,
     last_error = CASE
-        WHEN target.state IN ('pending', 'unavailable')
+        WHEN target.state IN ('pending', 'unavailable', 'dispatching')
          AND target.last_dispatched_at IS NULL
          AND target.curtail_dispatched_at IS NULL
          AND target.retry_count = 0
@@ -215,7 +215,7 @@ SET desired_state = CASE
         ELSE NULL
     END,
     curtail_state = CASE
-        WHEN target.state IN ('pending', 'unavailable')
+        WHEN target.state IN ('pending', 'unavailable', 'dispatching')
          AND target.last_dispatched_at IS NULL
          AND target.curtail_dispatched_at IS NULL
          AND target.retry_count = 0
@@ -224,7 +224,7 @@ SET desired_state = CASE
         ELSE target.curtail_state
     END,
     curtail_completed_at = CASE
-        WHEN target.state IN ('pending', 'unavailable')
+        WHEN target.state IN ('pending', 'unavailable', 'dispatching')
          AND target.last_dispatched_at IS NULL
          AND target.curtail_dispatched_at IS NULL
          AND target.retry_count = 0
@@ -233,7 +233,7 @@ SET desired_state = CASE
         ELSE target.curtail_completed_at
     END,
     restore_state = CASE
-        WHEN target.state IN ('pending', 'unavailable')
+        WHEN target.state IN ('pending', 'unavailable', 'dispatching')
          AND target.last_dispatched_at IS NULL
          AND target.curtail_dispatched_at IS NULL
          AND target.retry_count = 0
@@ -242,7 +242,7 @@ SET desired_state = CASE
         ELSE 'pending'
     END,
     restore_started_at = CASE
-        WHEN target.state IN ('pending', 'unavailable')
+        WHEN target.state IN ('pending', 'unavailable', 'dispatching')
          AND target.last_dispatched_at IS NULL
          AND target.curtail_dispatched_at IS NULL
          AND target.retry_count = 0

--- a/server/generated/sqlc/curtailment.sql.go
+++ b/server/generated/sqlc/curtailment.sql.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/lib/pq"
+	"github.com/sqlc-dev/pqtype"
 )
 
 const adminTerminateCurtailmentEvent = `-- name: AdminTerminateCurtailmentEvent :one
@@ -172,6 +173,113 @@ func (q *Queries) BeginCurtailmentRestoration(ctx context.Context, id int64) (Cu
 	return i, err
 }
 
+const beginCurtailmentTopologyTargetRestore = `-- name: BeginCurtailmentTopologyTargetRestore :execrows
+WITH locked_event AS MATERIALIZED (
+    SELECT id
+    FROM curtailment_event
+    WHERE id = $2
+      AND state = $3::TEXT
+      AND state IN ('pending', 'active')
+    FOR UPDATE
+)
+UPDATE curtailment_target target
+SET desired_state = CASE
+        WHEN target.state IN ('pending', 'unavailable')
+         AND target.last_dispatched_at IS NULL
+         AND target.curtail_dispatched_at IS NULL
+         AND target.retry_count = 0
+         AND target.restore_started_at IS NULL
+        THEN target.desired_state
+        ELSE 'active'
+    END,
+    state = CASE
+        WHEN target.state IN ('pending', 'unavailable')
+         AND target.last_dispatched_at IS NULL
+         AND target.curtail_dispatched_at IS NULL
+         AND target.retry_count = 0
+         AND target.restore_started_at IS NULL
+        THEN 'released'
+        ELSE 'pending'
+    END,
+    retry_count = 0,
+    last_dispatched_at = NULL,
+    last_batch_uuid = NULL,
+    confirmed_at = NULL,
+    last_error = CASE
+        WHEN target.state IN ('pending', 'unavailable')
+         AND target.last_dispatched_at IS NULL
+         AND target.curtail_dispatched_at IS NULL
+         AND target.retry_count = 0
+         AND target.restore_started_at IS NULL
+        THEN COALESCE(target.last_error, 'released after leaving topology scope before Curtail dispatch')
+        ELSE NULL
+    END,
+    curtail_state = CASE
+        WHEN target.state IN ('pending', 'unavailable')
+         AND target.last_dispatched_at IS NULL
+         AND target.curtail_dispatched_at IS NULL
+         AND target.retry_count = 0
+         AND target.restore_started_at IS NULL
+        THEN 'released'
+        ELSE target.curtail_state
+    END,
+    curtail_completed_at = CASE
+        WHEN target.state IN ('pending', 'unavailable')
+         AND target.last_dispatched_at IS NULL
+         AND target.curtail_dispatched_at IS NULL
+         AND target.retry_count = 0
+         AND target.restore_started_at IS NULL
+        THEN COALESCE(target.curtail_completed_at, CURRENT_TIMESTAMP)
+        ELSE target.curtail_completed_at
+    END,
+    restore_state = CASE
+        WHEN target.state IN ('pending', 'unavailable')
+         AND target.last_dispatched_at IS NULL
+         AND target.curtail_dispatched_at IS NULL
+         AND target.retry_count = 0
+         AND target.restore_started_at IS NULL
+        THEN target.restore_state
+        ELSE 'pending'
+    END,
+    restore_started_at = CASE
+        WHEN target.state IN ('pending', 'unavailable')
+         AND target.last_dispatched_at IS NULL
+         AND target.curtail_dispatched_at IS NULL
+         AND target.retry_count = 0
+         AND target.restore_started_at IS NULL
+        THEN target.restore_started_at
+        ELSE CURRENT_TIMESTAMP
+    END,
+    restore_dispatched_at = NULL,
+    restore_batch_uuid = NULL,
+    restore_completed_at = NULL,
+    restore_retry_count = 0,
+    restore_failure_count = 0,
+    restore_last_error = NULL
+FROM locked_event
+WHERE target.curtailment_event_id = locked_event.id
+  AND target.device_identifier = ANY($1::TEXT[])
+  AND target.desired_state = 'curtailed'
+  AND target.state NOT IN ('resolved', 'restore_failed', 'released')
+`
+
+type BeginCurtailmentTopologyTargetRestoreParams struct {
+	DeviceIdentifiers  []string
+	CurtailmentEventID int64
+	ExpectedEventState string
+}
+
+// A topology watcher remains active while departed targets restore. Targets
+// with no possible Curtail attempt release immediately; every other target
+// enters the normal restore queue conservatively.
+func (q *Queries) BeginCurtailmentTopologyTargetRestore(ctx context.Context, arg BeginCurtailmentTopologyTargetRestoreParams) (int64, error) {
+	result, err := q.exec(ctx, q.beginCurtailmentTopologyTargetRestoreStmt, beginCurtailmentTopologyTargetRestore, pq.Array(arg.DeviceIdentifiers), arg.CurtailmentEventID, arg.ExpectedEventState)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const bulkInsertCurtailmentTargets = `-- name: BulkInsertCurtailmentTargets :execrows
 INSERT INTO curtailment_target (
     curtailment_event_id,
@@ -246,37 +354,106 @@ func (q *Queries) BulkInsertCurtailmentTargets(ctx context.Context, arg BulkInse
 
 const bulkRefreshAllPairedTargetReadiness = `-- name: BulkRefreshAllPairedTargetReadiness :many
 WITH locked_event AS MATERIALIZED (
-    SELECT id
+    SELECT curtailment_event.id
     FROM curtailment_event
-    WHERE id = $2
-      AND state IN ('pending', 'active')
-      AND state = $3::TEXT
+    WHERE curtailment_event.id = $2
+      AND curtailment_event.state IN ('pending', 'active', 'restoring')
+      AND curtailment_event.state = $3::TEXT
     FOR UPDATE
 )
 UPDATE curtailment_target AS target
 SET state              = t.state,
     last_error         = NULLIF(t.last_error, ''),
-    baseline_power_w   = COALESCE(target.baseline_power_w, t.baseline_power_w),
-    curtail_state      = t.state,
+    retry_count        = CASE
+        WHEN target.desired_state = 'active' AND t.state = 'pending' THEN 0
+        ELSE target.retry_count
+    END,
+    last_dispatched_at = CASE
+        WHEN target.desired_state = 'active' AND t.state = 'pending' THEN NULL
+        ELSE target.last_dispatched_at
+    END,
+    last_batch_uuid    = CASE
+        WHEN target.desired_state = 'active' AND t.state = 'pending' THEN NULL
+        ELSE target.last_batch_uuid
+    END,
+    confirmed_at       = CASE
+        WHEN target.desired_state = 'active' THEN NULL
+        ELSE target.confirmed_at
+    END,
+    baseline_power_w   = CASE
+        WHEN target.desired_state = 'curtailed' THEN COALESCE(target.baseline_power_w, t.baseline_power_w)
+        ELSE target.baseline_power_w
+    END,
+    curtail_state      = CASE
+        WHEN target.desired_state = 'curtailed' THEN t.state
+        ELSE target.curtail_state
+    END,
     curtail_failure_count = CASE
-        WHEN NULLIF(t.last_error, '') IS NOT NULL THEN target.curtail_failure_count + 1
+        WHEN target.desired_state = 'curtailed' AND NULLIF(t.last_error, '') IS NOT NULL
+        THEN target.curtail_failure_count + 1
         ELSE target.curtail_failure_count
     END,
     curtail_last_error = CASE
-        WHEN NULLIF(t.last_error, '') IS NOT NULL THEN t.last_error
+        WHEN target.desired_state = 'curtailed' AND NULLIF(t.last_error, '') IS NOT NULL THEN t.last_error
         ELSE target.curtail_last_error
+    END,
+    restore_state = CASE
+        WHEN target.desired_state = 'active' THEN t.state
+        ELSE target.restore_state
+    END,
+    restore_started_at = CASE
+        WHEN target.desired_state = 'active' THEN COALESCE(target.restore_started_at, CURRENT_TIMESTAMP)
+        ELSE target.restore_started_at
+    END,
+    restore_dispatched_at = CASE
+        WHEN target.desired_state = 'active' AND t.state = 'pending' THEN NULL
+        ELSE target.restore_dispatched_at
+    END,
+    restore_batch_uuid = CASE
+        WHEN target.desired_state = 'active' AND t.state = 'pending' THEN NULL
+        ELSE target.restore_batch_uuid
+    END,
+    restore_completed_at = CASE
+        WHEN target.desired_state = 'active' THEN NULL
+        ELSE target.restore_completed_at
+    END,
+    restore_retry_count = CASE
+        WHEN target.desired_state = 'active' AND t.state = 'pending' THEN 0
+        ELSE target.restore_retry_count
+    END,
+    restore_last_error = CASE
+        WHEN target.desired_state = 'active' THEN NULLIF(t.last_error, '')
+        ELSE target.restore_last_error
     END
 FROM locked_event
 JOIN jsonb_to_recordset($1::JSONB) AS t(
     device_identifier TEXT,
+    expected_state    TEXT,
     state             TEXT,
     last_error        TEXT,
     baseline_power_w  NUMERIC(12,3)
 ) ON TRUE
 WHERE target.curtailment_event_id = locked_event.id
   AND target.device_identifier = t.device_identifier
-  AND target.desired_state = 'curtailed'
-  AND target.state IN ('pending', 'unavailable')
+  AND target.state = t.expected_state
+  AND (
+      target.state <> 'restore_failed'
+      OR NOT EXISTS (
+          SELECT 1
+          FROM curtailment_target other_target
+          JOIN curtailment_event other_event
+            ON other_event.id = other_target.curtailment_event_id
+          WHERE other_target.device_identifier = target.device_identifier
+            AND other_target.curtailment_event_id <> target.curtailment_event_id
+            AND other_event.state IN ('pending', 'active', 'restoring')
+            AND other_target.state NOT IN ('resolved', 'restore_failed', 'released')
+      )
+  )
+  AND (
+      (target.desired_state = 'curtailed' AND target.state IN ('pending', 'unavailable'))
+      OR
+      (target.desired_state = 'active' AND target.state IN ('pending', 'unavailable', 'restore_failed'))
+  )
   AND t.state IN ('pending', 'unavailable')
 RETURNING target.device_identifier
 `
@@ -289,13 +466,15 @@ type BulkRefreshAllPairedTargetReadinessParams struct {
 
 // Per-tick readiness refresh for all-paired policy rows, batched into one
 // statement so a mass readiness flip (fleet-wide recovery or outage) does not
-// issue one UPDATE round trip per device inside the shared tick budget.
+// issue one UPDATE round trip per device inside the shared tick budget. The
+// same transition parks topology restore obligations while uncommandable and
+// requeues them after commandability returns.
 //
 // Guards mirror UpdateCurtailmentTargetState for this transition class:
 // the parent event is locked and must still be in the caller's expected
-// state, and each row must still be a refreshable policy row
-// (desired_state='curtailed', state pending/unavailable). Rows that advanced
-// concurrently (dispatch claim, Stop reset, release) are skipped; the next
+// state, and each row must still be a refreshable policy row: pending or
+// unavailable for curtail, plus restore_failed for topology restore parking.
+// Rows that advanced concurrently (dispatch claim, Stop reset, release) are skipped; the next
 // tick re-reads them. RETURNING reports exactly which rows applied so the
 // reconciler mirrors only those — a skipped row must not be treated as
 // promoted and dispatched against stale state. Empty last_error is the
@@ -398,7 +577,15 @@ reopened AS (
         curtail_completed_at  = NULL,
         curtail_retry_count   = 0,
         curtail_failure_count = 0,
-        curtail_last_error    = t.last_error
+        curtail_last_error    = t.last_error,
+        restore_state         = NULL,
+        restore_started_at    = NULL,
+        restore_dispatched_at = NULL,
+        restore_batch_uuid    = NULL,
+        restore_completed_at  = NULL,
+        restore_retry_count   = 0,
+        restore_failure_count = 0,
+        restore_last_error    = NULL
     FROM locked_event
     JOIN jsonb_to_recordset($2::JSONB) AS t(
         device_identifier         TEXT,
@@ -411,7 +598,7 @@ reopened AS (
     ) ON TRUE
     WHERE target.curtailment_event_id = locked_event.id
       AND target.device_identifier = t.device_identifier
-      AND target.state = 'released'
+      AND target.state IN ('released', 'resolved', 'restore_failed')
       AND NOT EXISTS (
           SELECT 1
           FROM curtailment_target other_target
@@ -477,8 +664,9 @@ type ClaimAllPairedPolicyTargetsParams struct {
 
 // Durable all-paired FULL_FLEET admission. Inserts targets in their computed
 // policy state (pending or unavailable) instead of immediately claiming them
-// as DISPATCHING. Same-event RELEASED rows may be reopened during a recurtail;
-// other same-event rows and cross-event conflicts are no-ops.
+// as DISPATCHING. Same-event RELEASED, topology-restored RESOLVED, or failed
+// restore rows may be reopened; other same-event rows and cross-event
+// conflicts are no-ops.
 func (q *Queries) ClaimAllPairedPolicyTargets(ctx context.Context, arg ClaimAllPairedPolicyTargetsParams) (int64, error) {
 	row := q.queryRow(ctx, q.claimAllPairedPolicyTargetsStmt, claimAllPairedPolicyTargets, arg.CurtailmentEventID, arg.TargetsJsonb)
 	var claimed_count int64
@@ -493,73 +681,164 @@ WITH locked_event AS MATERIALIZED (
         curtailment_event.org_id,
         curtailment_event.decision_snapshot_jsonb
     FROM curtailment_event
-    WHERE curtailment_event.id = $2
+    WHERE curtailment_event.id = $1
       AND curtailment_event.state IN ('pending', 'active')
       AND curtailment_event.mode = 'FULL_FLEET'
       AND curtailment_event.loop_type = 'closed'
     FOR UPDATE
+),
+reopened AS (
+    UPDATE curtailment_target target
+    SET state                 = 'dispatching',
+        desired_state         = t.desired_state,
+        last_error            = t.last_error,
+        baseline_power_w      = t.baseline_power_w,
+        selector_rationale_jsonb = t.selector_rationale_jsonb,
+        released_at           = NULL,
+        retry_count           = 0,
+        last_dispatched_at    = NULL,
+        last_batch_uuid       = NULL,
+        confirmed_at          = NULL,
+        curtail_state         = 'dispatching',
+        curtail_dispatched_at = NULL,
+        curtail_batch_uuid    = NULL,
+        curtail_completed_at  = NULL,
+        curtail_retry_count   = 0,
+        curtail_failure_count = 0,
+        curtail_last_error    = t.last_error,
+        restore_state         = NULL,
+        restore_started_at    = NULL,
+        restore_dispatched_at = NULL,
+        restore_batch_uuid    = NULL,
+        restore_completed_at  = NULL,
+        restore_retry_count   = 0,
+        restore_failure_count = 0,
+        restore_last_error    = NULL
+    FROM locked_event
+    JOIN jsonb_to_recordset($2::JSONB) AS t(
+        device_identifier         TEXT,
+        target_type               TEXT,
+        state                     TEXT,
+        desired_state             TEXT,
+        last_error                TEXT,
+        baseline_power_w          NUMERIC(12,3),
+        selector_rationale_jsonb  JSONB
+    ) ON TRUE
+    WHERE target.curtailment_event_id = locked_event.id
+      AND target.device_identifier = t.device_identifier
+      AND target.state IN ('resolved', 'restore_failed', 'released')
+      AND NOT EXISTS (
+          SELECT 1
+          FROM curtailment_target other_target
+          JOIN curtailment_event other_event
+            ON other_event.id = other_target.curtailment_event_id
+          WHERE other_target.device_identifier = t.device_identifier
+            AND other_target.curtailment_event_id <> locked_event.id
+            AND other_event.state IN ('pending', 'active', 'restoring')
+            AND other_target.state NOT IN ('resolved', 'restore_failed', 'released')
+      )
+    RETURNING target.curtailment_event_id, target.device_identifier, target.target_type, target.state, target.desired_state, target.baseline_power_w, target.added_at, target.released_at, target.last_dispatched_at, target.last_batch_uuid, target.observed_power_w, target.observed_at, target.confirmed_at, target.retry_count, target.last_error, target.selector_rationale_jsonb, target.curtail_state, target.curtail_dispatched_at, target.curtail_batch_uuid, target.curtail_completed_at, target.curtail_retry_count, target.curtail_failure_count, target.curtail_last_error, target.restore_state, target.restore_started_at, target.restore_dispatched_at, target.restore_batch_uuid, target.restore_completed_at, target.restore_retry_count, target.restore_failure_count, target.restore_last_error
+),
+inserted AS (
+    INSERT INTO curtailment_target (
+        curtailment_event_id,
+        device_identifier,
+        target_type,
+        state,
+        desired_state,
+        last_error,
+        curtail_state,
+        curtail_last_error,
+        baseline_power_w,
+        selector_rationale_jsonb
+    )
+    SELECT
+        locked_event.id,
+        t.device_identifier,
+        t.target_type,
+        'dispatching',
+        t.desired_state,
+        t.last_error,
+        'dispatching',
+        t.last_error,
+        t.baseline_power_w,
+        t.selector_rationale_jsonb
+    FROM locked_event
+    JOIN jsonb_to_recordset($2::JSONB) AS t(
+        device_identifier         TEXT,
+        target_type               TEXT,
+        state                     TEXT,
+        desired_state             TEXT,
+        last_error                TEXT,
+        baseline_power_w          NUMERIC(12,3),
+        selector_rationale_jsonb  JSONB
+    ) ON TRUE
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM curtailment_target existing
+        WHERE existing.curtailment_event_id = locked_event.id
+          AND existing.device_identifier = t.device_identifier
+    )
+    ON CONFLICT DO NOTHING
+    RETURNING curtailment_target.curtailment_event_id, curtailment_target.device_identifier, curtailment_target.target_type, curtailment_target.state, curtailment_target.desired_state, curtailment_target.baseline_power_w, curtailment_target.added_at, curtailment_target.released_at, curtailment_target.last_dispatched_at, curtailment_target.last_batch_uuid, curtailment_target.observed_power_w, curtailment_target.observed_at, curtailment_target.confirmed_at, curtailment_target.retry_count, curtailment_target.last_error, curtailment_target.selector_rationale_jsonb, curtailment_target.curtail_state, curtailment_target.curtail_dispatched_at, curtailment_target.curtail_batch_uuid, curtailment_target.curtail_completed_at, curtailment_target.curtail_retry_count, curtailment_target.curtail_failure_count, curtailment_target.curtail_last_error, curtailment_target.restore_state, curtailment_target.restore_started_at, curtailment_target.restore_dispatched_at, curtailment_target.restore_batch_uuid, curtailment_target.restore_completed_at, curtailment_target.restore_retry_count, curtailment_target.restore_failure_count, curtailment_target.restore_last_error
 )
-INSERT INTO curtailment_target (
-    curtailment_event_id,
-    device_identifier,
-    target_type,
-    state,
-    desired_state,
-    last_error,
-    curtail_state,
-    curtail_last_error,
-    baseline_power_w,
-    selector_rationale_jsonb
-)
-SELECT
-    locked_event.id,
-    t.device_identifier,
-    t.target_type,
-    'dispatching',
-    t.desired_state,
-    t.last_error,
-    'dispatching',
-    t.last_error,
-    t.baseline_power_w,
-    t.selector_rationale_jsonb
-FROM locked_event
-JOIN jsonb_to_recordset($1::JSONB) AS t(
-    device_identifier         TEXT,
-    target_type               TEXT,
-    state                     TEXT,
-    desired_state             TEXT,
-    last_error                TEXT,
-    baseline_power_w          NUMERIC(12,3),
-    selector_rationale_jsonb  JSONB
-) ON TRUE
-WHERE NOT EXISTS (
-    SELECT 1
-    FROM curtailment_target existing
-    WHERE existing.curtailment_event_id = locked_event.id
-      AND existing.device_identifier = t.device_identifier
-)
-ON CONFLICT DO NOTHING
-RETURNING curtailment_target.curtailment_event_id, curtailment_target.device_identifier, curtailment_target.target_type, curtailment_target.state, curtailment_target.desired_state, curtailment_target.baseline_power_w, curtailment_target.added_at, curtailment_target.released_at, curtailment_target.last_dispatched_at, curtailment_target.last_batch_uuid, curtailment_target.observed_power_w, curtailment_target.observed_at, curtailment_target.confirmed_at, curtailment_target.retry_count, curtailment_target.last_error, curtailment_target.selector_rationale_jsonb, curtailment_target.curtail_state, curtailment_target.curtail_dispatched_at, curtailment_target.curtail_batch_uuid, curtailment_target.curtail_completed_at, curtailment_target.curtail_retry_count, curtailment_target.curtail_failure_count, curtailment_target.curtail_last_error, curtailment_target.restore_state, curtailment_target.restore_started_at, curtailment_target.restore_dispatched_at, curtailment_target.restore_batch_uuid, curtailment_target.restore_completed_at, curtailment_target.restore_retry_count, curtailment_target.restore_failure_count, curtailment_target.restore_last_error
+SELECT curtailment_event_id, device_identifier, target_type, state, desired_state, baseline_power_w, added_at, released_at, last_dispatched_at, last_batch_uuid, observed_power_w, observed_at, confirmed_at, retry_count, last_error, selector_rationale_jsonb, curtail_state, curtail_dispatched_at, curtail_batch_uuid, curtail_completed_at, curtail_retry_count, curtail_failure_count, curtail_last_error, restore_state, restore_started_at, restore_dispatched_at, restore_batch_uuid, restore_completed_at, restore_retry_count, restore_failure_count, restore_last_error FROM reopened
+UNION ALL
+SELECT curtailment_event_id, device_identifier, target_type, state, desired_state, baseline_power_w, added_at, released_at, last_dispatched_at, last_batch_uuid, observed_power_w, observed_at, confirmed_at, retry_count, last_error, selector_rationale_jsonb, curtail_state, curtail_dispatched_at, curtail_batch_uuid, curtail_completed_at, curtail_retry_count, curtail_failure_count, curtail_last_error, restore_state, restore_started_at, restore_dispatched_at, restore_batch_uuid, restore_completed_at, restore_retry_count, restore_failure_count, restore_last_error FROM inserted
 `
 
 type ClaimClosedLoopFullFleetTargetsParams struct {
-	TargetsJsonb       json.RawMessage
 	CurtailmentEventID int64
+	TargetsJsonb       json.RawMessage
+}
+
+type ClaimClosedLoopFullFleetTargetsRow struct {
+	CurtailmentEventID     int64
+	DeviceIdentifier       string
+	TargetType             string
+	State                  string
+	DesiredState           string
+	BaselinePowerW         sql.NullString
+	AddedAt                time.Time
+	ReleasedAt             sql.NullTime
+	LastDispatchedAt       sql.NullTime
+	LastBatchUuid          sql.NullString
+	ObservedPowerW         sql.NullString
+	ObservedAt             sql.NullTime
+	ConfirmedAt            sql.NullTime
+	RetryCount             int32
+	LastError              sql.NullString
+	SelectorRationaleJsonb pqtype.NullRawMessage
+	CurtailState           string
+	CurtailDispatchedAt    sql.NullTime
+	CurtailBatchUuid       sql.NullString
+	CurtailCompletedAt     sql.NullTime
+	CurtailRetryCount      int32
+	CurtailFailureCount    int32
+	CurtailLastError       sql.NullString
+	RestoreState           sql.NullString
+	RestoreStartedAt       sql.NullTime
+	RestoreDispatchedAt    sql.NullTime
+	RestoreBatchUuid       sql.NullString
+	RestoreCompletedAt     sql.NullTime
+	RestoreRetryCount      int32
+	RestoreFailureCount    int32
+	RestoreLastError       sql.NullString
 }
 
 // Closed-loop FULL_FLEET dispatch claim. Locks the parent event so
 // Stop/AdminTerminate and dynamic target claims serialize on lifecycle state.
 // Same-event duplicates and cross-event target conflicts are no-ops; the
 // reconciler retries on a later tick if a conflicting event resolves.
-func (q *Queries) ClaimClosedLoopFullFleetTargets(ctx context.Context, arg ClaimClosedLoopFullFleetTargetsParams) ([]CurtailmentTarget, error) {
-	rows, err := q.query(ctx, q.claimClosedLoopFullFleetTargetsStmt, claimClosedLoopFullFleetTargets, arg.TargetsJsonb, arg.CurtailmentEventID)
+func (q *Queries) ClaimClosedLoopFullFleetTargets(ctx context.Context, arg ClaimClosedLoopFullFleetTargetsParams) ([]ClaimClosedLoopFullFleetTargetsRow, error) {
+	rows, err := q.query(ctx, q.claimClosedLoopFullFleetTargetsStmt, claimClosedLoopFullFleetTargets, arg.CurtailmentEventID, arg.TargetsJsonb)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var items []CurtailmentTarget
+	var items []ClaimClosedLoopFullFleetTargetsRow
 	for rows.Next() {
-		var i CurtailmentTarget
+		var i ClaimClosedLoopFullFleetTargetsRow
 		if err := rows.Scan(
 			&i.CurtailmentEventID,
 			&i.DeviceIdentifier,
@@ -647,19 +926,24 @@ WHERE org_id = $1
         scope_type IN ('whole_org', 'site')
         OR (
           scope_type = 'mixed'
-          AND jsonb_array_length(
-            CASE WHEN jsonb_typeof(scope_jsonb->'site_ids') = 'array'
-              THEN scope_jsonb->'site_ids'
-              ELSE '[]'::jsonb
-            END
-          ) > 0
-          AND jsonb_array_length(
-            CASE WHEN jsonb_typeof(scope_jsonb->'device_identifiers') = 'array'
-              THEN scope_jsonb->'device_identifiers'
-              ELSE '[]'::jsonb
-            END
-          ) = 0
-          AND NOT (scope_jsonb ?| ARRAY['building_ids', 'rack_ids', 'group_ids'])
+          AND (
+            scope_jsonb ?| ARRAY['building_ids', 'rack_ids', 'group_ids']
+            OR (
+              jsonb_array_length(
+                CASE WHEN jsonb_typeof(scope_jsonb->'site_ids') = 'array'
+                  THEN scope_jsonb->'site_ids'
+                  ELSE '[]'::jsonb
+                END
+              ) > 0
+              AND jsonb_array_length(
+                CASE WHEN jsonb_typeof(scope_jsonb->'device_identifiers') = 'array'
+                  THEN scope_jsonb->'device_identifiers'
+                  ELSE '[]'::jsonb
+                END
+              ) = 0
+              AND NOT (scope_jsonb ?| ARRAY['building_ids', 'rack_ids', 'group_ids'])
+            )
+          )
         )
       )
     )
@@ -693,20 +977,85 @@ WHERE org_id = $1
         )
       )
     )
+    OR (
+      $4::TEXT = 'mixed'
+      AND (
+        (
+          cardinality($6::BIGINT[]) > 0
+          AND (
+            scope_type = 'whole_org'
+            OR (
+              scope_type = 'mixed'
+              AND EXISTS (
+                SELECT 1
+                FROM jsonb_array_elements_text(
+                  CASE WHEN jsonb_typeof(scope_jsonb->'building_ids') = 'array'
+                    THEN scope_jsonb->'building_ids'
+                    ELSE '[]'::jsonb
+                  END
+                ) AS existing_building_id(building_id)
+                WHERE existing_building_id.building_id::BIGINT = ANY($6::BIGINT[])
+              )
+            )
+          )
+        )
+        OR (
+          cardinality($7::BIGINT[]) > 0
+          AND (
+            scope_type = 'whole_org'
+            OR (
+              scope_type = 'mixed'
+              AND EXISTS (
+                SELECT 1
+                FROM jsonb_array_elements_text(
+                  CASE WHEN jsonb_typeof(scope_jsonb->'rack_ids') = 'array'
+                    THEN scope_jsonb->'rack_ids'
+                    ELSE '[]'::jsonb
+                  END
+                ) AS existing_rack_id(rack_id)
+                WHERE existing_rack_id.rack_id::BIGINT = ANY($7::BIGINT[])
+              )
+            )
+          )
+        )
+        OR (
+          cardinality($8::BIGINT[]) > 0
+          AND (
+            scope_type = 'whole_org'
+            OR (
+              scope_type = 'mixed'
+              AND EXISTS (
+                SELECT 1
+                FROM jsonb_array_elements_text(
+                  CASE WHEN jsonb_typeof(scope_jsonb->'group_ids') = 'array'
+                    THEN scope_jsonb->'group_ids'
+                    ELSE '[]'::jsonb
+                  END
+                ) AS existing_group_id(group_id)
+                WHERE existing_group_id.group_id::BIGINT = ANY($8::BIGINT[])
+              )
+            )
+          )
+        )
+      )
+    )
   )
 `
 
 type CountCurtailmentScopeConflictsParams struct {
-	OrgID     int64
-	Mode      string
-	LoopType  string
-	ScopeType string
-	SiteIds   []int64
+	OrgID       int64
+	Mode        string
+	LoopType    string
+	ScopeType   string
+	SiteIds     []int64
+	BuildingIds []int64
+	RackIds     []int64
+	GroupIds    []int64
 }
 
-// Hierarchy for currently supported closed-loop scopes: org > site.
-// A new whole-org event conflicts with existing whole-org, site, or site-only mixed events.
-// A new site or site-only mixed event conflicts with existing whole-org or overlapping site ownership.
+// Serializes logical FULL_FLEET scope ownership. Whole-org conflicts with every
+// hierarchy watcher; site selectors conflict on overlap; topology selectors
+// conflict with whole-org and overlapping IDs of the same terminal type.
 func (q *Queries) CountCurtailmentScopeConflicts(ctx context.Context, arg CountCurtailmentScopeConflictsParams) (int64, error) {
 	row := q.queryRow(ctx, q.countCurtailmentScopeConflictsStmt, countCurtailmentScopeConflicts,
 		arg.OrgID,
@@ -714,6 +1063,9 @@ func (q *Queries) CountCurtailmentScopeConflicts(ctx context.Context, arg CountC
 		arg.LoopType,
 		arg.ScopeType,
 		pq.Array(arg.SiteIds),
+		pq.Array(arg.BuildingIds),
+		pq.Array(arg.RackIds),
+		pq.Array(arg.GroupIds),
 	)
 	var column_1 int64
 	err := row.Scan(&column_1)
@@ -1606,6 +1958,75 @@ JOIN device d ON d.org_id = ce.org_id
                 ) AS mixed_device(device_identifier)
             )
             AND NOT (ce.scope_jsonb ?| ARRAY['building_ids', 'rack_ids', 'group_ids'])
+        )
+        OR (
+            ce.scope_type = 'mixed'
+            AND jsonb_typeof(ce.scope_jsonb->'building_ids') = 'array'
+            AND EXISTS (
+                SELECT 1
+                FROM jsonb_array_elements_text(ce.scope_jsonb->'building_ids') AS selected_building(building_id)
+                JOIN building b
+                  ON b.id = selected_building.building_id::BIGINT
+                 AND b.org_id = ce.org_id
+                 AND b.deleted_at IS NULL
+                WHERE d.building_id = b.id
+                   OR EXISTS (
+                       SELECT 1
+                       FROM device_set_membership dsm
+                       JOIN device_set ds
+                         ON ds.id = dsm.device_set_id
+                        AND ds.org_id = dsm.org_id
+                        AND ds.type = 'rack'
+                        AND ds.deleted_at IS NULL
+                       JOIN device_set_rack dsr
+                         ON dsr.device_set_id = ds.id
+                        AND dsr.org_id = ds.org_id
+                       WHERE dsm.org_id = ce.org_id
+                         AND dsm.device_id = d.id
+                         AND dsm.device_set_type = 'rack'
+                         AND dsr.building_id = b.id
+                   )
+            )
+        )
+        OR (
+            ce.scope_type = 'mixed'
+            AND jsonb_typeof(ce.scope_jsonb->'rack_ids') = 'array'
+            AND EXISTS (
+                SELECT 1
+                FROM device_set_membership dsm
+                JOIN device_set ds
+                  ON ds.id = dsm.device_set_id
+                 AND ds.org_id = dsm.org_id
+                 AND ds.type = 'rack'
+                 AND ds.deleted_at IS NULL
+                WHERE dsm.org_id = ce.org_id
+                  AND dsm.device_id = d.id
+                  AND dsm.device_set_type = 'rack'
+                  AND dsm.device_set_id IN (
+                      SELECT selected_rack.rack_id::BIGINT
+                      FROM jsonb_array_elements_text(ce.scope_jsonb->'rack_ids') AS selected_rack(rack_id)
+                  )
+            )
+        )
+        OR (
+            ce.scope_type = 'mixed'
+            AND jsonb_typeof(ce.scope_jsonb->'group_ids') = 'array'
+            AND EXISTS (
+                SELECT 1
+                FROM device_set_membership dsm
+                JOIN device_set ds
+                  ON ds.id = dsm.device_set_id
+                 AND ds.org_id = dsm.org_id
+                 AND ds.type = 'group'
+                 AND ds.deleted_at IS NULL
+                WHERE dsm.org_id = ce.org_id
+                  AND dsm.device_id = d.id
+                  AND dsm.device_set_type = 'group'
+                  AND dsm.device_set_id IN (
+                      SELECT selected_group.group_id::BIGINT
+                      FROM jsonb_array_elements_text(ce.scope_jsonb->'group_ids') AS selected_group(group_id)
+                  )
+            )
         )
     )
 WHERE ce.org_id = $1
@@ -2859,6 +3280,177 @@ func (q *Queries) ListCurtailmentTargetsByEventPage(ctx context.Context, arg Lis
 	return items, nil
 }
 
+const listEarlierCurtailmentReservationDevices = `-- name: ListEarlierCurtailmentReservationDevices :many
+WITH current_event AS MATERIALIZED (
+    SELECT curtailment_event.id, curtailment_event.org_id
+    FROM curtailment_event
+    WHERE curtailment_event.id = $1
+      AND curtailment_event.state IN ('pending', 'active', 'restoring')
+),
+candidate_devices AS MATERIALIZED (
+    SELECT d.id, d.device_identifier, d.site_id, d.building_id, d.org_id
+    FROM device d
+    JOIN current_event current ON current.org_id = d.org_id
+    WHERE d.deleted_at IS NULL
+      AND d.device_identifier = ANY($2::TEXT[])
+)
+SELECT candidate.device_identifier
+FROM candidate_devices candidate
+JOIN current_event current ON TRUE
+WHERE EXISTS (
+    SELECT 1
+    FROM curtailment_event older
+    WHERE older.org_id = current.org_id
+      AND older.id < current.id
+      AND older.state IN ('pending', 'active', 'restoring')
+      AND (
+        EXISTS (
+            SELECT 1
+            FROM curtailment_target target
+            WHERE target.curtailment_event_id = older.id
+              AND target.device_identifier = candidate.device_identifier
+              AND target.state NOT IN ('resolved', 'restore_failed', 'released')
+        )
+        OR (
+          older.mode = 'FULL_FLEET'
+          AND older.loop_type = 'closed'
+          AND NOT (
+            older.force_include_all_paired_miners
+            AND older.state = 'restoring'
+            AND EXISTS (
+              SELECT 1
+              FROM curtailment_target released_target
+              WHERE released_target.curtailment_event_id = older.id
+                AND released_target.device_identifier = candidate.device_identifier
+                AND released_target.state = 'released'
+            )
+          )
+          AND (
+            older.scope_type = 'whole_org'
+            OR (
+              older.scope_type = 'site'
+              AND candidate.site_id = (older.scope_jsonb->>'site_id')::BIGINT
+            )
+            OR (
+              older.scope_type = 'mixed'
+              AND candidate.site_id IN (
+                  SELECT selected_site.site_id::BIGINT
+                  FROM jsonb_array_elements_text(
+                      CASE WHEN jsonb_typeof(older.scope_jsonb->'site_ids') = 'array'
+                        THEN older.scope_jsonb->'site_ids'
+                        ELSE '[]'::jsonb
+                      END
+                  ) AS selected_site(site_id)
+              )
+              AND NOT (older.scope_jsonb ?| ARRAY['building_ids', 'rack_ids', 'group_ids'])
+            )
+            OR (
+              older.scope_type = 'mixed'
+              AND jsonb_typeof(older.scope_jsonb->'building_ids') = 'array'
+              AND EXISTS (
+                  SELECT 1
+                  FROM jsonb_array_elements_text(older.scope_jsonb->'building_ids') AS selected_building(building_id)
+                  JOIN building b
+                    ON b.id = selected_building.building_id::BIGINT
+                   AND b.org_id = older.org_id
+                   AND b.deleted_at IS NULL
+                  WHERE candidate.building_id = b.id
+                     OR EXISTS (
+                         SELECT 1
+                         FROM device_set_membership dsm
+                         JOIN device_set ds
+                           ON ds.id = dsm.device_set_id
+                          AND ds.org_id = dsm.org_id
+                          AND ds.type = 'rack'
+                          AND ds.deleted_at IS NULL
+                         JOIN device_set_rack dsr
+                           ON dsr.device_set_id = ds.id
+                          AND dsr.org_id = ds.org_id
+                         WHERE dsm.org_id = older.org_id
+                           AND dsm.device_id = candidate.id
+                           AND dsm.device_set_type = 'rack'
+                           AND dsr.building_id = b.id
+                     )
+              )
+            )
+            OR (
+              older.scope_type = 'mixed'
+              AND jsonb_typeof(older.scope_jsonb->'rack_ids') = 'array'
+              AND EXISTS (
+                  SELECT 1
+                  FROM device_set_membership dsm
+                  JOIN device_set ds
+                    ON ds.id = dsm.device_set_id
+                   AND ds.org_id = dsm.org_id
+                   AND ds.type = 'rack'
+                   AND ds.deleted_at IS NULL
+                  WHERE dsm.org_id = older.org_id
+                    AND dsm.device_id = candidate.id
+                    AND dsm.device_set_type = 'rack'
+                    AND dsm.device_set_id IN (
+                        SELECT selected_rack.rack_id::BIGINT
+                        FROM jsonb_array_elements_text(older.scope_jsonb->'rack_ids') AS selected_rack(rack_id)
+                    )
+              )
+            )
+            OR (
+              older.scope_type = 'mixed'
+              AND jsonb_typeof(older.scope_jsonb->'group_ids') = 'array'
+              AND EXISTS (
+                  SELECT 1
+                  FROM device_set_membership dsm
+                  JOIN device_set ds
+                    ON ds.id = dsm.device_set_id
+                   AND ds.org_id = dsm.org_id
+                   AND ds.type = 'group'
+                   AND ds.deleted_at IS NULL
+                  WHERE dsm.org_id = older.org_id
+                    AND dsm.device_id = candidate.id
+                    AND dsm.device_set_type = 'group'
+                    AND dsm.device_set_id IN (
+                        SELECT selected_group.group_id::BIGINT
+                        FROM jsonb_array_elements_text(older.scope_jsonb->'group_ids') AS selected_group(group_id)
+                    )
+              )
+            )
+          )
+        )
+      )
+)
+ORDER BY candidate.device_identifier
+`
+
+type ListEarlierCurtailmentReservationDevicesParams struct {
+	CurtailmentEventID int64
+	DeviceIdentifiers  []string
+}
+
+// Returns requested devices owned by an older concrete target or logical
+// closed-loop scope. Admission holds the org scope lock while reading this
+// list and claiming targets, so persisted event order decides ownership.
+func (q *Queries) ListEarlierCurtailmentReservationDevices(ctx context.Context, arg ListEarlierCurtailmentReservationDevicesParams) ([]string, error) {
+	rows, err := q.query(ctx, q.listEarlierCurtailmentReservationDevicesStmt, listEarlierCurtailmentReservationDevices, arg.CurtailmentEventID, pq.Array(arg.DeviceIdentifiers))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var device_identifier string
+		if err := rows.Scan(&device_identifier); err != nil {
+			return nil, err
+		}
+		items = append(items, device_identifier)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listNonTerminalCurtailmentEvents = `-- name: ListNonTerminalCurtailmentEvents :many
 SELECT id, event_uuid, org_id, state, mode, strategy, level, priority, loop_type, scope_type, scope_jsonb, mode_params_jsonb, restore_batch_size, restore_batch_interval_sec, effective_batch_size, min_curtailed_duration_sec, max_duration_seconds, allow_unbounded, include_maintenance, force_include_maintenance, decision_snapshot_jsonb, source_actor_type, source_actor_id, external_source, external_reference, idempotency_key, supersedes_event_id, reason, scheduled_start_at, started_at, ended_at, created_at, updated_at, created_by_user_id, curtail_batch_size, curtail_batch_interval_sec, force_include_all_paired_miners, facility_fan_device_ids, facility_fan_site_ids, fan_off_delay_sec, fan_restore_delay_sec, fan_off_sent_at, fan_on_sent_at, fan_airflow_reopened_at, fan_last_error, last_curtail_pending_dispatch_at, authorization_envelope_jsonb
 FROM curtailment_event
@@ -3136,6 +3728,19 @@ func (q *Queries) LockCurtailmentEventForFanCommand(ctx context.Context, arg Loc
 	return id, err
 }
 
+const lockCurtailmentEventScopeForWrite = `-- name: LockCurtailmentEventScopeForWrite :exec
+SELECT pg_advisory_xact_lock(hashtextextended('curtailment_scope:' || org_id::TEXT, 0))
+FROM curtailment_event
+WHERE id = $1
+`
+
+// Admission already has the event ID; derive its organization before taking
+// the same lock used by Start conflict detection.
+func (q *Queries) LockCurtailmentEventScopeForWrite(ctx context.Context, curtailmentEventID int64) error {
+	_, err := q.exec(ctx, q.lockCurtailmentEventScopeForWriteStmt, lockCurtailmentEventScopeForWrite, curtailmentEventID)
+	return err
+}
+
 const lockCurtailmentFanDeviceForWrite = `-- name: LockCurtailmentFanDeviceForWrite :exec
 SELECT pg_advisory_xact_lock(hashtextextended('curtailment-fan:' || $1::TEXT, 0))
 `
@@ -3244,6 +3849,66 @@ SELECT pg_advisory_xact_lock(hashtextextended('curtailment_scope:' || $1::text, 
 func (q *Queries) LockCurtailmentScopeForWrite(ctx context.Context, orgID string) error {
 	_, err := q.exec(ctx, q.lockCurtailmentScopeForWriteStmt, lockCurtailmentScopeForWrite, orgID)
 	return err
+}
+
+const lockCurtailmentTargetPairingStatusesForWrite = `-- name: LockCurtailmentTargetPairingStatusesForWrite :many
+WITH locked_devices AS MATERIALIZED (
+    SELECT d.id, d.device_identifier
+    FROM device d
+    WHERE d.org_id = $1
+      AND d.device_identifier = ANY($2::TEXT[])
+    ORDER BY d.device_identifier
+    FOR UPDATE OF d
+),
+locked_pairings AS MATERIALIZED (
+    SELECT dp.device_id, dp.pairing_status
+    FROM device_pairing dp
+    JOIN locked_devices d ON d.id = dp.device_id
+    ORDER BY d.device_identifier
+    FOR UPDATE OF dp
+)
+SELECT d.device_identifier, COALESCE(p.pairing_status::TEXT, 'UNPAIRED'::TEXT)::TEXT AS pairing_status
+FROM locked_devices d
+LEFT JOIN locked_pairings p ON p.device_id = d.id
+ORDER BY d.device_identifier
+`
+
+type LockCurtailmentTargetPairingStatusesForWriteParams struct {
+	OrgID             int64
+	DeviceIdentifiers []string
+}
+
+type LockCurtailmentTargetPairingStatusesForWriteRow struct {
+	DeviceIdentifier string
+	PairingStatus    string
+}
+
+// Pairing status participates in all-paired topology membership. Lock these
+// device rows first, including devices that do not have a pairing row yet,
+// then any existing pairing rows. Pairing inserts take the same device lock,
+// so the later candidate read cannot classify a first-time pairing from a
+// stale pre-insert snapshot.
+func (q *Queries) LockCurtailmentTargetPairingStatusesForWrite(ctx context.Context, arg LockCurtailmentTargetPairingStatusesForWriteParams) ([]LockCurtailmentTargetPairingStatusesForWriteRow, error) {
+	rows, err := q.query(ctx, q.lockCurtailmentTargetPairingStatusesForWriteStmt, lockCurtailmentTargetPairingStatusesForWrite, arg.OrgID, pq.Array(arg.DeviceIdentifiers))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []LockCurtailmentTargetPairingStatusesForWriteRow
+	for rows.Next() {
+		var i LockCurtailmentTargetPairingStatusesForWriteRow
+		if err := rows.Scan(&i.DeviceIdentifier, &i.PairingStatus); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const lockCurtailmentTopologyMemberDeviceSitesByOrg = `-- name: LockCurtailmentTopologyMemberDeviceSitesByOrg :many

--- a/server/generated/sqlc/curtailment.sql.go
+++ b/server/generated/sqlc/curtailment.sql.go
@@ -3686,6 +3686,30 @@ func (q *Queries) ListRecentlyResolvedCurtailedDevicesByScope(ctx context.Contex
 	return items, nil
 }
 
+const lockCurtailmentAdmissionEventForWrite = `-- name: LockCurtailmentAdmissionEventForWrite :one
+SELECT org_id, scope_jsonb
+FROM curtailment_event
+WHERE id = $1
+  AND state IN ('pending', 'active')
+  AND mode = 'FULL_FLEET'
+  AND loop_type = 'closed'
+FOR UPDATE
+`
+
+type LockCurtailmentAdmissionEventForWriteRow struct {
+	OrgID      int64
+	ScopeJsonb json.RawMessage
+}
+
+// Keep the current event and its immutable selector in the same transaction
+// as dynamic membership fencing and target admission.
+func (q *Queries) LockCurtailmentAdmissionEventForWrite(ctx context.Context, curtailmentEventID int64) (LockCurtailmentAdmissionEventForWriteRow, error) {
+	row := q.queryRow(ctx, q.lockCurtailmentAdmissionEventForWriteStmt, lockCurtailmentAdmissionEventForWrite, curtailmentEventID)
+	var i LockCurtailmentAdmissionEventForWriteRow
+	err := row.Scan(&i.OrgID, &i.ScopeJsonb)
+	return i, err
+}
+
 const lockCurtailmentEventByUUIDForWrite = `-- name: LockCurtailmentEventByUUIDForWrite :one
 SELECT id, event_uuid, org_id, state, mode, strategy, level, priority, loop_type, scope_type, scope_jsonb, mode_params_jsonb, restore_batch_size, restore_batch_interval_sec, effective_batch_size, min_curtailed_duration_sec, max_duration_seconds, allow_unbounded, include_maintenance, force_include_maintenance, decision_snapshot_jsonb, source_actor_type, source_actor_id, external_source, external_reference, idempotency_key, supersedes_event_id, reason, scheduled_start_at, started_at, ended_at, created_at, updated_at, created_by_user_id, curtail_batch_size, curtail_batch_interval_sec, force_include_all_paired_miners, facility_fan_device_ids, facility_fan_site_ids, fan_off_delay_sec, fan_restore_delay_sec, fan_off_sent_at, fan_on_sent_at, fan_airflow_reopened_at, fan_last_error, last_curtail_pending_dispatch_at, authorization_envelope_jsonb
 FROM curtailment_event

--- a/server/generated/sqlc/curtailment.sql.go
+++ b/server/generated/sqlc/curtailment.sql.go
@@ -3282,6 +3282,101 @@ func (q *Queries) ListCurtailmentTargetsByEventPage(ctx context.Context, arg Lis
 	return items, nil
 }
 
+const listCurtailmentTopologyMemberDeviceIdentifiersByOrg = `-- name: ListCurtailmentTopologyMemberDeviceIdentifiersByOrg :many
+SELECT d.device_identifier
+FROM device d
+WHERE d.org_id = $1
+  AND d.deleted_at IS NULL
+  AND (
+    (
+      d.building_id = ANY($2::BIGINT[])
+      OR EXISTS (
+        SELECT 1
+        FROM device_set_membership dsm
+        JOIN device_set ds
+          ON ds.id = dsm.device_set_id
+         AND ds.org_id = dsm.org_id
+         AND ds.type = 'rack'
+         AND ds.deleted_at IS NULL
+        JOIN device_set_rack dsr
+          ON dsr.device_set_id = ds.id
+         AND dsr.org_id = ds.org_id
+        WHERE dsm.org_id = $1
+          AND dsm.device_id = d.id
+          AND dsm.device_set_type = 'rack'
+          AND dsr.building_id = ANY($2::BIGINT[])
+      )
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM device_set_membership dsm
+      JOIN device_set ds
+        ON ds.id = dsm.device_set_id
+       AND ds.org_id = dsm.org_id
+       AND ds.type = 'rack'
+       AND ds.deleted_at IS NULL
+      WHERE dsm.org_id = $1
+        AND dsm.device_id = d.id
+        AND dsm.device_set_type = 'rack'
+        AND dsm.device_set_id = ANY($3::BIGINT[])
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM device_set_membership dsm
+      JOIN device_set ds
+        ON ds.id = dsm.device_set_id
+       AND ds.org_id = dsm.org_id
+       AND ds.type = 'group'
+       AND ds.deleted_at IS NULL
+      WHERE dsm.org_id = $1
+        AND dsm.device_id = d.id
+        AND dsm.device_set_type = 'group'
+        AND dsm.device_set_id = ANY($4::BIGINT[])
+    )
+  )
+ORDER BY d.id
+LIMIT 10001
+`
+
+type ListCurtailmentTopologyMemberDeviceIdentifiersByOrgParams struct {
+	OrgID       int64
+	BuildingIds []int64
+	RackIds     []int64
+	GroupIds    []int64
+}
+
+// Restore reads the live member IDs after locking the selector resources, then
+// locks these IDs together with departed restore candidates in one canonical
+// device order. Keeping this read non-locking avoids taking current-member rows
+// before lower-ID departed rows and deadlocking with bulk placement writes.
+func (q *Queries) ListCurtailmentTopologyMemberDeviceIdentifiersByOrg(ctx context.Context, arg ListCurtailmentTopologyMemberDeviceIdentifiersByOrgParams) ([]string, error) {
+	rows, err := q.query(ctx, q.listCurtailmentTopologyMemberDeviceIdentifiersByOrgStmt, listCurtailmentTopologyMemberDeviceIdentifiersByOrg,
+		arg.OrgID,
+		pq.Array(arg.BuildingIds),
+		pq.Array(arg.RackIds),
+		pq.Array(arg.GroupIds),
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []string
+	for rows.Next() {
+		var device_identifier string
+		if err := rows.Scan(&device_identifier); err != nil {
+			return nil, err
+		}
+		items = append(items, device_identifier)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listEarlierCurtailmentReservationDevices = `-- name: ListEarlierCurtailmentReservationDevices :many
 WITH current_event AS MATERIALIZED (
     SELECT curtailment_event.id, curtailment_event.org_id

--- a/server/generated/sqlc/curtailment.sql.go
+++ b/server/generated/sqlc/curtailment.sql.go
@@ -3586,16 +3586,18 @@ SELECT DISTINCT ct.device_identifier
 FROM curtailment_target ct
 JOIN curtailment_event ce ON ce.id = ct.curtailment_event_id
 WHERE ce.org_id = $1
+    AND ($2::BIGINT = 0 OR ce.id <> $2::BIGINT)
     AND ct.state IN ('resolved', 'restore_failed')
     AND (
         ce.state IN ('pending', 'active', 'restoring')
-        OR ce.ended_at >= CURRENT_TIMESTAMP - ($2::int * INTERVAL '1 second')
+        OR ce.ended_at >= CURRENT_TIMESTAMP - ($3::int * INTERVAL '1 second')
     )
 `
 
 type ListRecentlyResolvedCurtailedDevicesByOrgParams struct {
-	OrgID       int64
-	CooldownSec int32
+	OrgID          int64
+	ExcludeEventID int64
+	CooldownSec    int32
 }
 
 // Restored/failed targets the selector excludes (unless priority=EMERGENCY,
@@ -3603,7 +3605,7 @@ type ListRecentlyResolvedCurtailedDevicesByOrgParams struct {
 // event is still non-terminal (the old org-level singleton enforced this
 // implicitly), then for `cooldown_sec` after the event ends.
 func (q *Queries) ListRecentlyResolvedCurtailedDevicesByOrg(ctx context.Context, arg ListRecentlyResolvedCurtailedDevicesByOrgParams) ([]string, error) {
-	rows, err := q.query(ctx, q.listRecentlyResolvedCurtailedDevicesByOrgStmt, listRecentlyResolvedCurtailedDevicesByOrg, arg.OrgID, arg.CooldownSec)
+	rows, err := q.query(ctx, q.listRecentlyResolvedCurtailedDevicesByOrgStmt, listRecentlyResolvedCurtailedDevicesByOrg, arg.OrgID, arg.ExcludeEventID, arg.CooldownSec)
 	if err != nil {
 		return nil, err
 	}
@@ -3627,30 +3629,32 @@ func (q *Queries) ListRecentlyResolvedCurtailedDevicesByOrg(ctx context.Context,
 
 const listRecentlyResolvedCurtailedDevicesByScope = `-- name: ListRecentlyResolvedCurtailedDevicesByScope :many
 WITH scoped_devices AS MATERIALIZED (
-    SELECT unnest($3::text[]) AS device_identifier
-    WHERE $3::text[] IS NOT NULL
+    SELECT unnest($4::text[]) AS device_identifier
+    WHERE $4::text[] IS NOT NULL
     UNION
     SELECT d.device_identifier
     FROM device d
     WHERE d.org_id = $1
         AND d.deleted_at IS NULL
-        AND $4::BIGINT[] IS NOT NULL
-        AND d.site_id = ANY($4::BIGINT[])
+        AND $5::BIGINT[] IS NOT NULL
+        AND d.site_id = ANY($5::BIGINT[])
 )
 SELECT DISTINCT ct.device_identifier
 FROM scoped_devices sd
 JOIN curtailment_target ct ON ct.device_identifier = sd.device_identifier
 JOIN curtailment_event ce ON ce.id = ct.curtailment_event_id
 WHERE ce.org_id = $1
+    AND ($2::BIGINT = 0 OR ce.id <> $2::BIGINT)
     AND ct.state IN ('resolved', 'restore_failed')
     AND (
         ce.state IN ('pending', 'active', 'restoring')
-        OR ce.ended_at >= CURRENT_TIMESTAMP - ($2::int * INTERVAL '1 second')
+        OR ce.ended_at >= CURRENT_TIMESTAMP - ($3::int * INTERVAL '1 second')
     )
 `
 
 type ListRecentlyResolvedCurtailedDevicesByScopeParams struct {
 	OrgID             int64
+	ExcludeEventID    int64
 	CooldownSec       int32
 	DeviceIdentifiers []string
 	SiteIds           []int64
@@ -3661,6 +3665,7 @@ type ListRecentlyResolvedCurtailedDevicesByScopeParams struct {
 func (q *Queries) ListRecentlyResolvedCurtailedDevicesByScope(ctx context.Context, arg ListRecentlyResolvedCurtailedDevicesByScopeParams) ([]string, error) {
 	rows, err := q.query(ctx, q.listRecentlyResolvedCurtailedDevicesByScopeStmt, listRecentlyResolvedCurtailedDevicesByScope,
 		arg.OrgID,
+		arg.ExcludeEventID,
 		arg.CooldownSec,
 		pq.Array(arg.DeviceIdentifiers),
 		pq.Array(arg.SiteIds),

--- a/server/generated/sqlc/curtailment_response_profile.sql.go
+++ b/server/generated/sqlc/curtailment_response_profile.sql.go
@@ -402,7 +402,7 @@ FROM device
 WHERE org_id = $1
   AND device_identifier = ANY($2::text[])
   AND deleted_at IS NULL
-ORDER BY device_identifier
+ORDER BY id
 FOR UPDATE
 `
 

--- a/server/generated/sqlc/curtailment_response_profile.sql.go
+++ b/server/generated/sqlc/curtailment_response_profile.sql.go
@@ -403,7 +403,7 @@ WHERE org_id = $1
   AND device_identifier = ANY($2::text[])
   AND deleted_at IS NULL
 ORDER BY id
-FOR UPDATE
+FOR NO KEY UPDATE
 `
 
 type LockCurtailmentResponseProfileDeviceSitesByOrgParams struct {
@@ -416,6 +416,8 @@ type LockCurtailmentResponseProfileDeviceSitesByOrgRow struct {
 	SiteID           sql.NullInt64
 }
 
+// Topology and site writes still conflict with this lock, while command queue
+// inserts can take the foreign-key KEY SHARE lock without self-deadlocking.
 func (q *Queries) LockCurtailmentResponseProfileDeviceSitesByOrg(ctx context.Context, arg LockCurtailmentResponseProfileDeviceSitesByOrgParams) ([]LockCurtailmentResponseProfileDeviceSitesByOrgRow, error) {
 	rows, err := q.query(ctx, q.lockCurtailmentResponseProfileDeviceSitesByOrgStmt, lockCurtailmentResponseProfileDeviceSitesByOrg, arg.OrgID, pq.Array(arg.DeviceIdentifiers))
 	if err != nil {

--- a/server/generated/sqlc/db.go
+++ b/server/generated/sqlc/db.go
@@ -1032,6 +1032,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.listEarlierCurtailmentReservationDevicesStmt, err = db.PrepareContext(ctx, listEarlierCurtailmentReservationDevices); err != nil {
 		return nil, fmt.Errorf("error preparing query ListEarlierCurtailmentReservationDevices: %w", err)
 	}
+	if q.listEarlierCurtailmentTopologyReservationScopesStmt, err = db.PrepareContext(ctx, listEarlierCurtailmentTopologyReservationScopes); err != nil {
+		return nil, fmt.Errorf("error preparing query ListEarlierCurtailmentTopologyReservationScopes: %w", err)
+	}
 	if q.listEffectivePermissionsForUserStmt, err = db.PrepareContext(ctx, listEffectivePermissionsForUser); err != nil {
 		return nil, fmt.Errorf("error preparing query ListEffectivePermissionsForUser: %w", err)
 	}
@@ -3380,6 +3383,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing listEarlierCurtailmentReservationDevicesStmt: %w", cerr)
 		}
 	}
+	if q.listEarlierCurtailmentTopologyReservationScopesStmt != nil {
+		if cerr := q.listEarlierCurtailmentTopologyReservationScopesStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing listEarlierCurtailmentTopologyReservationScopesStmt: %w", cerr)
+		}
+	}
 	if q.listEffectivePermissionsForUserStmt != nil {
 		if cerr := q.listEffectivePermissionsForUserStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing listEffectivePermissionsForUserStmt: %w", cerr)
@@ -4860,6 +4868,7 @@ type Queries struct {
 	listDeviceSetMembersPaginatedFilteredStmt                    *sql.Stmt
 	listDeviceSetMembersPaginatedFilteredAfterStmt               *sql.Stmt
 	listEarlierCurtailmentReservationDevicesStmt                 *sql.Stmt
+	listEarlierCurtailmentTopologyReservationScopesStmt          *sql.Stmt
 	listEffectivePermissionsForUserStmt                          *sql.Stmt
 	listEffectivePermissionsForUserForUpdateStmt                 *sql.Stmt
 	listEligibleConfirmationTargetsStmt                          *sql.Stmt
@@ -5423,6 +5432,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		listDeviceSetMembersPaginatedFilteredStmt:                    q.listDeviceSetMembersPaginatedFilteredStmt,
 		listDeviceSetMembersPaginatedFilteredAfterStmt:               q.listDeviceSetMembersPaginatedFilteredAfterStmt,
 		listEarlierCurtailmentReservationDevicesStmt:                 q.listEarlierCurtailmentReservationDevicesStmt,
+		listEarlierCurtailmentTopologyReservationScopesStmt:          q.listEarlierCurtailmentTopologyReservationScopesStmt,
 		listEffectivePermissionsForUserStmt:                          q.listEffectivePermissionsForUserStmt,
 		listEffectivePermissionsForUserForUpdateStmt:                 q.listEffectivePermissionsForUserForUpdateStmt,
 		listEligibleConfirmationTargetsStmt:                          q.listEligibleConfirmationTargetsStmt,

--- a/server/generated/sqlc/db.go
+++ b/server/generated/sqlc/db.go
@@ -66,6 +66,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.beginCurtailmentRestorationStmt, err = db.PrepareContext(ctx, beginCurtailmentRestoration); err != nil {
 		return nil, fmt.Errorf("error preparing query BeginCurtailmentRestoration: %w", err)
 	}
+	if q.beginCurtailmentTopologyTargetRestoreStmt, err = db.PrepareContext(ctx, beginCurtailmentTopologyTargetRestore); err != nil {
+		return nil, fmt.Errorf("error preparing query BeginCurtailmentTopologyTargetRestore: %w", err)
+	}
 	if q.bindEnrollmentToFleetNodeStmt, err = db.PrepareContext(ctx, bindEnrollmentToFleetNode); err != nil {
 		return nil, fmt.Errorf("error preparing query BindEnrollmentToFleetNode: %w", err)
 	}
@@ -1026,6 +1029,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.listDeviceSetMembersPaginatedFilteredAfterStmt, err = db.PrepareContext(ctx, listDeviceSetMembersPaginatedFilteredAfter); err != nil {
 		return nil, fmt.Errorf("error preparing query ListDeviceSetMembersPaginatedFilteredAfter: %w", err)
 	}
+	if q.listEarlierCurtailmentReservationDevicesStmt, err = db.PrepareContext(ctx, listEarlierCurtailmentReservationDevices); err != nil {
+		return nil, fmt.Errorf("error preparing query ListEarlierCurtailmentReservationDevices: %w", err)
+	}
 	if q.listEffectivePermissionsForUserStmt, err = db.PrepareContext(ctx, listEffectivePermissionsForUser); err != nil {
 		return nil, fmt.Errorf("error preparing query ListEffectivePermissionsForUser: %w", err)
 	}
@@ -1161,6 +1167,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.lockCurtailmentEventForFanCommandStmt, err = db.PrepareContext(ctx, lockCurtailmentEventForFanCommand); err != nil {
 		return nil, fmt.Errorf("error preparing query LockCurtailmentEventForFanCommand: %w", err)
 	}
+	if q.lockCurtailmentEventScopeForWriteStmt, err = db.PrepareContext(ctx, lockCurtailmentEventScopeForWrite); err != nil {
+		return nil, fmt.Errorf("error preparing query LockCurtailmentEventScopeForWrite: %w", err)
+	}
 	if q.lockCurtailmentFanDeviceForWriteStmt, err = db.PrepareContext(ctx, lockCurtailmentFanDeviceForWrite); err != nil {
 		return nil, fmt.Errorf("error preparing query LockCurtailmentFanDeviceForWrite: %w", err)
 	}
@@ -1178,6 +1187,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	}
 	if q.lockCurtailmentScopeForWriteStmt, err = db.PrepareContext(ctx, lockCurtailmentScopeForWrite); err != nil {
 		return nil, fmt.Errorf("error preparing query LockCurtailmentScopeForWrite: %w", err)
+	}
+	if q.lockCurtailmentTargetPairingStatusesForWriteStmt, err = db.PrepareContext(ctx, lockCurtailmentTargetPairingStatusesForWrite); err != nil {
+		return nil, fmt.Errorf("error preparing query LockCurtailmentTargetPairingStatusesForWrite: %w", err)
 	}
 	if q.lockCurtailmentTopologyMemberDeviceSitesByOrgStmt, err = db.PrepareContext(ctx, lockCurtailmentTopologyMemberDeviceSitesByOrg); err != nil {
 		return nil, fmt.Errorf("error preparing query LockCurtailmentTopologyMemberDeviceSitesByOrg: %w", err)
@@ -1756,6 +1768,11 @@ func (q *Queries) Close() error {
 	if q.beginCurtailmentRestorationStmt != nil {
 		if cerr := q.beginCurtailmentRestorationStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing beginCurtailmentRestorationStmt: %w", cerr)
+		}
+	}
+	if q.beginCurtailmentTopologyTargetRestoreStmt != nil {
+		if cerr := q.beginCurtailmentTopologyTargetRestoreStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing beginCurtailmentTopologyTargetRestoreStmt: %w", cerr)
 		}
 	}
 	if q.bindEnrollmentToFleetNodeStmt != nil {
@@ -3358,6 +3375,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing listDeviceSetMembersPaginatedFilteredAfterStmt: %w", cerr)
 		}
 	}
+	if q.listEarlierCurtailmentReservationDevicesStmt != nil {
+		if cerr := q.listEarlierCurtailmentReservationDevicesStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing listEarlierCurtailmentReservationDevicesStmt: %w", cerr)
+		}
+	}
 	if q.listEffectivePermissionsForUserStmt != nil {
 		if cerr := q.listEffectivePermissionsForUserStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing listEffectivePermissionsForUserStmt: %w", cerr)
@@ -3583,6 +3605,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing lockCurtailmentEventForFanCommandStmt: %w", cerr)
 		}
 	}
+	if q.lockCurtailmentEventScopeForWriteStmt != nil {
+		if cerr := q.lockCurtailmentEventScopeForWriteStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing lockCurtailmentEventScopeForWriteStmt: %w", cerr)
+		}
+	}
 	if q.lockCurtailmentFanDeviceForWriteStmt != nil {
 		if cerr := q.lockCurtailmentFanDeviceForWriteStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing lockCurtailmentFanDeviceForWriteStmt: %w", cerr)
@@ -3611,6 +3638,11 @@ func (q *Queries) Close() error {
 	if q.lockCurtailmentScopeForWriteStmt != nil {
 		if cerr := q.lockCurtailmentScopeForWriteStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing lockCurtailmentScopeForWriteStmt: %w", cerr)
+		}
+	}
+	if q.lockCurtailmentTargetPairingStatusesForWriteStmt != nil {
+		if cerr := q.lockCurtailmentTargetPairingStatusesForWriteStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing lockCurtailmentTargetPairingStatusesForWriteStmt: %w", cerr)
 		}
 	}
 	if q.lockCurtailmentTopologyMemberDeviceSitesByOrgStmt != nil {
@@ -4506,6 +4538,7 @@ type Queries struct {
 	assignPermissionToRoleStmt                                   *sql.Stmt
 	assignRoleStmt                                               *sql.Stmt
 	beginCurtailmentRestorationStmt                              *sql.Stmt
+	beginCurtailmentTopologyTargetRestoreStmt                    *sql.Stmt
 	bindEnrollmentToFleetNodeStmt                                *sql.Stmt
 	buildingBelongsToOrgStmt                                     *sql.Stmt
 	buildingsByIDsStmt                                           *sql.Stmt
@@ -4826,6 +4859,7 @@ type Queries struct {
 	listDeviceSetMembersPaginatedAfterStmt                       *sql.Stmt
 	listDeviceSetMembersPaginatedFilteredStmt                    *sql.Stmt
 	listDeviceSetMembersPaginatedFilteredAfterStmt               *sql.Stmt
+	listEarlierCurtailmentReservationDevicesStmt                 *sql.Stmt
 	listEffectivePermissionsForUserStmt                          *sql.Stmt
 	listEffectivePermissionsForUserForUpdateStmt                 *sql.Stmt
 	listEligibleConfirmationTargetsStmt                          *sql.Stmt
@@ -4871,12 +4905,14 @@ type Queries struct {
 	lockCommandBatchStmt                                         *sql.Stmt
 	lockCurtailmentEventByUUIDForWriteStmt                       *sql.Stmt
 	lockCurtailmentEventForFanCommandStmt                        *sql.Stmt
+	lockCurtailmentEventScopeForWriteStmt                        *sql.Stmt
 	lockCurtailmentFanDeviceForWriteStmt                         *sql.Stmt
 	lockCurtailmentFanDevicesForWriteStmt                        *sql.Stmt
 	lockCurtailmentGroupsForWriteStmt                            *sql.Stmt
 	lockCurtailmentResponseProfileAutomationMutationStmt         *sql.Stmt
 	lockCurtailmentResponseProfileDeviceSitesByOrgStmt           *sql.Stmt
 	lockCurtailmentScopeForWriteStmt                             *sql.Stmt
+	lockCurtailmentTargetPairingStatusesForWriteStmt             *sql.Stmt
 	lockCurtailmentTopologyMemberDeviceSitesByOrgStmt            *sql.Stmt
 	lockDevicesForReassignStmt                                   *sql.Stmt
 	lockFleetNodeByIDStmt                                        *sql.Stmt
@@ -5065,6 +5101,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		assignPermissionToRoleStmt:                                   q.assignPermissionToRoleStmt,
 		assignRoleStmt:                                               q.assignRoleStmt,
 		beginCurtailmentRestorationStmt:                              q.beginCurtailmentRestorationStmt,
+		beginCurtailmentTopologyTargetRestoreStmt:                    q.beginCurtailmentTopologyTargetRestoreStmt,
 		bindEnrollmentToFleetNodeStmt:                                q.bindEnrollmentToFleetNodeStmt,
 		buildingBelongsToOrgStmt:                                     q.buildingBelongsToOrgStmt,
 		buildingsByIDsStmt:                                           q.buildingsByIDsStmt,
@@ -5385,6 +5422,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		listDeviceSetMembersPaginatedAfterStmt:                       q.listDeviceSetMembersPaginatedAfterStmt,
 		listDeviceSetMembersPaginatedFilteredStmt:                    q.listDeviceSetMembersPaginatedFilteredStmt,
 		listDeviceSetMembersPaginatedFilteredAfterStmt:               q.listDeviceSetMembersPaginatedFilteredAfterStmt,
+		listEarlierCurtailmentReservationDevicesStmt:                 q.listEarlierCurtailmentReservationDevicesStmt,
 		listEffectivePermissionsForUserStmt:                          q.listEffectivePermissionsForUserStmt,
 		listEffectivePermissionsForUserForUpdateStmt:                 q.listEffectivePermissionsForUserForUpdateStmt,
 		listEligibleConfirmationTargetsStmt:                          q.listEligibleConfirmationTargetsStmt,
@@ -5430,12 +5468,14 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		lockCommandBatchStmt:                                         q.lockCommandBatchStmt,
 		lockCurtailmentEventByUUIDForWriteStmt:                       q.lockCurtailmentEventByUUIDForWriteStmt,
 		lockCurtailmentEventForFanCommandStmt:                        q.lockCurtailmentEventForFanCommandStmt,
+		lockCurtailmentEventScopeForWriteStmt:                        q.lockCurtailmentEventScopeForWriteStmt,
 		lockCurtailmentFanDeviceForWriteStmt:                         q.lockCurtailmentFanDeviceForWriteStmt,
 		lockCurtailmentFanDevicesForWriteStmt:                        q.lockCurtailmentFanDevicesForWriteStmt,
 		lockCurtailmentGroupsForWriteStmt:                            q.lockCurtailmentGroupsForWriteStmt,
 		lockCurtailmentResponseProfileAutomationMutationStmt:         q.lockCurtailmentResponseProfileAutomationMutationStmt,
 		lockCurtailmentResponseProfileDeviceSitesByOrgStmt:           q.lockCurtailmentResponseProfileDeviceSitesByOrgStmt,
 		lockCurtailmentScopeForWriteStmt:                             q.lockCurtailmentScopeForWriteStmt,
+		lockCurtailmentTargetPairingStatusesForWriteStmt:             q.lockCurtailmentTargetPairingStatusesForWriteStmt,
 		lockCurtailmentTopologyMemberDeviceSitesByOrgStmt:            q.lockCurtailmentTopologyMemberDeviceSitesByOrgStmt,
 		lockDevicesForReassignStmt:                                   q.lockDevicesForReassignStmt,
 		lockFleetNodeByIDStmt:                                        q.lockFleetNodeByIDStmt,

--- a/server/generated/sqlc/db.go
+++ b/server/generated/sqlc/db.go
@@ -1164,6 +1164,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.lockCommandBatchStmt, err = db.PrepareContext(ctx, lockCommandBatch); err != nil {
 		return nil, fmt.Errorf("error preparing query LockCommandBatch: %w", err)
 	}
+	if q.lockCurtailmentAdmissionEventForWriteStmt, err = db.PrepareContext(ctx, lockCurtailmentAdmissionEventForWrite); err != nil {
+		return nil, fmt.Errorf("error preparing query LockCurtailmentAdmissionEventForWrite: %w", err)
+	}
 	if q.lockCurtailmentEventByUUIDForWriteStmt, err = db.PrepareContext(ctx, lockCurtailmentEventByUUIDForWrite); err != nil {
 		return nil, fmt.Errorf("error preparing query LockCurtailmentEventByUUIDForWrite: %w", err)
 	}
@@ -3603,6 +3606,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing lockCommandBatchStmt: %w", cerr)
 		}
 	}
+	if q.lockCurtailmentAdmissionEventForWriteStmt != nil {
+		if cerr := q.lockCurtailmentAdmissionEventForWriteStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing lockCurtailmentAdmissionEventForWriteStmt: %w", cerr)
+		}
+	}
 	if q.lockCurtailmentEventByUUIDForWriteStmt != nil {
 		if cerr := q.lockCurtailmentEventByUUIDForWriteStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing lockCurtailmentEventByUUIDForWriteStmt: %w", cerr)
@@ -4912,6 +4920,7 @@ type Queries struct {
 	lockBuildingForWriteStmt                                     *sql.Stmt
 	lockBuildingsBySiteForWriteStmt                              *sql.Stmt
 	lockCommandBatchStmt                                         *sql.Stmt
+	lockCurtailmentAdmissionEventForWriteStmt                    *sql.Stmt
 	lockCurtailmentEventByUUIDForWriteStmt                       *sql.Stmt
 	lockCurtailmentEventForFanCommandStmt                        *sql.Stmt
 	lockCurtailmentEventScopeForWriteStmt                        *sql.Stmt
@@ -5476,6 +5485,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		lockBuildingForWriteStmt:                                     q.lockBuildingForWriteStmt,
 		lockBuildingsBySiteForWriteStmt:                              q.lockBuildingsBySiteForWriteStmt,
 		lockCommandBatchStmt:                                         q.lockCommandBatchStmt,
+		lockCurtailmentAdmissionEventForWriteStmt:                    q.lockCurtailmentAdmissionEventForWriteStmt,
 		lockCurtailmentEventByUUIDForWriteStmt:                       q.lockCurtailmentEventByUUIDForWriteStmt,
 		lockCurtailmentEventForFanCommandStmt:                        q.lockCurtailmentEventForFanCommandStmt,
 		lockCurtailmentEventScopeForWriteStmt:                        q.lockCurtailmentEventScopeForWriteStmt,

--- a/server/generated/sqlc/db.go
+++ b/server/generated/sqlc/db.go
@@ -1014,6 +1014,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.listCurtailmentTargetsByEventPageStmt, err = db.PrepareContext(ctx, listCurtailmentTargetsByEventPage); err != nil {
 		return nil, fmt.Errorf("error preparing query ListCurtailmentTargetsByEventPage: %w", err)
 	}
+	if q.listCurtailmentTopologyMemberDeviceIdentifiersByOrgStmt, err = db.PrepareContext(ctx, listCurtailmentTopologyMemberDeviceIdentifiersByOrg); err != nil {
+		return nil, fmt.Errorf("error preparing query ListCurtailmentTopologyMemberDeviceIdentifiersByOrg: %w", err)
+	}
 	if q.listCustomRolesForOrgStmt, err = db.PrepareContext(ctx, listCustomRolesForOrg); err != nil {
 		return nil, fmt.Errorf("error preparing query ListCustomRolesForOrg: %w", err)
 	}
@@ -3356,6 +3359,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing listCurtailmentTargetsByEventPageStmt: %w", cerr)
 		}
 	}
+	if q.listCurtailmentTopologyMemberDeviceIdentifiersByOrgStmt != nil {
+		if cerr := q.listCurtailmentTopologyMemberDeviceIdentifiersByOrgStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing listCurtailmentTopologyMemberDeviceIdentifiersByOrgStmt: %w", cerr)
+		}
+	}
 	if q.listCustomRolesForOrgStmt != nil {
 		if cerr := q.listCustomRolesForOrgStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing listCustomRolesForOrgStmt: %w", cerr)
@@ -4870,6 +4878,7 @@ type Queries struct {
 	listCurtailmentTargetSiteCoverageByEventsStmt                *sql.Stmt
 	listCurtailmentTargetsByEventStmt                            *sql.Stmt
 	listCurtailmentTargetsByEventPageStmt                        *sql.Stmt
+	listCurtailmentTopologyMemberDeviceIdentifiersByOrgStmt      *sql.Stmt
 	listCustomRolesForOrgStmt                                    *sql.Stmt
 	listDeviceSetMembersPaginatedStmt                            *sql.Stmt
 	listDeviceSetMembersPaginatedAfterStmt                       *sql.Stmt
@@ -5435,6 +5444,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		listCurtailmentTargetSiteCoverageByEventsStmt:                q.listCurtailmentTargetSiteCoverageByEventsStmt,
 		listCurtailmentTargetsByEventStmt:                            q.listCurtailmentTargetsByEventStmt,
 		listCurtailmentTargetsByEventPageStmt:                        q.listCurtailmentTargetsByEventPageStmt,
+		listCurtailmentTopologyMemberDeviceIdentifiersByOrgStmt:      q.listCurtailmentTopologyMemberDeviceIdentifiersByOrgStmt,
 		listCustomRolesForOrgStmt:                                    q.listCustomRolesForOrgStmt,
 		listDeviceSetMembersPaginatedStmt:                            q.listDeviceSetMembersPaginatedStmt,
 		listDeviceSetMembersPaginatedAfterStmt:                       q.listDeviceSetMembersPaginatedAfterStmt,

--- a/server/generated/sqlc/device.sql.go
+++ b/server/generated/sqlc/device.sql.go
@@ -2118,15 +2118,21 @@ func (q *Queries) ReconcileDefaultPasswordPairingStatusByIdentifier(ctx context.
 }
 
 const setDevicePairingAuthNeededIfNotPaired = `-- name: SetDevicePairingAuthNeededIfNotPaired :execrows
+WITH locked_device AS MATERIALIZED (
+    SELECT device.id
+    FROM device
+    WHERE device.id = $1
+    FOR UPDATE
+)
 INSERT INTO device_pairing (
     device_id,
     pairing_status,
     paired_at
-) VALUES (
-    $1,
+) SELECT
+    locked_device.id,
     'AUTHENTICATION_NEEDED'::pairing_status_enum,
     CURRENT_TIMESTAMP
-)
+FROM locked_device
 ON CONFLICT (device_id) DO UPDATE SET
     pairing_status = 'AUTHENTICATION_NEEDED'::pairing_status_enum,
     paired_at = CURRENT_TIMESTAMP,
@@ -2339,15 +2345,21 @@ func (q *Queries) UpdateDeviceWorkerNamePoolSyncStatusByID(ctx context.Context, 
 }
 
 const upsertDevicePairing = `-- name: UpsertDevicePairing :execresult
+WITH locked_device AS MATERIALIZED (
+    SELECT device.id
+    FROM device
+    WHERE device.id = $2
+    FOR UPDATE
+)
 INSERT INTO device_pairing (
     device_id,
     pairing_status,
     paired_at
-) VALUES (
+) SELECT
+    locked_device.id,
     $1,
-    $2,
     CURRENT_TIMESTAMP
-)
+FROM locked_device
 ON CONFLICT (device_id) DO UPDATE SET
     pairing_status = EXCLUDED.pairing_status,
     paired_at = CURRENT_TIMESTAMP,
@@ -2355,12 +2367,12 @@ ON CONFLICT (device_id) DO UPDATE SET
 `
 
 type UpsertDevicePairingParams struct {
-	DeviceID      int64
 	PairingStatus PairingStatusEnum
+	DeviceID      int64
 }
 
 func (q *Queries) UpsertDevicePairing(ctx context.Context, arg UpsertDevicePairingParams) (sql.Result, error) {
-	return q.exec(ctx, q.upsertDevicePairingStmt, upsertDevicePairing, arg.DeviceID, arg.PairingStatus)
+	return q.exec(ctx, q.upsertDevicePairingStmt, upsertDevicePairing, arg.PairingStatus, arg.DeviceID)
 }
 
 const upsertDeviceStatus = `-- name: UpsertDeviceStatus :exec

--- a/server/generated/sqlc/device_set.sql.go
+++ b/server/generated/sqlc/device_set.sql.go
@@ -29,6 +29,7 @@ CROSS JOIN locked_device_set ds
 WHERE d.device_identifier = ANY($3::text[])
   AND d.org_id = $1
   AND d.deleted_at IS NULL
+ORDER BY d.id
 ON CONFLICT (device_set_id, device_id) DO NOTHING
 RETURNING device_identifier
 `

--- a/server/generated/sqlc/querier.go
+++ b/server/generated/sqlc/querier.go
@@ -78,6 +78,10 @@ type Querier interface {
 	// concurrency control; the loser sees zero rows and the store re-reads
 	// to distinguish "already restoring" from "already terminal."
 	BeginCurtailmentRestoration(ctx context.Context, id int64) (CurtailmentEvent, error)
+	// A topology watcher remains active while departed targets restore. Targets
+	// with no possible Curtail attempt release immediately; every other target
+	// enters the normal restore queue conservatively.
+	BeginCurtailmentTopologyTargetRestore(ctx context.Context, arg BeginCurtailmentTopologyTargetRestoreParams) (int64, error)
 	BindEnrollmentToFleetNode(ctx context.Context, arg BindEnrollmentToFleetNodeParams) (int64, error)
 	BuildingBelongsToOrg(ctx context.Context, arg BuildingBelongsToOrgParams) (bool, error)
 	// Returns the subset of requested IDs that correspond to live
@@ -100,13 +104,15 @@ type Querier interface {
 	BulkInsertNotificationHistory(ctx context.Context, rowsJsonb json.RawMessage) (int64, error)
 	// Per-tick readiness refresh for all-paired policy rows, batched into one
 	// statement so a mass readiness flip (fleet-wide recovery or outage) does not
-	// issue one UPDATE round trip per device inside the shared tick budget.
+	// issue one UPDATE round trip per device inside the shared tick budget. The
+	// same transition parks topology restore obligations while uncommandable and
+	// requeues them after commandability returns.
 	//
 	// Guards mirror UpdateCurtailmentTargetState for this transition class:
 	// the parent event is locked and must still be in the caller's expected
-	// state, and each row must still be a refreshable policy row
-	// (desired_state='curtailed', state pending/unavailable). Rows that advanced
-	// concurrently (dispatch claim, Stop reset, release) are skipped; the next
+	// state, and each row must still be a refreshable policy row: pending or
+	// unavailable for curtail, plus restore_failed for topology restore parking.
+	// Rows that advanced concurrently (dispatch claim, Stop reset, release) are skipped; the next
 	// tick re-reads them. RETURNING reports exactly which rows applied so the
 	// reconciler mirrors only those — a skipped row must not be treated as
 	// promoted and dispatched against stale state. Empty last_error is the
@@ -177,14 +183,15 @@ type Querier interface {
 	CascadeRackDeviceSitesBulk(ctx context.Context, arg CascadeRackDeviceSitesBulkParams) (int64, error)
 	// Durable all-paired FULL_FLEET admission. Inserts targets in their computed
 	// policy state (pending or unavailable) instead of immediately claiming them
-	// as DISPATCHING. Same-event RELEASED rows may be reopened during a recurtail;
-	// other same-event rows and cross-event conflicts are no-ops.
+	// as DISPATCHING. Same-event RELEASED, topology-restored RESOLVED, or failed
+	// restore rows may be reopened; other same-event rows and cross-event
+	// conflicts are no-ops.
 	ClaimAllPairedPolicyTargets(ctx context.Context, arg ClaimAllPairedPolicyTargetsParams) (int64, error)
 	// Closed-loop FULL_FLEET dispatch claim. Locks the parent event so
 	// Stop/AdminTerminate and dynamic target claims serialize on lifecycle state.
 	// Same-event duplicates and cross-event target conflicts are no-ops; the
 	// reconciler retries on a later tick if a conflicting event resolves.
-	ClaimClosedLoopFullFleetTargets(ctx context.Context, arg ClaimClosedLoopFullFleetTargetsParams) ([]CurtailmentTarget, error)
+	ClaimClosedLoopFullFleetTargets(ctx context.Context, arg ClaimClosedLoopFullFleetTargetsParams) ([]ClaimClosedLoopFullFleetTargetsRow, error)
 	ClaimMessageForProcessing(ctx context.Context, id int64) (sql.Result, error)
 	ClaimRigConfigReconciliation(ctx context.Context) (CurtailmentRigConfigReconciliation, error)
 	ClassifyFleetRuntimeLeaseAcquisition(ctx context.Context, arg ClassifyFleetRuntimeLeaseAcquisitionParams) (string, error)
@@ -254,9 +261,9 @@ type Querier interface {
 	CountCurtailmentAutomationRulesByMQTTSource(ctx context.Context, arg CountCurtailmentAutomationRulesByMQTTSourceParams) (int64, error)
 	CountCurtailmentAutomationRulesByResponseProfile(ctx context.Context, arg CountCurtailmentAutomationRulesByResponseProfileParams) (int64, error)
 	CountCurtailmentResponseProfilesBySite(ctx context.Context, arg CountCurtailmentResponseProfilesBySiteParams) (int64, error)
-	// Hierarchy for currently supported closed-loop scopes: org > site.
-	// A new whole-org event conflicts with existing whole-org, site, or site-only mixed events.
-	// A new site or site-only mixed event conflicts with existing whole-org or overlapping site ownership.
+	// Serializes logical FULL_FLEET scope ownership. Whole-org conflicts with every
+	// hierarchy watcher; site selectors conflict on overlap; topology selectors
+	// conflict with whole-org and overlapping IDs of the same terminal type.
 	CountCurtailmentScopeConflicts(ctx context.Context, arg CountCurtailmentScopeConflictsParams) (int64, error)
 	// Counts distinct devices that have errors matching filter criteria.
 	CountDevicesWithErrors(ctx context.Context, arg CountDevicesWithErrorsParams) (int64, error)
@@ -956,6 +963,10 @@ type Querier interface {
 	ListDeviceSetMembersPaginatedAfter(ctx context.Context, arg ListDeviceSetMembersPaginatedAfterParams) ([]ListDeviceSetMembersPaginatedAfterRow, error)
 	ListDeviceSetMembersPaginatedFiltered(ctx context.Context, arg ListDeviceSetMembersPaginatedFilteredParams) ([]ListDeviceSetMembersPaginatedFilteredRow, error)
 	ListDeviceSetMembersPaginatedFilteredAfter(ctx context.Context, arg ListDeviceSetMembersPaginatedFilteredAfterParams) ([]ListDeviceSetMembersPaginatedFilteredAfterRow, error)
+	// Returns requested devices owned by an older concrete target or logical
+	// closed-loop scope. Admission holds the org scope lock while reading this
+	// list and claiming targets, so persisted event order decides ownership.
+	ListEarlierCurtailmentReservationDevices(ctx context.Context, arg ListEarlierCurtailmentReservationDevicesParams) ([]string, error)
 	// Single-query resolver source: one row per (assignment, permission)
 	// pair the user holds within an organization, with a NULL permission
 	// column when the assignment's role has no permissions attached.
@@ -1175,6 +1186,9 @@ type Querier interface {
 	// terminal UPDATE behind an in-flight command and rejects stale commands that
 	// begin after the transition.
 	LockCurtailmentEventForFanCommand(ctx context.Context, arg LockCurtailmentEventForFanCommandParams) (int64, error)
+	// Admission already has the event ID; derive its organization before taking
+	// the same lock used by Start conflict detection.
+	LockCurtailmentEventScopeForWrite(ctx context.Context, curtailmentEventID int64) error
 	// Per-device transaction lock closes concurrent Start races before the array
 	// overlap check. Callers acquire these in ascending ID order.
 	LockCurtailmentFanDeviceForWrite(ctx context.Context, infrastructureDeviceID string) error
@@ -1194,6 +1208,12 @@ type Querier interface {
 	// Serialize hierarchy start checks by org so conflict detection and event
 	// insertion happen under one database-backed critical section.
 	LockCurtailmentScopeForWrite(ctx context.Context, orgID string) error
+	// Pairing status participates in all-paired topology membership. Lock these
+	// device rows first, including devices that do not have a pairing row yet,
+	// then any existing pairing rows. Pairing inserts take the same device lock,
+	// so the later candidate read cannot classify a first-time pairing from a
+	// stale pre-insert snapshot.
+	LockCurtailmentTargetPairingStatusesForWrite(ctx context.Context, arg LockCurtailmentTargetPairingStatusesForWriteParams) ([]LockCurtailmentTargetPairingStatusesForWriteRow, error)
 	// Stabilizes the current member rows while an authorization envelope and its
 	// event targets/profile row are persisted. The query mirrors the executable
 	// topology selector predicates and locks in device.id order, matching the

--- a/server/generated/sqlc/querier.go
+++ b/server/generated/sqlc/querier.go
@@ -954,6 +954,11 @@ type Querier interface {
 	ListCurtailmentTargetsByEvent(ctx context.Context, arg ListCurtailmentTargetsByEventParams) ([]CurtailmentTarget, error)
 	// Org-scoped, cursor-paginated target detail for large activity expansion.
 	ListCurtailmentTargetsByEventPage(ctx context.Context, arg ListCurtailmentTargetsByEventPageParams) ([]CurtailmentTarget, error)
+	// Restore reads the live member IDs after locking the selector resources, then
+	// locks these IDs together with departed restore candidates in one canonical
+	// device order. Keeping this read non-locking avoids taking current-member rows
+	// before lower-ID departed rows and deadlocking with bulk placement writes.
+	ListCurtailmentTopologyMemberDeviceIdentifiersByOrg(ctx context.Context, arg ListCurtailmentTopologyMemberDeviceIdentifiersByOrgParams) ([]string, error)
 	// Per-org custom roles. The role-list handler calls this with the
 	// caller's organization_id; the query never returns rows from other
 	// orgs, so an admin in org A cannot see or assign org B's custom

--- a/server/generated/sqlc/querier.go
+++ b/server/generated/sqlc/querier.go
@@ -1217,6 +1217,8 @@ type Querier interface {
 	// re-read their compatibility conditions after acquiring this lock so a
 	// concurrent pair cannot commit an invalid automation binding.
 	LockCurtailmentResponseProfileAutomationMutation(ctx context.Context, arg LockCurtailmentResponseProfileAutomationMutationParams) error
+	// Topology and site writes still conflict with this lock, while command queue
+	// inserts can take the foreign-key KEY SHARE lock without self-deadlocking.
 	LockCurtailmentResponseProfileDeviceSitesByOrg(ctx context.Context, arg LockCurtailmentResponseProfileDeviceSitesByOrgParams) ([]LockCurtailmentResponseProfileDeviceSitesByOrgRow, error)
 	// Serialize hierarchy start checks by org so conflict detection and event
 	// insertion happen under one database-backed critical section.

--- a/server/generated/sqlc/querier.go
+++ b/server/generated/sqlc/querier.go
@@ -967,6 +967,11 @@ type Querier interface {
 	// closed-loop scope. Admission holds the org scope lock while reading this
 	// list and claiming targets, so persisted event order decides ownership.
 	ListEarlierCurtailmentReservationDevices(ctx context.Context, arg ListEarlierCurtailmentReservationDevicesParams) ([]string, error)
+	// Returns topology selector envelopes for older logical reservations. Dynamic
+	// admission locks these resources before locking candidate devices and
+	// re-reading ListEarlierCurtailmentReservationDevices, so membership changes
+	// cannot commit between reservation classification and target claim.
+	ListEarlierCurtailmentTopologyReservationScopes(ctx context.Context, arg ListEarlierCurtailmentTopologyReservationScopesParams) ([]json.RawMessage, error)
 	// Single-query resolver source: one row per (assignment, permission)
 	// pair the user holds within an organization, with a NULL permission
 	// column when the assignment's role has no permissions attached.

--- a/server/generated/sqlc/querier.go
+++ b/server/generated/sqlc/querier.go
@@ -1185,6 +1185,9 @@ type Querier interface {
 	// is what matters).
 	LockBuildingsBySiteForWrite(ctx context.Context, arg LockBuildingsBySiteForWriteParams) ([]int64, error)
 	LockCommandBatch(ctx context.Context, uuid string) (BatchStatusEnum, error)
+	// Keep the current event and its immutable selector in the same transaction
+	// as dynamic membership fencing and target admission.
+	LockCurtailmentAdmissionEventForWrite(ctx context.Context, curtailmentEventID int64) (LockCurtailmentAdmissionEventForWriteRow, error)
 	LockCurtailmentEventByUUIDForWrite(ctx context.Context, arg LockCurtailmentEventByUUIDForWriteParams) (CurtailmentEvent, error)
 	// Physical fan commands run only while this exact lifecycle phase remains
 	// current. Holding the row lock through the command serializes Force Release's

--- a/server/generated/sqlc/retrying_querier.gen.go
+++ b/server/generated/sqlc/retrying_querier.gen.go
@@ -3810,6 +3810,18 @@ func (q *retryingQuerier) ListCurtailmentTargetsByEventPage(ctx context.Context,
 	return result, err
 }
 
+func (q *retryingQuerier) ListCurtailmentTopologyMemberDeviceIdentifiersByOrg(ctx context.Context, arg ListCurtailmentTopologyMemberDeviceIdentifiersByOrgParams) ([]string, error) {
+	var result []string
+	err := q.retrier.RetryQuery(ctx, "ListCurtailmentTopologyMemberDeviceIdentifiersByOrg", func() error {
+		callResult, callErr := q.next.ListCurtailmentTopologyMemberDeviceIdentifiersByOrg(ctx, arg)
+		if callErr == nil {
+			result = callResult
+		}
+		return callErr
+	})
+	return result, err
+}
+
 func (q *retryingQuerier) ListCustomRolesForOrg(ctx context.Context, organizationID sql.NullInt64) ([]Role, error) {
 	var result []Role
 	err := q.retrier.RetryQuery(ctx, "ListCustomRolesForOrg", func() error {

--- a/server/generated/sqlc/retrying_querier.gen.go
+++ b/server/generated/sqlc/retrying_querier.gen.go
@@ -4404,6 +4404,18 @@ func (q *retryingQuerier) LockCommandBatch(ctx context.Context, uuid string) (Ba
 	return result, err
 }
 
+func (q *retryingQuerier) LockCurtailmentAdmissionEventForWrite(ctx context.Context, curtailmentEventID int64) (LockCurtailmentAdmissionEventForWriteRow, error) {
+	var result LockCurtailmentAdmissionEventForWriteRow
+	err := q.retrier.RetryQuery(ctx, "LockCurtailmentAdmissionEventForWrite", func() error {
+		callResult, callErr := q.next.LockCurtailmentAdmissionEventForWrite(ctx, curtailmentEventID)
+		if callErr == nil {
+			result = callResult
+		}
+		return callErr
+	})
+	return result, err
+}
+
 func (q *retryingQuerier) LockCurtailmentEventByUUIDForWrite(ctx context.Context, arg LockCurtailmentEventByUUIDForWriteParams) (CurtailmentEvent, error) {
 	var result CurtailmentEvent
 	err := q.retrier.RetryQuery(ctx, "LockCurtailmentEventByUUIDForWrite", func() error {

--- a/server/generated/sqlc/retrying_querier.gen.go
+++ b/server/generated/sqlc/retrying_querier.gen.go
@@ -174,6 +174,18 @@ func (q *retryingQuerier) BeginCurtailmentRestoration(ctx context.Context, id in
 	return result, err
 }
 
+func (q *retryingQuerier) BeginCurtailmentTopologyTargetRestore(ctx context.Context, arg BeginCurtailmentTopologyTargetRestoreParams) (int64, error) {
+	var result int64
+	err := q.retrier.RetryQuery(ctx, "BeginCurtailmentTopologyTargetRestore", func() error {
+		callResult, callErr := q.next.BeginCurtailmentTopologyTargetRestore(ctx, arg)
+		if callErr == nil {
+			result = callResult
+		}
+		return callErr
+	})
+	return result, err
+}
+
 func (q *retryingQuerier) BindEnrollmentToFleetNode(ctx context.Context, arg BindEnrollmentToFleetNodeParams) (int64, error) {
 	var result int64
 	err := q.retrier.RetryQuery(ctx, "BindEnrollmentToFleetNode", func() error {
@@ -402,8 +414,8 @@ func (q *retryingQuerier) ClaimAllPairedPolicyTargets(ctx context.Context, arg C
 	return result, err
 }
 
-func (q *retryingQuerier) ClaimClosedLoopFullFleetTargets(ctx context.Context, arg ClaimClosedLoopFullFleetTargetsParams) ([]CurtailmentTarget, error) {
-	var result []CurtailmentTarget
+func (q *retryingQuerier) ClaimClosedLoopFullFleetTargets(ctx context.Context, arg ClaimClosedLoopFullFleetTargetsParams) ([]ClaimClosedLoopFullFleetTargetsRow, error) {
+	var result []ClaimClosedLoopFullFleetTargetsRow
 	err := q.retrier.RetryQuery(ctx, "ClaimClosedLoopFullFleetTargets", func() error {
 		callResult, callErr := q.next.ClaimClosedLoopFullFleetTargets(ctx, arg)
 		if callErr == nil {
@@ -3858,6 +3870,18 @@ func (q *retryingQuerier) ListDeviceSetMembersPaginatedFilteredAfter(ctx context
 	return result, err
 }
 
+func (q *retryingQuerier) ListEarlierCurtailmentReservationDevices(ctx context.Context, arg ListEarlierCurtailmentReservationDevicesParams) ([]string, error) {
+	var result []string
+	err := q.retrier.RetryQuery(ctx, "ListEarlierCurtailmentReservationDevices", func() error {
+		callResult, callErr := q.next.ListEarlierCurtailmentReservationDevices(ctx, arg)
+		if callErr == nil {
+			result = callResult
+		}
+		return callErr
+	})
+	return result, err
+}
+
 func (q *retryingQuerier) ListEffectivePermissionsForUser(ctx context.Context, arg ListEffectivePermissionsForUserParams) ([]ListEffectivePermissionsForUserRow, error) {
 	var result []ListEffectivePermissionsForUserRow
 	err := q.retrier.RetryQuery(ctx, "ListEffectivePermissionsForUser", func() error {
@@ -4392,6 +4416,12 @@ func (q *retryingQuerier) LockCurtailmentEventForFanCommand(ctx context.Context,
 	return result, err
 }
 
+func (q *retryingQuerier) LockCurtailmentEventScopeForWrite(ctx context.Context, curtailmentEventID int64) error {
+	return q.retrier.RetryQuery(ctx, "LockCurtailmentEventScopeForWrite", func() error {
+		return q.next.LockCurtailmentEventScopeForWrite(ctx, curtailmentEventID)
+	})
+}
+
 func (q *retryingQuerier) LockCurtailmentFanDeviceForWrite(ctx context.Context, infrastructureDeviceID string) error {
 	return q.retrier.RetryQuery(ctx, "LockCurtailmentFanDeviceForWrite", func() error {
 		return q.next.LockCurtailmentFanDeviceForWrite(ctx, infrastructureDeviceID)
@@ -4444,6 +4474,18 @@ func (q *retryingQuerier) LockCurtailmentScopeForWrite(ctx context.Context, orgI
 	return q.retrier.RetryQuery(ctx, "LockCurtailmentScopeForWrite", func() error {
 		return q.next.LockCurtailmentScopeForWrite(ctx, orgID)
 	})
+}
+
+func (q *retryingQuerier) LockCurtailmentTargetPairingStatusesForWrite(ctx context.Context, arg LockCurtailmentTargetPairingStatusesForWriteParams) ([]LockCurtailmentTargetPairingStatusesForWriteRow, error) {
+	var result []LockCurtailmentTargetPairingStatusesForWriteRow
+	err := q.retrier.RetryQuery(ctx, "LockCurtailmentTargetPairingStatusesForWrite", func() error {
+		callResult, callErr := q.next.LockCurtailmentTargetPairingStatusesForWrite(ctx, arg)
+		if callErr == nil {
+			result = callResult
+		}
+		return callErr
+	})
+	return result, err
 }
 
 func (q *retryingQuerier) LockCurtailmentTopologyMemberDeviceSitesByOrg(ctx context.Context, arg LockCurtailmentTopologyMemberDeviceSitesByOrgParams) ([]LockCurtailmentTopologyMemberDeviceSitesByOrgRow, error) {

--- a/server/generated/sqlc/retrying_querier.gen.go
+++ b/server/generated/sqlc/retrying_querier.gen.go
@@ -3882,6 +3882,18 @@ func (q *retryingQuerier) ListEarlierCurtailmentReservationDevices(ctx context.C
 	return result, err
 }
 
+func (q *retryingQuerier) ListEarlierCurtailmentTopologyReservationScopes(ctx context.Context, arg ListEarlierCurtailmentTopologyReservationScopesParams) ([]json.RawMessage, error) {
+	var result []json.RawMessage
+	err := q.retrier.RetryQuery(ctx, "ListEarlierCurtailmentTopologyReservationScopes", func() error {
+		callResult, callErr := q.next.ListEarlierCurtailmentTopologyReservationScopes(ctx, arg)
+		if callErr == nil {
+			result = callResult
+		}
+		return callErr
+	})
+	return result, err
+}
+
 func (q *retryingQuerier) ListEffectivePermissionsForUser(ctx context.Context, arg ListEffectivePermissionsForUserParams) ([]ListEffectivePermissionsForUserRow, error) {
 	var result []ListEffectivePermissionsForUserRow
 	err := q.retrier.RetryQuery(ctx, "ListEffectivePermissionsForUser", func() error {

--- a/server/generated/sqlc/site.sql.go
+++ b/server/generated/sqlc/site.sql.go
@@ -824,6 +824,7 @@ SELECT id FROM device
 WHERE org_id = $1
   AND device_identifier = ANY($2::text[])
   AND deleted_at IS NULL
+ORDER BY id
 FOR UPDATE
 `
 

--- a/server/internal/domain/curtailment/reconciler/dispatch_authorization.go
+++ b/server/internal/domain/curtailment/reconciler/dispatch_authorization.go
@@ -195,20 +195,31 @@ func (r *Reconciler) fenceTopologyRestoreDispatch(
 		ctx,
 		ev,
 		deviceIdentifiers,
-		func(fenced interfaces.CurtailmentTopologyDispatchFenceSnapshot) error {
+		func(fenced interfaces.CurtailmentTopologyRestoreDispatchFenceSnapshot) error {
 			fenceReached = true
+			if fenced.Event.State == models.EventStateRestoring {
+				commandTargets = targets
+				command(commandTargets)
+				return nil
+			}
 			currentMembers := make(map[string]struct{}, len(fenced.Topology.DispatchMemberDeviceIdentifiers))
 			for _, deviceIdentifier := range fenced.Topology.DispatchMemberDeviceIdentifiers {
 				currentMembers[deviceIdentifier] = struct{}{}
 			}
 			commandTargets = make([]*models.Target, 0, len(targets))
+			returnedDeviceIdentifiers := make([]string, 0, len(targets))
 			for _, target := range targets {
 				if target == nil {
 					continue
 				}
-				if _, returned := currentMembers[target.DeviceIdentifier]; !returned {
-					commandTargets = append(commandTargets, target)
+				if _, returned := currentMembers[target.DeviceIdentifier]; returned {
+					returnedDeviceIdentifiers = append(returnedDeviceIdentifiers, target.DeviceIdentifier)
+					continue
 				}
+				commandTargets = append(commandTargets, target)
+			}
+			if err := fenced.ParkReturnedTargets(returnedDeviceIdentifiers); err != nil {
+				return err
 			}
 			if len(commandTargets) > 0 {
 				command(commandTargets)

--- a/server/internal/domain/curtailment/reconciler/dispatch_authorization.go
+++ b/server/internal/domain/curtailment/reconciler/dispatch_authorization.go
@@ -8,6 +8,7 @@ import (
 	"github.com/block/proto-fleet/server/internal/domain/authz"
 	"github.com/block/proto-fleet/server/internal/domain/curtailment"
 	"github.com/block/proto-fleet/server/internal/domain/curtailment/models"
+	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 	"github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
 )
 
@@ -159,6 +160,63 @@ func (r *Reconciler) authorizeTopologyCurtailDispatch(
 		}, err)
 	}
 	return true, true
+}
+
+func (r *Reconciler) fenceTopologyRestoreDispatch(
+	ctx context.Context,
+	ev *models.Event,
+	targets []*models.Target,
+	command func([]*models.Target),
+) (handled bool, fenceReached bool, commandTargets []*models.Target, err error) {
+	if ev.ScopeType != models.ScopeTypeMixed {
+		return false, false, targets, nil
+	}
+	scope, hasScope, err := curtailment.ScopeFromJSON(ev.ScopeJSON)
+	if err != nil {
+		return true, false, nil, fleeterror.NewInternalErrorf("parse persisted mixed restore scope: %v", err)
+	}
+	if !hasScope {
+		return true, false, nil, fleeterror.NewInternalError("persisted mixed restore scope is missing")
+	}
+	if !curtailment.IsTopologyScope(scope) {
+		return false, false, targets, nil
+	}
+	fenceStore, ok := r.store.(interfaces.CurtailmentTopologyRestoreDispatchFenceStore)
+	if !ok {
+		return true, false, nil, fleeterror.NewInternalError("topology restore dispatch fence is not configured")
+	}
+	deviceIdentifiers := make([]string, 0, len(targets))
+	for _, target := range targets {
+		if target != nil {
+			deviceIdentifiers = append(deviceIdentifiers, target.DeviceIdentifier)
+		}
+	}
+	err = fenceStore.WithCurtailmentTopologyRestoreDispatchFence(
+		ctx,
+		ev,
+		deviceIdentifiers,
+		func(fenced interfaces.CurtailmentTopologyDispatchFenceSnapshot) error {
+			fenceReached = true
+			currentMembers := make(map[string]struct{}, len(fenced.Topology.DispatchMemberDeviceIdentifiers))
+			for _, deviceIdentifier := range fenced.Topology.DispatchMemberDeviceIdentifiers {
+				currentMembers[deviceIdentifier] = struct{}{}
+			}
+			commandTargets = make([]*models.Target, 0, len(targets))
+			for _, target := range targets {
+				if target == nil {
+					continue
+				}
+				if _, returned := currentMembers[target.DeviceIdentifier]; !returned {
+					commandTargets = append(commandTargets, target)
+				}
+			}
+			if len(commandTargets) > 0 {
+				command(commandTargets)
+			}
+			return nil
+		},
+	)
+	return true, fenceReached, commandTargets, err
 }
 
 var errTopologyDispatchRejected = errors.New("topology dispatch rejected")

--- a/server/internal/domain/curtailment/reconciler/reconciler.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler.go
@@ -1325,6 +1325,7 @@ func (r *Reconciler) claimClosedLoopFullFleetTargets(ctx context.Context, ev *mo
 			ctx,
 			interfaces.ListRecentlyResolvedCurtailedDevicesParams{
 				OrgID:             ev.OrgID,
+				ExcludeEventID:    ev.ID,
 				CooldownSec:       cooldownSec,
 				DeviceIdentifiers: params.DeviceIdentifiers,
 				SiteIDs:           params.SiteIDs,

--- a/server/internal/domain/curtailment/reconciler/reconciler.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler.go
@@ -1342,10 +1342,15 @@ func (r *Reconciler) claimClosedLoopFullFleetTargets(ctx context.Context, ev *mo
 	if len(targets) == 0 {
 		return nil
 	}
-	if batchSize := curtailBatchSizeForEvent(ev, len(targets)); len(targets) > int(batchSize) {
-		targets = targets[:batchSize]
-	}
-	claimed, err := r.store.ClaimClosedLoopFullFleetTargets(ctx, ev.ID, ev.OrgID, cooldownSec, targets)
+	batchSize := curtailBatchSizeForEvent(ev, len(targets))
+	claimed, err := r.store.ClaimClosedLoopFullFleetTargets(
+		ctx,
+		ev.ID,
+		ev.OrgID,
+		cooldownSec,
+		int(batchSize),
+		targets,
+	)
 	if err != nil {
 		slog.Error("curtailment reconciler: claim full_fleet targets failed",
 			"event_id", ev.ID, "candidate_count", len(targets), "error", err)

--- a/server/internal/domain/curtailment/reconciler/reconciler.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler.go
@@ -2347,7 +2347,6 @@ func (r *Reconciler) dispatchRestoreBatch(ctx context.Context, ev *models.Event,
 			return
 		}
 		commandTargets = fencedTargets
-		r.parkReturnedTopologyRestoreTargets(ctx, ev, dispatchSet, commandTargets)
 		if fenceErr != nil {
 			slog.Error("curtailment reconciler: topology restore fence ended after command callback",
 				"event_id", ev.ID, "error", fenceErr)
@@ -2426,41 +2425,6 @@ func (r *Reconciler) dispatchRestoreBatch(ctx context.Context, ev *models.Event,
 		t.LastDispatchedAt = &now
 		t.LastBatchUUID = &batchID
 		t.LastError = nil
-	}
-}
-
-func (r *Reconciler) parkReturnedTopologyRestoreTargets(
-	ctx context.Context,
-	ev *models.Event,
-	dispatchSet []*models.Target,
-	commandTargets []*models.Target,
-) {
-	commandDevices := make(map[string]struct{}, len(commandTargets))
-	for _, target := range commandTargets {
-		commandDevices[target.DeviceIdentifier] = struct{}{}
-	}
-	reason := "restore paused: device returned to topology scope"
-	expectedState := models.TargetStateDispatching
-	desiredActive := models.DesiredStateActive
-	for _, target := range dispatchSet {
-		if _, dispatched := commandDevices[target.DeviceIdentifier]; dispatched {
-			continue
-		}
-		params := interfaces.UpdateCurtailmentTargetStateParams{
-			State:                models.TargetStateRestoreFailed,
-			LastError:            &reason,
-			ExpectedDesiredState: &desiredActive,
-			ExpectedState:        &expectedState,
-		}
-		if err := r.writeTargetState(ctx, ev, target.DeviceIdentifier, params); err != nil {
-			if !errors.Is(err, interfaces.ErrCurtailmentEventStateRaceLoss) {
-				slog.Error("curtailment reconciler: failed to park returned topology restore target",
-					"event_id", ev.ID, "device", target.DeviceIdentifier, "error", err)
-			}
-			continue
-		}
-		target.State = models.TargetStateRestoreFailed
-		target.LastError = &reason
 	}
 }
 

--- a/server/internal/domain/curtailment/reconciler/reconciler.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler.go
@@ -866,9 +866,10 @@ func (r *Reconciler) recordDispatchFailureGuarded(ctx context.Context, ev *model
 		state = models.TargetStateRestoreFailed
 	}
 	params := interfaces.UpdateCurtailmentTargetStateParams{
-		State:      state,
-		LastError:  &errMsg,
-		RetryCount: &newRetry,
+		State:                state,
+		LastError:            &errMsg,
+		RetryCount:           &newRetry,
+		ExpectedDesiredState: &t.DesiredState,
 	}
 	if guard != nil {
 		params.ExpectedState = &guard.expectedState
@@ -2280,9 +2281,11 @@ func (r *Reconciler) dispatchRestoreBatch(ctx context.Context, ev *models.Event,
 		return
 	}
 	dispatchSet := make([]*models.Target, 0, len(claim))
+	desiredActive := models.DesiredStateActive
 	for _, t := range claim {
 		dispatchingParams := interfaces.UpdateCurtailmentTargetStateParams{
-			State: models.TargetStateDispatching,
+			State:                models.TargetStateDispatching,
+			ExpectedDesiredState: &desiredActive,
 		}
 		if err := r.writeTargetState(ctx, ev, t.DeviceIdentifier, dispatchingParams); err != nil {
 			if errors.Is(err, interfaces.ErrCurtailmentEventStateRaceLoss) {
@@ -2303,24 +2306,63 @@ func (r *Reconciler) dispatchRestoreBatch(ctx context.Context, ev *models.Event,
 		return
 	}
 
-	deviceIDs := make([]string, 0, len(dispatchSet))
-	for _, t := range dispatchSet {
-		deviceIDs = append(deviceIDs, t.DeviceIdentifier)
-	}
 	cmdCtx := reconcilerCommandContext(ctx, ev.OrgID, ev.CreatedByUserID)
-	selector := &pb.DeviceSelector{
-		SelectionType: &pb.DeviceSelector_IncludeDevices{
-			IncludeDevices: &commonpb.DeviceIdentifierList{
-				DeviceIdentifiers: deviceIDs,
+	var result *command.CommandResult
+	var dispatchErr error
+	runCommand := func(targets []*models.Target) {
+		deviceIDs := make([]string, 0, len(targets))
+		for _, target := range targets {
+			deviceIDs = append(deviceIDs, target.DeviceIdentifier)
+		}
+		selector := &pb.DeviceSelector{
+			SelectionType: &pb.DeviceSelector_IncludeDevices{
+				IncludeDevices: &commonpb.DeviceIdentifierList{
+					DeviceIdentifiers: deviceIDs,
+				},
 			},
-		},
+		}
+		result, dispatchErr = r.cmd.Uncurtail(cmdCtx, selector)
 	}
-	result, dispatchErr := r.cmd.Uncurtail(cmdCtx, selector)
+	commandTargets := dispatchSet
+	topologyHandled, fenceReached, fencedTargets, fenceErr := r.fenceTopologyRestoreDispatch(
+		ctx,
+		ev,
+		dispatchSet,
+		runCommand,
+	)
+	if topologyHandled {
+		if !fenceReached {
+			if errors.Is(fenceErr, interfaces.ErrCurtailmentEventStateRaceLoss) {
+				return
+			}
+			errMsg := "topology restore dispatch fence failed"
+			if fenceErr != nil {
+				errMsg = fenceErr.Error()
+			}
+			slog.Error("curtailment reconciler: topology restore dispatch fence failed",
+				"event_id", ev.ID, "error", fenceErr)
+			for _, target := range dispatchSet {
+				r.recordDispatchFailure(ctx, ev, target, errMsg, models.TargetStatePending)
+			}
+			return
+		}
+		commandTargets = fencedTargets
+		r.parkReturnedTopologyRestoreTargets(ctx, ev, dispatchSet, commandTargets)
+		if fenceErr != nil {
+			slog.Error("curtailment reconciler: topology restore fence ended after command callback",
+				"event_id", ev.ID, "error", fenceErr)
+		}
+		if len(commandTargets) == 0 {
+			return
+		}
+	} else {
+		runCommand(commandTargets)
+	}
 	if dispatchErr != nil {
 		errMsg := dispatchErr.Error()
 		slog.Error("curtailment reconciler: restore batch dispatch failed",
-			"event_id", ev.ID, "batch_size", len(dispatchSet), "error", dispatchErr)
-		for _, t := range dispatchSet {
+			"event_id", ev.ID, "batch_size", len(commandTargets), "error", dispatchErr)
+		for _, t := range commandTargets {
 			r.recordDispatchFailure(ctx, ev, t, errMsg, models.TargetStatePending)
 		}
 		return
@@ -2330,8 +2372,8 @@ func (r *Reconciler) dispatchRestoreBatch(ctx context.Context, ev *models.Event,
 	if result == nil || result.BatchIdentifier == "" {
 		const reason = "uncurtail command produced no batch (no live devices to dispatch)"
 		slog.Warn("curtailment reconciler: restore batch produced empty result",
-			"event_id", ev.ID, "batch_size", len(dispatchSet))
-		for _, t := range dispatchSet {
+			"event_id", ev.ID, "batch_size", len(commandTargets))
+		for _, t := range commandTargets {
 			r.recordDispatchFailure(ctx, ev, t, reason, models.TargetStatePending)
 		}
 		return
@@ -2348,7 +2390,7 @@ func (r *Reconciler) dispatchRestoreBatch(ctx context.Context, ev *models.Event,
 
 	now := r.now()
 	batchID := result.BatchIdentifier
-	for _, t := range dispatchSet {
+	for _, t := range commandTargets {
 		if reason, skipped := skippedSet[t.DeviceIdentifier]; skipped {
 			slog.Warn("curtailment reconciler: restore device filter-skipped",
 				"event_id", ev.ID, "device", t.DeviceIdentifier, "reason", reason)
@@ -2384,6 +2426,41 @@ func (r *Reconciler) dispatchRestoreBatch(ctx context.Context, ev *models.Event,
 		t.LastDispatchedAt = &now
 		t.LastBatchUUID = &batchID
 		t.LastError = nil
+	}
+}
+
+func (r *Reconciler) parkReturnedTopologyRestoreTargets(
+	ctx context.Context,
+	ev *models.Event,
+	dispatchSet []*models.Target,
+	commandTargets []*models.Target,
+) {
+	commandDevices := make(map[string]struct{}, len(commandTargets))
+	for _, target := range commandTargets {
+		commandDevices[target.DeviceIdentifier] = struct{}{}
+	}
+	reason := "restore paused: device returned to topology scope"
+	expectedState := models.TargetStateDispatching
+	desiredActive := models.DesiredStateActive
+	for _, target := range dispatchSet {
+		if _, dispatched := commandDevices[target.DeviceIdentifier]; dispatched {
+			continue
+		}
+		params := interfaces.UpdateCurtailmentTargetStateParams{
+			State:                models.TargetStateRestoreFailed,
+			LastError:            &reason,
+			ExpectedDesiredState: &desiredActive,
+			ExpectedState:        &expectedState,
+		}
+		if err := r.writeTargetState(ctx, ev, target.DeviceIdentifier, params); err != nil {
+			if !errors.Is(err, interfaces.ErrCurtailmentEventStateRaceLoss) {
+				slog.Error("curtailment reconciler: failed to park returned topology restore target",
+					"event_id", ev.ID, "device", target.DeviceIdentifier, "error", err)
+			}
+			continue
+		}
+		target.State = models.TargetStateRestoreFailed
+		target.LastError = &reason
 	}
 }
 

--- a/server/internal/domain/curtailment/reconciler/reconciler.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler.go
@@ -1311,7 +1311,7 @@ func (r *Reconciler) claimClosedLoopFullFleetTargets(ctx context.Context, ev *mo
 		ev.IncludeMaintenance && ev.ForceIncludeMaintenance,
 		candidateMinPowerWForEvent(ev, orgConfig.CandidateMinPowerW),
 	)
-	targets = excludeExistingTargetParams(targets, existingTargets)
+	targets = excludeNonReopenableExistingTargetParams(targets, existingTargets)
 	activeDevices, err := r.store.ListActiveCurtailmentTargetDevices(ctx, ev.OrgID)
 	if err != nil {
 		slog.Error("curtailment reconciler: list active devices (full_fleet admission) failed",
@@ -1391,24 +1391,6 @@ func postEventCooldownSecForEvent(ev *models.Event) int32 {
 	return snapshot.PostEventCooldownSec
 }
 
-func excludeExistingTargetParams(targets []models.InsertTargetParams, existingTargets []*models.Target) []models.InsertTargetParams {
-	if len(targets) == 0 || len(existingTargets) == 0 {
-		return targets
-	}
-	existing := make(map[string]struct{}, len(existingTargets))
-	for _, target := range existingTargets {
-		existing[target.DeviceIdentifier] = struct{}{}
-	}
-	filtered := targets[:0]
-	for _, target := range targets {
-		if _, ok := existing[target.DeviceIdentifier]; ok {
-			continue
-		}
-		filtered = append(filtered, target)
-	}
-	return filtered
-}
-
 func excludeNonReopenableExistingTargetParams(targets []models.InsertTargetParams, existingTargets []*models.Target) []models.InsertTargetParams {
 	if len(targets) == 0 || len(existingTargets) == 0 {
 		return targets
@@ -1420,12 +1402,18 @@ func excludeNonReopenableExistingTargetParams(targets []models.InsertTargetParam
 	filtered := targets[:0]
 	for _, target := range targets {
 		state, ok := existing[target.DeviceIdentifier]
-		if ok && state != models.TargetStateReleased {
+		if ok && !isReopenableTargetState(state) {
 			continue
 		}
 		filtered = append(filtered, target)
 	}
 	return filtered
+}
+
+func isReopenableTargetState(state models.TargetState) bool {
+	return state == models.TargetStateResolved ||
+		state == models.TargetStateRestoreFailed ||
+		state == models.TargetStateReleased
 }
 
 func excludeDeviceIdentifiers(targets []models.InsertTargetParams, deviceIdentifiers []string) []models.InsertTargetParams {

--- a/server/internal/domain/curtailment/reconciler/reconciler_allpaired.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler_allpaired.go
@@ -136,6 +136,7 @@ func (r *Reconciler) refreshAllPairedPolicyTargets(
 				if baseline := curtailment.AllPairedPromotionBaselinePowerW(candidate, minPowerW); baseline != nil {
 					updates = append(updates, interfaces.AllPairedReadinessUpdate{
 						DeviceIdentifier: target.DeviceIdentifier,
+						ExpectedState:    target.State,
 						State:            nextState,
 						Reason:           reason,
 						BaselinePowerW:   baseline,
@@ -150,6 +151,7 @@ func (r *Reconciler) refreshAllPairedPolicyTargets(
 		}
 		update := interfaces.AllPairedReadinessUpdate{
 			DeviceIdentifier: target.DeviceIdentifier,
+			ExpectedState:    target.State,
 			State:            nextState,
 			Reason:           reason,
 		}

--- a/server/internal/domain/curtailment/reconciler/reconciler_allpaired.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler_allpaired.go
@@ -75,7 +75,13 @@ func (r *Reconciler) claimAllPairedPolicyTargets(
 	if len(targets) == 0 {
 		return nil
 	}
-	claimed, err := r.store.ClaimAllPairedPolicyTargets(ctx, ev.ID, targets)
+	claimed, err := r.store.ClaimAllPairedPolicyTargets(
+		ctx,
+		ev.ID,
+		ev.OrgID,
+		int(curtailBatchSizeForEvent(ev, len(targets))),
+		targets,
+	)
 	if err != nil {
 		slog.Error("curtailment reconciler: claim all-paired policy targets failed",
 			"event_id", ev.ID, "candidate_count", len(targets),
@@ -135,11 +141,12 @@ func (r *Reconciler) refreshAllPairedPolicyTargets(
 			if nextState == models.TargetStatePending && target.BaselinePowerW == nil {
 				if baseline := curtailment.AllPairedPromotionBaselinePowerW(candidate, minPowerW); baseline != nil {
 					updates = append(updates, interfaces.AllPairedReadinessUpdate{
-						DeviceIdentifier: target.DeviceIdentifier,
-						ExpectedState:    target.State,
-						State:            nextState,
-						Reason:           reason,
-						BaselinePowerW:   baseline,
+						DeviceIdentifier:     target.DeviceIdentifier,
+						ExpectedState:        target.State,
+						ExpectedDesiredState: target.DesiredState,
+						State:                nextState,
+						Reason:               reason,
+						BaselinePowerW:       baseline,
 					})
 					refreshable[target.DeviceIdentifier] = target
 				}
@@ -150,10 +157,11 @@ func (r *Reconciler) refreshAllPairedPolicyTargets(
 			continue
 		}
 		update := interfaces.AllPairedReadinessUpdate{
-			DeviceIdentifier: target.DeviceIdentifier,
-			ExpectedState:    target.State,
-			State:            nextState,
-			Reason:           reason,
+			DeviceIdentifier:     target.DeviceIdentifier,
+			ExpectedState:        target.State,
+			ExpectedDesiredState: target.DesiredState,
+			State:                nextState,
+			Reason:               reason,
 		}
 		// Rows inserted while unavailable carry no pre-curtail baseline;
 		// backfill it from current telemetry at promotion so confirm/drift
@@ -168,7 +176,7 @@ func (r *Reconciler) refreshAllPairedPolicyTargets(
 	if len(updates) == 0 {
 		return
 	}
-	appliedDevices, err := r.store.BulkRefreshAllPairedTargetReadiness(ctx, ev.ID, ev.State, updates)
+	appliedDevices, err := r.store.BulkRefreshAllPairedTargetReadiness(ctx, ev.ID, ev.OrgID, ev.State, updates)
 	if err != nil {
 		r.metrics.IncTargetWriteFailure()
 		slog.Error("curtailment reconciler: all-paired readiness bulk refresh failed",

--- a/server/internal/domain/curtailment/reconciler/reconciler_test.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler_test.go
@@ -184,13 +184,27 @@ func (f *fakeStore) ClaimClosedLoopFullFleetTargets(
 ) ([]*models.Target, error) {
 	f.claimTargetsCalls++
 	f.claimedTargetParams = append([]models.InsertTargetParams(nil), targets...)
-	existing := map[string]struct{}{}
+	existing := map[string]*models.Target{}
 	for _, t := range f.targetsByEventID[eventID] {
-		existing[t.DeviceIdentifier] = struct{}{}
+		existing[t.DeviceIdentifier] = t
 	}
 	var claimed []*models.Target
 	for _, target := range targets {
-		if _, ok := existing[target.DeviceIdentifier]; ok {
+		if row, ok := existing[target.DeviceIdentifier]; ok {
+			if !isReopenableTargetState(row.State) {
+				continue
+			}
+			row.State = models.TargetStateDispatching
+			row.DesiredState = target.DesiredState
+			row.BaselinePowerW = target.BaselinePowerW
+			row.LastError = target.LastError
+			row.ReleasedAt = nil
+			row.CurtailPhase = models.TargetPhaseSummary{
+				Phase: models.TargetPhaseCurtail,
+				State: models.TargetStateDispatching,
+			}
+			row.RestorePhase = nil
+			claimed = append(claimed, row)
 			continue
 		}
 		row := &models.Target{
@@ -203,7 +217,7 @@ func (f *fakeStore) ClaimClosedLoopFullFleetTargets(
 		}
 		f.targetsByEventID[eventID] = append(f.targetsByEventID[eventID], row)
 		claimed = append(claimed, row)
-		existing[target.DeviceIdentifier] = struct{}{}
+		existing[target.DeviceIdentifier] = row
 	}
 	return claimed, nil
 }
@@ -231,7 +245,7 @@ func (f *fakeStore) ClaimAllPairedPolicyTargets(
 			state = models.TargetStatePending
 		}
 		if row, ok := existing[target.DeviceIdentifier]; ok {
-			if row.State != models.TargetStateReleased {
+			if !isReopenableTargetState(row.State) {
 				continue
 			}
 			row.State = state
@@ -1530,6 +1544,59 @@ func TestReconciler_ActiveClosedLoopFullFleetAdmitsAndDispatchesNewTarget(t *tes
 	assert.Equal(t, 1, disp.curtailCalls)
 	assert.ElementsMatch(t, []string{"miner-new"}, disp.curtailLastIDs)
 	assert.Equal(t, models.TargetStateDispatched, target.State)
+}
+
+func TestReconciler_ActiveClosedLoopFullFleetReadmitsReturnedTargets(t *testing.T) {
+	store := newFakeStore()
+	disp := &fakeDispatcher{}
+
+	eventID := int64(10)
+	effectiveBatchSize := int32(10)
+	store.events = []*models.Event{{
+		ID:                 eventID,
+		EventUUID:          uuid.New(),
+		OrgID:              1,
+		State:              models.EventStateActive,
+		Mode:               models.ModeFullFleet,
+		LoopType:           models.LoopTypeClosed,
+		ScopeType:          models.ScopeTypeWholeOrg,
+		CurtailBatchSize:   &effectiveBatchSize,
+		EffectiveBatchSize: &effectiveBatchSize,
+		CreatedByUserID:    99,
+	}}
+	store.targetsByEventID[eventID] = []*models.Target{
+		{CurtailmentEventID: eventID, DeviceIdentifier: "miner-released", State: models.TargetStateReleased},
+		{CurtailmentEventID: eventID, DeviceIdentifier: "miner-resolved", State: models.TargetStateResolved},
+	}
+	driver := "antminer"
+	now := time.Now()
+	for _, identifier := range []string{"miner-released", "miner-resolved"} {
+		store.candidates = append(store.candidates, &models.Candidate{
+			DeviceIdentifier: identifier,
+			DriverName:       &driver,
+			DeviceStatus:     "ACTIVE",
+			PairingStatus:    "PAIRED",
+			LatestMetricsAt:  &now,
+			LatestPowerW:     ptrFloat64(3000),
+			LatestHashRateHS: ptrFloat64(100),
+			AvgEfficiencyJH:  ptrFloat64(40),
+		})
+	}
+
+	r := newReconcilerForTest(store, disp)
+	r.runTick(context.Background())
+
+	assert.Equal(t, 1, store.claimTargetsCalls)
+	require.Len(t, store.claimedTargetParams, 2)
+	assert.ElementsMatch(t, []string{"miner-released", "miner-resolved"}, []string{
+		store.claimedTargetParams[0].DeviceIdentifier,
+		store.claimedTargetParams[1].DeviceIdentifier,
+	})
+	dispatched := make([]string, 0, 2)
+	for _, batch := range disp.curtailCallIDs {
+		dispatched = append(dispatched, batch...)
+	}
+	assert.ElementsMatch(t, []string{"miner-released", "miner-resolved"}, dispatched)
 }
 
 func TestReconciler_ActiveClosedLoopFullFleetSkipsCandidateScanWhenAdmissionIntervalBlocked(t *testing.T) {

--- a/server/internal/domain/curtailment/reconciler/reconciler_test.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler_test.go
@@ -210,9 +210,14 @@ func (f *fakeStore) ClaimClosedLoopFullFleetTargets(
 func (f *fakeStore) ClaimAllPairedPolicyTargets(
 	_ context.Context,
 	eventID int64,
+	_ int64,
+	maxTargets int,
 	targets []models.InsertTargetParams,
 ) (int64, error) {
 	f.claimAllPairedCalls++
+	if len(targets) > maxTargets {
+		targets = targets[:maxTargets]
+	}
 	f.claimedAllPairedParams = append([]models.InsertTargetParams(nil), targets...)
 	existing := map[string]*models.Target{}
 	for _, t := range f.targetsByEventID[eventID] {
@@ -263,6 +268,7 @@ func (f *fakeStore) ClaimAllPairedPolicyTargets(
 func (f *fakeStore) BulkRefreshAllPairedTargetReadiness(
 	_ context.Context,
 	eventID int64,
+	_ int64,
 	expectedEventState models.EventState,
 	updates []interfaces.AllPairedReadinessUpdate,
 ) ([]string, error) {
@@ -289,10 +295,14 @@ func (f *fakeStore) BulkRefreshAllPairedTargetReadiness(
 		if !ok {
 			continue
 		}
-		if t.DesiredState != "" && t.DesiredState != models.DesiredStateCurtailed {
+		if t.DesiredState != update.ExpectedDesiredState {
 			continue
 		}
-		if t.State != models.TargetStatePending && t.State != models.TargetStateUnavailable {
+		if t.State != update.ExpectedState {
+			continue
+		}
+		if (t.DesiredState == models.DesiredStateCurtailed && t.State != models.TargetStatePending && t.State != models.TargetStateUnavailable) ||
+			(t.DesiredState == models.DesiredStateActive && t.State != models.TargetStatePending && t.State != models.TargetStateUnavailable && t.State != models.TargetStateRestoreFailed) {
 			continue
 		}
 		if update.State != models.TargetStatePending && update.State != models.TargetStateUnavailable {
@@ -1675,6 +1685,42 @@ func TestReconciler_ActiveAllPairedPolicyClaimsDispatchableAndUnavailableTargets
 	assert.Equal(t, models.TargetStateUnavailable, store.targetsByEventID[eventID][2].State)
 	require.NotNil(t, store.targetsByEventID[eventID][2].LastError)
 	assert.Equal(t, "authentication_needed", *store.targetsByEventID[eventID][2].LastError)
+}
+
+func TestReconciler_ActiveAllPairedPolicyBoundsAdmissionToCurtailBatchSize(t *testing.T) {
+	store := newFakeStore()
+	disp := &fakeDispatcher{}
+
+	eventID := int64(10)
+	batchSize := int32(2)
+	store.events = []*models.Event{{
+		ID:                          eventID,
+		EventUUID:                   uuid.New(),
+		OrgID:                       1,
+		State:                       models.EventStateActive,
+		Mode:                        models.ModeFullFleet,
+		LoopType:                    models.LoopTypeClosed,
+		ScopeType:                   models.ScopeTypeWholeOrg,
+		ForceIncludeAllPairedMiners: true,
+		CurtailBatchSize:            &batchSize,
+		CreatedByUserID:             99,
+	}}
+	driver := "antminer"
+	store.candidates = []*models.Candidate{
+		{DeviceIdentifier: "first", DriverName: &driver, DeviceStatus: "ACTIVE", PairingStatus: "PAIRED", LatestPowerW: ptrFloat64(3000)},
+		{DeviceIdentifier: "second", DriverName: &driver, DeviceStatus: "ACTIVE", PairingStatus: "PAIRED", LatestPowerW: ptrFloat64(3000)},
+		{DeviceIdentifier: "deferred", DriverName: &driver, DeviceStatus: "ACTIVE", PairingStatus: "PAIRED", LatestPowerW: ptrFloat64(3000)},
+	}
+
+	r := newReconcilerForTest(store, disp)
+	r.runTick(context.Background())
+
+	assert.Equal(t, 1, store.claimAllPairedCalls)
+	require.Len(t, store.claimedAllPairedParams, 2)
+	assert.Equal(t, []string{"first", "second"}, []string{
+		store.claimedAllPairedParams[0].DeviceIdentifier,
+		store.claimedAllPairedParams[1].DeviceIdentifier,
+	})
 }
 
 func TestReconciler_AllPairedPolicyUnavailableTargetBecomesPendingAndDispatches(t *testing.T) {

--- a/server/internal/domain/curtailment/reconciler/reconciler_test.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler_test.go
@@ -485,7 +485,7 @@ func (f *fakeStore) WithCurtailmentTopologyRestoreDispatchFence(
 	ctx context.Context,
 	event *models.Event,
 	dispatchDeviceIdentifiers []string,
-	command func(interfaces.CurtailmentTopologyDispatchFenceSnapshot) error,
+	command func(interfaces.CurtailmentTopologyRestoreDispatchFenceSnapshot) error,
 ) error {
 	if f.topologyFenceErr != nil {
 		return f.topologyFenceErr
@@ -515,9 +515,27 @@ func (f *fakeStore) WithCurtailmentTopologyRestoreDispatchFence(
 	}
 	f.topologyFenceActive = true
 	defer func() { f.topologyFenceActive = false }()
-	if err := command(interfaces.CurtailmentTopologyDispatchFenceSnapshot{
-		Event:    latest,
-		Topology: topology,
+	parkReturnedTargets := func(returnedDeviceIdentifiers []string) error {
+		reason := "restore paused: device returned to topology scope"
+		expectedState := models.TargetStateDispatching
+		desiredActive := models.DesiredStateActive
+		for _, deviceIdentifier := range returnedDeviceIdentifiers {
+			if err := f.UpdateTargetState(ctx, latest.ID, deviceIdentifier, interfaces.UpdateCurtailmentTargetStateParams{
+				State:                models.TargetStateRestoreFailed,
+				LastError:            &reason,
+				ExpectedEventState:   &latest.State,
+				ExpectedDesiredState: &desiredActive,
+				ExpectedState:        &expectedState,
+			}); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if err := command(interfaces.CurtailmentTopologyRestoreDispatchFenceSnapshot{
+		Event:               latest,
+		Topology:            topology,
+		ParkReturnedTargets: parkReturnedTargets,
 	}); err != nil {
 		return err
 	}
@@ -1378,6 +1396,13 @@ func TestReconciler_TopologyRestoreSuppressesReturnedMemberAtCommandBoundary(t *
 
 	store, event, target := topologyDispatchFixture()
 	target.DesiredState = models.DesiredStateActive
+	store.updateTargetStateHook = func(_ string, params interfaces.UpdateCurtailmentTargetStateParams, _ int) error {
+		if params.State == models.TargetStateRestoreFailed {
+			assert.True(t, store.topologyFenceActive,
+				"returned target must be parked before topology locks are released")
+		}
+		return nil
+	}
 	dispatcher := &fakeDispatcher{}
 	reconciler := New(Config{TickInterval: time.Hour}, store, dispatcher)
 
@@ -1387,6 +1412,22 @@ func TestReconciler_TopologyRestoreSuppressesReturnedMemberAtCommandBoundary(t *
 	assert.Equal(t, models.TargetStateRestoreFailed, target.State)
 	require.NotNil(t, target.LastError)
 	assert.Contains(t, *target.LastError, "returned to topology scope")
+}
+
+func TestReconciler_TopologyRestoreDispatchesCurrentMemberWhenEventIsRestoring(t *testing.T) {
+	t.Parallel()
+
+	store, event, target := topologyDispatchFixture()
+	event.State = models.EventStateRestoring
+	target.DesiredState = models.DesiredStateActive
+	dispatcher := &fakeDispatcher{}
+	reconciler := New(Config{TickInterval: time.Hour}, store, dispatcher)
+
+	reconciler.dispatchRestoreBatch(t.Context(), event, []*models.Target{target})
+
+	assert.Equal(t, 1, dispatcher.uncurtailCalls)
+	assert.Equal(t, []string{target.DeviceIdentifier}, dispatcher.uncurtailLastIDs)
+	assert.Equal(t, models.TargetStateDispatched, target.State)
 }
 
 func TestReconciler_TopologyDispatchFenceFailurePreservesRestoreOwnership(t *testing.T) {

--- a/server/internal/domain/curtailment/reconciler/reconciler_test.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler_test.go
@@ -182,9 +182,13 @@ func (f *fakeStore) ClaimClosedLoopFullFleetTargets(
 	eventID int64,
 	_ int64,
 	_ int32,
+	maxTargets int,
 	targets []models.InsertTargetParams,
 ) ([]*models.Target, error) {
 	f.claimTargetsCalls++
+	if len(targets) > maxTargets {
+		targets = targets[:maxTargets]
+	}
 	f.claimedTargetParams = append([]models.InsertTargetParams(nil), targets...)
 	existing := map[string]*models.Target{}
 	for _, t := range f.targetsByEventID[eventID] {

--- a/server/internal/domain/curtailment/reconciler/reconciler_test.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler_test.go
@@ -481,6 +481,49 @@ func (f *fakeStore) WithCurtailmentTopologyDispatchFence(
 	return f.topologyFenceAfterCommandErr
 }
 
+func (f *fakeStore) WithCurtailmentTopologyRestoreDispatchFence(
+	ctx context.Context,
+	event *models.Event,
+	dispatchDeviceIdentifiers []string,
+	command func(interfaces.CurtailmentTopologyDispatchFenceSnapshot) error,
+) error {
+	if f.topologyFenceErr != nil {
+		return f.topologyFenceErr
+	}
+	latest, err := f.GetEventByUUID(ctx, event.OrgID, event.EventUUID)
+	if err != nil {
+		return err
+	}
+	if latest == nil || latest.ID != event.ID || latest.State != event.State || latest.State.IsTerminal() {
+		return interfaces.ErrCurtailmentEventStateRaceLoss
+	}
+	latestCopy := *latest
+	latest = &latestCopy
+	if f.topologyFenceHook != nil {
+		f.topologyFenceHook(latest)
+	}
+	if latest.State != event.State || latest.State.IsTerminal() {
+		return interfaces.ErrCurtailmentEventStateRaceLoss
+	}
+	topology, err := f.ResolveCurtailmentTopologyDispatch(
+		ctx,
+		interfaces.ListCandidatesParams{OrgID: event.OrgID},
+		dispatchDeviceIdentifiers,
+	)
+	if err != nil {
+		return err
+	}
+	f.topologyFenceActive = true
+	defer func() { f.topologyFenceActive = false }()
+	if err := command(interfaces.CurtailmentTopologyDispatchFenceSnapshot{
+		Event:    latest,
+		Topology: topology,
+	}); err != nil {
+		return err
+	}
+	return f.topologyFenceAfterCommandErr
+}
+
 func (f *fakeStore) ListEvents(context.Context, interfaces.ListEventsParams) ([]*models.Event, string, error) {
 	panic("ListEvents not exercised by reconciler tests")
 }
@@ -641,6 +684,9 @@ func (f *fakeStore) UpdateTargetState(_ context.Context, eventID int64, deviceId
 				}
 			}
 			if params.ExpectedDesiredState != nil && t.DesiredState != "" && t.DesiredState != *params.ExpectedDesiredState {
+				return interfaces.ErrCurtailmentEventStateRaceLoss
+			}
+			if params.ExpectedState != nil && t.State != *params.ExpectedState {
 				return interfaces.ErrCurtailmentEventStateRaceLoss
 			}
 			t.State = params.State
@@ -1306,6 +1352,41 @@ func TestReconciler_TopologyDispatchHoldsFenceThroughCommand(t *testing.T) {
 	assert.True(t, dispatched)
 	assert.Equal(t, 1, dispatcher.curtailCalls)
 	assert.False(t, store.topologyFenceActive)
+}
+
+func TestReconciler_TopologyRestoreHoldsFenceThroughCommand(t *testing.T) {
+	t.Parallel()
+
+	store, event, target := topologyDispatchFixture()
+	target.DesiredState = models.DesiredStateActive
+	store.candidates = nil
+	dispatcher := &fakeDispatcher{}
+	dispatcher.uncurtailHook = func(_ []string) {
+		assert.True(t, store.topologyFenceActive)
+	}
+	reconciler := New(Config{TickInterval: time.Hour}, store, dispatcher)
+
+	reconciler.dispatchRestoreBatch(t.Context(), event, []*models.Target{target})
+
+	assert.Equal(t, 1, dispatcher.uncurtailCalls)
+	assert.Equal(t, models.TargetStateDispatched, target.State)
+	assert.False(t, store.topologyFenceActive)
+}
+
+func TestReconciler_TopologyRestoreSuppressesReturnedMemberAtCommandBoundary(t *testing.T) {
+	t.Parallel()
+
+	store, event, target := topologyDispatchFixture()
+	target.DesiredState = models.DesiredStateActive
+	dispatcher := &fakeDispatcher{}
+	reconciler := New(Config{TickInterval: time.Hour}, store, dispatcher)
+
+	reconciler.dispatchRestoreBatch(t.Context(), event, []*models.Target{target})
+
+	assert.Zero(t, dispatcher.uncurtailCalls)
+	assert.Equal(t, models.TargetStateRestoreFailed, target.State)
+	require.NotNil(t, target.LastError)
+	assert.Contains(t, *target.LastError, "returned to topology scope")
 }
 
 func TestReconciler_TopologyDispatchFenceFailurePreservesRestoreOwnership(t *testing.T) {

--- a/server/internal/domain/curtailment/reconciler/reconciler_test.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler_test.go
@@ -1931,6 +1931,7 @@ func TestReconciler_AllPairedPolicyStablePendingTargetBackfillsMissingBaseline(t
 
 	require.Len(t, store.lastBulkRefreshUpdates, 1,
 		"a stable pending row with a missing baseline must still get a backfill update")
+	assert.Equal(t, models.TargetStatePending, store.lastBulkRefreshUpdates[0].ExpectedState)
 	require.NotNil(t, store.lastBulkRefreshUpdates[0].BaselinePowerW)
 	final := store.targetsByEventID[eventID][0]
 	require.NotNil(t, final.BaselinePowerW,
@@ -2391,6 +2392,13 @@ func TestReconciler_AllPairedPolicyReadinessRefreshBatchesFlipsIntoOneCall(t *te
 
 	assert.Equal(t, 1, store.bulkRefreshCalls, "one bulk statement per tick, not one write per device")
 	require.Len(t, store.lastBulkRefreshUpdates, 3)
+	for _, update := range store.lastBulkRefreshUpdates {
+		if update.DeviceIdentifier == "sleeps" {
+			assert.Equal(t, models.TargetStatePending, update.ExpectedState)
+		} else {
+			assert.Equal(t, models.TargetStateUnavailable, update.ExpectedState)
+		}
+	}
 	byDevice := map[string]*models.Target{}
 	for _, target := range store.targetsByEventID[eventID] {
 		byDevice[target.DeviceIdentifier] = target

--- a/server/internal/domain/curtailment/reconciler/reconciler_test.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler_test.go
@@ -74,6 +74,7 @@ type fakeStore struct {
 	cooldownDevices        []string
 	cooldownCalls          int
 	lastCooldownOrgID      int64
+	lastCooldownExcludeID  int64
 	lastCooldownSec        int32
 	lastCooldownFilter     []string
 	lastCooldownSiteIDs    []int64
@@ -141,6 +142,7 @@ func (f *fakeStore) ListRecentlyResolvedCurtailedDevices(
 ) ([]string, error) {
 	f.cooldownCalls++
 	f.lastCooldownOrgID = params.OrgID
+	f.lastCooldownExcludeID = params.ExcludeEventID
 	f.lastCooldownSec = params.CooldownSec
 	f.lastCooldownFilter = append([]string(nil), params.DeviceIdentifiers...)
 	f.lastCooldownSiteIDs = append([]int64(nil), params.SiteIDs...)
@@ -1553,16 +1555,17 @@ func TestReconciler_ActiveClosedLoopFullFleetReadmitsReturnedTargets(t *testing.
 	eventID := int64(10)
 	effectiveBatchSize := int32(10)
 	store.events = []*models.Event{{
-		ID:                 eventID,
-		EventUUID:          uuid.New(),
-		OrgID:              1,
-		State:              models.EventStateActive,
-		Mode:               models.ModeFullFleet,
-		LoopType:           models.LoopTypeClosed,
-		ScopeType:          models.ScopeTypeWholeOrg,
-		CurtailBatchSize:   &effectiveBatchSize,
-		EffectiveBatchSize: &effectiveBatchSize,
-		CreatedByUserID:    99,
+		ID:                   eventID,
+		EventUUID:            uuid.New(),
+		OrgID:                1,
+		State:                models.EventStateActive,
+		Mode:                 models.ModeFullFleet,
+		LoopType:             models.LoopTypeClosed,
+		ScopeType:            models.ScopeTypeWholeOrg,
+		CurtailBatchSize:     &effectiveBatchSize,
+		EffectiveBatchSize:   &effectiveBatchSize,
+		DecisionSnapshotJSON: []byte(`{"post_event_cooldown_sec":600}`),
+		CreatedByUserID:      99,
 	}}
 	store.targetsByEventID[eventID] = []*models.Target{
 		{CurtailmentEventID: eventID, DeviceIdentifier: "miner-released", State: models.TargetStateReleased},
@@ -1587,6 +1590,8 @@ func TestReconciler_ActiveClosedLoopFullFleetReadmitsReturnedTargets(t *testing.
 	r.runTick(context.Background())
 
 	assert.Equal(t, 1, store.claimTargetsCalls)
+	assert.Equal(t, 1, store.cooldownCalls)
+	assert.Equal(t, eventID, store.lastCooldownExcludeID)
 	require.Len(t, store.claimedTargetParams, 2)
 	assert.ElementsMatch(t, []string{"miner-released", "miner-resolved"}, []string{
 		store.claimedTargetParams[0].DeviceIdentifier,

--- a/server/internal/domain/curtailment/service_test.go
+++ b/server/internal/domain/curtailment/service_test.go
@@ -989,6 +989,8 @@ func (f *fakeStore) ClaimClosedLoopFullFleetTargets(
 func (f *fakeStore) ClaimAllPairedPolicyTargets(
 	context.Context,
 	int64,
+	int64,
+	int,
 	[]models.InsertTargetParams,
 ) (int64, error) {
 	panic("ClaimAllPairedPolicyTargets not exercised")
@@ -996,6 +998,7 @@ func (f *fakeStore) ClaimAllPairedPolicyTargets(
 
 func (f *fakeStore) BulkRefreshAllPairedTargetReadiness(
 	context.Context,
+	int64,
 	int64,
 	models.EventState,
 	[]interfaces.AllPairedReadinessUpdate,

--- a/server/internal/domain/curtailment/service_test.go
+++ b/server/internal/domain/curtailment/service_test.go
@@ -981,6 +981,7 @@ func (f *fakeStore) ClaimClosedLoopFullFleetTargets(
 	int64,
 	int64,
 	int32,
+	int,
 	[]models.InsertTargetParams,
 ) ([]*models.Target, error) {
 	panic("ClaimClosedLoopFullFleetTargets not exercised")

--- a/server/internal/domain/stores/interfaces/curtailment.go
+++ b/server/internal/domain/stores/interfaces/curtailment.go
@@ -232,6 +232,7 @@ type ListCandidatesParams struct {
 
 type ListRecentlyResolvedCurtailedDevicesParams struct {
 	OrgID             int64
+	ExcludeEventID    int64
 	CooldownSec       int32
 	DeviceIdentifiers []string
 	SiteIDs           []int64

--- a/server/internal/domain/stores/interfaces/curtailment.go
+++ b/server/internal/domain/stores/interfaces/curtailment.go
@@ -312,16 +312,24 @@ type CurtailmentTopologyDispatchFenceStore interface {
 	) error
 }
 
+// CurtailmentTopologyRestoreDispatchFenceSnapshot is the event and topology
+// state protected by a restore dispatch fence. ParkReturnedTargets persists
+// returned active-watcher targets before the fence releases its locks.
+type CurtailmentTopologyRestoreDispatchFenceSnapshot struct {
+	Event               *models.Event
+	Topology            CurtailmentTopologyDispatchSnapshot
+	ParkReturnedTargets func([]string) error
+}
+
 // CurtailmentTopologyRestoreDispatchFenceStore holds the current event and
-// topology membership stable through a physical Uncurtail command. Unlike the
-// Curtail fence, restore candidates are expected to be outside the selector;
-// the callback receives any that returned so the reconciler can suppress them.
+// topology membership stable through returned-target parking and a physical
+// Uncurtail command.
 type CurtailmentTopologyRestoreDispatchFenceStore interface {
 	WithCurtailmentTopologyRestoreDispatchFence(
 		ctx context.Context,
 		event *models.Event,
 		dispatchDeviceIdentifiers []string,
-		command func(CurtailmentTopologyDispatchFenceSnapshot) error,
+		command func(CurtailmentTopologyRestoreDispatchFenceSnapshot) error,
 	) error
 }
 

--- a/server/internal/domain/stores/interfaces/curtailment.go
+++ b/server/internal/domain/stores/interfaces/curtailment.go
@@ -506,13 +506,15 @@ type CurtailmentStore interface {
 
 	// ClaimClosedLoopFullFleetTargets inserts missing closed-loop FULL_FLEET
 	// targets as DISPATCHING while the parent event is still pending/active.
-	// Existing same-event rows and cross-event conflicts are skipped so
-	// reconciliation can retry later.
+	// Existing same-event rows and cross-event conflicts are skipped before at
+	// most maxTargets are selected, so a reserved prefix cannot underfill the
+	// bounded admission batch.
 	ClaimClosedLoopFullFleetTargets(
 		ctx context.Context,
 		eventID int64,
 		orgID int64,
 		cooldownSec int32,
+		maxTargets int,
 		targets []models.InsertTargetParams,
 	) ([]*models.Target, error)
 

--- a/server/internal/domain/stores/interfaces/curtailment.go
+++ b/server/internal/domain/stores/interfaces/curtailment.go
@@ -69,17 +69,18 @@ type UpdateCurtailmentTargetStateParams struct {
 // AllPairedReadinessUpdate is one pending/unavailable readiness flip in the
 // bulk all-paired refresh. Restore-failed topology obligations may first park
 // as unavailable so a later commandability transition can requeue them.
-// ExpectedState prevents a decision made from a stale target snapshot from
-// overwriting a concurrent transition. Reason is the unavailable reason;
-// empty clears last_error. BaselinePowerW, when set on a curtail promotion,
-// backfills a NULL baseline from current telemetry; the SQL never overwrites
-// an existing baseline.
+// ExpectedState and ExpectedDesiredState prevent a decision made from a stale
+// target snapshot from overwriting a concurrent state or phase transition.
+// Reason is the unavailable reason; empty clears last_error. BaselinePowerW,
+// when set on a curtail promotion, backfills a NULL baseline from current
+// telemetry; the SQL never overwrites an existing baseline.
 type AllPairedReadinessUpdate struct {
-	DeviceIdentifier string
-	ExpectedState    models.TargetState
-	State            models.TargetState
-	Reason           string
-	BaselinePowerW   *float64
+	DeviceIdentifier     string
+	ExpectedState        models.TargetState
+	ExpectedDesiredState string
+	State                models.TargetState
+	Reason               string
+	BaselinePowerW       *float64
 }
 
 // ConfirmationBatchSize bounds both one fast-path eligibility page and each
@@ -495,10 +496,14 @@ type CurtailmentStore interface {
 
 	// ClaimAllPairedPolicyTargets inserts or reopens durable all-paired
 	// FULL_FLEET policy targets in their computed state. Unlike closed-loop
-	// dispatch claims, this does not pre-claim rows as DISPATCHING.
+	// dispatch claims, this does not pre-claim rows as DISPATCHING. It skips
+	// earlier reservations before selecting at most maxTargets, so a reserved
+	// prefix cannot starve the bounded admission batch.
 	ClaimAllPairedPolicyTargets(
 		ctx context.Context,
 		eventID int64,
+		orgID int64,
+		maxTargets int,
 		targets []models.InsertTargetParams,
 	) (int64, error)
 
@@ -511,6 +516,7 @@ type CurtailmentStore interface {
 	BulkRefreshAllPairedTargetReadiness(
 		ctx context.Context,
 		eventID int64,
+		orgID int64,
 		expectedEventState models.EventState,
 		updates []AllPairedReadinessUpdate,
 	) ([]string, error)

--- a/server/internal/domain/stores/interfaces/curtailment.go
+++ b/server/internal/domain/stores/interfaces/curtailment.go
@@ -312,6 +312,19 @@ type CurtailmentTopologyDispatchFenceStore interface {
 	) error
 }
 
+// CurtailmentTopologyRestoreDispatchFenceStore holds the current event and
+// topology membership stable through a physical Uncurtail command. Unlike the
+// Curtail fence, restore candidates are expected to be outside the selector;
+// the callback receives any that returned so the reconciler can suppress them.
+type CurtailmentTopologyRestoreDispatchFenceStore interface {
+	WithCurtailmentTopologyRestoreDispatchFence(
+		ctx context.Context,
+		event *models.Event,
+		dispatchDeviceIdentifiers []string,
+		command func(CurtailmentTopologyDispatchFenceSnapshot) error,
+	) error
+}
+
 // UpdateOperatorFieldsParams carries the optional patch fields for a
 // partial event update. nil values preserve the column via COALESCE.
 // effective_batch_size is not on this surface — recomputing mid-event

--- a/server/internal/domain/stores/interfaces/curtailment.go
+++ b/server/internal/domain/stores/interfaces/curtailment.go
@@ -67,13 +67,16 @@ type UpdateCurtailmentTargetStateParams struct {
 }
 
 // AllPairedReadinessUpdate is one pending/unavailable readiness flip in the
-// bulk all-paired refresh. Reason is the unavailable reason; empty clears
-// last_error (the pending-promotion sentinel, matching the per-row query).
-// BaselinePowerW, when set on a promotion, backfills a NULL baseline from
-// current telemetry (targets inserted while unavailable have none); the SQL
-// never overwrites an existing baseline.
+// bulk all-paired refresh. Restore-failed topology obligations may first park
+// as unavailable so a later commandability transition can requeue them.
+// ExpectedState prevents a decision made from a stale target snapshot from
+// overwriting a concurrent transition. Reason is the unavailable reason;
+// empty clears last_error. BaselinePowerW, when set on a curtail promotion,
+// backfills a NULL baseline from current telemetry; the SQL never overwrites
+// an existing baseline.
 type AllPairedReadinessUpdate struct {
 	DeviceIdentifier string
+	ExpectedState    models.TargetState
 	State            models.TargetState
 	Reason           string
 	BaselinePowerW   *float64
@@ -253,6 +256,17 @@ type CurtailmentTopologyScopeStore interface {
 		ctx context.Context,
 		params ListCandidatesParams,
 	) (CurtailmentTopologyScopeCoverage, error)
+}
+
+// CurtailmentTopologyTargetRestoreStore moves targets that left a live
+// topology selector into the existing per-target restore state machine while
+// leaving the parent watcher active.
+type CurtailmentTopologyTargetRestoreStore interface {
+	BeginCurtailmentTopologyTargetRestore(
+		ctx context.Context,
+		event *models.Event,
+		deviceIdentifiers []string,
+	) (int64, error)
 }
 
 // CurtailmentTopologyDispatchSnapshot is one database snapshot of both the
@@ -488,13 +502,12 @@ type CurtailmentStore interface {
 		targets []models.InsertTargetParams,
 	) (int64, error)
 
-	// BulkRefreshAllPairedTargetReadiness applies pending/unavailable
-	// readiness flips for all-paired policy rows in one statement. Rows
-	// whose state or desired_state advanced concurrently — and every row
-	// when the parent event left expectedEventState — are skipped, not
-	// clobbered; the reconciler re-reads them next tick. Returns the
-	// device identifiers of the rows actually updated so callers mirror
-	// only applied flips.
+	// BulkRefreshAllPairedTargetReadiness applies batched readiness flips to
+	// all-paired curtail rows and topology restore obligations. Rows whose
+	// state or desired_state advanced concurrently — and every row when the
+	// parent event left expectedEventState — are skipped, not clobbered; the
+	// reconciler re-reads them next tick. Returns the device identifiers of
+	// the rows actually updated so callers mirror only applied flips.
 	BulkRefreshAllPairedTargetReadiness(
 		ctx context.Context,
 		eventID int64,

--- a/server/internal/domain/stores/sqlstores/curtailment.go
+++ b/server/internal/domain/stores/sqlstores/curtailment.go
@@ -2266,7 +2266,7 @@ func (s *SQLCurtailmentStore) WithCurtailmentTopologyRestoreDispatchFence(
 	ctx context.Context,
 	event *models.Event,
 	dispatchDeviceIdentifiers []string,
-	command func(interfaces.CurtailmentTopologyDispatchFenceSnapshot) error,
+	command func(interfaces.CurtailmentTopologyRestoreDispatchFenceSnapshot) error,
 ) error {
 	if event == nil || command == nil {
 		return fleeterror.NewInvalidArgumentError("topology restore dispatch fence requires an event and command")
@@ -2303,9 +2303,27 @@ func (s *SQLCurtailmentStore) WithCurtailmentTopologyRestoreDispatchFence(
 		if err != nil {
 			return err
 		}
-		return command(interfaces.CurtailmentTopologyDispatchFenceSnapshot{
-			Event:    latest,
-			Topology: topology,
+		parkReturnedTargets := func(returnedDeviceIdentifiers []string) error {
+			reason := "restore paused: device returned to topology scope"
+			expectedState := models.TargetStateDispatching
+			desiredActive := models.DesiredStateActive
+			for _, deviceIdentifier := range uniqueSortedStrings(returnedDeviceIdentifiers) {
+				if err := updateCurtailmentTargetState(ctx, q, latest.ID, deviceIdentifier, interfaces.UpdateCurtailmentTargetStateParams{
+					State:                models.TargetStateRestoreFailed,
+					LastError:            &reason,
+					ExpectedEventState:   &latest.State,
+					ExpectedDesiredState: &desiredActive,
+					ExpectedState:        &expectedState,
+				}); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+		return command(interfaces.CurtailmentTopologyRestoreDispatchFenceSnapshot{
+			Event:               latest,
+			Topology:            topology,
+			ParkReturnedTargets: parkReturnedTargets,
 		})
 	})
 }
@@ -2899,7 +2917,17 @@ func (s *SQLCurtailmentStore) RecoverTerminalFanState(
 }
 
 func (s *SQLCurtailmentStore) UpdateTargetState(ctx context.Context, eventID int64, deviceIdentifier string, params interfaces.UpdateCurtailmentTargetStateParams) error {
-	rows, err := s.GetQueries(ctx).UpdateCurtailmentTargetState(ctx, sqlc.UpdateCurtailmentTargetStateParams{
+	return updateCurtailmentTargetState(ctx, s.GetQueries(ctx), eventID, deviceIdentifier, params)
+}
+
+func updateCurtailmentTargetState(
+	ctx context.Context,
+	q sqlc.Querier,
+	eventID int64,
+	deviceIdentifier string,
+	params interfaces.UpdateCurtailmentTargetStateParams,
+) error {
+	rows, err := q.UpdateCurtailmentTargetState(ctx, sqlc.UpdateCurtailmentTargetStateParams{
 		CurtailmentEventID:        eventID,
 		DeviceIdentifier:          deviceIdentifier,
 		State:                     string(params.State),

--- a/server/internal/domain/stores/sqlstores/curtailment.go
+++ b/server/internal/domain/stores/sqlstores/curtailment.go
@@ -2290,18 +2290,25 @@ func (s *SQLCurtailmentStore) WithCurtailmentTopologyRestoreDispatchFence(
 			return interfaces.ErrCurtailmentEventStateRaceLoss
 		}
 		latest := convertEventRow(locked)
-		scope, hasScope, err := domainCurtailment.ScopeFromJSON(latest.ScopeJSON)
-		if err != nil || !hasScope || !domainCurtailment.IsTopologyScope(scope) {
-			return fleeterror.NewFailedPreconditionError("persisted topology scope is no longer valid")
-		}
-		params, err := domainCurtailment.ListCandidatesParamsForScope(scope)
-		if err != nil {
-			return err
-		}
-		params.OrgID = latest.OrgID
-		topology, err := lockCurtailmentTopologyRestoreDispatch(ctx, q, params, identifiers)
-		if err != nil {
-			return err
+		topology := interfaces.CurtailmentTopologyDispatchSnapshot{}
+		if latest.State == models.EventStateRestoring {
+			if _, _, err := lockDeviceScopeCoverage(ctx, q, latest.OrgID, identifiers, nil); err != nil {
+				return err
+			}
+		} else {
+			scope, hasScope, err := domainCurtailment.ScopeFromJSON(latest.ScopeJSON)
+			if err != nil || !hasScope || !domainCurtailment.IsTopologyScope(scope) {
+				return fleeterror.NewFailedPreconditionError("persisted topology scope is no longer valid")
+			}
+			params, err := domainCurtailment.ListCandidatesParamsForScope(scope)
+			if err != nil {
+				return err
+			}
+			params.OrgID = latest.OrgID
+			topology, err = lockCurtailmentTopologyRestoreDispatch(ctx, q, params, identifiers)
+			if err != nil {
+				return err
+			}
 		}
 		parkReturnedTargets := func(returnedDeviceIdentifiers []string) error {
 			reason := "restore paused: device returned to topology scope"
@@ -3518,7 +3525,12 @@ func lockCurtailmentTopologyRestoreDispatch(
 	scope interfaces.ListCandidatesParams,
 	deviceIdentifiers []string,
 ) (interfaces.CurtailmentTopologyDispatchSnapshot, error) {
-	if err := lockTopologySelectorResourcesForWrite(ctx, q, scope); err != nil {
+	if err := lockTopologySelectorResourcesForReservation(
+		ctx,
+		q,
+		scope,
+		interfaces.ListCandidatesParams{},
+	); err != nil {
 		return interfaces.CurtailmentTopologyDispatchSnapshot{}, err
 	}
 	memberIdentifiers, err := q.ListCurtailmentTopologyMemberDeviceIdentifiersByOrg(

--- a/server/internal/domain/stores/sqlstores/curtailment.go
+++ b/server/internal/domain/stores/sqlstores/curtailment.go
@@ -3205,9 +3205,10 @@ func (s *SQLCurtailmentStore) ClaimClosedLoopFullFleetTargets(
 	eventID int64,
 	orgID int64,
 	cooldownSec int32,
+	maxTargets int,
 	targets []models.InsertTargetParams,
 ) ([]*models.Target, error) {
-	if len(targets) == 0 {
+	if len(targets) == 0 || maxTargets <= 0 {
 		return nil, nil
 	}
 	rows, err := db.WithTransaction(ctx, s.conn.DB, func(q sqlc.Querier) ([]sqlc.CurtailmentTarget, error) {
@@ -3235,6 +3236,9 @@ func (s *SQLCurtailmentStore) ClaimClosedLoopFullFleetTargets(
 		available, err = filterCurrentCurtailmentTopologyTargets(ctx, q, currentScope, available)
 		if err != nil || len(available) == 0 {
 			return nil, err
+		}
+		if len(available) > maxTargets {
+			available = available[:maxTargets]
 		}
 		payload, err := buildBulkTargetPayload(available)
 		if err != nil {
@@ -3558,7 +3562,11 @@ func lockCurtailmentTopologyRestoreDispatch(
 	if _, _, err := lockDeviceScopeCoverage(ctx, q, scope.OrgID, lockIdentifiers, nil); err != nil {
 		return interfaces.CurtailmentTopologyDispatchSnapshot{}, err
 	}
-	return resolveCurtailmentTopologyDispatch(ctx, q, scope, deviceIdentifiers)
+	topology, err := resolveCurtailmentTopologyDispatch(ctx, q, scope, deviceIdentifiers)
+	if fleeterror.IsNotFoundError(err) {
+		return interfaces.CurtailmentTopologyDispatchSnapshot{}, nil
+	}
+	return topology, err
 }
 
 func (s *SQLCurtailmentStore) BeginCurtailmentTopologyTargetRestore(

--- a/server/internal/domain/stores/sqlstores/curtailment.go
+++ b/server/internal/domain/stores/sqlstores/curtailment.go
@@ -3472,10 +3472,29 @@ func (s *SQLCurtailmentStore) BeginCurtailmentTopologyTargetRestore(
 			return 0, err
 		}
 		scope.OrgID = lockedEvent.OrgID
-		if _, _, err := lockTopologyScopeCoverage(ctx, q, scope, nil); err != nil {
+		if err := lockTopologySelectorResourcesForWrite(ctx, q, scope); err != nil {
 			return 0, err
 		}
-		if _, _, err := lockDeviceScopeCoverage(ctx, q, event.OrgID, identifiers, nil); err != nil {
+		memberIdentifiers, err := q.ListCurtailmentTopologyMemberDeviceIdentifiersByOrg(
+			ctx,
+			sqlc.ListCurtailmentTopologyMemberDeviceIdentifiersByOrgParams{
+				OrgID:       scope.OrgID,
+				BuildingIds: scope.BuildingIDs,
+				RackIds:     scope.RackIDs,
+				GroupIds:    scope.GroupIDs,
+			},
+		)
+		if err != nil {
+			return 0, fleeterror.NewInternalErrorf("failed to list topology restore members: %v", err)
+		}
+		if len(memberIdentifiers) > interfaces.CurtailmentResolvedMinerMax {
+			return 0, fleeterror.NewResourceExhaustedErrorf(
+				"scope resolves to more than %d miners",
+				interfaces.CurtailmentResolvedMinerMax,
+			)
+		}
+		lockIdentifiers := append(append([]string(nil), memberIdentifiers...), identifiers...)
+		if _, _, err := lockDeviceScopeCoverage(ctx, q, event.OrgID, lockIdentifiers, nil); err != nil {
 			return 0, err
 		}
 		current, err := resolveCurtailmentTopologyDispatch(ctx, q, scope, identifiers)

--- a/server/internal/domain/stores/sqlstores/curtailment.go
+++ b/server/internal/domain/stores/sqlstores/curtailment.go
@@ -125,6 +125,7 @@ func (s *SQLCurtailmentStore) ListRecentlyResolvedCurtailedDevices(
 		}
 		devices, err := s.GetQueries(ctx).ListRecentlyResolvedCurtailedDevicesByScope(ctx, sqlc.ListRecentlyResolvedCurtailedDevicesByScopeParams{
 			OrgID:             params.OrgID,
+			ExcludeEventID:    params.ExcludeEventID,
 			SiteIds:           params.SiteIDs,
 			DeviceIdentifiers: params.DeviceIdentifiers,
 			CooldownSec:       params.CooldownSec,
@@ -135,8 +136,9 @@ func (s *SQLCurtailmentStore) ListRecentlyResolvedCurtailedDevices(
 		return devices, nil
 	}
 	devices, err := s.GetQueries(ctx).ListRecentlyResolvedCurtailedDevicesByOrg(ctx, sqlc.ListRecentlyResolvedCurtailedDevicesByOrgParams{
-		OrgID:       params.OrgID,
-		CooldownSec: params.CooldownSec,
+		OrgID:          params.OrgID,
+		ExcludeEventID: params.ExcludeEventID,
+		CooldownSec:    params.CooldownSec,
 	})
 	if err != nil {
 		return nil, fleeterror.NewInternalErrorf("failed to list recently resolved curtailed devices: %v", err)

--- a/server/internal/domain/stores/sqlstores/curtailment.go
+++ b/server/internal/domain/stores/sqlstores/curtailment.go
@@ -3330,6 +3330,32 @@ func filterCurrentCurtailmentTopologyTargets(
 	return filtered, nil
 }
 
+func filterDepartedCurtailmentTopologyTargets(
+	ctx context.Context,
+	q sqlc.Querier,
+	currentScope interfaces.ListCandidatesParams,
+	targets []models.InsertTargetParams,
+) ([]models.InsertTargetParams, error) {
+	if len(currentScope.BuildingIDs) == 0 && len(currentScope.RackIDs) == 0 && len(currentScope.GroupIDs) == 0 {
+		return targets, nil
+	}
+	current, err := filterCurrentCurtailmentTopologyTargets(ctx, q, currentScope, targets)
+	if err != nil || len(current) == 0 {
+		return targets, err
+	}
+	currentSet := make(map[string]struct{}, len(current))
+	for _, target := range current {
+		currentSet[target.DeviceIdentifier] = struct{}{}
+	}
+	departed := make([]models.InsertTargetParams, 0, len(targets)-len(currentSet))
+	for _, target := range targets {
+		if _, ok := currentSet[target.DeviceIdentifier]; !ok {
+			departed = append(departed, target)
+		}
+	}
+	return departed, nil
+}
+
 // lockEarlierCurtailmentReservationBoundary fences every topology selector
 // that can affect admission, then optionally locks candidate device rows.
 // Callers must re-read ListEarlierCurtailmentReservationDevices after this
@@ -3542,17 +3568,25 @@ func (s *SQLCurtailmentStore) BulkRefreshAllPairedTargetReadiness(
 			}
 		}
 		if len(restoreFailedTargets) > 0 {
+			currentScope, active, err := lockCurtailmentAdmissionEvent(ctx, q, eventID, orgID)
+			if err != nil || !active {
+				return nil, err
+			}
 			if err := lockEarlierCurtailmentReservationBoundary(
 				ctx,
 				q,
 				eventID,
 				orgID,
 				insertTargetDeviceIdentifiers(restoreFailedTargets),
-				interfaces.ListCandidatesParams{},
+				currentScope,
 			); err != nil {
 				return nil, err
 			}
 			available, err := excludeEarlierCurtailmentReservations(ctx, q, eventID, restoreFailedTargets)
+			if err != nil {
+				return nil, err
+			}
+			available, err = filterDepartedCurtailmentTopologyTargets(ctx, q, currentScope, available)
 			if err != nil {
 				return nil, err
 			}

--- a/server/internal/domain/stores/sqlstores/curtailment.go
+++ b/server/internal/domain/stores/sqlstores/curtailment.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sqlc-dev/pqtype"
 
 	"github.com/block/proto-fleet/server/generated/sqlc"
+	domainCurtailment "github.com/block/proto-fleet/server/internal/domain/curtailment"
 	"github.com/block/proto-fleet/server/internal/domain/curtailment/models"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 	"github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
@@ -1084,7 +1085,7 @@ func (s *SQLCurtailmentStore) InsertEventWithTargets(
 			return nil, nil
 		}
 
-		scopeSiteIDs, usesScopeGuard, err := hierarchicalScopeSiteIDs(event)
+		scopeFilter, usesScopeGuard, err := hierarchicalScopeFilter(event)
 		if err != nil {
 			return nil, err
 		}
@@ -1096,6 +1097,7 @@ func (s *SQLCurtailmentStore) InsertEventWithTargets(
 			return nil, fleeterror.NewFailedPreconditionError("facility fan authorization changed; retry the request")
 		}
 		usesFanGuard := !event.State.IsTerminal() && len(fanIDs) > 0
+		usesTargetReservationGuard := !event.State.IsTerminal() && len(targets) > 0
 		if usesFanGuard {
 			for _, fanID := range fanIDs {
 				if err := q.LockCurtailmentFanDeviceForWrite(ctx, strconv.FormatInt(fanID, 10)); err != nil {
@@ -1103,7 +1105,7 @@ func (s *SQLCurtailmentStore) InsertEventWithTargets(
 				}
 			}
 		}
-		if usesScopeGuard {
+		if usesScopeGuard || usesTargetReservationGuard {
 			if err := q.LockCurtailmentScopeForWrite(ctx, strconv.FormatInt(event.OrgID, 10)); err != nil {
 				return nil, fleeterror.NewInternalErrorf("failed to lock curtailment scope: %v", err)
 			}
@@ -1111,7 +1113,7 @@ func (s *SQLCurtailmentStore) InsertEventWithTargets(
 		// The fast-path lookup above can race another identical Start. Once all
 		// claim locks are held, recheck before reporting the winner as a fan or
 		// scope conflict instead of an idempotent replay.
-		if usesFanGuard || usesScopeGuard {
+		if usesFanGuard || usesScopeGuard || usesTargetReservationGuard {
 			if replay, err := lookupReplayEventInTx(ctx, q, event); err != nil {
 				return nil, err
 			} else if replay != nil {
@@ -1162,11 +1164,14 @@ func (s *SQLCurtailmentStore) InsertEventWithTargets(
 		}
 		if usesScopeGuard {
 			conflicts, err := q.CountCurtailmentScopeConflicts(ctx, sqlc.CountCurtailmentScopeConflictsParams{
-				OrgID:     event.OrgID,
-				Mode:      string(event.Mode),
-				LoopType:  string(event.LoopType),
-				ScopeType: string(event.ScopeType),
-				SiteIds:   scopeSiteIDs,
+				OrgID:       event.OrgID,
+				Mode:        string(event.Mode),
+				LoopType:    string(event.LoopType),
+				ScopeType:   string(event.ScopeType),
+				SiteIds:     scopeFilter.SiteIDs,
+				BuildingIds: scopeFilter.BuildingIDs,
+				RackIds:     scopeFilter.RackIDs,
+				GroupIds:    scopeFilter.GroupIDs,
 			})
 			if err != nil {
 				return nil, fleeterror.NewInternalErrorf("failed to check curtailment scope conflicts: %v", err)
@@ -1249,6 +1254,21 @@ func (s *SQLCurtailmentStore) InsertEventWithTargets(
 			return nil, fleeterror.NewInternalErrorf("failed to insert curtailment event: %v", err)
 		}
 		if len(targets) > 0 {
+			reserved, err := q.ListEarlierCurtailmentReservationDevices(
+				ctx,
+				sqlc.ListEarlierCurtailmentReservationDevicesParams{
+					CurtailmentEventID: row.ID,
+					DeviceIdentifiers:  insertTargetDeviceIdentifiers(targets),
+				},
+			)
+			if err != nil {
+				return nil, fleeterror.NewInternalErrorf("failed to check earlier curtailment reservations: %v", err)
+			}
+			if len(reserved) > 0 {
+				return nil, fleeterror.NewAlreadyExistsError(
+					"one or more selected devices are reserved by an older non-terminal curtailment; retry",
+				)
+			}
 			payload, err := buildBulkTargetPayload(targets)
 			if err != nil {
 				return nil, fleeterror.NewInternalErrorf(
@@ -1330,21 +1350,21 @@ func cooldownSecForInsert(event models.InsertEventParams) int32 {
 	return snapshot.PostEventCooldownSec
 }
 
-func hierarchicalScopeSiteIDs(event models.InsertEventParams) ([]int64, bool, error) {
+func hierarchicalScopeFilter(event models.InsertEventParams) (interfaces.ListCandidatesParams, bool, error) {
 	if event.State.IsTerminal() {
-		return nil, false, nil
+		return interfaces.ListCandidatesParams{}, false, nil
 	}
 	switch event.ScopeType {
 	case models.ScopeTypeWholeOrg:
-		return nil, true, nil
+		return interfaces.ListCandidatesParams{}, true, nil
 	case models.ScopeTypeSite:
 		var scope struct {
 			SiteID int64 `json:"site_id"`
 		}
 		if err := json.Unmarshal(event.ScopeJSON, &scope); err != nil || scope.SiteID <= 0 {
-			return nil, false, fleeterror.NewInternalErrorf("invalid site scope for closed-loop curtailment event")
+			return interfaces.ListCandidatesParams{}, false, fleeterror.NewInternalErrorf("invalid site scope for closed-loop curtailment event")
 		}
-		return []int64{scope.SiteID}, true, nil
+		return interfaces.ListCandidatesParams{SiteIDs: []int64{scope.SiteID}}, true, nil
 	case models.ScopeTypeMixed:
 		var scope struct {
 			SiteIDs           []int64  `json:"site_ids"`
@@ -1354,21 +1374,32 @@ func hierarchicalScopeSiteIDs(event models.InsertEventParams) ([]int64, bool, er
 			DeviceIdentifiers []string `json:"device_identifiers"`
 		}
 		if err := json.Unmarshal(event.ScopeJSON, &scope); err != nil {
-			return nil, false, fleeterror.NewInternalErrorf("invalid mixed scope for closed-loop curtailment event")
+			return interfaces.ListCandidatesParams{}, false, fleeterror.NewInternalErrorf("invalid mixed scope for closed-loop curtailment event")
 		}
-		if containsNonPositiveInt64(scope.SiteIDs) {
-			return nil, false, fleeterror.NewInternalErrorf("invalid mixed site scope for closed-loop curtailment event")
+		if containsNonPositiveInt64(scope.SiteIDs) || containsNonPositiveInt64(scope.BuildingIDs) ||
+			containsNonPositiveInt64(scope.RackIDs) || containsNonPositiveInt64(scope.GroupIDs) {
+			return interfaces.ListCandidatesParams{}, false, fleeterror.NewInternalErrorf("invalid mixed scope for closed-loop curtailment event")
 		}
-		siteIDs := uniqueSortedInt64s(scope.SiteIDs)
-		if len(siteIDs) > 0 && len(scope.BuildingIDs) == 0 && len(scope.RackIDs) == 0 &&
-			len(scope.GroupIDs) == 0 && len(scope.DeviceIdentifiers) == 0 {
-			return siteIDs, true, nil
+		filter := interfaces.ListCandidatesParams{
+			SiteIDs:     uniqueSortedInt64s(scope.SiteIDs),
+			BuildingIDs: uniqueSortedInt64s(scope.BuildingIDs),
+			RackIDs:     uniqueSortedInt64s(scope.RackIDs),
+			GroupIDs:    uniqueSortedInt64s(scope.GroupIDs),
 		}
-		return nil, false, nil
+		selectorCount := 0
+		for _, ids := range [][]int64{filter.SiteIDs, filter.BuildingIDs, filter.RackIDs, filter.GroupIDs} {
+			if len(ids) > 0 {
+				selectorCount++
+			}
+		}
+		if selectorCount == 1 && len(scope.DeviceIdentifiers) == 0 {
+			return filter, true, nil
+		}
+		return interfaces.ListCandidatesParams{}, false, nil
 	case models.ScopeTypeDeviceList:
-		return nil, false, nil
+		return interfaces.ListCandidatesParams{}, false, nil
 	default:
-		return nil, false, nil
+		return interfaces.ListCandidatesParams{}, false, nil
 	}
 }
 
@@ -2011,8 +2042,16 @@ func (s *SQLCurtailmentStore) GetTargetRollupByEvent(ctx context.Context, orgID 
 }
 
 func (s *SQLCurtailmentStore) ListCandidates(ctx context.Context, params interfaces.ListCandidatesParams) ([]*models.Candidate, error) {
+	return listCurtailmentCandidates(ctx, s.GetQueries(ctx), params)
+}
+
+func listCurtailmentCandidates(
+	ctx context.Context,
+	q sqlc.Querier,
+	params interfaces.ListCandidatesParams,
+) ([]*models.Candidate, error) {
 	params = normalizeListCandidatesParams(params)
-	rows, err := s.GetQueries(ctx).ListCurtailmentCandidatesByOrg(ctx, sqlc.ListCurtailmentCandidatesByOrgParams{
+	rows, err := q.ListCurtailmentCandidatesByOrg(ctx, sqlc.ListCurtailmentCandidatesByOrgParams{
 		OrgID:             params.OrgID,
 		ResultLimit:       int64(params.ResultLimit),
 		SiteIds:           params.SiteIDs,
@@ -3072,11 +3111,18 @@ func (s *SQLCurtailmentStore) ClaimClosedLoopFullFleetTargets(
 	if len(targets) == 0 {
 		return nil, nil
 	}
-	payload, err := buildBulkTargetPayload(targets)
-	if err != nil {
-		return nil, fleeterror.NewInternalErrorf("failed to encode curtailment target payload: %v", err)
-	}
 	rows, err := db.WithTransaction(ctx, s.conn.DB, func(q sqlc.Querier) ([]sqlc.CurtailmentTarget, error) {
+		if err := q.LockCurtailmentEventScopeForWrite(ctx, eventID); err != nil {
+			return nil, fleeterror.NewInternalErrorf("failed to lock curtailment admission scope: %v", err)
+		}
+		available, err := excludeEarlierCurtailmentReservations(ctx, q, eventID, targets)
+		if err != nil || len(available) == 0 {
+			return nil, err
+		}
+		payload, err := buildBulkTargetPayload(available)
+		if err != nil {
+			return nil, fleeterror.NewInternalErrorf("failed to encode curtailment target payload: %v", err)
+		}
 		rows, err := q.ClaimClosedLoopFullFleetTargets(ctx, sqlc.ClaimClosedLoopFullFleetTargetsParams{
 			CurtailmentEventID: eventID,
 			TargetsJsonb:       payload,
@@ -3084,10 +3130,14 @@ func (s *SQLCurtailmentStore) ClaimClosedLoopFullFleetTargets(
 		if err != nil {
 			return nil, err
 		}
-		if err := ensureTargetsOutsideCooldown(ctx, q, orgID, cooldownSec, targetDeviceIdentifiers(rows)); err != nil {
+		claimedTargets := make([]sqlc.CurtailmentTarget, len(rows))
+		for i, row := range rows {
+			claimedTargets[i] = sqlc.CurtailmentTarget(row)
+		}
+		if err := ensureTargetsOutsideCooldown(ctx, q, orgID, cooldownSec, targetDeviceIdentifiers(claimedTargets)); err != nil {
 			return nil, err
 		}
-		return rows, nil
+		return claimedTargets, nil
 	})
 	if err != nil {
 		var fleetErr fleeterror.FleetError
@@ -3111,13 +3161,22 @@ func (s *SQLCurtailmentStore) ClaimAllPairedPolicyTargets(
 	if len(targets) == 0 {
 		return 0, nil
 	}
-	payload, err := buildBulkTargetPayload(targets)
-	if err != nil {
-		return 0, fleeterror.NewInternalErrorf("failed to encode curtailment target payload: %v", err)
-	}
-	claimed, err := s.GetQueries(ctx).ClaimAllPairedPolicyTargets(ctx, sqlc.ClaimAllPairedPolicyTargetsParams{
-		CurtailmentEventID: eventID,
-		TargetsJsonb:       payload,
+	claimed, err := db.WithTransaction(ctx, s.conn.DB, func(q sqlc.Querier) (int64, error) {
+		if err := q.LockCurtailmentEventScopeForWrite(ctx, eventID); err != nil {
+			return 0, fleeterror.NewInternalErrorf("failed to lock all-paired admission scope: %v", err)
+		}
+		available, err := excludeEarlierCurtailmentReservations(ctx, q, eventID, targets)
+		if err != nil || len(available) == 0 {
+			return 0, err
+		}
+		payload, err := buildBulkTargetPayload(available)
+		if err != nil {
+			return 0, fleeterror.NewInternalErrorf("failed to encode curtailment target payload: %v", err)
+		}
+		return q.ClaimAllPairedPolicyTargets(ctx, sqlc.ClaimAllPairedPolicyTargetsParams{
+			CurtailmentEventID: eventID,
+			TargetsJsonb:       payload,
+		})
 	})
 	if err != nil {
 		return 0, fleeterror.NewInternalErrorf("failed to claim all-paired policy targets: %v", err)
@@ -3125,10 +3184,139 @@ func (s *SQLCurtailmentStore) ClaimAllPairedPolicyTargets(
 	return claimed, nil
 }
 
+func excludeEarlierCurtailmentReservations(
+	ctx context.Context,
+	q sqlc.Querier,
+	eventID int64,
+	targets []models.InsertTargetParams,
+) ([]models.InsertTargetParams, error) {
+	reserved, err := q.ListEarlierCurtailmentReservationDevices(ctx, sqlc.ListEarlierCurtailmentReservationDevicesParams{
+		CurtailmentEventID: eventID,
+		DeviceIdentifiers:  insertTargetDeviceIdentifiers(targets),
+	})
+	if err != nil {
+		return nil, fleeterror.NewInternalErrorf("failed to check earlier curtailment reservations: %v", err)
+	}
+	if len(reserved) == 0 {
+		return targets, nil
+	}
+	reservedSet := make(map[string]struct{}, len(reserved))
+	for _, deviceIdentifier := range reserved {
+		reservedSet[deviceIdentifier] = struct{}{}
+	}
+	available := make([]models.InsertTargetParams, 0, len(targets)-len(reservedSet))
+	for _, target := range targets {
+		if _, blocked := reservedSet[target.DeviceIdentifier]; !blocked {
+			available = append(available, target)
+		}
+	}
+	return available, nil
+}
+
+func (s *SQLCurtailmentStore) BeginCurtailmentTopologyTargetRestore(
+	ctx context.Context,
+	event *models.Event,
+	deviceIdentifiers []string,
+) (int64, error) {
+	if event == nil {
+		return 0, fleeterror.NewInvalidArgumentError("topology target restore requires an event")
+	}
+	identifiers := uniqueSortedStrings(deviceIdentifiers)
+	if len(identifiers) == 0 {
+		return 0, nil
+	}
+	rows, err := db.WithTransaction(ctx, s.conn.DB, func(q sqlc.Querier) (int64, error) {
+		locked, err := q.LockCurtailmentEventByUUIDForWrite(ctx, sqlc.LockCurtailmentEventByUUIDForWriteParams{
+			EventUuid: event.EventUUID,
+			OrgID:     event.OrgID,
+		})
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, interfaces.ErrCurtailmentEventStateRaceLoss
+		}
+		if err != nil {
+			return 0, fleeterror.NewInternalErrorf("failed to lock topology restore event: %v", err)
+		}
+		if locked.ID != event.ID || models.EventState(locked.State) != event.State ||
+			models.EventState(locked.State).IsTerminal() {
+			return 0, interfaces.ErrCurtailmentEventStateRaceLoss
+		}
+		lockedEvent := convertEventRow(locked)
+		persistedScope, hasScope, err := domainCurtailment.ScopeFromJSON(lockedEvent.ScopeJSON)
+		if err != nil || !hasScope || !domainCurtailment.IsTopologyScope(persistedScope) {
+			return 0, fleeterror.NewFailedPreconditionError("persisted topology scope is no longer valid")
+		}
+		scope, err := domainCurtailment.ListCandidatesParamsForScope(persistedScope)
+		if err != nil {
+			return 0, err
+		}
+		scope.OrgID = lockedEvent.OrgID
+		if _, _, err := lockTopologyScopeCoverage(ctx, q, scope, nil); err != nil {
+			return 0, err
+		}
+		if _, _, err := lockDeviceScopeCoverage(ctx, q, event.OrgID, identifiers, nil); err != nil {
+			return 0, err
+		}
+		current, err := resolveCurtailmentTopologyDispatch(ctx, q, scope, identifiers)
+		if err != nil {
+			return 0, err
+		}
+		currentMembers := make(map[string]struct{}, len(current.DispatchMemberDeviceIdentifiers))
+		for _, identifier := range current.DispatchMemberDeviceIdentifiers {
+			currentMembers[identifier] = struct{}{}
+		}
+		if lockedEvent.ForceIncludeAllPairedMiners {
+			if _, err := q.LockCurtailmentTargetPairingStatusesForWrite(
+				ctx,
+				sqlc.LockCurtailmentTargetPairingStatusesForWriteParams{
+					OrgID:             event.OrgID,
+					DeviceIdentifiers: identifiers,
+				},
+			); err != nil {
+				return 0, fleeterror.NewInternalErrorf("failed to lock topology restore pairing statuses: %v", err)
+			}
+			scope.ResultLimit = interfaces.CurtailmentResolvedMinerMax + 1
+			candidates, err := listCurtailmentCandidates(ctx, q, scope)
+			if err != nil {
+				return 0, err
+			}
+			for _, candidate := range candidates {
+				if candidate != nil && !domainCurtailment.IsAllPairedPolicyPairingStatus(candidate.PairingStatus) {
+					delete(currentMembers, candidate.DeviceIdentifier)
+				}
+			}
+		}
+		departed := make([]string, 0, len(identifiers))
+		for _, identifier := range identifiers {
+			if _, stillMember := currentMembers[identifier]; !stillMember {
+				departed = append(departed, identifier)
+			}
+		}
+		if len(departed) == 0 {
+			return 0, nil
+		}
+		return q.BeginCurtailmentTopologyTargetRestore(
+			ctx,
+			sqlc.BeginCurtailmentTopologyTargetRestoreParams{
+				CurtailmentEventID: event.ID,
+				ExpectedEventState: string(event.State),
+				DeviceIdentifiers:  departed,
+			},
+		)
+	})
+	if err != nil {
+		if errors.Is(err, interfaces.ErrCurtailmentEventStateRaceLoss) {
+			return 0, err
+		}
+		return 0, fleeterror.NewInternalErrorf("failed to begin topology target restore: %v", err)
+	}
+	return rows, nil
+}
+
 // bulkReadinessUpdateRow mirrors BulkRefreshAllPairedTargetReadiness's
 // jsonb_to_recordset column list.
 type bulkReadinessUpdateRow struct {
 	DeviceIdentifier string   `json:"device_identifier"`
+	ExpectedState    string   `json:"expected_state"`
 	State            string   `json:"state"`
 	LastError        string   `json:"last_error"`
 	BaselinePowerW   *float64 `json:"baseline_power_w"`
@@ -3147,6 +3335,7 @@ func (s *SQLCurtailmentStore) BulkRefreshAllPairedTargetReadiness(
 	for i, u := range updates {
 		rows[i] = bulkReadinessUpdateRow{
 			DeviceIdentifier: u.DeviceIdentifier,
+			ExpectedState:    string(u.ExpectedState),
 			State:            string(u.State),
 			LastError:        u.Reason,
 			BaselinePowerW:   u.BaselinePowerW,
@@ -3156,10 +3345,15 @@ func (s *SQLCurtailmentStore) BulkRefreshAllPairedTargetReadiness(
 	if err != nil {
 		return nil, fleeterror.NewInternalErrorf("encode all-paired readiness payload: %v", err)
 	}
-	applied, err := s.GetQueries(ctx).BulkRefreshAllPairedTargetReadiness(ctx, sqlc.BulkRefreshAllPairedTargetReadinessParams{
-		CurtailmentEventID: eventID,
-		ExpectedEventState: string(expectedEventState),
-		UpdatesJsonb:       payload,
+	applied, err := db.WithTransaction(ctx, s.conn.DB, func(q sqlc.Querier) ([]string, error) {
+		if err := q.LockCurtailmentEventScopeForWrite(ctx, eventID); err != nil {
+			return nil, fleeterror.NewInternalErrorf("failed to lock all-paired readiness scope: %v", err)
+		}
+		return q.BulkRefreshAllPairedTargetReadiness(ctx, sqlc.BulkRefreshAllPairedTargetReadinessParams{
+			CurtailmentEventID: eventID,
+			ExpectedEventState: string(expectedEventState),
+			UpdatesJsonb:       payload,
+		})
 	})
 	if err != nil {
 		return nil, fleeterror.NewInternalErrorf("failed to bulk refresh all-paired target readiness: %v", err)

--- a/server/internal/domain/stores/sqlstores/curtailment.go
+++ b/server/internal/domain/stores/sqlstores/curtailment.go
@@ -62,6 +62,7 @@ func mapOrgConfigError(err error, orgID int64) error {
 var _ interfaces.CurtailmentStore = &SQLCurtailmentStore{}
 var _ interfaces.CurtailmentTopologyScopeStore = &SQLCurtailmentStore{}
 var _ interfaces.CurtailmentTopologyDispatchFenceStore = &SQLCurtailmentStore{}
+var _ interfaces.CurtailmentTopologyRestoreDispatchFenceStore = &SQLCurtailmentStore{}
 var _ interfaces.ResponseProfileStore = &SQLCurtailmentStore{}
 var _ interfaces.AutomationStore = &SQLCurtailmentStore{}
 var _ interfaces.CurtailmentFanStateStore = &SQLCurtailmentStore{}
@@ -2261,6 +2262,54 @@ func (s *SQLCurtailmentStore) WithCurtailmentTopologyDispatchFence(
 	})
 }
 
+func (s *SQLCurtailmentStore) WithCurtailmentTopologyRestoreDispatchFence(
+	ctx context.Context,
+	event *models.Event,
+	dispatchDeviceIdentifiers []string,
+	command func(interfaces.CurtailmentTopologyDispatchFenceSnapshot) error,
+) error {
+	if event == nil || command == nil {
+		return fleeterror.NewInvalidArgumentError("topology restore dispatch fence requires an event and command")
+	}
+	identifiers := uniqueSortedStrings(dispatchDeviceIdentifiers)
+	if len(identifiers) == 0 {
+		return nil
+	}
+	return db.WithTransactionNoRetryNoResult(ctx, s.conn.DB, func(q sqlc.Querier) error {
+		locked, err := q.LockCurtailmentEventByUUIDForWrite(ctx, sqlc.LockCurtailmentEventByUUIDForWriteParams{
+			EventUuid: event.EventUUID,
+			OrgID:     event.OrgID,
+		})
+		if errors.Is(err, sql.ErrNoRows) {
+			return interfaces.ErrCurtailmentEventStateRaceLoss
+		}
+		if err != nil {
+			return fleeterror.NewInternalErrorf("failed to lock curtailment event for topology restore dispatch: %v", err)
+		}
+		if locked.ID != event.ID || models.EventState(locked.State) != event.State || models.EventState(locked.State).IsTerminal() {
+			return interfaces.ErrCurtailmentEventStateRaceLoss
+		}
+		latest := convertEventRow(locked)
+		scope, hasScope, err := domainCurtailment.ScopeFromJSON(latest.ScopeJSON)
+		if err != nil || !hasScope || !domainCurtailment.IsTopologyScope(scope) {
+			return fleeterror.NewFailedPreconditionError("persisted topology scope is no longer valid")
+		}
+		params, err := domainCurtailment.ListCandidatesParamsForScope(scope)
+		if err != nil {
+			return err
+		}
+		params.OrgID = latest.OrgID
+		topology, err := lockCurtailmentTopologyRestoreDispatch(ctx, q, params, identifiers)
+		if err != nil {
+			return err
+		}
+		return command(interfaces.CurtailmentTopologyDispatchFenceSnapshot{
+			Event:    latest,
+			Topology: topology,
+		})
+	})
+}
+
 func topologySelector(params interfaces.ListCandidatesParams) ([]int64, string, error) {
 	selectedTypeCount := 0
 	for _, ids := range [][]int64{params.BuildingIDs, params.RackIDs, params.GroupIDs} {
@@ -3435,6 +3484,43 @@ func excludeEarlierCurtailmentReservations(
 	return available, nil
 }
 
+func lockCurtailmentTopologyRestoreDispatch(
+	ctx context.Context,
+	q sqlc.Querier,
+	scope interfaces.ListCandidatesParams,
+	deviceIdentifiers []string,
+) (interfaces.CurtailmentTopologyDispatchSnapshot, error) {
+	if err := lockTopologySelectorResourcesForWrite(ctx, q, scope); err != nil {
+		return interfaces.CurtailmentTopologyDispatchSnapshot{}, err
+	}
+	memberIdentifiers, err := q.ListCurtailmentTopologyMemberDeviceIdentifiersByOrg(
+		ctx,
+		sqlc.ListCurtailmentTopologyMemberDeviceIdentifiersByOrgParams{
+			OrgID:       scope.OrgID,
+			BuildingIds: scope.BuildingIDs,
+			RackIds:     scope.RackIDs,
+			GroupIds:    scope.GroupIDs,
+		},
+	)
+	if err != nil {
+		return interfaces.CurtailmentTopologyDispatchSnapshot{}, fleeterror.NewInternalErrorf(
+			"failed to list topology restore members: %v",
+			err,
+		)
+	}
+	if len(memberIdentifiers) > interfaces.CurtailmentResolvedMinerMax {
+		return interfaces.CurtailmentTopologyDispatchSnapshot{}, fleeterror.NewResourceExhaustedErrorf(
+			"scope resolves to more than %d miners",
+			interfaces.CurtailmentResolvedMinerMax,
+		)
+	}
+	lockIdentifiers := append(append([]string(nil), memberIdentifiers...), deviceIdentifiers...)
+	if _, _, err := lockDeviceScopeCoverage(ctx, q, scope.OrgID, lockIdentifiers, nil); err != nil {
+		return interfaces.CurtailmentTopologyDispatchSnapshot{}, err
+	}
+	return resolveCurtailmentTopologyDispatch(ctx, q, scope, deviceIdentifiers)
+}
+
 func (s *SQLCurtailmentStore) BeginCurtailmentTopologyTargetRestore(
 	ctx context.Context,
 	event *models.Event,
@@ -3472,32 +3558,7 @@ func (s *SQLCurtailmentStore) BeginCurtailmentTopologyTargetRestore(
 			return 0, err
 		}
 		scope.OrgID = lockedEvent.OrgID
-		if err := lockTopologySelectorResourcesForWrite(ctx, q, scope); err != nil {
-			return 0, err
-		}
-		memberIdentifiers, err := q.ListCurtailmentTopologyMemberDeviceIdentifiersByOrg(
-			ctx,
-			sqlc.ListCurtailmentTopologyMemberDeviceIdentifiersByOrgParams{
-				OrgID:       scope.OrgID,
-				BuildingIds: scope.BuildingIDs,
-				RackIds:     scope.RackIDs,
-				GroupIds:    scope.GroupIDs,
-			},
-		)
-		if err != nil {
-			return 0, fleeterror.NewInternalErrorf("failed to list topology restore members: %v", err)
-		}
-		if len(memberIdentifiers) > interfaces.CurtailmentResolvedMinerMax {
-			return 0, fleeterror.NewResourceExhaustedErrorf(
-				"scope resolves to more than %d miners",
-				interfaces.CurtailmentResolvedMinerMax,
-			)
-		}
-		lockIdentifiers := append(append([]string(nil), memberIdentifiers...), identifiers...)
-		if _, _, err := lockDeviceScopeCoverage(ctx, q, event.OrgID, lockIdentifiers, nil); err != nil {
-			return 0, err
-		}
-		current, err := resolveCurtailmentTopologyDispatch(ctx, q, scope, identifiers)
+		current, err := lockCurtailmentTopologyRestoreDispatch(ctx, q, scope, identifiers)
 		if err != nil {
 			return 0, err
 		}

--- a/server/internal/domain/stores/sqlstores/curtailment.go
+++ b/server/internal/domain/stores/sqlstores/curtailment.go
@@ -1180,6 +1180,19 @@ func (s *SQLCurtailmentStore) InsertEventWithTargets(
 				return nil, fleeterror.NewAlreadyExistsError("a non-terminal curtailment event already owns this scope")
 			}
 		}
+		if usesTargetReservationGuard {
+			scopeFilter.OrgID = event.OrgID
+			if err := lockEarlierCurtailmentReservationBoundary(
+				ctx,
+				q,
+				0,
+				event.OrgID,
+				insertTargetDeviceIdentifiers(targets),
+				scopeFilter,
+			); err != nil {
+				return nil, err
+			}
+		}
 		authorizationEnvelopeJSON, err := buildAuthorizationEnvelopeJSON(
 			ctx,
 			q,
@@ -3115,6 +3128,16 @@ func (s *SQLCurtailmentStore) ClaimClosedLoopFullFleetTargets(
 		if err := q.LockCurtailmentEventScopeForWrite(ctx, eventID); err != nil {
 			return nil, fleeterror.NewInternalErrorf("failed to lock curtailment admission scope: %v", err)
 		}
+		if err := lockEarlierCurtailmentReservationBoundary(
+			ctx,
+			q,
+			eventID,
+			orgID,
+			insertTargetDeviceIdentifiers(targets),
+			interfaces.ListCandidatesParams{},
+		); err != nil {
+			return nil, err
+		}
 		available, err := excludeEarlierCurtailmentReservations(ctx, q, eventID, targets)
 		if err != nil || len(available) == 0 {
 			return nil, err
@@ -3156,16 +3179,38 @@ func (s *SQLCurtailmentStore) ClaimClosedLoopFullFleetTargets(
 func (s *SQLCurtailmentStore) ClaimAllPairedPolicyTargets(
 	ctx context.Context,
 	eventID int64,
+	orgID int64,
+	maxTargets int,
 	targets []models.InsertTargetParams,
 ) (int64, error) {
-	if len(targets) == 0 {
+	if len(targets) == 0 || maxTargets <= 0 {
+		return 0, nil
+	}
+	available, err := excludeEarlierCurtailmentReservations(ctx, s.GetQueries(ctx), eventID, targets)
+	if err != nil {
+		return 0, err
+	}
+	if len(available) > maxTargets {
+		available = available[:maxTargets]
+	}
+	if len(available) == 0 {
 		return 0, nil
 	}
 	claimed, err := db.WithTransaction(ctx, s.conn.DB, func(q sqlc.Querier) (int64, error) {
 		if err := q.LockCurtailmentEventScopeForWrite(ctx, eventID); err != nil {
 			return 0, fleeterror.NewInternalErrorf("failed to lock all-paired admission scope: %v", err)
 		}
-		available, err := excludeEarlierCurtailmentReservations(ctx, q, eventID, targets)
+		if err := lockEarlierCurtailmentReservationBoundary(
+			ctx,
+			q,
+			eventID,
+			orgID,
+			insertTargetDeviceIdentifiers(available),
+			interfaces.ListCandidatesParams{},
+		); err != nil {
+			return 0, err
+		}
+		available, err = excludeEarlierCurtailmentReservations(ctx, q, eventID, available)
 		if err != nil || len(available) == 0 {
 			return 0, err
 		}
@@ -3182,6 +3227,54 @@ func (s *SQLCurtailmentStore) ClaimAllPairedPolicyTargets(
 		return 0, fleeterror.NewInternalErrorf("failed to claim all-paired policy targets: %v", err)
 	}
 	return claimed, nil
+}
+
+// lockEarlierCurtailmentReservationBoundary fences every topology selector
+// that can dynamically reserve one of deviceIdentifiers, then locks those
+// device rows. Callers must re-read ListEarlierCurtailmentReservationDevices
+// after this returns and keep all subsequent target writes in the same
+// transaction. currentScope is included for Start, which has no event ID yet.
+func lockEarlierCurtailmentReservationBoundary(
+	ctx context.Context,
+	q sqlc.Querier,
+	eventID int64,
+	orgID int64,
+	deviceIdentifiers []string,
+	currentScope interfaces.ListCandidatesParams,
+) error {
+	scopeJSONs, err := q.ListEarlierCurtailmentTopologyReservationScopes(
+		ctx,
+		sqlc.ListEarlierCurtailmentTopologyReservationScopesParams{
+			OrgID:              orgID,
+			CurtailmentEventID: eventID,
+		},
+	)
+	if err != nil {
+		return fleeterror.NewInternalErrorf("failed to list earlier curtailment topology reservations: %v", err)
+	}
+	selectors := interfaces.ListCandidatesParams{
+		OrgID:       orgID,
+		BuildingIDs: append([]int64(nil), currentScope.BuildingIDs...),
+		RackIDs:     append([]int64(nil), currentScope.RackIDs...),
+		GroupIDs:    append([]int64(nil), currentScope.GroupIDs...),
+	}
+	for _, scopeJSON := range scopeJSONs {
+		scope, hasScope, err := domainCurtailment.ScopeFromJSON(scopeJSON)
+		if err != nil {
+			return fleeterror.NewInternalErrorf("invalid persisted topology reservation scope: %v", err)
+		}
+		if !hasScope || !domainCurtailment.IsTopologyScope(scope) {
+			return fleeterror.NewInternalError("invalid persisted topology reservation scope")
+		}
+		selectors.BuildingIDs = append(selectors.BuildingIDs, scope.BuildingIDs...)
+		selectors.RackIDs = append(selectors.RackIDs, scope.RackIDs...)
+		selectors.GroupIDs = append(selectors.GroupIDs, scope.GroupIDs...)
+	}
+	if err := lockTopologySelectorResourcesForReservation(ctx, q, selectors, currentScope); err != nil {
+		return err
+	}
+	_, _, err = lockDeviceScopeCoverage(ctx, q, orgID, deviceIdentifiers, nil)
+	return err
 }
 
 func excludeEarlierCurtailmentReservations(
@@ -3315,39 +3408,84 @@ func (s *SQLCurtailmentStore) BeginCurtailmentTopologyTargetRestore(
 // bulkReadinessUpdateRow mirrors BulkRefreshAllPairedTargetReadiness's
 // jsonb_to_recordset column list.
 type bulkReadinessUpdateRow struct {
-	DeviceIdentifier string   `json:"device_identifier"`
-	ExpectedState    string   `json:"expected_state"`
-	State            string   `json:"state"`
-	LastError        string   `json:"last_error"`
-	BaselinePowerW   *float64 `json:"baseline_power_w"`
+	DeviceIdentifier     string   `json:"device_identifier"`
+	ExpectedState        string   `json:"expected_state"`
+	ExpectedDesiredState string   `json:"expected_desired_state"`
+	State                string   `json:"state"`
+	LastError            string   `json:"last_error"`
+	BaselinePowerW       *float64 `json:"baseline_power_w"`
 }
 
 func (s *SQLCurtailmentStore) BulkRefreshAllPairedTargetReadiness(
 	ctx context.Context,
 	eventID int64,
+	orgID int64,
 	expectedEventState models.EventState,
 	updates []interfaces.AllPairedReadinessUpdate,
 ) ([]string, error) {
 	if len(updates) == 0 {
 		return nil, nil
 	}
-	rows := make([]bulkReadinessUpdateRow, len(updates))
-	for i, u := range updates {
-		rows[i] = bulkReadinessUpdateRow{
-			DeviceIdentifier: u.DeviceIdentifier,
-			ExpectedState:    string(u.ExpectedState),
-			State:            string(u.State),
-			LastError:        u.Reason,
-			BaselinePowerW:   u.BaselinePowerW,
-		}
-	}
-	payload, err := json.Marshal(rows)
-	if err != nil {
-		return nil, fleeterror.NewInternalErrorf("encode all-paired readiness payload: %v", err)
-	}
 	applied, err := db.WithTransaction(ctx, s.conn.DB, func(q sqlc.Querier) ([]string, error) {
 		if err := q.LockCurtailmentEventScopeForWrite(ctx, eventID); err != nil {
 			return nil, fleeterror.NewInternalErrorf("failed to lock all-paired readiness scope: %v", err)
+		}
+		restoreFailedTargets := make([]models.InsertTargetParams, 0, len(updates))
+		for _, update := range updates {
+			if update.ExpectedState == models.TargetStateRestoreFailed {
+				restoreFailedTargets = append(restoreFailedTargets, models.InsertTargetParams{
+					DeviceIdentifier: update.DeviceIdentifier,
+				})
+			}
+		}
+		if len(restoreFailedTargets) > 0 {
+			if err := lockEarlierCurtailmentReservationBoundary(
+				ctx,
+				q,
+				eventID,
+				orgID,
+				insertTargetDeviceIdentifiers(restoreFailedTargets),
+				interfaces.ListCandidatesParams{},
+			); err != nil {
+				return nil, err
+			}
+			available, err := excludeEarlierCurtailmentReservations(ctx, q, eventID, restoreFailedTargets)
+			if err != nil {
+				return nil, err
+			}
+			availableSet := make(map[string]struct{}, len(available))
+			for _, target := range available {
+				availableSet[target.DeviceIdentifier] = struct{}{}
+			}
+			filtered := make([]interfaces.AllPairedReadinessUpdate, 0, len(updates))
+			for _, update := range updates {
+				if update.ExpectedState != models.TargetStateRestoreFailed {
+					filtered = append(filtered, update)
+					continue
+				}
+				if _, ok := availableSet[update.DeviceIdentifier]; ok {
+					filtered = append(filtered, update)
+				}
+			}
+			updates = filtered
+			if len(updates) == 0 {
+				return nil, nil
+			}
+		}
+		rows := make([]bulkReadinessUpdateRow, len(updates))
+		for i, update := range updates {
+			rows[i] = bulkReadinessUpdateRow{
+				DeviceIdentifier:     update.DeviceIdentifier,
+				ExpectedState:        string(update.ExpectedState),
+				ExpectedDesiredState: update.ExpectedDesiredState,
+				State:                string(update.State),
+				LastError:            update.Reason,
+				BaselinePowerW:       update.BaselinePowerW,
+			}
+		}
+		payload, err := json.Marshal(rows)
+		if err != nil {
+			return nil, fleeterror.NewInternalErrorf("encode all-paired readiness payload: %v", err)
 		}
 		return q.BulkRefreshAllPairedTargetReadiness(ctx, sqlc.BulkRefreshAllPairedTargetReadinessParams{
 			CurtailmentEventID: eventID,

--- a/server/internal/domain/stores/sqlstores/curtailment.go
+++ b/server/internal/domain/stores/sqlstores/curtailment.go
@@ -3310,9 +3310,6 @@ func (s *SQLCurtailmentStore) ClaimAllPairedPolicyTargets(
 		if err != nil || len(available) == 0 {
 			return 0, err
 		}
-		if len(available) > maxTargets {
-			available = available[:maxTargets]
-		}
 		if _, _, err := lockDeviceScopeCoverage(
 			ctx,
 			q,
@@ -3329,6 +3326,9 @@ func (s *SQLCurtailmentStore) ClaimAllPairedPolicyTargets(
 		available, err = filterCurrentCurtailmentTopologyTargets(ctx, q, currentScope, available)
 		if err != nil || len(available) == 0 {
 			return 0, err
+		}
+		if len(available) > maxTargets {
+			available = available[:maxTargets]
 		}
 		payload, err := buildBulkTargetPayload(available)
 		if err != nil {

--- a/server/internal/domain/stores/sqlstores/curtailment.go
+++ b/server/internal/domain/stores/sqlstores/curtailment.go
@@ -3128,17 +3128,25 @@ func (s *SQLCurtailmentStore) ClaimClosedLoopFullFleetTargets(
 		if err := q.LockCurtailmentEventScopeForWrite(ctx, eventID); err != nil {
 			return nil, fleeterror.NewInternalErrorf("failed to lock curtailment admission scope: %v", err)
 		}
+		currentScope, active, err := lockCurtailmentAdmissionEvent(ctx, q, eventID, orgID)
+		if err != nil || !active {
+			return nil, err
+		}
 		if err := lockEarlierCurtailmentReservationBoundary(
 			ctx,
 			q,
 			eventID,
 			orgID,
 			insertTargetDeviceIdentifiers(targets),
-			interfaces.ListCandidatesParams{},
+			currentScope,
 		); err != nil {
 			return nil, err
 		}
 		available, err := excludeEarlierCurtailmentReservations(ctx, q, eventID, targets)
+		if err != nil || len(available) == 0 {
+			return nil, err
+		}
+		available, err = filterCurrentCurtailmentTopologyTargets(ctx, q, currentScope, available)
 		if err != nil || len(available) == 0 {
 			return nil, err
 		}
@@ -3186,31 +3194,49 @@ func (s *SQLCurtailmentStore) ClaimAllPairedPolicyTargets(
 	if len(targets) == 0 || maxTargets <= 0 {
 		return 0, nil
 	}
-	available, err := excludeEarlierCurtailmentReservations(ctx, s.GetQueries(ctx), eventID, targets)
-	if err != nil {
-		return 0, err
-	}
-	if len(available) > maxTargets {
-		available = available[:maxTargets]
-	}
-	if len(available) == 0 {
-		return 0, nil
-	}
 	claimed, err := db.WithTransaction(ctx, s.conn.DB, func(q sqlc.Querier) (int64, error) {
 		if err := q.LockCurtailmentEventScopeForWrite(ctx, eventID); err != nil {
 			return 0, fleeterror.NewInternalErrorf("failed to lock all-paired admission scope: %v", err)
+		}
+		currentScope, active, err := lockCurtailmentAdmissionEvent(ctx, q, eventID, orgID)
+		if err != nil || !active {
+			return 0, err
 		}
 		if err := lockEarlierCurtailmentReservationBoundary(
 			ctx,
 			q,
 			eventID,
 			orgID,
+			nil,
+			currentScope,
+		); err != nil {
+			return 0, err
+		}
+		available, err := excludeEarlierCurtailmentReservations(ctx, q, eventID, targets)
+		if err != nil || len(available) == 0 {
+			return 0, err
+		}
+		available, err = filterCurrentCurtailmentTopologyTargets(ctx, q, currentScope, available)
+		if err != nil || len(available) == 0 {
+			return 0, err
+		}
+		if len(available) > maxTargets {
+			available = available[:maxTargets]
+		}
+		if _, _, err := lockDeviceScopeCoverage(
+			ctx,
+			q,
+			orgID,
 			insertTargetDeviceIdentifiers(available),
-			interfaces.ListCandidatesParams{},
+			nil,
 		); err != nil {
 			return 0, err
 		}
 		available, err = excludeEarlierCurtailmentReservations(ctx, q, eventID, available)
+		if err != nil || len(available) == 0 {
+			return 0, err
+		}
+		available, err = filterCurrentCurtailmentTopologyTargets(ctx, q, currentScope, available)
 		if err != nil || len(available) == 0 {
 			return 0, err
 		}
@@ -3229,11 +3255,83 @@ func (s *SQLCurtailmentStore) ClaimAllPairedPolicyTargets(
 	return claimed, nil
 }
 
+func lockCurtailmentAdmissionEvent(
+	ctx context.Context,
+	q sqlc.Querier,
+	eventID int64,
+	orgID int64,
+) (interfaces.ListCandidatesParams, bool, error) {
+	row, err := q.LockCurtailmentAdmissionEventForWrite(ctx, eventID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return interfaces.ListCandidatesParams{}, false, nil
+	}
+	if err != nil {
+		return interfaces.ListCandidatesParams{}, false, fleeterror.NewInternalErrorf(
+			"failed to lock curtailment admission event: %v",
+			err,
+		)
+	}
+	if row.OrgID != orgID {
+		return interfaces.ListCandidatesParams{}, false, fleeterror.NewInvalidArgumentError(
+			"curtailment admission event does not belong to the organization",
+		)
+	}
+	scope, hasScope, err := domainCurtailment.ScopeFromJSON(row.ScopeJsonb)
+	if err != nil {
+		return interfaces.ListCandidatesParams{}, false, fleeterror.NewInternalErrorf(
+			"invalid persisted curtailment admission scope: %v",
+			err,
+		)
+	}
+	if !hasScope || !domainCurtailment.IsTopologyScope(scope) {
+		return interfaces.ListCandidatesParams{OrgID: orgID}, true, nil
+	}
+	params, err := domainCurtailment.ListCandidatesParamsForScope(scope)
+	if err != nil {
+		return interfaces.ListCandidatesParams{}, false, fleeterror.NewInternalErrorf(
+			"invalid persisted curtailment topology scope: %v",
+			err,
+		)
+	}
+	params.OrgID = orgID
+	return params, true, nil
+}
+
+func filterCurrentCurtailmentTopologyTargets(
+	ctx context.Context,
+	q sqlc.Querier,
+	currentScope interfaces.ListCandidatesParams,
+	targets []models.InsertTargetParams,
+) ([]models.InsertTargetParams, error) {
+	if len(currentScope.BuildingIDs) == 0 && len(currentScope.RackIDs) == 0 && len(currentScope.GroupIDs) == 0 {
+		return targets, nil
+	}
+	snapshot, err := resolveCurtailmentTopologyDispatch(
+		ctx,
+		q,
+		currentScope,
+		insertTargetDeviceIdentifiers(targets),
+	)
+	if err != nil {
+		return nil, err
+	}
+	members := make(map[string]struct{}, len(snapshot.DispatchMemberDeviceIdentifiers))
+	for _, identifier := range snapshot.DispatchMemberDeviceIdentifiers {
+		members[identifier] = struct{}{}
+	}
+	filtered := make([]models.InsertTargetParams, 0, len(members))
+	for _, target := range targets {
+		if _, ok := members[target.DeviceIdentifier]; ok {
+			filtered = append(filtered, target)
+		}
+	}
+	return filtered, nil
+}
+
 // lockEarlierCurtailmentReservationBoundary fences every topology selector
-// that can dynamically reserve one of deviceIdentifiers, then locks those
-// device rows. Callers must re-read ListEarlierCurtailmentReservationDevices
-// after this returns and keep all subsequent target writes in the same
-// transaction. currentScope is included for Start, which has no event ID yet.
+// that can affect admission, then optionally locks candidate device rows.
+// Callers must re-read ListEarlierCurtailmentReservationDevices after this
+// returns and keep all subsequent target writes in the same transaction.
 func lockEarlierCurtailmentReservationBoundary(
 	ctx context.Context,
 	q sqlc.Querier,
@@ -3272,6 +3370,9 @@ func lockEarlierCurtailmentReservationBoundary(
 	}
 	if err := lockTopologySelectorResourcesForReservation(ctx, q, selectors, currentScope); err != nil {
 		return err
+	}
+	if len(deviceIdentifiers) == 0 {
+		return nil
 	}
 	_, _, err = lockDeviceScopeCoverage(ctx, q, orgID, deviceIdentifiers, nil)
 	return err

--- a/server/internal/domain/stores/sqlstores/curtailment_allpaired_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/curtailment_allpaired_integration_test.go
@@ -207,6 +207,48 @@ func TestSQLCurtailmentStore_ClaimAllPairedPolicyTargets_FillsBatchPastEarlierRe
 	})
 }
 
+func TestSQLCurtailmentStore_ListRecentlyResolvedCurtailedDevicesExcludesCurrentEvent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping database integration test in short mode")
+	}
+
+	testContext := testutil.InitializeDBServiceInfrastructure(t)
+	user := testContext.DatabaseService.CreateSuperAdminUser()
+	ctx := t.Context()
+	store := sqlstores.NewSQLCurtailmentStore(testContext.DatabaseService.DB)
+	deviceIDs := testContext.DatabaseService.CreateTestMiners(user.OrganizationID, 2, "https://172.17.0.1:80")
+
+	insertResolved := func(deviceIdentifier string) *models.InsertEventResult {
+		params := curtailmentStoreTestEvent(
+			user.OrganizationID,
+			user.DatabaseID,
+			uuid.New(),
+			models.EventStateActive,
+			"cooldown-"+deviceIdentifier,
+		)
+		params.ScopeJSON = []byte(`{"device_identifiers":["` + deviceIdentifier + `"]}`)
+		inserted, err := store.InsertEventWithTargets(ctx, params, []models.InsertTargetParams{
+			curtailmentStoreTestTarget(deviceIdentifier, models.TargetStateResolved, models.DesiredStateActive),
+		})
+		require.NoError(t, err)
+		return inserted
+	}
+	current := insertResolved(deviceIDs[0])
+	insertResolved(deviceIDs[1])
+
+	cooldownDevices, err := store.ListRecentlyResolvedCurtailedDevices(
+		ctx,
+		interfaces.ListRecentlyResolvedCurtailedDevicesParams{
+			OrgID:             user.OrganizationID,
+			ExcludeEventID:    current.ID,
+			CooldownSec:       600,
+			DeviceIdentifiers: deviceIDs,
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, []string{deviceIDs[1]}, cooldownDevices)
+}
+
 // Pins the ownership-suppression semantics of ListActiveCurtailedDevices for
 // all-paired events: the scope watcher keeps devices locked before their
 // policy row exists (miners that became paired-like between admission ticks

--- a/server/internal/domain/stores/sqlstores/curtailment_allpaired_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/curtailment_allpaired_integration_test.go
@@ -147,6 +147,66 @@ func TestSQLCurtailmentStore_ClaimAllPairedPolicyTargets_InsertsReopensAndSkipsC
 	assert.Zero(t, deferredCount)
 }
 
+func TestSQLCurtailmentStore_ClaimAllPairedPolicyTargets_FillsBatchPastEarlierReservation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping database integration test in short mode")
+	}
+
+	testContext := testutil.InitializeDBServiceInfrastructure(t)
+	user := testContext.DatabaseService.CreateSuperAdminUser()
+	ctx := t.Context()
+	store := sqlstores.NewSQLCurtailmentStore(testContext.DatabaseService.DB)
+	deviceIDs := testContext.DatabaseService.CreateTestMiners(user.OrganizationID, 3, "https://172.17.0.1:80")
+
+	_, err := store.InsertEventWithTargets(
+		ctx,
+		curtailmentStoreTestEvent(
+			user.OrganizationID,
+			user.DatabaseID,
+			uuid.New(),
+			models.EventStateActive,
+			"all-paired-earlier-owner",
+		),
+		[]models.InsertTargetParams{
+			curtailmentStoreTestTarget(deviceIDs[0], models.TargetStateConfirmed, models.DesiredStateCurtailed),
+		},
+	)
+	require.NoError(t, err)
+	policy, err := store.InsertEventWithTargets(
+		ctx,
+		curtailmentStoreAllPairedEvent(
+			user.OrganizationID,
+			user.DatabaseID,
+			uuid.New(),
+			"all-paired-reserved-prefix",
+		),
+		nil,
+	)
+	require.NoError(t, err)
+
+	claimed, err := store.ClaimAllPairedPolicyTargets(
+		ctx,
+		policy.ID,
+		user.OrganizationID,
+		2,
+		[]models.InsertTargetParams{
+			curtailmentStoreAllPairedTarget(deviceIDs[0], models.TargetStatePending, ""),
+			curtailmentStoreAllPairedTarget(deviceIDs[1], models.TargetStatePending, ""),
+			curtailmentStoreAllPairedTarget(deviceIDs[2], models.TargetStatePending, ""),
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), claimed)
+
+	targets, err := store.ListTargetsByEvent(ctx, user.OrganizationID, policy.EventUUID)
+	require.NoError(t, err)
+	require.Len(t, targets, 2)
+	assert.ElementsMatch(t, []string{deviceIDs[1], deviceIDs[2]}, []string{
+		targets[0].DeviceIdentifier,
+		targets[1].DeviceIdentifier,
+	})
+}
+
 // Pins the ownership-suppression semantics of ListActiveCurtailedDevices for
 // all-paired events: the scope watcher keeps devices locked before their
 // policy row exists (miners that became paired-like between admission ticks

--- a/server/internal/domain/stores/sqlstores/curtailment_allpaired_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/curtailment_allpaired_integration_test.go
@@ -180,14 +180,22 @@ func TestSQLCurtailmentStore_ListActiveCurtailedDevices_AllPairedScopeLockAndRel
 	assert.Contains(t, got, unavailable)
 	assert.NotContains(t, got, released,
 		"during restoring, reopen is impossible: released rows free their device instead of holding it until terminal")
+
+	_, err = store.InsertEventWithTargets(
+		ctx,
+		curtailmentStoreTestEvent(user.OrganizationID, user.DatabaseID, uuid.New(), models.EventStateActive, "released-policy-row-competitor"),
+		[]models.InsertTargetParams{
+			curtailmentStoreTestTarget(released, models.TargetStateConfirmed, models.DesiredStateCurtailed),
+		},
+	)
+	require.NoError(t, err,
+		"the transactional reservation check must apply the same restoring/released exception as the selector")
 }
 
-// Pins BulkRefreshAllPairedTargetReadiness' real SQL: pending/unavailable
-// curtail-phase rows flip in one statement, rows that advanced past the
-// refreshable states are skipped (and reported via RETURNING so the caller
-// mirrors only applied rows), a stale expected event state applies nothing,
-// and promotion baselines backfill NULL only — an existing pre-curtail
-// baseline is never overwritten.
+// Pins BulkRefreshAllPairedTargetReadiness' real SQL: curtail and topology
+// restore readiness flips share one guarded batch, rows that advanced past
+// refreshable states are skipped, a stale event state applies nothing, and
+// curtail promotion baselines backfill NULL only.
 func TestSQLCurtailmentStore_BulkRefreshAllPairedTargetReadiness_FlipsAndSkips(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping database integration test in short mode")
@@ -202,6 +210,12 @@ func TestSQLCurtailmentStore_BulkRefreshAllPairedTargetReadiness_FlipsAndSkips(t
 	existingBaseline := 2500.0
 	seededBaselineTarget := curtailmentStoreAllPairedTarget("bulk-keeps-baseline", models.TargetStateUnavailable, "offline")
 	seededBaselineTarget.BaselinePowerW = &existingBaseline
+	restoreFailedTarget := curtailmentStoreAllPairedTarget("bulk-parks-restore-failure", models.TargetStateRestoreFailed, "restore dispatch failed")
+	restoreFailedTarget.DesiredState = models.DesiredStateActive
+	restoreUnavailableTarget := curtailmentStoreAllPairedTarget("bulk-requeues-restore", models.TargetStateUnavailable, "unpaired")
+	restoreUnavailableTarget.DesiredState = models.DesiredStateActive
+	staleRestoreTarget := curtailmentStoreAllPairedTarget("bulk-skips-stale-restore", models.TargetStateRestoreFailed, "restore dispatch failed")
+	staleRestoreTarget.DesiredState = models.DesiredStateActive
 
 	eventUUID := uuid.New()
 	inserted, err := store.InsertEventWithTargets(
@@ -212,6 +226,9 @@ func TestSQLCurtailmentStore_BulkRefreshAllPairedTargetReadiness_FlipsAndSkips(t
 			curtailmentStoreAllPairedTarget("bulk-demotes", models.TargetStatePending, ""),
 			curtailmentStoreAllPairedTarget("bulk-dispatched", models.TargetStateDispatched, ""),
 			seededBaselineTarget,
+			restoreFailedTarget,
+			restoreUnavailableTarget,
+			staleRestoreTarget,
 		},
 	)
 	require.NoError(t, err)
@@ -221,24 +238,31 @@ func TestSQLCurtailmentStore_BulkRefreshAllPairedTargetReadiness_FlipsAndSkips(t
 
 	applied, err := store.BulkRefreshAllPairedTargetReadiness(ctx, inserted.ID, models.EventStatePending,
 		[]interfaces.AllPairedReadinessUpdate{
-			{DeviceIdentifier: "bulk-promotes", State: models.TargetStatePending},
+			{DeviceIdentifier: "bulk-promotes", ExpectedState: models.TargetStateUnavailable, State: models.TargetStatePending},
 		})
 	require.NoError(t, err)
 	assert.Empty(t, applied, "stale expected event state must apply nothing")
 
 	applied, err = store.BulkRefreshAllPairedTargetReadiness(ctx, inserted.ID, models.EventStateActive,
 		[]interfaces.AllPairedReadinessUpdate{
-			{DeviceIdentifier: "bulk-promotes", State: models.TargetStatePending, BaselinePowerW: &promotionBaseline},
-			{DeviceIdentifier: "bulk-demotes", State: models.TargetStateUnavailable, Reason: "offline"},
-			{DeviceIdentifier: "bulk-dispatched", State: models.TargetStateUnavailable, Reason: "offline"},
-			{DeviceIdentifier: "bulk-keeps-baseline", State: models.TargetStatePending, BaselinePowerW: &overwriteAttempt},
+			{DeviceIdentifier: "bulk-promotes", ExpectedState: models.TargetStateUnavailable, State: models.TargetStatePending, BaselinePowerW: &promotionBaseline},
+			{DeviceIdentifier: "bulk-demotes", ExpectedState: models.TargetStatePending, State: models.TargetStateUnavailable, Reason: "offline"},
+			{DeviceIdentifier: "bulk-dispatched", ExpectedState: models.TargetStateDispatched, State: models.TargetStateUnavailable, Reason: "offline"},
+			{DeviceIdentifier: "bulk-keeps-baseline", ExpectedState: models.TargetStateUnavailable, State: models.TargetStatePending, BaselinePowerW: &overwriteAttempt},
+			{DeviceIdentifier: "bulk-parks-restore-failure", ExpectedState: models.TargetStateRestoreFailed, State: models.TargetStateUnavailable, Reason: "unpaired"},
+			{DeviceIdentifier: "bulk-requeues-restore", ExpectedState: models.TargetStateUnavailable, State: models.TargetStatePending},
+			{DeviceIdentifier: "bulk-skips-stale-restore", ExpectedState: models.TargetStateUnavailable, State: models.TargetStatePending},
 		})
 	require.NoError(t, err)
-	assert.ElementsMatch(t, []string{"bulk-promotes", "bulk-demotes", "bulk-keeps-baseline"}, applied,
+	assert.ElementsMatch(t, []string{
+		"bulk-promotes", "bulk-demotes", "bulk-keeps-baseline",
+		"bulk-parks-restore-failure", "bulk-requeues-restore",
+	}, applied,
 		"the dispatched row is past the refreshable states and must be skipped — and not reported as applied")
 
 	rows, err := db.QueryContext(ctx, `
-		SELECT device_identifier, state, last_error, curtail_state, curtail_failure_count, baseline_power_w
+		SELECT device_identifier, state, last_error, curtail_state, curtail_failure_count,
+		       baseline_power_w, restore_state, restore_completed_at, restore_retry_count
 		FROM curtailment_target
 		WHERE curtailment_event_id = $1
 	`, inserted.ID)
@@ -251,16 +275,22 @@ func TestSQLCurtailmentStore_BulkRefreshAllPairedTargetReadiness_FlipsAndSkips(t
 		curtailState        sql.NullString
 		curtailFailureCount int32
 		baselinePowerW      sql.NullFloat64
+		restoreState        sql.NullString
+		restoreCompletedAt  sql.NullTime
+		restoreRetryCount   int32
 	}
 	got := map[string]refreshedRow{}
 	for rows.Next() {
 		var device string
 		var row refreshedRow
-		require.NoError(t, rows.Scan(&device, &row.state, &row.lastError, &row.curtailState, &row.curtailFailureCount, &row.baselinePowerW))
+		require.NoError(t, rows.Scan(
+			&device, &row.state, &row.lastError, &row.curtailState, &row.curtailFailureCount,
+			&row.baselinePowerW, &row.restoreState, &row.restoreCompletedAt, &row.restoreRetryCount,
+		))
 		got[device] = row
 	}
 	require.NoError(t, rows.Err())
-	require.Len(t, got, 4)
+	require.Len(t, got, 7)
 
 	promoted := got["bulk-promotes"]
 	assert.Equal(t, string(models.TargetStatePending), promoted.state)
@@ -286,6 +316,22 @@ func TestSQLCurtailmentStore_BulkRefreshAllPairedTargetReadiness_FlipsAndSkips(t
 	require.True(t, keepsBaseline.baselinePowerW.Valid)
 	assert.InDelta(t, existingBaseline, keepsBaseline.baselinePowerW.Float64, 0.001,
 		"an existing pre-curtail baseline is never overwritten by promotion telemetry")
+
+	parkedRestore := got["bulk-parks-restore-failure"]
+	assert.Equal(t, string(models.TargetStateUnavailable), parkedRestore.state)
+	assert.Equal(t, string(models.TargetStateUnavailable), parkedRestore.restoreState.String)
+	assert.False(t, parkedRestore.restoreCompletedAt.Valid, "parking reopens the restore obligation")
+
+	requeuedRestore := got["bulk-requeues-restore"]
+	assert.Equal(t, string(models.TargetStatePending), requeuedRestore.state)
+	assert.False(t, requeuedRestore.lastError.Valid)
+	assert.Equal(t, string(models.TargetStatePending), requeuedRestore.restoreState.String)
+	assert.False(t, requeuedRestore.restoreCompletedAt.Valid)
+	assert.Zero(t, requeuedRestore.restoreRetryCount, "re-pairing grants a fresh bounded restore attempt")
+
+	staleRestore := got["bulk-skips-stale-restore"]
+	assert.Equal(t, string(models.TargetStateRestoreFailed), staleRestore.state)
+	assert.Equal(t, "restore dispatch failed", staleRestore.lastError.String)
 }
 
 // Pins the graceful-Stop release predicate against real SQL: only all-paired

--- a/server/internal/domain/stores/sqlstores/curtailment_allpaired_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/curtailment_allpaired_integration_test.go
@@ -66,7 +66,7 @@ func TestSQLCurtailmentStore_ClaimAllPairedPolicyTargets_InsertsReopensAndSkipsC
 	)
 	require.NoError(t, err)
 
-	claimed, err := store.ClaimAllPairedPolicyTargets(ctx, policyEvent.ID, []models.InsertTargetParams{
+	claimed, err := store.ClaimAllPairedPolicyTargets(ctx, policyEvent.ID, user.OrganizationID, 100, []models.InsertTargetParams{
 		curtailmentStoreAllPairedTarget("ap-claim-new-pending", models.TargetStatePending, ""),
 		curtailmentStoreAllPairedTarget("ap-claim-new-unavailable", models.TargetStateUnavailable, "offline"),
 		curtailmentStoreAllPairedTarget("ap-claim-released", models.TargetStatePending, ""),
@@ -117,7 +117,7 @@ func TestSQLCurtailmentStore_ClaimAllPairedPolicyTargets_InsertsReopensAndSkipsC
 	)
 	require.NoError(t, err)
 
-	claimed, err = store.ClaimAllPairedPolicyTargets(ctx, policyEvent.ID, []models.InsertTargetParams{
+	claimed, err = store.ClaimAllPairedPolicyTargets(ctx, policyEvent.ID, user.OrganizationID, 100, []models.InsertTargetParams{
 		curtailmentStoreAllPairedTarget("ap-claim-new-pending", models.TargetStatePending, ""),
 	})
 	require.NoError(t, err)
@@ -129,6 +129,22 @@ func TestSQLCurtailmentStore_ClaimAllPairedPolicyTargets_InsertsReopensAndSkipsC
 		WHERE curtailment_event_id = $1 AND device_identifier = 'ap-claim-new-pending'
 	`, policyEvent.ID).Scan(&state))
 	assert.Equal(t, string(models.TargetStateReleased), state)
+
+	claimed, err = store.ClaimAllPairedPolicyTargets(ctx, policyEvent.ID, user.OrganizationID, 2, []models.InsertTargetParams{
+		curtailmentStoreAllPairedTarget("ap-batch-first", models.TargetStatePending, ""),
+		curtailmentStoreAllPairedTarget("ap-batch-second", models.TargetStatePending, ""),
+		curtailmentStoreAllPairedTarget("ap-batch-deferred", models.TargetStatePending, ""),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), claimed, "one admission tick must not exceed its configured batch size")
+	var deferredCount int
+	require.NoError(t, db.QueryRowContext(ctx, `
+		SELECT count(*)
+		FROM curtailment_target
+		WHERE curtailment_event_id = $1
+		  AND device_identifier = 'ap-batch-deferred'
+	`, policyEvent.ID).Scan(&deferredCount))
+	assert.Zero(t, deferredCount)
 }
 
 // Pins the ownership-suppression semantics of ListActiveCurtailedDevices for
@@ -216,6 +232,8 @@ func TestSQLCurtailmentStore_BulkRefreshAllPairedTargetReadiness_FlipsAndSkips(t
 	restoreUnavailableTarget.DesiredState = models.DesiredStateActive
 	staleRestoreTarget := curtailmentStoreAllPairedTarget("bulk-skips-stale-restore", models.TargetStateRestoreFailed, "restore dispatch failed")
 	staleRestoreTarget.DesiredState = models.DesiredStateActive
+	staleCurtailDirection := curtailmentStoreAllPairedTarget("bulk-skips-active-direction", models.TargetStateUnavailable, "unpaired")
+	staleCurtailDirection.DesiredState = models.DesiredStateActive
 
 	eventUUID := uuid.New()
 	inserted, err := store.InsertEventWithTargets(
@@ -229,6 +247,8 @@ func TestSQLCurtailmentStore_BulkRefreshAllPairedTargetReadiness_FlipsAndSkips(t
 			restoreFailedTarget,
 			restoreUnavailableTarget,
 			staleRestoreTarget,
+			staleCurtailDirection,
+			curtailmentStoreAllPairedTarget("bulk-skips-curtailed-direction", models.TargetStatePending, ""),
 		},
 	)
 	require.NoError(t, err)
@@ -236,22 +256,24 @@ func TestSQLCurtailmentStore_BulkRefreshAllPairedTargetReadiness_FlipsAndSkips(t
 	promotionBaseline := 3000.0
 	overwriteAttempt := 9999.0
 
-	applied, err := store.BulkRefreshAllPairedTargetReadiness(ctx, inserted.ID, models.EventStatePending,
+	applied, err := store.BulkRefreshAllPairedTargetReadiness(ctx, inserted.ID, user.OrganizationID, models.EventStatePending,
 		[]interfaces.AllPairedReadinessUpdate{
-			{DeviceIdentifier: "bulk-promotes", ExpectedState: models.TargetStateUnavailable, State: models.TargetStatePending},
+			{DeviceIdentifier: "bulk-promotes", ExpectedState: models.TargetStateUnavailable, ExpectedDesiredState: models.DesiredStateCurtailed, State: models.TargetStatePending},
 		})
 	require.NoError(t, err)
 	assert.Empty(t, applied, "stale expected event state must apply nothing")
 
-	applied, err = store.BulkRefreshAllPairedTargetReadiness(ctx, inserted.ID, models.EventStateActive,
+	applied, err = store.BulkRefreshAllPairedTargetReadiness(ctx, inserted.ID, user.OrganizationID, models.EventStateActive,
 		[]interfaces.AllPairedReadinessUpdate{
-			{DeviceIdentifier: "bulk-promotes", ExpectedState: models.TargetStateUnavailable, State: models.TargetStatePending, BaselinePowerW: &promotionBaseline},
-			{DeviceIdentifier: "bulk-demotes", ExpectedState: models.TargetStatePending, State: models.TargetStateUnavailable, Reason: "offline"},
-			{DeviceIdentifier: "bulk-dispatched", ExpectedState: models.TargetStateDispatched, State: models.TargetStateUnavailable, Reason: "offline"},
-			{DeviceIdentifier: "bulk-keeps-baseline", ExpectedState: models.TargetStateUnavailable, State: models.TargetStatePending, BaselinePowerW: &overwriteAttempt},
-			{DeviceIdentifier: "bulk-parks-restore-failure", ExpectedState: models.TargetStateRestoreFailed, State: models.TargetStateUnavailable, Reason: "unpaired"},
-			{DeviceIdentifier: "bulk-requeues-restore", ExpectedState: models.TargetStateUnavailable, State: models.TargetStatePending},
-			{DeviceIdentifier: "bulk-skips-stale-restore", ExpectedState: models.TargetStateUnavailable, State: models.TargetStatePending},
+			{DeviceIdentifier: "bulk-promotes", ExpectedState: models.TargetStateUnavailable, ExpectedDesiredState: models.DesiredStateCurtailed, State: models.TargetStatePending, BaselinePowerW: &promotionBaseline},
+			{DeviceIdentifier: "bulk-demotes", ExpectedState: models.TargetStatePending, ExpectedDesiredState: models.DesiredStateCurtailed, State: models.TargetStateUnavailable, Reason: "offline"},
+			{DeviceIdentifier: "bulk-dispatched", ExpectedState: models.TargetStateDispatched, ExpectedDesiredState: models.DesiredStateCurtailed, State: models.TargetStateUnavailable, Reason: "offline"},
+			{DeviceIdentifier: "bulk-keeps-baseline", ExpectedState: models.TargetStateUnavailable, ExpectedDesiredState: models.DesiredStateCurtailed, State: models.TargetStatePending, BaselinePowerW: &overwriteAttempt},
+			{DeviceIdentifier: "bulk-parks-restore-failure", ExpectedState: models.TargetStateRestoreFailed, ExpectedDesiredState: models.DesiredStateActive, State: models.TargetStateUnavailable, Reason: "unpaired"},
+			{DeviceIdentifier: "bulk-requeues-restore", ExpectedState: models.TargetStateUnavailable, ExpectedDesiredState: models.DesiredStateActive, State: models.TargetStatePending},
+			{DeviceIdentifier: "bulk-skips-stale-restore", ExpectedState: models.TargetStateUnavailable, ExpectedDesiredState: models.DesiredStateActive, State: models.TargetStatePending},
+			{DeviceIdentifier: "bulk-skips-active-direction", ExpectedState: models.TargetStateUnavailable, ExpectedDesiredState: models.DesiredStateCurtailed, State: models.TargetStatePending},
+			{DeviceIdentifier: "bulk-skips-curtailed-direction", ExpectedState: models.TargetStatePending, ExpectedDesiredState: models.DesiredStateActive, State: models.TargetStateUnavailable, Reason: "unpaired"},
 		})
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []string{
@@ -290,7 +312,7 @@ func TestSQLCurtailmentStore_BulkRefreshAllPairedTargetReadiness_FlipsAndSkips(t
 		got[device] = row
 	}
 	require.NoError(t, rows.Err())
-	require.Len(t, got, 7)
+	require.Len(t, got, 9)
 
 	promoted := got["bulk-promotes"]
 	assert.Equal(t, string(models.TargetStatePending), promoted.state)
@@ -332,6 +354,10 @@ func TestSQLCurtailmentStore_BulkRefreshAllPairedTargetReadiness_FlipsAndSkips(t
 	staleRestore := got["bulk-skips-stale-restore"]
 	assert.Equal(t, string(models.TargetStateRestoreFailed), staleRestore.state)
 	assert.Equal(t, "restore dispatch failed", staleRestore.lastError.String)
+	assert.Equal(t, string(models.TargetStateUnavailable), got["bulk-skips-active-direction"].state,
+		"a curtail-phase decision must not overwrite a target that entered restore")
+	assert.Equal(t, string(models.TargetStatePending), got["bulk-skips-curtailed-direction"].state,
+		"a restore-phase decision must not overwrite a target that re-entered curtail")
 }
 
 // Pins the graceful-Stop release predicate against real SQL: only all-paired

--- a/server/internal/domain/stores/sqlstores/curtailment_authorization_envelope.go
+++ b/server/internal/domain/stores/sqlstores/curtailment_authorization_envelope.go
@@ -158,37 +158,8 @@ func lockTopologyScopeCoverage(
 	params interfaces.ListCandidatesParams,
 	requiredDeviceIdentifiers []string,
 ) ([]int64, bool, error) {
-	groupIDs := uniqueSortedInt64s(params.GroupIDs)
-	if len(groupIDs) > 0 {
-		lockedGroupIDs, err := q.LockCurtailmentGroupsForWrite(ctx, sqlc.LockCurtailmentGroupsForWriteParams{
-			OrgID: params.OrgID, GroupIds: groupIDs,
-		})
-		if err != nil {
-			return nil, false, fleeterror.NewInternalErrorf("failed to lock curtailment group scope: %v", err)
-		}
-		if len(lockedGroupIDs) != len(groupIDs) {
-			return nil, false, fleeterror.NewNotFoundError("one or more curtailment groups were not found")
-		}
-	}
-	for _, buildingID := range uniqueSortedInt64s(params.BuildingIDs) {
-		if _, err := q.LockBuildingForWrite(ctx, sqlc.LockBuildingForWriteParams{
-			ID: buildingID, OrgID: params.OrgID,
-		}); err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
-				return nil, false, fleeterror.NewNotFoundErrorf("building not found: %d", buildingID)
-			}
-			return nil, false, fleeterror.NewInternalErrorf("failed to lock curtailment building scope: %v", err)
-		}
-	}
-	for _, rackID := range uniqueSortedInt64s(params.RackIDs) {
-		if _, err := q.LockRackPlacementForWrite(ctx, sqlc.LockRackPlacementForWriteParams{
-			DeviceSetID: rackID, OrgID: params.OrgID,
-		}); err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
-				return nil, false, fleeterror.NewNotFoundErrorf("rack not found: %d", rackID)
-			}
-			return nil, false, fleeterror.NewInternalErrorf("failed to lock curtailment rack scope: %v", err)
-		}
+	if err := lockTopologySelectorResourcesForWrite(ctx, q, params); err != nil {
+		return nil, false, err
 	}
 
 	rows, err := q.LockCurtailmentTopologyMemberDeviceSitesByOrg(
@@ -228,6 +199,92 @@ func lockTopologyScopeCoverage(
 		}
 	}
 	return uniqueSortedInt64s(memberSites), unbounded, nil
+}
+
+// lockTopologySelectorResourcesForWrite locks selected topology resources in
+// the same group -> building -> rack order used by the full coverage fence,
+// without expanding and locking every current member. Admission uses it for
+// older logical reservations, then locks only the candidate device rows.
+func lockTopologySelectorResourcesForWrite(
+	ctx context.Context,
+	q sqlc.Querier,
+	params interfaces.ListCandidatesParams,
+) error {
+	return lockTopologySelectorResources(ctx, q, params, params)
+}
+
+// lockTopologySelectorResourcesForReservation tolerates an older watcher's
+// selector having been deleted, because that selector no longer reserves any
+// members. required contains the current Start selector, which must still
+// exist when it is locked together with the older selectors.
+func lockTopologySelectorResourcesForReservation(
+	ctx context.Context,
+	q sqlc.Querier,
+	params interfaces.ListCandidatesParams,
+	required interfaces.ListCandidatesParams,
+) error {
+	return lockTopologySelectorResources(ctx, q, params, required)
+}
+
+func lockTopologySelectorResources(
+	ctx context.Context,
+	q sqlc.Querier,
+	params interfaces.ListCandidatesParams,
+	required interfaces.ListCandidatesParams,
+) error {
+	requiredGroups := int64Set(required.GroupIDs)
+	groupIDs := uniqueSortedInt64s(params.GroupIDs)
+	if len(groupIDs) > 0 {
+		lockedGroupIDs, err := q.LockCurtailmentGroupsForWrite(ctx, sqlc.LockCurtailmentGroupsForWriteParams{
+			OrgID: params.OrgID, GroupIds: groupIDs,
+		})
+		if err != nil {
+			return fleeterror.NewInternalErrorf("failed to lock curtailment group scope: %v", err)
+		}
+		for _, groupID := range lockedGroupIDs {
+			delete(requiredGroups, groupID)
+		}
+		if len(requiredGroups) > 0 {
+			return fleeterror.NewNotFoundError("one or more curtailment groups were not found")
+		}
+	}
+	requiredBuildings := int64Set(required.BuildingIDs)
+	for _, buildingID := range uniqueSortedInt64s(params.BuildingIDs) {
+		if _, err := q.LockBuildingForWrite(ctx, sqlc.LockBuildingForWriteParams{
+			ID: buildingID, OrgID: params.OrgID,
+		}); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				if _, isRequired := requiredBuildings[buildingID]; !isRequired {
+					continue
+				}
+				return fleeterror.NewNotFoundErrorf("building not found: %d", buildingID)
+			}
+			return fleeterror.NewInternalErrorf("failed to lock curtailment building scope: %v", err)
+		}
+	}
+	requiredRacks := int64Set(required.RackIDs)
+	for _, rackID := range uniqueSortedInt64s(params.RackIDs) {
+		if _, err := q.LockRackPlacementForWrite(ctx, sqlc.LockRackPlacementForWriteParams{
+			DeviceSetID: rackID, OrgID: params.OrgID,
+		}); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				if _, isRequired := requiredRacks[rackID]; !isRequired {
+					continue
+				}
+				return fleeterror.NewNotFoundErrorf("rack not found: %d", rackID)
+			}
+			return fleeterror.NewInternalErrorf("failed to lock curtailment rack scope: %v", err)
+		}
+	}
+	return nil
+}
+
+func int64Set(values []int64) map[int64]struct{} {
+	set := make(map[int64]struct{}, len(values))
+	for _, value := range uniqueSortedInt64s(values) {
+		set[value] = struct{}{}
+	}
+	return set
 }
 
 func nonNilInt64Slice(values []int64) []int64 {

--- a/server/internal/domain/stores/sqlstores/curtailment_recurtail_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/curtailment_recurtail_integration_test.go
@@ -561,7 +561,7 @@ func TestSQLCurtailmentStore_ClaimClosedLoopFullFleetTargets(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	claimed, err := store.ClaimClosedLoopFullFleetTargets(ctx, source.ID, user.OrganizationID, 0, []models.InsertTargetParams{
+	claimed, err := store.ClaimClosedLoopFullFleetTargets(ctx, source.ID, user.OrganizationID, 0, 2, []models.InsertTargetParams{
 		curtailmentStoreTestTarget("claim-a", models.TargetStatePending, models.DesiredStateCurtailed),
 		curtailmentStoreTestTarget("claim-b", models.TargetStatePending, models.DesiredStateCurtailed),
 	})
@@ -570,7 +570,7 @@ func TestSQLCurtailmentStore_ClaimClosedLoopFullFleetTargets(t *testing.T) {
 	assert.Equal(t, models.TargetStateDispatching, claimed[0].State)
 	assert.Equal(t, models.TargetStateDispatching, claimed[1].State)
 
-	claimed, err = store.ClaimClosedLoopFullFleetTargets(ctx, source.ID, user.OrganizationID, 0, []models.InsertTargetParams{
+	claimed, err = store.ClaimClosedLoopFullFleetTargets(ctx, source.ID, user.OrganizationID, 0, 2, []models.InsertTargetParams{
 		curtailmentStoreTestTarget("claim-a", models.TargetStatePending, models.DesiredStateCurtailed),
 		curtailmentStoreTestTarget("claim-b", models.TargetStatePending, models.DesiredStateCurtailed),
 	})
@@ -585,7 +585,7 @@ func TestSQLCurtailmentStore_ClaimClosedLoopFullFleetTargets(t *testing.T) {
 	require.NoError(t, err)
 	require.NotZero(t, other.ID)
 
-	claimed, err = store.ClaimClosedLoopFullFleetTargets(ctx, source.ID, user.OrganizationID, 0, []models.InsertTargetParams{
+	claimed, err = store.ClaimClosedLoopFullFleetTargets(ctx, source.ID, user.OrganizationID, 0, 2, []models.InsertTargetParams{
 		curtailmentStoreTestTarget("claim-conflict", models.TargetStatePending, models.DesiredStateCurtailed),
 		curtailmentStoreTestTarget("claim-c", models.TargetStatePending, models.DesiredStateCurtailed),
 	})

--- a/server/internal/domain/stores/sqlstores/curtailment_test.go
+++ b/server/internal/domain/stores/sqlstores/curtailment_test.go
@@ -33,13 +33,13 @@ func TestInsertEventWithTargets_RejectsEmptyTargetsForNonTerminalEvent(t *testin
 	assert.True(t, fleeterror.IsInvalidArgumentError(err))
 }
 
-func TestHierarchicalScopeSiteIDs(t *testing.T) {
+func TestHierarchicalScopeFilter(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name              string
 		event             models.InsertEventParams
-		wantSiteIDs       []int64
+		wantFilter        interfaces.ListCandidatesParams
 		wantUsesScopeLock bool
 		wantErr           bool
 	}{
@@ -51,7 +51,7 @@ func TestHierarchicalScopeSiteIDs(t *testing.T) {
 		{
 			name:              "single site",
 			event:             models.InsertEventParams{State: models.EventStateActive, ScopeType: models.ScopeTypeSite, ScopeJSON: []byte(`{"site_id":7}`)},
-			wantSiteIDs:       []int64{7},
+			wantFilter:        interfaces.ListCandidatesParams{SiteIDs: []int64{7}},
 			wantUsesScopeLock: true,
 		},
 		{
@@ -61,7 +61,17 @@ func TestHierarchicalScopeSiteIDs(t *testing.T) {
 				ScopeType: models.ScopeTypeMixed,
 				ScopeJSON: []byte(`{"site_ids":[8,7,7],"device_identifiers":null}`),
 			},
-			wantSiteIDs:       []int64{7, 8},
+			wantFilter:        interfaces.ListCandidatesParams{SiteIDs: []int64{7, 8}},
+			wantUsesScopeLock: true,
+		},
+		{
+			name: "topology selectors use the scope lock",
+			event: models.InsertEventParams{
+				State:     models.EventStateActive,
+				ScopeType: models.ScopeTypeMixed,
+				ScopeJSON: []byte(`{"building_ids":[9,8,8]}`),
+			},
+			wantFilter:        interfaces.ListCandidatesParams{BuildingIDs: []int64{8, 9}},
 			wantUsesScopeLock: true,
 		},
 		{
@@ -91,14 +101,14 @@ func TestHierarchicalScopeSiteIDs(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			gotSiteIDs, gotUsesScopeLock, err := hierarchicalScopeSiteIDs(tc.event)
+			gotFilter, gotUsesScopeLock, err := hierarchicalScopeFilter(tc.event)
 
 			if tc.wantErr {
 				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
-			assert.Equal(t, tc.wantSiteIDs, gotSiteIDs)
+			assert.Equal(t, tc.wantFilter, gotFilter)
 			assert.Equal(t, tc.wantUsesScopeLock, gotUsesScopeLock)
 		})
 	}

--- a/server/internal/domain/stores/sqlstores/curtailment_topology_start_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/curtailment_topology_start_integration_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	collectionpb "github.com/block/proto-fleet/server/generated/grpc/collection/v1"
+	pairingpb "github.com/block/proto-fleet/server/generated/grpc/pairing/v1"
 	"github.com/block/proto-fleet/server/generated/sqlc"
 	buildingsmodels "github.com/block/proto-fleet/server/internal/domain/buildings/models"
 	"github.com/block/proto-fleet/server/internal/domain/curtailment/models"
@@ -21,6 +23,73 @@ import (
 	dbinfra "github.com/block/proto-fleet/server/internal/infrastructure/db"
 	"github.com/block/proto-fleet/server/internal/testutil"
 )
+
+func TestSQLCurtailmentStore_PairingInsertWaitsForTopologyRestoreLock(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping database integration test in short mode")
+	}
+
+	testContext := testutil.InitializeDBServiceInfrastructure(t)
+	user := testContext.DatabaseService.CreateSuperAdminUser()
+	ctx := t.Context()
+	database := testContext.DatabaseService.DB
+	device := testContext.DatabaseService.CreateDevice(user.OrganizationID, "proto")
+	_, err := database.ExecContext(ctx, `DELETE FROM device_pairing WHERE device_id = $1`, device.DatabaseID)
+	require.NoError(t, err)
+
+	locked := make(chan struct{})
+	release := make(chan struct{})
+	lockDone := make(chan error, 1)
+	go func() {
+		lockDone <- dbinfra.WithTransactionNoResult(ctx, database, func(q sqlc.Querier) error {
+			rows, err := q.LockCurtailmentTargetPairingStatusesForWrite(
+				ctx,
+				sqlc.LockCurtailmentTargetPairingStatusesForWriteParams{
+					OrgID:             user.OrganizationID,
+					DeviceIdentifiers: []string{device.ID},
+				},
+			)
+			if err != nil {
+				return err
+			}
+			if len(rows) != 1 || rows[0].PairingStatus != "UNPAIRED" {
+				return fmt.Errorf("unexpected locked pairing snapshot: %+v", rows)
+			}
+			close(locked)
+			<-release
+			return nil
+		})
+	}()
+	<-locked
+
+	pairDone := make(chan error, 1)
+	go func() {
+		pairDone <- sqlstores.NewSQLDeviceStore(database).UpsertDevicePairing(
+			ctx,
+			&pairingpb.Device{DeviceIdentifier: device.ID},
+			user.OrganizationID,
+			string(sqlc.PairingStatusEnumPAIRED),
+		)
+	}()
+	select {
+	case err := <-pairDone:
+		require.NoError(t, err)
+		t.Fatal("first pairing insert bypassed the topology restore device lock")
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	close(release)
+	require.NoError(t, <-lockDone)
+	require.NoError(t, <-pairDone)
+
+	var pairingStatus string
+	require.NoError(t, database.QueryRowContext(
+		ctx,
+		`SELECT pairing_status::TEXT FROM device_pairing WHERE device_id = $1`,
+		device.DatabaseID,
+	).Scan(&pairingStatus))
+	assert.Equal(t, "PAIRED", pairingStatus)
+}
 
 func TestSQLCurtailmentStore_FrozenTopologyStartPersistsEnvelopeAndRejectsMembershipDrift(t *testing.T) {
 	if testing.Short() {
@@ -85,6 +154,19 @@ func TestSQLCurtailmentStore_FrozenTopologyStartPersistsEnvelopeAndRejectsMember
 	require.NoError(t, err)
 	require.Len(t, targets, 1)
 	assert.Equal(t, device.ID, targets[0].DeviceIdentifier)
+
+	transitioned, err := store.BeginCurtailmentTopologyTargetRestore(
+		ctx,
+		persisted,
+		[]string{device.ID},
+	)
+	require.NoError(t, err)
+	assert.Zero(t, transitioned, "a stale departure snapshot must not restore a current topology member")
+	targets, err = store.ListTargetsByEvent(ctx, orgID, eventUUID)
+	require.NoError(t, err)
+	require.Len(t, targets, 1)
+	assert.Equal(t, models.DesiredStateCurtailed, targets[0].DesiredState)
+	assert.Equal(t, models.TargetStatePending, targets[0].State)
 
 	fenceSnapshot := make(chan interfaces.CurtailmentTopologyDispatchFenceSnapshot, 1)
 	releaseFence := make(chan struct{})
@@ -182,4 +264,288 @@ func TestSQLCurtailmentStore_FrozenTopologyStartPersistsEnvelopeAndRejectsMember
 	require.Len(t, targets, 1)
 	assert.Equal(t, models.TargetStateReleased, targets[0].State,
 		"a dispatch rejection must not queue Uncurtail for a miner that never received Curtail")
+}
+
+func TestSQLCurtailmentStore_TargetlessTopologyWatchersReserveEmptyScopesAndFollowMembership(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping database integration test in short mode")
+	}
+
+	testContext := testutil.InitializeDBServiceInfrastructure(t)
+	user := testContext.DatabaseService.CreateSuperAdminUser()
+	ctx := t.Context()
+	database := testContext.DatabaseService.DB
+	store := sqlstores.NewSQLCurtailmentStore(database)
+	buildingStore := sqlstores.NewSQLBuildingStore(database)
+	collectionStore := sqlstores.NewSQLCollectionStore(database)
+	siteStore := sqlstores.NewSQLSiteStore(database)
+	orgID := user.OrganizationID
+
+	site, err := siteStore.CreateSite(ctx, sitesmodels.CreateSiteParams{
+		OrgID: orgID,
+		Name:  "Topology watcher site",
+	})
+	require.NoError(t, err)
+	building, err := buildingStore.CreateBuilding(ctx, buildingsmodels.CreateParams{
+		OrgID:  orgID,
+		SiteID: &site.ID,
+		Name:   "Topology watcher building",
+	})
+	require.NoError(t, err)
+	rack, err := collectionStore.CreateCollection(
+		ctx,
+		orgID,
+		collectionpb.CollectionType_COLLECTION_TYPE_RACK,
+		"Topology watcher rack",
+		"",
+	)
+	require.NoError(t, err)
+	err = collectionStore.CreateRackExtension(ctx, interfaces.CreateRackExtensionParams{
+		OrgID:        orgID,
+		CollectionID: rack.Id,
+		Rows:         1,
+		Columns:      2,
+		Zone:         "Watcher zone",
+		SiteID:       &site.ID,
+	})
+	require.NoError(t, err)
+	group, err := collectionStore.CreateCollection(
+		ctx,
+		orgID,
+		collectionpb.CollectionType_COLLECTION_TYPE_GROUP,
+		"Topology watcher group",
+		"",
+	)
+	require.NoError(t, err)
+
+	devices := testContext.DatabaseService.CreateTestMiners(orgID, 6, "https://172.17.0.1:80")
+	_, err = siteStore.AssignDevicesToSite(ctx, orgID, &site.ID, devices)
+	require.NoError(t, err)
+
+	watchers := []struct {
+		name      string
+		scopeJSON []byte
+	}{
+		{
+			name:      "building",
+			scopeJSON: []byte(fmt.Sprintf(`{"scope_schema_version":1,"building_ids":[%d]}`, building.ID)),
+		},
+		{
+			name:      "rack",
+			scopeJSON: []byte(fmt.Sprintf(`{"scope_schema_version":1,"rack_ids":[%d]}`, rack.Id)),
+		},
+		{
+			name:      "group",
+			scopeJSON: []byte(fmt.Sprintf(`{"scope_schema_version":1,"group_ids":[%d]}`, group.Id)),
+		},
+	}
+	wholeOrgBlocker := curtailmentStoreClosedLoopFullFleetEvent(
+		orgID,
+		user.DatabaseID,
+		uuid.New(),
+		models.ScopeTypeWholeOrg,
+		0,
+		"whole-org-topology-blocker",
+	)
+	_, err = store.InsertEventWithTargets(ctx, wholeOrgBlocker, nil)
+	require.NoError(t, err)
+	blockedTopology := curtailmentStoreClosedLoopFullFleetEvent(
+		orgID,
+		user.DatabaseID,
+		uuid.New(),
+		models.ScopeTypeMixed,
+		0,
+		"topology-against-whole-org-watcher",
+	)
+	blockedTopology.ScopeJSON = watchers[0].scopeJSON
+	_, err = store.InsertEventWithTargets(ctx, blockedTopology, nil)
+	require.Error(t, err)
+	assert.True(t, fleeterror.IsAlreadyExistsError(err))
+	_, err = store.BeginRestoreTransition(ctx, orgID, wholeOrgBlocker.EventUUID, interfaces.BeginRestoreTransitionParams{})
+	require.NoError(t, err)
+
+	watcherEvents := make(map[string]*models.InsertEventResult, len(watchers))
+	for _, watcher := range watchers {
+		event := curtailmentStoreClosedLoopFullFleetEvent(
+			orgID,
+			user.DatabaseID,
+			uuid.New(),
+			models.ScopeTypeMixed,
+			0,
+			"topology-watcher-"+watcher.name,
+		)
+		event.ScopeJSON = watcher.scopeJSON
+		watcherEvents[watcher.name], err = store.InsertEventWithTargets(ctx, event, nil)
+		require.NoError(t, err)
+
+		duplicate := curtailmentStoreClosedLoopFullFleetEvent(
+			orgID,
+			user.DatabaseID,
+			uuid.New(),
+			models.ScopeTypeMixed,
+			0,
+			"duplicate-topology-watcher-"+watcher.name,
+		)
+		duplicate.ScopeJSON = watcher.scopeJSON
+		_, err = store.InsertEventWithTargets(ctx, duplicate, nil)
+		require.Error(t, err)
+		assert.True(t, fleeterror.IsAlreadyExistsError(err))
+	}
+
+	wholeOrg := curtailmentStoreClosedLoopFullFleetEvent(
+		orgID,
+		user.DatabaseID,
+		uuid.New(),
+		models.ScopeTypeWholeOrg,
+		0,
+		"whole-org-against-topology-watchers",
+	)
+	_, err = store.InsertEventWithTargets(ctx, wholeOrg, nil)
+	require.Error(t, err)
+	assert.True(t, fleeterror.IsAlreadyExistsError(err))
+
+	active, err := store.ListActiveCurtailedDevices(ctx, orgID)
+	require.NoError(t, err)
+	assert.Empty(t, active)
+
+	_, err = buildingStore.AssignDevicesToBuilding(ctx, orgID, &building.ID, devices[0:1])
+	require.NoError(t, err)
+	_, err = collectionStore.AddDevicesToCollection(ctx, orgID, rack.Id, devices[2:3])
+	require.NoError(t, err)
+	_, err = collectionStore.AddDevicesToCollection(ctx, orgID, group.Id, devices[4:5])
+	require.NoError(t, err)
+
+	active, err = store.ListActiveCurtailedDevices(ctx, orgID)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{devices[0], devices[2], devices[4]}, active)
+
+	_, err = store.InsertEventWithTargets(
+		ctx,
+		curtailmentStoreTestEvent(orgID, user.DatabaseID, uuid.New(), models.EventStateActive, "direct-target-against-topology-watcher"),
+		[]models.InsertTargetParams{
+			curtailmentStoreTestTarget(devices[0], models.TargetStateConfirmed, models.DesiredStateCurtailed),
+		},
+	)
+	require.Error(t, err)
+	assert.True(t, fleeterror.IsAlreadyExistsError(err),
+		"direct target insertion must honor the older building watcher's logical reservation")
+
+	_, err = collectionStore.AddDevicesToCollection(ctx, orgID, group.Id, devices[0:1])
+	require.NoError(t, err)
+	claimed, err := store.ClaimClosedLoopFullFleetTargets(
+		ctx,
+		watcherEvents["group"].ID,
+		orgID,
+		0,
+		[]models.InsertTargetParams{curtailmentStoreTestTarget(
+			devices[0],
+			models.TargetStatePending,
+			models.DesiredStateCurtailed,
+		)},
+	)
+	require.NoError(t, err)
+	assert.Empty(t, claimed, "the older building watcher must retain logical ownership")
+	_, err = collectionStore.RemoveDevicesFromCollection(ctx, orgID, group.Id, devices[0:1])
+	require.NoError(t, err)
+
+	_, err = buildingStore.AssignDevicesToBuilding(ctx, orgID, nil, devices[0:1])
+	require.NoError(t, err)
+	_, err = buildingStore.AssignDevicesToBuilding(ctx, orgID, &building.ID, devices[1:2])
+	require.NoError(t, err)
+	_, err = collectionStore.RemoveDevicesFromCollection(ctx, orgID, rack.Id, devices[2:3])
+	require.NoError(t, err)
+	_, err = collectionStore.AddDevicesToCollection(ctx, orgID, rack.Id, devices[3:4])
+	require.NoError(t, err)
+	_, err = collectionStore.RemoveDevicesFromCollection(ctx, orgID, group.Id, devices[4:5])
+	require.NoError(t, err)
+	_, err = collectionStore.AddDevicesToCollection(ctx, orgID, group.Id, devices[5:6])
+	require.NoError(t, err)
+
+	active, err = store.ListActiveCurtailedDevices(ctx, orgID)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{devices[1], devices[3], devices[5]}, active,
+		"logical topology ownership must follow current membership even before target rows are admitted")
+}
+
+func TestSQLCurtailmentStore_BulkReadinessDoesNotRequeueTopologyRestoreOwnedElsewhere(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping database integration test in short mode")
+	}
+
+	testContext := testutil.InitializeDBServiceInfrastructure(t)
+	user := testContext.DatabaseService.CreateSuperAdminUser()
+	ctx := t.Context()
+	database := testContext.DatabaseService.DB
+	store := sqlstores.NewSQLCurtailmentStore(database)
+	buildingStore := sqlstores.NewSQLBuildingStore(database)
+	siteStore := sqlstores.NewSQLSiteStore(database)
+	orgID := user.OrganizationID
+
+	site, err := siteStore.CreateSite(ctx, sitesmodels.CreateSiteParams{
+		OrgID: orgID,
+		Name:  "Topology restore owner site",
+	})
+	require.NoError(t, err)
+	building, err := buildingStore.CreateBuilding(ctx, buildingsmodels.CreateParams{
+		OrgID:  orgID,
+		SiteID: &site.ID,
+		Name:   "Topology restore owner building",
+	})
+	require.NoError(t, err)
+	device := testContext.DatabaseService.CreateDevice(orgID, "proto")
+	deviceIDs := []string{device.ID}
+	_, err = siteStore.AssignDevicesToSite(ctx, orgID, &site.ID, deviceIDs)
+	require.NoError(t, err)
+	_, err = buildingStore.AssignDevicesToBuilding(ctx, orgID, &building.ID, deviceIDs)
+	require.NoError(t, err)
+
+	policy := curtailmentStoreClosedLoopFullFleetEvent(
+		orgID,
+		user.DatabaseID,
+		uuid.New(),
+		models.ScopeTypeMixed,
+		0,
+		"topology-restore-owner-policy",
+	)
+	policy.ScopeJSON = []byte(fmt.Sprintf(`{"scope_schema_version":1,"building_ids":[%d]}`, building.ID))
+	policy.ForceIncludeAllPairedMiners = true
+	policyTarget := curtailmentStoreTestTarget(device.ID, models.TargetStateRestoreFailed, models.DesiredStateActive)
+	policyEvent, err := store.InsertEventWithTargets(ctx, policy, []models.InsertTargetParams{policyTarget})
+	require.NoError(t, err)
+
+	_, err = buildingStore.AssignDevicesToBuilding(ctx, orgID, nil, deviceIDs)
+	require.NoError(t, err)
+	competitorUUID := uuid.New()
+	_, err = store.InsertEventWithTargets(
+		ctx,
+		curtailmentStoreTestEvent(orgID, user.DatabaseID, competitorUUID, models.EventStateActive, "topology-restore-owner-competitor"),
+		[]models.InsertTargetParams{
+			curtailmentStoreTestTarget(device.ID, models.TargetStateConfirmed, models.DesiredStateCurtailed),
+		},
+	)
+	require.NoError(t, err, "a departed restore-failed target no longer reserves the miner")
+
+	_, err = buildingStore.AssignDevicesToBuilding(ctx, orgID, &building.ID, deviceIDs)
+	require.NoError(t, err)
+	applied, err := store.BulkRefreshAllPairedTargetReadiness(
+		ctx,
+		policyEvent.ID,
+		models.EventStateActive,
+		[]interfaces.AllPairedReadinessUpdate{{
+			DeviceIdentifier: device.ID,
+			ExpectedState:    models.TargetStateRestoreFailed,
+			State:            models.TargetStatePending,
+		}},
+	)
+	require.NoError(t, err)
+	assert.Empty(t, applied, "restore requeue must skip a miner now owned by another non-terminal event")
+
+	policyTargets, err := store.ListTargetsByEvent(ctx, orgID, policy.EventUUID)
+	require.NoError(t, err)
+	require.Len(t, policyTargets, 1)
+	assert.Equal(t, models.TargetStateRestoreFailed, policyTargets[0].State)
+	competitorTargets, err := store.ListTargetsByEvent(ctx, orgID, competitorUUID)
+	require.NoError(t, err)
+	require.Len(t, competitorTargets, 1)
+	assert.Equal(t, models.TargetStateConfirmed, competitorTargets[0].State)
 }

--- a/server/internal/domain/stores/sqlstores/curtailment_topology_start_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/curtailment_topology_start_integration_test.go
@@ -629,6 +629,7 @@ func TestSQLCurtailmentStore_TargetlessTopologyWatchersReserveEmptyScopesAndFoll
 		watcherEvents["group"].ID,
 		orgID,
 		0,
+		1,
 		[]models.InsertTargetParams{curtailmentStoreTestTarget(
 			devices[0],
 			models.TargetStatePending,
@@ -686,8 +687,14 @@ func TestSQLCurtailmentStore_ClaimWaitsForTopologyMoveBeforeCheckingEarlierReser
 		"",
 	)
 	require.NoError(t, err)
-	device := testContext.DatabaseService.CreateDevice(orgID, "proto")
-	_, err = collectionStore.AddDevicesToCollection(ctx, orgID, group.Id, []string{device.ID})
+	reservedDevice := testContext.DatabaseService.CreateDevice(orgID, "proto")
+	eligibleDevice := testContext.DatabaseService.CreateDevice(orgID, "proto")
+	_, err = collectionStore.AddDevicesToCollection(
+		ctx,
+		orgID,
+		group.Id,
+		[]string{reservedDevice.ID, eligibleDevice.ID},
+	)
 	require.NoError(t, err)
 
 	older := curtailmentStoreClosedLoopFullFleetEvent(
@@ -710,11 +717,11 @@ func TestSQLCurtailmentStore_ClaimWaitsForTopologyMoveBeforeCheckingEarlierReser
 	_, err = q.LockBuildingForWrite(ctx, sqlc.LockBuildingForWriteParams{ID: building.ID, OrgID: orgID})
 	require.NoError(t, err)
 	_, err = q.LockDevicesForReassign(ctx, sqlc.LockDevicesForReassignParams{
-		OrgID: orgID, DeviceIdentifiers: []string{device.ID},
+		OrgID: orgID, DeviceIdentifiers: []string{reservedDevice.ID},
 	})
 	require.NoError(t, err)
 	_, err = q.AssignDevicesToBuilding(ctx, sqlc.AssignDevicesToBuildingParams{
-		OrgID: orgID, TargetBuildingID: sql.NullInt64{Int64: building.ID, Valid: true}, DeviceIdentifiers: []string{device.ID},
+		OrgID: orgID, TargetBuildingID: sql.NullInt64{Int64: building.ID, Valid: true}, DeviceIdentifiers: []string{reservedDevice.ID},
 	})
 	require.NoError(t, err)
 
@@ -728,8 +735,10 @@ func TestSQLCurtailmentStore_ClaimWaitsForTopologyMoveBeforeCheckingEarlierReser
 			youngerEvent.ID,
 			orgID,
 			0,
+			1,
 			[]models.InsertTargetParams{
-				curtailmentStoreTestTarget(device.ID, models.TargetStatePending, models.DesiredStateCurtailed),
+				curtailmentStoreTestTarget(reservedDevice.ID, models.TargetStatePending, models.DesiredStateCurtailed),
+				curtailmentStoreTestTarget(eligibleDevice.ID, models.TargetStatePending, models.DesiredStateCurtailed),
 			},
 		)
 		claimDone <- struct {
@@ -746,7 +755,9 @@ func TestSQLCurtailmentStore_ClaimWaitsForTopologyMoveBeforeCheckingEarlierReser
 	require.NoError(t, tx.Commit())
 	result := <-claimDone
 	require.NoError(t, result.err)
-	assert.Empty(t, result.targets, "the committed move must make the older targetless watcher authoritative")
+	require.Len(t, result.targets, 1)
+	assert.Equal(t, eligibleDevice.ID, result.targets[0].DeviceIdentifier,
+		"the eligible candidate after the reserved prefix must refill the bounded batch")
 }
 
 func TestSQLCurtailmentStore_ClaimWaitsForCurrentTopologyMembershipRemoval(t *testing.T) {
@@ -803,6 +814,7 @@ func TestSQLCurtailmentStore_ClaimWaitsForCurrentTopologyMembershipRemoval(t *te
 			event.ID,
 			orgID,
 			0,
+			1,
 			[]models.InsertTargetParams{
 				curtailmentStoreTestTarget(device.ID, models.TargetStatePending, models.DesiredStateCurtailed),
 			},

--- a/server/internal/domain/stores/sqlstores/curtailment_topology_start_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/curtailment_topology_start_integration_test.go
@@ -495,6 +495,8 @@ func TestSQLCurtailmentStore_TargetlessTopologyWatchersReserveEmptyScopesAndFoll
 	active, err = store.ListActiveCurtailedDevices(ctx, orgID)
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []string{devices[0], devices[2], devices[4]}, active)
+	_, err = collectionStore.AddDevicesToCollection(ctx, orgID, group.Id, devices[6:7])
+	require.NoError(t, err)
 
 	claimedAllPaired, err := store.ClaimAllPairedPolicyTargets(
 		ctx,

--- a/server/internal/domain/stores/sqlstores/curtailment_topology_start_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/curtailment_topology_start_integration_test.go
@@ -266,6 +266,81 @@ func TestSQLCurtailmentStore_FrozenTopologyStartPersistsEnvelopeAndRejectsMember
 		"a dispatch rejection must not queue Uncurtail for a miner that never received Curtail")
 }
 
+func TestSQLCurtailmentStore_BeginTopologyRestoreReleasesUnsentAndQueuesAttemptedTargets(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping database integration test in short mode")
+	}
+
+	testContext := testutil.InitializeDBServiceInfrastructure(t)
+	user := testContext.DatabaseService.CreateSuperAdminUser()
+	ctx := t.Context()
+	database := testContext.DatabaseService.DB
+	store := sqlstores.NewSQLCurtailmentStore(database)
+	buildingStore := sqlstores.NewSQLBuildingStore(database)
+	orgID := user.OrganizationID
+
+	building, err := buildingStore.CreateBuilding(ctx, buildingsmodels.CreateParams{
+		OrgID: orgID,
+		Name:  "Topology departure branches",
+	})
+	require.NoError(t, err)
+	devices := testContext.DatabaseService.CreateTestMiners(orgID, 2, "https://172.17.0.1:80")
+	_, err = buildingStore.AssignDevicesToBuilding(ctx, orgID, &building.ID, devices)
+	require.NoError(t, err)
+
+	eventUUID := uuid.New()
+	event := curtailmentStoreClosedLoopFullFleetEvent(
+		orgID,
+		user.DatabaseID,
+		eventUUID,
+		models.ScopeTypeMixed,
+		0,
+		"topology-departure-branches",
+	)
+	event.ScopeJSON = []byte(fmt.Sprintf(`{"scope_schema_version":1,"building_ids":[%d]}`, building.ID))
+	inserted, err := store.InsertEventWithTargets(ctx, event, []models.InsertTargetParams{
+		curtailmentStoreTestTarget(devices[0], models.TargetStatePending, models.DesiredStateCurtailed),
+		curtailmentStoreTestTarget(devices[1], models.TargetStatePending, models.DesiredStateCurtailed),
+	})
+	require.NoError(t, err)
+	_, err = database.ExecContext(ctx, `
+		UPDATE curtailment_target
+		SET retry_count = 1,
+		    last_dispatched_at = CURRENT_TIMESTAMP,
+		    curtail_dispatched_at = CURRENT_TIMESTAMP
+		WHERE curtailment_event_id = $1
+		  AND device_identifier = $2
+	`, inserted.ID, devices[1])
+	require.NoError(t, err)
+
+	_, err = buildingStore.AssignDevicesToBuilding(ctx, orgID, nil, devices)
+	require.NoError(t, err)
+	persisted, err := store.GetEventByUUID(ctx, orgID, eventUUID)
+	require.NoError(t, err)
+	transitioned, err := store.BeginCurtailmentTopologyTargetRestore(ctx, persisted, devices)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), transitioned)
+
+	targets, err := store.ListTargetsByEvent(ctx, orgID, eventUUID)
+	require.NoError(t, err)
+	byDevice := make(map[string]*models.Target, len(targets))
+	for _, target := range targets {
+		byDevice[target.DeviceIdentifier] = target
+	}
+	unsent := byDevice[devices[0]]
+	require.NotNil(t, unsent)
+	assert.Equal(t, models.TargetStateReleased, unsent.State)
+	assert.Equal(t, models.DesiredStateCurtailed, unsent.DesiredState)
+	assert.Nil(t, unsent.RestorePhase.StartedAt)
+
+	attempted := byDevice[devices[1]]
+	require.NotNil(t, attempted)
+	assert.Equal(t, models.TargetStatePending, attempted.State)
+	assert.Equal(t, models.DesiredStateActive, attempted.DesiredState)
+	assert.Equal(t, models.TargetStatePending, attempted.RestorePhase.State)
+	require.NotNil(t, attempted.RestorePhase.StartedAt)
+}
+
 func TestSQLCurtailmentStore_TargetlessTopologyWatchersReserveEmptyScopesAndFollowMembership(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping database integration test in short mode")
@@ -318,7 +393,7 @@ func TestSQLCurtailmentStore_TargetlessTopologyWatchersReserveEmptyScopesAndFoll
 	)
 	require.NoError(t, err)
 
-	devices := testContext.DatabaseService.CreateTestMiners(orgID, 6, "https://172.17.0.1:80")
+	devices := testContext.DatabaseService.CreateTestMiners(orgID, 7, "https://172.17.0.1:80")
 	_, err = siteStore.AssignDevicesToSite(ctx, orgID, &site.ID, devices)
 	require.NoError(t, err)
 
@@ -375,6 +450,7 @@ func TestSQLCurtailmentStore_TargetlessTopologyWatchersReserveEmptyScopesAndFoll
 			"topology-watcher-"+watcher.name,
 		)
 		event.ScopeJSON = watcher.scopeJSON
+		event.ForceIncludeAllPairedMiners = watcher.name == "group"
 		watcherEvents[watcher.name], err = store.InsertEventWithTargets(ctx, event, nil)
 		require.NoError(t, err)
 
@@ -418,6 +494,32 @@ func TestSQLCurtailmentStore_TargetlessTopologyWatchersReserveEmptyScopesAndFoll
 	active, err = store.ListActiveCurtailedDevices(ctx, orgID)
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []string{devices[0], devices[2], devices[4]}, active)
+
+	claimedAllPaired, err := store.ClaimAllPairedPolicyTargets(
+		ctx,
+		watcherEvents["group"].ID,
+		orgID,
+		1,
+		[]models.InsertTargetParams{
+			curtailmentStoreTestTarget(devices[0], models.TargetStatePending, models.DesiredStateCurtailed),
+			curtailmentStoreTestTarget(devices[6], models.TargetStatePending, models.DesiredStateCurtailed),
+		},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), claimedAllPaired,
+		"the bounded batch must skip an earlier reservation without starving the next available miner")
+	var claimedDevice string
+	require.NoError(t, database.QueryRowContext(ctx, `
+		SELECT device_identifier
+		FROM curtailment_target
+		WHERE curtailment_event_id = $1
+	`, watcherEvents["group"].ID).Scan(&claimedDevice))
+	assert.Equal(t, devices[6], claimedDevice)
+	_, err = database.ExecContext(ctx, `
+		DELETE FROM curtailment_target
+		WHERE curtailment_event_id = $1
+	`, watcherEvents["group"].ID)
+	require.NoError(t, err)
 
 	_, err = store.InsertEventWithTargets(
 		ctx,
@@ -465,6 +567,196 @@ func TestSQLCurtailmentStore_TargetlessTopologyWatchersReserveEmptyScopesAndFoll
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []string{devices[1], devices[3], devices[5]}, active,
 		"logical topology ownership must follow current membership even before target rows are admitted")
+}
+
+func TestSQLCurtailmentStore_ClaimWaitsForTopologyMoveBeforeCheckingEarlierReservation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping database integration test in short mode")
+	}
+
+	testContext := testutil.InitializeDBServiceInfrastructure(t)
+	user := testContext.DatabaseService.CreateSuperAdminUser()
+	ctx := t.Context()
+	database := testContext.DatabaseService.DB
+	store := sqlstores.NewSQLCurtailmentStore(database)
+	buildingStore := sqlstores.NewSQLBuildingStore(database)
+	collectionStore := sqlstores.NewSQLCollectionStore(database)
+	orgID := user.OrganizationID
+
+	building, err := buildingStore.CreateBuilding(ctx, buildingsmodels.CreateParams{
+		OrgID: orgID,
+		Name:  "Admission reservation building",
+	})
+	require.NoError(t, err)
+	group, err := collectionStore.CreateCollection(
+		ctx,
+		orgID,
+		collectionpb.CollectionType_COLLECTION_TYPE_GROUP,
+		"Admission reservation group",
+		"",
+	)
+	require.NoError(t, err)
+	device := testContext.DatabaseService.CreateDevice(orgID, "proto")
+	_, err = collectionStore.AddDevicesToCollection(ctx, orgID, group.Id, []string{device.ID})
+	require.NoError(t, err)
+
+	older := curtailmentStoreClosedLoopFullFleetEvent(
+		orgID, user.DatabaseID, uuid.New(), models.ScopeTypeMixed, 0, "older-building-reservation",
+	)
+	older.ScopeJSON = []byte(fmt.Sprintf(`{"scope_schema_version":1,"building_ids":[%d]}`, building.ID))
+	_, err = store.InsertEventWithTargets(ctx, older, nil)
+	require.NoError(t, err)
+	younger := curtailmentStoreClosedLoopFullFleetEvent(
+		orgID, user.DatabaseID, uuid.New(), models.ScopeTypeMixed, 0, "younger-group-admission",
+	)
+	younger.ScopeJSON = []byte(fmt.Sprintf(`{"scope_schema_version":1,"group_ids":[%d]}`, group.Id))
+	youngerEvent, err := store.InsertEventWithTargets(ctx, younger, nil)
+	require.NoError(t, err)
+
+	tx, err := database.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = tx.Rollback() })
+	q := sqlc.New(tx)
+	_, err = q.LockBuildingForWrite(ctx, sqlc.LockBuildingForWriteParams{ID: building.ID, OrgID: orgID})
+	require.NoError(t, err)
+	_, err = q.LockDevicesForReassign(ctx, sqlc.LockDevicesForReassignParams{
+		OrgID: orgID, DeviceIdentifiers: []string{device.ID},
+	})
+	require.NoError(t, err)
+	_, err = q.AssignDevicesToBuilding(ctx, sqlc.AssignDevicesToBuildingParams{
+		OrgID: orgID, TargetBuildingID: sql.NullInt64{Int64: building.ID, Valid: true}, DeviceIdentifiers: []string{device.ID},
+	})
+	require.NoError(t, err)
+
+	claimDone := make(chan struct {
+		targets []*models.Target
+		err     error
+	}, 1)
+	go func() {
+		targets, claimErr := store.ClaimClosedLoopFullFleetTargets(
+			ctx,
+			youngerEvent.ID,
+			orgID,
+			0,
+			[]models.InsertTargetParams{
+				curtailmentStoreTestTarget(device.ID, models.TargetStatePending, models.DesiredStateCurtailed),
+			},
+		)
+		claimDone <- struct {
+			targets []*models.Target
+			err     error
+		}{targets: targets, err: claimErr}
+	}()
+	select {
+	case result := <-claimDone:
+		require.NoError(t, result.err)
+		t.Fatal("claim completed before the in-flight topology move committed")
+	case <-time.After(150 * time.Millisecond):
+	}
+	require.NoError(t, tx.Commit())
+	result := <-claimDone
+	require.NoError(t, result.err)
+	assert.Empty(t, result.targets, "the committed move must make the older targetless watcher authoritative")
+}
+
+func TestSQLCurtailmentStore_BulkReadinessWaitsForTargetlessTopologyReservation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping database integration test in short mode")
+	}
+
+	testContext := testutil.InitializeDBServiceInfrastructure(t)
+	user := testContext.DatabaseService.CreateSuperAdminUser()
+	ctx := t.Context()
+	database := testContext.DatabaseService.DB
+	store := sqlstores.NewSQLCurtailmentStore(database)
+	buildingStore := sqlstores.NewSQLBuildingStore(database)
+	collectionStore := sqlstores.NewSQLCollectionStore(database)
+	orgID := user.OrganizationID
+
+	building, err := buildingStore.CreateBuilding(ctx, buildingsmodels.CreateParams{
+		OrgID: orgID,
+		Name:  "Readiness reservation building",
+	})
+	require.NoError(t, err)
+	group, err := collectionStore.CreateCollection(
+		ctx,
+		orgID,
+		collectionpb.CollectionType_COLLECTION_TYPE_GROUP,
+		"Readiness policy group",
+		"",
+	)
+	require.NoError(t, err)
+	device := testContext.DatabaseService.CreateDevice(orgID, "proto")
+	_, err = collectionStore.AddDevicesToCollection(ctx, orgID, group.Id, []string{device.ID})
+	require.NoError(t, err)
+
+	older := curtailmentStoreClosedLoopFullFleetEvent(
+		orgID, user.DatabaseID, uuid.New(), models.ScopeTypeMixed, 0, "older-readiness-reservation",
+	)
+	older.ScopeJSON = []byte(fmt.Sprintf(`{"scope_schema_version":1,"building_ids":[%d]}`, building.ID))
+	_, err = store.InsertEventWithTargets(ctx, older, nil)
+	require.NoError(t, err)
+	policy := curtailmentStoreClosedLoopFullFleetEvent(
+		orgID, user.DatabaseID, uuid.New(), models.ScopeTypeMixed, 0, "younger-readiness-policy",
+	)
+	policy.ScopeJSON = []byte(fmt.Sprintf(`{"scope_schema_version":1,"group_ids":[%d]}`, group.Id))
+	policy.ForceIncludeAllPairedMiners = true
+	policyEvent, err := store.InsertEventWithTargets(ctx, policy, []models.InsertTargetParams{
+		curtailmentStoreTestTarget(device.ID, models.TargetStateRestoreFailed, models.DesiredStateActive),
+	})
+	require.NoError(t, err)
+
+	tx, err := database.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = tx.Rollback() })
+	q := sqlc.New(tx)
+	_, err = q.LockBuildingForWrite(ctx, sqlc.LockBuildingForWriteParams{ID: building.ID, OrgID: orgID})
+	require.NoError(t, err)
+	_, err = q.LockDevicesForReassign(ctx, sqlc.LockDevicesForReassignParams{
+		OrgID: orgID, DeviceIdentifiers: []string{device.ID},
+	})
+	require.NoError(t, err)
+	_, err = q.AssignDevicesToBuilding(ctx, sqlc.AssignDevicesToBuildingParams{
+		OrgID: orgID, TargetBuildingID: sql.NullInt64{Int64: building.ID, Valid: true}, DeviceIdentifiers: []string{device.ID},
+	})
+	require.NoError(t, err)
+
+	refreshDone := make(chan struct {
+		applied []string
+		err     error
+	}, 1)
+	go func() {
+		applied, refreshErr := store.BulkRefreshAllPairedTargetReadiness(
+			ctx,
+			policyEvent.ID,
+			orgID,
+			models.EventStateActive,
+			[]interfaces.AllPairedReadinessUpdate{{
+				DeviceIdentifier:     device.ID,
+				ExpectedState:        models.TargetStateRestoreFailed,
+				ExpectedDesiredState: models.DesiredStateActive,
+				State:                models.TargetStatePending,
+			}},
+		)
+		refreshDone <- struct {
+			applied []string
+			err     error
+		}{applied: applied, err: refreshErr}
+	}()
+	select {
+	case result := <-refreshDone:
+		require.NoError(t, result.err)
+		t.Fatal("readiness refresh completed before the in-flight topology move committed")
+	case <-time.After(150 * time.Millisecond):
+	}
+	require.NoError(t, tx.Commit())
+	result := <-refreshDone
+	require.NoError(t, result.err)
+	assert.Empty(t, result.applied)
+	targets, err := store.ListTargetsByEvent(ctx, orgID, policy.EventUUID)
+	require.NoError(t, err)
+	require.Len(t, targets, 1)
+	assert.Equal(t, models.TargetStateRestoreFailed, targets[0].State)
 }
 
 func TestSQLCurtailmentStore_BulkReadinessDoesNotRequeueTopologyRestoreOwnedElsewhere(t *testing.T) {
@@ -530,11 +822,13 @@ func TestSQLCurtailmentStore_BulkReadinessDoesNotRequeueTopologyRestoreOwnedElse
 	applied, err := store.BulkRefreshAllPairedTargetReadiness(
 		ctx,
 		policyEvent.ID,
+		orgID,
 		models.EventStateActive,
 		[]interfaces.AllPairedReadinessUpdate{{
-			DeviceIdentifier: device.ID,
-			ExpectedState:    models.TargetStateRestoreFailed,
-			State:            models.TargetStatePending,
+			DeviceIdentifier:     device.ID,
+			ExpectedState:        models.TargetStateRestoreFailed,
+			ExpectedDesiredState: models.DesiredStateActive,
+			State:                models.TargetStatePending,
 		}},
 	)
 	require.NoError(t, err)

--- a/server/internal/domain/stores/sqlstores/curtailment_topology_start_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/curtailment_topology_start_integration_test.go
@@ -846,6 +846,89 @@ func TestSQLCurtailmentStore_BulkReadinessWaitsForTargetlessTopologyReservation(
 	assert.Equal(t, models.TargetStateRestoreFailed, targets[0].State)
 }
 
+func TestSQLCurtailmentStore_BulkReadinessDoesNotRequeueRestoreReenteringCurrentTopology(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping database integration test in short mode")
+	}
+
+	testContext := testutil.InitializeDBServiceInfrastructure(t)
+	user := testContext.DatabaseService.CreateSuperAdminUser()
+	ctx := t.Context()
+	database := testContext.DatabaseService.DB
+	store := sqlstores.NewSQLCurtailmentStore(database)
+	collectionStore := sqlstores.NewSQLCollectionStore(database)
+	orgID := user.OrganizationID
+
+	group, err := collectionStore.CreateCollection(
+		ctx,
+		orgID,
+		collectionpb.CollectionType_COLLECTION_TYPE_GROUP,
+		"Restore reentry group",
+		"",
+	)
+	require.NoError(t, err)
+	device := testContext.DatabaseService.CreateDevice(orgID, "proto")
+
+	policy := curtailmentStoreClosedLoopFullFleetEvent(
+		orgID, user.DatabaseID, uuid.New(), models.ScopeTypeMixed, 0, "restore-reentry-policy",
+	)
+	policy.ScopeJSON = []byte(fmt.Sprintf(`{"scope_schema_version":1,"group_ids":[%d]}`, group.Id))
+	policy.ForceIncludeAllPairedMiners = true
+	policyEvent, err := store.InsertEventWithTargets(ctx, policy, []models.InsertTargetParams{
+		curtailmentStoreTestTarget(device.ID, models.TargetStateRestoreFailed, models.DesiredStateActive),
+	})
+	require.NoError(t, err)
+
+	tx, err := database.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = tx.Rollback() })
+	q := sqlc.New(tx)
+	added, err := q.AddDevicesToDeviceSet(ctx, sqlc.AddDevicesToDeviceSetParams{
+		OrgID:             orgID,
+		DeviceSetID:       group.Id,
+		DeviceIdentifiers: []string{device.ID},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{device.ID}, added)
+
+	refreshDone := make(chan struct {
+		applied []string
+		err     error
+	}, 1)
+	go func() {
+		applied, refreshErr := store.BulkRefreshAllPairedTargetReadiness(
+			ctx,
+			policyEvent.ID,
+			orgID,
+			models.EventStateActive,
+			[]interfaces.AllPairedReadinessUpdate{{
+				DeviceIdentifier:     device.ID,
+				ExpectedState:        models.TargetStateRestoreFailed,
+				ExpectedDesiredState: models.DesiredStateActive,
+				State:                models.TargetStatePending,
+			}},
+		)
+		refreshDone <- struct {
+			applied []string
+			err     error
+		}{applied: applied, err: refreshErr}
+	}()
+	select {
+	case result := <-refreshDone:
+		require.NoError(t, result.err)
+		t.Fatal("readiness refresh completed before the in-flight group addition committed")
+	case <-time.After(150 * time.Millisecond):
+	}
+	require.NoError(t, tx.Commit())
+	result := <-refreshDone
+	require.NoError(t, result.err)
+	assert.Empty(t, result.applied)
+	targets, err := store.ListTargetsByEvent(ctx, orgID, policy.EventUUID)
+	require.NoError(t, err)
+	require.Len(t, targets, 1)
+	assert.Equal(t, models.TargetStateRestoreFailed, targets[0].State)
+}
+
 func TestSQLCurtailmentStore_BulkReadinessDoesNotRequeueTopologyRestoreOwnedElsewhere(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping database integration test in short mode")

--- a/server/internal/domain/stores/sqlstores/curtailment_topology_start_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/curtailment_topology_start_integration_test.go
@@ -836,6 +836,90 @@ func TestSQLCurtailmentStore_ClaimWaitsForCurrentTopologyMembershipRemoval(t *te
 	assert.Empty(t, result.targets, "a miner removed from the current selector must not be admitted")
 }
 
+func TestSQLCurtailmentStore_AllPairedClaimRefillsAfterFinalTopologyRecheck(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping database integration test in short mode")
+	}
+
+	testContext := testutil.InitializeDBServiceInfrastructure(t)
+	user := testContext.DatabaseService.CreateSuperAdminUser()
+	ctx := t.Context()
+	database := testContext.DatabaseService.DB
+	store := sqlstores.NewSQLCurtailmentStore(database)
+	buildingStore := sqlstores.NewSQLBuildingStore(database)
+	orgID := user.OrganizationID
+
+	building, err := buildingStore.CreateBuilding(ctx, buildingsmodels.CreateParams{
+		OrgID: orgID,
+		Name:  "All-paired admission building",
+	})
+	require.NoError(t, err)
+	devices := testContext.DatabaseService.CreateTestMiners(orgID, 2, "https://172.17.0.1:80")
+	_, err = buildingStore.AssignDevicesToBuilding(ctx, orgID, &building.ID, devices)
+	require.NoError(t, err)
+
+	eventParams := curtailmentStoreClosedLoopFullFleetEvent(
+		orgID, user.DatabaseID, uuid.New(), models.ScopeTypeMixed, 0, "all-paired-final-membership-recheck",
+	)
+	eventParams.ScopeJSON = []byte(fmt.Sprintf(`{"scope_schema_version":1,"building_ids":[%d]}`, building.ID))
+	eventParams.ForceIncludeAllPairedMiners = true
+	event, err := store.InsertEventWithTargets(ctx, eventParams, nil)
+	require.NoError(t, err)
+
+	tx, err := database.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = tx.Rollback() })
+	q := sqlc.New(tx)
+	_, err = q.LockDevicesForReassign(ctx, sqlc.LockDevicesForReassignParams{
+		OrgID: orgID, DeviceIdentifiers: devices[:1],
+	})
+	require.NoError(t, err)
+	_, err = q.AssignDevicesToBuilding(ctx, sqlc.AssignDevicesToBuildingParams{
+		OrgID: orgID, TargetBuildingID: sql.NullInt64{}, DeviceIdentifiers: devices[:1],
+	})
+	require.NoError(t, err)
+
+	claimDone := make(chan struct {
+		claimed int64
+		err     error
+	}, 1)
+	go func() {
+		claimed, claimErr := store.ClaimAllPairedPolicyTargets(
+			ctx,
+			event.ID,
+			orgID,
+			1,
+			[]models.InsertTargetParams{
+				curtailmentStoreTestTarget(devices[0], models.TargetStatePending, models.DesiredStateCurtailed),
+				curtailmentStoreTestTarget(devices[1], models.TargetStatePending, models.DesiredStateCurtailed),
+			},
+		)
+		claimDone <- struct {
+			claimed int64
+			err     error
+		}{claimed: claimed, err: claimErr}
+	}()
+	select {
+	case result := <-claimDone:
+		require.NoError(t, result.err)
+		t.Fatal("claim completed before the in-flight topology move committed")
+	case <-time.After(150 * time.Millisecond):
+	}
+	require.NoError(t, tx.Commit())
+	result := <-claimDone
+	require.NoError(t, result.err)
+	assert.Equal(t, int64(1), result.claimed)
+
+	var claimedDevice string
+	require.NoError(t, database.QueryRowContext(ctx, `
+		SELECT device_identifier
+		FROM curtailment_target
+		WHERE curtailment_event_id = $1
+	`, event.ID).Scan(&claimedDevice))
+	assert.Equal(t, devices[1], claimedDevice,
+		"an eligible overflow candidate must refill the batch after the final membership recheck")
+}
+
 func TestSQLCurtailmentStore_BulkReadinessWaitsForTargetlessTopologyReservation(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping database integration test in short mode")

--- a/server/internal/domain/stores/sqlstores/curtailment_topology_start_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/curtailment_topology_start_integration_test.go
@@ -946,6 +946,8 @@ func TestSQLCurtailmentStore_BulkReadinessDoesNotRequeueRestoreReenteringCurrent
 	)
 	require.NoError(t, err)
 	device := testContext.DatabaseService.CreateDevice(orgID, "proto")
+	_, err = collectionStore.AddDevicesToCollection(ctx, orgID, group.Id, []string{device.ID})
+	require.NoError(t, err)
 
 	policy := curtailmentStoreClosedLoopFullFleetEvent(
 		orgID, user.DatabaseID, uuid.New(), models.ScopeTypeMixed, 0, "restore-reentry-policy",
@@ -955,6 +957,8 @@ func TestSQLCurtailmentStore_BulkReadinessDoesNotRequeueRestoreReenteringCurrent
 	policyEvent, err := store.InsertEventWithTargets(ctx, policy, []models.InsertTargetParams{
 		curtailmentStoreTestTarget(device.ID, models.TargetStateRestoreFailed, models.DesiredStateActive),
 	})
+	require.NoError(t, err)
+	_, err = collectionStore.RemoveDevicesFromCollection(ctx, orgID, group.Id, []string{device.ID})
 	require.NoError(t, err)
 
 	tx, err := database.BeginTx(ctx, nil)

--- a/server/internal/domain/stores/sqlstores/curtailment_topology_start_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/curtailment_topology_start_integration_test.go
@@ -266,6 +266,84 @@ func TestSQLCurtailmentStore_FrozenTopologyStartPersistsEnvelopeAndRejectsMember
 		"a dispatch rejection must not queue Uncurtail for a miner that never received Curtail")
 }
 
+func TestSQLCurtailmentStore_BeginTopologyRestoreLocksCandidatesAndMembersInDeviceOrder(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping database integration test in short mode")
+	}
+
+	testContext := testutil.InitializeDBServiceInfrastructure(t)
+	user := testContext.DatabaseService.CreateSuperAdminUser()
+	ctx := t.Context()
+	database := testContext.DatabaseService.DB
+	store := sqlstores.NewSQLCurtailmentStore(database)
+	buildingStore := sqlstores.NewSQLBuildingStore(database)
+	orgID := user.OrganizationID
+
+	building, err := buildingStore.CreateBuilding(ctx, buildingsmodels.CreateParams{
+		OrgID: orgID,
+		Name:  "Restore device lock order building",
+	})
+	require.NoError(t, err)
+	devices := testContext.DatabaseService.CreateTestMiners(orgID, 2, "https://172.17.0.1:80")
+	_, err = buildingStore.AssignDevicesToBuilding(ctx, orgID, &building.ID, devices)
+	require.NoError(t, err)
+
+	event := curtailmentStoreClosedLoopFullFleetEvent(
+		orgID, user.DatabaseID, uuid.New(), models.ScopeTypeMixed, 0, "restore-device-lock-order",
+	)
+	event.ScopeJSON = []byte(fmt.Sprintf(`{"scope_schema_version":1,"building_ids":[%d]}`, building.ID))
+	_, err = store.InsertEventWithTargets(ctx, event, []models.InsertTargetParams{
+		curtailmentStoreTestTarget(devices[0], models.TargetStatePending, models.DesiredStateCurtailed),
+	})
+	require.NoError(t, err)
+	_, err = buildingStore.AssignDevicesToBuilding(ctx, orgID, nil, devices[:1])
+	require.NoError(t, err)
+	persisted, err := store.GetEventByUUID(ctx, orgID, event.EventUUID)
+	require.NoError(t, err)
+
+	lowDeviceTx, err := database.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = lowDeviceTx.Rollback() })
+	lowDeviceQueries := sqlc.New(lowDeviceTx)
+	_, err = lowDeviceQueries.LockDevicesForReassign(ctx, sqlc.LockDevicesForReassignParams{
+		OrgID: orgID, DeviceIdentifiers: devices[:1],
+	})
+	require.NoError(t, err)
+
+	restoreDone := make(chan struct {
+		transitioned int64
+		err          error
+	}, 1)
+	go func() {
+		transitioned, restoreErr := store.BeginCurtailmentTopologyTargetRestore(ctx, persisted, devices[:1])
+		restoreDone <- struct {
+			transitioned int64
+			err          error
+		}{transitioned: transitioned, err: restoreErr}
+	}()
+	select {
+	case result := <-restoreDone:
+		require.NoError(t, result.err)
+		t.Fatal("topology restore completed before the lower-ID candidate lock was released")
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	highDeviceTx, err := database.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = highDeviceTx.Rollback() })
+	highDeviceQueries := sqlc.New(highDeviceTx)
+	_, err = highDeviceQueries.LockDevicesForReassign(ctx, sqlc.LockDevicesForReassignParams{
+		OrgID: orgID, DeviceIdentifiers: devices[1:],
+	})
+	require.NoError(t, err, "restore must wait on the lower-ID candidate before locking the higher-ID member")
+	require.NoError(t, highDeviceTx.Rollback())
+	require.NoError(t, lowDeviceTx.Commit())
+
+	result := <-restoreDone
+	require.NoError(t, result.err)
+	assert.Equal(t, int64(1), result.transitioned)
+}
+
 func TestSQLCurtailmentStore_BeginTopologyRestoreReleasesUnsentAndQueuesAttemptedTargets(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping database integration test in short mode")

--- a/server/internal/domain/stores/sqlstores/curtailment_topology_start_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/curtailment_topology_start_integration_test.go
@@ -1011,6 +1011,73 @@ func TestSQLCurtailmentStore_BulkReadinessDoesNotRequeueRestoreReenteringCurrent
 	assert.Equal(t, models.TargetStateRestoreFailed, targets[0].State)
 }
 
+func TestSQLCurtailmentStore_TopologyRestoreDispatchAllowsDeletedSelector(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping database integration test in short mode")
+	}
+
+	for _, eventState := range []models.EventState{models.EventStateActive, models.EventStateRestoring} {
+		t.Run(string(eventState), func(t *testing.T) {
+			testContext := testutil.InitializeDBServiceInfrastructure(t)
+			user := testContext.DatabaseService.CreateSuperAdminUser()
+			ctx := t.Context()
+			store := sqlstores.NewSQLCurtailmentStore(testContext.DatabaseService.DB)
+			collectionStore := sqlstores.NewSQLCollectionStore(testContext.DatabaseService.DB)
+			orgID := user.OrganizationID
+
+			group, err := collectionStore.CreateCollection(
+				ctx,
+				orgID,
+				collectionpb.CollectionType_COLLECTION_TYPE_GROUP,
+				"Deleted restore selector group",
+				"",
+			)
+			require.NoError(t, err)
+			device := testContext.DatabaseService.CreateDevice(orgID, "proto")
+			_, err = collectionStore.AddDevicesToCollection(ctx, orgID, group.Id, []string{device.ID})
+			require.NoError(t, err)
+
+			event := curtailmentStoreClosedLoopFullFleetEvent(
+				orgID, user.DatabaseID, uuid.New(), models.ScopeTypeMixed, 0, "deleted-restore-selector",
+			)
+			event.State = eventState
+			event.ScopeJSON = []byte(fmt.Sprintf(`{"scope_schema_version":1,"group_ids":[%d]}`, group.Id))
+			inserted, err := store.InsertEventWithTargets(ctx, event, []models.InsertTargetParams{
+				curtailmentStoreTestTarget(device.ID, models.TargetStateDispatching, models.DesiredStateActive),
+			})
+			require.NoError(t, err)
+			_, err = collectionStore.SoftDeleteCollection(ctx, orgID, group.Id)
+			require.NoError(t, err)
+
+			persisted, err := store.GetEventByUUID(ctx, orgID, inserted.EventUUID)
+			require.NoError(t, err)
+			err = store.WithCurtailmentTopologyRestoreDispatchFence(
+				ctx,
+				persisted,
+				[]string{device.ID},
+				func(snapshot interfaces.CurtailmentTopologyRestoreDispatchFenceSnapshot) error {
+					assert.Equal(t, eventState, snapshot.Event.State)
+					assert.Empty(t, snapshot.Topology.DispatchMemberDeviceIdentifiers)
+					if eventState == models.EventStateActive {
+						return snapshot.ParkReturnedTargets([]string{device.ID})
+					}
+					return nil
+				},
+			)
+			require.NoError(t, err)
+
+			targets, err := store.ListTargetsByEvent(ctx, orgID, inserted.EventUUID)
+			require.NoError(t, err)
+			require.Len(t, targets, 1)
+			if eventState == models.EventStateActive {
+				assert.Equal(t, models.TargetStateRestoreFailed, targets[0].State)
+			} else {
+				assert.Equal(t, models.TargetStateDispatching, targets[0].State)
+			}
+		})
+	}
+}
+
 func TestSQLCurtailmentStore_BulkReadinessDoesNotRequeueTopologyRestoreOwnedElsewhere(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping database integration test in short mode")

--- a/server/internal/domain/stores/sqlstores/curtailment_topology_start_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/curtailment_topology_start_integration_test.go
@@ -577,7 +577,7 @@ func TestSQLCurtailmentStore_TargetlessTopologyWatchersReserveEmptyScopesAndFoll
 
 	active, err = store.ListActiveCurtailedDevices(ctx, orgID)
 	require.NoError(t, err)
-	assert.ElementsMatch(t, []string{devices[1], devices[3], devices[5]}, active,
+	assert.ElementsMatch(t, []string{devices[1], devices[3], devices[5], devices[6]}, active,
 		"logical topology ownership must follow current membership even before target rows are admitted")
 }
 

--- a/server/internal/domain/stores/sqlstores/curtailment_topology_start_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/curtailment_topology_start_integration_test.go
@@ -284,7 +284,7 @@ func TestSQLCurtailmentStore_BeginTopologyRestoreReleasesUnsentAndQueuesAttempte
 		Name:  "Topology departure branches",
 	})
 	require.NoError(t, err)
-	devices := testContext.DatabaseService.CreateTestMiners(orgID, 2, "https://172.17.0.1:80")
+	devices := testContext.DatabaseService.CreateTestMiners(orgID, 3, "https://172.17.0.1:80")
 	_, err = buildingStore.AssignDevicesToBuilding(ctx, orgID, &building.ID, devices)
 	require.NoError(t, err)
 
@@ -301,16 +301,19 @@ func TestSQLCurtailmentStore_BeginTopologyRestoreReleasesUnsentAndQueuesAttempte
 	inserted, err := store.InsertEventWithTargets(ctx, event, []models.InsertTargetParams{
 		curtailmentStoreTestTarget(devices[0], models.TargetStatePending, models.DesiredStateCurtailed),
 		curtailmentStoreTestTarget(devices[1], models.TargetStatePending, models.DesiredStateCurtailed),
+		curtailmentStoreTestTarget(devices[2], models.TargetStatePending, models.DesiredStateCurtailed),
 	})
 	require.NoError(t, err)
 	_, err = database.ExecContext(ctx, `
 		UPDATE curtailment_target
-		SET retry_count = 1,
-		    last_dispatched_at = CURRENT_TIMESTAMP,
-		    curtail_dispatched_at = CURRENT_TIMESTAMP
+		SET state = CASE WHEN device_identifier = $2 THEN 'dispatching' ELSE state END,
+		    curtail_state = CASE WHEN device_identifier = $2 THEN 'dispatching' ELSE curtail_state END,
+		    retry_count = CASE WHEN device_identifier = $3 THEN 1 ELSE retry_count END,
+		    last_dispatched_at = CASE WHEN device_identifier = $3 THEN CURRENT_TIMESTAMP ELSE last_dispatched_at END,
+		    curtail_dispatched_at = CASE WHEN device_identifier = $3 THEN CURRENT_TIMESTAMP ELSE curtail_dispatched_at END
 		WHERE curtailment_event_id = $1
-		  AND device_identifier = $2
-	`, inserted.ID, devices[1])
+		  AND device_identifier IN ($2, $3)
+	`, inserted.ID, devices[1], devices[2])
 	require.NoError(t, err)
 
 	_, err = buildingStore.AssignDevicesToBuilding(ctx, orgID, nil, devices)
@@ -319,7 +322,7 @@ func TestSQLCurtailmentStore_BeginTopologyRestoreReleasesUnsentAndQueuesAttempte
 	require.NoError(t, err)
 	transitioned, err := store.BeginCurtailmentTopologyTargetRestore(ctx, persisted, devices)
 	require.NoError(t, err)
-	assert.Equal(t, int64(2), transitioned)
+	assert.Equal(t, int64(3), transitioned)
 
 	targets, err := store.ListTargetsByEvent(ctx, orgID, eventUUID)
 	require.NoError(t, err)
@@ -333,7 +336,13 @@ func TestSQLCurtailmentStore_BeginTopologyRestoreReleasesUnsentAndQueuesAttempte
 	assert.Equal(t, models.DesiredStateCurtailed, unsent.DesiredState)
 	assert.Nil(t, unsent.RestorePhase)
 
-	attempted := byDevice[devices[1]]
+	unsentDispatching := byDevice[devices[1]]
+	require.NotNil(t, unsentDispatching)
+	assert.Equal(t, models.TargetStateReleased, unsentDispatching.State)
+	assert.Equal(t, models.DesiredStateCurtailed, unsentDispatching.DesiredState)
+	assert.Nil(t, unsentDispatching.RestorePhase)
+
+	attempted := byDevice[devices[2]]
 	require.NotNil(t, attempted)
 	assert.Equal(t, models.TargetStatePending, attempted.State)
 	assert.Equal(t, models.DesiredStateActive, attempted.DesiredState)

--- a/server/internal/domain/stores/sqlstores/curtailment_topology_start_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/curtailment_topology_start_integration_test.go
@@ -660,6 +660,81 @@ func TestSQLCurtailmentStore_ClaimWaitsForTopologyMoveBeforeCheckingEarlierReser
 	assert.Empty(t, result.targets, "the committed move must make the older targetless watcher authoritative")
 }
 
+func TestSQLCurtailmentStore_ClaimWaitsForCurrentTopologyMembershipRemoval(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping database integration test in short mode")
+	}
+
+	testContext := testutil.InitializeDBServiceInfrastructure(t)
+	user := testContext.DatabaseService.CreateSuperAdminUser()
+	ctx := t.Context()
+	database := testContext.DatabaseService.DB
+	store := sqlstores.NewSQLCurtailmentStore(database)
+	collectionStore := sqlstores.NewSQLCollectionStore(database)
+	orgID := user.OrganizationID
+
+	group, err := collectionStore.CreateCollection(
+		ctx,
+		orgID,
+		collectionpb.CollectionType_COLLECTION_TYPE_GROUP,
+		"Current admission group",
+		"",
+	)
+	require.NoError(t, err)
+	device := testContext.DatabaseService.CreateDevice(orgID, "proto")
+	_, err = collectionStore.AddDevicesToCollection(ctx, orgID, group.Id, []string{device.ID})
+	require.NoError(t, err)
+
+	eventParams := curtailmentStoreClosedLoopFullFleetEvent(
+		orgID, user.DatabaseID, uuid.New(), models.ScopeTypeMixed, 0, "current-group-admission",
+	)
+	eventParams.ScopeJSON = []byte(fmt.Sprintf(`{"scope_schema_version":1,"group_ids":[%d]}`, group.Id))
+	event, err := store.InsertEventWithTargets(ctx, eventParams, nil)
+	require.NoError(t, err)
+
+	tx, err := database.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = tx.Rollback() })
+	q := sqlc.New(tx)
+	removed, err := q.RemoveDevicesFromDeviceSet(ctx, sqlc.RemoveDevicesFromDeviceSetParams{
+		DeviceSetID:       group.Id,
+		OrgID:             orgID,
+		DeviceIdentifiers: []string{device.ID},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{device.ID}, removed)
+
+	claimDone := make(chan struct {
+		targets []*models.Target
+		err     error
+	}, 1)
+	go func() {
+		targets, claimErr := store.ClaimClosedLoopFullFleetTargets(
+			ctx,
+			event.ID,
+			orgID,
+			0,
+			[]models.InsertTargetParams{
+				curtailmentStoreTestTarget(device.ID, models.TargetStatePending, models.DesiredStateCurtailed),
+			},
+		)
+		claimDone <- struct {
+			targets []*models.Target
+			err     error
+		}{targets: targets, err: claimErr}
+	}()
+	select {
+	case result := <-claimDone:
+		require.NoError(t, result.err)
+		t.Fatal("claim completed before the in-flight membership removal committed")
+	case <-time.After(150 * time.Millisecond):
+	}
+	require.NoError(t, tx.Commit())
+	result := <-claimDone
+	require.NoError(t, result.err)
+	assert.Empty(t, result.targets, "a miner removed from the current selector must not be admitted")
+}
+
 func TestSQLCurtailmentStore_BulkReadinessWaitsForTargetlessTopologyReservation(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping database integration test in short mode")

--- a/server/internal/domain/stores/sqlstores/curtailment_topology_start_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/curtailment_topology_start_integration_test.go
@@ -1033,8 +1033,9 @@ func TestSQLCurtailmentStore_TopologyRestoreDispatchAllowsDeletedSelector(t *tes
 			testContext := testutil.InitializeDBServiceInfrastructure(t)
 			user := testContext.DatabaseService.CreateSuperAdminUser()
 			ctx := t.Context()
-			store := sqlstores.NewSQLCurtailmentStore(testContext.DatabaseService.DB)
-			collectionStore := sqlstores.NewSQLCollectionStore(testContext.DatabaseService.DB)
+			database := testContext.DatabaseService.DB
+			store := sqlstores.NewSQLCurtailmentStore(database)
+			collectionStore := sqlstores.NewSQLCollectionStore(database)
 			orgID := user.OrganizationID
 
 			group, err := collectionStore.CreateCollection(
@@ -1068,6 +1069,28 @@ func TestSQLCurtailmentStore_TopologyRestoreDispatchAllowsDeletedSelector(t *tes
 				persisted,
 				[]string{device.ID},
 				func(snapshot interfaces.CurtailmentTopologyRestoreDispatchFenceSnapshot) error {
+					batchUUID := uuid.NewString()
+					if err := dbinfra.WithTransactionNoResult(ctx, database, func(q sqlc.Querier) error {
+						if _, err := q.CreateCommandBatchLog(ctx, sqlc.CreateCommandBatchLogParams{
+							Uuid:           batchUUID,
+							Type:           "UNCURTAIL",
+							CreatedBy:      user.DatabaseID,
+							CreatedAt:      time.Now(),
+							Status:         sqlc.BatchStatusEnumPENDING,
+							DevicesCount:   1,
+							OrganizationID: sql.NullInt64{Int64: orgID, Valid: true},
+						}); err != nil {
+							return err
+						}
+						return q.CreateQueueMessage(ctx, sqlc.CreateQueueMessageParams{
+							CommandBatchLogUuid: batchUUID,
+							CommandType:         "UNCURTAIL",
+							DeviceID:            device.DatabaseID,
+							Status:              sqlc.QueueStatusEnumPENDING,
+						})
+					}); err != nil {
+						return err
+					}
 					assert.Equal(t, eventState, snapshot.Event.State)
 					assert.Empty(t, snapshot.Topology.DispatchMemberDeviceIdentifiers)
 					if eventState == models.EventStateActive {

--- a/server/internal/domain/stores/sqlstores/curtailment_topology_start_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/curtailment_topology_start_integration_test.go
@@ -331,12 +331,13 @@ func TestSQLCurtailmentStore_BeginTopologyRestoreReleasesUnsentAndQueuesAttempte
 	require.NotNil(t, unsent)
 	assert.Equal(t, models.TargetStateReleased, unsent.State)
 	assert.Equal(t, models.DesiredStateCurtailed, unsent.DesiredState)
-	assert.Nil(t, unsent.RestorePhase.StartedAt)
+	assert.Nil(t, unsent.RestorePhase)
 
 	attempted := byDevice[devices[1]]
 	require.NotNil(t, attempted)
 	assert.Equal(t, models.TargetStatePending, attempted.State)
 	assert.Equal(t, models.DesiredStateActive, attempted.DesiredState)
+	require.NotNil(t, attempted.RestorePhase)
 	assert.Equal(t, models.TargetStatePending, attempted.RestorePhase.State)
 	require.NotNil(t, attempted.RestorePhase.StartedAt)
 }

--- a/server/internal/handlers/curtailment/handler_admin_terminate_test.go
+++ b/server/internal/handlers/curtailment/handler_admin_terminate_test.go
@@ -117,6 +117,7 @@ func (s *adminTerminateStubStore) ClaimClosedLoopFullFleetTargets(
 	int64,
 	int64,
 	int32,
+	int,
 	[]models.InsertTargetParams,
 ) ([]*models.Target, error) {
 	panic("ClaimClosedLoopFullFleetTargets not exercised by AdminTerminate handler tests")

--- a/server/internal/handlers/curtailment/handler_admin_terminate_test.go
+++ b/server/internal/handlers/curtailment/handler_admin_terminate_test.go
@@ -124,12 +124,15 @@ func (s *adminTerminateStubStore) ClaimClosedLoopFullFleetTargets(
 func (s *adminTerminateStubStore) ClaimAllPairedPolicyTargets(
 	context.Context,
 	int64,
+	int64,
+	int,
 	[]models.InsertTargetParams,
 ) (int64, error) {
 	panic("ClaimAllPairedPolicyTargets not exercised by AdminTerminate handler tests")
 }
 func (s *adminTerminateStubStore) BulkRefreshAllPairedTargetReadiness(
 	context.Context,
+	int64,
 	int64,
 	models.EventState,
 	[]interfaces.AllPairedReadinessUpdate,

--- a/server/internal/handlers/curtailment/handler_list_test.go
+++ b/server/internal/handlers/curtailment/handler_list_test.go
@@ -114,12 +114,15 @@ func (s *listStubStore) ClaimClosedLoopFullFleetTargets(
 func (s *listStubStore) ClaimAllPairedPolicyTargets(
 	context.Context,
 	int64,
+	int64,
+	int,
 	[]models.InsertTargetParams,
 ) (int64, error) {
 	panic("ClaimAllPairedPolicyTargets not exercised by List handler tests")
 }
 func (s *listStubStore) BulkRefreshAllPairedTargetReadiness(
 	context.Context,
+	int64,
 	int64,
 	models.EventState,
 	[]interfaces.AllPairedReadinessUpdate,

--- a/server/internal/handlers/curtailment/handler_list_test.go
+++ b/server/internal/handlers/curtailment/handler_list_test.go
@@ -107,6 +107,7 @@ func (s *listStubStore) ClaimClosedLoopFullFleetTargets(
 	int64,
 	int64,
 	int32,
+	int,
 	[]models.InsertTargetParams,
 ) ([]*models.Target, error) {
 	panic("ClaimClosedLoopFullFleetTargets not exercised by List handler tests")

--- a/server/internal/handlers/curtailment/handler_start_test.go
+++ b/server/internal/handlers/curtailment/handler_start_test.go
@@ -102,6 +102,7 @@ func (s *startStubStore) ClaimClosedLoopFullFleetTargets(
 	int64,
 	int64,
 	int32,
+	int,
 	[]models.InsertTargetParams,
 ) ([]*models.Target, error) {
 	panic("ClaimClosedLoopFullFleetTargets not exercised by handler Start tests")

--- a/server/internal/handlers/curtailment/handler_start_test.go
+++ b/server/internal/handlers/curtailment/handler_start_test.go
@@ -109,6 +109,8 @@ func (s *startStubStore) ClaimClosedLoopFullFleetTargets(
 func (s *startStubStore) ClaimAllPairedPolicyTargets(
 	context.Context,
 	int64,
+	int64,
+	int,
 	[]models.InsertTargetParams,
 ) (int64, error) {
 	panic("ClaimAllPairedPolicyTargets not exercised by handler Start tests")
@@ -116,6 +118,7 @@ func (s *startStubStore) ClaimAllPairedPolicyTargets(
 
 func (s *startStubStore) BulkRefreshAllPairedTargetReadiness(
 	context.Context,
+	int64,
 	int64,
 	models.EventState,
 	[]interfaces.AllPairedReadinessUpdate,

--- a/server/internal/handlers/curtailment/handler_stop_test.go
+++ b/server/internal/handlers/curtailment/handler_stop_test.go
@@ -75,12 +75,15 @@ func (s *stopStubStore) ClaimClosedLoopFullFleetTargets(
 func (s *stopStubStore) ClaimAllPairedPolicyTargets(
 	context.Context,
 	int64,
+	int64,
+	int,
 	[]models.InsertTargetParams,
 ) (int64, error) {
 	panic("ClaimAllPairedPolicyTargets not exercised by Stop handler tests")
 }
 func (s *stopStubStore) BulkRefreshAllPairedTargetReadiness(
 	context.Context,
+	int64,
 	int64,
 	models.EventState,
 	[]interfaces.AllPairedReadinessUpdate,

--- a/server/internal/handlers/curtailment/handler_stop_test.go
+++ b/server/internal/handlers/curtailment/handler_stop_test.go
@@ -68,6 +68,7 @@ func (s *stopStubStore) ClaimClosedLoopFullFleetTargets(
 	int64,
 	int64,
 	int32,
+	int,
 	[]models.InsertTargetParams,
 ) ([]*models.Target, error) {
 	panic("ClaimClosedLoopFullFleetTargets not exercised by Stop handler tests")

--- a/server/internal/handlers/curtailment/handler_update_test.go
+++ b/server/internal/handlers/curtailment/handler_update_test.go
@@ -155,12 +155,15 @@ func (s *updateStubStore) ClaimClosedLoopFullFleetTargets(
 func (s *updateStubStore) ClaimAllPairedPolicyTargets(
 	context.Context,
 	int64,
+	int64,
+	int,
 	[]models.InsertTargetParams,
 ) (int64, error) {
 	panic("ClaimAllPairedPolicyTargets not exercised by Update handler tests")
 }
 func (s *updateStubStore) BulkRefreshAllPairedTargetReadiness(
 	context.Context,
+	int64,
 	int64,
 	models.EventState,
 	[]interfaces.AllPairedReadinessUpdate,

--- a/server/internal/handlers/curtailment/handler_update_test.go
+++ b/server/internal/handlers/curtailment/handler_update_test.go
@@ -148,6 +148,7 @@ func (s *updateStubStore) ClaimClosedLoopFullFleetTargets(
 	int64,
 	int64,
 	int32,
+	int,
 	[]models.InsertTargetParams,
 ) ([]*models.Target, error) {
 	panic("ClaimClosedLoopFullFleetTargets not exercised by Update handler tests")

--- a/server/sqlc/queries/curtailment.sql
+++ b/server/sqlc/queries/curtailment.sql
@@ -2274,6 +2274,65 @@ LIMIT 10001
 -- can take the foreign-key KEY SHARE lock on device without self-deadlocking.
 FOR NO KEY UPDATE;
 
+-- name: ListCurtailmentTopologyMemberDeviceIdentifiersByOrg :many
+-- Restore reads the live member IDs after locking the selector resources, then
+-- locks these IDs together with departed restore candidates in one canonical
+-- device order. Keeping this read non-locking avoids taking current-member rows
+-- before lower-ID departed rows and deadlocking with bulk placement writes.
+SELECT d.device_identifier
+FROM device d
+WHERE d.org_id = sqlc.arg('org_id')
+  AND d.deleted_at IS NULL
+  AND (
+    (
+      d.building_id = ANY(sqlc.arg('building_ids')::BIGINT[])
+      OR EXISTS (
+        SELECT 1
+        FROM device_set_membership dsm
+        JOIN device_set ds
+          ON ds.id = dsm.device_set_id
+         AND ds.org_id = dsm.org_id
+         AND ds.type = 'rack'
+         AND ds.deleted_at IS NULL
+        JOIN device_set_rack dsr
+          ON dsr.device_set_id = ds.id
+         AND dsr.org_id = ds.org_id
+        WHERE dsm.org_id = sqlc.arg('org_id')
+          AND dsm.device_id = d.id
+          AND dsm.device_set_type = 'rack'
+          AND dsr.building_id = ANY(sqlc.arg('building_ids')::BIGINT[])
+      )
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM device_set_membership dsm
+      JOIN device_set ds
+        ON ds.id = dsm.device_set_id
+       AND ds.org_id = dsm.org_id
+       AND ds.type = 'rack'
+       AND ds.deleted_at IS NULL
+      WHERE dsm.org_id = sqlc.arg('org_id')
+        AND dsm.device_id = d.id
+        AND dsm.device_set_type = 'rack'
+        AND dsm.device_set_id = ANY(sqlc.arg('rack_ids')::BIGINT[])
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM device_set_membership dsm
+      JOIN device_set ds
+        ON ds.id = dsm.device_set_id
+       AND ds.org_id = dsm.org_id
+       AND ds.type = 'group'
+       AND ds.deleted_at IS NULL
+      WHERE dsm.org_id = sqlc.arg('org_id')
+        AND dsm.device_id = d.id
+        AND dsm.device_set_type = 'group'
+        AND dsm.device_set_id = ANY(sqlc.arg('group_ids')::BIGINT[])
+    )
+  )
+ORDER BY d.id
+LIMIT 10001;
+
 -- name: LockCurtailmentGroupsForWrite :many
 -- Serializes group membership changes with topology target/envelope writes.
 -- AddDevicesToDeviceSet, RemoveDevicesFromDeviceSet, and

--- a/server/sqlc/queries/curtailment.sql
+++ b/server/sqlc/queries/curtailment.sql
@@ -91,6 +91,75 @@ JOIN device d ON d.org_id = ce.org_id
             )
             AND NOT (ce.scope_jsonb ?| ARRAY['building_ids', 'rack_ids', 'group_ids'])
         )
+        OR (
+            ce.scope_type = 'mixed'
+            AND jsonb_typeof(ce.scope_jsonb->'building_ids') = 'array'
+            AND EXISTS (
+                SELECT 1
+                FROM jsonb_array_elements_text(ce.scope_jsonb->'building_ids') AS selected_building(building_id)
+                JOIN building b
+                  ON b.id = selected_building.building_id::BIGINT
+                 AND b.org_id = ce.org_id
+                 AND b.deleted_at IS NULL
+                WHERE d.building_id = b.id
+                   OR EXISTS (
+                       SELECT 1
+                       FROM device_set_membership dsm
+                       JOIN device_set ds
+                         ON ds.id = dsm.device_set_id
+                        AND ds.org_id = dsm.org_id
+                        AND ds.type = 'rack'
+                        AND ds.deleted_at IS NULL
+                       JOIN device_set_rack dsr
+                         ON dsr.device_set_id = ds.id
+                        AND dsr.org_id = ds.org_id
+                       WHERE dsm.org_id = ce.org_id
+                         AND dsm.device_id = d.id
+                         AND dsm.device_set_type = 'rack'
+                         AND dsr.building_id = b.id
+                   )
+            )
+        )
+        OR (
+            ce.scope_type = 'mixed'
+            AND jsonb_typeof(ce.scope_jsonb->'rack_ids') = 'array'
+            AND EXISTS (
+                SELECT 1
+                FROM device_set_membership dsm
+                JOIN device_set ds
+                  ON ds.id = dsm.device_set_id
+                 AND ds.org_id = dsm.org_id
+                 AND ds.type = 'rack'
+                 AND ds.deleted_at IS NULL
+                WHERE dsm.org_id = ce.org_id
+                  AND dsm.device_id = d.id
+                  AND dsm.device_set_type = 'rack'
+                  AND dsm.device_set_id IN (
+                      SELECT selected_rack.rack_id::BIGINT
+                      FROM jsonb_array_elements_text(ce.scope_jsonb->'rack_ids') AS selected_rack(rack_id)
+                  )
+            )
+        )
+        OR (
+            ce.scope_type = 'mixed'
+            AND jsonb_typeof(ce.scope_jsonb->'group_ids') = 'array'
+            AND EXISTS (
+                SELECT 1
+                FROM device_set_membership dsm
+                JOIN device_set ds
+                  ON ds.id = dsm.device_set_id
+                 AND ds.org_id = dsm.org_id
+                 AND ds.type = 'group'
+                 AND ds.deleted_at IS NULL
+                WHERE dsm.org_id = ce.org_id
+                  AND dsm.device_id = d.id
+                  AND dsm.device_set_type = 'group'
+                  AND dsm.device_set_id IN (
+                      SELECT selected_group.group_id::BIGINT
+                      FROM jsonb_array_elements_text(ce.scope_jsonb->'group_ids') AS selected_group(group_id)
+                  )
+            )
+        )
     )
 WHERE ce.org_id = sqlc.arg('org_id')
     AND ce.state IN ('pending', 'active', 'restoring')
@@ -128,6 +197,148 @@ JOIN curtailment_event ce ON ce.id = ct.curtailment_event_id
 WHERE ce.org_id = sqlc.arg('org_id')
     AND ce.state IN ('pending', 'active', 'restoring')
     AND ct.state NOT IN ('resolved', 'restore_failed', 'released');
+
+-- name: ListEarlierCurtailmentReservationDevices :many
+-- Returns requested devices owned by an older concrete target or logical
+-- closed-loop scope. Admission holds the org scope lock while reading this
+-- list and claiming targets, so persisted event order decides ownership.
+WITH current_event AS MATERIALIZED (
+    SELECT curtailment_event.id, curtailment_event.org_id
+    FROM curtailment_event
+    WHERE curtailment_event.id = sqlc.arg('curtailment_event_id')
+      AND curtailment_event.state IN ('pending', 'active', 'restoring')
+),
+candidate_devices AS MATERIALIZED (
+    SELECT d.id, d.device_identifier, d.site_id, d.building_id, d.org_id
+    FROM device d
+    JOIN current_event current ON current.org_id = d.org_id
+    WHERE d.deleted_at IS NULL
+      AND d.device_identifier = ANY(sqlc.arg('device_identifiers')::TEXT[])
+)
+SELECT candidate.device_identifier
+FROM candidate_devices candidate
+JOIN current_event current ON TRUE
+WHERE EXISTS (
+    SELECT 1
+    FROM curtailment_event older
+    WHERE older.org_id = current.org_id
+      AND older.id < current.id
+      AND older.state IN ('pending', 'active', 'restoring')
+      AND (
+        EXISTS (
+            SELECT 1
+            FROM curtailment_target target
+            WHERE target.curtailment_event_id = older.id
+              AND target.device_identifier = candidate.device_identifier
+              AND target.state NOT IN ('resolved', 'restore_failed', 'released')
+        )
+        OR (
+          older.mode = 'FULL_FLEET'
+          AND older.loop_type = 'closed'
+          AND NOT (
+            older.force_include_all_paired_miners
+            AND older.state = 'restoring'
+            AND EXISTS (
+              SELECT 1
+              FROM curtailment_target released_target
+              WHERE released_target.curtailment_event_id = older.id
+                AND released_target.device_identifier = candidate.device_identifier
+                AND released_target.state = 'released'
+            )
+          )
+          AND (
+            older.scope_type = 'whole_org'
+            OR (
+              older.scope_type = 'site'
+              AND candidate.site_id = (older.scope_jsonb->>'site_id')::BIGINT
+            )
+            OR (
+              older.scope_type = 'mixed'
+              AND candidate.site_id IN (
+                  SELECT selected_site.site_id::BIGINT
+                  FROM jsonb_array_elements_text(
+                      CASE WHEN jsonb_typeof(older.scope_jsonb->'site_ids') = 'array'
+                        THEN older.scope_jsonb->'site_ids'
+                        ELSE '[]'::jsonb
+                      END
+                  ) AS selected_site(site_id)
+              )
+              AND NOT (older.scope_jsonb ?| ARRAY['building_ids', 'rack_ids', 'group_ids'])
+            )
+            OR (
+              older.scope_type = 'mixed'
+              AND jsonb_typeof(older.scope_jsonb->'building_ids') = 'array'
+              AND EXISTS (
+                  SELECT 1
+                  FROM jsonb_array_elements_text(older.scope_jsonb->'building_ids') AS selected_building(building_id)
+                  JOIN building b
+                    ON b.id = selected_building.building_id::BIGINT
+                   AND b.org_id = older.org_id
+                   AND b.deleted_at IS NULL
+                  WHERE candidate.building_id = b.id
+                     OR EXISTS (
+                         SELECT 1
+                         FROM device_set_membership dsm
+                         JOIN device_set ds
+                           ON ds.id = dsm.device_set_id
+                          AND ds.org_id = dsm.org_id
+                          AND ds.type = 'rack'
+                          AND ds.deleted_at IS NULL
+                         JOIN device_set_rack dsr
+                           ON dsr.device_set_id = ds.id
+                          AND dsr.org_id = ds.org_id
+                         WHERE dsm.org_id = older.org_id
+                           AND dsm.device_id = candidate.id
+                           AND dsm.device_set_type = 'rack'
+                           AND dsr.building_id = b.id
+                     )
+              )
+            )
+            OR (
+              older.scope_type = 'mixed'
+              AND jsonb_typeof(older.scope_jsonb->'rack_ids') = 'array'
+              AND EXISTS (
+                  SELECT 1
+                  FROM device_set_membership dsm
+                  JOIN device_set ds
+                    ON ds.id = dsm.device_set_id
+                   AND ds.org_id = dsm.org_id
+                   AND ds.type = 'rack'
+                   AND ds.deleted_at IS NULL
+                  WHERE dsm.org_id = older.org_id
+                    AND dsm.device_id = candidate.id
+                    AND dsm.device_set_type = 'rack'
+                    AND dsm.device_set_id IN (
+                        SELECT selected_rack.rack_id::BIGINT
+                        FROM jsonb_array_elements_text(older.scope_jsonb->'rack_ids') AS selected_rack(rack_id)
+                    )
+              )
+            )
+            OR (
+              older.scope_type = 'mixed'
+              AND jsonb_typeof(older.scope_jsonb->'group_ids') = 'array'
+              AND EXISTS (
+                  SELECT 1
+                  FROM device_set_membership dsm
+                  JOIN device_set ds
+                    ON ds.id = dsm.device_set_id
+                   AND ds.org_id = dsm.org_id
+                   AND ds.type = 'group'
+                   AND ds.deleted_at IS NULL
+                  WHERE dsm.org_id = older.org_id
+                    AND dsm.device_id = candidate.id
+                    AND dsm.device_set_type = 'group'
+                    AND dsm.device_set_id IN (
+                        SELECT selected_group.group_id::BIGINT
+                        FROM jsonb_array_elements_text(older.scope_jsonb->'group_ids') AS selected_group(group_id)
+                    )
+              )
+            )
+          )
+        )
+      )
+)
+ORDER BY candidate.device_identifier;
 
 -- name: ListRecentlyResolvedCurtailedDevicesByOrg :many
 -- Restored/failed targets the selector excludes (unless priority=EMERGENCY,
@@ -750,10 +961,17 @@ WHERE sqlc.arg('cooldown_sec')::INT <= 0
 -- insertion happen under one database-backed critical section.
 SELECT pg_advisory_xact_lock(hashtextextended('curtailment_scope:' || sqlc.arg('org_id')::text, 0));
 
+-- name: LockCurtailmentEventScopeForWrite :exec
+-- Admission already has the event ID; derive its organization before taking
+-- the same lock used by Start conflict detection.
+SELECT pg_advisory_xact_lock(hashtextextended('curtailment_scope:' || org_id::TEXT, 0))
+FROM curtailment_event
+WHERE id = sqlc.arg('curtailment_event_id');
+
 -- name: CountCurtailmentScopeConflicts :one
--- Hierarchy for currently supported closed-loop scopes: org > site.
--- A new whole-org event conflicts with existing whole-org, site, or site-only mixed events.
--- A new site or site-only mixed event conflicts with existing whole-org or overlapping site ownership.
+-- Serializes logical FULL_FLEET scope ownership. Whole-org conflicts with every
+-- hierarchy watcher; site selectors conflict on overlap; topology selectors
+-- conflict with whole-org and overlapping IDs of the same terminal type.
 SELECT count(*)::BIGINT
 FROM curtailment_event
 WHERE org_id = sqlc.arg('org_id')
@@ -769,19 +987,24 @@ WHERE org_id = sqlc.arg('org_id')
         scope_type IN ('whole_org', 'site')
         OR (
           scope_type = 'mixed'
-          AND jsonb_array_length(
-            CASE WHEN jsonb_typeof(scope_jsonb->'site_ids') = 'array'
-              THEN scope_jsonb->'site_ids'
-              ELSE '[]'::jsonb
-            END
-          ) > 0
-          AND jsonb_array_length(
-            CASE WHEN jsonb_typeof(scope_jsonb->'device_identifiers') = 'array'
-              THEN scope_jsonb->'device_identifiers'
-              ELSE '[]'::jsonb
-            END
-          ) = 0
-          AND NOT (scope_jsonb ?| ARRAY['building_ids', 'rack_ids', 'group_ids'])
+          AND (
+            scope_jsonb ?| ARRAY['building_ids', 'rack_ids', 'group_ids']
+            OR (
+              jsonb_array_length(
+                CASE WHEN jsonb_typeof(scope_jsonb->'site_ids') = 'array'
+                  THEN scope_jsonb->'site_ids'
+                  ELSE '[]'::jsonb
+                END
+              ) > 0
+              AND jsonb_array_length(
+                CASE WHEN jsonb_typeof(scope_jsonb->'device_identifiers') = 'array'
+                  THEN scope_jsonb->'device_identifiers'
+                  ELSE '[]'::jsonb
+                END
+              ) = 0
+              AND NOT (scope_jsonb ?| ARRAY['building_ids', 'rack_ids', 'group_ids'])
+            )
+          )
         )
       )
     )
@@ -815,6 +1038,68 @@ WHERE org_id = sqlc.arg('org_id')
         )
       )
     )
+    OR (
+      sqlc.arg('scope_type')::TEXT = 'mixed'
+      AND (
+        (
+          cardinality(sqlc.arg('building_ids')::BIGINT[]) > 0
+          AND (
+            scope_type = 'whole_org'
+            OR (
+              scope_type = 'mixed'
+              AND EXISTS (
+                SELECT 1
+                FROM jsonb_array_elements_text(
+                  CASE WHEN jsonb_typeof(scope_jsonb->'building_ids') = 'array'
+                    THEN scope_jsonb->'building_ids'
+                    ELSE '[]'::jsonb
+                  END
+                ) AS existing_building_id(building_id)
+                WHERE existing_building_id.building_id::BIGINT = ANY(sqlc.arg('building_ids')::BIGINT[])
+              )
+            )
+          )
+        )
+        OR (
+          cardinality(sqlc.arg('rack_ids')::BIGINT[]) > 0
+          AND (
+            scope_type = 'whole_org'
+            OR (
+              scope_type = 'mixed'
+              AND EXISTS (
+                SELECT 1
+                FROM jsonb_array_elements_text(
+                  CASE WHEN jsonb_typeof(scope_jsonb->'rack_ids') = 'array'
+                    THEN scope_jsonb->'rack_ids'
+                    ELSE '[]'::jsonb
+                  END
+                ) AS existing_rack_id(rack_id)
+                WHERE existing_rack_id.rack_id::BIGINT = ANY(sqlc.arg('rack_ids')::BIGINT[])
+              )
+            )
+          )
+        )
+        OR (
+          cardinality(sqlc.arg('group_ids')::BIGINT[]) > 0
+          AND (
+            scope_type = 'whole_org'
+            OR (
+              scope_type = 'mixed'
+              AND EXISTS (
+                SELECT 1
+                FROM jsonb_array_elements_text(
+                  CASE WHEN jsonb_typeof(scope_jsonb->'group_ids') = 'array'
+                    THEN scope_jsonb->'group_ids'
+                    ELSE '[]'::jsonb
+                  END
+                ) AS existing_group_id(group_id)
+                WHERE existing_group_id.group_id::BIGINT = ANY(sqlc.arg('group_ids')::BIGINT[])
+              )
+            )
+          )
+        )
+      )
+    )
   );
 
 -- name: ClaimClosedLoopFullFleetTargets :many
@@ -833,54 +1118,112 @@ WITH locked_event AS MATERIALIZED (
       AND curtailment_event.mode = 'FULL_FLEET'
       AND curtailment_event.loop_type = 'closed'
     FOR UPDATE
+),
+reopened AS (
+    UPDATE curtailment_target target
+    SET state                 = 'dispatching',
+        desired_state         = t.desired_state,
+        last_error            = t.last_error,
+        baseline_power_w      = t.baseline_power_w,
+        selector_rationale_jsonb = t.selector_rationale_jsonb,
+        released_at           = NULL,
+        retry_count           = 0,
+        last_dispatched_at    = NULL,
+        last_batch_uuid       = NULL,
+        confirmed_at          = NULL,
+        curtail_state         = 'dispatching',
+        curtail_dispatched_at = NULL,
+        curtail_batch_uuid    = NULL,
+        curtail_completed_at  = NULL,
+        curtail_retry_count   = 0,
+        curtail_failure_count = 0,
+        curtail_last_error    = t.last_error,
+        restore_state         = NULL,
+        restore_started_at    = NULL,
+        restore_dispatched_at = NULL,
+        restore_batch_uuid    = NULL,
+        restore_completed_at  = NULL,
+        restore_retry_count   = 0,
+        restore_failure_count = 0,
+        restore_last_error    = NULL
+    FROM locked_event
+    JOIN jsonb_to_recordset(sqlc.arg('targets_jsonb')::JSONB) AS t(
+        device_identifier         TEXT,
+        target_type               TEXT,
+        state                     TEXT,
+        desired_state             TEXT,
+        last_error                TEXT,
+        baseline_power_w          NUMERIC(12,3),
+        selector_rationale_jsonb  JSONB
+    ) ON TRUE
+    WHERE target.curtailment_event_id = locked_event.id
+      AND target.device_identifier = t.device_identifier
+      AND target.state IN ('resolved', 'restore_failed', 'released')
+      AND NOT EXISTS (
+          SELECT 1
+          FROM curtailment_target other_target
+          JOIN curtailment_event other_event
+            ON other_event.id = other_target.curtailment_event_id
+          WHERE other_target.device_identifier = t.device_identifier
+            AND other_target.curtailment_event_id <> locked_event.id
+            AND other_event.state IN ('pending', 'active', 'restoring')
+            AND other_target.state NOT IN ('resolved', 'restore_failed', 'released')
+      )
+    RETURNING target.*
+),
+inserted AS (
+    INSERT INTO curtailment_target (
+        curtailment_event_id,
+        device_identifier,
+        target_type,
+        state,
+        desired_state,
+        last_error,
+        curtail_state,
+        curtail_last_error,
+        baseline_power_w,
+        selector_rationale_jsonb
+    )
+    SELECT
+        locked_event.id,
+        t.device_identifier,
+        t.target_type,
+        'dispatching',
+        t.desired_state,
+        t.last_error,
+        'dispatching',
+        t.last_error,
+        t.baseline_power_w,
+        t.selector_rationale_jsonb
+    FROM locked_event
+    JOIN jsonb_to_recordset(sqlc.arg('targets_jsonb')::JSONB) AS t(
+        device_identifier         TEXT,
+        target_type               TEXT,
+        state                     TEXT,
+        desired_state             TEXT,
+        last_error                TEXT,
+        baseline_power_w          NUMERIC(12,3),
+        selector_rationale_jsonb  JSONB
+    ) ON TRUE
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM curtailment_target existing
+        WHERE existing.curtailment_event_id = locked_event.id
+          AND existing.device_identifier = t.device_identifier
+    )
+    ON CONFLICT DO NOTHING
+    RETURNING curtailment_target.*
 )
-INSERT INTO curtailment_target (
-    curtailment_event_id,
-    device_identifier,
-    target_type,
-    state,
-    desired_state,
-    last_error,
-    curtail_state,
-    curtail_last_error,
-    baseline_power_w,
-    selector_rationale_jsonb
-)
-SELECT
-    locked_event.id,
-    t.device_identifier,
-    t.target_type,
-    'dispatching',
-    t.desired_state,
-    t.last_error,
-    'dispatching',
-    t.last_error,
-    t.baseline_power_w,
-    t.selector_rationale_jsonb
-FROM locked_event
-JOIN jsonb_to_recordset(sqlc.arg('targets_jsonb')::JSONB) AS t(
-    device_identifier         TEXT,
-    target_type               TEXT,
-    state                     TEXT,
-    desired_state             TEXT,
-    last_error                TEXT,
-    baseline_power_w          NUMERIC(12,3),
-    selector_rationale_jsonb  JSONB
-) ON TRUE
-WHERE NOT EXISTS (
-    SELECT 1
-    FROM curtailment_target existing
-    WHERE existing.curtailment_event_id = locked_event.id
-      AND existing.device_identifier = t.device_identifier
-)
-ON CONFLICT DO NOTHING
-RETURNING curtailment_target.*;
+SELECT * FROM reopened
+UNION ALL
+SELECT * FROM inserted;
 
 -- name: ClaimAllPairedPolicyTargets :one
 -- Durable all-paired FULL_FLEET admission. Inserts targets in their computed
 -- policy state (pending or unavailable) instead of immediately claiming them
--- as DISPATCHING. Same-event RELEASED rows may be reopened during a recurtail;
--- other same-event rows and cross-event conflicts are no-ops.
+-- as DISPATCHING. Same-event RELEASED, topology-restored RESOLVED, or failed
+-- restore rows may be reopened; other same-event rows and cross-event
+-- conflicts are no-ops.
 WITH locked_event AS MATERIALIZED (
     SELECT
         curtailment_event.id,
@@ -910,7 +1253,15 @@ reopened AS (
         curtail_completed_at  = NULL,
         curtail_retry_count   = 0,
         curtail_failure_count = 0,
-        curtail_last_error    = t.last_error
+        curtail_last_error    = t.last_error,
+        restore_state         = NULL,
+        restore_started_at    = NULL,
+        restore_dispatched_at = NULL,
+        restore_batch_uuid    = NULL,
+        restore_completed_at  = NULL,
+        restore_retry_count   = 0,
+        restore_failure_count = 0,
+        restore_last_error    = NULL
     FROM locked_event
     JOIN jsonb_to_recordset(sqlc.arg('targets_jsonb')::JSONB) AS t(
         device_identifier         TEXT,
@@ -923,7 +1274,7 @@ reopened AS (
     ) ON TRUE
     WHERE target.curtailment_event_id = locked_event.id
       AND target.device_identifier = t.device_identifier
-      AND target.state = 'released'
+      AND target.state IN ('released', 'resolved', 'restore_failed')
       AND NOT EXISTS (
           SELECT 1
           FROM curtailment_target other_target
@@ -984,13 +1335,15 @@ SELECT ((SELECT COUNT(*) FROM reopened) + (SELECT COUNT(*) FROM inserted))::BIGI
 -- name: BulkRefreshAllPairedTargetReadiness :many
 -- Per-tick readiness refresh for all-paired policy rows, batched into one
 -- statement so a mass readiness flip (fleet-wide recovery or outage) does not
--- issue one UPDATE round trip per device inside the shared tick budget.
+-- issue one UPDATE round trip per device inside the shared tick budget. The
+-- same transition parks topology restore obligations while uncommandable and
+-- requeues them after commandability returns.
 --
 -- Guards mirror UpdateCurtailmentTargetState for this transition class:
 -- the parent event is locked and must still be in the caller's expected
--- state, and each row must still be a refreshable policy row
--- (desired_state='curtailed', state pending/unavailable). Rows that advanced
--- concurrently (dispatch claim, Stop reset, release) are skipped; the next
+-- state, and each row must still be a refreshable policy row: pending or
+-- unavailable for curtail, plus restore_failed for topology restore parking.
+-- Rows that advanced concurrently (dispatch claim, Stop reset, release) are skipped; the next
 -- tick re-reads them. RETURNING reports exactly which rows applied so the
 -- reconciler mirrors only those — a skipped row must not be treated as
 -- promoted and dispatched against stale state. Empty last_error is the
@@ -1003,37 +1356,106 @@ SELECT ((SELECT COUNT(*) FROM reopened) + (SELECT COUNT(*) FROM inserted))::BIGI
 -- degrade to the hash-only fallback forever. An existing baseline is never
 -- overwritten; readiness flaps must not capture asleep-power as baseline.
 WITH locked_event AS MATERIALIZED (
-    SELECT id
+    SELECT curtailment_event.id
     FROM curtailment_event
-    WHERE id = sqlc.arg('curtailment_event_id')
-      AND state IN ('pending', 'active')
-      AND state = sqlc.arg('expected_event_state')::TEXT
+    WHERE curtailment_event.id = sqlc.arg('curtailment_event_id')
+      AND curtailment_event.state IN ('pending', 'active', 'restoring')
+      AND curtailment_event.state = sqlc.arg('expected_event_state')::TEXT
     FOR UPDATE
 )
 UPDATE curtailment_target AS target
 SET state              = t.state,
     last_error         = NULLIF(t.last_error, ''),
-    baseline_power_w   = COALESCE(target.baseline_power_w, t.baseline_power_w),
-    curtail_state      = t.state,
+    retry_count        = CASE
+        WHEN target.desired_state = 'active' AND t.state = 'pending' THEN 0
+        ELSE target.retry_count
+    END,
+    last_dispatched_at = CASE
+        WHEN target.desired_state = 'active' AND t.state = 'pending' THEN NULL
+        ELSE target.last_dispatched_at
+    END,
+    last_batch_uuid    = CASE
+        WHEN target.desired_state = 'active' AND t.state = 'pending' THEN NULL
+        ELSE target.last_batch_uuid
+    END,
+    confirmed_at       = CASE
+        WHEN target.desired_state = 'active' THEN NULL
+        ELSE target.confirmed_at
+    END,
+    baseline_power_w   = CASE
+        WHEN target.desired_state = 'curtailed' THEN COALESCE(target.baseline_power_w, t.baseline_power_w)
+        ELSE target.baseline_power_w
+    END,
+    curtail_state      = CASE
+        WHEN target.desired_state = 'curtailed' THEN t.state
+        ELSE target.curtail_state
+    END,
     curtail_failure_count = CASE
-        WHEN NULLIF(t.last_error, '') IS NOT NULL THEN target.curtail_failure_count + 1
+        WHEN target.desired_state = 'curtailed' AND NULLIF(t.last_error, '') IS NOT NULL
+        THEN target.curtail_failure_count + 1
         ELSE target.curtail_failure_count
     END,
     curtail_last_error = CASE
-        WHEN NULLIF(t.last_error, '') IS NOT NULL THEN t.last_error
+        WHEN target.desired_state = 'curtailed' AND NULLIF(t.last_error, '') IS NOT NULL THEN t.last_error
         ELSE target.curtail_last_error
+    END,
+    restore_state = CASE
+        WHEN target.desired_state = 'active' THEN t.state
+        ELSE target.restore_state
+    END,
+    restore_started_at = CASE
+        WHEN target.desired_state = 'active' THEN COALESCE(target.restore_started_at, CURRENT_TIMESTAMP)
+        ELSE target.restore_started_at
+    END,
+    restore_dispatched_at = CASE
+        WHEN target.desired_state = 'active' AND t.state = 'pending' THEN NULL
+        ELSE target.restore_dispatched_at
+    END,
+    restore_batch_uuid = CASE
+        WHEN target.desired_state = 'active' AND t.state = 'pending' THEN NULL
+        ELSE target.restore_batch_uuid
+    END,
+    restore_completed_at = CASE
+        WHEN target.desired_state = 'active' THEN NULL
+        ELSE target.restore_completed_at
+    END,
+    restore_retry_count = CASE
+        WHEN target.desired_state = 'active' AND t.state = 'pending' THEN 0
+        ELSE target.restore_retry_count
+    END,
+    restore_last_error = CASE
+        WHEN target.desired_state = 'active' THEN NULLIF(t.last_error, '')
+        ELSE target.restore_last_error
     END
 FROM locked_event
 JOIN jsonb_to_recordset(sqlc.arg('updates_jsonb')::JSONB) AS t(
     device_identifier TEXT,
+    expected_state    TEXT,
     state             TEXT,
     last_error        TEXT,
     baseline_power_w  NUMERIC(12,3)
 ) ON TRUE
 WHERE target.curtailment_event_id = locked_event.id
   AND target.device_identifier = t.device_identifier
-  AND target.desired_state = 'curtailed'
-  AND target.state IN ('pending', 'unavailable')
+  AND target.state = t.expected_state
+  AND (
+      target.state <> 'restore_failed'
+      OR NOT EXISTS (
+          SELECT 1
+          FROM curtailment_target other_target
+          JOIN curtailment_event other_event
+            ON other_event.id = other_target.curtailment_event_id
+          WHERE other_target.device_identifier = target.device_identifier
+            AND other_target.curtailment_event_id <> target.curtailment_event_id
+            AND other_event.state IN ('pending', 'active', 'restoring')
+            AND other_target.state NOT IN ('resolved', 'restore_failed', 'released')
+      )
+  )
+  AND (
+      (target.desired_state = 'curtailed' AND target.state IN ('pending', 'unavailable'))
+      OR
+      (target.desired_state = 'active' AND target.state IN ('pending', 'unavailable', 'restore_failed'))
+  )
   AND t.state IN ('pending', 'unavailable')
 RETURNING target.device_identifier;
 
@@ -1207,6 +1629,124 @@ SET desired_state      = 'active',
     restore_last_error    = NULL
 WHERE curtailment_event_id = sqlc.arg('curtailment_event_id')
   AND state NOT IN ('resolved', 'restore_failed', 'released');
+
+-- name: BeginCurtailmentTopologyTargetRestore :execrows
+-- A topology watcher remains active while departed targets restore. Targets
+-- with no possible Curtail attempt release immediately; every other target
+-- enters the normal restore queue conservatively.
+WITH locked_event AS MATERIALIZED (
+    SELECT id
+    FROM curtailment_event
+    WHERE id = sqlc.arg('curtailment_event_id')
+      AND state = sqlc.arg('expected_event_state')::TEXT
+      AND state IN ('pending', 'active')
+    FOR UPDATE
+)
+UPDATE curtailment_target target
+SET desired_state = CASE
+        WHEN target.state IN ('pending', 'unavailable')
+         AND target.last_dispatched_at IS NULL
+         AND target.curtail_dispatched_at IS NULL
+         AND target.retry_count = 0
+         AND target.restore_started_at IS NULL
+        THEN target.desired_state
+        ELSE 'active'
+    END,
+    state = CASE
+        WHEN target.state IN ('pending', 'unavailable')
+         AND target.last_dispatched_at IS NULL
+         AND target.curtail_dispatched_at IS NULL
+         AND target.retry_count = 0
+         AND target.restore_started_at IS NULL
+        THEN 'released'
+        ELSE 'pending'
+    END,
+    retry_count = 0,
+    last_dispatched_at = NULL,
+    last_batch_uuid = NULL,
+    confirmed_at = NULL,
+    last_error = CASE
+        WHEN target.state IN ('pending', 'unavailable')
+         AND target.last_dispatched_at IS NULL
+         AND target.curtail_dispatched_at IS NULL
+         AND target.retry_count = 0
+         AND target.restore_started_at IS NULL
+        THEN COALESCE(target.last_error, 'released after leaving topology scope before Curtail dispatch')
+        ELSE NULL
+    END,
+    curtail_state = CASE
+        WHEN target.state IN ('pending', 'unavailable')
+         AND target.last_dispatched_at IS NULL
+         AND target.curtail_dispatched_at IS NULL
+         AND target.retry_count = 0
+         AND target.restore_started_at IS NULL
+        THEN 'released'
+        ELSE target.curtail_state
+    END,
+    curtail_completed_at = CASE
+        WHEN target.state IN ('pending', 'unavailable')
+         AND target.last_dispatched_at IS NULL
+         AND target.curtail_dispatched_at IS NULL
+         AND target.retry_count = 0
+         AND target.restore_started_at IS NULL
+        THEN COALESCE(target.curtail_completed_at, CURRENT_TIMESTAMP)
+        ELSE target.curtail_completed_at
+    END,
+    restore_state = CASE
+        WHEN target.state IN ('pending', 'unavailable')
+         AND target.last_dispatched_at IS NULL
+         AND target.curtail_dispatched_at IS NULL
+         AND target.retry_count = 0
+         AND target.restore_started_at IS NULL
+        THEN target.restore_state
+        ELSE 'pending'
+    END,
+    restore_started_at = CASE
+        WHEN target.state IN ('pending', 'unavailable')
+         AND target.last_dispatched_at IS NULL
+         AND target.curtail_dispatched_at IS NULL
+         AND target.retry_count = 0
+         AND target.restore_started_at IS NULL
+        THEN target.restore_started_at
+        ELSE CURRENT_TIMESTAMP
+    END,
+    restore_dispatched_at = NULL,
+    restore_batch_uuid = NULL,
+    restore_completed_at = NULL,
+    restore_retry_count = 0,
+    restore_failure_count = 0,
+    restore_last_error = NULL
+FROM locked_event
+WHERE target.curtailment_event_id = locked_event.id
+  AND target.device_identifier = ANY(sqlc.arg('device_identifiers')::TEXT[])
+  AND target.desired_state = 'curtailed'
+  AND target.state NOT IN ('resolved', 'restore_failed', 'released');
+
+-- name: LockCurtailmentTargetPairingStatusesForWrite :many
+-- Pairing status participates in all-paired topology membership. Lock these
+-- device rows first, including devices that do not have a pairing row yet,
+-- then any existing pairing rows. Pairing inserts take the same device lock,
+-- so the later candidate read cannot classify a first-time pairing from a
+-- stale pre-insert snapshot.
+WITH locked_devices AS MATERIALIZED (
+    SELECT d.id, d.device_identifier
+    FROM device d
+    WHERE d.org_id = sqlc.arg('org_id')
+      AND d.device_identifier = ANY(sqlc.arg('device_identifiers')::TEXT[])
+    ORDER BY d.device_identifier
+    FOR UPDATE OF d
+),
+locked_pairings AS MATERIALIZED (
+    SELECT dp.device_id, dp.pairing_status
+    FROM device_pairing dp
+    JOIN locked_devices d ON d.id = dp.device_id
+    ORDER BY d.device_identifier
+    FOR UPDATE OF dp
+)
+SELECT d.device_identifier, COALESCE(p.pairing_status::TEXT, 'UNPAIRED'::TEXT)::TEXT AS pairing_status
+FROM locked_devices d
+LEFT JOIN locked_pairings p ON p.device_id = d.id
+ORDER BY d.device_identifier;
 
 -- name: ReleaseUndispatchedTargetsForRestore :execrows
 -- Targets that never received a Curtail command do not need Uncurtail. Release

--- a/server/sqlc/queries/curtailment.sql
+++ b/server/sqlc/queries/curtailment.sql
@@ -987,6 +987,17 @@ SELECT pg_advisory_xact_lock(hashtextextended('curtailment_scope:' || org_id::TE
 FROM curtailment_event
 WHERE id = sqlc.arg('curtailment_event_id');
 
+-- name: LockCurtailmentAdmissionEventForWrite :one
+-- Keep the current event and its immutable selector in the same transaction
+-- as dynamic membership fencing and target admission.
+SELECT org_id, scope_jsonb
+FROM curtailment_event
+WHERE id = sqlc.arg('curtailment_event_id')
+  AND state IN ('pending', 'active')
+  AND mode = 'FULL_FLEET'
+  AND loop_type = 'closed'
+FOR UPDATE;
+
 -- name: CountCurtailmentScopeConflicts :one
 -- Serializes logical FULL_FLEET scope ownership. Whole-org conflicts with every
 -- hierarchy watcher; site selectors conflict on overlap; topology selectors

--- a/server/sqlc/queries/curtailment.sql
+++ b/server/sqlc/queries/curtailment.sql
@@ -1676,7 +1676,7 @@ WITH locked_event AS MATERIALIZED (
 )
 UPDATE curtailment_target target
 SET desired_state = CASE
-        WHEN target.state IN ('pending', 'unavailable')
+        WHEN target.state IN ('pending', 'unavailable', 'dispatching')
          AND target.last_dispatched_at IS NULL
          AND target.curtail_dispatched_at IS NULL
          AND target.retry_count = 0
@@ -1685,7 +1685,7 @@ SET desired_state = CASE
         ELSE 'active'
     END,
     state = CASE
-        WHEN target.state IN ('pending', 'unavailable')
+        WHEN target.state IN ('pending', 'unavailable', 'dispatching')
          AND target.last_dispatched_at IS NULL
          AND target.curtail_dispatched_at IS NULL
          AND target.retry_count = 0
@@ -1698,7 +1698,7 @@ SET desired_state = CASE
     last_batch_uuid = NULL,
     confirmed_at = NULL,
     last_error = CASE
-        WHEN target.state IN ('pending', 'unavailable')
+        WHEN target.state IN ('pending', 'unavailable', 'dispatching')
          AND target.last_dispatched_at IS NULL
          AND target.curtail_dispatched_at IS NULL
          AND target.retry_count = 0
@@ -1707,7 +1707,7 @@ SET desired_state = CASE
         ELSE NULL
     END,
     curtail_state = CASE
-        WHEN target.state IN ('pending', 'unavailable')
+        WHEN target.state IN ('pending', 'unavailable', 'dispatching')
          AND target.last_dispatched_at IS NULL
          AND target.curtail_dispatched_at IS NULL
          AND target.retry_count = 0
@@ -1716,7 +1716,7 @@ SET desired_state = CASE
         ELSE target.curtail_state
     END,
     curtail_completed_at = CASE
-        WHEN target.state IN ('pending', 'unavailable')
+        WHEN target.state IN ('pending', 'unavailable', 'dispatching')
          AND target.last_dispatched_at IS NULL
          AND target.curtail_dispatched_at IS NULL
          AND target.retry_count = 0
@@ -1725,7 +1725,7 @@ SET desired_state = CASE
         ELSE target.curtail_completed_at
     END,
     restore_state = CASE
-        WHEN target.state IN ('pending', 'unavailable')
+        WHEN target.state IN ('pending', 'unavailable', 'dispatching')
          AND target.last_dispatched_at IS NULL
          AND target.curtail_dispatched_at IS NULL
          AND target.retry_count = 0
@@ -1734,7 +1734,7 @@ SET desired_state = CASE
         ELSE 'pending'
     END,
     restore_started_at = CASE
-        WHEN target.state IN ('pending', 'unavailable')
+        WHEN target.state IN ('pending', 'unavailable', 'dispatching')
          AND target.last_dispatched_at IS NULL
          AND target.curtail_dispatched_at IS NULL
          AND target.retry_count = 0

--- a/server/sqlc/queries/curtailment.sql
+++ b/server/sqlc/queries/curtailment.sql
@@ -349,6 +349,7 @@ SELECT DISTINCT ct.device_identifier
 FROM curtailment_target ct
 JOIN curtailment_event ce ON ce.id = ct.curtailment_event_id
 WHERE ce.org_id = sqlc.arg('org_id')
+    AND (sqlc.arg('exclude_event_id')::BIGINT = 0 OR ce.id <> sqlc.arg('exclude_event_id')::BIGINT)
     AND ct.state IN ('resolved', 'restore_failed')
     AND (
         ce.state IN ('pending', 'active', 'restoring')
@@ -374,6 +375,7 @@ FROM scoped_devices sd
 JOIN curtailment_target ct ON ct.device_identifier = sd.device_identifier
 JOIN curtailment_event ce ON ce.id = ct.curtailment_event_id
 WHERE ce.org_id = sqlc.arg('org_id')
+    AND (sqlc.arg('exclude_event_id')::BIGINT = 0 OR ce.id <> sqlc.arg('exclude_event_id')::BIGINT)
     AND ct.state IN ('resolved', 'restore_failed')
     AND (
         ce.state IN ('pending', 'active', 'restoring')

--- a/server/sqlc/queries/curtailment.sql
+++ b/server/sqlc/queries/curtailment.sql
@@ -953,8 +953,27 @@ WHERE sqlc.arg('cooldown_sec')::INT <= 0
             AND (
                 cooldown_event.state IN ('pending', 'active', 'restoring')
                 OR cooldown_event.ended_at >= CURRENT_TIMESTAMP - (sqlc.arg('cooldown_sec')::INT * INTERVAL '1 second')
-            )
+      )
     );
+
+-- name: ListEarlierCurtailmentTopologyReservationScopes :many
+-- Returns topology selector envelopes for older logical reservations. Dynamic
+-- admission locks these resources before locking candidate devices and
+-- re-reading ListEarlierCurtailmentReservationDevices, so membership changes
+-- cannot commit between reservation classification and target claim.
+SELECT older.scope_jsonb
+FROM curtailment_event older
+WHERE older.org_id = sqlc.arg('org_id')
+  AND (
+      sqlc.arg('curtailment_event_id')::BIGINT = 0
+      OR older.id < sqlc.arg('curtailment_event_id')::BIGINT
+  )
+  AND older.state IN ('pending', 'active', 'restoring')
+  AND older.mode = 'FULL_FLEET'
+  AND older.loop_type = 'closed'
+  AND older.scope_type = 'mixed'
+  AND older.scope_jsonb ?| ARRAY['building_ids', 'rack_ids', 'group_ids']
+ORDER BY older.id;
 
 -- name: LockCurtailmentScopeForWrite :exec
 -- Serialize hierarchy start checks by org so conflict detection and event
@@ -1429,15 +1448,17 @@ SET state              = t.state,
     END
 FROM locked_event
 JOIN jsonb_to_recordset(sqlc.arg('updates_jsonb')::JSONB) AS t(
-    device_identifier TEXT,
-    expected_state    TEXT,
-    state             TEXT,
-    last_error        TEXT,
-    baseline_power_w  NUMERIC(12,3)
+    device_identifier      TEXT,
+    expected_state         TEXT,
+    expected_desired_state TEXT,
+    state                  TEXT,
+    last_error             TEXT,
+    baseline_power_w       NUMERIC(12,3)
 ) ON TRUE
 WHERE target.curtailment_event_id = locked_event.id
   AND target.device_identifier = t.device_identifier
   AND target.state = t.expected_state
+  AND target.desired_state = t.expected_desired_state
   AND (
       target.state <> 'restore_failed'
       OR NOT EXISTS (

--- a/server/sqlc/queries/curtailment_response_profile.sql
+++ b/server/sqlc/queries/curtailment_response_profile.sql
@@ -33,13 +33,15 @@ WHERE org_id = sqlc.arg('org_id')
 ORDER BY device_identifier;
 
 -- name: LockCurtailmentResponseProfileDeviceSitesByOrg :many
+-- Topology and site writes still conflict with this lock, while command queue
+-- inserts can take the foreign-key KEY SHARE lock without self-deadlocking.
 SELECT device_identifier, site_id
 FROM device
 WHERE org_id = sqlc.arg('org_id')
   AND device_identifier = ANY(sqlc.arg('device_identifiers')::text[])
   AND deleted_at IS NULL
 ORDER BY id
-FOR UPDATE;
+FOR NO KEY UPDATE;
 
 -- name: ListResponseProfileInfrastructureDevicesByOrg :many
 SELECT id, site_id, enabled

--- a/server/sqlc/queries/curtailment_response_profile.sql
+++ b/server/sqlc/queries/curtailment_response_profile.sql
@@ -38,7 +38,7 @@ FROM device
 WHERE org_id = sqlc.arg('org_id')
   AND device_identifier = ANY(sqlc.arg('device_identifiers')::text[])
   AND deleted_at IS NULL
-ORDER BY device_identifier
+ORDER BY id
 FOR UPDATE;
 
 -- name: ListResponseProfileInfrastructureDevicesByOrg :many

--- a/server/sqlc/queries/device.sql
+++ b/server/sqlc/queries/device.sql
@@ -65,15 +65,21 @@ WHERE dp.pairing_status = 'AUTHENTICATION_NEEDED'
     AND d.org_id = $1;
 
 -- name: UpsertDevicePairing :execresult
+WITH locked_device AS MATERIALIZED (
+    SELECT device.id
+    FROM device
+    WHERE device.id = sqlc.arg('device_id')
+    FOR UPDATE
+)
 INSERT INTO device_pairing (
     device_id,
     pairing_status,
     paired_at
-) VALUES (
-    $1,
-    $2,
+) SELECT
+    locked_device.id,
+    sqlc.arg('pairing_status'),
     CURRENT_TIMESTAMP
-)
+FROM locked_device
 ON CONFLICT (device_id) DO UPDATE SET
     pairing_status = EXCLUDED.pairing_status,
     paired_at = CURRENT_TIMESTAMP,
@@ -85,15 +91,21 @@ ON CONFLICT (device_id) DO UPDATE SET
 -- caller's read and this write (the DO UPDATE branch re-reads the latest committed row).
 -- Zero rows means paired-like won.
 -- name: SetDevicePairingAuthNeededIfNotPaired :execrows
+WITH locked_device AS MATERIALIZED (
+    SELECT device.id
+    FROM device
+    WHERE device.id = sqlc.arg('device_id')
+    FOR UPDATE
+)
 INSERT INTO device_pairing (
     device_id,
     pairing_status,
     paired_at
-) VALUES (
-    $1,
+) SELECT
+    locked_device.id,
     'AUTHENTICATION_NEEDED'::pairing_status_enum,
     CURRENT_TIMESTAMP
-)
+FROM locked_device
 ON CONFLICT (device_id) DO UPDATE SET
     pairing_status = 'AUTHENTICATION_NEEDED'::pairing_status_enum,
     paired_at = CURRENT_TIMESTAMP,

--- a/server/sqlc/queries/device_set.sql
+++ b/server/sqlc/queries/device_set.sql
@@ -357,6 +357,7 @@ CROSS JOIN locked_device_set ds
 WHERE d.device_identifier = ANY(@device_identifiers::text[])
   AND d.org_id = $1
   AND d.deleted_at IS NULL
+ORDER BY d.id
 ON CONFLICT (device_set_id, device_id) DO NOTHING
 RETURNING device_identifier;
 

--- a/server/sqlc/queries/site.sql
+++ b/server/sqlc/queries/site.sql
@@ -404,6 +404,7 @@ SELECT id FROM device
 WHERE org_id = sqlc.arg('org_id')
   AND device_identifier = ANY(sqlc.arg('device_identifiers')::text[])
   AND deleted_at IS NULL
+ORDER BY id
 FOR UPDATE;
 
 -- name: FindDeviceSiteConflicts :many


### PR DESCRIPTION
Reviewable diff: +896/-135 across 5 files (excludes generated, test, and story files).

## Summary

This PR adds the persistence foundation for topology-scoped FULL_FLEET curtailment. It introduces deterministic logical-scope reservations, transactional target admission, topology departure transitions, and guarded bulk readiness updates without enabling the new reconciliation behavior by itself.

**Stack:** this PR → #968 adds the reconciliation and API behavior. #968 is based directly on this branch; the shared drill-down UI and remaining frontend/E2E work stay tracked in #909.

## How it works

The store serializes curtailment scope changes per organization and resolves older logical scopes against each candidate before allowing ownership. New targets are inserted or reopened under the same event lock, while cross-event conflicts remain no-ops for a later retry.

For live topology changes, the store can move departed targets into the existing restore phase while leaving the parent watcher active. All-paired readiness changes carry the target state observed by the reconciler into expected-state guards, so a stale snapshot cannot overwrite a concurrent lifecycle transition. Device and pairing-row locks serialize departure checks with pairing updates, including the first pairing insert. Dispatch fencing resolves membership, authorization coverage, and event state in one database transaction before the caller sends physical commands.

## Diagrams

```mermaid
flowchart TD
  A["Admission request"] --> B["Lock organization scope"]
  B --> C["Resolve earlier logical reservations"]
  C --> D["Lock parent event"]
  D --> E["Insert or reopen eligible targets"]
  E --> F["Return claimed rows"]
  C --> G["Skip conflicting devices"]
```

```mermaid
flowchart LR
  A["Topology member leaves"] --> B["Lock event and topology coverage"]
  B --> C["No Curtail attempt"]
  B --> D["Curtail may have been sent"]
  C --> E["Release target"]
  D --> F["Create restore obligation"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/sqlc/queries/curtailment.sql` | Adds logical reservation, admission claim, dispatch fence, departure restore, and guarded readiness queries. | Defines locking, ownership, and race behavior. |
| `server/sqlc/queries/device.sql` | Makes pairing inserts take the same device lock as topology departure checks. | Prevents a first pairing from racing a stale restore decision. |
| `server/internal/domain/stores/interfaces/curtailment.go` | Exposes topology restore and expected-state readiness contracts. | Establishes the boundary consumed by the stacked reconciler PR. |
| `server/internal/domain/stores/sqlstores/curtailment.go` | Implements the new transactional store operations and payload conversion. | Connects domain operations to the SQL invariants. |
| `server/internal/domain/curtailment/reconciler/reconciler_allpaired.go` | Supplies the observed target state to the guarded bulk readiness API. | Makes the new store primitive independently safe before the stacked behavior lands. |
| `server/generated/sqlc/` | Regenerated SQL bindings — skip. | Mechanical output from the query changes. |
| SQL store and reconciler tests | Covers topology scope ownership, dispatch fencing, all-paired guards, and claim results. | Verifies database-level concurrency and caller behavior. |

## Key technical decisions & trade-offs

- Serialize logical reservations with an organization-scoped advisory lock instead of allowing overlapping watchers to race; persisted event order becomes deterministic at the cost of per-organization admission serialization.
- Keep ownership conflicts as no-ops instead of errors so active watchers can retry after the earlier owner resolves.
- Use expected event, target, and desired-state guards instead of unconditional updates so stale reconciliation work cannot clobber concurrent Stop or restore transitions.
- Lock device rows before optional pairing rows and make pairing inserts honor the same order, covering devices with no pairing row without weakening existing-row serialization.
- Return inserted and reopened CTE rows directly instead of rereading them through the statement snapshot, ensuring successful claims are visible to the caller.

## Testing & validation

- `go test ./internal/domain/curtailment/reconciler -run 'TestReconciler_AllPairedPolicy' -count=1`
- `golangci-lint run ./internal/domain/stores/... ./generated/sqlc/...`
- SQL store package compilation and non-database unit coverage
- Focused first-pairing concurrency test added; local execution requires the repository database harness and is delegated to CI.
- `git diff --check`
- Database-backed integration tests could not run locally because the local Postgres credentials do not match the repository test harness; they are delegated to CI.

Refs #909
