### PR TITLE
Add Linux Fleet Node packaging and installer

### DIFF
--- a/.github/path-filters.yml
+++ b/.github/path-filters.yml
@@ -19,6 +19,7 @@ global: &global
 
 deployment_config:
   - *global
+  - deployment-files/fleetnode/**
   - deployment-files/ha/**
   - deployment-files/profiles/**
   - deployment-files/tests/**

--- a/.github/workflows/deployment-config-checks.yml
+++ b/.github/workflows/deployment-config-checks.yml
@@ -49,3 +49,16 @@ jobs:
 
       - name: Validate uninstaller updater cleanup
         run: ./deployment-files/tests/test-uninstall-updater-cleanup.sh
+
+  fleetnode-installer:
+    name: Fleet Node installer
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Validate shell syntax
+        run: bash -n deployment-files/fleetnode/install-fleetnode.sh deployment-files/fleetnode/tests/test-install-fleetnode.sh
+
+      - name: Test installer
+        run: ./deployment-files/fleetnode/tests/test-install-fleetnode.sh

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -127,6 +127,13 @@ jobs:
           path: /tmp/nightly-assets/server
           merge-multiple: true
 
+      - name: Download Fleet Node artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: fleetnode-linux-*
+          path: /tmp/nightly-assets/fleetnode
+          merge-multiple: true
+
       - name: Download client artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -157,6 +164,23 @@ jobs:
             sha256sum "$bundle" > "$expected_sidecar"
             if ! cmp -s "$expected_sidecar" "$bundle.sha256"; then
               echo "::error::Deployment bundle checksum is not bound to $bundle"
+              exit 1
+            fi
+          done
+
+      - name: Verify Fleet Node checksums
+        run: |
+          cd /tmp/nightly-assets/fleetnode
+          for arch in amd64 arm64; do
+            archive="fleetnode-${VERSION}-linux-${arch}.tar.gz"
+            if [[ ! -f "$archive" || ! -f "$archive.sha256" ]]; then
+              echo "::error::Missing Fleet Node archive or checksum for $arch"
+              exit 1
+            fi
+            expected_sidecar="$RUNNER_TEMP/fleetnode-${arch}.sha256"
+            sha256sum "$archive" > "$expected_sidecar"
+            if ! cmp -s "$expected_sidecar" "$archive.sha256"; then
+              echo "::error::Fleet Node checksum is not bound to $archive"
               exit 1
             fi
           done
@@ -202,10 +226,13 @@ jobs:
             /tmp/nightly-assets/windows/installer.exe \
             /tmp/nightly-assets/windows/uninstall.exe \
             /tmp/nightly-assets/server/proto-fleet-server-${VERSION}-*.tar.gz \
+            /tmp/nightly-assets/fleetnode/fleetnode-${VERSION}-linux-*.tar.gz \
+            /tmp/nightly-assets/fleetnode/fleetnode-${VERSION}-linux-*.tar.gz.sha256 \
             /tmp/nightly-assets/client/proto-fleet-client-${VERSION}.tar.gz \
             /tmp/nightly-assets/proto-os/proto-os-${VERSION}.tar.gz \
             /tmp/nightly-assets/proto-os/proto-os_${VERSION}.ipk \
             ./deployment-files/install.sh \
+            ./deployment-files/fleetnode/install-fleetnode.sh \
             ./deployment-files/uninstall.sh \
             --draft \
             --notes-file /tmp/nightly-release-notes.md \
@@ -222,10 +249,13 @@ jobs:
             /tmp/nightly-assets/windows/installer.exe \
             /tmp/nightly-assets/windows/uninstall.exe \
             /tmp/nightly-assets/server/proto-fleet-server-${VERSION}-*.tar.gz \
+            /tmp/nightly-assets/fleetnode/fleetnode-${VERSION}-linux-*.tar.gz \
+            /tmp/nightly-assets/fleetnode/fleetnode-${VERSION}-linux-*.tar.gz.sha256 \
             /tmp/nightly-assets/client/proto-fleet-client-${VERSION}.tar.gz \
             /tmp/nightly-assets/proto-os/proto-os-${VERSION}.tar.gz \
             /tmp/nightly-assets/proto-os/proto-os_${VERSION}.ipk \
             ./deployment-files/install.sh \
+            ./deployment-files/fleetnode/install-fleetnode.sh \
             ./deployment-files/uninstall.sh \
             --clobber
 
@@ -298,10 +328,13 @@ jobs:
             echo "- \`proto-fleet-${NIGHTLY_VERSION}-arm64.tar.gz\`"
             echo "- \`proto-fleet-server-${NIGHTLY_VERSION}-amd64.tar.gz\`"
             echo "- \`proto-fleet-server-${NIGHTLY_VERSION}-arm64.tar.gz\`"
+            echo "- \`fleetnode-${NIGHTLY_VERSION}-linux-amd64.tar.gz\`"
+            echo "- \`fleetnode-${NIGHTLY_VERSION}-linux-arm64.tar.gz\`"
             echo "- \`proto-fleet-client-${NIGHTLY_VERSION}.tar.gz\`"
             echo "- \`proto-os-${NIGHTLY_VERSION}.tar.gz\`"
             echo "- \`proto-os_${NIGHTLY_VERSION}.ipk\`"
             echo "- \`installer.exe\`"
             echo "- \`uninstall.exe\`"
             echo "- \`install.sh\`"
+            echo "- \`install-fleetnode.sh\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/proto-fleet-artifact-build.yml
+++ b/.github/workflows/proto-fleet-artifact-build.yml
@@ -237,6 +237,80 @@ jobs:
           path: ./server/proto-fleet-server-${{ needs.metadata.outputs.version }}-${{ matrix.arch }}.tar.gz
           retention-days: ${{ inputs.retention_days }}
 
+  package-fleet-node:
+    name: Package Fleet Node (${{ matrix.arch }})
+    needs: [metadata]
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    env:
+      VERSION: ${{ needs.metadata.outputs.version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Hermit
+        uses: ./.github/actions/hermit-setup
+
+      - name: Configure Go cache
+        uses: ./.github/actions/go-cache-setup
+
+      - name: Build Fleet Node and Go plugins
+        run: |
+          go work sync
+          go build -v -o server/fleetnode ./server/cmd/fleetnode
+          go build -o server/proto-plugin ./plugin/proto
+          go build -o server/antminer-plugin ./plugin/antminer
+          go build -o server/virtual-plugin ./plugin/virtual
+          cp plugin/virtual/config.json server/virtual-plugin.json
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Build asicrs plugin
+        run: |
+          docker buildx build \
+            --file plugin/asicrs/Dockerfile.build \
+            --output "type=local,dest=/tmp/asicrs" \
+            .
+          cp /tmp/asicrs/asicrs-plugin server/asicrs-plugin
+          cp /tmp/asicrs/asicrs-config.yaml server/asicrs-config.yaml
+
+      - name: Package Fleet Node
+        working-directory: ./server
+        run: |
+          package_dir="fleetnode-${VERSION}-linux-${{ matrix.arch }}"
+          archive="${package_dir}.tar.gz"
+
+          mkdir -p "$package_dir/plugins"
+          install -m 0755 fleetnode "$package_dir/fleetnode"
+          install -m 0644 ../deployment-files/fleetnode/fleetnode.service "$package_dir/fleetnode.service"
+          install -m 0755 proto-plugin "$package_dir/plugins/proto-plugin"
+          install -m 0755 antminer-plugin "$package_dir/plugins/antminer-plugin"
+          install -m 0755 virtual-plugin "$package_dir/plugins/virtual-plugin"
+          install -m 0644 virtual-plugin.json "$package_dir/plugins/virtual-plugin.json"
+          install -m 0755 asicrs-plugin "$package_dir/plugins/asicrs-plugin"
+          install -m 0644 asicrs-config.yaml "$package_dir/plugins/asicrs-config.yaml"
+          printf 'version: %s\n' "$VERSION" > "$package_dir/version.txt"
+
+          tar -czf "$archive" "$package_dir"
+          sha256sum "$archive" > "$archive.sha256"
+          sha256sum -c "$archive.sha256"
+
+      - name: Upload Fleet Node artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fleetnode-linux-${{ matrix.arch }}
+          path: |
+            ./server/fleetnode-${{ needs.metadata.outputs.version }}-linux-${{ matrix.arch }}.tar.gz
+            ./server/fleetnode-${{ needs.metadata.outputs.version }}-linux-${{ matrix.arch }}.tar.gz.sha256
+          retention-days: ${{ inputs.retention_days }}
+
   build-proto-fleet-client:
     name: Build ProtoFleet client
     runs-on: ubuntu-latest

--- a/.github/workflows/proto-fleet-artifact-build.yml
+++ b/.github/workflows/proto-fleet-artifact-build.yml
@@ -249,6 +249,7 @@ jobs:
             runner: ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
     env:
+      CGO_ENABLED: 0
       VERSION: ${{ needs.metadata.outputs.version }}
     steps:
       - name: Checkout code
@@ -268,6 +269,17 @@ jobs:
           go build -o server/antminer-plugin ./plugin/antminer
           go build -o server/virtual-plugin ./plugin/virtual
           cp plugin/virtual/config.json server/virtual-plugin.json
+
+          for binary in fleetnode proto-plugin antminer-plugin virtual-plugin; do
+            if ! readelf -h "server/$binary" >/dev/null; then
+              echo "::error::Unable to inspect Fleet Node binary $binary"
+              exit 1
+            fi
+            if readelf -l "server/$binary" | grep INTERP >/dev/null || readelf -d "server/$binary" | grep NEEDED >/dev/null; then
+              echo "::error::Fleet Node binary $binary must be statically linked"
+              exit 1
+            fi
+          done
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,13 @@ jobs:
           path: /tmp/release-assets/server
           merge-multiple: true
 
+      - name: Download Fleet Node artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: fleetnode-linux-*
+          path: /tmp/release-assets/fleetnode
+          merge-multiple: true
+
       - name: Download client artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -128,6 +135,25 @@ jobs:
             fi
           done
 
+      - name: Verify Fleet Node checksums
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: |
+          cd /tmp/release-assets/fleetnode
+          for arch in amd64 arm64; do
+            archive="fleetnode-${VERSION}-linux-${arch}.tar.gz"
+            if [[ ! -f "$archive" || ! -f "$archive.sha256" ]]; then
+              echo "::error::Missing Fleet Node archive or checksum for $arch"
+              exit 1
+            fi
+            expected_sidecar="$RUNNER_TEMP/fleetnode-${arch}.sha256"
+            sha256sum "$archive" > "$expected_sidecar"
+            if ! cmp -s "$expected_sidecar" "$archive.sha256"; then
+              echo "::error::Fleet Node checksum is not bound to $archive"
+              exit 1
+            fi
+          done
+
       - name: Create or refresh draft release and upload assets
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -142,10 +168,13 @@ jobs:
             /tmp/release-assets/windows/installer.exe
             /tmp/release-assets/windows/uninstall.exe
             /tmp/release-assets/server/proto-fleet-server-"$TAG_NAME"-*.tar.gz
+            /tmp/release-assets/fleetnode/fleetnode-"$TAG_NAME"-linux-*.tar.gz
+            /tmp/release-assets/fleetnode/fleetnode-"$TAG_NAME"-linux-*.tar.gz.sha256
             /tmp/release-assets/client/proto-fleet-client-"$TAG_NAME".tar.gz
             /tmp/release-assets/proto-os/proto-os-"$TAG_NAME".tar.gz
             /tmp/release-assets/proto-os/proto-os_"$TAG_NAME".ipk
             ./deployment-files/install.sh
+            ./deployment-files/fleetnode/install-fleetnode.sh
             ./deployment-files/uninstall.sh
           )
           # Refuse to clobber a non-draft release — published assets are immutable from this workflow.

--- a/deployment-files/fleetnode/fleetnode.service
+++ b/deployment-files/fleetnode/fleetnode.service
@@ -1,0 +1,32 @@
+[Unit]
+Description=Proto Fleet Node
+Documentation=https://github.com/block/proto-fleet
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+User=fleetnode
+Group=fleetnode
+EnvironmentFile=-/etc/fleetnode/fleetnode.env
+ExecStart=/opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode run
+Restart=on-failure
+RestartSec=5s
+TimeoutStopSec=90s
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true
+ProtectSystem=strict
+ReadOnlyPaths=/opt/fleetnode /etc/fleetnode
+ReadWritePaths=/var/lib/fleetnode
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+LockPersonality=true
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+UMask=0077
+
+[Install]
+WantedBy=multi-user.target

--- a/deployment-files/fleetnode/fleetnode.service
+++ b/deployment-files/fleetnode/fleetnode.service
@@ -8,8 +8,9 @@ After=network-online.target
 Type=simple
 User=fleetnode
 Group=fleetnode
+Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 EnvironmentFile=-/etc/fleetnode/fleetnode.env
-ExecStart=/opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode run
+ExecStart=/usr/bin/env PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin /opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode run
 Restart=on-failure
 RestartSec=5s
 TimeoutStopSec=90s

--- a/deployment-files/fleetnode/fleetnode.service
+++ b/deployment-files/fleetnode/fleetnode.service
@@ -25,7 +25,7 @@ ProtectKernelLogs=true
 ProtectControlGroups=true
 RestrictSUIDSGID=true
 LockPersonality=true
-RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
 UMask=0077
 
 [Install]

--- a/deployment-files/fleetnode/install-fleetnode.sh
+++ b/deployment-files/fleetnode/install-fleetnode.sh
@@ -81,6 +81,8 @@ PROGRAM_DIR="${ROOT_PREFIX}/opt/fleetnode"
 CONFIG_DIR="${ROOT_PREFIX}/etc/fleetnode"
 STATE_DIR="${ROOT_PREFIX}/var/lib/fleetnode"
 UNIT_PATH="${ROOT_PREFIX}/etc/systemd/system/fleetnode.service"
+INSTALL_LOCK_DIR="${ROOT_PREFIX}/run/proto-fleet"
+INSTALL_LOCK_PATH="$INSTALL_LOCK_DIR/fleetnode-installer.lock"
 SYSTEMCTL="${FLEETNODE_SYSTEMCTL:-systemctl}"
 ARCHIVE_ROOT="fleetnode-${VERSION}-linux-${ARCH}"
 ARCHIVE_NAME="${ARCHIVE_ROOT}.tar.gz"
@@ -88,7 +90,7 @@ if [[ -z "$DOWNLOAD_BASE_URL" ]]; then
   DOWNLOAD_BASE_URL="https://github.com/block/proto-fleet/releases/download/${VERSION}"
 fi
 
-for command in curl sha256sum tar install "$SYSTEMCTL"; do
+for command in curl sha256sum tar install flock "$SYSTEMCTL"; do
   command -v "$command" >/dev/null 2>&1 || { echo "required command not found: $command" >&2; exit 1; }
 done
 if [[ "$TEST_MODE" != "1" && ! -x /usr/bin/env ]]; then
@@ -105,7 +107,7 @@ if [[ "$TEST_MODE" != "1" ]]; then
   done
 fi
 
-for path in "$PROGRAM_DIR" "$CONFIG_DIR" "$STATE_DIR" "$UNIT_PATH"; do
+for path in "$PROGRAM_DIR" "$CONFIG_DIR" "$STATE_DIR" "$UNIT_PATH" "$INSTALL_LOCK_DIR" "$INSTALL_LOCK_PATH"; do
   if [[ -L "$path" ]]; then
     echo "refusing to install through symlink: $path" >&2
     exit 1
@@ -113,6 +115,23 @@ for path in "$PROGRAM_DIR" "$CONFIG_DIR" "$STATE_DIR" "$UNIT_PATH"; do
 done
 if [[ -e "$PROGRAM_DIR" && ! -d "$PROGRAM_DIR" ]]; then
   echo "program path exists but is not a directory: $PROGRAM_DIR" >&2
+  exit 1
+fi
+
+if [[ "$TEST_MODE" == "1" ]]; then
+  install -d -m 0755 "$INSTALL_LOCK_DIR"
+else
+  install -d -o root -g root -m 0755 "$INSTALL_LOCK_DIR"
+fi
+(
+  umask 077
+  : >> "$INSTALL_LOCK_PATH"
+)
+chmod 0600 "$INSTALL_LOCK_PATH"
+INSTALL_LOCK_FD=9
+exec 9<>"$INSTALL_LOCK_PATH"
+if ! flock -n "$INSTALL_LOCK_FD"; then
+  echo "another Fleet Node installer is running" >&2
   exit 1
 fi
 

--- a/deployment-files/fleetnode/install-fleetnode.sh
+++ b/deployment-files/fleetnode/install-fleetnode.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION=""
+DOWNLOAD_BASE_URL="${FLEETNODE_DOWNLOAD_BASE_URL:-}"
+TEST_MODE="${FLEETNODE_TEST_MODE:-0}"
+ROOT_PREFIX="${FLEETNODE_ROOT_PREFIX:-}"
+
+usage() {
+  cat <<'EOF'
+Usage: install-fleetnode.sh --version VERSION
+
+Install one exact Proto Fleet Node release on Linux. VERSION must be a
+release-specific tag such as v1.2.3 or nightly-20260825-0123456789ab.
+
+The installer creates the service but leaves a fresh installation disabled.
+After installation, enroll the node and then explicitly enable the service.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version)
+      [[ $# -ge 2 && -n "${2:-}" ]] || { echo "--version requires a value" >&2; exit 2; }
+      VERSION="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ ! "$VERSION" =~ ^[A-Za-z0-9_][A-Za-z0-9._-]{0,127}$ ]] || [[ "$VERSION" == "latest" ]]; then
+  echo "version must be an explicit release identifier (1-128 letters, numbers, dots, underscores, or hyphens; not latest)" >&2
+  exit 2
+fi
+if [[ "$(uname -s)" != "Linux" && "$TEST_MODE" != "1" ]]; then
+  echo "Fleet Node installation currently supports Linux only" >&2
+  exit 1
+fi
+if [[ "$TEST_MODE" != "1" ]]; then
+  if [[ -n "$ROOT_PREFIX" ]]; then
+    echo "FLEETNODE_ROOT_PREFIX is only available in test mode" >&2
+    exit 1
+  fi
+  if [[ "$(id -u)" -ne 0 ]]; then
+    echo "run this installer as root (for example: sudo ./install-fleetnode.sh --version $VERSION)" >&2
+    exit 1
+  fi
+fi
+if [[ "$TEST_MODE" != "1" ]]; then
+  if [[ -n "${FLEETNODE_ARCH:-}" || -n "$DOWNLOAD_BASE_URL" ]]; then
+    echo "download and architecture overrides are restricted to automated tests" >&2
+    exit 1
+  fi
+fi
+
+case "${FLEETNODE_ARCH:-$(uname -m)}" in
+  x86_64|amd64) ARCH=amd64 ;;
+  aarch64|arm64) ARCH=arm64 ;;
+  *) echo "unsupported Linux architecture: ${FLEETNODE_ARCH:-$(uname -m)}" >&2; exit 1 ;;
+esac
+
+if [[ "$TEST_MODE" == "1" ]]; then
+  [[ -n "$ROOT_PREFIX" && "$ROOT_PREFIX" == /* && "$ROOT_PREFIX" != "/" ]] || {
+    echo "test mode requires an absolute, non-root FLEETNODE_ROOT_PREFIX" >&2
+    exit 1
+  }
+fi
+
+PROGRAM_DIR="${ROOT_PREFIX}/opt/fleetnode"
+CONFIG_DIR="${ROOT_PREFIX}/etc/fleetnode"
+STATE_DIR="${ROOT_PREFIX}/var/lib/fleetnode"
+UNIT_PATH="${ROOT_PREFIX}/etc/systemd/system/fleetnode.service"
+SYSTEMCTL="${FLEETNODE_SYSTEMCTL:-systemctl}"
+ARCHIVE_ROOT="fleetnode-${VERSION}-linux-${ARCH}"
+ARCHIVE_NAME="${ARCHIVE_ROOT}.tar.gz"
+if [[ -z "$DOWNLOAD_BASE_URL" ]]; then
+  DOWNLOAD_BASE_URL="https://github.com/block/proto-fleet/releases/download/${VERSION}"
+fi
+
+for command in curl sha256sum tar install "$SYSTEMCTL"; do
+  command -v "$command" >/dev/null 2>&1 || { echo "required command not found: $command" >&2; exit 1; }
+done
+if [[ "$TEST_MODE" != "1" ]]; then
+  for command in getent useradd nologin; do
+    command -v "$command" >/dev/null 2>&1 || { echo "required command not found: $command" >&2; exit 1; }
+  done
+fi
+
+for path in "$PROGRAM_DIR" "$CONFIG_DIR" "$STATE_DIR" "$UNIT_PATH"; do
+  if [[ -L "$path" ]]; then
+    echo "refusing to install through symlink: $path" >&2
+    exit 1
+  fi
+done
+if [[ -e "$PROGRAM_DIR" && ! -d "$PROGRAM_DIR" ]]; then
+  echo "program path exists but is not a directory: $PROGRAM_DIR" >&2
+  exit 1
+fi
+
+work_dir=$(mktemp -d)
+incoming="${PROGRAM_DIR%/*}/.fleetnode.install.$$"
+previous="${PROGRAM_DIR%/*}/.fleetnode.previous.$$"
+unit_backup="$work_dir/fleetnode.service.previous"
+fresh_install=1
+[[ -d "$PROGRAM_DIR" ]] && fresh_install=0
+was_active=0
+previous_saved=0
+program_replaced=0
+unit_replaced=0
+install_complete=0
+
+cleanup() {
+  status=$?
+  if [[ "$install_complete" != "1" ]]; then
+    if [[ "$unit_replaced" == "1" ]]; then
+      if [[ -f "$unit_backup" ]]; then
+        install -m 0644 "$unit_backup" "$UNIT_PATH"
+      else
+        rm -f "$UNIT_PATH"
+      fi
+      "$SYSTEMCTL" daemon-reload >/dev/null 2>&1 || true
+    fi
+    if [[ "$program_replaced" == "1" ]]; then
+      rm -rf "$PROGRAM_DIR"
+    fi
+    if [[ "$previous_saved" == "1" && -d "$previous" ]]; then
+      mv "$previous" "$PROGRAM_DIR"
+    fi
+    if [[ "$was_active" == "1" ]]; then
+      "$SYSTEMCTL" start fleetnode.service >/dev/null 2>&1 || true
+    fi
+  fi
+  rm -rf "$work_dir" "$incoming"
+  if [[ "$install_complete" == "1" ]]; then
+    rm -rf "$previous"
+  fi
+  exit "$status"
+}
+trap cleanup EXIT
+
+echo "Downloading Fleet Node $VERSION for linux/$ARCH..."
+curl --fail --location --silent --show-error \
+  --output "$work_dir/$ARCHIVE_NAME" "$DOWNLOAD_BASE_URL/$ARCHIVE_NAME"
+curl --fail --location --silent --show-error \
+  --output "$work_dir/$ARCHIVE_NAME.sha256" "$DOWNLOAD_BASE_URL/$ARCHIVE_NAME.sha256"
+
+(
+  cd "$work_dir"
+  sha256sum "$ARCHIVE_NAME" > expected.sha256
+  if ! cmp -s expected.sha256 "$ARCHIVE_NAME.sha256"; then
+    echo "checksum sidecar is not bound to $ARCHIVE_NAME" >&2
+    exit 1
+  fi
+  sha256sum -c "$ARCHIVE_NAME.sha256"
+)
+
+while IFS= read -r entry; do
+  case "$entry" in
+    "$ARCHIVE_ROOT"|"$ARCHIVE_ROOT/"|"$ARCHIVE_ROOT/"*) ;;
+    *) echo "archive contains an unexpected path: $entry" >&2; exit 1 ;;
+  esac
+  case "/$entry/" in
+    */../*|*/./*) echo "archive contains an unsafe path: $entry" >&2; exit 1 ;;
+  esac
+done < <(tar -tzf "$work_dir/$ARCHIVE_NAME")
+
+mkdir -p "$work_dir/extracted"
+tar -xzf "$work_dir/$ARCHIVE_NAME" -C "$work_dir/extracted"
+source_dir="$work_dir/extracted/$ARCHIVE_ROOT"
+for required in \
+  fleetnode \
+  version.txt \
+  fleetnode.service \
+  plugins/proto-plugin \
+  plugins/antminer-plugin \
+  plugins/virtual-plugin \
+  plugins/virtual-plugin.json \
+  plugins/asicrs-plugin \
+  plugins/asicrs-config.yaml; do
+  [[ -f "$source_dir/$required" ]] || { echo "archive is missing $required" >&2; exit 1; }
+done
+if find "$source_dir" -type l -print -quit | grep -q .; then
+  echo "archive must not contain symlinks" >&2
+  exit 1
+fi
+if ! grep -Fxq "version: $VERSION" "$source_dir/version.txt"; then
+  echo "Fleet Node archive metadata does not match requested version '$VERSION'" >&2
+  exit 1
+fi
+
+if "$SYSTEMCTL" is-active --quiet fleetnode.service; then
+  was_active=1
+  "$SYSTEMCTL" stop fleetnode.service
+fi
+
+install -d -m 0755 "${PROGRAM_DIR%/*}" "${UNIT_PATH%/*}"
+if [[ "$TEST_MODE" == "1" ]]; then
+  install -d -m 0750 "$CONFIG_DIR"
+  install -d -m 0700 "$STATE_DIR"
+else
+  if ! getent passwd fleetnode >/dev/null; then
+    if getent group fleetnode >/dev/null; then
+      useradd --system --gid fleetnode --home-dir /var/lib/fleetnode --shell "$(command -v nologin)" fleetnode
+    else
+      useradd --system --user-group --home-dir /var/lib/fleetnode --shell "$(command -v nologin)" fleetnode
+    fi
+  fi
+  getent group fleetnode >/dev/null || { echo "fleetnode user exists without a fleetnode group" >&2; exit 1; }
+  install -d -o root -g fleetnode -m 0750 "$CONFIG_DIR"
+  install -d -o fleetnode -g fleetnode -m 0700 "$STATE_DIR"
+fi
+
+rm -rf "$incoming" "$previous"
+install -d -m 0755 "$incoming"
+cp -a "$source_dir/." "$incoming/"
+chmod 0755 "$incoming/fleetnode" "$incoming/plugins/"*-plugin
+chmod 0644 "$incoming/version.txt" "$incoming/fleetnode.service" "$incoming/plugins/"*.json "$incoming/plugins/"*.yaml
+if [[ "$TEST_MODE" != "1" ]]; then
+  chown -R root:root "$incoming"
+fi
+if [[ -d "$PROGRAM_DIR" ]]; then
+  mv "$PROGRAM_DIR" "$previous"
+  previous_saved=1
+fi
+mv "$incoming" "$PROGRAM_DIR"
+program_replaced=1
+
+if [[ -f "$UNIT_PATH" ]]; then
+  cp -p "$UNIT_PATH" "$unit_backup"
+fi
+install -m 0644 "$PROGRAM_DIR/fleetnode.service" "$UNIT_PATH"
+unit_replaced=1
+"$SYSTEMCTL" daemon-reload
+
+if [[ "$was_active" == "1" ]]; then
+  "$SYSTEMCTL" start fleetnode.service
+fi
+
+install_complete=1
+echo "Fleet Node $VERSION installed."
+echo "Configuration: $CONFIG_DIR"
+echo "Protected state: $STATE_DIR"
+if [[ "$fresh_install" == "1" ]]; then
+  echo "The new service remains disabled until enrollment is complete."
+elif [[ "$was_active" == "1" ]]; then
+  echo "The previously running service was restarted; its enablement state was preserved."
+else
+  echo "The service was not started; its enablement state was preserved."
+fi
+echo
+echo "Enroll:"
+echo "  sudo -u fleetnode $PROGRAM_DIR/fleetnode --state-dir $STATE_DIR enroll --server-url=https://YOUR-FLEET-SERVER"
+echo "Then enable and start:"
+echo "  sudo systemctl enable --now fleetnode.service"
+echo "Inspect:"
+echo "  systemctl status fleetnode.service"
+echo "  journalctl -u fleetnode.service"

--- a/deployment-files/fleetnode/install-fleetnode.sh
+++ b/deployment-files/fleetnode/install-fleetnode.sh
@@ -140,8 +140,8 @@ incoming="${PROGRAM_DIR%/*}/.fleetnode.install.$$"
 previous="${PROGRAM_DIR%/*}/.fleetnode.previous.$$"
 unit_backup="$work_dir/fleetnode.service.previous"
 fresh_install=1
-[[ -d "$PROGRAM_DIR" ]] && fresh_install=0
-was_active=0
+[[ -x "$PROGRAM_DIR/fleetnode" && -f "$UNIT_PATH" ]] && fresh_install=0
+service_stopped=0
 previous_saved=0
 program_replaced=0
 unit_replaced=0
@@ -164,7 +164,7 @@ cleanup() {
     if [[ "$previous_saved" == "1" && -d "$previous" ]]; then
       mv "$previous" "$PROGRAM_DIR"
     fi
-    if [[ "$was_active" == "1" ]]; then
+    if [[ "$service_stopped" == "1" ]]; then
       "$SYSTEMCTL" start fleetnode.service >/dev/null 2>&1 || true
     fi
   fi
@@ -242,9 +242,9 @@ if ! grep -Fxq "version: $VERSION" "$source_dir/version.txt"; then
   exit 1
 fi
 
-if "$SYSTEMCTL" is-active --quiet fleetnode.service; then
-  was_active=1
+if [[ "$fresh_install" == "0" ]]; then
   "$SYSTEMCTL" stop fleetnode.service
+  service_stopped=1
 fi
 
 install -d -m 0755 "${PROGRAM_DIR%/*}" "${UNIT_PATH%/*}"
@@ -296,7 +296,7 @@ if [[ "$fresh_install" == "1" ]]; then
   if "$SYSTEMCTL" is-enabled --quiet fleetnode.service; then
     "$SYSTEMCTL" disable fleetnode.service
   fi
-elif [[ "$was_active" == "1" ]]; then
+else
   "$SYSTEMCTL" start fleetnode.service
 fi
 
@@ -306,10 +306,8 @@ echo "Configuration: $CONFIG_DIR"
 echo "Protected state: $STATE_DIR"
 if [[ "$fresh_install" == "1" ]]; then
   echo "The new service remains disabled until enrollment is complete."
-elif [[ "$was_active" == "1" ]]; then
-  echo "The previously running service was restarted; its enablement state was preserved."
 else
-  echo "The service was not started; its enablement state was preserved."
+  echo "The service was restarted; its enablement state was preserved."
 fi
 echo
 echo "Enroll:"

--- a/deployment-files/fleetnode/install-fleetnode.sh
+++ b/deployment-files/fleetnode/install-fleetnode.sh
@@ -89,6 +89,10 @@ fi
 for command in curl sha256sum tar install "$SYSTEMCTL"; do
   command -v "$command" >/dev/null 2>&1 || { echo "required command not found: $command" >&2; exit 1; }
 done
+if ! command -v nmap >/dev/null 2>&1; then
+  echo "required command not found: nmap; install nmap and ensure it is on PATH" >&2
+  exit 1
+fi
 if [[ "$TEST_MODE" != "1" ]]; then
   for command in getent useradd nologin; do
     command -v "$command" >/dev/null 2>&1 || { echo "required command not found: $command" >&2; exit 1; }
@@ -241,7 +245,11 @@ install -m 0644 "$PROGRAM_DIR/fleetnode.service" "$UNIT_PATH"
 unit_replaced=1
 "$SYSTEMCTL" daemon-reload
 
-if [[ "$was_active" == "1" ]]; then
+if [[ "$fresh_install" == "1" ]]; then
+  if "$SYSTEMCTL" is-enabled --quiet fleetnode.service; then
+    "$SYSTEMCTL" disable fleetnode.service
+  fi
+elif [[ "$was_active" == "1" ]]; then
   "$SYSTEMCTL" start fleetnode.service
 fi
 

--- a/deployment-files/fleetnode/install-fleetnode.sh
+++ b/deployment-files/fleetnode/install-fleetnode.sh
@@ -5,6 +5,12 @@ VERSION=""
 DOWNLOAD_BASE_URL="${FLEETNODE_DOWNLOAD_BASE_URL:-}"
 TEST_MODE="${FLEETNODE_TEST_MODE:-0}"
 ROOT_PREFIX="${FLEETNODE_ROOT_PREFIX:-}"
+LINUX_SERVICE_PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+if [[ "$TEST_MODE" != "1" ]]; then
+  PATH="$LINUX_SERVICE_PATH"
+  export PATH
+fi
 
 usage() {
   cat <<'EOF'
@@ -85,8 +91,12 @@ fi
 for command in curl sha256sum tar install "$SYSTEMCTL"; do
   command -v "$command" >/dev/null 2>&1 || { echo "required command not found: $command" >&2; exit 1; }
 done
+if [[ "$TEST_MODE" != "1" && ! -x /usr/bin/env ]]; then
+  echo "required command not found: /usr/bin/env" >&2
+  exit 1
+fi
 if ! command -v nmap >/dev/null 2>&1; then
-  echo "required command not found: nmap; install nmap and ensure it is on PATH" >&2
+  echo "required command not found: nmap; install nmap in the Fleet Node service PATH ($LINUX_SERVICE_PATH)" >&2
   exit 1
 fi
 if [[ "$TEST_MODE" != "1" ]]; then

--- a/deployment-files/fleetnode/install-fleetnode.sh
+++ b/deployment-files/fleetnode/install-fleetnode.sh
@@ -19,8 +19,8 @@ Usage: install-fleetnode.sh --version VERSION
 Install one exact Proto Fleet Node release on Linux. VERSION must be a
 release-specific tag such as v1.2.3 or nightly-20260825-0123456789ab.
 
-The installer creates the service but leaves a fresh installation disabled.
-After installation, enroll the node and then explicitly enable the service.
+The installer starts the service but leaves a fresh installation disabled at
+boot. After installation, enroll the node and then enable the service.
 EOF
 }
 
@@ -296,24 +296,23 @@ if [[ "$fresh_install" == "1" ]]; then
   if "$SYSTEMCTL" is-enabled --quiet fleetnode.service; then
     "$SYSTEMCTL" disable fleetnode.service
   fi
-else
-  "$SYSTEMCTL" start fleetnode.service
 fi
+"$SYSTEMCTL" start fleetnode.service
 
 install_complete=1
 echo "Fleet Node $VERSION installed."
 echo "Configuration: $CONFIG_DIR"
 echo "Protected state: $STATE_DIR"
 if [[ "$fresh_install" == "1" ]]; then
-  echo "The new service remains disabled until enrollment is complete."
+  echo "The service was started and remains disabled at boot until enrollment is complete."
 else
   echo "The service was restarted; its enablement state was preserved."
 fi
 echo
 echo "Enroll:"
 echo "  sudo -u fleetnode $PROGRAM_DIR/fleetnode --state-dir $STATE_DIR enroll --server-url=https://YOUR-FLEET-SERVER"
-echo "Then enable and start:"
-echo "  sudo systemctl enable --now fleetnode.service"
+echo "Then enable at boot:"
+echo "  sudo systemctl enable fleetnode.service"
 echo "Inspect:"
 echo "  systemctl status fleetnode.service"
 echo "  journalctl -u fleetnode.service"

--- a/deployment-files/fleetnode/install-fleetnode.sh
+++ b/deployment-files/fleetnode/install-fleetnode.sh
@@ -41,23 +41,19 @@ if [[ ! "$VERSION" =~ ^[A-Za-z0-9_][A-Za-z0-9._-]{0,127}$ ]] || [[ "$VERSION" ==
   echo "version must be an explicit release identifier (1-128 letters, numbers, dots, underscores, or hyphens; not latest)" >&2
   exit 2
 fi
+if [[ "$TEST_MODE" != "1" ]]; then
+  if [[ -n "$ROOT_PREFIX" || -n "${FLEETNODE_ARCH:-}" || -n "$DOWNLOAD_BASE_URL" || -n "${FLEETNODE_SYSTEMCTL:-}" ]]; then
+    echo "Fleet Node installer overrides are restricted to automated tests" >&2
+    exit 1
+  fi
+fi
 if [[ "$(uname -s)" != "Linux" && "$TEST_MODE" != "1" ]]; then
   echo "Fleet Node installation currently supports Linux only" >&2
   exit 1
 fi
 if [[ "$TEST_MODE" != "1" ]]; then
-  if [[ -n "$ROOT_PREFIX" ]]; then
-    echo "FLEETNODE_ROOT_PREFIX is only available in test mode" >&2
-    exit 1
-  fi
   if [[ "$(id -u)" -ne 0 ]]; then
     echo "run this installer as root (for example: sudo ./install-fleetnode.sh --version $VERSION)" >&2
-    exit 1
-  fi
-fi
-if [[ "$TEST_MODE" != "1" ]]; then
-  if [[ -n "${FLEETNODE_ARCH:-}" || -n "$DOWNLOAD_BASE_URL" ]]; then
-    echo "download and architecture overrides are restricted to automated tests" >&2
     exit 1
   fi
 fi
@@ -152,9 +148,13 @@ cleanup() {
 trap cleanup EXIT
 
 echo "Downloading Fleet Node $VERSION for linux/$ARCH..."
-curl --fail --location --silent --show-error \
+curl_options=(--disable --fail --location --silent --show-error)
+if [[ "$TEST_MODE" != "1" ]]; then
+  curl_options+=(--proto '=https' --proto-redir '=https')
+fi
+curl "${curl_options[@]}" \
   --output "$work_dir/$ARCHIVE_NAME" "$DOWNLOAD_BASE_URL/$ARCHIVE_NAME"
-curl --fail --location --silent --show-error \
+curl "${curl_options[@]}" \
   --output "$work_dir/$ARCHIVE_NAME.sha256" "$DOWNLOAD_BASE_URL/$ARCHIVE_NAME.sha256"
 
 (
@@ -180,6 +180,7 @@ done < <(tar -tzf "$work_dir/$ARCHIVE_NAME")
 mkdir -p "$work_dir/extracted"
 tar -xzf "$work_dir/$ARCHIVE_NAME" -C "$work_dir/extracted"
 source_dir="$work_dir/extracted/$ARCHIVE_ROOT"
+[[ -d "$source_dir" && ! -L "$source_dir" ]] || { echo "archive root must be a directory" >&2; exit 1; }
 for required in \
   fleetnode \
   version.txt \
@@ -196,6 +197,17 @@ if find "$source_dir" -type l -print -quit | grep -q .; then
   echo "archive must not contain symlinks" >&2
   exit 1
 fi
+if find "$source_dir" -type f -links +1 -print -quit | grep -q .; then
+  echo "archive must not contain hard links" >&2
+  exit 1
+fi
+while IFS= read -r -d '' path; do
+  relative_path="${path#"$source_dir"/}"
+  case "$relative_path" in
+    fleetnode|version.txt|fleetnode.service|plugins|plugins/proto-plugin|plugins/antminer-plugin|plugins/virtual-plugin|plugins/virtual-plugin.json|plugins/asicrs-plugin|plugins/asicrs-config.yaml) ;;
+    *) echo "archive contains an unexpected entry: $relative_path" >&2; exit 1 ;;
+  esac
+done < <(find "$source_dir" -mindepth 1 -print0)
 if ! grep -Fxq "version: $VERSION" "$source_dir/version.txt"; then
   echo "Fleet Node archive metadata does not match requested version '$VERSION'" >&2
   exit 1
@@ -224,10 +236,16 @@ else
 fi
 
 rm -rf "$incoming" "$previous"
-install -d -m 0755 "$incoming"
-cp -a "$source_dir/." "$incoming/"
-chmod 0755 "$incoming/fleetnode" "$incoming/plugins/"*-plugin
-chmod 0644 "$incoming/version.txt" "$incoming/fleetnode.service" "$incoming/plugins/"*.json "$incoming/plugins/"*.yaml
+install -d -m 0755 "$incoming" "$incoming/plugins"
+install -m 0755 "$source_dir/fleetnode" "$incoming/fleetnode"
+install -m 0644 "$source_dir/version.txt" "$incoming/version.txt"
+install -m 0644 "$source_dir/fleetnode.service" "$incoming/fleetnode.service"
+install -m 0755 "$source_dir/plugins/proto-plugin" "$incoming/plugins/proto-plugin"
+install -m 0755 "$source_dir/plugins/antminer-plugin" "$incoming/plugins/antminer-plugin"
+install -m 0755 "$source_dir/plugins/virtual-plugin" "$incoming/plugins/virtual-plugin"
+install -m 0644 "$source_dir/plugins/virtual-plugin.json" "$incoming/plugins/virtual-plugin.json"
+install -m 0755 "$source_dir/plugins/asicrs-plugin" "$incoming/plugins/asicrs-plugin"
+install -m 0644 "$source_dir/plugins/asicrs-config.yaml" "$incoming/plugins/asicrs-config.yaml"
 if [[ "$TEST_MODE" != "1" ]]; then
   chown -R root:root "$incoming"
 fi

--- a/deployment-files/fleetnode/tests/test-install-fleetnode.sh
+++ b/deployment-files/fleetnode/tests/test-install-fleetnode.sh
@@ -59,15 +59,11 @@ cat > "$TEST_DIR/bin/systemctl" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >> "$SYSTEMCTL_LOG"
-if [[ "${1:-}" == "is-active" && -n "${FAKE_FLEETNODE_LOCK_READY:-}" ]]; then
+if [[ "${1:-}" == "stop" && -n "${FAKE_FLEETNODE_LOCK_READY:-}" ]]; then
   : > "$FAKE_FLEETNODE_LOCK_READY"
   while [[ -e "${FAKE_FLEETNODE_LOCK_BLOCK:-}" ]]; do
     sleep 0.05
   done
-fi
-if [[ "${1:-}" == "is-active" ]]; then
-  [[ "${FAKE_FLEETNODE_ACTIVE:-0}" == "1" ]]
-  exit
 fi
 if [[ "${1:-}" == "is-enabled" ]]; then
   [[ "${FAKE_FLEETNODE_ENABLED:-0}" == "1" ]]
@@ -112,6 +108,9 @@ assert_file_contains "$FLEETNODE_DIR/install-fleetnode.sh" "LINUX_SERVICE_PATH=\
 assert_file_contains "$FLEETNODE_DIR/install-fleetnode.sh" 'PATH="$LINUX_SERVICE_PATH"'
 assert_file_contains "$FLEETNODE_DIR/install-fleetnode.sh" 'exec 9<>"$INSTALL_LOCK_PATH"'
 assert_file_contains "$FLEETNODE_DIR/install-fleetnode.sh" 'if ! flock -n "$INSTALL_LOCK_FD"; then'
+if grep -Fq 'is-active' "$FLEETNODE_DIR/install-fleetnode.sh"; then
+  fail "installer checks active state before restarting"
+fi
 
 if FLEETNODE_SYSTEMCTL="$TEST_DIR/bin/systemctl" \
     /bin/bash "$FLEETNODE_DIR/install-fleetnode.sh" --version v1.0.0 2> "$TEST_DIR/systemctl-override.err"; then
@@ -128,7 +127,6 @@ printf 'proto = "=https"\n' > "$TEST_DIR/curl-home/.curlrc"
 
 run_installer() {
   local version="$1"
-  FAKE_FLEETNODE_ACTIVE="${FAKE_FLEETNODE_ACTIVE:-0}" \
   FAKE_FLEETNODE_ENABLED="${FAKE_FLEETNODE_ENABLED:-0}" \
   FAKE_FLEETNODE_LOCK_READY="${FAKE_FLEETNODE_LOCK_READY:-}" \
   FAKE_FLEETNODE_LOCK_BLOCK="${FAKE_FLEETNODE_LOCK_BLOCK:-}" \
@@ -144,7 +142,7 @@ run_installer() {
 }
 
 : > "$SYSTEMCTL_LOG"
-CURL_HOME="$TEST_DIR/curl-home" FAKE_FLEETNODE_ACTIVE=0 FAKE_FLEETNODE_ENABLED=1 run_installer v1.0.0
+CURL_HOME="$TEST_DIR/curl-home" FAKE_FLEETNODE_ENABLED=1 run_installer v1.0.0
 
 [[ -x "$ROOT_PREFIX/opt/fleetnode/fleetnode" ]] || fail "Fleet Node binary was not installed"
 assert_file_contains "$ROOT_PREFIX/opt/fleetnode/version.txt" "version: v1.0.0"
@@ -163,7 +161,7 @@ printf 'identity material\n' > "$ROOT_PREFIX/var/lib/fleetnode/state.yaml"
 printf 'stale program file\n' > "$ROOT_PREFIX/opt/fleetnode/stale.txt"
 
 : > "$SYSTEMCTL_LOG"
-FAKE_FLEETNODE_ACTIVE=1 run_installer v1.1.0
+run_installer v1.1.0
 
 assert_file_contains "$ROOT_PREFIX/opt/fleetnode/version.txt" "version: v1.1.0"
 [[ ! -e "$ROOT_PREFIX/opt/fleetnode/stale.txt" ]] || fail "upgrade retained stale program files"
@@ -177,7 +175,6 @@ if REAL_FLOCK_BINARY=$(command -v flock 2>/dev/null); then
   LOCK_BLOCK="$TEST_DIR/installer-lock.block"
   : > "$LOCK_BLOCK"
   REAL_FLOCK="$REAL_FLOCK_BINARY" \
-    FAKE_FLEETNODE_ACTIVE=0 \
     FAKE_FLEETNODE_LOCK_READY="$LOCK_READY" \
     FAKE_FLEETNODE_LOCK_BLOCK="$LOCK_BLOCK" \
     run_installer v1.1.0 > "$TEST_DIR/first-installer.log" 2>&1 &

--- a/deployment-files/fleetnode/tests/test-install-fleetnode.sh
+++ b/deployment-files/fleetnode/tests/test-install-fleetnode.sh
@@ -151,10 +151,11 @@ assert_file_contains "$ROOT_PREFIX/etc/systemd/system/fleetnode.service" "Enviro
 assert_file_contains "$ROOT_PREFIX/etc/systemd/system/fleetnode.service" "ExecStart=/usr/bin/env PATH=$LINUX_SERVICE_PATH /opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode run"
 assert_file_contains "$ROOT_PREFIX/etc/systemd/system/fleetnode.service" "Restart=on-failure"
 assert_file_contains "$ROOT_PREFIX/etc/systemd/system/fleetnode.service" "RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK"
-if grep -Eq '(^| )enable( |$)|(^| )start( |$)' "$SYSTEMCTL_LOG"; then
-  fail "fresh install enabled or started the service"
+if grep -Eq '(^| )enable( |$)|(^| )stop( |$)' "$SYSTEMCTL_LOG"; then
+  fail "fresh install enabled or stopped the service"
 fi
 assert_file_contains "$SYSTEMCTL_LOG" "disable fleetnode.service"
+assert_file_contains "$SYSTEMCTL_LOG" "start fleetnode.service"
 
 printf 'operator config\n' > "$ROOT_PREFIX/etc/fleetnode/config.yaml"
 printf 'identity material\n' > "$ROOT_PREFIX/var/lib/fleetnode/state.yaml"

--- a/deployment-files/fleetnode/tests/test-install-fleetnode.sh
+++ b/deployment-files/fleetnode/tests/test-install-fleetnode.sh
@@ -57,9 +57,34 @@ if [[ "${1:-}" == "is-active" ]]; then
   [[ "${FAKE_FLEETNODE_ACTIVE:-0}" == "1" ]]
   exit
 fi
+if [[ "${1:-}" == "is-enabled" ]]; then
+  [[ "${FAKE_FLEETNODE_ENABLED:-0}" == "1" ]]
+  exit
+fi
 exit 0
 EOF
 chmod 0755 "$TEST_DIR/bin/systemctl"
+
+cat > "$TEST_DIR/bin/nmap" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod 0755 "$TEST_DIR/bin/nmap"
+
+NO_NMAP_BIN="$TEST_DIR/no-nmap-bin"
+mkdir -p "$NO_NMAP_BIN"
+for command in uname curl sha256sum tar install; do
+  ln -s "$(command -v "$command")" "$NO_NMAP_BIN/$command"
+done
+if PATH="$NO_NMAP_BIN" \
+  FLEETNODE_TEST_MODE=1 \
+  FLEETNODE_ROOT_PREFIX="$ROOT_PREFIX" \
+  FLEETNODE_ARCH=amd64 \
+  FLEETNODE_SYSTEMCTL="$TEST_DIR/bin/systemctl" \
+    /bin/bash "$FLEETNODE_DIR/install-fleetnode.sh" --version v1.0.0 2> "$TEST_DIR/missing-nmap.err"; then
+  fail "installer accepted a host without nmap on PATH"
+fi
+assert_file_contains "$TEST_DIR/missing-nmap.err" "required command not found: nmap"
 
 create_release v1.0.0
 create_release v1.1.0
@@ -67,7 +92,9 @@ create_release v1.1.0
 run_installer() {
   local version="$1"
   FAKE_FLEETNODE_ACTIVE="${FAKE_FLEETNODE_ACTIVE:-0}" \
+  FAKE_FLEETNODE_ENABLED="${FAKE_FLEETNODE_ENABLED:-0}" \
   SYSTEMCTL_LOG="$SYSTEMCTL_LOG" \
+  PATH="$TEST_DIR/bin:$PATH" \
   FLEETNODE_TEST_MODE=1 \
   FLEETNODE_ROOT_PREFIX="$ROOT_PREFIX" \
   FLEETNODE_ARCH=amd64 \
@@ -77,7 +104,7 @@ run_installer() {
 }
 
 : > "$SYSTEMCTL_LOG"
-FAKE_FLEETNODE_ACTIVE=0 run_installer v1.0.0
+FAKE_FLEETNODE_ACTIVE=0 FAKE_FLEETNODE_ENABLED=1 run_installer v1.0.0
 
 [[ -x "$ROOT_PREFIX/opt/fleetnode/fleetnode" ]] || fail "Fleet Node binary was not installed"
 assert_file_contains "$ROOT_PREFIX/opt/fleetnode/version.txt" "version: v1.0.0"
@@ -87,6 +114,7 @@ assert_file_contains "$ROOT_PREFIX/etc/systemd/system/fleetnode.service" "Restar
 if grep -Eq '(^| )enable( |$)|(^| )start( |$)' "$SYSTEMCTL_LOG"; then
   fail "fresh install enabled or started the service"
 fi
+assert_file_contains "$SYSTEMCTL_LOG" "disable fleetnode.service"
 
 printf 'operator config\n' > "$ROOT_PREFIX/etc/fleetnode/config.yaml"
 printf 'identity material\n' > "$ROOT_PREFIX/var/lib/fleetnode/state.yaml"

--- a/deployment-files/fleetnode/tests/test-install-fleetnode.sh
+++ b/deployment-files/fleetnode/tests/test-install-fleetnode.sh
@@ -9,6 +9,7 @@ trap 'rm -rf "$TEST_DIR"' EXIT
 ASSETS_DIR="$TEST_DIR/assets"
 ROOT_PREFIX="$TEST_DIR/root"
 SYSTEMCTL_LOG="$TEST_DIR/systemctl.log"
+LINUX_SERVICE_PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 mkdir -p "$ASSETS_DIR" "$ROOT_PREFIX" "$TEST_DIR/bin"
 
 fail() {
@@ -90,6 +91,8 @@ if PATH="$NO_NMAP_BIN" \
   fail "installer accepted a host without nmap on PATH"
 fi
 assert_file_contains "$TEST_DIR/missing-nmap.err" "required command not found: nmap"
+assert_file_contains "$FLEETNODE_DIR/install-fleetnode.sh" "LINUX_SERVICE_PATH=\"$LINUX_SERVICE_PATH\""
+assert_file_contains "$FLEETNODE_DIR/install-fleetnode.sh" 'PATH="$LINUX_SERVICE_PATH"'
 
 if FLEETNODE_SYSTEMCTL="$TEST_DIR/bin/systemctl" \
     /bin/bash "$FLEETNODE_DIR/install-fleetnode.sh" --version v1.0.0 2> "$TEST_DIR/systemctl-override.err"; then
@@ -124,7 +127,8 @@ CURL_HOME="$TEST_DIR/curl-home" FAKE_FLEETNODE_ACTIVE=0 FAKE_FLEETNODE_ENABLED=1
 [[ -x "$ROOT_PREFIX/opt/fleetnode/fleetnode" ]] || fail "Fleet Node binary was not installed"
 assert_file_contains "$ROOT_PREFIX/opt/fleetnode/version.txt" "version: v1.0.0"
 [[ -f "$ROOT_PREFIX/etc/systemd/system/fleetnode.service" ]] || fail "systemd unit was not installed"
-assert_file_contains "$ROOT_PREFIX/etc/systemd/system/fleetnode.service" "ExecStart=/opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode run"
+assert_file_contains "$ROOT_PREFIX/etc/systemd/system/fleetnode.service" "Environment=PATH=$LINUX_SERVICE_PATH"
+assert_file_contains "$ROOT_PREFIX/etc/systemd/system/fleetnode.service" "ExecStart=/usr/bin/env PATH=$LINUX_SERVICE_PATH /opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode run"
 assert_file_contains "$ROOT_PREFIX/etc/systemd/system/fleetnode.service" "Restart=on-failure"
 assert_file_contains "$ROOT_PREFIX/etc/systemd/system/fleetnode.service" "RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK"
 if grep -Eq '(^| )enable( |$)|(^| )start( |$)' "$SYSTEMCTL_LOG"; then

--- a/deployment-files/fleetnode/tests/test-install-fleetnode.sh
+++ b/deployment-files/fleetnode/tests/test-install-fleetnode.sh
@@ -24,6 +24,7 @@ assert_file_contains() {
 
 create_release() {
   local version="$1"
+  local extra_entry="${2:-}"
   local release_dir="$ASSETS_DIR/$version"
   local archive_root="fleetnode-${version}-linux-amd64"
   mkdir -p "$release_dir/$archive_root/plugins"
@@ -40,6 +41,10 @@ create_release() {
   done
   printf '{}\n' > "$release_dir/$archive_root/plugins/virtual-plugin.json"
   printf 'plugin: {}\nminers: {}\n' > "$release_dir/$archive_root/plugins/asicrs-config.yaml"
+  if [[ -n "$extra_entry" ]]; then
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$release_dir/$archive_root/$extra_entry"
+    chmod 4755 "$release_dir/$archive_root/$extra_entry"
+  fi
 
   (
     cd "$release_dir"
@@ -86,8 +91,18 @@ if PATH="$NO_NMAP_BIN" \
 fi
 assert_file_contains "$TEST_DIR/missing-nmap.err" "required command not found: nmap"
 
+if FLEETNODE_SYSTEMCTL="$TEST_DIR/bin/systemctl" \
+    /bin/bash "$FLEETNODE_DIR/install-fleetnode.sh" --version v1.0.0 2> "$TEST_DIR/systemctl-override.err"; then
+  fail "installer accepted a systemctl override outside test mode"
+fi
+assert_file_contains "$TEST_DIR/systemctl-override.err" "installer overrides are restricted to automated tests"
+
 create_release v1.0.0
 create_release v1.1.0
+create_release v1.2.0 unexpected-setuid
+
+mkdir -p "$TEST_DIR/curl-home"
+printf 'proto = "=https"\n' > "$TEST_DIR/curl-home/.curlrc"
 
 run_installer() {
   local version="$1"
@@ -104,7 +119,7 @@ run_installer() {
 }
 
 : > "$SYSTEMCTL_LOG"
-FAKE_FLEETNODE_ACTIVE=0 FAKE_FLEETNODE_ENABLED=1 run_installer v1.0.0
+CURL_HOME="$TEST_DIR/curl-home" FAKE_FLEETNODE_ACTIVE=0 FAKE_FLEETNODE_ENABLED=1 run_installer v1.0.0
 
 [[ -x "$ROOT_PREFIX/opt/fleetnode/fleetnode" ]] || fail "Fleet Node binary was not installed"
 assert_file_contains "$ROOT_PREFIX/opt/fleetnode/version.txt" "version: v1.0.0"
@@ -130,6 +145,12 @@ assert_file_contains "$ROOT_PREFIX/etc/fleetnode/config.yaml" "operator config"
 assert_file_contains "$ROOT_PREFIX/var/lib/fleetnode/state.yaml" "identity material"
 assert_file_contains "$SYSTEMCTL_LOG" "stop fleetnode.service"
 assert_file_contains "$SYSTEMCTL_LOG" "start fleetnode.service"
+
+if run_installer v1.2.0; then
+  fail "installer accepted an archive entry outside the Fleet Node manifest"
+fi
+assert_file_contains "$ROOT_PREFIX/opt/fleetnode/version.txt" "version: v1.1.0"
+[[ ! -e "$ROOT_PREFIX/opt/fleetnode/unexpected-setuid" ]] || fail "installer persisted an unexpected archive entry"
 
 cp -R "$ASSETS_DIR/v1.1.0" "$ASSETS_DIR/bad-checksum"
 printf 'tampered\n' >> "$ASSETS_DIR/bad-checksum/fleetnode-v1.1.0-linux-amd64.tar.gz"

--- a/deployment-files/fleetnode/tests/test-install-fleetnode.sh
+++ b/deployment-files/fleetnode/tests/test-install-fleetnode.sh
@@ -59,6 +59,12 @@ cat > "$TEST_DIR/bin/systemctl" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >> "$SYSTEMCTL_LOG"
+if [[ "${1:-}" == "is-active" && -n "${FAKE_FLEETNODE_LOCK_READY:-}" ]]; then
+  : > "$FAKE_FLEETNODE_LOCK_READY"
+  while [[ -e "${FAKE_FLEETNODE_LOCK_BLOCK:-}" ]]; do
+    sleep 0.05
+  done
+fi
 if [[ "${1:-}" == "is-active" ]]; then
   [[ "${FAKE_FLEETNODE_ACTIVE:-0}" == "1" ]]
   exit
@@ -77,11 +83,22 @@ exit 0
 EOF
 chmod 0755 "$TEST_DIR/bin/nmap"
 
+cat > "$TEST_DIR/bin/flock" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ -n "${REAL_FLOCK:-}" ]]; then
+  exec "$REAL_FLOCK" "$@"
+fi
+exit 0
+EOF
+chmod 0755 "$TEST_DIR/bin/flock"
+
 NO_NMAP_BIN="$TEST_DIR/no-nmap-bin"
 mkdir -p "$NO_NMAP_BIN"
 for command in uname curl sha256sum tar install; do
   ln -s "$(command -v "$command")" "$NO_NMAP_BIN/$command"
 done
+ln -s "$TEST_DIR/bin/flock" "$NO_NMAP_BIN/flock"
 if PATH="$NO_NMAP_BIN" \
   FLEETNODE_TEST_MODE=1 \
   FLEETNODE_ROOT_PREFIX="$ROOT_PREFIX" \
@@ -93,6 +110,8 @@ fi
 assert_file_contains "$TEST_DIR/missing-nmap.err" "required command not found: nmap"
 assert_file_contains "$FLEETNODE_DIR/install-fleetnode.sh" "LINUX_SERVICE_PATH=\"$LINUX_SERVICE_PATH\""
 assert_file_contains "$FLEETNODE_DIR/install-fleetnode.sh" 'PATH="$LINUX_SERVICE_PATH"'
+assert_file_contains "$FLEETNODE_DIR/install-fleetnode.sh" 'exec 9<>"$INSTALL_LOCK_PATH"'
+assert_file_contains "$FLEETNODE_DIR/install-fleetnode.sh" 'if ! flock -n "$INSTALL_LOCK_FD"; then'
 
 if FLEETNODE_SYSTEMCTL="$TEST_DIR/bin/systemctl" \
     /bin/bash "$FLEETNODE_DIR/install-fleetnode.sh" --version v1.0.0 2> "$TEST_DIR/systemctl-override.err"; then
@@ -111,6 +130,9 @@ run_installer() {
   local version="$1"
   FAKE_FLEETNODE_ACTIVE="${FAKE_FLEETNODE_ACTIVE:-0}" \
   FAKE_FLEETNODE_ENABLED="${FAKE_FLEETNODE_ENABLED:-0}" \
+  FAKE_FLEETNODE_LOCK_READY="${FAKE_FLEETNODE_LOCK_READY:-}" \
+  FAKE_FLEETNODE_LOCK_BLOCK="${FAKE_FLEETNODE_LOCK_BLOCK:-}" \
+  REAL_FLOCK="${REAL_FLOCK:-}" \
   SYSTEMCTL_LOG="$SYSTEMCTL_LOG" \
   PATH="$TEST_DIR/bin:$PATH" \
   FLEETNODE_TEST_MODE=1 \
@@ -150,6 +172,39 @@ assert_file_contains "$ROOT_PREFIX/var/lib/fleetnode/state.yaml" "identity mater
 assert_file_contains "$SYSTEMCTL_LOG" "stop fleetnode.service"
 assert_file_contains "$SYSTEMCTL_LOG" "start fleetnode.service"
 
+if REAL_FLOCK_BINARY=$(command -v flock 2>/dev/null); then
+  LOCK_READY="$TEST_DIR/installer-lock.ready"
+  LOCK_BLOCK="$TEST_DIR/installer-lock.block"
+  : > "$LOCK_BLOCK"
+  REAL_FLOCK="$REAL_FLOCK_BINARY" \
+    FAKE_FLEETNODE_ACTIVE=0 \
+    FAKE_FLEETNODE_LOCK_READY="$LOCK_READY" \
+    FAKE_FLEETNODE_LOCK_BLOCK="$LOCK_BLOCK" \
+    run_installer v1.1.0 > "$TEST_DIR/first-installer.log" 2>&1 &
+  first_installer_pid=$!
+
+  for _ in {1..100}; do
+    [[ -e "$LOCK_READY" ]] && break
+    sleep 0.05
+  done
+  if [[ ! -e "$LOCK_READY" ]]; then
+    rm -f "$LOCK_BLOCK"
+    wait "$first_installer_pid" || true
+    fail "first installer did not reach the lock test barrier"
+  fi
+
+  if REAL_FLOCK="$REAL_FLOCK_BINARY" run_installer v1.1.0 > "$TEST_DIR/second-installer.log" 2>&1; then
+    rm -f "$LOCK_BLOCK"
+    wait "$first_installer_pid" || true
+    fail "installer accepted an overlapping invocation"
+  fi
+  assert_file_contains "$TEST_DIR/second-installer.log" "another Fleet Node installer is running"
+
+  rm -f "$LOCK_BLOCK"
+  wait "$first_installer_pid"
+  assert_file_contains "$ROOT_PREFIX/opt/fleetnode/version.txt" "version: v1.1.0"
+fi
+
 if run_installer v1.2.0; then
   fail "installer accepted an archive entry outside the Fleet Node manifest"
 fi
@@ -163,9 +218,12 @@ if FLEETNODE_TEST_MODE=1 \
   FLEETNODE_ARCH=amd64 \
   FLEETNODE_SYSTEMCTL="$TEST_DIR/bin/systemctl" \
   FLEETNODE_DOWNLOAD_BASE_URL="file://$ASSETS_DIR/bad-checksum" \
-    bash "$FLEETNODE_DIR/install-fleetnode.sh" --version v1.1.0; then
+  SYSTEMCTL_LOG="$SYSTEMCTL_LOG" \
+  PATH="$TEST_DIR/bin:$PATH" \
+    bash "$FLEETNODE_DIR/install-fleetnode.sh" --version v1.1.0 2> "$TEST_DIR/bad-checksum.err"; then
   fail "installer accepted a checksum mismatch"
 fi
+assert_file_contains "$TEST_DIR/bad-checksum.err" "checksum sidecar is not bound"
 assert_file_contains "$ROOT_PREFIX/opt/fleetnode/version.txt" "version: v1.1.0"
 assert_file_contains "$ROOT_PREFIX/var/lib/fleetnode/state.yaml" "identity material"
 

--- a/deployment-files/fleetnode/tests/test-install-fleetnode.sh
+++ b/deployment-files/fleetnode/tests/test-install-fleetnode.sh
@@ -111,6 +111,7 @@ assert_file_contains "$ROOT_PREFIX/opt/fleetnode/version.txt" "version: v1.0.0"
 [[ -f "$ROOT_PREFIX/etc/systemd/system/fleetnode.service" ]] || fail "systemd unit was not installed"
 assert_file_contains "$ROOT_PREFIX/etc/systemd/system/fleetnode.service" "ExecStart=/opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode run"
 assert_file_contains "$ROOT_PREFIX/etc/systemd/system/fleetnode.service" "Restart=on-failure"
+assert_file_contains "$ROOT_PREFIX/etc/systemd/system/fleetnode.service" "RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK"
 if grep -Eq '(^| )enable( |$)|(^| )start( |$)' "$SYSTEMCTL_LOG"; then
   fail "fresh install enabled or started the service"
 fi

--- a/deployment-files/fleetnode/tests/test-install-fleetnode.sh
+++ b/deployment-files/fleetnode/tests/test-install-fleetnode.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+FLEETNODE_DIR=$(cd "$SCRIPT_DIR/.." && pwd)
+TEST_DIR=$(mktemp -d)
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+ASSETS_DIR="$TEST_DIR/assets"
+ROOT_PREFIX="$TEST_DIR/root"
+SYSTEMCTL_LOG="$TEST_DIR/systemctl.log"
+mkdir -p "$ASSETS_DIR" "$ROOT_PREFIX" "$TEST_DIR/bin"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_file_contains() {
+  local path="$1"
+  local expected="$2"
+  grep -Fq "$expected" "$path" || fail "$path does not contain: $expected"
+}
+
+create_release() {
+  local version="$1"
+  local release_dir="$ASSETS_DIR/$version"
+  local archive_root="fleetnode-${version}-linux-amd64"
+  mkdir -p "$release_dir/$archive_root/plugins"
+
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$release_dir/$archive_root/fleetnode"
+  chmod 0755 "$release_dir/$archive_root/fleetnode"
+  printf 'version: %s\n' "$version" > "$release_dir/$archive_root/version.txt"
+  cp "$FLEETNODE_DIR/fleetnode.service" "$release_dir/$archive_root/fleetnode.service"
+
+  local plugin
+  for plugin in proto-plugin antminer-plugin virtual-plugin asicrs-plugin; do
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$release_dir/$archive_root/plugins/$plugin"
+    chmod 0755 "$release_dir/$archive_root/plugins/$plugin"
+  done
+  printf '{}\n' > "$release_dir/$archive_root/plugins/virtual-plugin.json"
+  printf 'plugin: {}\nminers: {}\n' > "$release_dir/$archive_root/plugins/asicrs-config.yaml"
+
+  (
+    cd "$release_dir"
+    tar -czf "$archive_root.tar.gz" "$archive_root"
+    sha256sum "$archive_root.tar.gz" > "$archive_root.tar.gz.sha256"
+    rm -rf "$archive_root"
+  )
+}
+
+cat > "$TEST_DIR/bin/systemctl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$SYSTEMCTL_LOG"
+if [[ "${1:-}" == "is-active" ]]; then
+  [[ "${FAKE_FLEETNODE_ACTIVE:-0}" == "1" ]]
+  exit
+fi
+exit 0
+EOF
+chmod 0755 "$TEST_DIR/bin/systemctl"
+
+create_release v1.0.0
+create_release v1.1.0
+
+run_installer() {
+  local version="$1"
+  FAKE_FLEETNODE_ACTIVE="${FAKE_FLEETNODE_ACTIVE:-0}" \
+  SYSTEMCTL_LOG="$SYSTEMCTL_LOG" \
+  FLEETNODE_TEST_MODE=1 \
+  FLEETNODE_ROOT_PREFIX="$ROOT_PREFIX" \
+  FLEETNODE_ARCH=amd64 \
+  FLEETNODE_SYSTEMCTL="$TEST_DIR/bin/systemctl" \
+  FLEETNODE_DOWNLOAD_BASE_URL="file://$ASSETS_DIR/$version" \
+    bash "$FLEETNODE_DIR/install-fleetnode.sh" --version "$version"
+}
+
+: > "$SYSTEMCTL_LOG"
+FAKE_FLEETNODE_ACTIVE=0 run_installer v1.0.0
+
+[[ -x "$ROOT_PREFIX/opt/fleetnode/fleetnode" ]] || fail "Fleet Node binary was not installed"
+assert_file_contains "$ROOT_PREFIX/opt/fleetnode/version.txt" "version: v1.0.0"
+[[ -f "$ROOT_PREFIX/etc/systemd/system/fleetnode.service" ]] || fail "systemd unit was not installed"
+assert_file_contains "$ROOT_PREFIX/etc/systemd/system/fleetnode.service" "ExecStart=/opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode run"
+assert_file_contains "$ROOT_PREFIX/etc/systemd/system/fleetnode.service" "Restart=on-failure"
+if grep -Eq '(^| )enable( |$)|(^| )start( |$)' "$SYSTEMCTL_LOG"; then
+  fail "fresh install enabled or started the service"
+fi
+
+printf 'operator config\n' > "$ROOT_PREFIX/etc/fleetnode/config.yaml"
+printf 'identity material\n' > "$ROOT_PREFIX/var/lib/fleetnode/state.yaml"
+printf 'stale program file\n' > "$ROOT_PREFIX/opt/fleetnode/stale.txt"
+
+: > "$SYSTEMCTL_LOG"
+FAKE_FLEETNODE_ACTIVE=1 run_installer v1.1.0
+
+assert_file_contains "$ROOT_PREFIX/opt/fleetnode/version.txt" "version: v1.1.0"
+[[ ! -e "$ROOT_PREFIX/opt/fleetnode/stale.txt" ]] || fail "upgrade retained stale program files"
+assert_file_contains "$ROOT_PREFIX/etc/fleetnode/config.yaml" "operator config"
+assert_file_contains "$ROOT_PREFIX/var/lib/fleetnode/state.yaml" "identity material"
+assert_file_contains "$SYSTEMCTL_LOG" "stop fleetnode.service"
+assert_file_contains "$SYSTEMCTL_LOG" "start fleetnode.service"
+
+cp -R "$ASSETS_DIR/v1.1.0" "$ASSETS_DIR/bad-checksum"
+printf 'tampered\n' >> "$ASSETS_DIR/bad-checksum/fleetnode-v1.1.0-linux-amd64.tar.gz"
+if FLEETNODE_TEST_MODE=1 \
+  FLEETNODE_ROOT_PREFIX="$ROOT_PREFIX" \
+  FLEETNODE_ARCH=amd64 \
+  FLEETNODE_SYSTEMCTL="$TEST_DIR/bin/systemctl" \
+  FLEETNODE_DOWNLOAD_BASE_URL="file://$ASSETS_DIR/bad-checksum" \
+    bash "$FLEETNODE_DIR/install-fleetnode.sh" --version v1.1.0; then
+  fail "installer accepted a checksum mismatch"
+fi
+assert_file_contains "$ROOT_PREFIX/opt/fleetnode/version.txt" "version: v1.1.0"
+assert_file_contains "$ROOT_PREFIX/var/lib/fleetnode/state.yaml" "identity material"
+
+echo "Fleet Node installer tests passed"


### PR DESCRIPTION
Reviewable diff: +468/-0 across 7 files (excludes generated, test, and story files).

## Summary

Adds installable Linux amd64 and arm64 Fleet Node releases with a checksum-verifying installer and hardened systemd unit. Stable and nightly publishing carry the Fleet Node archives, checksum sidecars, and installer from the artifact build into GitHub Releases, matching the installer's default download location.

## How it works

The artifact workflow builds Fleet Node and its required plugins with CGO disabled on native amd64 and arm64 runners, then verifies the Go ELF binaries are statically linked. Each matrix run creates a versioned tarball and SHA-256 sidecar. Stable and nightly publishers download both architectures, verify that each checksum is bound to the expected filename, and publish the archives, sidecars, and installer as release assets.

An operator runs the installer with an explicit release version. The installer verifies that `nmap` is available, selects the host architecture, downloads and validates the matching archive, installs the program under `/opt/fleetnode`, creates protected config and state directories, and installs the unit under `/etc/systemd/system`. Existing active services are stopped for replacement and restarted afterward; fresh installations are explicitly disabled and remain stopped for enrollment.

```mermaid
flowchart LR
  A["Artifact workflow"] --> B["Build static Fleet Node and plugins"]
  B --> C["Versioned archives and checksums"]
  C --> D["Stable and nightly publishers"]
  D --> E["GitHub Release assets"]
  F["Installer with explicit version"] --> G["Verify nmap, archive, and checksum"]
  G --> E
  G --> H["Install fixed system paths"]
  H --> I["Install disabled systemd unit"]
  I --> J["Enroll, then enable service"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `.github/workflows/proto-fleet-artifact-build.yml` | Adds amd64/arm64 CGO-disabled Fleet Node packaging and static-link checks | Review build inputs, architecture handling, archive layout, and checksum generation |
| `.github/workflows/release.yml` | Publishes and verifies stable Fleet Node assets | Ensures versioned installer URLs resolve for stable releases |
| `.github/workflows/nightly-builds.yml` | Publishes, verifies, repairs, and summarizes nightly Fleet Node assets | Ensures nightly versions remain installable and draft repair is complete |
| `deployment-files/fleetnode/install-fleetnode.sh` | Adds the Linux installer, `nmap` prerequisite, and upgrade behavior | Review privilege boundaries, validation, ownership, service state, and replacement behavior |
| `deployment-files/fleetnode/fleetnode.service` | Adds the native systemd service | Review execution paths, restart policy, and hardening directives |
| `.github/workflows/deployment-config-checks.yml` | Adds an installer-test job | Review the CI entry point and test isolation |
| `.github/path-filters.yml` | Routes Fleet Node deployment changes to deployment checks | Ensures installer-only changes run CI |
| `deployment-files/fleetnode/tests/test-install-fleetnode.sh` | Tests prerequisites, install, upgrade, state preservation, service handling, and checksum rejection | Test file |

## Key technical decisions & trade-offs

- Packages include Fleet Node and all required plugins rather than relying on host-installed plugin binaries.
- Go host binaries use `CGO_ENABLED=0` and fail packaging if an ELF interpreter or shared-library dependency is present.
- `nmap` remains a host prerequisite instead of being copied from a runner-specific distribution into the archive.
- The installer requires an exact version instead of resolving `latest`, keeping archive and checksum selection deterministic.
- Stable and nightly publishers re-create each checksum sidecar before publishing, validating both digest and filename.
- Program files are replaced as a unit while `/etc/fleetnode` and `/var/lib/fleetnode` remain outside the replacement tree.
- Fresh installs reconcile stale systemd enablement and are not started; enrollment remains an explicit operator step.

## Testing & validation

- Installer contract test covers missing `nmap`, stale service enablement, fresh installation, active-service upgrade, program replacement, config/state preservation, fixed systemd paths, and checksum rejection.
- Installer and test scripts pass `bash -n`.
- Modified workflow files parse as YAML.
- Repository-wide `just lint` passes.
- Fleet Node and Go plugins cross-build as static Linux amd64 and arm64 ELF binaries with `CGO_ENABLED=0`.
- Pre-commit and pre-push hooks pass.
- `actionlint`, `shellcheck`, and local `readelf` were unavailable; workflow static-link checks use `readelf` on Ubuntu runners, and local `file` inspection confirmed static ELF output.
