### PR TITLE
Refine Slack alert notification copy

### DIFF
--- a/server/internal/domain/alerts/deliver.go
+++ b/server/internal/domain/alerts/deliver.go
@@ -184,11 +184,11 @@ func (d *Deliverer) deliverOrg(ctx context.Context, orgID int64, orgAlerts []Ale
 					alerts = append(alerts, orgAlerts[i])
 				}
 			}
-			alerts, hiddenFiring := dropMutedAlerts(alerts, muted, muteAll)
+			alerts = dropMutedAlerts(alerts, muted, muteAll)
 			if len(alerts) == 0 {
 				return
 			}
-			d.deliverChannel(ctx, orgID, rec, alerts, hiddenFiring, identities)
+			d.deliverChannel(ctx, orgID, rec, alerts, identities)
 		}(rec, idxs, muted, muteAll)
 	}
 	wg.Wait()
@@ -232,15 +232,14 @@ func channelMutedRules(windows []MaintenanceWindowRecord, channelID int64) (mute
 	return muted, false
 }
 
-// dropMutedAlerts returns the channel's visible batch and the firing alerts hidden by maintenance.
-// Resolutions always stay so a destination that saw a firing notification can close it. The hidden
-// firing set gives Slack enough context to avoid declaring an all-clear while an alert is merely
-// muted. Unattributed firing alerts stay under a rule-scoped window because no rule can claim them.
-// The input slice is shared across channel goroutines and never mutated; it is returned as-is (no
+// dropMutedAlerts returns the channel's batch minus firing alerts covered by a maintenance
+// window. Resolutions always stay so a destination that saw a firing notification can close it.
+// Unattributed firing alerts stay under a rule-scoped window because no rule can claim them. The
+// input slice is shared across channel goroutines and never mutated; it is returned as-is (no
 // copy) until an alert actually drops.
