### PR TITLE
fix(client): refocus password input after weak-password warning

### DIFF
--- a/client/src/protoFleet/features/auth/components/UpdatePasswordForm.test.tsx
+++ b/client/src/protoFleet/features/auth/components/UpdatePasswordForm.test.tsx
@@ -170,4 +170,20 @@ describe("UpdatePasswordForm", () => {
       getByText("You logged in with a temporary password. Enter your new password to continue."),
     ).toBeInTheDocument();
   });
+
+  it("refocuses the new password input when the user chooses to create a stronger password", async () => {
+    const { getByLabelText, getByText, findByText, queryByText } = render(
+      <UpdatePasswordForm onSubmit={mockOnSubmit} />,
+    );
+
+    fireEvent.change(getByLabelText("New password"), { target: { value: "aaaaaaaa" } });
+    fireEvent.change(getByLabelText("Confirm password"), { target: { value: "aaaaaaaa" } });
+    fireEvent.click(getByText("Continue"));
+
+    const returnButton = await findByText("Create a stronger password");
+    fireEvent.click(returnButton);
+
+    expect(queryByText("Create a stronger password")).not.toBeInTheDocument();
+    expect(getByLabelText("New password")).toHaveFocus();
+  });
 });

--- a/client/src/protoFleet/features/auth/components/UpdatePasswordForm.tsx
+++ b/client/src/protoFleet/features/auth/components/UpdatePasswordForm.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { RefObject, useCallback, useRef, useState } from "react";
 import Footer from "@/protoFleet/components/Footer";
 import { Alert, Logo } from "@/shared/assets/icons";
 import Button from "@/shared/components/Button";
