### PR TITLE
Reconcile topology-scoped full-fleet curtailment (2/2)

### DIFF
--- a/client/src/protoFleet/api/generated/curtailment/v1/curtailment_pb.ts
+++ b/client/src/protoFleet/api/generated/curtailment/v1/curtailment_pb.ts
@@ -971,7 +971,7 @@ export type PreviewCurtailmentPlanRequest = Message<"curtailment.v1.PreviewCurta
   postEventCooldownSec: number;
 
   /**
-   * Admin-only FULL_FLEET override (whole-org or site scopes only). When
+   * Admin-only FULL_FLEET override (whole-org, site, building, rack, or group scopes only). When
    * set, the event targets all paired-like miners in scope and holds
    * unavailable miners until they become commandable.
    *
@@ -1258,7 +1258,7 @@ export type StartCurtailmentRequest = Message<"curtailment.v1.StartCurtailmentRe
   postEventCooldownSec: number;
 
   /**
-   * Admin-only FULL_FLEET override (whole-org or site scopes only). When
+   * Admin-only FULL_FLEET override (whole-org, site, building, rack, or group scopes only). When
    * set, the event targets all paired-like miners in scope and holds
    * unavailable miners until they become commandable.
    *

--- a/proto/curtailment/v1/curtailment.proto
+++ b/proto/curtailment/v1/curtailment.proto
@@ -548,7 +548,7 @@ message PreviewCurtailmentPlanRequest {
     // How long restored targets remain excluded from selection. Zero disables cooldown.
     uint32 post_event_cooldown_sec = 28 [(buf.validate.field).uint32 = {lte: 86400}];
 
-    // Admin-only FULL_FLEET override (whole-org or site scopes only). When
+    // Admin-only FULL_FLEET override (whole-org, site, building, rack, or group scopes only). When
     // set, the event targets all paired-like miners in scope and holds
     // unavailable miners until they become commandable.
     //
@@ -688,7 +688,7 @@ message StartCurtailmentRequest {
     // How long restored targets remain excluded from selection. Zero disables cooldown.
     uint32 post_event_cooldown_sec = 29 [(buf.validate.field).uint32 = {lte: 86400}];
 
-    // Admin-only FULL_FLEET override (whole-org or site scopes only). When
+    // Admin-only FULL_FLEET override (whole-org, site, building, rack, or group scopes only). When
     // set, the event targets all paired-like miners in scope and holds
     // unavailable miners until they become commandable.
     //

--- a/server/generated/grpc/curtailment/v1/curtailment.pb.go
+++ b/server/generated/grpc/curtailment/v1/curtailment.pb.go
@@ -2237,7 +2237,7 @@ type PreviewCurtailmentPlanRequest struct {
 	CandidateMinPowerWOverride *uint32 `protobuf:"varint,26,opt,name=candidate_min_power_w_override,json=candidateMinPowerWOverride,proto3,oneof" json:"candidate_min_power_w_override,omitempty"`
 	// How long restored targets remain excluded from selection. Zero disables cooldown.
 	PostEventCooldownSec uint32 `protobuf:"varint,28,opt,name=post_event_cooldown_sec,json=postEventCooldownSec,proto3" json:"post_event_cooldown_sec,omitempty"`
-	// Admin-only FULL_FLEET override (whole-org or site scopes only). When
+	// Admin-only FULL_FLEET override (whole-org, site, building, rack, or group scopes only). When
 	// set, the event targets all paired-like miners in scope and holds
 	// unavailable miners until they become commandable.
 	//
@@ -2680,7 +2680,7 @@ type StartCurtailmentRequest struct {
 	AllowUnbounded bool `protobuf:"varint,27,opt,name=allow_unbounded,json=allowUnbounded,proto3" json:"allow_unbounded,omitempty"`
 	// How long restored targets remain excluded from selection. Zero disables cooldown.
 	PostEventCooldownSec uint32 `protobuf:"varint,29,opt,name=post_event_cooldown_sec,json=postEventCooldownSec,proto3" json:"post_event_cooldown_sec,omitempty"`
-	// Admin-only FULL_FLEET override (whole-org or site scopes only). When
+	// Admin-only FULL_FLEET override (whole-org, site, building, rack, or group scopes only). When
 	// set, the event targets all paired-like miners in scope and holds
 	// unavailable miners until they become commandable.
 	//

--- a/server/internal/domain/authz/resolver.go
+++ b/server/internal/domain/authz/resolver.go
@@ -57,6 +57,16 @@ func (r *PermissionResolver) LoadEffective(ctx context.Context, userID, organiza
 	return LoadEffectiveTx(ctx, r.queries, userID, organizationID)
 }
 
+// LoadRoleName returns the user's current primary role in the organization.
+// Callers use this alongside effective permissions when a persisted operation
+// depends on controls reserved to the built-in Admin and SuperAdmin roles.
+func (r *PermissionResolver) LoadRoleName(ctx context.Context, userID, organizationID int64) (string, error) {
+	return r.queries.GetUserRoleName(ctx, sqlc.GetUserRoleNameParams{
+		UserID:         userID,
+		OrganizationID: organizationID,
+	})
+}
+
 // LoadEffectiveTx runs the same query against a caller-supplied
 // sqlc.Querier handle so callers that already hold a transaction can
 // re-load the effective set inside their own snapshot. The role-

--- a/server/internal/domain/curtailment/reconciler/dispatch_authorization.go
+++ b/server/internal/domain/curtailment/reconciler/dispatch_authorization.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 
+	domainAuth "github.com/block/proto-fleet/server/internal/domain/auth"
 	"github.com/block/proto-fleet/server/internal/domain/authz"
 	"github.com/block/proto-fleet/server/internal/domain/curtailment"
 	"github.com/block/proto-fleet/server/internal/domain/curtailment/models"
@@ -16,6 +17,7 @@ import (
 // immediately before a topology-scoped Curtail command is sent.
 type DispatchPermissionResolver interface {
 	LoadEffective(ctx context.Context, userID, organizationID int64) (*authz.EffectivePermissions, error)
+	LoadRoleName(ctx context.Context, userID, organizationID int64) (string, error)
 }
 
 func WithDispatchPermissionResolver(resolver DispatchPermissionResolver) Option {
@@ -142,6 +144,13 @@ func (r *Reconciler) authorizeTopologyCurtailDispatch(
 			if !authorizationEnvelopeAllowsDispatch(effective, envelope, coverage) {
 				return rejectFence("event creator no longer has required permissions", nil)
 			}
+			adminAllowed, err := r.eventCreatorCanUseRequiredAdminControls(ctx, latest)
+			if err != nil {
+				return rejectFence("evaluate event admin requirements", err)
+			}
+			if !adminAllowed {
+				return rejectFence("event creator no longer has the admin role required by this event", nil)
+			}
 			commandAttempted = true
 			command()
 			return nil
@@ -230,6 +239,26 @@ func (r *Reconciler) fenceTopologyRestoreDispatch(
 	return true, fenceReached, commandTargets, err
 }
 
+func (r *Reconciler) eventCreatorCanUseRequiredAdminControls(ctx context.Context, ev *models.Event) (bool, error) {
+	var orgConfig *models.OrgConfig
+	var err error
+	if ev != nil && ev.MaxDurationSeconds != nil {
+		orgConfig, err = r.store.GetOrgConfig(ctx, ev.OrgID)
+		if err != nil {
+			return false, err
+		}
+	}
+	required, err := curtailment.EventRequiresAdminControls(ev, orgConfig)
+	if err != nil || !required {
+		return !required, err
+	}
+	roleName, err := r.permissions.LoadRoleName(ctx, ev.CreatedByUserID, ev.OrgID)
+	if err != nil {
+		return false, err
+	}
+	return roleName == domainAuth.AdminRoleName || roleName == domainAuth.SuperAdminRoleName, nil
+}
+
 var errTopologyDispatchRejected = errors.New("topology dispatch rejected")
 
 type topologyDispatchRejection struct {
@@ -269,6 +298,9 @@ func authorizationEnvelopeAllowsDispatch(
 	envelope models.AuthorizationEnvelope,
 	coverage interfaces.CurtailmentTopologyScopeCoverage,
 ) bool {
+	if effective == nil {
+		return false
+	}
 	requireOrgWideManage := envelope.MinerScopeUnbounded || envelope.FacilityFanScopeUnbounded || coverage.RequireOrgWide
 	if requireOrgWideManage && !effective.HasOrgWide(authz.PermCurtailmentManage) {
 		return false

--- a/server/internal/domain/curtailment/reconciler/facility_fans_test.go
+++ b/server/internal/domain/curtailment/reconciler/facility_fans_test.go
@@ -213,6 +213,117 @@ func TestReconciler_ActiveFanOffDoesNotUseTargetlessClosedLoopWatcher(t *testing
 	assert.Nil(t, event.FanOffSentAt)
 }
 
+func TestDriveTopologyRestoresUsesFansThatWereNeverTurnedOff(t *testing.T) {
+	store := newFakeStore()
+	dispatcher := &fakeDispatcher{}
+	fans := &fakeFanController{}
+	r := newReconcilerWithFansForTest(store, dispatcher, fans)
+	event := &models.Event{
+		ID:                   84,
+		EventUUID:            uuid.New(),
+		OrgID:                1,
+		State:                models.EventStateActive,
+		FacilityFanDeviceIDs: []int64{31},
+		FanRestoreDelaySec:   30,
+	}
+	target := &models.Target{
+		CurtailmentEventID: event.ID,
+		DeviceIdentifier:   "departed-miner",
+		DesiredState:       models.DesiredStateActive,
+		State:              models.TargetStatePending,
+		RestorePhase: &models.TargetPhaseSummary{
+			Phase: models.TargetPhaseRestore,
+			State: models.TargetStatePending,
+		},
+	}
+	store.events = []*models.Event{event}
+	store.targetsByEventID[event.ID] = []*models.Target{target}
+
+	assert.True(t, r.driveTopologyRestores(t.Context(), event, []*models.Target{target}))
+	assert.Empty(t, fans.powers, "fans that were never turned off do not need an ON command")
+	assert.Equal(t, 1, dispatcher.uncurtailCalls)
+	assert.Equal(t, models.TargetStateDispatched, target.State)
+}
+
+func TestDriveTopologyRestoresPreservesFanRestoreDelayBoundary(t *testing.T) {
+	store := newFakeStore()
+	dispatcher := &fakeDispatcher{}
+	fans := &fakeFanController{}
+	r := newReconcilerWithFansForTest(store, dispatcher, fans)
+	fanOffAt := r.now().Add(-time.Minute)
+	event := &models.Event{
+		ID:                   89,
+		EventUUID:            uuid.New(),
+		OrgID:                1,
+		State:                models.EventStateActive,
+		FacilityFanDeviceIDs: []int64{31},
+		FanOffSentAt:         &fanOffAt,
+		FanRestoreDelaySec:   30,
+	}
+	target := &models.Target{
+		CurtailmentEventID: event.ID,
+		DeviceIdentifier:   "departed-miner",
+		DesiredState:       models.DesiredStateActive,
+		State:              models.TargetStatePending,
+		RestorePhase: &models.TargetPhaseSummary{
+			Phase: models.TargetPhaseRestore,
+			State: models.TargetStatePending,
+		},
+	}
+	store.events = []*models.Event{event}
+	store.targetsByEventID[event.ID] = []*models.Target{target}
+
+	assert.True(t, r.driveTopologyRestores(t.Context(), event, []*models.Target{target}))
+	require.NotNil(t, event.FanAirflowReopenedAt)
+	reopenedAt := *event.FanAirflowReopenedAt
+	assert.Equal(t, []driver.PowerMode{driver.PowerOn}, fans.powers)
+	assert.Zero(t, dispatcher.uncurtailCalls)
+
+	r.now = func() time.Time { return reopenedAt.Add(15 * time.Second) }
+	assert.True(t, r.driveTopologyRestores(t.Context(), event, []*models.Target{target}))
+	assert.Equal(t, []driver.PowerMode{driver.PowerOn}, fans.powers)
+	assert.Zero(t, dispatcher.uncurtailCalls)
+
+	r.now = func() time.Time { return reopenedAt.Add(30 * time.Second) }
+	assert.True(t, r.driveTopologyRestores(t.Context(), event, []*models.Target{target}))
+	assert.Equal(t, []driver.PowerMode{driver.PowerOn}, fans.powers)
+	assert.Equal(t, 1, dispatcher.uncurtailCalls)
+}
+
+func TestReconciler_PartialRestoreFailureKeepsFacilityFansOn(t *testing.T) {
+	store := newFakeStore()
+	fans := &fakeFanController{}
+	r := newReconcilerWithFansForTest(store, &fakeDispatcher{}, fans)
+	fanOffAt := r.now().Add(-time.Minute)
+	event := &models.Event{
+		ID:                   85,
+		EventUUID:            uuid.New(),
+		OrgID:                1,
+		State:                models.EventStateActive,
+		FacilityFanDeviceIDs: []int64{31},
+		FanOffSentAt:         &fanOffAt,
+	}
+	targets := []*models.Target{
+		{
+			CurtailmentEventID: event.ID,
+			DeviceIdentifier:   "in-scope-miner",
+			DesiredState:       models.DesiredStateCurtailed,
+			State:              models.TargetStateConfirmed,
+		},
+		{
+			CurtailmentEventID: event.ID,
+			DeviceIdentifier:   "departed-miner",
+			DesiredState:       models.DesiredStateActive,
+			State:              models.TargetStateRestoreFailed,
+		},
+	}
+	store.events = []*models.Event{event}
+
+	assert.True(t, r.reconcileActiveFans(t.Context(), event, targets))
+	assert.Equal(t, []driver.PowerMode{driver.PowerOn}, fans.powers)
+	require.NotNil(t, event.FanAirflowReopenedAt)
+}
+
 func TestReconciler_ClosedLoopReopensFansBeforeDispatchingNewTarget(t *testing.T) {
 	store := newFakeStore()
 	dispatcher := &fakeDispatcher{}
@@ -304,6 +415,109 @@ func TestReconciler_ClosedLoopReopensFansBeforeDispatchingNewTarget(t *testing.T
 
 	assert.Equal(t, []driver.PowerMode{driver.PowerOn, driver.PowerOn, driver.PowerOff}, fans.powers)
 	assert.Nil(t, event.FanAirflowReopenedAt, "the active-airflow marker clears after fans turn off again")
+}
+
+func TestReconciler_TopologyAdmissionWaitsForAirflowDelay(t *testing.T) {
+	for _, allPaired := range []bool{false, true} {
+		name := "selected miners"
+		if allPaired {
+			name = "all paired miners"
+		}
+		t.Run(name, func(t *testing.T) {
+			store, event := topologyAdmissionTestFixture(topologyAdmissionTestBuildingScope)
+			dispatcher := &fakeDispatcher{}
+			fans := &fakeFanController{}
+			r := newReconcilerWithFansForTest(
+				store,
+				dispatcher,
+				fans,
+				WithDispatchPermissionResolver(staticDispatchPermissionResolver{
+					effective: topologyDispatchManagePermission(),
+				}),
+			)
+
+			startedAt := r.now().Add(-time.Minute)
+			fanOffAt := r.now().Add(-30 * time.Second)
+			lastCurtailBatchAt := r.now()
+			curtailBatchSize := int32(1)
+			event.StartedAt = &startedAt
+			event.FacilityFanDeviceIDs = []int64{31}
+			event.FanOffSentAt = &fanOffAt
+			event.FanOffDelaySec = 30
+			event.FanRestoreDelaySec = 30
+			event.ForceIncludeAllPairedMiners = allPaired
+			event.CurtailBatchSize = &curtailBatchSize
+			event.CurtailBatchIntervalSec = 20
+			event.LastCurtailPendingDispatchAt = &lastCurtailBatchAt
+			store.targetsByEventID[event.ID] = []*models.Target{{
+				CurtailmentEventID: event.ID,
+				DeviceIdentifier:   "miner-existing",
+				DesiredState:       models.DesiredStateCurtailed,
+				State:              models.TargetStateConfirmed,
+				ConfirmedAt:        &startedAt,
+				BaselinePowerW:     ptrFloat64(3000),
+			}}
+			driverName := "antminer"
+			metricsAt := r.now()
+			store.candidates = []*models.Candidate{
+				{
+					DeviceIdentifier: "miner-existing",
+					DriverName:       &driverName,
+					DeviceStatus:     "ACTIVE",
+					PairingStatus:    "PAIRED",
+					LatestMetricsAt:  &metricsAt,
+					LatestPowerW:     ptrFloat64(50),
+					LatestHashRateHS: ptrFloat64(0),
+					AvgEfficiencyJH:  ptrFloat64(40),
+				},
+				{
+					DeviceIdentifier: "miner-new",
+					DriverName:       &driverName,
+					DeviceStatus:     "ACTIVE",
+					PairingStatus:    "PAIRED",
+					LatestMetricsAt:  &metricsAt,
+					LatestPowerW:     ptrFloat64(3000),
+					LatestHashRateHS: ptrFloat64(100),
+					AvgEfficiencyJH:  ptrFloat64(40),
+				},
+			}
+
+			r.runTick(t.Context())
+
+			assert.Equal(t, []driver.PowerMode{driver.PowerOn}, fans.powers)
+			assert.True(t, r.now().Sub(lastCurtailBatchAt) < 20*time.Second,
+				"airflow must reopen even while topology admission pacing is active")
+			assert.Zero(t, store.claimTargetsCalls, "the target must remain unclaimed while airflow starts")
+			assert.Zero(t, store.claimAllPairedCalls)
+			assert.Zero(t, dispatcher.curtailCalls)
+			reopenedAt := *event.FanAirflowReopenedAt
+
+			r.now = func() time.Time { return reopenedAt.Add(29 * time.Second) }
+			r.runTick(t.Context())
+
+			assert.Equal(t, []driver.PowerMode{driver.PowerOn}, fans.powers)
+			assert.Zero(t, store.claimTargetsCalls)
+			assert.Zero(t, store.claimAllPairedCalls)
+			assert.Zero(t, dispatcher.curtailCalls)
+
+			r.now = func() time.Time { return reopenedAt.Add(30 * time.Second) }
+			r.runTick(t.Context())
+
+			assert.NotContains(t, fans.powers, driver.PowerOff,
+				"admission must not turn fans off before the new target is observed")
+			if allPaired {
+				assert.Equal(t, 1, store.claimAllPairedCalls)
+				assert.Zero(t, dispatcher.curtailCalls, "all-paired rows dispatch on the following pass")
+				r.now = func() time.Time { return reopenedAt.Add(31 * time.Second) }
+				r.runTick(t.Context())
+			} else {
+				assert.Equal(t, 1, store.claimTargetsCalls)
+			}
+
+			assert.Equal(t, 1, dispatcher.curtailCalls)
+			assert.Equal(t, []string{"miner-new"}, dispatcher.curtailLastIDs)
+		})
+	}
 }
 
 func TestReconciler_DriftRedispatchWaitsForSuccessfulFanOn(t *testing.T) {
@@ -412,6 +626,33 @@ func TestReconciler_RecurtailedPendingEventRetriesFanOnBeforeMinerDispatch(t *te
 	assert.Nil(t, event.FanLastError)
 	assert.Equal(t, &successAt, event.FanAirflowReopenedAt,
 		"successful pending recovery starts a fresh cooling delay")
+}
+
+func TestReconciler_PendingTopologyFanRecoveryPrecedesAdmissionPreflight(t *testing.T) {
+	store, event := topologyAdmissionTestFixture(topologyAdmissionTestBuildingScope)
+	store.topologyCoverageErr = errors.New("topology unavailable")
+	event.State = models.EventStatePending
+	event.FacilityFanDeviceIDs = []int64{31}
+	fanOffAt := time.Now().Add(-time.Minute)
+	event.FanOffSentAt = &fanOffAt
+	fanError := "fan ON failed"
+	event.FanLastError = &fanError
+	target := &models.Target{
+		CurtailmentEventID: event.ID,
+		DeviceIdentifier:   "topology-miner",
+		DesiredState:       models.DesiredStateCurtailed,
+		State:              models.TargetStatePending,
+	}
+	store.targetsByEventID[event.ID] = []*models.Target{target}
+	dispatcher := &fakeDispatcher{}
+	fans := &fakeFanController{}
+	r := newReconcilerWithFansForTest(store, dispatcher, fans)
+
+	r.dispatchPending(t.Context(), event)
+
+	assert.Equal(t, []driver.PowerMode{driver.PowerOn}, fans.powers)
+	assert.Nil(t, event.FanLastError)
+	assert.Zero(t, dispatcher.curtailCalls)
 }
 
 func TestReconciler_RestoringFanTimeoutReservesTimeForMinerRestore(t *testing.T) {

--- a/server/internal/domain/curtailment/reconciler/reconciler.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler.go
@@ -21,6 +21,7 @@ import (
 	"github.com/block/proto-fleet/server/internal/domain/command"
 	"github.com/block/proto-fleet/server/internal/domain/curtailment"
 	"github.com/block/proto-fleet/server/internal/domain/curtailment/models"
+	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 	"github.com/block/proto-fleet/server/internal/domain/infrastructure/driver"
 	"github.com/block/proto-fleet/server/internal/domain/session"
 	"github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
@@ -478,7 +479,12 @@ func (r *Reconciler) dispatchPending(ctx context.Context, ev *models.Event) {
 	if !r.reconcilePendingFans(ctx, ev) {
 		return
 	}
-	if len(targets) == 0 {
+	topologyRestoreInProgress := r.driveTopologyRestores(ctx, ev, targets)
+	topologySnapshot, stopTick := r.prepareClosedLoopTopologyTick(ctx, ev, targets)
+	if stopTick || topologyRestoreInProgress {
+		return
+	}
+	if len(targets) == 0 && !isAllPairedPolicyEvent(ev) {
 		if isClosedLoopFullFleet(ev) {
 			now := r.now()
 			if err := r.store.UpdateEventState(ctx, ev.ID, ev.State, models.EventStateActive, &now, nil); err != nil {
@@ -528,8 +534,16 @@ func (r *Reconciler) dispatchPending(ctx context.Context, ev *models.Event) {
 	// multi-tick re-confirmation window unless admission also runs here.
 	// Claimed/reopened rows enter as pending/unavailable and dispatch on the
 	// next tick's pending pass, mirroring the observeActive claim ordering.
-	if isAllPairedPolicyEvent(ev) {
-		claimed := r.claimClosedLoopFullFleetTargets(ctx, ev, targets)
+	if topologySnapshot != nil || isAllPairedPolicyEvent(ev) {
+		claimed, deferDispatch := r.claimClosedLoopFullFleetTargetsFromSnapshot(
+			ctx,
+			ev,
+			targets,
+			topologySnapshot,
+		)
+		if deferDispatch {
+			return
+		}
 		r.dispatchClaimedCurtailTargets(cmdCtx, ev, claimed)
 		// Claimed rows are a separate slice the deferred wakeIfDispatchedWork
 		// (which only sees `targets`) never covers, so a dynamically-admitted
@@ -588,7 +602,7 @@ func (r *Reconciler) dispatchPendingCurtailBatches(ctx context.Context, ev *mode
 		}
 		claim := make([]*models.Target, 0, batchSize)
 		for _, t := range targets {
-			if t.State != state {
+			if t.State != state || !isCurtailRetryTarget(t) {
 				continue
 			}
 			claim = append(claim, t)
@@ -871,6 +885,10 @@ func (r *Reconciler) recordDispatchFailureGuarded(ctx context.Context, ev *model
 		RetryCount:           &newRetry,
 		ExpectedDesiredState: &t.DesiredState,
 	}
+	if t.DesiredState != "" {
+		expectedDesiredState := t.DesiredState
+		params.ExpectedDesiredState = &expectedDesiredState
+	}
 	if guard != nil {
 		params.ExpectedState = &guard.expectedState
 		params.ExpectedDispatchBatchUUID = guard.expectedBatchUUID
@@ -961,6 +979,11 @@ func (r *Reconciler) observeActive(ctx context.Context, ev *models.Event) {
 	if r.enforceMaxDuration(ctx, ev, targets) {
 		return
 	}
+	topologyRestoreInProgress := r.driveTopologyRestores(ctx, ev, targets)
+	topologySnapshot, stopTick := r.prepareClosedLoopTopologyTick(ctx, ev, targets)
+	if stopTick {
+		return
+	}
 
 	// Per-tick liveness check; per-target race closure is in dispatchOneCurtail.
 	if !r.eventStillDispatchable(ctx, ev) {
@@ -982,7 +1005,7 @@ func (r *Reconciler) observeActive(ctx context.Context, ev *models.Event) {
 			slog.Error("curtailment reconciler: list candidates (drift) failed",
 				"event_id", ev.ID, "error", err)
 			if ev.FanOffSentAt != nil && len(ev.FacilityFanDeviceIDs) > 0 {
-				if !r.reopenActiveFans(ctx, ev) {
+				if !r.reopenEventFans(ctx, ev) {
 					return
 				}
 				airflowReopened = true
@@ -993,12 +1016,15 @@ func (r *Reconciler) observeActive(ctx context.Context, ev *models.Event) {
 				r.refreshAllPairedPolicyTargets(cmdCtx, ev, targets, candByID)
 			}
 			for _, t := range targets {
+				if !isCurtailRetryTarget(t) {
+					continue
+				}
 				switch t.State {
 				case models.TargetStateConfirmed:
 					if ev.FanOffSentAt != nil &&
 						!hasFreshTelemetry(candByID[t.DeviceIdentifier]) {
 						if !airflowReopened {
-							if !r.reopenActiveFans(ctx, ev) {
+							if !r.reopenEventFans(ctx, ev) {
 								return
 							}
 							airflowReopened = true
@@ -1073,8 +1099,22 @@ func (r *Reconciler) observeActive(ctx context.Context, ev *models.Event) {
 			r.dispatchPendingCurtailBatches(cmdCtx, ev, targets)
 		}
 	}
-	claimed := r.claimClosedLoopFullFleetTargets(ctx, ev, targets)
-	if len(claimed) > 0 && !airflowReopened && ev.FanOffSentAt != nil {
+	if topologyRestoreInProgress {
+		if !airflowReopened {
+			_ = r.reconcileActiveFans(ctx, ev, targets)
+		}
+		return
+	}
+	claimed, deferDispatch := r.claimClosedLoopFullFleetTargetsFromSnapshot(
+		ctx,
+		ev,
+		targets,
+		topologySnapshot,
+	)
+	if deferDispatch {
+		return
+	}
+	if len(claimed) > 0 && !airflowReopened && fanAirflowNeedsReopen(ev) {
 		// A closed-loop event may discover a hashing miner after airflow was
 		// stopped. Reopen the fans while the new target is still undispatched;
 		// later ticks keep them ON until every admitted target confirms curtailment.
@@ -1090,6 +1130,43 @@ func (r *Reconciler) observeActive(ctx context.Context, ev *models.Event) {
 	if !airflowReopened {
 		_ = r.reconcileActiveFans(ctx, ev, append(targets, claimed...))
 	}
+}
+
+func (r *Reconciler) driveTopologyRestores(ctx context.Context, ev *models.Event, targets []*models.Target) bool {
+	if ev == nil || (ev.State != models.EventStatePending && ev.State != models.EventStateActive) {
+		return false
+	}
+	if !r.refreshAllPairedTopologyRestoreTargets(ctx, ev, targets) {
+		return true
+	}
+	if !hasTopologyRestoreWork(targets) {
+		return false
+	}
+	r.confirmDispatchedRestores(ctx, ev, targets)
+	if !hasTopologyRestoreWork(targets) {
+		return false
+	}
+	if len(ev.FacilityFanDeviceIDs) > 0 && fanAirflowNeedsReopen(ev) {
+		if !r.reopenEventFans(ctx, ev) {
+			return true
+		}
+	}
+	r.maybeClaimRestoreBatch(ctx, ev, targets)
+	r.wakeIfDispatchedWork(targets)
+	return hasTopologyRestoreWork(targets)
+}
+
+func hasTopologyRestoreWork(targets []*models.Target) bool {
+	for _, target := range targets {
+		if target == nil || target.DesiredState != models.DesiredStateActive {
+			continue
+		}
+		if target.State != models.TargetStateUnavailable && target.State != models.TargetStateResolved && target.State != models.TargetStateRestoreFailed &&
+			target.State != models.TargetStateReleased {
+			return true
+		}
+	}
+	return false
 }
 
 // reconcileActiveFans reports true only when the requested hardware command
@@ -1198,6 +1275,12 @@ func hasFreshTelemetry(c *models.Candidate) bool {
 func activeFanTargetConfirmation(targets []*models.Target) (confirmed int, allConfirmed bool) {
 	allConfirmed = true
 	for _, target := range targets {
+		if target.DesiredState == models.DesiredStateActive {
+			if target.State != models.TargetStateResolved && target.State != models.TargetStateReleased {
+				allConfirmed = false
+			}
+			continue
+		}
 		if target.DesiredState != "" && target.DesiredState != models.DesiredStateCurtailed {
 			continue
 		}
@@ -1243,13 +1326,13 @@ func activeFanOffDelayElapsed(ev *models.Event, targets []*models.Target, now ti
 	return !now.Before(delayStartedAt.Add(time.Duration(ev.FanOffDelaySec) * time.Second))
 }
 
-func (r *Reconciler) reopenActiveFans(ctx context.Context, ev *models.Event) bool {
+func (r *Reconciler) reopenEventFans(ctx context.Context, ev *models.Event) bool {
 	if r.fans == nil || r.fanStore == nil || ev == nil || len(ev.FacilityFanDeviceIDs) == 0 || ev.FanOffSentAt == nil {
 		return false
 	}
 	now := r.now()
 	params := interfaces.UpdateCurtailmentFanStateParams{
-		ExpectedEventState: models.EventStateActive,
+		ExpectedEventState: ev.State,
 	}
 	if ev.FanAirflowReopenedAt == nil {
 		params.FanAirflowReopenedAt = &now
@@ -1271,41 +1354,132 @@ func (r *Reconciler) reopenActiveFans(ctx context.Context, ev *models.Event) boo
 	return lastError == nil
 }
 
-func (r *Reconciler) claimClosedLoopFullFleetTargets(ctx context.Context, ev *models.Event, existingTargets []*models.Target) []*models.Target {
-	if !isClosedLoopFullFleet(ev) || (ev.State != models.EventStatePending && ev.State != models.EventStateActive) {
-		return nil
+func (r *Reconciler) claimClosedLoopFullFleetTargets(
+	ctx context.Context,
+	ev *models.Event,
+	existingTargets []*models.Target,
+) ([]*models.Target, bool) {
+	return r.claimClosedLoopFullFleetTargetsFromSnapshot(ctx, ev, existingTargets, nil)
+}
+
+type closedLoopTopologySnapshot struct {
+	params     interfaces.ListCandidatesParams
+	candidates []*models.Candidate
+}
+
+func (r *Reconciler) prepareClosedLoopTopologyTick(
+	ctx context.Context,
+	ev *models.Event,
+	existingTargets []*models.Target,
+) (*closedLoopTopologySnapshot, bool) {
+	if !isClosedLoopFullFleet(ev) || (ev.State != models.EventStatePending && ev.State != models.EventStateActive) ||
+		ev.ScopeType != models.ScopeTypeMixed {
+		return nil, false
 	}
-	params, ok := listCandidatesParamsForEventScope(ev)
-	if !ok {
-		slog.Warn("curtailment reconciler: unsupported closed-loop full-fleet scope",
-			"event_id", ev.ID, "scope_type", ev.ScopeType)
-		return nil
+	scope, hasScope, err := curtailment.ScopeFromJSON(ev.ScopeJSON)
+	if err != nil || !hasScope {
+		r.rejectClosedLoopAdmission(ctx, ev, "persisted topology scope is invalid", err)
+		return nil, true
+	}
+	if !curtailment.IsTopologyScope(scope) {
+		return nil, false
+	}
+	params, err := curtailment.ListCandidatesParamsForScope(scope)
+	if err != nil {
+		r.rejectClosedLoopAdmission(ctx, ev, "persisted topology scope is invalid", err)
+		return nil, true
 	}
 	params.OrgID = ev.OrgID
-	// Admission gates run before the fleet-scale candidate scan for both
-	// policies. For all-paired events this paces only the discovery of
-	// brand-new devices and reopens; readiness refresh of existing targets
-	// stays per-tick via the device-scoped refresh path.
-	if curtailBatchIntervalActive(ev) && !r.curtailBatchIntervalElapsed(ev) {
-		return nil
+	if !r.validateClosedLoopTopologyAdmission(ctx, ev, params) {
+		return nil, true
 	}
-	if hasInFlightCurtailDispatch(existingTargets) {
-		return nil
-	}
+	params.ResultLimit = curtailment.ScopeResolvedMinerMax + 1
 	candidates, err := r.store.ListCandidates(ctx, params)
 	if err != nil {
-		slog.Error("curtailment reconciler: list candidates (full_fleet admission) failed",
+		slog.Error("curtailment reconciler: list candidates (topology reconciliation) failed",
 			"event_id", ev.ID, "error", err)
-		return nil
+		return nil, true
+	}
+	if len(candidates) > curtailment.ScopeResolvedMinerMax {
+		r.rejectClosedLoopAdmission(ctx, ev, "resolved miner limit exceeded", nil,
+			"resolved_count", len(candidates), "limit", curtailment.ScopeResolvedMinerMax)
+		return nil, true
+	}
+	departures, ok := r.reconcileClosedLoopTopologyDepartures(ctx, ev, existingTargets, candidates)
+	if !ok || departures {
+		return nil, true
+	}
+	return &closedLoopTopologySnapshot{params: params, candidates: candidates}, false
+}
+
+func (r *Reconciler) claimClosedLoopFullFleetTargetsFromSnapshot(
+	ctx context.Context,
+	ev *models.Event,
+	existingTargets []*models.Target,
+	topologySnapshot *closedLoopTopologySnapshot,
+) ([]*models.Target, bool) {
+	if !isClosedLoopFullFleet(ev) || (ev.State != models.EventStatePending && ev.State != models.EventStateActive) {
+		return nil, false
+	}
+	var params interfaces.ListCandidatesParams
+	var candidates []*models.Candidate
+	if topologySnapshot != nil {
+		params = topologySnapshot.params
+		candidates = topologySnapshot.candidates
+	} else {
+		var ok bool
+		params, ok = listCandidatesParamsForEventScope(ev)
+		if !ok {
+			slog.Warn("curtailment reconciler: unsupported closed-loop full-fleet scope",
+				"event_id", ev.ID, "scope_type", ev.ScopeType)
+			return nil, false
+		}
+		params.OrgID = ev.OrgID
+		if !r.validateClosedLoopTopologyAdmission(ctx, ev, params) {
+			return nil, isTopologyCandidateFilter(params)
+		}
+		// Closed-loop selectors are re-expanded on every admission pass. Bound the
+		// query at max+1 so an oversized topology change fails closed without
+		// materializing an unbounded candidate set in the reconciler.
+		params.ResultLimit = curtailment.ScopeResolvedMinerMax + 1
+	}
+	topologyFilter := isTopologyCandidateFilter(params)
+	if !topologyFilter {
+		if curtailBatchIntervalActive(ev) && !r.curtailBatchIntervalElapsed(ev) {
+			return nil, false
+		}
+		if hasInFlightCurtailDispatch(existingTargets) {
+			return nil, false
+		}
+	}
+	if topologySnapshot == nil {
+		var err error
+		candidates, err = r.store.ListCandidates(ctx, params)
+		if err != nil {
+			slog.Error("curtailment reconciler: list candidates (full_fleet admission) failed",
+				"event_id", ev.ID, "error", err)
+			return nil, topologyFilter
+		}
+		if len(candidates) > curtailment.ScopeResolvedMinerMax {
+			r.rejectClosedLoopAdmission(ctx, ev, "resolved miner limit exceeded", nil,
+				"resolved_count", len(candidates), "limit", curtailment.ScopeResolvedMinerMax)
+			return nil, topologyFilter
+		}
+		if topologyFilter {
+			departures, ok := r.reconcileClosedLoopTopologyDepartures(ctx, ev, existingTargets, candidates)
+			if !ok || departures {
+				return nil, true
+			}
+		}
 	}
 	if isAllPairedPolicyEvent(ev) {
-		return r.claimAllPairedPolicyTargets(ctx, ev, existingTargets, candidates, params)
+		return nil, r.claimAllPairedPolicyTargets(ctx, ev, existingTargets, candidates, params)
 	}
 	orgConfig, err := r.store.GetOrgConfig(ctx, ev.OrgID)
 	if err != nil {
 		slog.Error("curtailment reconciler: get org config (full_fleet admission) failed",
 			"event_id", ev.ID, "error", err)
-		return nil
+		return nil, false
 	}
 	targets, _ := curtailment.BuildFullFleetAdmissionTargets(
 		candidates,
@@ -1317,30 +1491,48 @@ func (r *Reconciler) claimClosedLoopFullFleetTargets(ctx context.Context, ev *mo
 	if err != nil {
 		slog.Error("curtailment reconciler: list active devices (full_fleet admission) failed",
 			"event_id", ev.ID, "error", err)
-		return nil
+		return nil, false
 	}
 	targets = excludeDeviceIdentifiers(targets, activeDevices)
 	cooldownSec := postEventCooldownSecForEvent(ev)
 	if cooldownSec > 0 {
+		candidateIdentifiers := make([]string, 0, len(candidates))
+		for _, candidate := range candidates {
+			if candidate != nil && candidate.DeviceIdentifier != "" {
+				candidateIdentifiers = append(candidateIdentifiers, candidate.DeviceIdentifier)
+			}
+		}
 		cooldownDevices, err := r.store.ListRecentlyResolvedCurtailedDevices(
 			ctx,
 			interfaces.ListRecentlyResolvedCurtailedDevicesParams{
 				OrgID:             ev.OrgID,
 				ExcludeEventID:    ev.ID,
 				CooldownSec:       cooldownSec,
-				DeviceIdentifiers: params.DeviceIdentifiers,
-				SiteIDs:           params.SiteIDs,
+				DeviceIdentifiers: candidateIdentifiers,
 			},
 		)
 		if err != nil {
 			slog.Error("curtailment reconciler: list cooldown devices (full_fleet admission) failed",
 				"event_id", ev.ID, "error", err)
-			return nil
+			return nil, false
 		}
 		targets = excludeDeviceIdentifiers(targets, cooldownDevices)
 	}
 	if len(targets) == 0 {
-		return nil
+		return nil, false
+	}
+	if topologyFilter && !r.topologyAdmissionAirflowReady(ctx, ev) {
+		return nil, true
+	}
+	// Admission pacing never delays topology departures or airflow recovery:
+	// both are handled above before new Curtail work is gated.
+	if topologyFilter {
+		if curtailBatchIntervalActive(ev) && !r.curtailBatchIntervalElapsed(ev) {
+			return nil, false
+		}
+		if hasInFlightCurtailDispatch(existingTargets) {
+			return nil, false
+		}
 	}
 	batchSize := curtailBatchSizeForEvent(ev, len(targets))
 	claimed, err := r.store.ClaimClosedLoopFullFleetTargets(
@@ -1354,13 +1546,172 @@ func (r *Reconciler) claimClosedLoopFullFleetTargets(ctx context.Context, ev *mo
 	if err != nil {
 		slog.Error("curtailment reconciler: claim full_fleet targets failed",
 			"event_id", ev.ID, "candidate_count", len(targets), "error", err)
-		return nil
+		return nil, false
 	}
 	if len(claimed) > 0 {
 		slog.Info("curtailment reconciler: claimed full_fleet targets",
 			"event_id", ev.ID, "claimed", len(claimed))
 	}
-	return claimed
+	return claimed, false
+}
+
+// topologyAdmissionAirflowReady keeps newly discovered topology members
+// unclaimed until facility airflow has been restored for the configured delay.
+// Returning to the next tick is intentional: scope membership and permissions
+// must be resolved again after the delay before ownership is claimed.
+func (r *Reconciler) topologyAdmissionAirflowReady(ctx context.Context, ev *models.Event) bool {
+	if ev == nil || ev.FanOffSentAt == nil || len(ev.FacilityFanDeviceIDs) == 0 {
+		return true
+	}
+	if fanAirflowNeedsReopen(ev) {
+		_ = r.reopenEventFans(ctx, ev)
+		return false
+	}
+	delay := max(ev.FanRestoreDelaySec, 0)
+	return !r.now().Before(ev.FanAirflowReopenedAt.Add(time.Duration(delay) * time.Second))
+}
+
+func fanAirflowNeedsReopen(ev *models.Event) bool {
+	return ev != nil && ev.FanOffSentAt != nil &&
+		(ev.FanAirflowReopenedAt == nil || ev.FanLastError != nil)
+}
+
+func isTopologyCandidateFilter(params interfaces.ListCandidatesParams) bool {
+	return len(params.BuildingIDs) > 0 || len(params.RackIDs) > 0 || len(params.GroupIDs) > 0
+}
+
+func (r *Reconciler) reconcileClosedLoopTopologyDepartures(
+	ctx context.Context,
+	ev *models.Event,
+	existingTargets []*models.Target,
+	candidates []*models.Candidate,
+) (bool, bool) {
+	members := make(map[string]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		if candidate == nil || candidate.DeviceIdentifier == "" {
+			continue
+		}
+		if isAllPairedPolicyEvent(ev) && !curtailment.IsAllPairedPolicyPairingStatus(candidate.PairingStatus) {
+			continue
+		}
+		members[candidate.DeviceIdentifier] = struct{}{}
+	}
+	departures := make([]string, 0)
+	for _, target := range existingTargets {
+		if target == nil || target.DesiredState == models.DesiredStateActive {
+			continue
+		}
+		switch target.State { //nolint:exhaustive // Only terminal departure states are skipped.
+		case models.TargetStateResolved, models.TargetStateRestoreFailed, models.TargetStateReleased:
+			continue
+		}
+		if _, stillMember := members[target.DeviceIdentifier]; !stillMember {
+			departures = append(departures, target.DeviceIdentifier)
+		}
+	}
+	if len(departures) == 0 {
+		return false, true
+	}
+	restoreStore, ok := r.store.(interfaces.CurtailmentTopologyTargetRestoreStore)
+	if !ok {
+		r.rejectClosedLoopAdmission(ctx, ev, "topology target restore store is not configured", nil)
+		return true, false
+	}
+	transitioned, err := restoreStore.BeginCurtailmentTopologyTargetRestore(ctx, ev, departures)
+	if err != nil {
+		if !errors.Is(err, interfaces.ErrCurtailmentEventStateRaceLoss) {
+			slog.Error("curtailment reconciler: topology departure restore transition failed",
+				"event_id", ev.ID, "departures", len(departures), "error", err)
+		}
+		return true, false
+	}
+	slog.Info("curtailment reconciler: topology departures entered restore",
+		"event_id", ev.ID, "departures", len(departures), "transitioned", transitioned)
+	return true, true
+}
+
+func (r *Reconciler) validateClosedLoopTopologyAdmission(
+	ctx context.Context,
+	ev *models.Event,
+	params interfaces.ListCandidatesParams,
+) bool {
+	if len(params.BuildingIDs) == 0 && len(params.RackIDs) == 0 && len(params.GroupIDs) == 0 {
+		return true
+	}
+	topologyStore, ok := r.store.(interfaces.CurtailmentTopologyScopeStore)
+	if !ok {
+		r.rejectClosedLoopAdmission(ctx, ev, "topology scope resolver is not configured", nil)
+		return false
+	}
+	coverage, err := topologyStore.ResolveCurtailmentTopologyScope(ctx, params)
+	if err != nil {
+		if fleeterror.IsNotFoundError(err) || fleeterror.IsInvalidArgumentError(err) ||
+			fleeterror.IsFailedPreconditionError(err) || fleeterror.IsResourceExhaustedError(err) {
+			r.rejectClosedLoopAdmission(ctx, ev, "persisted topology scope is no longer valid", err)
+		} else {
+			slog.Error("curtailment reconciler: topology scope validation failed; admission deferred",
+				"event_id", ev.ID, "error", err)
+		}
+		return false
+	}
+	envelope, err := curtailment.AuthorizationEnvelopeFromJSON(ev.AuthorizationEnvelopeJSON)
+	if err != nil {
+		r.rejectClosedLoopAdmission(ctx, ev, "persisted authorization envelope is invalid", err)
+		return false
+	}
+	if !topologyCoverageWithinEnvelope(coverage, envelope) {
+		r.rejectClosedLoopAdmission(ctx, ev, "current topology exceeds the persisted authorization envelope", nil)
+		return false
+	}
+	if r.permissions == nil {
+		r.rejectClosedLoopAdmission(ctx, ev, "admission permission resolver is not configured", nil)
+		return false
+	}
+	effective, err := r.permissions.LoadEffective(ctx, ev.CreatedByUserID, ev.OrgID)
+	if err != nil {
+		slog.Error("curtailment reconciler: admission permission validation failed; admission deferred",
+			"event_id", ev.ID, "error", err)
+		return false
+	}
+	if !authorizationEnvelopeAllowsDispatch(effective, envelope, coverage) {
+		r.rejectClosedLoopAdmission(ctx, ev, "event creator no longer has required permissions", nil)
+		return false
+	}
+	adminAllowed, err := r.eventCreatorCanUseRequiredAdminControls(ctx, ev)
+	if err != nil {
+		slog.Error("curtailment reconciler: admission admin-control validation failed; admission deferred",
+			"event_id", ev.ID, "error", err)
+		return false
+	}
+	if !adminAllowed {
+		r.rejectClosedLoopAdmission(ctx, ev, "event creator no longer has the admin role required by this event", nil)
+		return false
+	}
+	return true
+}
+
+func (r *Reconciler) rejectClosedLoopAdmission(
+	ctx context.Context,
+	ev *models.Event,
+	reason string,
+	cause error,
+	attributes ...any,
+) {
+	logAttributes := []any{"event_id", ev.ID, "event_uuid", ev.EventUUID, "reason", reason}
+	if cause != nil {
+		logAttributes = append(logAttributes, "error", cause)
+	}
+	logAttributes = append(logAttributes, attributes...)
+	slog.Error("curtailment reconciler: closed-loop admission rejected", logAttributes...)
+	if _, err := r.store.BeginRestoreTransition(
+		ctx,
+		ev.OrgID,
+		ev.EventUUID,
+		interfaces.BeginRestoreTransitionParams{},
+	); err != nil && !errors.Is(err, interfaces.ErrCurtailmentEventStateRaceLoss) {
+		slog.Error("curtailment reconciler: failed to restore after closed-loop admission rejection",
+			"event_id", ev.ID, "event_uuid", ev.EventUUID, "error", err)
+	}
 }
 
 func hasInFlightCurtailDispatch(targets []*models.Target) bool {
@@ -1483,10 +1834,14 @@ func listCandidatesParamsForEventScope(ev *models.Event) (interfaces.ListCandida
 		return interfaces.ListCandidatesParams{SiteIDs: []int64{scope.SiteID}}, true
 	case models.ScopeTypeMixed:
 		scope, hasScope, err := curtailment.ScopeFromJSON(ev.ScopeJSON)
-		if err != nil || !hasScope || !curtailment.IsSiteOnlyScope(scope) {
+		if err != nil || !hasScope {
 			return interfaces.ListCandidatesParams{}, false
 		}
-		return interfaces.ListCandidatesParams{SiteIDs: scope.SiteIDs}, true
+		params, err := curtailment.ListCandidatesParamsForScope(scope)
+		if err != nil {
+			return interfaces.ListCandidatesParams{}, false
+		}
+		return params, true
 	case models.ScopeTypeDeviceList:
 		return interfaces.ListCandidatesParams{}, false
 	default:
@@ -1623,11 +1978,21 @@ func (r *Reconciler) checkDrift(ctx context.Context, ev *models.Event, t *models
 // completed_with_failures so they can't sit indefinitely.
 func (r *Reconciler) maybeMarkActive(ctx context.Context, ev *models.Event, targets []*models.Target) {
 	confirmed, terminalFailures, unavailable, releasedPolicy := 0, 0, 0, 0
+	topologyWatcher := isClosedLoopTopologyEvent(ev)
+	if len(targets) == 0 && isAllPairedPolicyEvent(ev) {
+		r.warnIfAllPairedPendingStalled(ev, 0, 0)
+		return
+	}
 	for _, t := range targets {
 		switch t.State {
 		case models.TargetStateConfirmed:
 			confirmed++
 		case models.TargetStateRestoreFailed:
+			if topologyWatcher && t.DesiredState == models.DesiredStateActive {
+				// A departed miner exhausted its restore retries. The target keeps
+				// the failure visible, but it must not terminate the scope watcher.
+				continue
+			}
 			terminalFailures++
 		case models.TargetStateUnavailable:
 			if isAllPairedPolicyEvent(ev) {
@@ -1650,11 +2015,18 @@ func (r *Reconciler) maybeMarkActive(ctx context.Context, ev *models.Event, targ
 				releasedPolicy++
 				continue
 			}
+			if topologyWatcher {
+				// The miner left the scope before Curtail was dispatched, so there
+				// is no restore obligation and the watcher can continue.
+				continue
+			}
 			// Unreachable on a pending event; hold for manual cleanup.
 			return
 		case models.TargetStateResolved:
-			// Unreachable on a pending event; hold for manual cleanup.
-			return
+			if t.DesiredState != models.DesiredStateActive || !isClosedLoopFullFleet(ev) {
+				// Unreachable outside a completed topology restore; hold for manual cleanup.
+				return
+			}
 		}
 	}
 	if confirmed == 0 && (unavailable > 0 || releasedPolicy > 0) {
@@ -1937,6 +2309,9 @@ func (r *Reconciler) observeRestoring(ctx context.Context, ev *models.Event) {
 	defer func() { r.wakeIfDispatchedWork(targets) }()
 	r.reconcileRestoringFans(ctx, ev)
 
+	if !r.refreshAllPairedTopologyRestoreTargets(ctx, ev, targets) {
+		return
+	}
 	r.confirmDispatchedRestores(ctx, ev, targets)
 	if r.maybeCompleteRestoring(ctx, ev, targets) {
 		return
@@ -2081,9 +2456,12 @@ func (r *Reconciler) confirmDispatchedRestores(ctx context.Context, ev *models.E
 
 // confirmOneRestore promotes Dispatched → Resolved when telemetry shows
 // the miner is back above the restore threshold; mirrors
-// confirmOneDispatched. Vanished devices burn retry budget to keep
-// progress.
+// confirmOneDispatched. Vanished devices normally burn retry budget to keep
+// progress; all-paired topology obligations park until commandable instead.
 func (r *Reconciler) confirmOneRestore(ctx context.Context, ev *models.Event, t *models.Target, c *models.Candidate) {
+	if isAllPairedTopologyPolicyEvent(ev) && r.parkUncommandableTopologyRestore(ctx, ev, t, c) {
+		return
+	}
 	if c == nil {
 		r.recordDispatchedObservationFailure(ctx, ev, t,
 			"candidate row missing (device unpaired or deleted)",
@@ -2112,6 +2490,8 @@ func (r *Reconciler) confirmOneRestore(ctx context.Context, ev *models.Event, t 
 	}
 	now := r.now()
 	params := resolvedRestoreTargetParams(now, c.LatestPowerW)
+	desiredActive := models.DesiredStateActive
+	params.ExpectedDesiredState = &desiredActive
 	expectedTargetState := models.TargetStateDispatched
 	params.ExpectedState = &expectedTargetState
 	params.ExpectedDispatchBatchUUID = loadedDispatchBatchUUID(t)
@@ -2179,14 +2559,27 @@ func restoreClaimBatchSize(ev *models.Event) int32 {
 // pending restore targets and dispatches one Uncurtail covering the batch.
 func (r *Reconciler) maybeClaimRestoreBatch(ctx context.Context, ev *models.Event, targets []*models.Target) {
 	if len(ev.FacilityFanDeviceIDs) > 0 {
-		if ev.FanOnSentAt == nil {
-			return
+		var delayStartedAt *time.Time
+		if ev.State == models.EventStateActive || ev.State == models.EventStatePending {
+			// If OFF was never attempted, airflow has remained available and no
+			// fan-start delay is needed. Otherwise a successful reopen establishes
+			// the delay boundary before any miner is restored.
+			if ev.FanOffSentAt != nil {
+				delayStartedAt = ev.FanAirflowReopenedAt
+				if delayStartedAt == nil {
+					return
+				}
+			}
+		} else {
+			delayStartedAt = ev.FanOnSentAt
+			if airflowStartedAt := restoringFanAirflowStartedAt(ev); airflowStartedAt != nil {
+				delayStartedAt = airflowStartedAt
+			}
+			if delayStartedAt == nil {
+				return
+			}
 		}
-		delayStartedAt := ev.FanOnSentAt
-		if airflowStartedAt := restoringFanAirflowStartedAt(ev); airflowStartedAt != nil {
-			delayStartedAt = airflowStartedAt
-		}
-		if r.now().Before(delayStartedAt.Add(time.Duration(ev.FanRestoreDelaySec) * time.Second)) {
+		if delayStartedAt != nil && r.now().Before(delayStartedAt.Add(time.Duration(ev.FanRestoreDelaySec)*time.Second)) {
 			return
 		}
 	}
@@ -2288,9 +2681,11 @@ func (r *Reconciler) dispatchRestoreBatch(ctx context.Context, ev *models.Event,
 	dispatchSet := make([]*models.Target, 0, len(claim))
 	desiredActive := models.DesiredStateActive
 	for _, t := range claim {
+		expectedState := t.State
 		dispatchingParams := interfaces.UpdateCurtailmentTargetStateParams{
 			State:                models.TargetStateDispatching,
 			ExpectedDesiredState: &desiredActive,
+			ExpectedState:        &expectedState,
 		}
 		if err := r.writeTargetState(ctx, ev, t.DeviceIdentifier, dispatchingParams); err != nil {
 			if errors.Is(err, interfaces.ErrCurtailmentEventStateRaceLoss) {
@@ -2366,9 +2761,7 @@ func (r *Reconciler) dispatchRestoreBatch(ctx context.Context, ev *models.Event,
 		errMsg := dispatchErr.Error()
 		slog.Error("curtailment reconciler: restore batch dispatch failed",
 			"event_id", ev.ID, "batch_size", len(commandTargets), "error", dispatchErr)
-		for _, t := range commandTargets {
-			r.recordDispatchFailure(ctx, ev, t, errMsg, models.TargetStatePending)
-		}
+		r.recordRestoreDispatchFailures(ctx, ev, restoreDispatchFailures(commandTargets, errMsg))
 		return
 	}
 
@@ -2377,9 +2770,7 @@ func (r *Reconciler) dispatchRestoreBatch(ctx context.Context, ev *models.Event,
 		const reason = "uncurtail command produced no batch (no live devices to dispatch)"
 		slog.Warn("curtailment reconciler: restore batch produced empty result",
 			"event_id", ev.ID, "batch_size", len(commandTargets))
-		for _, t := range commandTargets {
-			r.recordDispatchFailure(ctx, ev, t, reason, models.TargetStatePending)
-		}
+		r.recordRestoreDispatchFailures(ctx, ev, restoreDispatchFailures(commandTargets, reason))
 		return
 	}
 
@@ -2394,18 +2785,19 @@ func (r *Reconciler) dispatchRestoreBatch(ctx context.Context, ev *models.Event,
 
 	now := r.now()
 	batchID := result.BatchIdentifier
+	failures := make([]restoreDispatchFailure, 0, len(commandTargets))
 	for _, t := range commandTargets {
 		if reason, skipped := skippedSet[t.DeviceIdentifier]; skipped {
 			slog.Warn("curtailment reconciler: restore device filter-skipped",
 				"event_id", ev.ID, "device", t.DeviceIdentifier, "reason", reason)
-			r.recordDispatchFailure(ctx, ev, t, reason, models.TargetStatePending)
+			failures = append(failures, restoreDispatchFailure{target: t, reason: reason})
 			continue
 		}
 		if _, dispatched := dispatchedSet[t.DeviceIdentifier]; !dispatched {
 			const reason = "uncurtail command did not enqueue device"
 			slog.Warn("curtailment reconciler: restore device not dispatched",
 				"event_id", ev.ID, "device", t.DeviceIdentifier)
-			r.recordDispatchFailure(ctx, ev, t, reason, models.TargetStatePending)
+			failures = append(failures, restoreDispatchFailure{target: t, reason: reason})
 			continue
 		}
 		emptyErr := ""
@@ -2431,6 +2823,128 @@ func (r *Reconciler) dispatchRestoreBatch(ctx context.Context, ev *models.Event,
 		t.LastBatchUUID = &batchID
 		t.LastError = nil
 	}
+	r.recordRestoreDispatchFailures(ctx, ev, failures)
+}
+
+type restoreDispatchFailure struct {
+	target *models.Target
+	reason string
+}
+
+func restoreDispatchFailures(targets []*models.Target, reason string) []restoreDispatchFailure {
+	failures := make([]restoreDispatchFailure, 0, len(targets))
+	for _, target := range targets {
+		failures = append(failures, restoreDispatchFailure{target: target, reason: reason})
+	}
+	return failures
+}
+
+// recordRestoreDispatchFailures parks all-paired topology obligations that
+// became uncommandable between the readiness pass and Uncurtail. This records
+// the unavailable transition while it is observable, so a later repair can
+// safely requeue the obligation without reopening ordinary terminal failures.
+func (r *Reconciler) recordRestoreDispatchFailures(
+	ctx context.Context,
+	ev *models.Event,
+	failures []restoreDispatchFailure,
+) {
+	if len(failures) == 0 {
+		return
+	}
+
+	parked := make(map[string]struct{}, len(failures))
+	if isAllPairedTopologyPolicyEvent(ev) {
+		deviceIdentifiers := make([]string, 0, len(failures))
+		for _, failure := range failures {
+			if failure.target != nil && failure.target.DeviceIdentifier != "" {
+				deviceIdentifiers = append(deviceIdentifiers, failure.target.DeviceIdentifier)
+			}
+		}
+		candidates, err := r.store.ListCandidates(ctx, interfaces.ListCandidatesParams{
+			OrgID:             ev.OrgID,
+			DeviceIdentifiers: deviceIdentifiers,
+		})
+		if err != nil {
+			slog.Error("curtailment reconciler: restore failure readiness refresh failed",
+				"event_id", ev.ID, "error", err)
+		} else {
+			candidatesByID := candidatesByDeviceID(candidates)
+			for _, failure := range failures {
+				if failure.target != nil && r.parkUncommandableTopologyRestore(
+					ctx,
+					ev,
+					failure.target,
+					candidatesByID[failure.target.DeviceIdentifier],
+				) {
+					parked[failure.target.DeviceIdentifier] = struct{}{}
+				}
+			}
+		}
+	}
+
+	for _, failure := range failures {
+		if failure.target == nil {
+			continue
+		}
+		if _, ok := parked[failure.target.DeviceIdentifier]; ok {
+			continue
+		}
+		r.recordDispatchFailureGuarded(
+			ctx,
+			ev,
+			failure.target,
+			failure.reason,
+			models.TargetStatePending,
+			&dispatchFailureGuard{expectedState: models.TargetStateDispatching},
+		)
+	}
+}
+
+func isAllPairedTopologyPolicyEvent(ev *models.Event) bool {
+	return isAllPairedPolicyEvent(ev) && isClosedLoopTopologyEvent(ev)
+}
+
+func isClosedLoopTopologyEvent(ev *models.Event) bool {
+	if !isClosedLoopFullFleet(ev) {
+		return false
+	}
+	scopeParams, hasScope := listCandidatesParamsForEventScope(ev)
+	return hasScope && isTopologyCandidateFilter(scopeParams)
+}
+
+func (r *Reconciler) parkUncommandableTopologyRestore(
+	ctx context.Context,
+	ev *models.Event,
+	target *models.Target,
+	candidate *models.Candidate,
+) bool {
+	nextState, reason := curtailment.AllPairedPolicyRestoreTargetState(candidate)
+	if nextState != models.TargetStateUnavailable {
+		return false
+	}
+	desiredActive := models.DesiredStateActive
+	expectedState := target.State
+	params := interfaces.UpdateCurtailmentTargetStateParams{
+		State:                models.TargetStateUnavailable,
+		LastError:            &reason,
+		ExpectedState:        &expectedState,
+		ExpectedDesiredState: &desiredActive,
+	}
+	if err := r.writeTargetState(ctx, ev, target.DeviceIdentifier, params); err != nil {
+		if errors.Is(err, interfaces.ErrCurtailmentEventStateRaceLoss) {
+			return true
+		}
+		slog.Error("curtailment reconciler: park uncommandable restore failed",
+			"event_id", ev.ID, "device", target.DeviceIdentifier, "error", err)
+		return false
+	}
+	target.State = models.TargetStateUnavailable
+	target.LastError = &reason
+	if target.RestorePhase != nil {
+		target.RestorePhase.State = models.TargetStateUnavailable
+		target.RestorePhase.LastError = &reason
+	}
+	return true
 }
 
 func (r *Reconciler) eventStillDispatchable(ctx context.Context, ev *models.Event) bool {

--- a/server/internal/domain/curtailment/reconciler/reconciler.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler.go
@@ -1608,7 +1608,11 @@ func (r *Reconciler) reconcileClosedLoopTopologyDepartures(
 		if candidate == nil || candidate.DeviceIdentifier == "" {
 			continue
 		}
-		if isAllPairedPolicyEvent(ev) && !curtailment.IsAllPairedPolicyPairingStatus(candidate.PairingStatus) {
+		if isAllPairedPolicyEvent(ev) {
+			if !curtailment.IsAllPairedPolicyPairingStatus(candidate.PairingStatus) {
+				continue
+			}
+		} else if candidate.PairingStatus != "PAIRED" {
 			continue
 		}
 		members[candidate.DeviceIdentifier] = struct{}{}

--- a/server/internal/domain/curtailment/reconciler/reconciler.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler.go
@@ -684,6 +684,24 @@ func (r *Reconciler) dispatchOneCurtail(ctx context.Context, ev *models.Event, t
 // dispatchCurtailBatch issues one Curtail command for every device in claim and
 // records per-target dispatched/skipped/failed outcomes.
 func (r *Reconciler) dispatchCurtailBatch(ctx context.Context, ev *models.Event, claim []*models.Target, nonTerminalFailureState models.TargetState, recordPendingDispatch bool) bool {
+	return r.dispatchCurtailBatchWithKnownUnsent(
+		ctx,
+		ev,
+		claim,
+		nonTerminalFailureState,
+		recordPendingDispatch,
+		nil,
+	)
+}
+
+func (r *Reconciler) dispatchCurtailBatchWithKnownUnsent(
+	ctx context.Context,
+	ev *models.Event,
+	claim []*models.Target,
+	nonTerminalFailureState models.TargetState,
+	recordPendingDispatch bool,
+	preclaimedUnsentDeviceIdentifiers []string,
+) bool {
 	if len(claim) == 0 {
 		return true
 	}
@@ -698,7 +716,7 @@ func (r *Reconciler) dispatchCurtailBatch(ctx context.Context, ev *models.Event,
 	// last_dispatched_at is *not* stamped here — only successful enqueues
 	// advance it (used by the restore-batch interval gate).
 	dispatchSet := make([]*models.Target, 0, len(claim))
-	knownUnsentDeviceIdentifiers := make([]string, 0, len(claim))
+	knownUnsentDeviceIdentifiers := append([]string(nil), preclaimedUnsentDeviceIdentifiers...)
 	for _, t := range claim {
 		if t.State == models.TargetStatePending {
 			knownUnsentDeviceIdentifiers = append(knownUnsentDeviceIdentifiers, t.DeviceIdentifier)
@@ -880,10 +898,9 @@ func (r *Reconciler) recordDispatchFailureGuarded(ctx context.Context, ev *model
 		state = models.TargetStateRestoreFailed
 	}
 	params := interfaces.UpdateCurtailmentTargetStateParams{
-		State:                state,
-		LastError:            &errMsg,
-		RetryCount:           &newRetry,
-		ExpectedDesiredState: &t.DesiredState,
+		State:      state,
+		LastError:  &errMsg,
+		RetryCount: &newRetry,
 	}
 	if t.DesiredState != "" {
 		expectedDesiredState := t.DesiredState
@@ -1805,7 +1822,18 @@ func (r *Reconciler) dispatchClaimedCurtailTargets(ctx context.Context, ev *mode
 	if len(dispatchable) == 0 {
 		return
 	}
-	_ = r.dispatchCurtailBatch(ctx, ev, dispatchable, models.TargetStateDispatching, recordPendingDispatchClock)
+	knownUnsentDeviceIdentifiers := make([]string, 0, len(dispatchable))
+	for _, target := range dispatchable {
+		knownUnsentDeviceIdentifiers = append(knownUnsentDeviceIdentifiers, target.DeviceIdentifier)
+	}
+	_ = r.dispatchCurtailBatchWithKnownUnsent(
+		ctx,
+		ev,
+		dispatchable,
+		models.TargetStateDispatching,
+		recordPendingDispatchClock,
+		knownUnsentDeviceIdentifiers,
+	)
 }
 
 func isClosedLoopFullFleet(ev *models.Event) bool {

--- a/server/internal/domain/curtailment/reconciler/reconciler_allpaired.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler_allpaired.go
@@ -35,26 +35,27 @@ func isAllPairedPolicyReleasedCurtailTarget(ev *models.Event, target *models.Tar
 // claimAllPairedPolicyTargets inserts or reopens durable policy rows for
 // every paired-like miner in scope that no event owns yet. Unlike the
 // closed-loop dispatch claim, rows enter in their computed policy state
-// (pending or unavailable) and dispatch on a later pending pass, so this
-// always returns nil.
+// (pending or unavailable) and dispatch on a later pending pass. The return
+// value tells the caller to end the current tick while topology airflow starts
+// or while newly admitted rows wait for that later dispatch pass.
 func (r *Reconciler) claimAllPairedPolicyTargets(
 	ctx context.Context,
 	ev *models.Event,
 	existingTargets []*models.Target,
 	candidates []*models.Candidate,
 	params interfaces.ListCandidatesParams,
-) []*models.Target {
+) bool {
 	orgConfig, err := r.store.GetOrgConfig(ctx, ev.OrgID)
 	if err != nil {
 		slog.Error("curtailment reconciler: get org config (all-paired admission) failed",
 			"event_id", ev.ID, "error", err)
-		return nil
+		return false
 	}
 	activeDevices, err := r.store.ListActiveCurtailmentTargetDevices(ctx, ev.OrgID)
 	if err != nil {
 		slog.Error("curtailment reconciler: list active devices (all-paired admission) failed",
 			"event_id", ev.ID, "error", err)
-		return nil
+		return false
 	}
 	activeSet := toStringSet(activeDevices)
 	for _, target := range existingTargets {
@@ -71,9 +72,21 @@ func (r *Reconciler) claimAllPairedPolicyTargets(
 		models.ModeFullFleet,
 		candidateMinPowerWForEvent(ev, orgConfig.CandidateMinPowerW),
 	)
+	topologyFilter := isTopologyCandidateFilter(params)
 	targets = excludeNonReopenableExistingTargetParams(targets, existingTargets)
 	if len(targets) == 0 {
-		return nil
+		return false
+	}
+	if topologyFilter && !r.topologyAdmissionAirflowReady(ctx, ev) {
+		return true
+	}
+	if topologyFilter {
+		if curtailBatchIntervalActive(ev) && !r.curtailBatchIntervalElapsed(ev) {
+			return false
+		}
+		if hasInFlightCurtailDispatch(existingTargets) {
+			return false
+		}
 	}
 	claimed, err := r.store.ClaimAllPairedPolicyTargets(
 		ctx,
@@ -88,13 +101,14 @@ func (r *Reconciler) claimAllPairedPolicyTargets(
 			"scope_device_count", len(params.DeviceIdentifiers),
 			"scope_site_count", len(params.SiteIDs),
 			"error", err)
-		return nil
+		return false
 	}
 	if claimed > 0 {
 		slog.Info("curtailment reconciler: claimed all-paired policy targets",
 			"event_id", ev.ID, "claimed", claimed)
+		return topologyFilter
 	}
-	return nil
+	return false
 }
 
 // refreshAllPairedPolicyTargets re-evaluates dispatch readiness for policy
@@ -176,12 +190,98 @@ func (r *Reconciler) refreshAllPairedPolicyTargets(
 	if len(updates) == 0 {
 		return
 	}
+	r.applyAllPairedReadinessUpdates(ctx, ev, refreshable, updates)
+}
+
+// refreshAllPairedTopologyRestoreTargets keeps departed policy miners out of
+// the restore dispatcher while they cannot receive commands. A restore-failed
+// row only leaves its terminal state after first observing an unavailable
+// miner; that commandability transition avoids turning ordinary dispatch
+// failures into an unbounded retry loop.
+func (r *Reconciler) refreshAllPairedTopologyRestoreTargets(
+	ctx context.Context,
+	ev *models.Event,
+	targets []*models.Target,
+) bool {
+	if !isAllPairedTopologyPolicyEvent(ev) {
+		return true
+	}
+
+	refreshable := make(map[string]*models.Target, len(targets))
+	deviceIdentifiers := make([]string, 0, len(targets))
+	for _, target := range targets {
+		if target == nil || target.DeviceIdentifier == "" || target.DesiredState != models.DesiredStateActive {
+			continue
+		}
+		switch target.State { //nolint:exhaustive // Only restore states can change commandability.
+		case models.TargetStatePending, models.TargetStateUnavailable, models.TargetStateRestoreFailed:
+			refreshable[target.DeviceIdentifier] = target
+			deviceIdentifiers = append(deviceIdentifiers, target.DeviceIdentifier)
+		}
+	}
+	if len(deviceIdentifiers) == 0 {
+		return true
+	}
+
+	candidates, err := r.store.ListCandidates(ctx, interfaces.ListCandidatesParams{
+		OrgID:             ev.OrgID,
+		DeviceIdentifiers: deviceIdentifiers,
+	})
+	if err != nil {
+		slog.Error("curtailment reconciler: list all-paired topology restore candidates failed",
+			"event_id", ev.ID, "error", err)
+		return false
+	}
+	candidatesByID := candidatesByDeviceID(candidates)
+	updates := make([]interfaces.AllPairedReadinessUpdate, 0, len(refreshable))
+	for deviceIdentifier, target := range refreshable {
+		nextState, reason := curtailment.AllPairedPolicyRestoreTargetState(candidatesByID[deviceIdentifier])
+		if !shouldRefreshAllPairedRestoreTarget(target, nextState, reason) {
+			continue
+		}
+		updates = append(updates, interfaces.AllPairedReadinessUpdate{
+			DeviceIdentifier:     deviceIdentifier,
+			ExpectedState:        target.State,
+			ExpectedDesiredState: target.DesiredState,
+			State:                nextState,
+			Reason:               reason,
+		})
+	}
+	if len(updates) == 0 {
+		return true
+	}
+	return r.applyAllPairedReadinessUpdates(ctx, ev, refreshable, updates)
+}
+
+func shouldRefreshAllPairedRestoreTarget(
+	target *models.Target,
+	nextState models.TargetState,
+	reason string,
+) bool {
+	switch target.State { //nolint:exhaustive // Callers provide only refreshable restore states.
+	case models.TargetStatePending:
+		return nextState != models.TargetStatePending
+	case models.TargetStateUnavailable:
+		return nextState != target.State || reason != targetErrorString(target)
+	case models.TargetStateRestoreFailed:
+		return nextState != models.TargetStatePending
+	default:
+		return false
+	}
+}
+
+func (r *Reconciler) applyAllPairedReadinessUpdates(
+	ctx context.Context,
+	ev *models.Event,
+	refreshable map[string]*models.Target,
+	updates []interfaces.AllPairedReadinessUpdate,
+) bool {
 	appliedDevices, err := r.store.BulkRefreshAllPairedTargetReadiness(ctx, ev.ID, ev.OrgID, ev.State, updates)
 	if err != nil {
 		r.metrics.IncTargetWriteFailure()
 		slog.Error("curtailment reconciler: all-paired readiness bulk refresh failed",
 			"event_id", ev.ID, "update_count", len(updates), "error", err)
-		return
+		return false
 	}
 	applied := toStringSet(appliedDevices)
 	if len(applied) < len(updates) {
@@ -212,7 +312,26 @@ func (r *Reconciler) refreshAllPairedPolicyTargets(
 			baseline := *update.BaselinePowerW
 			target.BaselinePowerW = &baseline
 		}
+		if target.DesiredState == models.DesiredStateActive {
+			target.ConfirmedAt = nil
+			if target.RestorePhase != nil {
+				target.RestorePhase.State = update.State
+				target.RestorePhase.CompletedAt = nil
+				target.RestorePhase.LastError = target.LastError
+			}
+			if update.State == models.TargetStatePending {
+				target.RetryCount = 0
+				target.LastDispatchedAt = nil
+				target.LastBatchUUID = nil
+				if target.RestorePhase != nil {
+					target.RestorePhase.RetryCount = 0
+					target.RestorePhase.DispatchedAt = nil
+					target.RestorePhase.BatchUUID = nil
+				}
+			}
+		}
 	}
+	return true
 }
 
 func (r *Reconciler) releaseAllPairedPolicyTarget(ctx context.Context, ev *models.Event, target *models.Target, reason string) {

--- a/server/internal/domain/curtailment/reconciler/reconciler_test.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler_test.go
@@ -360,9 +360,6 @@ func (f *fakeStore) BulkRefreshAllPairedTargetReadiness(
 		if update.State != models.TargetStatePending && update.State != models.TargetStateUnavailable {
 			continue
 		}
-		if t.State != update.ExpectedState {
-			continue
-		}
 		t.State = update.State
 		if update.Reason == "" {
 			t.LastError = nil
@@ -1440,6 +1437,30 @@ func TestReconciler_TopologyDispatchHoldsFenceThroughCommand(t *testing.T) {
 	assert.True(t, dispatched)
 	assert.Equal(t, 1, dispatcher.curtailCalls)
 	assert.False(t, store.topologyFenceActive)
+}
+
+func TestReconciler_TopologyDispatchReleasesRejectedPreclaimedTarget(t *testing.T) {
+	t.Parallel()
+
+	store, event, target := topologyDispatchFixture()
+	target.State = models.TargetStateDispatching
+	store.candidates = nil
+	dispatcher := &fakeDispatcher{}
+	reconciler := New(
+		Config{TickInterval: time.Hour},
+		store,
+		dispatcher,
+		WithDispatchPermissionResolver(staticDispatchPermissionResolver{
+			effective: topologyDispatchManagePermission(),
+		}),
+	)
+
+	reconciler.dispatchClaimedCurtailTargets(t.Context(), event, []*models.Target{target})
+
+	assert.Zero(t, dispatcher.curtailCalls)
+	assert.Equal(t, models.EventStateRestoring, event.State)
+	assert.Equal(t, models.TargetStateReleased, target.State)
+	assert.Equal(t, models.DesiredStateCurtailed, target.DesiredState)
 }
 
 func TestReconciler_TopologyRestoreHoldsFenceThroughCommand(t *testing.T) {
@@ -4308,6 +4329,36 @@ func TestReconciler_CurtailPreWriteFailureBurnsRetryBudget(t *testing.T) {
 	assert.Equal(t, int32(1), final.RetryCount,
 		"pre-write failure must bump retry_count so the event can't stall indefinitely")
 	require.NotNil(t, final.LastError, "pre-write failure must record last_error")
+}
+
+func TestRecordDispatchFailureUsesEventDirectionWhenLoadedTargetDirectionIsEmpty(t *testing.T) {
+	store := newFakeStore()
+	event := &models.Event{
+		ID:        10,
+		EventUUID: uuid.New(),
+		OrgID:     1,
+		State:     models.EventStatePending,
+	}
+	target := &models.Target{
+		CurtailmentEventID: event.ID,
+		DeviceIdentifier:   "miner-1",
+		State:              models.TargetStateDispatching,
+	}
+	store.events = []*models.Event{event}
+	store.targetsByEventID[event.ID] = []*models.Target{target}
+	reconciler := newReconcilerForTest(store, &fakeDispatcher{})
+
+	reconciler.recordDispatchFailure(
+		t.Context(),
+		event,
+		target,
+		"queue unavailable",
+		models.TargetStatePending,
+	)
+
+	params := store.updateTargetParams[target.DeviceIdentifier]
+	require.NotNil(t, params.ExpectedDesiredState)
+	assert.Equal(t, models.DesiredStateCurtailed, *params.ExpectedDesiredState)
 }
 
 // If Stop moves the parent event out of the active phase after the liveness

--- a/server/internal/domain/curtailment/reconciler/reconciler_test.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler_test.go
@@ -14,10 +14,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	pb "github.com/block/proto-fleet/server/generated/grpc/minercommand/v1"
+	domainAuth "github.com/block/proto-fleet/server/internal/domain/auth"
 	"github.com/block/proto-fleet/server/internal/domain/authz"
 	"github.com/block/proto-fleet/server/internal/domain/command"
 	"github.com/block/proto-fleet/server/internal/domain/curtailment"
 	"github.com/block/proto-fleet/server/internal/domain/curtailment/models"
+	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 	"github.com/block/proto-fleet/server/internal/domain/infrastructure/driver"
 	"github.com/block/proto-fleet/server/internal/domain/session"
 	"github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
@@ -60,10 +62,13 @@ type fakeStore struct {
 	listTargetsByEventCalls int
 	listCandidatesCalls     int
 	listCandidatesErr       error
+	listCandidatesHook      func()
 	claimTargetsCalls       int
 	claimedTargetParams     []models.InsertTargetParams
 	claimAllPairedCalls     int
 	claimedAllPairedParams  []models.InsertTargetParams
+	topologyRestoreCalls    int
+	topologyRestoreDevices  []string
 	bulkRefreshCalls        int
 	lastBulkRefreshUpdates  []interfaces.AllPairedReadinessUpdate
 	bulkRefreshErr          error
@@ -77,16 +82,15 @@ type fakeStore struct {
 	lastCooldownExcludeID  int64
 	lastCooldownSec        int32
 	lastCooldownFilter     []string
-	lastCooldownSiteIDs    []int64
 
 	heartbeatCalls               int
 	lastHeartbeatActive          int32
 	lastHeartbeatTickUUID        uuid.UUID
-	lastListCandidatesSiteIDs    []int64
-	lastListCandidatesFilter     []string
+	lastListCandidatesParams     interfaces.ListCandidatesParams
 	listCandidatesFilters        [][]string
 	topologyCoverage             interfaces.CurtailmentTopologyScopeCoverage
 	topologyCoverageErr          error
+	topologyDispatchMembers      []string
 	topologyDispatchErr          error
 	topologyDispatchCalls        int
 	topologyFenceErr             error
@@ -145,7 +149,6 @@ func (f *fakeStore) ListRecentlyResolvedCurtailedDevices(
 	f.lastCooldownExcludeID = params.ExcludeEventID
 	f.lastCooldownSec = params.CooldownSec
 	f.lastCooldownFilter = append([]string(nil), params.DeviceIdentifiers...)
-	f.lastCooldownSiteIDs = append([]int64(nil), params.SiteIDs...)
 	return append([]string(nil), f.cooldownDevices...), nil
 }
 func (f *fakeStore) SiteBelongsToOrg(context.Context, int64, int64) (bool, error) {
@@ -227,6 +230,30 @@ func (f *fakeStore) ClaimClosedLoopFullFleetTargets(
 	}
 	return claimed, nil
 }
+
+func (f *fakeStore) BeginCurtailmentTopologyTargetRestore(
+	_ context.Context,
+	event *models.Event,
+	deviceIdentifiers []string,
+) (int64, error) {
+	f.topologyRestoreCalls++
+	f.topologyRestoreDevices = append([]string(nil), deviceIdentifiers...)
+	wanted := toStringSet(deviceIdentifiers)
+	var transitioned int64
+	for _, target := range f.targetsByEventID[event.ID] {
+		if _, ok := wanted[target.DeviceIdentifier]; !ok || target.DesiredState == models.DesiredStateActive {
+			continue
+		}
+		target.DesiredState = models.DesiredStateActive
+		target.State = models.TargetStatePending
+		target.RestorePhase = &models.TargetPhaseSummary{
+			Phase: models.TargetPhaseRestore,
+			State: models.TargetStatePending,
+		}
+		transitioned++
+	}
+	return transitioned, nil
+}
 func (f *fakeStore) ClaimAllPairedPolicyTargets(
 	_ context.Context,
 	eventID int64,
@@ -260,6 +287,7 @@ func (f *fakeStore) ClaimAllPairedPolicyTargets(
 			row.LastError = target.LastError
 			row.ReleasedAt = nil
 			row.CurtailPhase = models.TargetPhaseSummary{}
+			row.RestorePhase = nil
 			claimed++
 			continue
 		}
@@ -282,9 +310,9 @@ func (f *fakeStore) ClaimAllPairedPolicyTargets(
 }
 
 // BulkRefreshAllPairedTargetReadiness: real-fake mirroring the SQL guards —
-// only pending/unavailable curtail-phase rows on an event still in the
-// expected state flip; everything else is skipped, not clobbered. Returns
-// the applied device identifiers, mirroring the RETURNING clause.
+// only refreshable curtail or topology-restore policy rows on an event still
+// in the expected state flip; everything else is skipped, not clobbered.
+// Returns the applied device identifiers, mirroring the RETURNING clause.
 func (f *fakeStore) BulkRefreshAllPairedTargetReadiness(
 	_ context.Context,
 	eventID int64,
@@ -315,17 +343,24 @@ func (f *fakeStore) BulkRefreshAllPairedTargetReadiness(
 		if !ok {
 			continue
 		}
-		if t.DesiredState != update.ExpectedDesiredState {
+		desiredState := t.DesiredState
+		if desiredState == "" {
+			desiredState = models.DesiredStateCurtailed
+		}
+		if desiredState != update.ExpectedDesiredState {
 			continue
 		}
 		if t.State != update.ExpectedState {
 			continue
 		}
-		if (t.DesiredState == models.DesiredStateCurtailed && t.State != models.TargetStatePending && t.State != models.TargetStateUnavailable) ||
-			(t.DesiredState == models.DesiredStateActive && t.State != models.TargetStatePending && t.State != models.TargetStateUnavailable && t.State != models.TargetStateRestoreFailed) {
+		if (desiredState == models.DesiredStateCurtailed && t.State != models.TargetStatePending && t.State != models.TargetStateUnavailable) ||
+			(desiredState == models.DesiredStateActive && t.State != models.TargetStatePending && t.State != models.TargetStateUnavailable && t.State != models.TargetStateRestoreFailed) {
 			continue
 		}
 		if update.State != models.TargetStatePending && update.State != models.TargetStateUnavailable {
+			continue
+		}
+		if t.State != update.ExpectedState {
 			continue
 		}
 		t.State = update.State
@@ -338,6 +373,12 @@ func (f *fakeStore) BulkRefreshAllPairedTargetReadiness(
 		if update.BaselinePowerW != nil && t.BaselinePowerW == nil {
 			baseline := *update.BaselinePowerW
 			t.BaselinePowerW = &baseline
+		}
+		if desiredState == models.DesiredStateActive && update.State == models.TargetStatePending {
+			t.RetryCount = 0
+			t.LastDispatchedAt = nil
+			t.LastBatchUUID = nil
+			t.ConfirmedAt = nil
 		}
 		reason := update.Reason
 		updateTargetPhaseSummary(t, interfaces.UpdateCurtailmentTargetStateParams{
@@ -389,9 +430,11 @@ func (f *fakeStore) GetTargetRollupByEvent(context.Context, int64, uuid.UUID) (*
 
 func (f *fakeStore) ListCandidates(_ context.Context, params interfaces.ListCandidatesParams) ([]*models.Candidate, error) {
 	f.listCandidatesCalls++
-	f.lastListCandidatesSiteIDs = append([]int64(nil), params.SiteIDs...)
-	f.lastListCandidatesFilter = append([]string(nil), params.DeviceIdentifiers...)
+	f.lastListCandidatesParams = params
 	f.listCandidatesFilters = append(f.listCandidatesFilters, append([]string(nil), params.DeviceIdentifiers...))
+	if f.listCandidatesHook != nil {
+		f.listCandidatesHook()
+	}
 	if f.listCandidatesErr != nil {
 		return nil, f.listCandidatesErr
 	}
@@ -428,9 +471,13 @@ func (f *fakeStore) ResolveCurtailmentTopologyDispatch(
 		return interfaces.CurtailmentTopologyDispatchSnapshot{}, f.topologyDispatchErr
 	}
 	members := make(map[string]struct{}, len(f.candidates))
-	for _, candidate := range f.candidates {
-		if candidate != nil {
-			members[candidate.DeviceIdentifier] = struct{}{}
+	if f.topologyDispatchMembers != nil {
+		members = toStringSet(f.topologyDispatchMembers)
+	} else {
+		for _, candidate := range f.candidates {
+			if candidate != nil {
+				members[candidate.DeviceIdentifier] = struct{}{}
+			}
 		}
 	}
 	dispatchMembers := make([]string, 0, len(dispatchDeviceIdentifiers))
@@ -1021,24 +1068,30 @@ func identifiersFromSelector(selector *pb.DeviceSelector) []string {
 
 // --- helpers ---
 
-func newReconcilerForTest(store *fakeStore, disp *fakeDispatcher) *Reconciler {
+func newReconcilerForTest(store *fakeStore, disp *fakeDispatcher, options ...Option) *Reconciler {
 	r := New(Config{
 		TickInterval:         time.Hour, // tests drive runTick directly
 		MaxRetries:           3,
 		CurtailMaxRetries:    3,
 		DriftThresholdFactor: 0.5,
-	}, store, disp)
+	}, store, disp, options...)
 	r.now = func() time.Time { return time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC) }
 	return r
 }
 
-func newReconcilerWithFansForTest(store *fakeStore, disp *fakeDispatcher, fans *fakeFanController) *Reconciler {
+func newReconcilerWithFansForTest(
+	store *fakeStore,
+	disp *fakeDispatcher,
+	fans *fakeFanController,
+	options ...Option,
+) *Reconciler {
+	options = append([]Option{WithFacilityFanController(fans)}, options...)
 	r := New(Config{
 		TickInterval:         time.Hour,
 		MaxRetries:           3,
 		CurtailMaxRetries:    3,
 		DriftThresholdFactor: 0.5,
-	}, store, disp, WithFacilityFanController(fans))
+	}, store, disp, options...)
 	r.now = func() time.Time { return time.Date(2026, 5, 7, 12, 0, 0, 0, time.UTC) }
 	return r
 }
@@ -1064,6 +1117,8 @@ func ptrFloat64(v float64) *float64 { return &v }
 type staticDispatchPermissionResolver struct {
 	effective *authz.EffectivePermissions
 	err       error
+	roleName  string
+	roleErr   error
 }
 
 func (r staticDispatchPermissionResolver) LoadEffective(
@@ -1072,6 +1127,17 @@ func (r staticDispatchPermissionResolver) LoadEffective(
 	int64,
 ) (*authz.EffectivePermissions, error) {
 	return r.effective, r.err
+}
+
+func (r staticDispatchPermissionResolver) LoadRoleName(
+	context.Context,
+	int64,
+	int64,
+) (string, error) {
+	if r.roleName == "" && r.roleErr == nil {
+		return domainAuth.AdminRoleName, nil
+	}
+	return r.roleName, r.roleErr
 }
 
 // --- tests ---
@@ -2336,19 +2402,12 @@ func TestReconciler_AllPairedPolicyRefreshQueriesOnlyRefreshableTargets(t *testi
 			State:              models.TargetStateReleased,
 			DesiredState:       models.DesiredStateCurtailed,
 		},
-		{
-			CurtailmentEventID: eventID,
-			DeviceIdentifier:   "restore-pending",
-			State:              models.TargetStatePending,
-			DesiredState:       models.DesiredStateActive,
-		},
 	}
 	driver := "antminer"
 	store.candidates = []*models.Candidate{
 		{DeviceIdentifier: "needs-refresh", DriverName: &driver, DeviceStatus: "OFFLINE", PairingStatus: "PAIRED"},
 		{DeviceIdentifier: "confirmed", DriverName: &driver, DeviceStatus: "ACTIVE", PairingStatus: "PAIRED"},
 		{DeviceIdentifier: "released", DriverName: &driver, DeviceStatus: "ACTIVE", PairingStatus: "PAIRED"},
-		{DeviceIdentifier: "restore-pending", DriverName: &driver, DeviceStatus: "ACTIVE", PairingStatus: "PAIRED"},
 	}
 
 	r := newReconcilerForTest(store, disp)
@@ -2998,9 +3057,9 @@ func TestReconciler_ActiveClosedLoopFullFleetUsesPersistedSiteScope(t *testing.T
 	r := newReconcilerForTest(store, disp)
 	r.runTick(context.Background())
 
-	assert.Equal(t, []int64{siteID}, store.lastListCandidatesSiteIDs)
+	assert.Equal(t, []int64{siteID}, store.lastListCandidatesParams.SiteIDs)
 	assert.Equal(t, 1, store.cooldownCalls)
-	assert.Equal(t, []int64{siteID}, store.lastCooldownSiteIDs)
+	assert.Equal(t, []string{"site-miner"}, store.lastCooldownFilter)
 	assert.ElementsMatch(t, []string{"site-miner"}, disp.curtailLastIDs)
 }
 
@@ -3042,11 +3101,808 @@ func TestReconciler_ActiveClosedLoopFullFleetUsesPersistedMultiSiteScope(t *test
 	r := newReconcilerForTest(store, disp)
 	r.runTick(context.Background())
 
-	assert.Equal(t, siteIDs, store.lastListCandidatesSiteIDs)
+	assert.Equal(t, siteIDs, store.lastListCandidatesParams.SiteIDs)
 	assert.Equal(t, 1, store.cooldownCalls)
-	assert.Equal(t, siteIDs, store.lastCooldownSiteIDs)
+	assert.Equal(t, []string{"site-miner"}, store.lastCooldownFilter)
 	assert.Equal(t, 1, store.claimTargetsCalls)
 	assert.ElementsMatch(t, []string{"site-miner"}, disp.curtailLastIDs)
+}
+
+const (
+	topologyAdmissionTestEnvelope      = `{"schema_version":1,"selected_resource_site_ids":[7],"current_member_site_ids":[7],"miner_scope_unbounded":false,"facility_fan_site_ids":[],"facility_fan_scope_unbounded":false}`
+	topologyAdmissionTestBuildingScope = `{"scope_schema_version":1,"building_ids":[7]}`
+)
+
+func topologyAdmissionTestFixture(scopeJSON string) (*fakeStore, *models.Event) {
+	store := newFakeStore()
+	store.topologyCoverage = interfaces.CurtailmentTopologyScopeCoverage{
+		SelectedResourceSiteIDs: []int64{7},
+		CurrentMemberSiteIDs:    []int64{7},
+	}
+	event := &models.Event{
+		ID:                        10,
+		EventUUID:                 uuid.New(),
+		OrgID:                     1,
+		CreatedByUserID:           99,
+		State:                     models.EventStateActive,
+		Mode:                      models.ModeFullFleet,
+		LoopType:                  models.LoopTypeClosed,
+		ScopeType:                 models.ScopeTypeMixed,
+		ScopeJSON:                 []byte(scopeJSON),
+		AuthorizationEnvelopeJSON: []byte(topologyAdmissionTestEnvelope),
+	}
+	store.events = []*models.Event{event}
+	return store, event
+}
+
+func TestClaimClosedLoopFullFleetTargetsUsesPersistedTopologyScope(t *testing.T) {
+	tests := []struct {
+		name       string
+		scopeJSON  string
+		wantParams interfaces.ListCandidatesParams
+	}{
+		{
+			name:       "buildings",
+			scopeJSON:  `{"scope_schema_version":1,"building_ids":[7,8]}`,
+			wantParams: interfaces.ListCandidatesParams{BuildingIDs: []int64{7, 8}},
+		},
+		{
+			name:       "racks",
+			scopeJSON:  `{"scope_schema_version":1,"rack_ids":[9,10]}`,
+			wantParams: interfaces.ListCandidatesParams{RackIDs: []int64{9, 10}},
+		},
+		{
+			name:       "groups",
+			scopeJSON:  `{"scope_schema_version":1,"group_ids":[11,12]}`,
+			wantParams: interfaces.ListCandidatesParams{GroupIDs: []int64{11, 12}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store, event := topologyAdmissionTestFixture(tt.scopeJSON)
+			driver := "antminer"
+			now := time.Now()
+			store.candidates = []*models.Candidate{{
+				DeviceIdentifier: "topology-miner",
+				DriverName:       &driver,
+				DeviceStatus:     "ACTIVE",
+				PairingStatus:    "PAIRED",
+				LatestMetricsAt:  &now,
+				LatestPowerW:     ptrFloat64(3000),
+				LatestHashRateHS: ptrFloat64(100),
+			}}
+			event.DecisionSnapshotJSON = []byte(`{"post_event_cooldown_sec":600}`)
+
+			r := newReconcilerForTest(
+				store,
+				&fakeDispatcher{},
+				WithDispatchPermissionResolver(staticDispatchPermissionResolver{
+					effective: topologyDispatchManagePermission(),
+				}),
+			)
+			claimed, _ := r.claimClosedLoopFullFleetTargets(t.Context(), event, nil)
+
+			require.Len(t, claimed, 1)
+			tt.wantParams.OrgID = event.OrgID
+			tt.wantParams.ResultLimit = curtailment.ScopeResolvedMinerMax + 1
+			assert.Equal(t, tt.wantParams, store.lastListCandidatesParams)
+			assert.Equal(t, []string{"topology-miner"}, store.lastCooldownFilter)
+		})
+	}
+}
+
+func TestClaimClosedLoopFullFleetTargetsRejectsOversizedExpansion(t *testing.T) {
+	store, event := topologyAdmissionTestFixture(topologyAdmissionTestBuildingScope)
+	store.candidates = make([]*models.Candidate, curtailment.ScopeResolvedMinerMax+1)
+	for index := range store.candidates {
+		store.candidates[index] = &models.Candidate{DeviceIdentifier: fmt.Sprintf("miner-%05d", index)}
+	}
+
+	r := newReconcilerForTest(
+		store,
+		&fakeDispatcher{},
+		WithDispatchPermissionResolver(staticDispatchPermissionResolver{
+			effective: topologyDispatchManagePermission(),
+		}),
+	)
+	claimed, _ := r.claimClosedLoopFullFleetTargets(t.Context(), event, nil)
+
+	assert.Empty(t, claimed)
+	assert.Equal(t, int32(curtailment.ScopeResolvedMinerMax+1), store.lastListCandidatesParams.ResultLimit)
+	assert.Equal(t, 0, store.claimTargetsCalls)
+	assert.Equal(t, 1, store.beginRestoreCalls)
+}
+
+func TestClaimClosedLoopFullFleetTargetsRestoresTopologyDeparturesBeforeAdmission(t *testing.T) {
+	store, event := topologyAdmissionTestFixture(topologyAdmissionTestBuildingScope)
+	store.targetsByEventID[event.ID] = []*models.Target{{
+		CurtailmentEventID: event.ID,
+		DeviceIdentifier:   "departed-miner",
+		State:              models.TargetStateConfirmed,
+		DesiredState:       models.DesiredStateCurtailed,
+	}}
+	driver := "antminer"
+	now := time.Now()
+	store.candidates = []*models.Candidate{{
+		DeviceIdentifier: "new-member",
+		DriverName:       &driver,
+		DeviceStatus:     "ACTIVE",
+		PairingStatus:    "PAIRED",
+		LatestMetricsAt:  &now,
+		LatestPowerW:     ptrFloat64(3000),
+		LatestHashRateHS: ptrFloat64(100),
+	}}
+	dispatcher := &fakeDispatcher{}
+	r := newReconcilerForTest(
+		store,
+		dispatcher,
+		WithDispatchPermissionResolver(staticDispatchPermissionResolver{
+			effective: topologyDispatchManagePermission(),
+		}),
+	)
+
+	claimed, _ := r.claimClosedLoopFullFleetTargets(t.Context(), event, store.targetsByEventID[event.ID])
+
+	assert.Empty(t, claimed)
+	assert.Equal(t, 1, store.topologyRestoreCalls)
+	assert.Equal(t, []string{"departed-miner"}, store.topologyRestoreDevices)
+	assert.Equal(t, 0, store.claimTargetsCalls, "departure restoration must run before new admission")
+	restored := store.targetsByEventID[event.ID][0]
+	assert.Equal(t, models.DesiredStateActive, restored.DesiredState)
+	assert.Equal(t, models.TargetStatePending, restored.State)
+
+	r.observeActive(t.Context(), event)
+
+	assert.Equal(t, 1, dispatcher.uncurtailCalls)
+	assert.Equal(t, []string{"departed-miner"}, dispatcher.uncurtailLastIDs)
+	assert.Equal(t, 0, dispatcher.curtailCalls)
+}
+
+func TestReconcileClosedLoopTopologyDeparturesRestoresUnpairedOwnedMiner(t *testing.T) {
+	store, event := topologyAdmissionTestFixture(topologyAdmissionTestBuildingScope)
+	event.ForceIncludeAllPairedMiners = true
+	target := &models.Target{
+		CurtailmentEventID: event.ID,
+		DeviceIdentifier:   "unpaired-miner",
+		State:              models.TargetStateConfirmed,
+		DesiredState:       models.DesiredStateCurtailed,
+	}
+	store.targetsByEventID[event.ID] = []*models.Target{target}
+	r := newReconcilerForTest(store, &fakeDispatcher{})
+
+	departures, ok := r.reconcileClosedLoopTopologyDepartures(
+		t.Context(),
+		event,
+		store.targetsByEventID[event.ID],
+		[]*models.Candidate{{DeviceIdentifier: target.DeviceIdentifier, PairingStatus: "UNPAIRED"}},
+	)
+
+	assert.True(t, ok)
+	assert.True(t, departures)
+	assert.Equal(t, []string{target.DeviceIdentifier}, store.topologyRestoreDevices)
+	assert.Equal(t, models.DesiredStateActive, target.DesiredState)
+	assert.Equal(t, models.TargetStatePending, target.State)
+}
+
+func TestDriveTopologyRestoresCompletesWhileEventIsPending(t *testing.T) {
+	store := newFakeStore()
+	event := &models.Event{
+		ID:        11,
+		EventUUID: uuid.New(),
+		OrgID:     1,
+		State:     models.EventStatePending,
+		Mode:      models.ModeFullFleet,
+		LoopType:  models.LoopTypeClosed,
+	}
+	restoreTarget := &models.Target{
+		CurtailmentEventID: event.ID,
+		DeviceIdentifier:   "departed-miner",
+		State:              models.TargetStatePending,
+		DesiredState:       models.DesiredStateActive,
+		RestorePhase: &models.TargetPhaseSummary{
+			Phase: models.TargetPhaseRestore,
+			State: models.TargetStatePending,
+		},
+	}
+	confirmedTarget := &models.Target{
+		CurtailmentEventID: event.ID,
+		DeviceIdentifier:   "curtailed-miner",
+		State:              models.TargetStateConfirmed,
+		DesiredState:       models.DesiredStateCurtailed,
+	}
+	targets := []*models.Target{restoreTarget, confirmedTarget}
+	store.events = []*models.Event{event}
+	store.targetsByEventID[event.ID] = targets
+	dispatcher := &fakeDispatcher{}
+	r := newReconcilerForTest(store, dispatcher)
+
+	assert.True(t, r.driveTopologyRestores(t.Context(), event, targets))
+	assert.Equal(t, 1, dispatcher.uncurtailCalls)
+	assert.Equal(t, models.TargetStateDispatched, restoreTarget.State)
+
+	metricsAt := r.now()
+	store.candidates = []*models.Candidate{{
+		DeviceIdentifier: restoreTarget.DeviceIdentifier,
+		LatestMetricsAt:  &metricsAt,
+		LatestHashRateHS: ptrFloat64(100),
+	}}
+	assert.False(t, r.driveTopologyRestores(t.Context(), event, targets))
+	assert.Equal(t, models.TargetStateResolved, restoreTarget.State)
+
+	r.maybeMarkActive(t.Context(), event, targets)
+	assert.Equal(t, models.EventStateActive, event.State)
+}
+
+func TestMaybeMarkActiveIgnoresCompletedTopologyDepartures(t *testing.T) {
+	tests := []struct {
+		name         string
+		state        models.TargetState
+		desiredState string
+	}{
+		{
+			name:         "released before curtail dispatch",
+			state:        models.TargetStateReleased,
+			desiredState: models.DesiredStateCurtailed,
+		},
+		{
+			name:         "restore retries exhausted",
+			state:        models.TargetStateRestoreFailed,
+			desiredState: models.DesiredStateActive,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store, event := topologyAdmissionTestFixture(topologyAdmissionTestBuildingScope)
+			event.State = models.EventStatePending
+			target := &models.Target{
+				CurtailmentEventID: event.ID,
+				DeviceIdentifier:   "departed-miner",
+				State:              tt.state,
+				DesiredState:       tt.desiredState,
+			}
+			r := newReconcilerForTest(store, &fakeDispatcher{})
+
+			r.maybeMarkActive(t.Context(), event, []*models.Target{target})
+
+			assert.Equal(t, models.EventStateActive, event.State)
+			assert.Equal(t, models.EventStateActive, store.updateEventLast[event.ID])
+		})
+	}
+}
+
+func TestPendingEmptyAllPairedTopologyWatcherWaitsForConfirmedMember(t *testing.T) {
+	store, event := topologyAdmissionTestFixture(topologyAdmissionTestBuildingScope)
+	event.State = models.EventStatePending
+	event.ForceIncludeAllPairedMiners = true
+	event.CreatedAt = time.Now()
+	driver := "antminer"
+	metricsAt := time.Now()
+	candidate := &models.Candidate{
+		DeviceIdentifier: "newly-paired-miner",
+		DriverName:       &driver,
+		DeviceStatus:     "ACTIVE",
+		PairingStatus:    "UNPAIRED",
+		LatestMetricsAt:  &metricsAt,
+		LatestPowerW:     ptrFloat64(3000),
+		LatestHashRateHS: ptrFloat64(100),
+	}
+	store.candidates = []*models.Candidate{candidate}
+	dispatcher := &fakeDispatcher{}
+	r := newReconcilerForTest(
+		store,
+		dispatcher,
+		WithDispatchPermissionResolver(staticDispatchPermissionResolver{
+			effective: topologyDispatchManagePermission(),
+		}),
+	)
+
+	r.runTick(t.Context())
+	assert.Equal(t, models.EventStatePending, event.State)
+	assert.Empty(t, store.targetsByEventID[event.ID])
+	assert.NotContains(t, store.updateEventLast, event.ID)
+
+	candidate.PairingStatus = "PAIRED"
+	r.runTick(t.Context())
+	assert.Equal(t, models.EventStatePending, event.State)
+	require.Len(t, store.targetsByEventID[event.ID], 1)
+	assert.Equal(t, models.TargetStatePending, store.targetsByEventID[event.ID][0].State)
+	assert.Equal(t, 0, dispatcher.curtailCalls)
+
+	dispatcher.curtailHook = func(_ []string) {
+		candidate.LatestPowerW = ptrFloat64(0)
+		candidate.LatestHashRateHS = ptrFloat64(0)
+	}
+	r.runTick(t.Context())
+
+	assert.Equal(t, 1, dispatcher.curtailCalls)
+	assert.Equal(t, models.TargetStateConfirmed, store.targetsByEventID[event.ID][0].State)
+	assert.Equal(t, models.EventStateActive, event.State)
+}
+
+func TestObserveRestoringRequeuesRepairedAllPairedTopologyTarget(t *testing.T) {
+	store, event := topologyAdmissionTestFixture(topologyAdmissionTestBuildingScope)
+	event.State = models.EventStateRestoring
+	event.ForceIncludeAllPairedMiners = true
+	driver := "antminer"
+	reason := "unpaired"
+	target := &models.Target{
+		CurtailmentEventID: event.ID,
+		DeviceIdentifier:   "departed-miner",
+		State:              models.TargetStateUnavailable,
+		DesiredState:       models.DesiredStateActive,
+		RetryCount:         2,
+		LastError:          &reason,
+		RestorePhase: &models.TargetPhaseSummary{
+			Phase:      models.TargetPhaseRestore,
+			State:      models.TargetStateUnavailable,
+			RetryCount: 2,
+		},
+	}
+	store.targetsByEventID[event.ID] = []*models.Target{target}
+	store.candidates = []*models.Candidate{{
+		DeviceIdentifier: target.DeviceIdentifier,
+		DriverName:       &driver,
+		DeviceStatus:     "INACTIVE",
+		PairingStatus:    "PAIRED",
+	}}
+	dispatcher := &fakeDispatcher{}
+	r := newReconcilerForTest(store, dispatcher)
+
+	r.observeRestoring(t.Context(), event)
+
+	assert.Equal(t, models.TargetStateDispatched, target.State)
+	assert.Zero(t, target.RetryCount)
+	assert.Equal(t, 1, dispatcher.uncurtailCalls)
+	assert.Equal(t, []string{target.DeviceIdentifier}, dispatcher.uncurtailLastIDs)
+}
+
+func TestObserveActiveReconcilesTopologyDepartureBeforeCurtailRedispatch(t *testing.T) {
+	store, event := topologyAdmissionTestFixture(topologyAdmissionTestBuildingScope)
+	target := &models.Target{
+		CurtailmentEventID: event.ID,
+		DeviceIdentifier:   "departed-miner",
+		State:              models.TargetStateDrifted,
+		DesiredState:       models.DesiredStateCurtailed,
+	}
+	store.targetsByEventID[event.ID] = []*models.Target{target}
+	dispatcher := &fakeDispatcher{}
+	r := newReconcilerForTest(
+		store,
+		dispatcher,
+		WithDispatchPermissionResolver(staticDispatchPermissionResolver{
+			effective: topologyDispatchManagePermission(),
+		}),
+	)
+
+	r.observeActive(t.Context(), event)
+
+	assert.Equal(t, 1, store.topologyRestoreCalls)
+	assert.Equal(t, models.DesiredStateActive, target.DesiredState)
+	assert.Equal(t, models.TargetStatePending, target.State)
+	assert.Zero(t, dispatcher.curtailCalls)
+}
+
+func TestObserveActiveFindsAdditionalDepartureWhileTopologyRestoreIsParked(t *testing.T) {
+	store, event := topologyAdmissionTestFixture(topologyAdmissionTestBuildingScope)
+	event.ForceIncludeAllPairedMiners = true
+	parked := &models.Target{
+		CurtailmentEventID: event.ID,
+		DeviceIdentifier:   "already-departed",
+		State:              models.TargetStateUnavailable,
+		DesiredState:       models.DesiredStateActive,
+	}
+	newDeparture := &models.Target{
+		CurtailmentEventID: event.ID,
+		DeviceIdentifier:   "newly-departed",
+		State:              models.TargetStateConfirmed,
+		DesiredState:       models.DesiredStateCurtailed,
+	}
+	store.targetsByEventID[event.ID] = []*models.Target{parked, newDeparture}
+	r := newReconcilerForTest(
+		store,
+		&fakeDispatcher{},
+		WithDispatchPermissionResolver(staticDispatchPermissionResolver{
+			effective: topologyDispatchManagePermission(),
+		}),
+	)
+
+	r.observeActive(t.Context(), event)
+
+	assert.Equal(t, 1, store.topologyRestoreCalls)
+	assert.Equal(t, []string{newDeparture.DeviceIdentifier}, store.topologyRestoreDevices)
+	assert.Equal(t, models.DesiredStateActive, newDeparture.DesiredState)
+	assert.Equal(t, models.TargetStatePending, newDeparture.State)
+}
+
+func TestParkedTopologyRestoreDoesNotBlockAdmission(t *testing.T) {
+	for _, eventState := range []models.EventState{models.EventStatePending, models.EventStateActive} {
+		t.Run(string(eventState), func(t *testing.T) {
+			store, event := topologyAdmissionTestFixture(topologyAdmissionTestBuildingScope)
+			event.State = eventState
+			event.ForceIncludeAllPairedMiners = true
+			reason := "unpaired"
+			parked := &models.Target{
+				CurtailmentEventID: event.ID,
+				DeviceIdentifier:   "departed-miner",
+				State:              models.TargetStateUnavailable,
+				DesiredState:       models.DesiredStateActive,
+				LastError:          &reason,
+				RestorePhase: &models.TargetPhaseSummary{
+					Phase:     models.TargetPhaseRestore,
+					State:     models.TargetStateUnavailable,
+					LastError: &reason,
+				},
+			}
+			store.targetsByEventID[event.ID] = []*models.Target{parked}
+			driver := "antminer"
+			now := time.Now()
+			store.candidates = []*models.Candidate{
+				{
+					DeviceIdentifier: parked.DeviceIdentifier,
+					DeviceStatus:     "INACTIVE",
+					PairingStatus:    "UNPAIRED",
+				},
+				{
+					DeviceIdentifier: "new-member",
+					DriverName:       &driver,
+					DeviceStatus:     "ACTIVE",
+					PairingStatus:    "PAIRED",
+					LatestMetricsAt:  &now,
+					LatestPowerW:     ptrFloat64(3000),
+					LatestHashRateHS: ptrFloat64(100),
+				},
+			}
+			r := newReconcilerForTest(
+				store,
+				&fakeDispatcher{},
+				WithDispatchPermissionResolver(staticDispatchPermissionResolver{
+					effective: topologyDispatchManagePermission(),
+				}),
+			)
+
+			r.runTick(t.Context())
+
+			assert.Equal(t, 1, store.claimAllPairedCalls)
+			require.Len(t, store.targetsByEventID[event.ID], 2)
+			assert.Equal(t, "new-member", store.targetsByEventID[event.ID][1].DeviceIdentifier)
+			assert.Equal(t, models.TargetStatePending, store.targetsByEventID[event.ID][1].State)
+		})
+	}
+}
+
+func TestObserveActiveAdvancesTopologyRestoreBeforeAdmissionPreflight(t *testing.T) {
+	store, event := topologyAdmissionTestFixture(topologyAdmissionTestBuildingScope)
+	store.topologyCoverageErr = errors.New("topology unavailable")
+	target := &models.Target{
+		CurtailmentEventID: event.ID,
+		DeviceIdentifier:   "departed-miner",
+		State:              models.TargetStatePending,
+		DesiredState:       models.DesiredStateActive,
+		RestorePhase: &models.TargetPhaseSummary{
+			Phase: models.TargetPhaseRestore,
+			State: models.TargetStatePending,
+		},
+	}
+	store.targetsByEventID[event.ID] = []*models.Target{target}
+	dispatcher := &fakeDispatcher{}
+	r := newReconcilerForTest(store, dispatcher)
+
+	r.observeActive(t.Context(), event)
+
+	assert.Equal(t, 1, dispatcher.uncurtailCalls)
+	assert.Equal(t, []string{target.DeviceIdentifier}, dispatcher.uncurtailLastIDs)
+	assert.Equal(t, models.TargetStateDispatched, target.State)
+	assert.Zero(t, dispatcher.curtailCalls)
+}
+
+func TestDriveTopologyRestoresRetriesFailedAllPairedObligationAfterRepair(t *testing.T) {
+	store, event := topologyAdmissionTestFixture(topologyAdmissionTestBuildingScope)
+	event.ForceIncludeAllPairedMiners = true
+	store.topologyDispatchMembers = []string{}
+	driver := "antminer"
+	target := &models.Target{
+		CurtailmentEventID: event.ID,
+		DeviceIdentifier:   "departed-miner",
+		State:              models.TargetStateRestoreFailed,
+		DesiredState:       models.DesiredStateActive,
+		RetryCount:         10,
+		RestorePhase: &models.TargetPhaseSummary{
+			Phase:      models.TargetPhaseRestore,
+			State:      models.TargetStateRestoreFailed,
+			RetryCount: 10,
+		},
+	}
+	store.targetsByEventID[event.ID] = []*models.Target{target}
+	store.candidates = []*models.Candidate{{
+		DeviceIdentifier: target.DeviceIdentifier,
+		DriverName:       &driver,
+		DeviceStatus:     "ACTIVE",
+		PairingStatus:    "UNPAIRED",
+	}}
+	dispatcher := &fakeDispatcher{}
+	r := newReconcilerForTest(store, dispatcher)
+
+	assert.False(t, r.driveTopologyRestores(t.Context(), event, store.targetsByEventID[event.ID]))
+	assert.Equal(t, models.TargetStateUnavailable, target.State)
+	assert.Zero(t, dispatcher.uncurtailCalls)
+
+	store.candidates[0].PairingStatus = "PAIRED"
+	store.candidates[0].DeviceStatus = "INACTIVE"
+	assert.True(t, r.driveTopologyRestores(t.Context(), event, store.targetsByEventID[event.ID]))
+	assert.Equal(t, int32(0), target.RetryCount)
+	assert.Equal(t, models.TargetStateDispatched, target.State)
+	assert.Equal(t, 1, dispatcher.uncurtailCalls)
+	assert.Equal(t, []string{target.DeviceIdentifier}, dispatcher.uncurtailLastIDs)
+}
+
+func TestDriveTopologyRestoresParksMinerThatUnpairsDuringDispatch(t *testing.T) {
+	store, event := topologyAdmissionTestFixture(topologyAdmissionTestBuildingScope)
+	event.ForceIncludeAllPairedMiners = true
+	store.topologyDispatchMembers = []string{}
+	driver := "antminer"
+	target := &models.Target{
+		CurtailmentEventID: event.ID,
+		DeviceIdentifier:   "departed-miner",
+		State:              models.TargetStatePending,
+		DesiredState:       models.DesiredStateActive,
+		RetryCount:         2,
+		RestorePhase: &models.TargetPhaseSummary{
+			Phase:      models.TargetPhaseRestore,
+			State:      models.TargetStatePending,
+			RetryCount: 2,
+		},
+	}
+	store.targetsByEventID[event.ID] = []*models.Target{target}
+	store.candidates = []*models.Candidate{{
+		DeviceIdentifier: target.DeviceIdentifier,
+		DriverName:       &driver,
+		DeviceStatus:     "INACTIVE",
+		PairingStatus:    "PAIRED",
+	}}
+	dispatcher := &fakeDispatcher{
+		uncurtailResultOverride: &command.CommandResult{},
+	}
+	dispatcher.uncurtailHook = func(_ []string) {
+		store.candidates[0].PairingStatus = "UNPAIRED"
+	}
+	r := newReconcilerForTest(store, dispatcher)
+
+	assert.False(t, r.driveTopologyRestores(t.Context(), event, store.targetsByEventID[event.ID]))
+	assert.Equal(t, models.TargetStateUnavailable, target.State)
+	assert.Equal(t, int32(2), target.RetryCount)
+
+	dispatcher.uncurtailHook = nil
+	dispatcher.uncurtailResultOverride = nil
+	store.candidates[0].PairingStatus = "PAIRED"
+	assert.True(t, r.driveTopologyRestores(t.Context(), event, store.targetsByEventID[event.ID]))
+	assert.Equal(t, models.TargetStateDispatched, target.State)
+	assert.Equal(t, int32(0), target.RetryCount)
+	assert.Equal(t, 2, dispatcher.uncurtailCalls)
+}
+
+func TestDriveTopologyRestoresParksDispatchedMinerThatBecomesUnpaired(t *testing.T) {
+	store, event := topologyAdmissionTestFixture(topologyAdmissionTestBuildingScope)
+	event.ForceIncludeAllPairedMiners = true
+	target := &models.Target{
+		CurtailmentEventID: event.ID,
+		DeviceIdentifier:   "departed-miner",
+		State:              models.TargetStateDispatched,
+		DesiredState:       models.DesiredStateActive,
+		RetryCount:         2,
+		RestorePhase: &models.TargetPhaseSummary{
+			Phase:      models.TargetPhaseRestore,
+			State:      models.TargetStateDispatched,
+			RetryCount: 2,
+		},
+	}
+	store.targetsByEventID[event.ID] = []*models.Target{target}
+	store.candidates = []*models.Candidate{{
+		DeviceIdentifier: target.DeviceIdentifier,
+		DeviceStatus:     "INACTIVE",
+		PairingStatus:    "UNPAIRED",
+	}}
+	r := newReconcilerForTest(store, &fakeDispatcher{})
+
+	assert.False(t, r.driveTopologyRestores(t.Context(), event, store.targetsByEventID[event.ID]))
+	assert.Equal(t, models.TargetStateUnavailable, target.State)
+	assert.Equal(t, int32(2), target.RetryCount)
+}
+
+func TestClaimClosedLoopFullFleetTargetsReadmitsRestoredTopologyMember(t *testing.T) {
+	store, event := topologyAdmissionTestFixture(topologyAdmissionTestBuildingScope)
+	store.targetsByEventID[event.ID] = []*models.Target{{
+		CurtailmentEventID: event.ID,
+		DeviceIdentifier:   "returning-miner",
+		State:              models.TargetStateResolved,
+		DesiredState:       models.DesiredStateActive,
+	}}
+	driver := "antminer"
+	now := time.Now()
+	store.candidates = []*models.Candidate{{
+		DeviceIdentifier: "returning-miner",
+		DriverName:       &driver,
+		DeviceStatus:     "ACTIVE",
+		PairingStatus:    "PAIRED",
+		LatestMetricsAt:  &now,
+		LatestPowerW:     ptrFloat64(3000),
+		LatestHashRateHS: ptrFloat64(100),
+	}}
+	r := newReconcilerForTest(
+		store,
+		&fakeDispatcher{},
+		WithDispatchPermissionResolver(staticDispatchPermissionResolver{
+			effective: topologyDispatchManagePermission(),
+		}),
+	)
+
+	claimed, _ := r.claimClosedLoopFullFleetTargets(t.Context(), event, store.targetsByEventID[event.ID])
+
+	require.Len(t, claimed, 1)
+	assert.Equal(t, "returning-miner", claimed[0].DeviceIdentifier)
+	assert.Equal(t, models.DesiredStateCurtailed, claimed[0].DesiredState)
+	assert.Equal(t, models.TargetStateDispatching, claimed[0].State)
+}
+
+func TestClaimClosedLoopFullFleetTargetsReadmitsRestoreFailedTopologyMember(t *testing.T) {
+	for _, allPaired := range []bool{false, true} {
+		name := "selected miners"
+		if allPaired {
+			name = "all paired miners"
+		}
+		t.Run(name, func(t *testing.T) {
+			store, event := topologyAdmissionTestFixture(topologyAdmissionTestBuildingScope)
+			event.ForceIncludeAllPairedMiners = allPaired
+			store.targetsByEventID[event.ID] = []*models.Target{{
+				CurtailmentEventID: event.ID,
+				DeviceIdentifier:   "returning-miner",
+				State:              models.TargetStateRestoreFailed,
+				DesiredState:       models.DesiredStateActive,
+				RestorePhase: &models.TargetPhaseSummary{
+					Phase: models.TargetPhaseRestore,
+					State: models.TargetStateRestoreFailed,
+				},
+			}}
+			driver := "antminer"
+			now := time.Now()
+			store.candidates = []*models.Candidate{{
+				DeviceIdentifier: "returning-miner",
+				DriverName:       &driver,
+				DeviceStatus:     "ACTIVE",
+				PairingStatus:    "PAIRED",
+				LatestMetricsAt:  &now,
+				LatestPowerW:     ptrFloat64(3000),
+				LatestHashRateHS: ptrFloat64(100),
+			}}
+			r := newReconcilerForTest(
+				store,
+				&fakeDispatcher{},
+				WithDispatchPermissionResolver(staticDispatchPermissionResolver{
+					effective: topologyDispatchManagePermission(),
+				}),
+			)
+
+			claimed, _ := r.claimClosedLoopFullFleetTargets(t.Context(), event, store.targetsByEventID[event.ID])
+
+			target := store.targetsByEventID[event.ID][0]
+			assert.Equal(t, models.DesiredStateCurtailed, target.DesiredState)
+			assert.Nil(t, target.RestorePhase)
+			if allPaired {
+				assert.Empty(t, claimed)
+				assert.Equal(t, 1, store.claimAllPairedCalls)
+				assert.Equal(t, models.TargetStatePending, target.State)
+			} else {
+				require.Len(t, claimed, 1)
+				assert.Equal(t, 1, store.claimTargetsCalls)
+				assert.Equal(t, models.TargetStateDispatching, target.State)
+			}
+		})
+	}
+}
+
+func TestClaimClosedLoopFullFleetTargetsHandlesTopologyAdmissionFailure(t *testing.T) {
+	outsideEnvelope := interfaces.CurtailmentTopologyScopeCoverage{
+		SelectedResourceSiteIDs: []int64{8},
+	}
+	tests := []struct {
+		name                  string
+		coverage              *interfaces.CurtailmentTopologyScopeCoverage
+		resolveErr            error
+		permissions           DispatchPermissionResolver
+		configure             func(*fakeStore, *models.Event)
+		requiresAdminControls bool
+		wantRestoreCalls      int
+	}{
+		{
+			name:             "restores when topology exceeds envelope",
+			coverage:         &outsideEnvelope,
+			wantRestoreCalls: 1,
+		},
+		{
+			name:             "restores when topology resource is gone",
+			resolveErr:       fleeterror.NewNotFoundError("building not found"),
+			wantRestoreCalls: 1,
+		},
+		{
+			name:             "restores when topology exceeds miner limit",
+			resolveErr:       fleeterror.NewResourceExhaustedErrorf("scope resolves to too many miners"),
+			wantRestoreCalls: 1,
+		},
+		{
+			name:       "defers transient topology failure",
+			resolveErr: errors.New("database unavailable"),
+		},
+		{
+			name:             "restores when creator permission is revoked",
+			permissions:      staticDispatchPermissionResolver{effective: authz.NewEffectivePermissions(nil)},
+			wantRestoreCalls: 1,
+		},
+		{
+			name:                  "restores when admin-only event creator is demoted",
+			permissions:           staticDispatchPermissionResolver{effective: topologyDispatchManagePermission(), roleName: "CUSTOM"},
+			requiresAdminControls: true,
+			wantRestoreCalls:      1,
+		},
+		{
+			name:        "restores after update raises restore interval and creator is demoted",
+			permissions: staticDispatchPermissionResolver{effective: topologyDispatchManagePermission(), roleName: "CUSTOM"},
+			configure: func(_ *fakeStore, event *models.Event) {
+				event.RestoreBatchIntervalSec = int32((6 * time.Minute) / time.Second)
+			},
+			wantRestoreCalls: 1,
+		},
+		{
+			name:        "restores after update raises max duration and creator is demoted",
+			permissions: staticDispatchPermissionResolver{effective: topologyDispatchManagePermission(), roleName: "CUSTOM"},
+			configure: func(store *fakeStore, event *models.Event) {
+				store.orgConfig = &models.OrgConfig{OrgID: event.OrgID, MaxDurationDefaultSec: 100}
+				maxDurationSeconds := int32(101)
+				event.MaxDurationSeconds = &maxDurationSeconds
+			},
+			wantRestoreCalls: 1,
+		},
+		{
+			name:                  "defers transient role failure",
+			permissions:           staticDispatchPermissionResolver{effective: topologyDispatchManagePermission(), roleErr: errors.New("role database unavailable")},
+			requiresAdminControls: true,
+		},
+		{
+			name:        "defers transient permission failure",
+			permissions: staticDispatchPermissionResolver{err: errors.New("permission database unavailable")},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store, event := topologyAdmissionTestFixture(topologyAdmissionTestBuildingScope)
+			if tt.requiresAdminControls {
+				event.DecisionSnapshotJSON = []byte(`{"requires_admin_controls":true}`)
+			}
+			if tt.configure != nil {
+				tt.configure(store, event)
+			}
+			if tt.coverage != nil {
+				store.topologyCoverage = *tt.coverage
+			}
+			store.topologyCoverageErr = tt.resolveErr
+			permissions := tt.permissions
+			if permissions == nil {
+				permissions = staticDispatchPermissionResolver{effective: topologyDispatchManagePermission()}
+			}
+
+			r := newReconcilerForTest(
+				store,
+				&fakeDispatcher{},
+				WithDispatchPermissionResolver(permissions),
+			)
+			claimed, _ := r.claimClosedLoopFullFleetTargets(t.Context(), event, nil)
+
+			assert.Empty(t, claimed)
+			assert.Equal(t, 0, store.listCandidatesCalls)
+			assert.Equal(t, tt.wantRestoreCalls, store.beginRestoreCalls)
+		})
+	}
 }
 
 func TestReconciler_DispatchingFailureDoesNotRetryAgainAsPendingInSameTick(t *testing.T) {
@@ -3081,6 +3937,40 @@ func TestReconciler_DispatchingFailureDoesNotRetryAgainAsPendingInSameTick(t *te
 		"failed DISPATCHING recovery must consume only one retry slot per tick")
 	require.NotNil(t, final.LastError)
 	assert.Contains(t, *final.LastError, "queue unavailable")
+}
+
+func TestDispatchPendingCurtailBatchesSkipsRestoreDirectionTargets(t *testing.T) {
+	store := newFakeStore()
+	dispatcher := &fakeDispatcher{}
+	event := &models.Event{
+		ID:        10,
+		EventUUID: uuid.New(),
+		OrgID:     1,
+		State:     models.EventStateActive,
+	}
+	curtailTarget := &models.Target{
+		CurtailmentEventID: event.ID,
+		DeviceIdentifier:   "curtail-miner",
+		State:              models.TargetStatePending,
+		DesiredState:       models.DesiredStateCurtailed,
+	}
+	restoreTarget := &models.Target{
+		CurtailmentEventID: event.ID,
+		DeviceIdentifier:   "restore-miner",
+		State:              models.TargetStatePending,
+		DesiredState:       models.DesiredStateActive,
+	}
+	targets := []*models.Target{curtailTarget, restoreTarget}
+	store.events = []*models.Event{event}
+	store.targetsByEventID[event.ID] = targets
+	r := newReconcilerForTest(store, dispatcher)
+
+	r.dispatchPendingCurtailBatches(t.Context(), event, targets)
+
+	assert.Equal(t, 1, dispatcher.curtailCalls)
+	assert.Equal(t, []string{curtailTarget.DeviceIdentifier}, dispatcher.curtailLastIDs)
+	assert.Equal(t, models.TargetStateDispatched, curtailTarget.State)
+	assert.Equal(t, models.TargetStatePending, restoreTarget.State)
 }
 
 func TestReconciler_CurtailBatchRecordsSkippedAndNotEnqueuedFailures(t *testing.T) {

--- a/server/internal/domain/curtailment/reconciler/reconciler_test.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler_test.go
@@ -3306,6 +3306,31 @@ func TestReconcileClosedLoopTopologyDeparturesRestoresUnpairedOwnedMiner(t *test
 	assert.Equal(t, models.TargetStatePending, target.State)
 }
 
+func TestReconcileClosedLoopTopologyDeparturesRestoresUnpairedOwnedMinerWithoutAllPairedPolicy(t *testing.T) {
+	store, event := topologyAdmissionTestFixture(topologyAdmissionTestBuildingScope)
+	target := &models.Target{
+		CurtailmentEventID: event.ID,
+		DeviceIdentifier:   "unpaired-miner",
+		State:              models.TargetStateConfirmed,
+		DesiredState:       models.DesiredStateCurtailed,
+	}
+	store.targetsByEventID[event.ID] = []*models.Target{target}
+	reconciler := newReconcilerForTest(store, &fakeDispatcher{})
+
+	departures, ok := reconciler.reconcileClosedLoopTopologyDepartures(
+		t.Context(),
+		event,
+		store.targetsByEventID[event.ID],
+		[]*models.Candidate{{DeviceIdentifier: target.DeviceIdentifier, PairingStatus: "UNPAIRED"}},
+	)
+
+	assert.True(t, ok)
+	assert.True(t, departures)
+	assert.Equal(t, []string{target.DeviceIdentifier}, store.topologyRestoreDevices)
+	assert.Equal(t, models.DesiredStateActive, target.DesiredState)
+	assert.Equal(t, models.TargetStatePending, target.State)
+}
+
 func TestDriveTopologyRestoresCompletesWhileEventIsPending(t *testing.T) {
 	store := newFakeStore()
 	event := &models.Event{

--- a/server/internal/domain/curtailment/reconciler/restore_test.go
+++ b/server/internal/domain/curtailment/reconciler/restore_test.go
@@ -568,6 +568,74 @@ func TestReconciler_Restoring_UncurtailErrorKeepsBatchPending(t *testing.T) {
 	}
 }
 
+func TestDispatchRestoreBatchDoesNotOverwriteConcurrentStateAdvance(t *testing.T) {
+	store := newFakeStore()
+	dispatcher := &fakeDispatcher{}
+	event := &models.Event{
+		ID:        81,
+		EventUUID: uuid.New(),
+		OrgID:     1,
+		State:     models.EventStateRestoring,
+	}
+	target := &models.Target{
+		CurtailmentEventID: event.ID,
+		DeviceIdentifier:   "m1",
+		State:              models.TargetStatePending,
+		DesiredState:       models.DesiredStateActive,
+	}
+	store.events = []*models.Event{event}
+	store.targetsByEventID[event.ID] = []*models.Target{target}
+	store.updateTargetStateHook = func(_ string, params interfaces.UpdateCurtailmentTargetStateParams, _ int) error {
+		if params.State == models.TargetStateDispatching {
+			target.State = models.TargetStateResolved
+		}
+		return nil
+	}
+	r := newReconcilerForTest(store, dispatcher)
+
+	r.dispatchRestoreBatch(t.Context(), event, []*models.Target{target})
+
+	assert.Equal(t, models.TargetStateResolved, target.State)
+	assert.Zero(t, dispatcher.uncurtailCalls)
+	params := store.updateTargetParams[target.DeviceIdentifier]
+	require.NotNil(t, params.ExpectedState)
+	assert.Equal(t, models.TargetStatePending, *params.ExpectedState)
+}
+
+func TestRecordRestoreDispatchFailuresDoesNotOverwriteConcurrentStateAdvance(t *testing.T) {
+	store, event := topologyAdmissionTestFixture(topologyAdmissionTestBuildingScope)
+	event.ForceIncludeAllPairedMiners = true
+	driver := "antminer"
+	target := &models.Target{
+		CurtailmentEventID: event.ID,
+		DeviceIdentifier:   "m1",
+		State:              models.TargetStateDispatching,
+		DesiredState:       models.DesiredStateActive,
+	}
+	store.targetsByEventID[event.ID] = []*models.Target{target}
+	store.candidates = []*models.Candidate{{
+		DeviceIdentifier: target.DeviceIdentifier,
+		DriverName:       &driver,
+		DeviceStatus:     "INACTIVE",
+		PairingStatus:    "PAIRED",
+	}}
+	store.listCandidatesHook = func() {
+		target.State = models.TargetStateDispatched
+	}
+	r := newReconcilerForTest(store, &fakeDispatcher{})
+
+	r.recordRestoreDispatchFailures(t.Context(), event, []restoreDispatchFailure{{
+		target: target,
+		reason: "queue down",
+	}})
+
+	assert.Equal(t, models.TargetStateDispatched, target.State)
+	assert.Zero(t, target.RetryCount)
+	params := store.updateTargetParams[target.DeviceIdentifier]
+	require.NotNil(t, params.ExpectedState)
+	assert.Equal(t, models.TargetStateDispatching, *params.ExpectedState)
+}
+
 // A non-race-loss pre-write failure drops one target from the batch
 // (remaining devices proceed) and burns one retry slot so persistent
 // failures escalate to RESTORE_FAILED instead of cycling.

--- a/server/internal/domain/curtailment/selector.go
+++ b/server/internal/domain/curtailment/selector.go
@@ -255,6 +255,7 @@ func BuildPlan(
 
 const (
 	allPairedUnavailableAuthenticationNeeded = "authentication_needed"
+	allPairedUnavailableUnpaired             = "unpaired"
 	allPairedUnavailableNoDriver             = "no_driver"
 	allPairedUnavailableMissingStatus        = "missing_status"
 	allPairedUnavailableOffline              = "offline"
@@ -271,10 +272,11 @@ const (
 	allPairedUnavailableStaleTelemetry = "stale_telemetry"
 )
 
-// deviceStatusNeedsMiningPool is the device_status_enum value for a reachable
-// miner with no pool configured. Referenced by both admission classifiers and
-// the status-authoritative hash override below.
-const deviceStatusNeedsMiningPool = "NEEDS_MINING_POOL"
+const (
+	deviceStatusNeedsMiningPool       = "NEEDS_MINING_POOL"
+	deviceStatusInactive              = "INACTIVE"
+	pairingStatusAuthenticationNeeded = "AUTHENTICATION_NEEDED"
+)
 
 // statusAuthoritativeHashRateHS returns the hash sample to use for selection
 // accounting and baseline-persistence decisions. Device status is
@@ -375,7 +377,7 @@ func AllPairedPolicyTargetState(c *models.Candidate, includeMaintenance bool) (m
 	if c == nil {
 		return models.TargetStateUnavailable, allPairedUnavailableMissingStatus
 	}
-	if c.PairingStatus == "AUTHENTICATION_NEEDED" {
+	if c.PairingStatus == pairingStatusAuthenticationNeeded {
 		return models.TargetStateUnavailable, allPairedUnavailableAuthenticationNeeded
 	}
 	if c.DriverName == nil || *c.DriverName == "" {
@@ -390,7 +392,7 @@ func AllPairedPolicyTargetState(c *models.Candidate, includeMaintenance bool) (m
 		return models.TargetStateUnavailable, allPairedUnavailableUpdating
 	case "REBOOT_REQUIRED":
 		return models.TargetStateUnavailable, allPairedUnavailableRebootRequired
-	case "INACTIVE", "ERROR", "UNKNOWN":
+	case deviceStatusInactive, "ERROR", "UNKNOWN":
 		return models.TargetStateUnavailable, allPairedUnavailableNonActionableStatus
 	case deviceStatusNeedsMiningPool:
 		// Commandable (#663), but only dispatchable once a positive power
@@ -414,11 +416,35 @@ func AllPairedPolicyTargetState(c *models.Candidate, includeMaintenance bool) (m
 
 func IsAllPairedPolicyPairingStatus(status string) bool {
 	switch status {
-	case "PAIRED", "DEFAULT_PASSWORD", "AUTHENTICATION_NEEDED":
+	case "PAIRED", "DEFAULT_PASSWORD", pairingStatusAuthenticationNeeded:
 		return true
 	default:
 		return false
 	}
+}
+
+// AllPairedPolicyRestoreTargetState classifies whether a topology restore
+// obligation can currently receive an Uncurtail command. INACTIVE is
+// intentionally commandable here: unlike curtail admission, this row proves
+// the policy previously put the miner to sleep and now owes the wake-up.
+func AllPairedPolicyRestoreTargetState(c *models.Candidate) (models.TargetState, string) {
+	if c == nil {
+		return models.TargetStateUnavailable, allPairedUnavailableMissingStatus
+	}
+	switch c.PairingStatus {
+	case "PAIRED", "DEFAULT_PASSWORD":
+	case pairingStatusAuthenticationNeeded:
+		return models.TargetStateUnavailable, allPairedUnavailableAuthenticationNeeded
+	default:
+		return models.TargetStateUnavailable, allPairedUnavailableUnpaired
+	}
+	if c.DriverName == nil || *c.DriverName == "" {
+		return models.TargetStateUnavailable, allPairedUnavailableNoDriver
+	}
+	if c.DeviceStatus == deviceStatusInactive {
+		return models.TargetStatePending, ""
+	}
+	return AllPairedPolicyTargetState(c, true)
 }
 
 // AllPairedPromotionBaselinePowerW returns the pre-curtail baseline to

--- a/server/internal/domain/curtailment/selector.go
+++ b/server/internal/domain/curtailment/selector.go
@@ -441,7 +441,7 @@ func AllPairedPolicyRestoreTargetState(c *models.Candidate) (models.TargetState,
 	if c.DriverName == nil || *c.DriverName == "" {
 		return models.TargetStateUnavailable, allPairedUnavailableNoDriver
 	}
-	if c.DeviceStatus == deviceStatusInactive {
+	if c.DeviceStatus == deviceStatusInactive || c.DeviceStatus == deviceStatusNeedsMiningPool {
 		return models.TargetStatePending, ""
 	}
 	return AllPairedPolicyTargetState(c, true)

--- a/server/internal/domain/curtailment/selector_test.go
+++ b/server/internal/domain/curtailment/selector_test.go
@@ -332,6 +332,16 @@ func TestAllPairedPolicyRestoreTargetState_WakesOwnedInactiveMinerAfterRepair(t 
 	assert.Empty(t, reason)
 }
 
+func TestAllPairedPolicyRestoreTargetState_WakesOwnedPoolLessMinerAtZeroPower(t *testing.T) {
+	t.Parallel()
+
+	candidate := miner("restore-owned", "NEEDS_MINING_POOL", "PAIRED", 0, 0)
+	state, reason := AllPairedPolicyRestoreTargetState(candidate)
+
+	assert.Equal(t, models.TargetStatePending, state)
+	assert.Empty(t, reason)
+}
+
 // Device status is authoritative over a stale-positive hash sample: a
 // pool-less miner cannot be mining, so selection accounting and the baseline
 // min-power floor must treat it as non-hashing even when the latest hash

--- a/server/internal/domain/curtailment/selector_test.go
+++ b/server/internal/domain/curtailment/selector_test.go
@@ -318,6 +318,20 @@ func TestAllPairedPolicyTargetState_PoolLessRequiresPositivePowerSample(t *testi
 	assert.Empty(t, reason)
 }
 
+func TestAllPairedPolicyRestoreTargetState_WakesOwnedInactiveMinerAfterRepair(t *testing.T) {
+	t.Parallel()
+
+	candidate := miner("restore-owned", "INACTIVE", "UNPAIRED", 0, 0)
+	state, reason := AllPairedPolicyRestoreTargetState(candidate)
+	assert.Equal(t, models.TargetStateUnavailable, state)
+	assert.Equal(t, "unpaired", reason)
+
+	candidate.PairingStatus = "PAIRED"
+	state, reason = AllPairedPolicyRestoreTargetState(candidate)
+	assert.Equal(t, models.TargetStatePending, state)
+	assert.Empty(t, reason)
+}
+
 // Device status is authoritative over a stale-positive hash sample: a
 // pool-less miner cannot be mining, so selection accounting and the baseline
 // min-power floor must treat it as non-hashing even when the latest hash

--- a/server/internal/domain/curtailment/service.go
+++ b/server/internal/domain/curtailment/service.go
@@ -202,11 +202,6 @@ func (s *Service) Start(ctx context.Context, req StartRequest) (*Plan, error) {
 			"topology-scoped Start is not available for automation",
 		)
 	}
-	if hasTopologySelectors(req.Scope) && req.Mode == models.ModeFullFleet {
-		return nil, fleeterror.NewUnimplementedError(
-			"topology-scoped FULL_FLEET Start requires topology-following lifecycle support",
-		)
-	}
 	req.PostEventCooldownSec = effectivePostEventCooldownSec(req.PreviewRequest)
 
 	// Idempotent-replay lookup: a prior persisted match short-circuits
@@ -291,7 +286,8 @@ func (s *Service) Start(ctx context.Context, req StartRequest) (*Plan, error) {
 	plan.EffectiveCurtailBatchSize = cloneInt32Ptr(req.CurtailBatchSize)
 	plan.EffectiveCurtailBatchIntervalSec = req.CurtailBatchIntervalSec
 
-	eventParams, targetParams, err := buildInsertParams(req, plan, minPowerW)
+	requiresAdminControls := startRequiresAdminControls(req, orgConfig)
+	eventParams, targetParams, err := buildInsertParams(req, plan, minPowerW, requiresAdminControls)
 	if err != nil {
 		return nil, err
 	}
@@ -1596,7 +1592,7 @@ func validatePreviewRequest(req PreviewRequest) error {
 	// and never reclaim them, silently breaking the policy's promise.
 	if req.ForceIncludeAllPairedMiners && !isClosedLoopFullFleetStart(req.Scope, req.Mode) {
 		return fleeterror.NewInvalidArgumentError(
-			"force_include_all_paired_miners requires a whole-org or site scope; explicit miner or device-set scopes are not supported",
+			"force_include_all_paired_miners requires a whole-org, site, building, rack, or group scope; explicit miner scopes are not supported",
 		)
 	}
 	if req.Level != "" && req.Level != models.LevelFull {
@@ -1961,7 +1957,7 @@ func classifyCandidates(cands []*models.Candidate, opts classifyOpts) ([]Candida
 			skipped = append(skipped, SkippedDevice{c.DeviceIdentifier, SkipUnreachableResidualLoad})
 			summary.ExcludedOffline++
 			continue
-		case "INACTIVE":
+		case deviceStatusInactive:
 			// Excluded by design: INACTIVE means the miner is sleeping
 			// (operator- or curtailment-initiated). Curtailing it is a no-op
 			// and restoring it would wake a miner someone deliberately put
@@ -2091,7 +2087,12 @@ const targetTypeMiner = "miner"
 // plan. baseline_power_w comes from the telemetry snapshot the selector
 // ranked against; non-positive PowerW maps to NULL (a zero baseline would
 // produce a misleading "100% reduction" report at restore).
-func buildInsertParams(req StartRequest, plan *Plan, minPowerW int32) (models.InsertEventParams, []models.InsertTargetParams, error) {
+func buildInsertParams(
+	req StartRequest,
+	plan *Plan,
+	minPowerW int32,
+	requiresAdminControls bool,
+) (models.InsertEventParams, []models.InsertTargetParams, error) {
 	scope := normalizeScope(req.Scope)
 	scopeJSON, err := MarshalScopeJSON(scope)
 	if err != nil {
@@ -2113,23 +2114,25 @@ func buildInsertParams(req StartRequest, plan *Plan, minPowerW int32) (models.In
 			)
 		}
 	}
-	decisionJSON, err := marshalDecisionSnapshot(plan, minPowerW, req.PostEventCooldownSec, req.ForceIncludeAllPairedMiners)
+	decisionJSON, err := marshalDecisionSnapshot(
+		plan,
+		minPowerW,
+		req.PostEventCooldownSec,
+		req.ForceIncludeAllPairedMiners,
+		requiresAdminControls,
+	)
 	if err != nil {
 		return models.InsertEventParams{}, nil, err
 	}
 
 	startState := eventStartState(scope, mode, len(plan.Selected))
-	// An all-paired start whose every paired miner is currently unavailable
-	// holds in pending: closed-loop full-fleet starts otherwise insert as
-	// ACTIVE with started_at stamped, so observeActive would enforce
-	// max_duration_seconds before a single Curtail could be dispatched and
-	// the forced restore would release the never-dispatched policy rows —
-	// dropping durable ownership having curtailed nothing. The reconciler
-	// promotes the event to active (stamping started_at) once a target
-	// confirms; readiness refresh and admission both run during pending.
+	// An all-paired start with no currently owned miner, or whose every owned
+	// miner is unavailable, holds in pending. Otherwise max_duration_seconds
+	// could expire before a single Curtail is dispatched, dropping durable
+	// ownership having curtailed nothing. The reconciler promotes the event
+	// once a target confirms; readiness refresh and admission run while pending.
 	if req.ForceIncludeAllPairedMiners &&
-		len(plan.Selected) > 0 &&
-		plan.UnavailableTargetCount == len(plan.Selected) {
+		(len(plan.Selected) == 0 || plan.UnavailableTargetCount == len(plan.Selected)) {
 		startState = models.EventStatePending
 	}
 
@@ -2300,6 +2303,9 @@ func isClosedLoopFullFleetStart(scope Scope, mode models.Mode) bool {
 	scope = normalizeScope(scope)
 	if mode != models.ModeFullFleet {
 		return false
+	}
+	if IsTopologyScope(scope) {
+		return true
 	}
 	switch scope.Type {
 	case models.ScopeTypeWholeOrg, models.ScopeTypeSite:
@@ -2555,7 +2561,13 @@ func cloneInt32Ptr(v *int32) *int32 {
 // marshalDecisionSnapshot captures the selector outputs for the
 // decision_snapshot column (rejection counters, realized vs. requested
 // kW, resolved candidate floor).
-func marshalDecisionSnapshot(plan *Plan, minPowerW int32, postEventCooldownSec int32, forceIncludeAllPairedMiners bool) ([]byte, error) {
+func marshalDecisionSnapshot(
+	plan *Plan,
+	minPowerW int32,
+	postEventCooldownSec int32,
+	forceIncludeAllPairedMiners bool,
+	requiresAdminControls bool,
+) ([]byte, error) {
 	skipped := make([]map[string]string, len(plan.Skipped))
 	for i, s := range plan.Skipped {
 		skipped[i] = map[string]string{
@@ -2572,6 +2584,7 @@ func marshalDecisionSnapshot(plan *Plan, minPowerW int32, postEventCooldownSec i
 		"policy_target_count":             plan.PolicyTargetCount,
 		"unavailable_target_count":        plan.UnavailableTargetCount,
 		"force_include_all_paired_miners": forceIncludeAllPairedMiners,
+		"requires_admin_controls":         requiresAdminControls,
 		"skipped":                         skipped,
 	}
 	b, err := json.Marshal(snapshot)
@@ -2581,4 +2594,42 @@ func marshalDecisionSnapshot(plan *Plan, minPowerW int32, postEventCooldownSec i
 		)
 	}
 	return b, nil
+}
+
+func startRequiresAdminControls(req StartRequest, orgConfig *models.OrgConfig) bool {
+	if req.AllowUnbounded || req.CandidateMinPowerWOverride != nil ||
+		req.ForceIncludeMaintenance || req.ForceIncludeAllPairedMiners ||
+		req.CurtailBatchIntervalSec > nonAdminRestoreBatchIntervalMax ||
+		req.RestoreBatchIntervalSec > nonAdminRestoreBatchIntervalMax {
+		return true
+	}
+	return req.MaxDurationSeconds != nil && orgConfig != nil &&
+		orgConfig.MaxDurationDefaultSec > 0 && *req.MaxDurationSeconds > orgConfig.MaxDurationDefaultSec
+}
+
+// EventRequiresAdminControls combines the immutable Start-time marker with
+// controls that an operator may change while an event is pending or active.
+// Comparing max duration with the current organization default mirrors the
+// Update gate and prevents a later role demotion from authorizing new members.
+func EventRequiresAdminControls(ev *models.Event, orgConfig *models.OrgConfig) (bool, error) {
+	if ev == nil {
+		return false, nil
+	}
+	if ev.AllowUnbounded || ev.ForceIncludeMaintenance || ev.ForceIncludeAllPairedMiners ||
+		ev.CurtailBatchIntervalSec > nonAdminRestoreBatchIntervalMax ||
+		ev.RestoreBatchIntervalSec > nonAdminRestoreBatchIntervalMax ||
+		(ev.MaxDurationSeconds != nil && orgConfig != nil && orgConfig.MaxDurationDefaultSec > 0 &&
+			*ev.MaxDurationSeconds > orgConfig.MaxDurationDefaultSec) {
+		return true, nil
+	}
+	if len(ev.DecisionSnapshotJSON) == 0 {
+		return false, nil
+	}
+	var snapshot struct {
+		RequiresAdminControls bool `json:"requires_admin_controls"`
+	}
+	if err := json.Unmarshal(ev.DecisionSnapshotJSON, &snapshot); err != nil {
+		return false, fmt.Errorf("parse decision snapshot admin marker: %w", err)
+	}
+	return snapshot.RequiresAdminControls, nil
 }

--- a/server/internal/domain/curtailment/service_start_fullfleet_test.go
+++ b/server/internal/domain/curtailment/service_start_fullfleet_test.go
@@ -139,11 +139,13 @@ func TestService_Start_FullFleet_AllPairedPersistsPolicyTargetsImmediately(t *te
 
 	var snapshot struct {
 		ForceIncludeAllPairedMiners bool `json:"force_include_all_paired_miners"`
+		RequiresAdminControls       bool `json:"requires_admin_controls"`
 		PolicyTargetCount           int  `json:"policy_target_count"`
 		UnavailableTargetCount      int  `json:"unavailable_target_count"`
 	}
 	require.NoError(t, json.Unmarshal(store.lastInsertEvent.DecisionSnapshotJSON, &snapshot))
 	assert.True(t, snapshot.ForceIncludeAllPairedMiners)
+	assert.True(t, snapshot.RequiresAdminControls)
 	assert.Equal(t, 3, snapshot.PolicyTargetCount)
 	assert.Equal(t, 2, snapshot.UnavailableTargetCount)
 }
@@ -256,10 +258,12 @@ func TestService_Start_FullFleet_AllPairedBypassesPostEventCooldown(t *testing.T
 	var snapshot struct {
 		PostEventCooldownSec        int32 `json:"post_event_cooldown_sec"`
 		ForceIncludeAllPairedMiners bool  `json:"force_include_all_paired_miners"`
+		RequiresAdminControls       bool  `json:"requires_admin_controls"`
 	}
 	require.NoError(t, json.Unmarshal(store.lastInsertEvent.DecisionSnapshotJSON, &snapshot))
 	assert.Equal(t, int32(600), snapshot.PostEventCooldownSec)
 	assert.True(t, snapshot.ForceIncludeAllPairedMiners)
+	assert.True(t, snapshot.RequiresAdminControls)
 }
 
 func TestService_Preview_FullFleet_SkipsMissingTelemetrySamples(t *testing.T) {

--- a/server/internal/domain/curtailment/service_start_test.go
+++ b/server/internal/domain/curtailment/service_start_test.go
@@ -54,7 +54,7 @@ func TestService_Start_RejectsEmptyReason(t *testing.T) {
 	}
 }
 
-func TestService_Start_TopologyScopesFreezeSelectedTargets(t *testing.T) {
+func TestService_Start_FixedKWTopologyScopesFreezeSelectedTargets(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range []struct {
@@ -123,25 +123,113 @@ func TestService_Start_TopologyScopesFreezeSelectedTargets(t *testing.T) {
 	}
 }
 
-func TestService_Start_RejectsTopologyFullFleetUntilLifecycleLands(t *testing.T) {
+func TestService_Start_TopologyFullFleetStartsClosedLoopWithoutFrozenTargets(t *testing.T) {
 	t.Parallel()
 
-	store := newFakeStore()
-	svc := NewService(store)
-	req := validStartRequest(1)
-	req.Scope = Scope{
-		SchemaVersion: ScopeSchemaVersionCurrent,
-		BuildingIDs:   []int64{7},
+	for _, tc := range []struct {
+		name  string
+		scope Scope
+		seed  func(*fakeStore, int64, *models.Candidate)
+	}{
+		{
+			name:  "building",
+			scope: Scope{SchemaVersion: ScopeSchemaVersionCurrent, BuildingIDs: []int64{7}},
+			seed: func(store *fakeStore, orgID int64, candidate *models.Candidate) {
+				store.candidatesByBuilding[orgID] = map[int64][]*models.Candidate{7: {candidate}}
+			},
+		},
+		{
+			name:  "rack",
+			scope: Scope{SchemaVersion: ScopeSchemaVersionCurrent, RackIDs: []int64{8}},
+			seed: func(store *fakeStore, orgID int64, candidate *models.Candidate) {
+				store.candidatesByRack[orgID] = map[int64][]*models.Candidate{8: {candidate}}
+			},
+		},
+		{
+			name:  "group",
+			scope: Scope{SchemaVersion: ScopeSchemaVersionCurrent, GroupIDs: []int64{9}},
+			seed: func(store *fakeStore, orgID int64, candidate *models.Candidate) {
+				store.candidatesByGroup[orgID] = map[int64][]*models.Candidate{9: {candidate}}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			const orgID = int64(1)
+			candidate := minerWithEff(tc.name+"-miner", 3000, 100, 30)
+			store := newFakeStore()
+			store.orgConfigByOrg[orgID] = defaultOrgConfig(orgID)
+			store.topologyCoverage = interfaces.CurtailmentTopologyScopeCoverage{SiteIDs: []int64{42}}
+			tc.seed(store, orgID, candidate)
+			svc := NewService(store)
+			req := validStartRequest(orgID)
+			req.Scope = tc.scope
+			req.Mode = models.ModeFullFleet
+			req.TargetKW = 0
+
+			plan, err := svc.Start(t.Context(), req)
+
+			require.NoError(t, err)
+			require.Len(t, plan.Selected, 1)
+			assert.Equal(t, models.EventStateActive, store.lastInsertEvent.State)
+			assert.Equal(t, models.LoopTypeClosed, store.lastInsertEvent.LoopType)
+			assert.Empty(t, store.lastInsertTargets)
+		})
 	}
+}
+
+func TestService_Start_AllPairedTopologyFullFleetPersistsPolicyTargets(t *testing.T) {
+	t.Parallel()
+
+	const orgID = int64(1)
+	candidate := minerWithEff("building-miner", 3000, 100, 30)
+	store := newFakeStore()
+	store.orgConfigByOrg[orgID] = defaultOrgConfig(orgID)
+	store.topologyCoverage = interfaces.CurtailmentTopologyScopeCoverage{SiteIDs: []int64{42}}
+	store.candidatesByBuilding[orgID] = map[int64][]*models.Candidate{7: {candidate}}
+	svc := NewService(store)
+	req := validStartRequest(orgID)
+	req.Scope = Scope{SchemaVersion: ScopeSchemaVersionCurrent, BuildingIDs: []int64{7}}
 	req.Mode = models.ModeFullFleet
-	req.TargetKW = 0
+	req.ForceIncludeAllPairedMiners = true
+	req.CanUseAdminControls = true
 
-	_, err := svc.Start(t.Context(), req)
+	plan, err := svc.Start(t.Context(), req)
 
-	require.Error(t, err)
-	assert.True(t, fleeterror.IsUnimplementedError(err))
-	assert.Contains(t, err.Error(), "topology-following lifecycle")
-	assert.Zero(t, store.listCandidatesCalls)
+	require.NoError(t, err)
+	require.Len(t, plan.Selected, 1)
+	assert.Equal(t, models.EventStateActive, store.lastInsertEvent.State)
+	assert.Equal(t, models.LoopTypeClosed, store.lastInsertEvent.LoopType)
+	require.Len(t, store.lastInsertTargets, 1)
+	assert.Equal(t, candidate.DeviceIdentifier, store.lastInsertTargets[0].DeviceIdentifier)
+}
+
+func TestService_Start_EmptyAllPairedTopologyPersistsPendingWatcher(t *testing.T) {
+	t.Parallel()
+
+	const orgID = int64(1)
+	candidate := minerWithEff("unpaired-building-miner", 3000, 100, 30)
+	candidate.PairingStatus = "UNPAIRED"
+	store := newFakeStore()
+	store.orgConfigByOrg[orgID] = defaultOrgConfig(orgID)
+	store.topologyCoverage = interfaces.CurtailmentTopologyScopeCoverage{SiteIDs: []int64{42}}
+	store.candidatesByBuilding[orgID] = map[int64][]*models.Candidate{7: {candidate}}
+	svc := NewService(store)
+	req := validStartRequest(orgID)
+	req.Scope = Scope{SchemaVersion: ScopeSchemaVersionCurrent, BuildingIDs: []int64{7}}
+	req.Mode = models.ModeFullFleet
+	req.ForceIncludeAllPairedMiners = true
+	req.CanUseAdminControls = true
+
+	plan, err := svc.Start(t.Context(), req)
+
+	require.NoError(t, err)
+	assert.Empty(t, plan.Selected)
+	assert.Equal(t, 1, store.insertEventCalls)
+	assert.Equal(t, models.EventStatePending, store.lastInsertEvent.State)
+	assert.Nil(t, store.lastInsertEvent.StartedAt)
+	assert.Empty(t, store.lastInsertTargets)
 }
 
 func TestService_Start_EmptyTopologyScopeReturnsInsufficientLoadWithoutPersisting(t *testing.T) {
@@ -256,7 +344,7 @@ func TestService_Start_RejectsForceIncludeAllPairedMinersForOpenLoopScopes(t *te
 			_, err := svc.Start(t.Context(), req)
 			require.Error(t, err)
 			assert.True(t, fleeterror.IsInvalidArgumentError(err))
-			assert.Contains(t, err.Error(), "whole-org or site scope")
+			assert.Contains(t, err.Error(), "whole-org, site, building, rack, or group scope")
 		})
 	}
 }
@@ -946,6 +1034,34 @@ func TestService_Start_AllowUnboundedPersistsNullMaxDuration(t *testing.T) {
 	assert.True(t, store.lastInsertEvent.AllowUnbounded)
 	assert.Nil(t, store.lastInsertEvent.MaxDurationSeconds,
 		"allow_unbounded events must persist max_duration_seconds = NULL")
+}
+
+func TestStartRequiresAdminControls(t *testing.T) {
+	t.Parallel()
+
+	orgConfig := &models.OrgConfig{MaxDurationDefaultSec: 100}
+	tests := []struct {
+		name string
+		req  StartRequest
+		want bool
+	}{
+		{name: "ordinary settings"},
+		{name: "allow unbounded", req: StartRequest{AllowUnbounded: true}, want: true},
+		{name: "candidate power override", req: StartRequest{PreviewRequest: PreviewRequest{CandidateMinPowerWOverride: int32Ptr(1)}}, want: true},
+		{name: "force maintenance", req: StartRequest{PreviewRequest: PreviewRequest{ForceIncludeMaintenance: true}}, want: true},
+		{name: "force all paired", req: StartRequest{PreviewRequest: PreviewRequest{ForceIncludeAllPairedMiners: true}}, want: true},
+		{name: "curtail pacing above operator limit", req: StartRequest{CurtailBatchIntervalSec: nonAdminRestoreBatchIntervalMax + 1}, want: true},
+		{name: "restore pacing above operator limit", req: StartRequest{RestoreBatchIntervalSec: nonAdminRestoreBatchIntervalMax + 1}, want: true},
+		{name: "duration above org default", req: StartRequest{MaxDurationSeconds: int32Ptr(101)}, want: true},
+		{name: "duration at org default", req: StartRequest{MaxDurationSeconds: int32Ptr(100)}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, startRequiresAdminControls(tt.req, orgConfig))
+		})
+	}
 }
 
 func TestService_Start_ForwardsIdempotencyAndExternalAttribution(t *testing.T) {

--- a/server/internal/domain/fleeterror/error.go
+++ b/server/internal/domain/fleeterror/error.go
@@ -394,6 +394,25 @@ func IsInvalidArgumentError(err error) bool {
 	return false
 }
 
+// IsResourceExhaustedError checks if an error is a resource exhausted error.
+func IsResourceExhaustedError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var fleetErr FleetError
+	if errors.As(err, &fleetErr) {
+		return fleetErr.GRPCCode == connect.CodeResourceExhausted
+	}
+
+	var connectErr *connect.Error
+	if errors.As(err, &connectErr) {
+		return connectErr.Code() == connect.CodeResourceExhausted
+	}
+
+	return false
+}
+
 // IsCanceledError checks if an error is a cancellation error (e.g., client disconnect)
 func IsCanceledError(err error) bool {
 	if err == nil {

--- a/server/internal/domain/fleeterror/error_test.go
+++ b/server/internal/domain/fleeterror/error_test.go
@@ -350,6 +350,26 @@ func TestIsFailedPreconditionError(t *testing.T) {
 	}
 }
 
+func TestIsResourceExhaustedError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil},
+		{name: "fleet error", err: NewResourceExhaustedErrorf("too many miners"), want: true},
+		{name: "wrapped fleet error", err: fmt.Errorf("resolve scope: %w", NewResourceExhaustedErrorf("too many miners")), want: true},
+		{name: "connect error", err: connect.NewError(connect.CodeResourceExhausted, errors.New("too many miners")), want: true},
+		{name: "different error", err: NewInvalidArgumentError("invalid scope")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsResourceExhaustedError(tt.err))
+		})
+	}
+}
+
 func TestIsCanceledError(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/server/internal/handlers/curtailment/translate.go
+++ b/server/internal/handlers/curtailment/translate.go
@@ -398,10 +398,10 @@ func toTerminalScope(scopes []*pb.CurtailmentScope) (curtailment.Scope, error) {
 
 // startResponseState mirrors the persisted state for the synchronous Start response.
 func startResponseState(req *pb.StartCurtailmentRequest, selected, unavailable int) pb.CurtailmentEventState {
-	// Mirrors buildInsertParams: an all-paired start whose every paired
-	// miner is currently unavailable persists as PENDING (no started_at)
-	// so the max-duration clock does not run before anything dispatches.
-	if req.GetForceIncludeAllPairedMiners() && selected > 0 && unavailable == selected {
+	// Mirrors buildInsertParams: an all-paired start with no owned miner, or
+	// whose every owned miner is unavailable, persists as PENDING (no
+	// started_at) so the max-duration clock does not run before a dispatch.
+	if req.GetForceIncludeAllPairedMiners() && (selected == 0 || unavailable == selected) {
 		return pb.CurtailmentEventState_CURTAILMENT_EVENT_STATE_PENDING
 	}
 	if isClosedLoopFullFleetStartResponse(req) {
@@ -422,7 +422,8 @@ func isClosedLoopFullFleetStartResponse(req *pb.StartCurtailmentRequest) bool {
 		if err != nil {
 			return false
 		}
-		return scope.Type == models.ScopeTypeWholeOrg || curtailment.IsSiteOnlyScope(scope)
+		return scope.Type == models.ScopeTypeWholeOrg || curtailment.IsSiteOnlyScope(scope) ||
+			curtailment.IsTopologyScope(scope)
 	}
 	switch req.GetScope().(type) {
 	case *pb.StartCurtailmentRequest_WholeOrg, *pb.StartCurtailmentRequest_Site:

--- a/server/internal/handlers/curtailment/translate_fullfleet_test.go
+++ b/server/internal/handlers/curtailment/translate_fullfleet_test.go
@@ -168,6 +168,57 @@ func TestToStartResponse_MultiSiteFullFleetReturnsActiveTargetlessEvent(t *testi
 	assert.Nil(t, event.GetEndedAt())
 }
 
+func TestToStartResponse_TopologyFullFleetReturnsActiveTargetlessEvent(t *testing.T) {
+	t.Parallel()
+
+	for _, selected := range [][]curtailment.SelectedDevice{
+		nil,
+		{{DeviceIdentifier: "miner-a", PowerW: 3000}},
+	} {
+		plan := &curtailment.Plan{Selected: selected}
+		req := &pb.StartCurtailmentRequest{
+			Mode: pb.CurtailmentMode_CURTAILMENT_MODE_FULL_FLEET,
+			Scopes: []*pb.CurtailmentScope{{
+				Scope: &pb.CurtailmentScope_Building{Building: &pb.ScopeBuilding{BuildingId: 7}},
+			}},
+		}
+
+		event := toStartResponse(plan, req).GetEvent()
+		require.NotNil(t, event)
+		assert.Equal(t, pb.CurtailmentEventState_CURTAILMENT_EVENT_STATE_ACTIVE, event.GetState())
+		assert.Empty(t, event.GetTargets())
+		assert.Equal(t, int32(0), event.GetTargetRollup().GetTotal())
+	}
+}
+
+func TestToStartResponse_AllPairedTopologyFullFleetUsesBoundedTargetRollup(t *testing.T) {
+	t.Parallel()
+
+	plan := &curtailment.Plan{
+		Selected: []curtailment.SelectedDevice{
+			{DeviceIdentifier: "online", PowerW: 3000},
+			{DeviceIdentifier: "offline", TargetState: models.TargetStateUnavailable, LastError: "offline"},
+		},
+		PolicyTargetCount:      2,
+		UnavailableTargetCount: 1,
+	}
+	req := &pb.StartCurtailmentRequest{
+		Mode: pb.CurtailmentMode_CURTAILMENT_MODE_FULL_FLEET,
+		Scopes: []*pb.CurtailmentScope{{
+			Scope: &pb.CurtailmentScope_Group{Group: &pb.ScopeGroup{GroupId: 9}},
+		}},
+		ForceIncludeAllPairedMiners: true,
+	}
+
+	event := toStartResponse(plan, req).GetEvent()
+	require.NotNil(t, event)
+	assert.Equal(t, pb.CurtailmentEventState_CURTAILMENT_EVENT_STATE_ACTIVE, event.GetState())
+	assert.Empty(t, event.GetTargets())
+	assert.Equal(t, int32(1), event.GetTargetRollup().GetPending())
+	assert.Equal(t, int32(1), event.GetTargetRollup().GetUnavailable())
+	assert.Equal(t, int32(2), event.GetTargetRollup().GetTotal())
+}
+
 func TestToStartResponse_AllPairedFullFleetUsesBoundedTargetRollup(t *testing.T) {
 	t.Parallel()
 
@@ -224,6 +275,27 @@ func TestToStartResponse_AllPairedAllUnavailableReturnsPending(t *testing.T) {
 	assert.Equal(t, int32(0), event.GetTargetRollup().GetPending())
 	assert.Equal(t, int32(2), event.GetTargetRollup().GetUnavailable())
 	assert.Equal(t, int32(2), event.GetTargetRollup().GetTotal())
+}
+
+func TestToStartResponse_EmptyAllPairedTopologyReturnsPending(t *testing.T) {
+	t.Parallel()
+
+	plan := &curtailment.Plan{}
+	req := &pb.StartCurtailmentRequest{
+		Mode: pb.CurtailmentMode_CURTAILMENT_MODE_FULL_FLEET,
+		Scopes: []*pb.CurtailmentScope{{
+			Scope: &pb.CurtailmentScope_Building{Building: &pb.ScopeBuilding{BuildingId: 7}},
+		}},
+		ForceIncludeAllPairedMiners: true,
+	}
+
+	event := toStartResponse(plan, req).GetEvent()
+
+	require.NotNil(t, event)
+	assert.Equal(t, pb.CurtailmentEventState_CURTAILMENT_EVENT_STATE_PENDING, event.GetState())
+	assert.Nil(t, event.GetStartedAt())
+	assert.Empty(t, event.GetTargets())
+	assert.Equal(t, int32(0), event.GetTargetRollup().GetTotal())
 }
 
 func TestToPreviewResponse_AllPairedUsesBoundedCounts(t *testing.T) {


### PR DESCRIPTION
Reviewable diff: +914/-110 across 9 files (excludes generated, test, and story files).

## Summary

This PR enables topology-scoped FULL_FLEET curtailment watchers for buildings, racks, and groups. These watchers follow current membership, admit newly eligible miners, and safely restore miners that leave scope without terminating the parent event. It also extends all-paired policies to topology scopes, including empty watchers that wait in pending until a miner is paired and confirmed.

**Stack:** #967 is merged into `main` and provides the store and persistence primitives consumed here. This PR now contains only the reconciliation and API behavior relative to `main`; shared drill-down UI and remaining frontend/E2E work stay tracked in #909.

## How it works

Start persists the terminal topology selector instead of freezing it into a miner list. It also records whether the selected behavior uses admin-only controls. On each pending or active tick, the reconciler resolves current membership, validates the persisted authorization envelope and creator permissions, and rechecks the creator's Admin/SuperAdmin role when required by either the Start settings or later operator updates.

New members are claimed through the store layer and revalidated at the physical dispatch boundary. Members that leave before Curtail are released; members that may have received Curtail enter the existing restore state machine. All-paired topology targets remain parked while uncommandable and resume only after a later commandability transition. Facility airflow reopens before restore or newly admitted work and stops again only after confirmation and the configured delay.

## Diagrams

```mermaid
flowchart TD
  A["Start with building, rack, or group selector"] --> B["Persist logical scope and authorization envelope"]
  B --> C["Resolve current membership each tick"]
  C --> D["Validate limits, ownership, permission, and required admin role"]
  D --> E["Claim and fence new members"]
  D --> F["Move departed members to safe restore"]
  E --> G["Curtail and confirm telemetry"]
  F --> H["Reopen airflow and Uncurtail"]
  G --> C
  H --> C
```

```mermaid
stateDiagram-v2
  [*] --> Pending
  Pending --> Active: first target confirms
  Pending --> Pending: empty or unavailable policy
  Active --> Active: membership changes
  Active --> RestoreObligation: owned miner leaves scope
  RestoreObligation --> Resolved: restore confirms
  RestoreObligation --> Unavailable: command cannot be sent
  Unavailable --> RestoreObligation: miner becomes commandable
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `proto/curtailment/v1/` | Documents all-paired support for topology scopes. | Confirms the public API contract. |
| `server/internal/domain/curtailment/service.go` and `selector.go` | Enables topology FULL_FLEET starts, records required-admin behavior, and classifies all-paired restore commandability. | Defines selection and lifecycle semantics exposed by Start. |
| `server/internal/domain/authz/resolver.go` | Exposes the creator's current primary role to the reconciler. | Ensures admin-only controls stop admitting work after role demotion. |
| `server/internal/domain/curtailment/reconciler/` | Adds membership snapshots, departure restoration, admission fencing, live authorization checks, fan sequencing, and readiness refresh. | Main safety-critical control loop. |
| `server/internal/handlers/curtailment/` | Aligns synchronous Start responses with persisted topology and empty-policy states. | Prevents API responses from disagreeing with storage. |
| Generated protobuf bindings | Regenerated — skip. | Mechanical output from the proto comment change. |
| Reconciler, service, handler, selector, and error tests | Covers admission, departure, return, permission and role races, fan ordering, and empty watchers. | Primary regression coverage for the lifecycle. |

## Key technical decisions & trade-offs

- Re-resolve logical selectors each tick instead of snapshotting miner membership, so assignment changes drive behavior.
- Revalidate topology, authorization, ownership, and any required admin role at admission and dispatch instead of trusting the earlier candidate scan.
- Persist the Start-time admin requirement in the immutable decision snapshot and also evaluate mutable duration and pacing fields against current limits after operator updates.
- Reuse each target's `desired_state` and restore phase instead of creating a second event, preserving one durable ownership record.
- Requeue failed all-paired restores only after an unavailable-to-commandable transition instead of retrying terminal failures indefinitely.

## Testing & validation

- `buf lint`
- `golangci-lint run -c .golangci.yaml` from `server/`
- `go test ./internal/domain/curtailment/... ./internal/handlers/curtailment -count=1`
- `go test ./internal/domain/authz -run '^$'`
- `go test ./... -run '^$'` from `server/`
- `git diff --check`
- Client lint, formatting, type checking, tests, build, and generated-code verification passed in CI; the pinned local npm install could not be run because of cache-integrity errors.
- Full local authz tests require the repository database harness and are delegated to CI.

Refs #909
