### PR TITLE
fix(asicrs): raise async trait recursion limit

### DIFF
--- a/plugin/asicrs/src/main.rs
+++ b/plugin/asicrs/src/main.rs
@@ -1,3 +1,7 @@
+// ASIC-RS exposes deeply nested async miner-factory futures. Rust nightly's
+// auto-trait solver needs more than the default recursion depth to prove Send.
+#![recursion_limit = "256"]
+
 mod capabilities;
 mod config;
 mod device;


### PR DESCRIPTION
Reviewable diff: +4/-0 across 1 files (excludes generated, test, and story files).

## Summary

This PR restores ASIC-RS Clippy checks on the current Rust nightly compiler. The compiler now requires a deeper auto-trait proof for ASIC-RS's nested async miner-factory future; the crate opts into recursion depth 256 without changing runtime behavior or dependency versions.

## How it works

The plugin's `discover_device` future must prove that the nested ASIC-RS factory future is `Send`. Current nightly emits `recursion-depth-exceeding-limit` before completing that proof, and CI promotes the warning to an error with `-D warnings`. A crate-level recursion limit gives the compiler enough depth to finish the existing proof while leaving the generated code, dependency graph, and miner behavior unchanged.

## Diagrams

```mermaid
flowchart LR
    A["discover_device async future"] --> B["ASIC-RS miner factory future"]
    B --> C["Compiler proves nested future is Send"]
    C --> D{"Recursion depth available?"}
    D -->|"Default limit"| E["Nightly Clippy failure"]
    D -->|"Crate limit 256"| F["Proof completes"]
    F --> G["Clippy and tests pass"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `plugin/asicrs/src/main.rs` | Added a documented crate-level recursion limit of 256 | Verify this is a compile-time-only accommodation for the nested async trait proof |

## Key technical decisions & trade-offs

- **Increase the crate recursion limit instead of suppressing the lint** so the compiler still completes and validates the `Send` proof.
- **Keep ASIC-RS at 0.5.4 instead of upgrading to 0.7.3** because the live latest release still reproduces the recursion failure and also removes board-temperature fields consumed by the plugin.
- **Scope the setting to the ASIC-RS binary crate** rather than changing Rust flags globally for unrelated Rust packages.

## Testing & validation

Using `rustlang/rust:nightly-alpine` with `rustc 1.100.0-nightly (e7769602a 2026-08-24)`:

- Reproduced the main-branch Clippy failure before the change.
- `cargo clippy -- -D warnings` — passed after the change.
- `cargo fmt --check` — passed.
- `cargo test` — 50 passed.
- Verified against crates.io that ASIC-RS and ASIC-RS Core 0.7.3 are the current non-yanked latest releases; testing that update did not resolve this compiler failure.