@@ -26,6 +26,7 @@ export const UpdatePasswordForm = ({
   const [score, setScore] = useState(0);
   const [validationError, setValidationError] = useState("");
   const [showWeakPasswordWarning, setShowWeakPasswordWarning] = useState(false);
+  const newPasswordInputRef = useRef<HTMLInputElement>(null) as RefObject<HTMLInputElement>;
 
   const handlePasswordChange = (value: string) => {
     setNewPassword(value);
@@ -84,7 +85,13 @@ export const UpdatePasswordForm = ({
 
               <div className="flex flex-col gap-4">
                 <div className="flex flex-col gap-2">
-                  <Input id="newPassword" label="New password" type="password" onChange={handlePasswordChange} />
+                  <Input
+                    id="newPassword"
+                    label="New password"
+                    type="password"
+                    onChange={handlePasswordChange}
+                    inputRef={newPasswordInputRef}
+                  />
                   <div className="flex items-center justify-between gap-5">
                     <div>
                       <div className="text-200 text-text-primary-50">Password strength</div>
@@ -103,7 +110,10 @@ export const UpdatePasswordForm = ({
 
               {showWeakPasswordWarning && !isSubmitting ? (
                 <WeakPasswordWarning
-                  onReturn={() => setShowWeakPasswordWarning(false)}
+                  onReturn={() => {
+                    setShowWeakPasswordWarning(false);
+                    newPasswordInputRef.current?.focus();
+                  }}
                   onContinue={() => handleSubmit(true)}
                 />
               ) : null}

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/ManageSecurity/UpdateMinerPasswordModal.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/ManageSecurity/UpdateMinerPasswordModal.test.tsx
@@ -50,12 +50,21 @@ vi.mock("@/shared/components/Modal/Modal", () => ({
   }),
 }));
 
-// Mock Input component
+// Mock Input component. Like the real Input, it seeds its value from
+// initValue on mount (the real one keeps internal state; defaultValue is the
+// uncontrolled equivalent).
 vi.mock("@/shared/components/Input", () => ({
-  default: vi.fn(({ id, label, type, onChange, autoFocus }) => (
+  default: vi.fn(({ id, label, type, onChange, autoFocus, initValue }) => (
     <div>
       <label htmlFor={id}>{label}</label>
-      <input id={id} type={type} onChange={(e) => onChange(e.target.value)} autoFocus={autoFocus} data-testid={id} />
+      <input
+        id={id}
+        type={type}
+        defaultValue={initValue}
+        onChange={(e) => onChange(e.target.value)}
+        autoFocus={autoFocus}
+        data-testid={id}
+      />
     </div>
   )),
 }));
@@ -372,6 +381,35 @@ describe("UpdateMinerPasswordModal", () => {
       await waitFor(() => {
         expect(screen.getByTestId("newPassword")).toHaveFocus();
       });
+    });
+
+    test("preserves entered values when user clicks 'Create a stronger password'", async () => {
+      render(
+        <UpdateMinerPasswordModal
+          open={true}
+          hasThirdPartyMiners={false}
+          onConfirm={mockOnConfirm}
+          onDismiss={mockOnDismiss}
+        />,
+      );
+
+      fireEvent.change(screen.getByTestId("currentPassword"), { target: { value: "CurrentPassword123" } });
+      fireEvent.change(screen.getByTestId("newPassword"), { target: { value: "weakpass" } });
+      fireEvent.change(screen.getByTestId("confirmPassword"), { target: { value: "weakpass" } });
+      fireEvent.click(screen.getByTestId("modal-button-0"));
+
+      await waitFor(() => {
+        expect(screen.getByTestId("weak-password-warning")).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByText("Create a stronger password"));
+
+      await waitFor(() => {
+        expect(screen.getByTestId("update-password-modal")).toBeInTheDocument();
+      });
+      expect(screen.getByTestId("currentPassword")).toHaveValue("CurrentPassword123");
+      expect(screen.getByTestId("newPassword")).toHaveValue("weakpass");
+      expect(screen.getByTestId("confirmPassword")).toHaveValue("weakpass");
     });
   });
 

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/ManageSecurity/UpdateMinerPasswordModal.test.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/ManageSecurity/UpdateMinerPasswordModal.test.tsx
@@ -347,6 +347,32 @@ describe("UpdateMinerPasswordModal", () => {
         expect(screen.queryByTestId("weak-password-warning")).not.toBeInTheDocument();
       });
     });
+
+    test("refocuses the new password input when user clicks 'Create a stronger password'", async () => {
+      render(
+        <UpdateMinerPasswordModal
+          open={true}
+          hasThirdPartyMiners={false}
+          onConfirm={mockOnConfirm}
+          onDismiss={mockOnDismiss}
+        />,
+      );
+
+      fireEvent.change(screen.getByTestId("currentPassword"), { target: { value: "CurrentPassword123" } });
+      fireEvent.change(screen.getByTestId("newPassword"), { target: { value: "weakpass" } });
+      fireEvent.change(screen.getByTestId("confirmPassword"), { target: { value: "weakpass" } });
+      fireEvent.click(screen.getByTestId("modal-button-0"));
+
+      await waitFor(() => {
+        expect(screen.getByTestId("weak-password-warning")).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByText("Create a stronger password"));
+
+      await waitFor(() => {
+        expect(screen.getByTestId("newPassword")).toHaveFocus();
+      });
+    });
   });
 
   describe("Validation - Third-Party Miners", () => {

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/ManageSecurity/UpdateMinerPasswordModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/ManageSecurity/UpdateMinerPasswordModal.tsx
@@ -26,6 +26,10 @@ const UpdateMinerPasswordModal = ({
   const [score, setScore] = useState(0);
   const [validationError, setValidationError] = useState("");
   const [showWeakPasswordWarning, setShowWeakPasswordWarning] = useState(false);
+  // The modal subtree unmounts while the weak-password warning is shown, so the
+  // new password field can't be focused via a ref when the user returns.
+  // Instead, hand it the autoFocus when the modal remounts.
+  const [refocusNewPassword, setRefocusNewPassword] = useState(false);
 
   // Reset form when modal is dismissed
   const [prevOpen, setPrevOpen] = useState(open);
@@ -38,6 +42,7 @@ const UpdateMinerPasswordModal = ({
       setScore(0);
       setValidationError("");
       setShowWeakPasswordWarning(false);
+      setRefocusNewPassword(false);
     }
   }
 
@@ -104,7 +109,13 @@ const UpdateMinerPasswordModal = ({
   // Conditionally render one modal at a time for proper animations
   if (showWeakPasswordWarning) {
     return (
-      <WeakPasswordWarning onReturn={() => setShowWeakPasswordWarning(false)} onContinue={() => handleConfirm(true)} />
+      <WeakPasswordWarning
+        onReturn={() => {
+          setShowWeakPasswordWarning(false);
+          setRefocusNewPassword(true);
+        }}
+        onContinue={() => handleConfirm(true)}
+      />
     );
   }
 
@@ -139,7 +150,7 @@ const UpdateMinerPasswordModal = ({
           label="Current miner password"
           type="password"
           onChange={(value) => setCurrentPassword(value)}
-          autoFocus
+          autoFocus={!refocusNewPassword}
         />
 
         <div className="flex flex-col gap-2">
@@ -148,6 +159,7 @@ const UpdateMinerPasswordModal = ({
             label="New miner password"
             type="password"
             onChange={(value) => setNewPassword(value)}
+            autoFocus={refocusNewPassword}
           />
           {!hasThirdPartyMiners ? (
             <div className="flex items-center justify-between gap-5">

--- a/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/ManageSecurity/UpdateMinerPasswordModal.tsx
+++ b/client/src/protoFleet/features/fleetManagement/components/MinerActionsMenu/ManageSecurity/UpdateMinerPasswordModal.tsx
@@ -145,10 +145,15 @@ const UpdateMinerPasswordModal = ({
       ) : null}
 
       <div className="flex flex-col gap-4" onKeyDown={handleKeyDown}>
+        {/* initValue re-seeds the inputs from retained state when the modal
+            remounts after the weak-password warning; without it the fields
+            render empty while the state (and the enabled Continue button)
+            still hold the previously typed values. */}
         <Input
           id="currentPassword"
           label="Current miner password"
           type="password"
+          initValue={currentPassword}
           onChange={(value) => setCurrentPassword(value)}
           autoFocus={!refocusNewPassword}
         />
@@ -158,6 +163,7 @@ const UpdateMinerPasswordModal = ({
             id="newPassword"
             label="New miner password"
             type="password"
+            initValue={newPassword}
             onChange={(value) => setNewPassword(value)}
             autoFocus={refocusNewPassword}
           />
@@ -173,6 +179,7 @@ const UpdateMinerPasswordModal = ({
           id="confirmPassword"
           label="Confirm new miner password"
           type="password"
+          initValue={confirmPassword}
           onChange={(value) => setConfirmPassword(value)}
         />
       </div>

--- a/client/src/protoFleet/features/settings/components/Auth.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Auth.test.tsx
@@ -77,6 +77,42 @@ describe("AuthenticationSettings", () => {
       });
     });
 
+    it("refocuses the new password field when the user chooses to create a stronger password", async () => {
+      mockLogin.mockImplementation(({ onSuccess, onFinally }) => {
+        onSuccess(false);
+        onFinally?.();
+      });
+
+      const { getByTestId, getByLabelText, getByText, findByText, queryByText } = render(<AuthenticationSettings />);
+
+      // Click Update button for password
+      const passwordRow = getByTestId("password-row");
+      const updateButton = passwordRow.querySelector("button");
+      if (updateButton) {
+        fireEvent.click(updateButton);
+      }
+
+      // Fill password and submit authenticate step
+      await waitFor(() => {
+        const passwordInput = getByLabelText("Password");
+        fireEvent.change(passwordInput, { target: { value: "currentpass" } });
+      });
+      fireEvent.click(getByText("Confirm"));
+
+      // Submit a weak new password to trigger the warning
+      await waitFor(() => {
+        fireEvent.change(getByLabelText("New password"), { target: { value: "aaaaaaaa" } });
+      });
+      fireEvent.change(getByLabelText("Confirm password"), { target: { value: "aaaaaaaa" } });
+      fireEvent.click(getByText("Confirm"));
+
+      const returnButton = await findByText("Create a stronger password");
+      fireEvent.click(returnButton);
+
+      expect(queryByText("Create a stronger password")).not.toBeInTheDocument();
+      expect(getByLabelText("New password")).toHaveFocus();
+    });
+
     it("autofocuses the new username field in update username step", async () => {
       mockLogin.mockImplementation(({ onSuccess }) => {
         onSuccess(false);

--- a/client/src/protoFleet/features/settings/components/Auth.tsx
+++ b/client/src/protoFleet/features/settings/components/Auth.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { RefObject, useCallback, useRef, useState } from "react";
 import clsx from "clsx";
 import { create } from "@bufbuild/protobuf";
 import { AuthenticateRequestSchema } from "@/protoFleet/api/generated/auth/v1/auth_pb";
@@ -79,6 +79,7 @@ const AuthenticationSettings = () => {
   const [passwordUpdateApiError, setPasswordUpdateApiError] = useState<string | null>(null);
   const [usernameUpdateApiError, setUsernameUpdateApiError] = useState<string | null>(null);
   const [showWeakPasswordWarning, setShowWeakPasswordWarning] = useState(false);
+  const newPasswordInputRef = useRef<HTMLInputElement>(null) as RefObject<HTMLInputElement>;
 
   // Reset form state when modal closes
   const [prevShowModal, setPrevShowModal] = useState(showModal);
@@ -353,6 +354,7 @@ const AuthenticationSettings = () => {
                         onChange={handleNewPasswordChange}
                         error={passwordErrorMsg}
                         autoFocus
+                        inputRef={newPasswordInputRef}
                       />
                       <div className="flex items-center justify-between gap-5">
                         <div>
@@ -371,7 +373,10 @@ const AuthenticationSettings = () => {
                 </div>
                 {showWeakPasswordWarning && !isSubmitting ? (
                   <WeakPasswordWarning
-                    onReturn={() => setShowWeakPasswordWarning(false)}
+                    onReturn={() => {
+                      setShowWeakPasswordWarning(false);
+                      newPasswordInputRef.current?.focus();
+                    }}
                     onContinue={() => submitPasswordUpdate(true)}
                   />
                 ) : null}

--- a/client/src/shared/components/Setup/Authentication.test.tsx
+++ b/client/src/shared/components/Setup/Authentication.test.tsx
@@ -110,4 +110,21 @@ describe("Authentication", () => {
       expect(usernameInput).toHaveValue("newuser");
     });
   });
+
+  describe("weak password warning", () => {
+    it("refocuses the password input when the user chooses to create a stronger password", async () => {
+      const { getByLabelText, getByText, findByText, queryByText } = render(<Authentication {...defaultProps} />);
+
+      fireEvent.change(getByLabelText("Username"), { target: { value: "testuser" } });
+      fireEvent.change(getByLabelText("Password"), { target: { value: "aaaaaaaa" } });
+      fireEvent.change(getByLabelText("Confirm password"), { target: { value: "aaaaaaaa" } });
+      fireEvent.click(getByText("Continue"));
+
+      const returnButton = await findByText("Create a stronger password");
+      fireEvent.click(returnButton);
+
+      expect(queryByText("Create a stronger password")).not.toBeInTheDocument();
+      expect(getByLabelText("Password")).toHaveFocus();
+    });
+  });
 });

--- a/client/src/shared/components/Setup/Authentication.tsx
+++ b/client/src/shared/components/Setup/Authentication.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useCallback, useEffect, useMemo, useState } from "react";
+import { ReactNode, RefObject, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import clsx from "clsx";
 import { Alert, Success } from "@/shared/assets/icons";
 import Button, { sizes, variants } from "@/shared/components/Button";
@@ -150,6 +150,7 @@ const Authentication = ({
   const [errors, setErrors] = useState<Values>(deepClone(initErrors));
   const [score, setScore] = useState(0);
   const [showWeakPasswordWarning, setShowWeakPasswordWarning] = useState(false);
+  const passwordInputRef = useRef<HTMLInputElement>(null) as RefObject<HTMLInputElement>;
 
   const validate = useCallback(() => {
     let newErrors: Values = deepClone(initErrors);
@@ -268,6 +269,7 @@ const Authentication = ({
             initValue={values.password}
             error={errors.password}
             autoFocus={initUsername ? !isUpdateMode : false}
+            inputRef={passwordInputRef}
           />
           <div className="flex items-center justify-between gap-5">
             <div>
@@ -290,7 +292,10 @@ const Authentication = ({
       ) : null}
       {showWeakPasswordWarning && !isSubmitting ? (
         <WeakPasswordWarning
-          onReturn={() => setShowWeakPasswordWarning(false)}
+          onReturn={() => {
+            setShowWeakPasswordWarning(false);
+            passwordInputRef.current?.focus();
+          }}
           onContinue={() => handleContinue(true)}
         />
       ) : null}


### PR DESCRIPTION
Reviewable diff: +48/-9 across 4 files (excludes generated, test, and story files).

## Summary

When a user submits a weak password, the weak-password dialog offers "Continue anyway" or "Create a stronger password". Choosing the latter previously just closed the dialog, leaving focus nowhere — the user had to click back into the password field. This PR returns focus to the relevant password input in all four flows that show the dialog, and fixes a pre-existing bug in the miner password modal where returning from the dialog rendered the fields empty while the submit button stayed enabled with the invisible stale values.

## How it works

All four flows render the shared `WeakPasswordWarning` dialog, but they fall into two structural cases:

**Form stays mounted during the warning** (account-creation `Authentication`, temporary-password `UpdatePasswordForm`, fleet security settings `Auth`): the dialog overlays the form via a portal, and neither `Dialog` nor `PageOverlay` does focus restoration on close. Each flow now holds a `RefObject` on its password input (via the `inputRef` prop the shared `Input` already supports) and calls `.focus()` in the dialog's `onReturn` handler. The `Input` component's existing password-focus effect places the cursor at the end of the current value, so the user can immediately edit.

**Form unmounts during the warning** (`UpdateMinerPasswordModal` returns the warning *instead of* the modal for animation reasons): there is no input to focus at click time. `onReturn` instead sets a `refocusNewPassword` flag; when the modal remounts, `autoFocus` is handed to the new-password input rather than the current-password input (which keeps `autoFocus` on a fresh open). The same remount previously caused the value-loss bug: `Input` seeds its internal display state from `initValue` only on mount, so remounted fields rendered empty while component state (and the enabled Continue button) still held the typed values. The three inputs now pass their retained state back as `initValue`, making the display consistent with state and with the other three flows.

## Diagrams

```mermaid
flowchart TD
    A["User submits weak password"] --> B["WeakPasswordWarning dialog"]
    B -->|"Continue anyway"| C["Submit proceeds"]
    B -->|"Create a stronger password"| D{"Is the form still mounted?"}
    D -->|"Yes: Authentication, UpdatePasswordForm, settings Auth"| E["onReturn closes dialog and calls focus() via inputRef"]
    D -->|"No: UpdateMinerPasswordModal"| F["onReturn sets refocusNewPassword flag"]
    F --> G["Modal remounts: autoFocus goes to new-password input; initValue re-seeds all field values"]
```

```mermaid
sequenceDiagram
    participant U as User
    participant M as UpdateMinerPasswordModal
    participant W as WeakPasswordWarning
    U->>M: Continue with weak password
    M->>W: unmount modal, render warning
    U->>W: Create a stronger password
    W->>M: onReturn sets refocusNewPassword, modal remounts
    M->>M: inputs re-seed from initValue
    M->>U: new-password input focused, values visible
```

## Areas of the code involved

| Area / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/src/shared/components/Setup/Authentication.tsx` | Ref on password input, focused in `onReturn` | Shared component used by account creation in both ProtoOS and ProtoFleet onboarding |
| `client/src/protoFleet/features/auth/components/UpdatePasswordForm.tsx` | Same ref treatment on "New password" | Temporary-password login flow |
| `client/src/protoFleet/features/settings/components/Auth.tsx` | Same ref treatment inside the settings modal | Fleet security settings password update |
| `client/.../ManageSecurity/UpdateMinerPasswordModal.tsx` | `refocusNewPassword` flag swaps `autoFocus` on remount; `initValue` re-seeds field values | Different mechanism because the modal unmounts during the warning; also fixes the stale-invisible-values bug |
| Four `*.test.tsx` files | Focus and value-persistence tests | Test-only |

## Key technical decisions & trade-offs

- **Direct `.focus()` in `onReturn` over an effect-based approach** for the three mounted flows: the dialog does no focus management of its own, so a synchronous call is sufficient and avoids extra state.
- **`autoFocus` swap over ref-plus-effect in the miner modal**: the input does not exist when the button is clicked, so a flag consumed at remount is the simplest correct mechanism; a ref would require an effect watching a flag anyway.
- **`initValue` re-seeding over clearing state on return**: preserving values matches the behavior of the other three flows (where the form never unmounts) and keeps the current-password field intact so the user only retypes the field they came back to change.

## Testing & validation

- New vitest cases in all four component test files: focus lands on the password input after "Create a stronger password", and (miner modal) all three field values survive the warning round-trip. 86 tests across the four files pass.
- The miner modal test file's `Input` mock now forwards `initValue` as `defaultValue` to mirror the real component's seed-on-mount behavior.
- Not covered: E2E; verified via unit tests and the lefthook typecheck on push.