-func dropMutedAlerts(alerts []Alert, muted map[string]bool, muteAll bool) (visible, hiddenFiring []Alert) {
+func dropMutedAlerts(alerts []Alert, muted map[string]bool, muteAll bool) []Alert {
 	if !muteAll && len(muted) == 0 {
-		return alerts, nil
+		return alerts
 	}
 	isMuted := func(a Alert) bool {
 		if a.Status == alertStatusResolved {
@@ -250,19 +249,16 @@ func dropMutedAlerts(alerts []Alert, muted map[string]bool, muteAll bool) (visib
 	}
 	first := slices.IndexFunc(alerts, isMuted)
 	if first < 0 {
-		return alerts, nil
+		return alerts
 	}
-	visible = make([]Alert, 0, len(alerts)-1)
-	visible = append(visible, alerts[:first]...)
-	hiddenFiring = append(hiddenFiring, alerts[first])
+	out := make([]Alert, 0, len(alerts)-1)
+	out = append(out, alerts[:first]...)
 	for _, a := range alerts[first+1:] {
-		if isMuted(a) {
-			hiddenFiring = append(hiddenFiring, a)
-		} else {
-			visible = append(visible, a)
+		if !isMuted(a) {
+			out = append(out, a)
 		}
 	}
-	return visible, hiddenFiring
+	return out
 }
 
 // routeAlerts splits the org batch per its route policies: no policy or no rule UID → every channel (fail open),
@@ -344,13 +340,13 @@ func (d *Deliverer) routeAlerts(ctx context.Context, orgID int64, orgAlerts []Al
 	return defaultAlerts, extraIdx, routedUnique
 }
 
-func (d *Deliverer) deliverChannel(ctx context.Context, orgID int64, rec ChannelRecord, orgAlerts, hiddenFiring []Alert, identities map[string]DeviceIdentity) {
+func (d *Deliverer) deliverChannel(ctx context.Context, orgID int64, rec ChannelRecord, orgAlerts []Alert, identities map[string]DeviceIdentity) {
 	cfg, err := decodeChannelConfig(d.crypto, rec.EncryptedConfig)
 	if err != nil {
 		slog.Error("alerts.deliver_decode_failed", "org", orgID, "channel", rec.ID, "err", err)
 		return
 	}
-	body, err := d.render(rec.Kind, orgID, orgAlerts, hiddenFiring, identities)
+	body, err := d.render(rec.Kind, orgID, orgAlerts, identities)
 	if err != nil {
 		slog.Error("alerts.deliver_render_failed", "org", orgID, "channel", rec.ID, "err", err)
 		return
@@ -381,11 +377,11 @@ func (d *Deliverer) resolveDevices(ctx context.Context, orgID int64, alerts []Al
 	return m
 }
 
-func (d *Deliverer) render(kind ChannelKind, orgID int64, alerts, hiddenFiring []Alert, identities map[string]DeviceIdentity) ([]byte, error) {
+func (d *Deliverer) render(kind ChannelKind, orgID int64, alerts []Alert, identities map[string]DeviceIdentity) ([]byte, error) {
 	var payload any
 	switch kind {
 	case ChannelKindSlack:
-		payload = renderSlackWithHiddenFiring(d.publicURL, alerts, hiddenFiring)
+		payload = renderSlack(d.publicURL, alerts, identities)
 	case ChannelKindWebhook:
 		payload = renderWebhook(orgID, alerts, identities)
 	default:
@@ -422,7 +418,7 @@ func (d *Deliverer) SendTest(ctx context.Context, kind ChannelKind, url, bearer 
 		Labels:      map[string]string{"alertname": "Proto Fleet test alert", "severity": "info"},
 		Annotations: map[string]string{"summary": "This is a test notification from Proto Fleet."},
 	}}
-	body, err := d.render(kind, 0, sample, nil, nil)
+	body, err := d.render(kind, 0, sample, nil)
 	if err != nil {
 		return false, "", err
 	}

--- a/server/internal/domain/alerts/deliver.go
+++ b/server/internal/domain/alerts/deliver.go
@@ -184,11 +184,11 @@ func (d *Deliverer) deliverOrg(ctx context.Context, orgID int64, orgAlerts []Ale
 					alerts = append(alerts, orgAlerts[i])
 				}
 			}
-			alerts = dropMutedAlerts(alerts, muted, muteAll)
+			alerts, hiddenFiring := dropMutedAlerts(alerts, muted, muteAll)
 			if len(alerts) == 0 {
 				return
 			}
-			d.deliverChannel(ctx, orgID, rec, alerts, identities)
+			d.deliverChannel(ctx, orgID, rec, alerts, hiddenFiring, identities)
 		}(rec, idxs, muted, muteAll)
 	}
 	wg.Wait()
@@ -232,14 +232,15 @@ func channelMutedRules(windows []MaintenanceWindowRecord, channelID int64) (mute
 	return muted, false
 }
 
-// dropMutedAlerts returns the channel's batch minus firing alerts covered by a maintenance
-// window. Resolutions always stay so a destination that saw a firing notification can close it.
-// Unattributed firing alerts stay under a rule-scoped window because no rule can claim them. The
-// input slice is shared across channel goroutines and never mutated; it is returned as-is (no
+// dropMutedAlerts returns the channel's visible batch and the firing alerts hidden by maintenance.
+// Resolutions always stay so a destination that saw a firing notification can close it. The hidden
+// firing set gives Slack enough context to avoid declaring an all-clear while an alert is merely
+// muted. Unattributed firing alerts stay under a rule-scoped window because no rule can claim them.
+// The input slice is shared across channel goroutines and never mutated; it is returned as-is (no
 // copy) until an alert actually drops.
-func dropMutedAlerts(alerts []Alert, muted map[string]bool, muteAll bool) []Alert {
+func dropMutedAlerts(alerts []Alert, muted map[string]bool, muteAll bool) (visible, hiddenFiring []Alert) {
 	if !muteAll && len(muted) == 0 {
-		return alerts
+		return alerts, nil
 	}
 	isMuted := func(a Alert) bool {
 		if a.Status == alertStatusResolved {
@@ -249,16 +250,19 @@ func dropMutedAlerts(alerts []Alert, muted map[string]bool, muteAll bool) []Aler
 	}
 	first := slices.IndexFunc(alerts, isMuted)
 	if first < 0 {
-		return alerts
+		return alerts, nil
 	}
-	out := make([]Alert, 0, len(alerts)-1)
-	out = append(out, alerts[:first]...)
+	visible = make([]Alert, 0, len(alerts)-1)
+	visible = append(visible, alerts[:first]...)
+	hiddenFiring = append(hiddenFiring, alerts[first])
 	for _, a := range alerts[first+1:] {
-		if !isMuted(a) {
-			out = append(out, a)
+		if isMuted(a) {
+			hiddenFiring = append(hiddenFiring, a)
+		} else {
+			visible = append(visible, a)
 		}
 	}
-	return out
+	return visible, hiddenFiring
 }
 
 // routeAlerts splits the org batch per its route policies: no policy or no rule UID → every channel (fail open),
@@ -340,13 +344,13 @@ func (d *Deliverer) routeAlerts(ctx context.Context, orgID int64, orgAlerts []Al
 	return defaultAlerts, extraIdx, routedUnique
 }
 
-func (d *Deliverer) deliverChannel(ctx context.Context, orgID int64, rec ChannelRecord, orgAlerts []Alert, identities map[string]DeviceIdentity) {
+func (d *Deliverer) deliverChannel(ctx context.Context, orgID int64, rec ChannelRecord, orgAlerts, hiddenFiring []Alert, identities map[string]DeviceIdentity) {
 	cfg, err := decodeChannelConfig(d.crypto, rec.EncryptedConfig)
 	if err != nil {
 		slog.Error("alerts.deliver_decode_failed", "org", orgID, "channel", rec.ID, "err", err)
 		return
 	}
-	body, err := d.render(rec.Kind, orgID, orgAlerts, identities)
+	body, err := d.render(rec.Kind, orgID, orgAlerts, hiddenFiring, identities)
 	if err != nil {
 		slog.Error("alerts.deliver_render_failed", "org", orgID, "channel", rec.ID, "err", err)
 		return
@@ -377,11 +381,11 @@ func (d *Deliverer) resolveDevices(ctx context.Context, orgID int64, alerts []Al
 	return m
 }
 
-func (d *Deliverer) render(kind ChannelKind, orgID int64, alerts []Alert, identities map[string]DeviceIdentity) ([]byte, error) {
+func (d *Deliverer) render(kind ChannelKind, orgID int64, alerts, hiddenFiring []Alert, identities map[string]DeviceIdentity) ([]byte, error) {
 	var payload any
 	switch kind {
 	case ChannelKindSlack:
-		payload = renderSlack(d.publicURL, alerts, identities)
+		payload = renderSlackWithHiddenFiring(d.publicURL, alerts, hiddenFiring)
 	case ChannelKindWebhook:
 		payload = renderWebhook(orgID, alerts, identities)
 	default:
@@ -418,7 +422,7 @@ func (d *Deliverer) SendTest(ctx context.Context, kind ChannelKind, url, bearer 
 		Labels:      map[string]string{"alertname": "Proto Fleet test alert", "severity": "info"},
 		Annotations: map[string]string{"summary": "This is a test notification from Proto Fleet."},
 	}}
-	body, err := d.render(kind, 0, sample, nil)
+	body, err := d.render(kind, 0, sample, nil, nil)
 	if err != nil {
 		return false, "", err
 	}

--- a/server/internal/domain/alerts/deliver_test.go
+++ b/server/internal/domain/alerts/deliver_test.go
@@ -424,7 +424,7 @@ func TestDeliverAllScopeWindowPreservesResolutions(t *testing.T) {
 	body := string((*got)[0].body)
 	assert.NotContains(t, body, "Firing Rule")
 	assert.Contains(t, body, "Resolved Rule resolved", "resolutions still close alerts delivered before the window")
-	assert.NotContains(t, body, "All alerts resolved", "a maintenance-hidden firing alert prevents a false all-clear")
+	assert.NotContains(t, body, "All alerts resolved", "resolution-only notifications stay condition-specific")
 }
 
 func TestDeliverWindowMutesOnlyListedChannels(t *testing.T) {

--- a/server/internal/domain/alerts/deliver_test.go
+++ b/server/internal/domain/alerts/deliver_test.go
@@ -423,7 +423,8 @@ func TestDeliverAllScopeWindowPreservesResolutions(t *testing.T) {
 	require.Len(t, *got, 1)
 	body := string((*got)[0].body)
 	assert.NotContains(t, body, "Firing Rule")
-	assert.Contains(t, body, "All alerts resolved", "resolutions close alerts delivered before the window")
+	assert.Contains(t, body, "Resolved Rule resolved", "resolutions still close alerts delivered before the window")
+	assert.NotContains(t, body, "All alerts resolved", "a maintenance-hidden firing alert prevents a false all-clear")
 }
 
 func TestDeliverWindowMutesOnlyListedChannels(t *testing.T) {
@@ -465,18 +466,19 @@ func TestDeliverRuleScopedWindowPreservesMutedRuleResolution(t *testing.T) {
 	d, store, windows, crypto := newMutingDeliverer(t)
 	seedChannel(t, store, crypto, 7, ChannelKindSlack, srv.URL, "")
 	seedWindow(windows, 7, []string{"rule-a"}, nil, 0)
-	resolved := firingRuleAlert("7", "dev-b", "Resolved Muted Rule", "rule-a")
+	resolved := firingRuleAlert("7", "dev-b", "Muted Rule", "rule-a")
 	resolved.Status = "resolved"
 
 	d.Deliver(context.Background(), []Alert{
-		firingRuleAlert("7", "dev-a", "Firing Muted Rule", "rule-a"),
+		firingRuleAlert("7", "dev-a", "Muted Rule", "rule-a"),
 		resolved,
 	})
 
 	require.Len(t, *got, 1)
 	body := string((*got)[0].body)
-	assert.NotContains(t, body, "Firing Muted Rule")
-	assert.Contains(t, body, "All alerts resolved")
+	assert.NotContains(t, body, "Muted Rule summary", "the maintenance-muted firing copy stays hidden")
+	assert.Contains(t, body, "Muted Rule resolved for 1 device")
+	assert.NotContains(t, body, "All alerts resolved")
 }
 
 func TestDeliverIgnoresExpiredAndFutureWindows(t *testing.T) {

--- a/server/internal/domain/alerts/deliver_test.go
+++ b/server/internal/domain/alerts/deliver_test.go
@@ -79,7 +79,9 @@ func TestDeliverSlackChannel(t *testing.T) {
 	require.Len(t, *got, 1)
 	body := string((*got)[0].body)
 	assert.Contains(t, body, "blocks")
-	assert.Contains(t, body, "miner-01 (`aa:bb`)")
+	assert.Contains(t, body, "Device Offline summary (1 device affected)")
+	assert.NotContains(t, body, "miner-01")
+	assert.NotContains(t, body, "dev-a")
 	assert.NotContains(t, body, "grafana")
 	assert.Empty(t, (*got)[0].auth, "slack webhook posts carry no bearer")
 }
@@ -146,8 +148,8 @@ func TestDeliverFansOutPerOrg(t *testing.T) {
 
 	assert.Len(t, *gotA, 1)
 	assert.Len(t, *gotB, 1)
-	assert.Contains(t, string((*gotA)[0].body), "*A*")
-	assert.Contains(t, string((*gotB)[0].body), "*B*")
+	assert.Contains(t, string((*gotA)[0].body), "A summary (1 device affected)")
+	assert.Contains(t, string((*gotB)[0].body), "B summary (1 device affected)")
 }
 
 func TestDeliverSkipsPrivateDestinationUnderPolicy(t *testing.T) {
@@ -421,7 +423,7 @@ func TestDeliverAllScopeWindowPreservesResolutions(t *testing.T) {
 	require.Len(t, *got, 1)
 	body := string((*got)[0].body)
 	assert.NotContains(t, body, "Firing Rule")
-	assert.Contains(t, body, "Resolved Rule", "resolutions close alerts delivered before the window")
+	assert.Contains(t, body, "All alerts resolved", "resolutions close alerts delivered before the window")
 }
 
 func TestDeliverWindowMutesOnlyListedChannels(t *testing.T) {
@@ -474,7 +476,7 @@ func TestDeliverRuleScopedWindowPreservesMutedRuleResolution(t *testing.T) {
 	require.Len(t, *got, 1)
 	body := string((*got)[0].body)
 	assert.NotContains(t, body, "Firing Muted Rule")
-	assert.Contains(t, body, "Resolved Muted Rule")
+	assert.Contains(t, body, "All alerts resolved")
 }
 
 func TestDeliverIgnoresExpiredAndFutureWindows(t *testing.T) {

--- a/server/internal/domain/alerts/render.go
+++ b/server/internal/domain/alerts/render.go
@@ -29,9 +29,22 @@ var slackSeverityDots = []struct{ severity, dot string }{
 // renderSlack builds a Block Kit message that carries no alerting-engine internals. Alerts are rolled up per
 // rule, so a fleet-wide outage is a handful of sections with device counts rather than thousands of device lines.
 func renderSlack(publicURL string, alerts []Alert, _ map[string]DeviceIdentity) map[string]any {
+	return renderSlackWithHiddenFiring(publicURL, alerts, nil)
+}
+
+// renderSlackWithHiddenFiring keeps maintenance-muted firing alerts out of the message while retaining them
+// as resolution context. A hidden firing alert must prevent a false all-clear or "all devices" recovery claim.
+func renderSlackWithHiddenFiring(publicURL string, alerts, hiddenFiring []Alert) map[string]any {
 	firing, resolved := partitionAlerts(alerts)
 	firingGroups := groupAlerts(firing)
 	resolvedGroups := groupAlerts(resolved)
+	activeRuleIdentities := make(map[string]bool, len(firingGroups)+len(hiddenFiring))
+	for _, g := range firingGroups {
+		activeRuleIdentities[g.Identity] = true
+	}
+	for _, g := range groupAlerts(hiddenFiring) {
+		activeRuleIdentities[g.Identity] = true
+	}
 	plain, linked := instanceLabels(publicURL)
 
 	// Keep product and instance context in a neutral header. Severity belongs to each alert line so a
@@ -44,13 +57,13 @@ func renderSlack(publicURL string, alerts []Alert, _ map[string]DeviceIdentity) 
 			if remaining <= 0 {
 				return
 			}
-			line := groupLine(g, resolved)
+			line := groupLineWithActiveState(g, resolved, resolved && activeRuleIdentities[g.Identity])
 			blocks = append(blocks, mrkdwnSection(line))
 			fallbackLines = append(fallbackLines, line)
 			remaining--
 		}
 	}
-	if len(firingGroups) == 0 {
+	if len(firingGroups) == 0 && len(hiddenFiring) == 0 {
 		// When the batch has gone quiet, the individual resolution list adds noise without changing the action.
 		const line = "✅ All alerts resolved"
 		blocks = append(blocks, mrkdwnSection(line))
@@ -99,8 +112,12 @@ func severityDot(severity string) string {
 // groupLine renders one rule's rollup as natural language. It intentionally omits individual device
 // identifiers: one fleet-wide event can cover thousands of devices, and the linked app holds the drill-in.
 func groupLine(g alertGroup, resolved bool) string {
+	return groupLineWithActiveState(g, resolved, false)
+}
+
+func groupLineWithActiveState(g alertGroup, resolved, sameRuleStillFiring bool) string {
 	if resolved {
-		return "✅ " + escapeMrkdwn(resolvedGroupCopy(g))
+		return "✅ " + escapeMrkdwn(resolvedGroupCopy(g, sameRuleStillFiring))
 	}
 	dot := severityDot(g.Severity)
 	if g.DeviceCount > 0 {
@@ -145,12 +162,38 @@ func activeDeviceGroupCopy(g alertGroup) string {
 	return fmt.Sprintf("%s affecting %s", g.Name, count)
 }
 
-func resolvedGroupCopy(g alertGroup) string {
+func resolvedGroupCopy(g alertGroup, sameRuleStillFiring bool) string {
+	if sameRuleStillFiring {
+		count := fmt.Sprintf("%d device%s", g.DeviceCount, plural(g.DeviceCount))
+		switch RuleTemplate(g.Template) {
+		case RuleTemplateOffline:
+			return count + " reachable again"
+		case RuleTemplateHashrate:
+			return count + " hashing above alert threshold again"
+		case RuleTemplateTemperature:
+			return count + " below temperature threshold again"
+		case RuleTemplatePool,
+			RuleTemplateCommandFailure,
+			RuleTemplateTelemetryPoll,
+			RuleTemplateMQTTCurtailment,
+			RuleTemplateMQTTDisconnected,
+			RuleTemplateCurtailmentFanRestore,
+			RuleTemplateMetricIngest,
+			RuleTemplateHAReadiness:
+			// Use the generic rule wording below for templates without device recovery copy.
+		default:
+			// Unknown templates use the same generic rule wording.
+		}
+		if g.DeviceCount > 0 {
+			return fmt.Sprintf("%s resolved for %s", sentenceText(g.Name), count)
+		}
+		return fmt.Sprintf("%s resolved for %d instance%s", sentenceText(g.Name), g.InstanceCount, plural(g.InstanceCount))
+	}
 	switch RuleTemplate(g.Template) {
 	case RuleTemplateOffline:
 		return "All devices reachable"
 	case RuleTemplateHashrate:
-		return "All devices hashing at expected rate"
+		return "All devices hashing above alert threshold"
 	case RuleTemplateTemperature:
 		return "All devices below temperature threshold"
 	case RuleTemplateTelemetryPoll:
@@ -224,6 +267,7 @@ const groupSampleSummaries = 3
 
 // alertGroup is one rule's rollup within a delivery batch. Every outward-facing renderer groups through it.
 type alertGroup struct {
+	Identity  string
 	Name      string
 	RuleGroup string
 	Severity  string
@@ -241,20 +285,22 @@ type alertGroup struct {
 	summaries map[string]bool
 }
 
-// groupAlerts rolls a batch up per firing rule (identified by alertname + rule group, matching the API's
-// active rollup), widest blast radius first.
+// groupAlerts rolls a batch up per firing rule, widest blast radius first. RuleUID is authoritative;
+// copy-defining fields separate legacy alerts that predate rule identity propagation.
 func groupAlerts(alerts []Alert) []alertGroup {
-	type groupKey struct{ name, ruleGroup string }
+	type groupKey struct{ name, ruleGroup, identity string }
 	byKey := map[groupKey]*alertGroup{}
 	for _, a := range alerts {
 		name := a.Labels["alertname"]
 		if name == "" {
 			name = "Alert"
 		}
-		key := groupKey{name, a.Labels[ruleLabelRuleGroup]}
+		identity := alertGroupIdentity(a)
+		key := groupKey{name, a.Labels[ruleLabelRuleGroup], identity}
 		g := byKey[key]
 		if g == nil {
 			g = &alertGroup{
+				Identity:  identity,
 				Name:      name,
 				RuleGroup: a.Labels[ruleLabelRuleGroup],
 				Severity:  a.Labels["severity"],
@@ -290,9 +336,27 @@ func groupAlerts(alerts []Alert) []alertGroup {
 			cmp.Compare(b.DeviceCount, a.DeviceCount),
 			strings.Compare(a.Name, b.Name),
 			strings.Compare(a.RuleGroup, b.RuleGroup),
+			strings.Compare(a.Identity, b.Identity),
 		)
 	})
 	return out
+}
+
+// alertGroupIdentity keeps distinct rules separate even when user-selected names collide. Current alerts carry
+// RuleUID; legacy/unattributed alerts fall back to stable rule-level fields. Summary is intentionally excluded:
+// some rules interpolate the alert instance there and still need all of their instances rolled up together.
+func alertGroupIdentity(a Alert) string {
+	if uid := strings.TrimSpace(a.RuleUID); uid != "" {
+		return "uid:" + uid
+	}
+	if uid := strings.TrimSpace(a.Labels[ruleLabelRuleUID]); uid != "" {
+		return "uid:" + uid
+	}
+	return strings.Join([]string{
+		"legacy",
+		a.Labels[ruleLabelTemplate],
+		a.Labels["severity"],
+	}, "\x00")
 }
 
 // webhookAlert is the clean, Grafana-free shape delivered to generic webhook channels.

--- a/server/internal/domain/alerts/render.go
+++ b/server/internal/domain/alerts/render.go
@@ -18,8 +18,8 @@ const (
 	slackInstanceMaxRunes = 50
 )
 
-// The title's dot carries the batch's worst severity, worst first. An unrecognized or missing severity ranks
-// with the worst: rules can carry any severity label, and a colour is a weak reason to under-signal one.
+// Each alert line carries its own severity. An unrecognized or missing severity uses the critical dot:
+// rules can carry any severity label, and a colour is a weak reason to under-signal one.
 var slackSeverityDots = []struct{ severity, dot string }{
 	{"critical", "🔴"},
 	{"warning", "🟡"},
@@ -27,36 +27,47 @@ var slackSeverityDots = []struct{ severity, dot string }{
 }
 
 // renderSlack builds a Block Kit message that carries no alerting-engine internals. Alerts are rolled up per
-// rule, so a fleet-wide outage is a handful of sections with miner counts rather than thousands of miner lines.
-func renderSlack(publicURL string, alerts []Alert, identities map[string]DeviceIdentity) map[string]any {
+// rule, so a fleet-wide outage is a handful of sections with device counts rather than thousands of device lines.
+func renderSlack(publicURL string, alerts []Alert, _ map[string]DeviceIdentity) map[string]any {
 	firing, resolved := partitionAlerts(alerts)
 	firingGroups := groupAlerts(firing)
 	resolvedGroups := groupAlerts(resolved)
-	firingDevices := distinctDevices(firing)
 	plain, linked := instanceLabels(publicURL)
-	// The fallback carries the same title without the link markup, which clients that don't render blocks
-	// would show verbatim.
-	title := slackTitle(plain, firingGroups, firingDevices)
 
-	blocks := []map[string]any{mrkdwnSection("*" + slackTitle(linked, firingGroups, firingDevices) + "*")}
+	// Keep product and instance context in a neutral header. Severity belongs to each alert line so a
+	// mixed batch is not represented by one umbrella icon.
+	blocks := []map[string]any{mrkdwnSection("*" + linked + "*")}
+	fallbackLines := []string{plain}
 	remaining := slackMaxAlertSections
 	appendGroups := func(groups []alertGroup, resolved bool) {
 		for _, g := range groups {
 			if remaining <= 0 {
 				return
 			}
-			blocks = append(blocks, mrkdwnSection(groupLine(g, identities, resolved)))
+			line := groupLine(g, resolved)
+			blocks = append(blocks, mrkdwnSection(line))
+			fallbackLines = append(fallbackLines, line)
 			remaining--
 		}
 	}
-	appendGroups(firingGroups, false)
-	appendGroups(resolvedGroups, true)
-	if overflow := len(firingGroups) + len(resolvedGroups) - slackMaxAlertSections; overflow > 0 {
-		blocks = append(blocks, mrkdwnSection(fmt.Sprintf("_…and %d more — open Proto Fleet for the full list._", overflow)))
+	if len(firingGroups) == 0 {
+		// When the batch has gone quiet, the individual resolution list adds noise without changing the action.
+		const line = "✅ All alerts resolved"
+		blocks = append(blocks, mrkdwnSection(line))
+		fallbackLines = append(fallbackLines, line)
+	} else {
+		appendGroups(firingGroups, false)
+		appendGroups(resolvedGroups, true)
+		if overflow := len(firingGroups) + len(resolvedGroups) - slackMaxAlertSections; overflow > 0 {
+			line := fmt.Sprintf("_…and %d more — open Proto Fleet for the full list._", overflow)
+			blocks = append(blocks, mrkdwnSection(line))
+			fallbackLines = append(fallbackLines, line)
+		}
 	}
 
-	// The top-level text is the notification/preview fallback for clients that don't render blocks.
-	return map[string]any{"text": title, "blocks": blocks}
+	// The top-level text is the notification/preview fallback for clients that don't render blocks. Include
+	// every rendered line rather than reducing the preview to generic alert state.
+	return map[string]any{"text": strings.Join(fallbackLines, "\n"), "blocks": blocks}
 }
 
 // instanceLabels names the sending fleet: several instances can post to one channel, and nothing else in the
@@ -75,81 +86,118 @@ func instanceLabels(publicURL string) (plain, linked string) {
 		fmt.Sprintf("%s (<%s|%s>)", product, publicURL, escapeMrkdwn(host))
 }
 
-// severityDot picks the dot for the worst severity firing, so a batch of warnings doesn't read as an outage.
-func severityDot(firing []alertGroup) string {
-	worst := len(slackSeverityDots) - 1
-	for _, g := range firing {
-		worst = min(worst, severityRank(g.Severity))
-	}
-	return slackSeverityDots[worst].dot
-}
-
-func severityRank(severity string) int {
+func severityDot(severity string) string {
 	severity = strings.TrimSpace(severity)
-	for i, s := range slackSeverityDots {
+	for _, s := range slackSeverityDots {
 		if strings.EqualFold(severity, s.severity) {
-			return i
+			return s.dot
 		}
 	}
-	return 0
+	return slackSeverityDots[0].dot
 }
 
-func slackTitle(instance string, firing []alertGroup, firingDevices int) string {
-	if len(firing) == 0 {
-		return "✅ " + instance + " — alerts resolved"
-	}
-	base := fmt.Sprintf("%s %s — %d alert%s firing", severityDot(firing), instance, len(firing), plural(len(firing)))
-	// Fleet- and source-scoped alerts have no miners to count; don't claim "on 0 miners".
-	if firingDevices == 0 {
-		return base
-	}
-	return fmt.Sprintf("%s on %d miner%s", base, firingDevices, plural(firingDevices))
-}
-
-// groupLine renders one rule's rollup for Slack: the alert, its blast radius, and enough miner names to act on.
-// Labels are escaped here, not in the rollup, so a non-Slack renderer formats the same group its own way.
-func groupLine(g alertGroup, identities map[string]DeviceIdentity, resolved bool) string {
-	var b strings.Builder
+// groupLine renders one rule's rollup as natural language. It intentionally omits individual device
+// identifiers: one fleet-wide event can cover thousands of devices, and the linked app holds the drill-in.
+func groupLine(g alertGroup, resolved bool) string {
 	if resolved {
-		b.WriteString("*Resolved: " + escapeMrkdwn(g.Name) + "*")
-	} else {
-		b.WriteString("*" + escapeMrkdwn(g.Name) + "*")
+		return "✅ " + escapeMrkdwn(resolvedGroupCopy(g))
 	}
-	if !resolved && g.Severity != "" {
-		b.WriteString(" _(" + escapeMrkdwn(g.Severity) + ")_")
+	dot := severityDot(g.Severity)
+	if g.DeviceCount > 0 {
+		return dot + " " + escapeMrkdwn(activeDeviceGroupCopy(g))
 	}
-	switch {
-	case g.DeviceCount == 0:
-		// No miners to name, but a rule that fires on another dimension (per curtailment source, per host)
-		// still has one instance per affected thing; say how many so none of them go unreported.
-		if g.InstanceCount > 1 {
-			b.WriteString(fmt.Sprintf(" — %d instances", g.InstanceCount))
+	return devicelessGroupLine(dot, g)
+}
+
+func activeDeviceGroupCopy(g alertGroup) string {
+	summary := firstSummary(g)
+	count := fmt.Sprintf("%d device%s", g.DeviceCount, plural(g.DeviceCount))
+	switch RuleTemplate(g.Template) {
+	case RuleTemplateOffline:
+		if rest, ok := strings.CutPrefix(summary, "Device is offline"); ok {
+			return count + " unreachable" + rest
 		}
-	case g.DeviceCount == 1:
-		// A single miner reads better named inline than as "1 miner" plus a list of one.
-		b.WriteString(" — " + deviceLabel(g.SampleDeviceIDs[0], identities))
+	case RuleTemplateHashrate:
+		for _, prefix := range []string{"Device hashrate has fallen below ", "Device hashrate is below "} {
+			if rest, ok := strings.CutPrefix(summary, prefix); ok {
+				return count + " hashing below " + rest
+			}
+		}
+	case RuleTemplateTemperature:
+		if rest, ok := strings.CutPrefix(summary, "Max sensor temperature for device is "); ok {
+			return count + " with sensor temperatures " + rest
+		}
+	case RuleTemplatePool,
+		RuleTemplateCommandFailure,
+		RuleTemplateTelemetryPoll,
+		RuleTemplateMQTTCurtailment,
+		RuleTemplateMQTTDisconnected,
+		RuleTemplateCurtailmentFanRestore,
+		RuleTemplateMetricIngest,
+		RuleTemplateHAReadiness:
+		// These templates are device-less today or have no specialized device copy.
 	default:
-		b.WriteString(fmt.Sprintf(" — %d miners", g.DeviceCount))
-		labels := make([]string, 0, len(g.SampleDeviceIDs))
-		for _, id := range g.SampleDeviceIDs {
-			labels = append(labels, deviceLabel(id, identities))
-		}
-		b.WriteString("\n" + strings.Join(labels, ", "))
-		if more := g.DeviceCount - len(g.SampleDeviceIDs); more > 0 {
-			b.WriteString(fmt.Sprintf(" and %d more", more))
-		}
+		// Other and future templates use their rule-provided summary below.
 	}
-	// Miner-backed resolutions are identifiable from their miner labels and stay terse. Device-less alerts
-	// often identify their source or host only in the summary, so retain those summaries on resolution.
-	if !resolved || g.DeviceCount == 0 {
-		for _, summary := range g.Summaries {
-			b.WriteString("\n" + escapeMrkdwn(summary))
-		}
-		if more := g.SummaryCount - len(g.Summaries); more > 0 {
-			b.WriteString(fmt.Sprintf("\n_…and %d more_", more))
-		}
+	if summary != "" {
+		return summary + " (" + count + " affected)"
 	}
-	return b.String()
+	return fmt.Sprintf("%s affecting %s", g.Name, count)
+}
+
+func resolvedGroupCopy(g alertGroup) string {
+	switch RuleTemplate(g.Template) {
+	case RuleTemplateOffline:
+		return "All devices reachable"
+	case RuleTemplateHashrate:
+		return "All devices hashing at expected rate"
+	case RuleTemplateTemperature:
+		return "All devices below temperature threshold"
+	case RuleTemplateTelemetryPoll:
+		return "Telemetry polling recovered"
+	case RuleTemplateMQTTCurtailment:
+		return "Miners restored"
+	case RuleTemplateMQTTDisconnected:
+		return "All curtailment sources reachable"
+	case RuleTemplateCurtailmentFanRestore:
+		return "Facility fan control restored"
+	case RuleTemplateMetricIngest:
+		return "Metric ingest resumed"
+	case RuleTemplateHAReadiness:
+		return "HA ready to fail over"
+	case RuleTemplatePool, RuleTemplateCommandFailure:
+		return sentenceText(g.Name) + " resolved"
+	default:
+		return sentenceText(g.Name) + " resolved"
+	}
+}
+
+func devicelessGroupLine(dot string, g alertGroup) string {
+	if len(g.Summaries) == 0 {
+		if g.InstanceCount > 1 {
+			return fmt.Sprintf("%s %d instances affected by %s", dot, g.InstanceCount, escapeMrkdwn(g.Name))
+		}
+		return dot + " " + escapeMrkdwn(sentenceText(g.Name))
+	}
+	lines := make([]string, 0, len(g.Summaries)+1)
+	for _, summary := range g.Summaries {
+		lines = append(lines, dot+" "+escapeMrkdwn(sentenceText(summary)))
+	}
+	if more := g.SummaryCount - len(g.Summaries); more > 0 {
+		lines = append(lines, fmt.Sprintf("_…and %d more_", more))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func firstSummary(g alertGroup) string {
+	if len(g.Summaries) == 0 {
+		return ""
+	}
+	return sentenceText(g.Summaries[0])
+}
+
+func sentenceText(s string) string {
+	return strings.TrimSuffix(strings.TrimSpace(s), ".")
 }
 
 // escapeMrkdwn neutralizes the mrkdwn chars that let user-controlled text escape its own field: the link syntax,
@@ -171,27 +219,23 @@ func mrkdwnSection(text string) map[string]any {
 	}
 }
 
-// Miners named inline per alert before the "+N more" tail; the app holds the full list.
-const groupSampleDevices = 3
-
 // Distinct summaries named inline before the "+N more" tail, for rules that interpolate the alert instance.
 const groupSampleSummaries = 3
 
-// alertGroup is one rule's rollup within a delivery batch. Every outward-facing renderer groups through it, so
-// it carries device ids rather than display labels: each medium formats and escapes them its own way.
+// alertGroup is one rule's rollup within a delivery batch. Every outward-facing renderer groups through it.
 type alertGroup struct {
 	Name      string
 	RuleGroup string
 	Severity  string
+	Template  string
 	// Distinct instance summaries, capped at groupSampleSummaries; SummaryCount is how many there were. Most
 	// rules render summary from the rule, so a group has one; the ones that interpolate the firing instance
 	// ("Curtailment source maestro-b is unreachable") have one per instance, and no single one describes them.
 	Summaries    []string
 	SummaryCount int
 	// Instances in the group, which exceeds DeviceCount only when a rule fires on a non-device dimension.
-	InstanceCount   int
-	DeviceCount     int
-	SampleDeviceIDs []string
+	InstanceCount int
+	DeviceCount   int
 	// Dedupe sets behind DeviceCount and SummaryCount, released once the group is materialized.
 	devices   map[string]bool
 	summaries map[string]bool
@@ -214,6 +258,7 @@ func groupAlerts(alerts []Alert) []alertGroup {
 				Name:      name,
 				RuleGroup: a.Labels[ruleLabelRuleGroup],
 				Severity:  a.Labels["severity"],
+				Template:  a.Labels[ruleLabelTemplate],
 				devices:   map[string]bool{},
 				summaries: map[string]bool{},
 			}
@@ -232,9 +277,6 @@ func groupAlerts(alerts []Alert) []alertGroup {
 			continue
 		}
 		g.devices[id] = true
-		if len(g.SampleDeviceIDs) < groupSampleDevices {
-			g.SampleDeviceIDs = append(g.SampleDeviceIDs, id)
-		}
 	}
 	out := make([]alertGroup, 0, len(byKey))
 	for _, g := range byKey {
@@ -251,42 +293,6 @@ func groupAlerts(alerts []Alert) []alertGroup {
 		)
 	})
 	return out
-}
-
-// distinctDevices counts the miners a batch covers in total, for the "N alerts on M miners" headline.
-func distinctDevices(alerts []Alert) int {
-	seen := map[string]bool{}
-	for _, a := range alerts {
-		if id := a.Labels["device_id"]; id != "" {
-			seen[id] = true
-		}
-	}
-	return len(seen)
-}
-
-// macCode renders a MAC as inline code, which is both how an identifier reads best and the only mrkdwn context
-// where Slack leaves `:shortcode:` alone — a colon-separated MAC otherwise interpolates `:ab:` as 🆎.
-func macCode(mac string) string {
-	if mac == "" {
-		return ""
-	}
-	return "`" + escapeMrkdwn(mac) + "`"
-}
-
-func deviceLabel(id string, identities map[string]DeviceIdentity) string {
-	ident := identities[id]
-	name := escapeMrkdwn(strings.TrimSpace(ident.Name))
-	mac := macCode(ident.MAC)
-	switch {
-	case name != "" && mac != "":
-		return fmt.Sprintf("%s (%s)", name, mac)
-	case name != "":
-		return name
-	case mac != "":
-		return mac
-	default:
-		return escapeMrkdwn(id)
-	}
 }
 
 // webhookAlert is the clean, Grafana-free shape delivered to generic webhook channels.

--- a/server/internal/domain/alerts/render.go
+++ b/server/internal/domain/alerts/render.go
@@ -9,9 +9,10 @@ import (
 	"unicode/utf8"
 )
 
-// Slack limits: section text ≤3000, ≤50 blocks per message.
+// Slack limits: section text ≤3000, top-level fallback text should stay ≤4000, ≤50 blocks per message.
 const (
-	slackSectionMaxRunes = 2900
+	slackSectionMaxRunes  = 2900
+	slackFallbackMaxRunes = 4000
 	// Cap alert sections so the title and overflow line stay under Slack's 50-block limit.
 	slackMaxAlertSections = 40
 	// Keep the instance name from crowding the alert counts out of the truncated title.
@@ -62,7 +63,8 @@ func renderSlack(publicURL string, alerts []Alert, _ map[string]DeviceIdentity) 
 
 	// The top-level text is the notification/preview fallback for clients that don't render blocks. Include
 	// every rendered line rather than reducing the preview to generic alert state.
-	return map[string]any{"text": strings.Join(fallbackLines, "\n"), "blocks": blocks}
+	fallback := truncate(strings.Join(fallbackLines, "\n"), slackFallbackMaxRunes)
+	return map[string]any{"text": fallback, "blocks": blocks}
 }
 
 // instanceLabels names the sending fleet: several instances can post to one channel, and nothing else in the
@@ -182,14 +184,7 @@ func resolvedGroupCopy(g alertGroup) string {
 		}
 		return sentenceText(g.Name) + " resolved"
 	case RuleTemplateMQTTDisconnected:
-		if summary := firstSummary(g); summary != "" {
-			if source, ok := strings.CutPrefix(summary, "Curtailment source "); ok {
-				if source, ok = strings.CutSuffix(source, " is unreachable; cannot curtail"); ok && source != "" {
-					return "Curtailment source " + source + " reachable again"
-				}
-			}
-		}
-		return fmt.Sprintf("%d curtailment source%s reachable again", g.InstanceCount, plural(g.InstanceCount))
+		return resolvedMQTTDisconnectedCopy(g)
 	case RuleTemplateCurtailmentFanRestore:
 		return fmt.Sprintf("Fan control restored for %d curtailment event%s", g.InstanceCount, plural(g.InstanceCount))
 	case RuleTemplateMetricIngest:
@@ -208,12 +203,42 @@ func resolvedGroupCopy(g alertGroup) string {
 	return sentenceText(g.Name) + " resolved"
 }
 
+func resolvedMQTTDisconnectedCopy(g alertGroup) string {
+	fallback := fmt.Sprintf("%d curtailment source%s reachable again", g.InstanceCount, plural(g.InstanceCount))
+	if len(g.Summaries) == 0 {
+		return fallback
+	}
+	lines := make([]string, 0, len(g.Summaries)+1)
+	for _, summary := range g.Summaries {
+		source, ok := strings.CutPrefix(sentenceText(summary), "Curtailment source ")
+		if !ok {
+			return fallback
+		}
+		source, ok = strings.CutSuffix(source, " is unreachable; cannot curtail")
+		if !ok || source == "" {
+			return fallback
+		}
+		lines = append(lines, "Curtailment source "+source+" reachable again")
+	}
+	if more := g.SummaryCount - len(g.Summaries); more > 0 {
+		lines = append(lines, fmt.Sprintf("…and %d more curtailment source%s reachable again", more, plural(more)))
+	}
+	return strings.Join(lines, "\n✅ ")
+}
+
 func devicelessGroupLine(dot string, g alertGroup) string {
 	if len(g.Summaries) == 0 {
 		if g.InstanceCount > 1 {
 			return fmt.Sprintf("%s %d instances affected by %s", dot, g.InstanceCount, escapeMrkdwn(g.Name))
 		}
 		return dot + " " + escapeMrkdwn(sentenceText(g.Name))
+	}
+	if len(g.Summaries) == 1 && g.InstanceCount > 1 {
+		affected := fmt.Sprintf("%d instance%s", g.InstanceCount, plural(g.InstanceCount))
+		if RuleTemplate(g.Template) == RuleTemplateCurtailmentFanRestore {
+			affected = fmt.Sprintf("%d curtailment event%s", g.InstanceCount, plural(g.InstanceCount))
+		}
+		return fmt.Sprintf("%s %s (%s affected)", dot, escapeMrkdwn(sentenceText(g.Summaries[0])), affected)
 	}
 	lines := make([]string, 0, len(g.Summaries)+1)
 	for _, summary := range g.Summaries {

--- a/server/internal/domain/alerts/render.go
+++ b/server/internal/domain/alerts/render.go
@@ -261,6 +261,7 @@ const groupSampleSummaries = 3
 // alertGroup is one rule's rollup within a delivery batch. Every outward-facing renderer groups through it.
 type alertGroup struct {
 	Identity  string
+	RuleUID   string
 	Name      string
 	RuleGroup string
 	Severity  string
@@ -294,6 +295,7 @@ func groupAlerts(alerts []Alert) []alertGroup {
 		if g == nil {
 			g = &alertGroup{
 				Identity:  identity,
+				RuleUID:   alertRuleUID(a),
 				Name:      name,
 				RuleGroup: a.Labels[ruleLabelRuleGroup],
 				Severity:  a.Labels["severity"],
@@ -339,10 +341,7 @@ func groupAlerts(alerts []Alert) []alertGroup {
 // RuleUID; legacy/unattributed alerts fall back to stable rule-level fields. Summary is intentionally excluded:
 // some rules interpolate the alert instance there and still need all of their instances rolled up together.
 func alertGroupIdentity(a Alert) string {
-	if uid := strings.TrimSpace(a.RuleUID); uid != "" {
-		return "uid:" + uid
-	}
-	if uid := strings.TrimSpace(a.Labels[ruleLabelRuleUID]); uid != "" {
+	if uid := alertRuleUID(a); uid != "" {
 		return "uid:" + uid
 	}
 	return strings.Join([]string{
@@ -352,9 +351,17 @@ func alertGroupIdentity(a Alert) string {
 	}, "\x00")
 }
 
+func alertRuleUID(a Alert) string {
+	if uid := strings.TrimSpace(a.RuleUID); uid != "" {
+		return uid
+	}
+	return strings.TrimSpace(a.Labels[ruleLabelRuleUID])
+}
+
 // webhookAlert is the clean, Grafana-free shape delivered to generic webhook channels.
 type webhookAlert struct {
 	Status     string `json:"status"`
+	RuleUID    string `json:"rule_uid,omitempty"`
 	AlertName  string `json:"alert_name"`
 	Severity   string `json:"severity,omitempty"`
 	Summary    string `json:"summary,omitempty"`
@@ -367,6 +374,7 @@ type webhookAlert struct {
 // a consumer that only wants "what is firing and how bad" reads the groups and ignores the instance arrays.
 type webhookAlertGroup struct {
 	AlertName string `json:"alert_name"`
+	RuleUID   string `json:"rule_uid,omitempty"`
 	Severity  string `json:"severity,omitempty"`
 	RuleGroup string `json:"rule_group,omitempty"`
 	// One of the group's distinct summaries; the per-instance arrays carry every instance's own.
@@ -384,6 +392,7 @@ func renderWebhook(orgID int64, alerts []Alert, identities map[string]DeviceIden
 			ident := identities[id]
 			out = append(out, webhookAlert{
 				Status:     a.Status,
+				RuleUID:    alertRuleUID(a),
 				AlertName:  a.Labels["alertname"],
 				Severity:   a.Labels["severity"],
 				Summary:    a.Annotations["summary"],
@@ -404,6 +413,7 @@ func renderWebhook(orgID int64, alerts []Alert, identities map[string]DeviceIden
 			}
 			out = append(out, webhookAlertGroup{
 				AlertName:   g.Name,
+				RuleUID:     g.RuleUID,
 				Severity:    g.Severity,
 				RuleGroup:   g.RuleGroup,
 				Summary:     summary,

--- a/server/internal/domain/alerts/render.go
+++ b/server/internal/domain/alerts/render.go
@@ -29,22 +29,9 @@ var slackSeverityDots = []struct{ severity, dot string }{
 // renderSlack builds a Block Kit message that carries no alerting-engine internals. Alerts are rolled up per
 // rule, so a fleet-wide outage is a handful of sections with device counts rather than thousands of device lines.
 func renderSlack(publicURL string, alerts []Alert, _ map[string]DeviceIdentity) map[string]any {
-	return renderSlackWithHiddenFiring(publicURL, alerts, nil)
-}
-
-// renderSlackWithHiddenFiring keeps maintenance-muted firing alerts out of the message while retaining them
-// as resolution context. A hidden firing alert must prevent a false all-clear or "all devices" recovery claim.
-func renderSlackWithHiddenFiring(publicURL string, alerts, hiddenFiring []Alert) map[string]any {
 	firing, resolved := partitionAlerts(alerts)
 	firingGroups := groupAlerts(firing)
 	resolvedGroups := groupAlerts(resolved)
-	activeRuleIdentities := make(map[string]bool, len(firingGroups)+len(hiddenFiring))
-	for _, g := range firingGroups {
-		activeRuleIdentities[g.Identity] = true
-	}
-	for _, g := range groupAlerts(hiddenFiring) {
-		activeRuleIdentities[g.Identity] = true
-	}
 	plain, linked := instanceLabels(publicURL)
 
 	// Keep product and instance context in a neutral header. Severity belongs to each alert line so a
@@ -57,25 +44,20 @@ func renderSlackWithHiddenFiring(publicURL string, alerts, hiddenFiring []Alert)
 			if remaining <= 0 {
 				return
 			}
-			line := groupLineWithActiveState(g, resolved, resolved && activeRuleIdentities[g.Identity])
+			line := groupLine(g, resolved)
 			blocks = append(blocks, mrkdwnSection(line))
 			fallbackLines = append(fallbackLines, line)
 			remaining--
 		}
 	}
-	if len(firingGroups) == 0 && len(hiddenFiring) == 0 {
-		// When the batch has gone quiet, the individual resolution list adds noise without changing the action.
-		const line = "✅ All alerts resolved"
+	// A notification batch is one Alertmanager group, not a fleet-wide state snapshot. Retain each resolved
+	// condition instead of turning a resolution-only group into a global all-clear.
+	appendGroups(firingGroups, false)
+	appendGroups(resolvedGroups, true)
+	if overflow := len(firingGroups) + len(resolvedGroups) - slackMaxAlertSections; overflow > 0 {
+		line := fmt.Sprintf("_…and %d more — open Proto Fleet for the full list._", overflow)
 		blocks = append(blocks, mrkdwnSection(line))
 		fallbackLines = append(fallbackLines, line)
-	} else {
-		appendGroups(firingGroups, false)
-		appendGroups(resolvedGroups, true)
-		if overflow := len(firingGroups) + len(resolvedGroups) - slackMaxAlertSections; overflow > 0 {
-			line := fmt.Sprintf("_…and %d more — open Proto Fleet for the full list._", overflow)
-			blocks = append(blocks, mrkdwnSection(line))
-			fallbackLines = append(fallbackLines, line)
-		}
 	}
 
 	// The top-level text is the notification/preview fallback for clients that don't render blocks. Include
@@ -112,12 +94,8 @@ func severityDot(severity string) string {
 // groupLine renders one rule's rollup as natural language. It intentionally omits individual device
 // identifiers: one fleet-wide event can cover thousands of devices, and the linked app holds the drill-in.
 func groupLine(g alertGroup, resolved bool) string {
-	return groupLineWithActiveState(g, resolved, false)
-}
-
-func groupLineWithActiveState(g alertGroup, resolved, sameRuleStillFiring bool) string {
 	if resolved {
-		return "✅ " + escapeMrkdwn(resolvedGroupCopy(g, sameRuleStillFiring))
+		return "✅ " + escapeMrkdwn(resolvedGroupCopy(g))
 	}
 	dot := severityDot(g.Severity)
 	if g.DeviceCount > 0 {
@@ -162,8 +140,8 @@ func activeDeviceGroupCopy(g alertGroup) string {
 	return fmt.Sprintf("%s affecting %s", g.Name, count)
 }
 
-func resolvedGroupCopy(g alertGroup, sameRuleStillFiring bool) string {
-	if sameRuleStillFiring {
+func resolvedGroupCopy(g alertGroup) string {
+	if g.DeviceCount > 0 {
 		count := fmt.Sprintf("%d device%s", g.DeviceCount, plural(g.DeviceCount))
 		switch RuleTemplate(g.Template) {
 		case RuleTemplateOffline:
@@ -184,35 +162,41 @@ func resolvedGroupCopy(g alertGroup, sameRuleStillFiring bool) string {
 		default:
 			// Unknown templates use the same generic rule wording.
 		}
-		if g.DeviceCount > 0 {
-			return fmt.Sprintf("%s resolved for %s", sentenceText(g.Name), count)
-		}
-		return fmt.Sprintf("%s resolved for %d instance%s", sentenceText(g.Name), g.InstanceCount, plural(g.InstanceCount))
+		return fmt.Sprintf("%s resolved for %s", sentenceText(g.Name), count)
 	}
 	switch RuleTemplate(g.Template) {
-	case RuleTemplateOffline:
-		return "All devices reachable"
-	case RuleTemplateHashrate:
-		return "All devices hashing above alert threshold"
-	case RuleTemplateTemperature:
-		return "All devices below temperature threshold"
 	case RuleTemplateTelemetryPoll:
 		return "Telemetry polling recovered"
 	case RuleTemplateMQTTCurtailment:
-		return "Miners restored"
+		if source, ok := strings.CutPrefix(firstSummary(g), "Miners are curtailed by "); ok && source != "" {
+			return "Curtailment by " + source + " ended"
+		}
+		return sentenceText(g.Name) + " resolved"
 	case RuleTemplateMQTTDisconnected:
-		return "All curtailment sources reachable"
+		if summary := firstSummary(g); summary != "" {
+			if source, ok := strings.CutPrefix(summary, "Curtailment source "); ok {
+				if source, ok = strings.CutSuffix(source, " is unreachable; cannot curtail"); ok && source != "" {
+					return "Curtailment source " + source + " reachable again"
+				}
+			}
+		}
+		return fmt.Sprintf("%d curtailment source%s reachable again", g.InstanceCount, plural(g.InstanceCount))
 	case RuleTemplateCurtailmentFanRestore:
-		return "Facility fan control restored"
+		return fmt.Sprintf("Fan control restored for %d curtailment event%s", g.InstanceCount, plural(g.InstanceCount))
 	case RuleTemplateMetricIngest:
 		return "Metric ingest resumed"
 	case RuleTemplateHAReadiness:
 		return "HA ready to fail over"
-	case RuleTemplatePool, RuleTemplateCommandFailure:
-		return sentenceText(g.Name) + " resolved"
+	case RuleTemplateOffline, RuleTemplateHashrate, RuleTemplateTemperature,
+		RuleTemplatePool, RuleTemplateCommandFailure:
+		// Device-backed templates without a device label use the generic instance wording below.
 	default:
-		return sentenceText(g.Name) + " resolved"
+		// Unknown templates use the same generic instance wording.
 	}
+	if g.InstanceCount > 1 {
+		return fmt.Sprintf("%s resolved for %d instances", sentenceText(g.Name), g.InstanceCount)
+	}
+	return sentenceText(g.Name) + " resolved"
 }
 
 func devicelessGroupLine(dot string, g alertGroup) string {

--- a/server/internal/domain/alerts/render.go
+++ b/server/internal/domain/alerts/render.go
@@ -110,17 +110,17 @@ func activeDeviceGroupCopy(g alertGroup) string {
 	switch RuleTemplate(g.Template) {
 	case RuleTemplateOffline:
 		if rest, ok := strings.CutPrefix(summary, "Device is offline"); ok {
-			return count + " unreachable" + rest
+			return customRuleDeviceCopy(g, count+" unreachable"+rest)
 		}
 	case RuleTemplateHashrate:
 		for _, prefix := range []string{"Device hashrate has fallen below ", "Device hashrate is below "} {
 			if rest, ok := strings.CutPrefix(summary, prefix); ok {
-				return count + " hashing below " + rest
+				return customRuleDeviceCopy(g, count+" hashing below "+rest)
 			}
 		}
 	case RuleTemplateTemperature:
 		if rest, ok := strings.CutPrefix(summary, "Max sensor temperature for device is "); ok {
-			return count + " with sensor temperatures " + rest
+			return customRuleDeviceCopy(g, count+" with sensor temperatures "+rest)
 		}
 	case RuleTemplatePool,
 		RuleTemplateCommandFailure,
@@ -135,9 +135,18 @@ func activeDeviceGroupCopy(g alertGroup) string {
 		// Other and future templates use their rule-provided summary below.
 	}
 	if summary != "" {
-		return summary + " (" + count + " affected)"
+		return customRuleDeviceCopy(g, summary+" ("+count+" affected)")
 	}
 	return fmt.Sprintf("%s affecting %s", g.Name, count)
+}
+
+// Custom rule names carry the operator's scope or intent (for example, which site the rule watches).
+// Provisioned rules keep the shorter condition-only copy because their names add no new context.
+func customRuleDeviceCopy(g alertGroup, condition string) string {
+	if !strings.HasPrefix(g.RuleGroup, "proto-fleet-user-") {
+		return condition
+	}
+	return sentenceText(g.Name) + ": " + condition
 }
 
 func resolvedGroupCopy(g alertGroup) string {
@@ -145,11 +154,11 @@ func resolvedGroupCopy(g alertGroup) string {
 		count := fmt.Sprintf("%d device%s", g.DeviceCount, plural(g.DeviceCount))
 		switch RuleTemplate(g.Template) {
 		case RuleTemplateOffline:
-			return count + " reachable again"
+			return customRuleDeviceCopy(g, count+" reachable again")
 		case RuleTemplateHashrate:
-			return count + " hashing above alert threshold again"
+			return customRuleDeviceCopy(g, count+" hashing above alert threshold again")
 		case RuleTemplateTemperature:
-			return count + " below temperature threshold again"
+			return customRuleDeviceCopy(g, count+" below temperature threshold again")
 		case RuleTemplatePool,
 			RuleTemplateCommandFailure,
 			RuleTemplateTelemetryPoll,

--- a/server/internal/domain/alerts/render_test.go
+++ b/server/internal/domain/alerts/render_test.go
@@ -501,6 +501,38 @@ func TestRenderWebhookIncludesGroupRollup(t *testing.T) {
 	assert.Equal(t, "Device is offline for at least five minutes.", resolvedGroups[0].Summary)
 }
 
+func TestRenderWebhookKeepsSameNamedRulesAttributableByRuleUID(t *testing.T) {
+	alerts := []Alert{
+		{
+			Status: "firing", RuleUID: "user-offline",
+			Labels: map[string]string{
+				"alertname": "Watch miners", "severity": "warning", "device_id": "dev-a",
+				"rule_group": "proto-fleet-user-7", "template": "offline",
+			},
+			Annotations: map[string]string{"summary": "Device is offline for at least five minutes."},
+		},
+		{
+			Status: "firing", RuleUID: "user-temperature",
+			Labels: map[string]string{
+				"alertname": "Watch miners", "severity": "warning", "device_id": "dev-b",
+				"rule_group": "proto-fleet-user-7", "template": "temperature",
+			},
+			Annotations: map[string]string{"summary": "Max sensor temperature for device is above 95°C for at least ten minutes."},
+		},
+	}
+
+	out := renderWebhook(7, alerts, nil)
+	groups, ok := out["firing_groups"].([]webhookAlertGroup)
+	require.True(t, ok)
+	require.Len(t, groups, 2)
+	assert.ElementsMatch(t, []string{"user-offline", "user-temperature"}, []string{groups[0].RuleUID, groups[1].RuleUID})
+
+	firing, ok := out["firing"].([]webhookAlert)
+	require.True(t, ok)
+	require.Len(t, firing, 2)
+	assert.ElementsMatch(t, []string{"user-offline", "user-temperature"}, []string{firing[0].RuleUID, firing[1].RuleUID})
+}
+
 func TestRenderSlackEscapesUserControlledText(t *testing.T) {
 	alerts := []Alert{
 		{

--- a/server/internal/domain/alerts/render_test.go
+++ b/server/internal/domain/alerts/render_test.go
@@ -146,6 +146,70 @@ func TestRenderSlackUsesAlertSpecificResolvedCopyInMixedBatch(t *testing.T) {
 	}, "\n"), renderSlack("https://fleet.example.com", []Alert{firing, resolved}, nil)["text"])
 }
 
+func TestRenderSlackCountsPartialRecoveryWhileSameRuleStillFires(t *testing.T) {
+	alert := func(status, deviceID string) Alert {
+		return Alert{
+			Status:  status,
+			RuleUID: "offline-rule",
+			Labels: map[string]string{
+				"alertname": "Device Offline", "severity": "critical", "device_id": deviceID,
+				"rule_group": "proto-fleet-defaults", "template": "offline",
+			},
+			Annotations: map[string]string{"summary": "Device is offline for at least five minutes."},
+		}
+	}
+	alerts := make([]Alert, 0, 100)
+	for i := range 95 {
+		alerts = append(alerts, alert("firing", fmt.Sprintf("firing-%d", i)))
+	}
+	for i := range 5 {
+		alerts = append(alerts, alert("resolved", fmt.Sprintf("resolved-%d", i)))
+	}
+
+	text := allSectionText(t, renderSlack("", alerts, nil))
+	assert.Contains(t, text, "🔴 95 devices unreachable for at least five minutes")
+	assert.Contains(t, text, "✅ 5 devices reachable again")
+	assert.NotContains(t, text, "All devices reachable")
+}
+
+func TestRenderSlackUsesThresholdNeutralHashrateRecoveryCopy(t *testing.T) {
+	assert.Equal(t, "✅ All devices hashing above alert threshold", groupLine(alertGroup{
+		Template: string(RuleTemplateHashrate), DeviceCount: 3,
+	}, true))
+	assert.Equal(t, "✅ 3 devices hashing above alert threshold again", groupLineWithActiveState(alertGroup{
+		Template: string(RuleTemplateHashrate), DeviceCount: 3,
+	}, true, true))
+}
+
+func TestRenderSlackKeepsSameNamedUserRulesSeparateByRuleUID(t *testing.T) {
+	alerts := []Alert{
+		{
+			Status: "firing", RuleUID: "user-offline",
+			Labels: map[string]string{
+				"alertname": "Watch miners", "severity": "critical", "device_id": "dev-a",
+				"rule_group": "proto-fleet-user-7", "template": "offline",
+			},
+			Annotations: map[string]string{"summary": "Device is offline for at least five minutes."},
+		},
+		{
+			Status: "firing", RuleUID: "user-temperature",
+			Labels: map[string]string{
+				"alertname": "Watch miners", "severity": "warning", "device_id": "dev-b",
+				"rule_group": "proto-fleet-user-7", "template": "temperature",
+			},
+			Annotations: map[string]string{"summary": "Max sensor temperature for device is above 95°C for at least ten minutes."},
+		},
+	}
+
+	msg := renderSlack("", alerts, nil)
+	blocks, ok := msg["blocks"].([]map[string]any)
+	require.True(t, ok)
+	assert.Len(t, blocks, 3, "the shared name and rule group must not merge distinct rule UIDs")
+	text := allSectionText(t, msg)
+	assert.Contains(t, text, "1 device unreachable for at least five minutes")
+	assert.Contains(t, text, "1 device with sensor temperatures above 95°C for at least ten minutes")
+}
+
 func TestRenderSlackOmitsLinkWhenNoPublicURL(t *testing.T) {
 	msg := renderSlack("", sampleAlerts(), nil)
 	blocks, ok := msg["blocks"].([]map[string]any)

--- a/server/internal/domain/alerts/render_test.go
+++ b/server/internal/domain/alerts/render_test.go
@@ -13,19 +13,19 @@ import (
 // sampleAlerts mirrors a real Grafana batch: two firing device alerts + one resolved, each
 // carrying the internal labels the old native message leaked.
 func sampleAlerts() []Alert {
-	labels := func(name, sev, dev string) map[string]string {
+	labels := func(name, sev, dev, template string) map[string]string {
 		return map[string]string{
 			"alertname": name, "severity": sev, "device_id": dev,
 			"organization_id": "1", "grafana_folder": "Proto Fleet",
-			"proto_fleet_scope": "shared", "rule_group": "proto-fleet-defaults", "template": "x",
+			"proto_fleet_scope": "shared", "rule_group": "proto-fleet-defaults", "template": template,
 		}
 	}
 	return []Alert{
-		{Status: "firing", Labels: labels("Device Hashrate Low", "warning", "dev-a"),
-			Annotations: map[string]string{"summary": "Device hashrate has fallen below expected."}},
-		{Status: "firing", Labels: labels("Device Temperature High", "warning", "dev-b"),
-			Annotations: map[string]string{"summary": "Max sensor temperature is above 90C."}},
-		{Status: "resolved", Labels: labels("Device Offline", "warning", "dev-a"),
+		{Status: "firing", Labels: labels("Device Hashrate Low", "warning", "dev-a", "hashrate"),
+			Annotations: map[string]string{"summary": "Device hashrate is below 75% of expected for at least ten minutes."}},
+		{Status: "firing", Labels: labels("Device Temperature High", "warning", "dev-b", "temperature"),
+			Annotations: map[string]string{"summary": "Max sensor temperature for device is above 90°C for at least ten minutes."}},
+		{Status: "resolved", Labels: labels("Device Offline", "warning", "dev-a", "offline"),
 			Annotations: map[string]string{"summary": "Device is offline for at least five minutes."}},
 	}
 }
@@ -47,45 +47,114 @@ func TestRenderSlackHidesAlertingInternals(t *testing.T) {
 	}
 }
 
-func TestRenderSlackTitleLinksTheInstanceName(t *testing.T) {
+func TestRenderSlackLinksTheInstanceHeaderAndUsesPerAlertCopy(t *testing.T) {
 	ids := map[string]DeviceIdentity{
 		"dev-a": {Name: "miner-01", MAC: "aa:bb:cc:dd:ee:ff"},
 		"dev-b": {Name: "miner-02", MAC: "11:22:33:44:55:66"},
 	}
 	msg := renderSlack("https://fleet.example.com", sampleAlerts(), ids)
 
-	// The fallback preview is the same title without link markup, which a blockless client would show raw.
-	assert.Equal(t, "🟡 Proto Fleet (fleet.example.com) — 2 alerts firing on 2 miners", msg["text"])
+	// The fallback preview includes the same copy without link markup.
+	assert.Equal(t, strings.Join([]string{
+		"Proto Fleet (fleet.example.com)",
+		"🟡 1 device hashing below 75% of expected for at least ten minutes",
+		"🟡 1 device with sensor temperatures above 90°C for at least ten minutes",
+		"✅ All devices reachable",
+	}, "\n"), msg["text"])
 
 	blocks, ok := msg["blocks"].([]map[string]any)
 	require.True(t, ok)
 	require.NotEmpty(t, blocks)
-	// The instance name is itself the link, so the message carries no separate "open the app" line.
+	// The neutral instance header is itself the link; severity appears only on each alert line.
 	assert.Equal(t,
-		"*🟡 Proto Fleet (<https://fleet.example.com|fleet.example.com>) — 2 alerts firing on 2 miners*",
+		"*Proto Fleet (<https://fleet.example.com|fleet.example.com>)*",
 		sectionText(t, blocks[0]))
 
 	body := mustJSON(t, msg)
-	// Firing alerts need no heading — the title counts them — and resolved rows carry their status in the name.
-	assert.NotContains(t, body, "*Firing*")
-	assert.NotContains(t, body, "*Resolved*")
-	assert.Contains(t, body, "*Device Temperature High* _(warning)_ — miner-02 (`11:22:33:44:55:66`)")
-	assert.Contains(t, body, "Max sensor temperature is above 90C.")
-	resolvedText := sectionText(t, blocks[len(blocks)-1])
-	assert.Equal(t, "*Resolved: Device Offline* — miner-01 (`aa:bb:cc:dd:ee:ff`)", resolvedText)
-	assert.NotContains(t, resolvedText, "warning")
-	assert.NotContains(t, resolvedText, "Device is offline for at least five minutes.")
+	assert.NotContains(t, body, "firing")
+	assert.NotContains(t, body, "_(warning)_")
+	assert.NotContains(t, body, "miner-01")
+	assert.NotContains(t, body, "miner-02")
+	assert.NotContains(t, body, "dev-a")
+	assert.NotContains(t, body, "dev-b")
+}
+
+func TestRenderSlackUsesNaturalDeviceCopyWithThresholdContext(t *testing.T) {
+	tests := []struct {
+		name     string
+		template RuleTemplate
+		summary  string
+		count    int
+		want     string
+	}{
+		{
+			name:     "offline",
+			template: RuleTemplateOffline,
+			summary:  "Device is offline for at least five minutes.",
+			count:    12,
+			want:     "🔴 12 devices unreachable for at least five minutes",
+		},
+		{
+			name:     "hashrate percent",
+			template: RuleTemplateHashrate,
+			summary:  "Device hashrate is below 75% of expected for at least ten minutes.",
+			count:    84,
+			want:     "🟡 84 devices hashing below 75% of expected for at least ten minutes",
+		},
+		{
+			name:     "temperature",
+			template: RuleTemplateTemperature,
+			summary:  "Max sensor temperature for device is above 90°C for at least ten minutes.",
+			count:    8,
+			want:     "🟡 8 devices with sensor temperatures above 90°C for at least ten minutes",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			severity := "warning"
+			if tc.template == RuleTemplateOffline {
+				severity = "critical"
+			}
+			assert.Equal(t, tc.want, groupLine(alertGroup{
+				Severity: severity, Template: string(tc.template), DeviceCount: tc.count,
+				Summaries: []string{tc.summary}, SummaryCount: 1,
+			}, false))
+		})
+	}
+}
+
+func TestRenderSlackUsesAlertSpecificResolvedCopyInMixedBatch(t *testing.T) {
+	firing := Alert{
+		Status: "firing",
+		Labels: map[string]string{
+			"alertname": "Device Hashrate Low", "severity": "warning", "device_id": "dev-a", "template": "hashrate",
+		},
+		Annotations: map[string]string{"summary": "Device hashrate is below 75% of expected for at least ten minutes."},
+	}
+	resolved := Alert{
+		Status: "resolved",
+		Labels: map[string]string{
+			"alertname": "Device Offline", "severity": "warning", "device_id": "dev-b", "template": "offline",
+		},
+	}
+
+	assert.Equal(t, strings.Join([]string{
+		"Proto Fleet (fleet.example.com)",
+		"🟡 1 device hashing below 75% of expected for at least ten minutes",
+		"✅ All devices reachable",
+	}, "\n"), renderSlack("https://fleet.example.com", []Alert{firing, resolved}, nil)["text"])
 }
 
 func TestRenderSlackOmitsLinkWhenNoPublicURL(t *testing.T) {
 	msg := renderSlack("", sampleAlerts(), nil)
 	blocks, ok := msg["blocks"].([]map[string]any)
 	require.True(t, ok)
-	// With nothing to link to, the title is the plain product name rather than an empty link.
-	assert.Equal(t, "*🟡 Proto Fleet — 2 alerts firing on 2 miners*", sectionText(t, blocks[0]))
+	// With nothing to link to, the header is the plain product name rather than an empty link.
+	assert.Equal(t, "*Proto Fleet*", sectionText(t, blocks[0]))
 }
 
-func TestRenderSlackDotMatchesTheWorstFiringSeverity(t *testing.T) {
+func TestRenderSlackDotMatchesEachAlertSeverity(t *testing.T) {
 	alert := func(name, severity string) Alert {
 		return Alert{Status: "firing", Labels: map[string]string{"alertname": name, "severity": severity}}
 	}
@@ -96,7 +165,7 @@ func TestRenderSlackDotMatchesTheWorstFiringSeverity(t *testing.T) {
 	}{
 		{"info alone is blue", []Alert{alert("A", "info")}, "🔵"},
 		{"warning alone is yellow", []Alert{alert("A", "warning")}, "🟡"},
-		{"one critical reddens a batch of warnings", []Alert{alert("A", "warning"), alert("B", "critical")}, "🔴"},
+		{"critical alone is red", []Alert{alert("A", "critical")}, "🔴"},
 		{"case and padding are still the same severity", []Alert{alert("A", " Warning ")}, "🟡"},
 		// A rule can carry any severity label; a colour is a weak reason to signal one as less than it is.
 		{"an unrecognized severity is not downgraded", []Alert{alert("A", "page-me"), alert("B", "info")}, "🔴"},
@@ -105,37 +174,25 @@ func TestRenderSlackDotMatchesTheWorstFiringSeverity(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			title, ok := renderSlack("", tc.alerts, nil)["text"].(string)
+			blocks, ok := renderSlack("", tc.alerts, nil)["blocks"].([]map[string]any)
 			require.True(t, ok)
-			assert.True(t, strings.HasPrefix(title, tc.want), "want %s dot, got %q", tc.want, title)
+			require.GreaterOrEqual(t, len(blocks), 2)
+			assert.True(t, strings.HasPrefix(sectionText(t, blocks[1]), tc.want),
+				"want %s dot, got %q", tc.want, sectionText(t, blocks[1]))
 		})
 	}
 }
 
-func TestRenderSlackFallsBackToDeviceID(t *testing.T) {
-	body := renderSlackJSON(t, "", sampleAlerts(), nil)
-	assert.Contains(t, body, "— dev-b", "with no identity, the raw device id is shown")
-}
-
-func TestRenderSlackRendersMACsAsCode(t *testing.T) {
-	ids := map[string]DeviceIdentity{
-		// ":ab:" is a Slack shortcode (🆎) and "ab" is a valid octet, so a bare MAC interpolates mid-address.
-		"dev-a": {Name: "miner-01", MAC: "12:ab:34:cd:56:ef"},
-		// A backtick in any field of the section would close a MAC's span early, name and address alike.
-		"dev-b": {Name: "miner`02", MAC: "aa:`:bb"},
-	}
-	text := allSectionText(t, renderSlack("", sampleAlerts(), ids))
-
-	assert.Contains(t, text, "miner-01 (`12:ab:34:cd:56:ef`)")
-	assert.Contains(t, text, "miner02 (`aa::bb`)")
-}
-
-func TestRenderSlackAllResolvedTitle(t *testing.T) {
+func TestRenderSlackAllResolvedCollapsesToOneLine(t *testing.T) {
 	resolvedOnly := []Alert{{Status: "resolved", Labels: map[string]string{"alertname": "Device Offline"}}}
-	assert.Equal(t, "✅ Proto Fleet — alerts resolved", renderSlack("", resolvedOnly, nil)["text"])
+	assert.Equal(t, "Proto Fleet\n✅ All alerts resolved", renderSlack("", resolvedOnly, nil)["text"])
 	// A quiet channel shared by several fleets still has to say whose alerts cleared.
 	msg := renderSlack("https://fleet.example.com", resolvedOnly, nil)
-	assert.Equal(t, "✅ Proto Fleet (fleet.example.com) — alerts resolved", msg["text"])
+	assert.Equal(t, "Proto Fleet (fleet.example.com)\n✅ All alerts resolved", msg["text"])
+	blocks, ok := msg["blocks"].([]map[string]any)
+	require.True(t, ok)
+	require.Len(t, blocks, 2)
+	assert.Equal(t, "✅ All alerts resolved", sectionText(t, blocks[1]))
 }
 
 func TestRenderSlackNamesTheInstanceInTheTitle(t *testing.T) {
@@ -147,23 +204,25 @@ func TestRenderSlackNamesTheInstanceInTheTitle(t *testing.T) {
 		{
 			name:      "host only, so the scheme and path stay out of the title",
 			publicURL: "https://fleet.rockdale.example.com/miners?tab=all",
-			want:      "🟡 Proto Fleet (fleet.rockdale.example.com) — 2 alerts firing on 2 miners",
+			want:      "Proto Fleet (fleet.rockdale.example.com)",
 		},
 		{
 			name:      "port kept, since two local instances differ only by it",
 			publicURL: "http://localhost:8080",
-			want:      "🟡 Proto Fleet (localhost:8080) — 2 alerts firing on 2 miners",
+			want:      "Proto Fleet (localhost:8080)",
 		},
 		{
 			name:      "no host to name, so the title is left as it was",
 			publicURL: "fleet.navarro.example.com",
-			want:      "🟡 Proto Fleet — 2 alerts firing on 2 miners",
+			want:      "Proto Fleet",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, renderSlack(tc.publicURL, sampleAlerts(), nil)["text"])
+			text, ok := renderSlack(tc.publicURL, sampleAlerts(), nil)["text"].(string)
+			require.True(t, ok)
+			assert.Equal(t, tc.want, strings.Split(text, "\n")[0])
 		})
 	}
 }
@@ -171,8 +230,10 @@ func TestRenderSlackNamesTheInstanceInTheTitle(t *testing.T) {
 func TestRenderSlackTruncatesALongInstanceName(t *testing.T) {
 	msg := renderSlack("https://"+strings.Repeat("a", 200)+".example.com", sampleAlerts(), nil)
 
-	want := "🟡 Proto Fleet (" + strings.Repeat("a", slackInstanceMaxRunes) + ") — 2 alerts firing on 2 miners"
-	assert.Equal(t, want, msg["text"], "the counts survive a hostname that would fill the title")
+	want := "Proto Fleet (" + strings.Repeat("a", slackInstanceMaxRunes) + ")"
+	text, ok := msg["text"].(string)
+	require.True(t, ok)
+	assert.Equal(t, want, strings.Split(text, "\n")[0])
 }
 
 func TestRenderWebhookResolvesDeviceMetadata(t *testing.T) {
@@ -208,7 +269,7 @@ func outageAlerts(count int) []Alert {
 			Status: "firing",
 			Labels: map[string]string{
 				"alertname": "Device Offline", "severity": "critical",
-				"device_id": fmt.Sprintf("dev-%02d", i), "rule_group": "proto-fleet-defaults",
+				"device_id": fmt.Sprintf("dev-%02d", i), "rule_group": "proto-fleet-defaults", "template": "offline",
 			},
 			Annotations: map[string]string{"summary": "Device is offline for at least five minutes."},
 		})
@@ -219,7 +280,7 @@ func outageAlerts(count int) []Alert {
 func TestRenderSlackRollsUpOneAlertAcrossManyMiners(t *testing.T) {
 	msg := renderSlack("https://fleet.example.com", outageAlerts(500), nil)
 
-	assert.Equal(t, "🔴 Proto Fleet (fleet.example.com) — 1 alert firing on 500 miners", msg["text"])
+	assert.Equal(t, "Proto Fleet (fleet.example.com)\n🔴 500 devices unreachable for at least five minutes", msg["text"])
 
 	blocks, ok := msg["blocks"].([]map[string]any)
 	require.True(t, ok)
@@ -227,10 +288,9 @@ func TestRenderSlackRollsUpOneAlertAcrossManyMiners(t *testing.T) {
 	assert.Len(t, blocks, 2)
 
 	text := allSectionText(t, msg)
-	assert.Contains(t, text, "*Device Offline* _(critical)_ — 500 miners")
-	assert.Contains(t, text, "dev-00, dev-01, dev-02 and 497 more")
-	// The rule's threshold text is the only thing that says what "offline" means; the rollup must keep it.
-	assert.Contains(t, text, "Device is offline for at least five minutes.")
+	assert.Contains(t, text, "🔴 500 devices unreachable for at least five minutes")
+	assert.NotContains(t, text, "dev-00")
+	assert.NotContains(t, text, "critical")
 }
 
 func TestRenderSlackCountsInstancesForDevicelessAlerts(t *testing.T) {
@@ -242,13 +302,13 @@ func TestRenderSlackCountsInstancesForDevicelessAlerts(t *testing.T) {
 		}
 	}
 	text := allSectionText(t, renderSlack("", []Alert{source("maestro-a"), source("maestro-b")}, nil))
-	assert.Contains(t, text, "*Curtailment Source Unreachable* _(critical)_ — 2 instances")
-	// The rule interpolates the source into summary, so naming only one would leave the other unreported.
-	assert.Contains(t, text, "Curtailment source maestro-a is unreachable; cannot curtail.")
-	assert.Contains(t, text, "Curtailment source maestro-b is unreachable; cannot curtail.")
+	// The rule interpolates the source into summary, so each affected source remains a separate alert line.
+	assert.Contains(t, text, "🔴 Curtailment source maestro-a is unreachable; cannot curtail")
+	assert.Contains(t, text, "🔴 Curtailment source maestro-b is unreachable; cannot curtail")
+	assert.NotContains(t, text, "_(critical)_")
 }
 
-func TestRenderSlackResolvedDevicelessAlertsKeepIdentifyingSummaries(t *testing.T) {
+func TestRenderSlackResolvedDevicelessAlertsCollapseWhenNothingIsActive(t *testing.T) {
 	source := func(kind string) Alert {
 		return Alert{
 			Status:      "resolved",
@@ -258,10 +318,8 @@ func TestRenderSlackResolvedDevicelessAlertsKeepIdentifyingSummaries(t *testing.
 	}
 	text := allSectionText(t, renderSlack("", []Alert{source("maestro-a"), source("maestro-b")}, nil))
 
-	assert.Contains(t, text, "*Resolved: Curtailment Source Unreachable* — 2 instances")
-	assert.NotContains(t, text, "_(critical)_", "resolved alerts omit severity")
-	assert.Contains(t, text, "Curtailment source maestro-a is unreachable; cannot curtail.")
-	assert.Contains(t, text, "Curtailment source maestro-b is unreachable; cannot curtail.")
+	assert.Contains(t, text, "✅ All alerts resolved")
+	assert.NotContains(t, text, "unreachable")
 }
 
 func TestRenderSlackTailsSummariesPastTheSampleCap(t *testing.T) {
@@ -275,7 +333,7 @@ func TestRenderSlackTailsSummariesPastTheSampleCap(t *testing.T) {
 	alerts := []Alert{source("a"), source("b"), source("c"), source("d"), source("e")}
 	text := allSectionText(t, renderSlack("", alerts, nil))
 	// Past the cap the section says how many it left out rather than growing without bound.
-	assert.Contains(t, text, "Curtailment source c is unreachable; cannot curtail.")
+	assert.Contains(t, text, "Curtailment source c is unreachable; cannot curtail")
 	assert.NotContains(t, text, "Curtailment source d is unreachable")
 	assert.Contains(t, text, "…and 2 more")
 }
@@ -283,20 +341,20 @@ func TestRenderSlackTailsSummariesPastTheSampleCap(t *testing.T) {
 // Every instance of a rule that renders summary from the rule carries the same text, so it stays one line.
 func TestRenderSlackKeepsOneSummaryForARuleTextGroup(t *testing.T) {
 	text := allSectionText(t, renderSlack("", outageAlerts(3), nil))
-	assert.Equal(t, 1, strings.Count(text, "Device is offline for at least five minutes."))
+	assert.Equal(t, 1, strings.Count(text, "3 devices unreachable for at least five minutes"))
 	assert.NotContains(t, text, "…and")
 }
 
-func TestRenderSlackCountsEachMinerOnceAcrossAlerts(t *testing.T) {
-	both := func(name string) Alert {
+func TestRenderSlackCountsEachDeviceOnceWithinAnAlert(t *testing.T) {
+	alert := func() Alert {
 		return Alert{
 			Status: "firing",
-			Labels: map[string]string{"alertname": name, "severity": "warning", "device_id": "dev-a"},
+			Labels: map[string]string{"alertname": "Device Offline", "severity": "warning", "device_id": "dev-a"},
 		}
 	}
-	msg := renderSlack("", []Alert{both("Device Offline"), both("Device Hashrate Low")}, nil)
-	// One miner with two alerts is one affected miner, not two.
-	assert.Equal(t, "🟡 Proto Fleet — 2 alerts firing on 1 miner", msg["text"])
+	msg := renderSlack("", []Alert{alert(), alert()}, nil)
+	assert.Contains(t, msg["text"], "🟡 Device Offline affecting 1 device")
+	assert.NotContains(t, msg["text"], "2 devices")
 }
 
 func TestRenderSlackOrdersGroupsByBlastRadius(t *testing.T) {
@@ -305,7 +363,7 @@ func TestRenderSlackOrdersGroupsByBlastRadius(t *testing.T) {
 		Labels: map[string]string{"alertname": "Device Temperature High", "severity": "warning", "device_id": "dev-x"},
 	})
 	text := allSectionText(t, renderSlack("", alerts, nil))
-	assert.Less(t, strings.Index(text, "Device Offline"), strings.Index(text, "Device Temperature High"))
+	assert.Less(t, strings.Index(text, "5 devices unreachable"), strings.Index(text, "Device Temperature High"))
 }
 
 func TestRenderSlackKeepsSummaryForFleetWideAlert(t *testing.T) {
@@ -316,8 +374,8 @@ func TestRenderSlackKeepsSummaryForFleetWideAlert(t *testing.T) {
 		Annotations: map[string]string{"summary": "No telemetry received in 5 minutes."},
 	}}
 	msg := renderSlack("", alerts, nil)
-	assert.Equal(t, "🔴 Proto Fleet — 1 alert firing", msg["text"], "no miners to count")
-	assert.Contains(t, allSectionText(t, msg), "No telemetry received in 5 minutes.")
+	assert.Equal(t, "Proto Fleet\n🔴 No telemetry received in 5 minutes", msg["text"])
+	assert.Contains(t, allSectionText(t, msg), "No telemetry received in 5 minutes")
 }
 
 func TestRenderWebhookIncludesGroupRollup(t *testing.T) {
@@ -344,18 +402,21 @@ func TestRenderWebhookIncludesGroupRollup(t *testing.T) {
 }
 
 func TestRenderSlackEscapesUserControlledText(t *testing.T) {
-	ids := map[string]DeviceIdentity{"dev-a": {Name: "<https://evil.example|click>", MAC: "m"}}
-	alerts := []Alert{{
-		Status:      "firing",
-		Labels:      map[string]string{"alertname": "A & B", "severity": "warning", "device_id": "dev-a"},
-		Annotations: map[string]string{"summary": "x < y > z"},
-	}}
-	text := allSectionText(t, renderSlack("", alerts, ids))
-	// The reserved chars are escaped, so a device name can't inject a mrkdwn link.
-	assert.Contains(t, text, "&lt;https://evil.example|click&gt;")
+	alerts := []Alert{
+		{
+			Status: "firing",
+			Labels: map[string]string{"alertname": "A & B", "severity": "warning", "device_id": "dev-a"},
+		},
+		{
+			Status:      "firing",
+			Labels:      map[string]string{"alertname": "Summary", "severity": "warning"},
+			Annotations: map[string]string{"summary": "x < y > z"},
+		},
+	}
+	text := allSectionText(t, renderSlack("", alerts, nil))
+	// Reserved chars are escaped so alert names and summaries can't inject mrkdwn links.
 	assert.Contains(t, text, "A &amp; B")
 	assert.Contains(t, text, "x &lt; y &gt; z")
-	assert.NotContains(t, text, "<https://evil.example|click>")
 }
 
 func TestRenderSlackCapsBlocksForLargeBatch(t *testing.T) {

--- a/server/internal/domain/alerts/render_test.go
+++ b/server/internal/domain/alerts/render_test.go
@@ -179,24 +179,24 @@ func TestRenderSlackUsesThresholdNeutralHashrateRecoveryCopy(t *testing.T) {
 }
 
 func TestRenderSlackRecoveryStaysScopedAcrossRules(t *testing.T) {
-	alert := func(status, ruleUID, deviceID string) Alert {
+	alert := func(status, ruleUID, name, deviceID string) Alert {
 		return Alert{
 			Status: status, RuleUID: ruleUID,
 			Labels: map[string]string{
-				"alertname": "Device Offline", "severity": "critical", "device_id": deviceID,
+				"alertname": name, "severity": "critical", "device_id": deviceID,
 				"rule_group": "proto-fleet-user-7", "template": "offline",
 			},
 			Annotations: map[string]string{"summary": "Device is offline for at least five minutes."},
 		}
 	}
 	alerts := []Alert{
-		alert("firing", "offline-site-a", "dev-a"),
-		alert("resolved", "offline-site-b", "dev-b"),
+		alert("firing", "offline-site-a", "Site A offline", "dev-a"),
+		alert("resolved", "offline-site-b", "Site B offline", "dev-b"),
 	}
 
 	text := allSectionText(t, renderSlack("", alerts, nil))
-	assert.Contains(t, text, "🔴 1 device unreachable for at least five minutes")
-	assert.Contains(t, text, "✅ 1 device reachable again")
+	assert.Contains(t, text, "🔴 Site A offline: 1 device unreachable for at least five minutes")
+	assert.Contains(t, text, "✅ Site B offline: 1 device reachable again")
 	assert.NotContains(t, text, "All devices reachable")
 }
 
@@ -225,8 +225,8 @@ func TestRenderSlackKeepsSameNamedUserRulesSeparateByRuleUID(t *testing.T) {
 	require.True(t, ok)
 	assert.Len(t, blocks, 3, "the shared name and rule group must not merge distinct rule UIDs")
 	text := allSectionText(t, msg)
-	assert.Contains(t, text, "1 device unreachable for at least five minutes")
-	assert.Contains(t, text, "1 device with sensor temperatures above 95°C for at least ten minutes")
+	assert.Contains(t, text, "Watch miners: 1 device unreachable for at least five minutes")
+	assert.Contains(t, text, "Watch miners: 1 device with sensor temperatures above 95°C for at least ten minutes")
 }
 
 func TestRenderSlackOmitsLinkWhenNoPublicURL(t *testing.T) {

--- a/server/internal/domain/alerts/render_test.go
+++ b/server/internal/domain/alerts/render_test.go
@@ -59,7 +59,7 @@ func TestRenderSlackLinksTheInstanceHeaderAndUsesPerAlertCopy(t *testing.T) {
 		"Proto Fleet (fleet.example.com)",
 		"🟡 1 device hashing below 75% of expected for at least ten minutes",
 		"🟡 1 device with sensor temperatures above 90°C for at least ten minutes",
-		"✅ All devices reachable",
+		"✅ 1 device reachable again",
 	}, "\n"), msg["text"])
 
 	blocks, ok := msg["blocks"].([]map[string]any)
@@ -142,7 +142,7 @@ func TestRenderSlackUsesAlertSpecificResolvedCopyInMixedBatch(t *testing.T) {
 	assert.Equal(t, strings.Join([]string{
 		"Proto Fleet (fleet.example.com)",
 		"🟡 1 device hashing below 75% of expected for at least ten minutes",
-		"✅ All devices reachable",
+		"✅ 1 device reachable again",
 	}, "\n"), renderSlack("https://fleet.example.com", []Alert{firing, resolved}, nil)["text"])
 }
 
@@ -173,12 +173,31 @@ func TestRenderSlackCountsPartialRecoveryWhileSameRuleStillFires(t *testing.T) {
 }
 
 func TestRenderSlackUsesThresholdNeutralHashrateRecoveryCopy(t *testing.T) {
-	assert.Equal(t, "✅ All devices hashing above alert threshold", groupLine(alertGroup{
+	assert.Equal(t, "✅ 3 devices hashing above alert threshold again", groupLine(alertGroup{
 		Template: string(RuleTemplateHashrate), DeviceCount: 3,
 	}, true))
-	assert.Equal(t, "✅ 3 devices hashing above alert threshold again", groupLineWithActiveState(alertGroup{
-		Template: string(RuleTemplateHashrate), DeviceCount: 3,
-	}, true, true))
+}
+
+func TestRenderSlackRecoveryStaysScopedAcrossRules(t *testing.T) {
+	alert := func(status, ruleUID, deviceID string) Alert {
+		return Alert{
+			Status: status, RuleUID: ruleUID,
+			Labels: map[string]string{
+				"alertname": "Device Offline", "severity": "critical", "device_id": deviceID,
+				"rule_group": "proto-fleet-user-7", "template": "offline",
+			},
+			Annotations: map[string]string{"summary": "Device is offline for at least five minutes."},
+		}
+	}
+	alerts := []Alert{
+		alert("firing", "offline-site-a", "dev-a"),
+		alert("resolved", "offline-site-b", "dev-b"),
+	}
+
+	text := allSectionText(t, renderSlack("", alerts, nil))
+	assert.Contains(t, text, "🔴 1 device unreachable for at least five minutes")
+	assert.Contains(t, text, "✅ 1 device reachable again")
+	assert.NotContains(t, text, "All devices reachable")
 }
 
 func TestRenderSlackKeepsSameNamedUserRulesSeparateByRuleUID(t *testing.T) {
@@ -247,16 +266,20 @@ func TestRenderSlackDotMatchesEachAlertSeverity(t *testing.T) {
 	}
 }
 
-func TestRenderSlackAllResolvedCollapsesToOneLine(t *testing.T) {
-	resolvedOnly := []Alert{{Status: "resolved", Labels: map[string]string{"alertname": "Device Offline"}}}
-	assert.Equal(t, "Proto Fleet\n✅ All alerts resolved", renderSlack("", resolvedOnly, nil)["text"])
-	// A quiet channel shared by several fleets still has to say whose alerts cleared.
+func TestRenderSlackResolutionOnlyBatchKeepsConditionSpecificCopy(t *testing.T) {
+	resolvedOnly := []Alert{{
+		Status: "resolved", RuleUID: "protofleet-ha-readiness",
+		Labels: map[string]string{
+			"alertname": "HA Failover Readiness Degraded", "template": "ha-readiness",
+		},
+	}}
 	msg := renderSlack("https://fleet.example.com", resolvedOnly, nil)
-	assert.Equal(t, "Proto Fleet (fleet.example.com)\n✅ All alerts resolved", msg["text"])
+	assert.Equal(t, "Proto Fleet (fleet.example.com)\n✅ HA ready to fail over", msg["text"])
 	blocks, ok := msg["blocks"].([]map[string]any)
 	require.True(t, ok)
 	require.Len(t, blocks, 2)
-	assert.Equal(t, "✅ All alerts resolved", sectionText(t, blocks[1]))
+	assert.Equal(t, "✅ HA ready to fail over", sectionText(t, blocks[1]))
+	assert.NotContains(t, allSectionText(t, msg), "All alerts resolved")
 }
 
 func TestRenderSlackNamesTheInstanceInTheTitle(t *testing.T) {
@@ -372,18 +395,31 @@ func TestRenderSlackCountsInstancesForDevicelessAlerts(t *testing.T) {
 	assert.NotContains(t, text, "_(critical)_")
 }
 
-func TestRenderSlackResolvedDevicelessAlertsCollapseWhenNothingIsActive(t *testing.T) {
+func TestRenderSlackResolvedCurtailmentSourceNamesRecoveredCondition(t *testing.T) {
 	source := func(kind string) Alert {
 		return Alert{
-			Status:      "resolved",
-			Labels:      map[string]string{"alertname": "Curtailment Source Unreachable", "severity": "critical"},
+			Status: "resolved", RuleUID: "protofleet-mqtt-source-disconnected",
+			Labels: map[string]string{
+				"alertname": "Curtailment Source Unreachable", "severity": "critical", "template": "mqtt-disconnected",
+			},
 			Annotations: map[string]string{"summary": "Curtailment source " + kind + " is unreachable; cannot curtail."},
 		}
 	}
-	text := allSectionText(t, renderSlack("", []Alert{source("maestro-a"), source("maestro-b")}, nil))
+	text := allSectionText(t, renderSlack("", []Alert{source("maestro-a")}, nil))
 
-	assert.Contains(t, text, "✅ All alerts resolved")
+	assert.Contains(t, text, "✅ Curtailment source maestro-a reachable again")
+	assert.NotContains(t, text, "All alerts resolved")
 	assert.NotContains(t, text, "unreachable")
+}
+
+func TestRenderSlackUsesConditionSpecificCurtailmentRecoveryCopy(t *testing.T) {
+	assert.Equal(t, "✅ Curtailment by maestro-a ended", groupLine(alertGroup{
+		Name: "Curtailment Active", Template: string(RuleTemplateMQTTCurtailment), InstanceCount: 1,
+		Summaries: []string{"Miners are curtailed by maestro-a"}, SummaryCount: 1,
+	}, true))
+	assert.Equal(t, "✅ Fan control restored for 2 curtailment events", groupLine(alertGroup{
+		Name: "Curtailment Fan Restore Failed", Template: string(RuleTemplateCurtailmentFanRestore), InstanceCount: 2,
+	}, true))
 }
 
 func TestRenderSlackTailsSummariesPastTheSampleCap(t *testing.T) {

--- a/server/internal/domain/alerts/render_test.go
+++ b/server/internal/domain/alerts/render_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -395,7 +396,23 @@ func TestRenderSlackCountsInstancesForDevicelessAlerts(t *testing.T) {
 	assert.NotContains(t, text, "_(critical)_")
 }
 
-func TestRenderSlackResolvedCurtailmentSourceNamesRecoveredCondition(t *testing.T) {
+func TestRenderSlackCountsRepeatedDevicelessSummaries(t *testing.T) {
+	alert := func(eventID string) Alert {
+		return Alert{
+			Status: "firing", RuleUID: "protofleet-curtailment-fan-restore-fail",
+			Labels: map[string]string{
+				"alertname": "Curtailment Fan Restore Failed", "severity": "critical",
+				"template": "curtailment-fan-restore", "kind": eventID,
+			},
+			Annotations: map[string]string{"summary": "Facility fan restore failed before miners resumed."},
+		}
+	}
+	text := allSectionText(t, renderSlack("", []Alert{alert("event-a"), alert("event-b")}, nil))
+
+	assert.Contains(t, text, "🔴 Facility fan restore failed before miners resumed (2 curtailment events affected)")
+}
+
+func TestRenderSlackResolvedCurtailmentSourcesNameEveryRecoveredCondition(t *testing.T) {
 	source := func(kind string) Alert {
 		return Alert{
 			Status: "resolved", RuleUID: "protofleet-mqtt-source-disconnected",
@@ -405,9 +422,16 @@ func TestRenderSlackResolvedCurtailmentSourceNamesRecoveredCondition(t *testing.
 			Annotations: map[string]string{"summary": "Curtailment source " + kind + " is unreachable; cannot curtail."},
 		}
 	}
-	text := allSectionText(t, renderSlack("", []Alert{source("maestro-a")}, nil))
+	text := allSectionText(t, renderSlack("", []Alert{
+		source("maestro-a"), source("maestro-b"), source("maestro-c"), source("maestro-d"), source("maestro-e"),
+	}, nil))
 
 	assert.Contains(t, text, "✅ Curtailment source maestro-a reachable again")
+	assert.Contains(t, text, "✅ Curtailment source maestro-b reachable again")
+	assert.Contains(t, text, "✅ Curtailment source maestro-c reachable again")
+	assert.Contains(t, text, "✅ …and 2 more curtailment sources reachable again")
+	assert.NotContains(t, text, "maestro-d")
+	assert.NotContains(t, text, "maestro-e")
 	assert.NotContains(t, text, "All alerts resolved")
 	assert.NotContains(t, text, "unreachable")
 }
@@ -561,6 +585,24 @@ func TestRenderSlackCapsBlocksForLargeBatch(t *testing.T) {
 	require.True(t, ok)
 	assert.LessOrEqual(t, len(blocks), 50, "must stay under Slack's 50-block-per-message limit")
 	assert.Contains(t, mustJSON(t, msg), "more — open Proto Fleet")
+}
+
+func TestRenderSlackCapsFallbackTextIndependently(t *testing.T) {
+	alerts := []Alert{{
+		Status:      "firing",
+		Labels:      map[string]string{"alertname": "Long summary", "severity": "warning"},
+		Annotations: map[string]string{"summary": strings.Repeat("温", slackFallbackMaxRunes+100)},
+	}}
+	msg := renderSlack("", alerts, nil)
+
+	fallback, ok := msg["text"].(string)
+	require.True(t, ok)
+	assert.Equal(t, slackFallbackMaxRunes, utf8.RuneCountInString(fallback))
+
+	blocks, ok := msg["blocks"].([]map[string]any)
+	require.True(t, ok)
+	require.Len(t, blocks, 2)
+	assert.Equal(t, slackSectionMaxRunes, utf8.RuneCountInString(sectionText(t, blocks[1])))
 }
 
 func allSectionText(t *testing.T, msg map[string]any) string {

--- a/server/internal/domain/alerts/user_rules.go
+++ b/server/internal/domain/alerts/user_rules.go
@@ -936,8 +936,8 @@ GROUP BY organization_id, device_id
 HAVING max(latest_temp) > %s`,
 			metricDeviceTemperatureMaxCelsius, org, scopeFilterSQL(org, cfg.Scope, "      "), userRuleEvalWindowMinute,
 			scopeSiteColumnSQL(org, "latest_per_kind.device_id", cfg.Scope, "    "), limit)
-		summary = fmt.Sprintf("Max sensor temperature for device is above %sC for at least %s.", limit, dur)
-		description = fmt.Sprintf("Maximum sensor temperature for device {{ $labels.device_id }}\nhas been above %sC for at least %s.", limit, dur)
+		summary = fmt.Sprintf("Max sensor temperature for device is above %s°C for at least %s.", limit, dur)
+		description = fmt.Sprintf("Maximum sensor temperature for device {{ $labels.device_id }}\nhas been above %s°C for at least %s.", limit, dur)
 	}
 	return sql, summary, description
 }

--- a/server/internal/domain/alerts/user_rules_test.go
+++ b/server/internal/domain/alerts/user_rules_test.go
@@ -176,7 +176,7 @@ func TestCompileUserRule(t *testing.T) {
 			},
 			wantMetric:  "fleet_device_temperature_max_celsius",
 			wantSQLFrag: "HAVING max(latest_temp) > 85",
-			wantSummary: "Max sensor temperature for device is above 85C for at least 15 minutes.",
+			wantSummary: "Max sensor temperature for device is above 85°C for at least 15 minutes.",
 		},
 	}
 	for _, tc := range cases {

--- a/server/monitoring/grafana/provisioning/alerting/proto-fleet-rules.yaml
+++ b/server/monitoring/grafana/provisioning/alerting/proto-fleet-rules.yaml
@@ -100,7 +100,7 @@ groups:
           rule_group: proto-fleet-defaults
           template: hashrate
         annotations:
-          summary: "Device hashrate has fallen below expected for at least ten minutes."
+          summary: "Device hashrate is below 75% of expected for at least ten minutes."
           description: |
             Device {{ $labels.device_id }} (org {{ $labels.organization_id }})
             has been hashing below its expected rate for at least ten minutes.
@@ -161,10 +161,10 @@ groups:
           rule_group: proto-fleet-defaults
           template: temperature
         annotations:
-          summary: "Max sensor temperature for device is above 90C for ten minutes."
+          summary: "Max sensor temperature for device is above 90°C for at least ten minutes."
           description: |
             Maximum sensor temperature for device {{ $labels.device_id }}
-            has been above 90C for at least ten minutes.
+            has been above 90°C for at least ten minutes.
 
       - uid: protofleet-telemetry-poll-failure-rate
         title: Telemetry Poll Failure Rate High


### PR DESCRIPTION
Reviewable diff: +185/-122 across 3 files (excludes generated, test, and story files).

## Summary

Proto Fleet Slack notifications now lead with a neutral, linked instance header and put severity on each alert line. Alert copy uses device counts, natural-language conditions, threshold context, and custom rule names without exposing individual device identifiers. Recovery copy is always condition-specific and count-aware, and same-named user rules remain separate.

## How it works

Fleet receives Alertmanager notification groups and routes each organization to its configured channels. Each renderer rollup is keyed by the producing rule UID (with a stable legacy fallback), so duplicate user-selected names cannot merge different conditions. The Slack renderer links the configured Proto Fleet hostname or IP in a neutral header, rolls device-backed instances into counts, and converts known rule templates into concise active or resolved sentences. Custom device rules prefix those sentences with their configured name so operators retain the rule's scope; provisioned rules keep the shorter condition-only form. Every resolved group keeps its own recovery line because one notification group cannot prove fleet-wide alert or device health; generic webhook payload structure is unchanged.

## Affected message copy

`<instance>` is the configured Proto Fleet hostname or IP, linked to the fleet UI in the Block Kit header. `<emoji>` is derived from each alert's severity: 🔴 critical, 🟡 warning, 🔵 info, and ✅ resolved.

| Message / condition | Previous Slack copy | New Slack copy |
| --- | --- | --- |
| Instance header | `<worst emoji> Proto Fleet (<instance>) — N alerts firing on M miners` | `Proto Fleet (<instance>)` |
| Device offline | `Device Offline (severity) — N miners` plus sample miner names and the rule summary | `<emoji> N devices unreachable for at least <duration>` |
| Device hashrate low | `Device Hashrate Low (severity) — N miners` plus sample miner names and the rule summary | `<emoji> N devices hashing below <threshold> for at least <duration>` |
| Device temperature high | `Device Temperature High (severity) — N miners` plus sample miner names and the rule summary | `<emoji> N devices with sensor temperatures above <threshold> for at least <duration>` |
| Other device-backed rule | `<alert name> (severity) — N miners` plus sample miner names and summary | `<emoji> <natural-language summary> (N devices affected)`; if no summary exists, `<emoji> <alert name> affecting N devices` |
| Device-less rule with one condition | `<alert name> (severity)` followed by its summary | `<emoji> <natural-language summary>` |
| Device-less rule with multiple conditions | One alert heading followed by up to three summaries | One `<emoji> <natural-language summary>` line per condition, with the existing overflow count retained |
| Same-named user rules in one organization | Could merge device counts and display whichever template or threshold arrived first | Each RuleUID renders as its own condition line with its own count, severity, template, and threshold |
| Custom device rule firing | Specialized condition copy could omit the configured rule name and scope | `<emoji> <custom rule name>: <condition and count>` |
| Device offline resolved | `Resolved: Device Offline — <sample miner>` | `✅ N devices reachable again` |
| Device hashrate resolved | `Resolved: <hashrate rule name> — <sample miner>` | `✅ N devices hashing above alert threshold again` |
| Device temperature resolved | `Resolved: <temperature rule name> — <sample miner>` | `✅ N devices below temperature threshold again` |
| Custom device rule resolved | Specialized recovery copy could omit the configured rule name and scope | `✅ <custom rule name>: <recovery condition and count>` |
| Other device-backed rule resolved | `Resolved: <alert name> — <sample miner>` | `✅ <alert name> resolved for N devices` |
| Telemetry polling resolved | `Resolved: <telemetry rule name>` | `✅ Telemetry polling recovered` |
| Curtailment ended | `Resolved: Curtailment Active` | `✅ Curtailment by <source> ended` |
| Curtailment source restored | `Resolved: Curtailment Source Unreachable` | `✅ Curtailment source <source> reachable again` |
| Facility fan control restored | `Resolved: Curtailment Fan Restore Failed` | `✅ Fan control restored for N curtailment events` |
| Metric ingest restored | `Resolved: Metric Ingest Stalled` | `✅ Metric ingest resumed` |
| HA readiness restored | `Resolved: HA Failover Readiness Degraded` | `✅ HA ready to fail over` |
| Pool, command, custom, or unknown rule resolved | `Resolved: <alert name>` | `✅ <alert name> resolved`; multiple device-less instances become `✅ <alert name> resolved for N instances` |
| Resolutions delivered while firing alerts are maintenance-muted | Could render a global all-clear because muted firing rows were removed before rendering | Per-condition recovery rows; muted firing copy remains hidden |
| Resolution-only Alertmanager group | `✅ Proto Fleet (<instance>) — alerts resolved` plus individual rows | The neutral instance header followed by each condition-specific recovery line; no fleet-wide all-clear |
| Notification preview / blockless fallback | Generic title only | The same instance header and alert lines shown in Block Kit, without link markup |

Recovery counts describe only the resolved instances in that notification group. The copy is the same whether other instances or rules remain active, so it never claims fleet-wide recovery.

## Diagrams

```mermaid
flowchart TD
    A["Alertmanager notification group"] --> B["Route alerts by organization and channel"]
    B --> C["Group visible instances by rule UID"]
    C --> D["Build linked Proto Fleet instance header"]
    D --> E["Render firing and resolved condition lines"]
    E --> F["Post one batched Slack message per instance"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/internal/domain/alerts/render.go` | Reworked Slack headers, per-alert severity, template-aware active/resolved copy, custom rule-name context, scoped recovery counts, RuleUID grouping, device-detail suppression, and fallback text | Main behavior change; review copy selection, rule isolation, batching, escaping, and Slack limits |
| `server/monitoring/grafana/provisioning/alerting/proto-fleet-rules.yaml` | Added the 75% hashrate threshold and corrected temperature context to `90°C` | Supplies actionable threshold context to provisioned-rule notifications |
| `server/internal/domain/alerts/user_rules.go` | Uses `°C` in generated temperature summaries and descriptions | Keeps custom temperature-rule copy technically precise and consistent |
| Alert delivery and rendering tests | Updated existing expectations and added coverage for each copy path, mixed resolutions, rollups, severity, privacy, escaping, and limits | Confirms the new copy does not regress routing, batching, or safe Slack rendering |

## Key technical decisions & trade-offs

- Put severity on each alert line instead of the instance header so mixed-severity batches remain accurate.
- Use rule templates and rule-provided summaries instead of alert-name fragments alone so thresholds and durations remain visible.
- Show aggregate device counts instead of sample device names, MAC addresses, or IDs so fleet-wide incidents remain compact.
- Key rollups by RuleUID instead of display name and shared rule group so duplicate user-rule names remain independent; legacy alerts fall back to stable rule-level labels.
- Prefix custom device conditions with the configured rule name instead of dropping operator-defined scope; provisioned rules remain concise.
- Use counted, threshold-neutral device recovery copy for every resolved group instead of inferring complete recovery.
- Preserve condition-specific rows for resolution-only batches instead of treating one Alertmanager group as fleet-wide state.
- Keep unknown severities red and unknown templates on a generic natural-language fallback rather than under-signaling or dropping them.
- Leave Slack app name/avatar configuration, location enrichment, resolution debounce, and historical escalation out of scope; those require integration or data-model work beyond copy rendering.

## Testing & validation

- `bin/go -C server test ./internal/domain/alerts`
- `just lint`
- Parsed `server/monitoring/grafana/provisioning/alerting/proto-fleet-rules.yaml` with `yq`
- Verified the Slack renderer still caps block count, escapes untrusted mrkdwn, hides Grafana internals, and omits device identifiers.
- Not covered: a live post to a customer-configured Slack webhook; app avatar and display name are controlled in the external Slack integration.
