### PR TITLE
docs: record Codex benchmark outcome

### DIFF
--- a/docs/codex-security-review-benchmark-report.md
+++ b/docs/codex-security-review-benchmark-report.md
@@ -55,9 +55,13 @@ every per-case finalizer succeeded and produced one uniquely named artifact.
   `MEDIUM`, `MEDIUM`, and `HIGH` across its three trials. All missed the
   existing-deployment compatibility `MEDIUM`.
 - The medium-effort PR #948 review missed the adjudicated topology-preview
-  `MEDIUM` and reported a different `HIGH` about enabled automations retaining
-  non-executable profiles. The new finding does not count as recall of the
-  expected finding.
+  `MEDIUM`. Its different `HIGH` about enabled automations retaining
+  non-executable profiles was adjudicated invalid. At merged commit
+  `e37f97c1c41004667ff9bc467a98cc130736a012`, the
+  [domain service](https://github.com/block/proto-fleet/blob/e37f97c1c41004667ff9bc467a98cc130736a012/server/internal/domain/curtailment/response_profile.go#L135)
+  and [SQL store](https://github.com/block/proto-fleet/blob/e37f97c1c41004667ff9bc467a98cc130736a012/server/internal/domain/stores/sqlstores/curtailment.go#L246)
+  already reject this transition, an advisory transaction lock serializes it
+  against automation changes, and unit and integration tests cover the case.
 - The medium-effort PR #954 review recalled the abandoned-staging-database
   `MEDIUM` and missed the connection-retry/deadline `MEDIUM`.
 - PR #953, which contains one expected `HIGH` and one expected `MEDIUM`, timed
@@ -98,8 +102,9 @@ other candidates ran once across the six-case corpus.
 | `unified-40` | `xhigh` | bounded | 2/6 | 4 | 0/2 | 0/5 | Reject: downgraded an adjudicated `HIGH` |
 
 `medium` materially improved completion, but it recalled only 20% of expected
-`MEDIUM` findings and missed the `HIGH` in timed-out PR #953. Lower effort is
-therefore not safe to roll out despite its runtime improvement.
+`MEDIUM` findings, missed the `HIGH` in timed-out PR #953, and introduced an
+invalid `HIGH` on PR #948. Lower effort is therefore not safe to roll out
+despite its runtime improvement.
 
 ### Completed-run metrics
 
@@ -129,6 +134,7 @@ cancellation cleanup.
 | Retain every adjudicated `HIGH` without downgrade | Failed by compact context and bounded prompt; other candidates timed out on PR #953 |
 | Retain at least 90% of adjudicated `MEDIUM` findings | Failed by every tested configuration; best observed recall was 1/5 at `medium` |
 | No invalid `HIGH` on completed clean controls | Passed; every completed PR #944 and PR #956 control returned `NONE` |
+| New medium-or-higher findings are valid | Failed; medium effort produced an invalid `HIGH` on PR #948 |
 | No increase in median tool calls or compactions | Not decision-bearing because recall failed |
 | At least 20% faster or equivalent with lower token use | `medium` improved completion, but recall failed |
 

--- a/docs/codex-security-review-benchmark-report.md
+++ b/docs/codex-security-review-benchmark-report.md
@@ -8,12 +8,12 @@ Keep the production reviewer on `unified=40`, `xhigh` reasoning effort, and the
 baseline prompt. None of the context, effort, or prompt candidates met the
 finding-recall and completion gates in the
 [bounded-review plan](./plans/2026-08-25-bounded-codex-security-review-plan.md).
-Do not test `medium` effort or the large-PR corpus: `high` already failed the
-adjudicated corpus, and the plan gates large-PR replay on selecting a candidate.
+The experiment included the two planned context repeats and all three effort
+levels.
 
 The bounded execution and fail-closed finalizer remain useful independently of
-model tuning. Across 30 matrix cases, 22 reviews exhausted the outer budget and
-all 30 trusted finalizers uploaded either a completed-result or verified-timeout
+model tuning. Across 72 matrix cases, 50 reviews exhausted the outer budget and
+all 72 trusted finalizers uploaded either a completed-result or verified-timeout
 artifact. No ambiguous cancellation was admitted as benchmark data.
 
 Further runtime work should evaluate architecture-aware sharding rather than
@@ -22,16 +22,24 @@ reducing context, effort, or prompt scope again. See the
 
 ## Method
 
-All runs used the trusted `repository_dispatch` workflow from `main` at
-`c126c0b6bfa0947967caa5a04474503cdff5c200`. The fixed corpus contains two
-adjudicated `HIGH` findings, five adjudicated `MEDIUM` findings, and two clean
-controls across PRs #944, #948, #953, #954, #956, and #961. A timeout counts as
-no recalled finding because it produces no usable review.
+All runs used the trusted `repository_dispatch` workflow from `main`. The first
+three loaded main at `c126c0b6bfa0947967caa5a04474503cdff5c200`; the repeats
+and medium-effort run loaded `413e4e5cd0fbc9ab3885f8ab04779456d74379a3`.
+Both commits contain the same benchmark workflow blob,
+`84baadfa572efbf601ff53444b4b3902cb221564`.
+
+The fixed corpus contains two adjudicated `HIGH` findings, five adjudicated
+`MEDIUM` findings, and two clean controls across PRs #944, #948, #953, #954,
+#956, and #961. Each context variant ran three times. A timeout counts as no
+recalled finding because it produces no usable review.
 
 | Experiment | Run | Cases | Constant dimensions |
 | --- | --- | ---: | --- |
-| Context | [33009198561](https://github.com/block/proto-fleet/actions/runs/33009198561) | 18 | `xhigh`, baseline prompt |
-| Effort | [33046668278](https://github.com/block/proto-fleet/actions/runs/33046668278) | 6 | `unified=40`, baseline prompt |
+| Context, initial | [33009198561](https://github.com/block/proto-fleet/actions/runs/33009198561) | 18 | `xhigh`, baseline prompt |
+| Context, repeat 1 | [33070365755](https://github.com/block/proto-fleet/actions/runs/33070365755) | 18 | `xhigh`, baseline prompt |
+| Context, repeat 2 | [33080598457](https://github.com/block/proto-fleet/actions/runs/33080598457) | 18 | `xhigh`, baseline prompt |
+| Effort, `high` | [33046668278](https://github.com/block/proto-fleet/actions/runs/33046668278) | 6 | `unified=40`, baseline prompt |
+| Effort, `medium` | [33092678963](https://github.com/block/proto-fleet/actions/runs/33092678963) | 6 | `unified=40`, baseline prompt |
 | Prompt | [33065249002](https://github.com/block/proto-fleet/actions/runs/33065249002) | 6 | `unified=40`, `xhigh` |
 
 GitHub reports each run as cancelled because timed-out matrix jobs are cancelled
@@ -40,64 +48,77 @@ every per-case finalizer succeeded and produced one uniquely named artifact.
 
 ## Human adjudication
 
-- The two completed PR #956 control reviews in the context run correctly
-  returned `NONE`.
-- The PR #961 `unified=40` control recalled the adjudicated `HIGH` certificate
-  lifetime finding and missed the other adjudicated `MEDIUM` finding.
-- The compact PR #961 result described the same certificate lifetime issue as
-  `MEDIUM`, which is a downgrade of the adjudicated `HIGH`, and also missed the
-  other adjudicated `MEDIUM`.
-- Later PR #961 effort and prompt outputs were compared against the same
-  adjudicated findings: `high` retained only the `HIGH`; the bounded prompt
-  downgraded it to `MEDIUM`; both missed the other `MEDIUM`.
+- Every completed PR #944 and PR #956 clean-control review correctly returned
+  `NONE`.
+- Every completed PR #961 review found only the certificate-expiry issue. The
+  `unified=40` and `unified-10` outputs rated it `HIGH`; compact context rated it
+  `MEDIUM`, `MEDIUM`, and `HIGH` across its three trials. All missed the
+  existing-deployment compatibility `MEDIUM`.
+- The medium-effort PR #948 review missed the adjudicated topology-preview
+  `MEDIUM` and reported a different `HIGH` about enabled automations retaining
+  non-executable profiles. The new finding does not count as recall of the
+  expected finding.
+- The medium-effort PR #954 review recalled the abandoned-staging-database
+  `MEDIUM` and missed the connection-retry/deadline `MEDIUM`.
+- PR #953, which contains one expected `HIGH` and one expected `MEDIUM`, timed
+  out in every experiment.
+- The bounded prompt downgraded PR #961's expected `HIGH` to `MEDIUM` and missed
+  its expected `MEDIUM`.
 
 ## Results
 
 ### Context experiment
 
+The recall denominators include all three trials: six expected `HIGH`
+observations and 15 expected `MEDIUM` observations per variant.
+
 | Variant | Completed | Verified timeouts | `HIGH` recall | `MEDIUM` recall | Completed clean controls | Result |
 | --- | ---: | ---: | ---: | ---: | --- | --- |
-| `unified-40` | 2/6 | 4 | 1/2 | 0/5 | PR #956: `NONE` | Retain as control only |
-| `unified-10` | 1/6 | 5 | 0/2 | 0/5 | PR #956: `NONE` | Reject: insufficient completion and recall |
-| compact | 1/6 | 5 | 0/2 | 0/5 | None completed | Reject: downgraded an adjudicated `HIGH` |
+| `unified-40` | 4/18 | 14 | 3/6 | 0/15 | 1/6: `NONE` | Retain as control only |
+| `unified-10` | 4/18 | 14 | 2/6 | 0/15 | 2/6: `NONE` | Reject: insufficient completion and recall |
+| compact | 5/18 | 13 | 1/6 | 0/15 | 2/6: `NONE` | Reject: two `HIGH` downgrades |
 
-The smaller packet did not reliably improve completion. For PR #956,
-`unified-10` reduced the packet from 812,319 to 359,607 bytes but took 159
-seconds versus 124 seconds for `unified-40`. For PR #961, compact context reduced
-the packet from 2,347 to 849 bytes and completed 11 seconds faster, but it
-introduced a disqualifying severity downgrade.
+The repeats confirmed substantial model variance but did not rescue a context
+candidate. For PR #956, `unified-10` reduced the packet from 812,319 to 359,607
+bytes, yet its completed trials took 159 and 163 seconds; the completed
+`unified-40` control took 124 seconds. For PR #961, compact context reduced the
+packet from 2,347 to 849 bytes, but it downgraded the expected `HIGH` in two of
+three trials and missed the expected `MEDIUM` in all three.
 
 ### Effort and prompt experiments
 
+The `xhigh` baseline row includes all three `unified=40` context trials. The
+other candidates ran once across the six-case corpus.
+
 | Context | Effort | Prompt | Completed | Verified timeouts | `HIGH` recall | `MEDIUM` recall | Result |
 | --- | --- | --- | ---: | ---: | ---: | ---: | --- |
-| `unified-40` | `xhigh` | baseline | 2/6 | 4 | 1/2 | 0/5 | Production control; did not pass tuning gate |
-| `unified-40` | `high` | baseline | 2/6 | 4 | 1/2 | 0/5 | Reject; do not test `medium` |
-| `unified-40` | `xhigh` | bounded | 2/6 | 4 | 0/2 | 0/5 | Reject; downgraded an adjudicated `HIGH` |
+| `unified-40` | `xhigh` | baseline | 4/18 | 14 | 3/6 | 0/15 | Production control; did not pass tuning gate |
+| `unified-40` | `high` | baseline | 2/6 | 4 | 1/2 | 0/5 | Reject: no completion improvement |
+| `unified-40` | `medium` | baseline | 5/6 | 1 | 1/2 | 1/5 | Reject: recall below both gates |
+| `unified-40` | `xhigh` | bounded | 2/6 | 4 | 0/2 | 0/5 | Reject: downgraded an adjudicated `HIGH` |
 
-Neither lower effort nor budget guidance changed which cases completed. The
-bounded prompt also regressed severity on the only completed finding-bearing
-case.
+`medium` materially improved completion, but it recalled only 20% of expected
+`MEDIUM` findings and missed the `HIGH` in timed-out PR #953. Lower effort is
+therefore not safe to roll out despite its runtime improvement.
 
 ### Completed-run metrics
 
-Metrics below come from the result artifacts and the Codex action logs. “Repeat”
-counts byte-identical repeated shell commands; no context-compaction marker was
+Metrics come from result artifacts and Codex action logs. Wall time, tool calls,
+and tokens show the median and range among completed cases. “Repeat commands”
+counts byte-identical repeated shell commands. No context-compaction marker was
 observed in any completed log.
 
-| Experiment | Case / variant | Wall time | Tool calls | Reported tokens | Repeat | Compactions | Risk |
-| --- | --- | ---: | ---: | ---: | ---: | ---: | --- |
-| Context | PR #956 / `unified-40` | 124s | 20 | 67,165 | 0 | 0 | `NONE` |
-| Context | PR #956 / `unified-10` | 159s | 17 | 75,713 | 2 | 0 | `NONE` |
-| Context | PR #961 / `unified-40` | 102s | 13 | 43,719 | 0 | 0 | `HIGH` |
-| Context | PR #961 / compact | 91s | 4 | 36,310 | 0 | 0 | `MEDIUM` |
-| Effort | PR #956 / `unified-40` | 116s | 18 | 80,664 | 0 | 0 | `NONE` |
-| Effort | PR #961 / `unified-40` | 83s | 7 | 53,508 | 0 | 0 | `HIGH` |
-| Prompt | PR #956 / `unified-40` | 136s | 20 | 64,796 | 0 | 0 | `NONE` |
-| Prompt | PR #961 / `unified-40` | 90s | 7 | 36,375 | 0 | 0 | `MEDIUM` |
+| Run | Completed | Wall time | Tool calls | Reported tokens | Repeat commands | Compactions |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Context initial | 4 | 113s (91–159) | 15 (4–20) | 55,442 (36,310–75,713) | 2 | 0 |
+| Context repeat 1 | 5 | 98s (94–163) | 8 (7–23) | 60,142 (52,512–97,852) | 0 | 0 |
+| Context repeat 2 | 4 | 124s (99–172) | 20 (8–23) | 79,708 (56,893–110,174) | 2 | 0 |
+| `high` effort | 2 | 100s (83–116) | 13 (7–18) | 67,086 (53,508–80,664) | 0 | 0 |
+| `medium` effort | 5 | 115s (46–130) | 12 (5–21) | 67,524 (34,043–111,720) | 0 | 0 |
+| Bounded prompt | 2 | 113s (90–136) | 14 (7–20) | 50,586 (36,375–64,796) | 0 | 0 |
 
-These timings describe only the eight cases that completed. They are not a
-representative latency distribution because the other 22 cases reached the
+These timings describe only the 22 cases that completed. They are not a
+representative latency distribution because the other 50 cases reached the
 12-minute model budget and then spent approximately five minutes in Actions
 cancellation cleanup.
 
@@ -105,16 +126,15 @@ cancellation cleanup.
 
 | Gate | Outcome |
 | --- | --- |
-| Retain every adjudicated `HIGH` without downgrade | Failed by compact context and bounded prompt |
-| Retain at least 90% of adjudicated `MEDIUM` findings | Failed by every tested configuration |
-| No invalid `HIGH` on completed clean controls | Passed for completed PR #956 controls; PR #944 did not complete |
+| Retain every adjudicated `HIGH` without downgrade | Failed by compact context and bounded prompt; other candidates timed out on PR #953 |
+| Retain at least 90% of adjudicated `MEDIUM` findings | Failed by every tested configuration; best observed recall was 1/5 at `medium` |
+| No invalid `HIGH` on completed clean controls | Passed; every completed PR #944 and PR #956 control returned `NONE` |
 | No increase in median tool calls or compactions | Not decision-bearing because recall failed |
-| At least 20% faster or equivalent with lower token use | Not decision-bearing because recall failed |
+| At least 20% faster or equivalent with lower token use | `medium` improved completion, but recall failed |
 
-Additional repeats cannot make the compact or bounded candidates satisfy the
-“every `HIGH`” gate because each already produced a completed severity
-downgrade. The `high` effort candidate also produced no completion improvement
-and missed the only adjudicated `MEDIUM` in its completed finding-bearing case.
+The planned repeats showed that compact severity varies, but two completed
+trials still downgraded an adjudicated `HIGH`. Testing `medium` closed the effort
+matrix and showed that its completion gain comes with unacceptable recall.
 
 ## Follow-up
 

--- a/docs/codex-security-review-benchmark-report.md
+++ b/docs/codex-security-review-benchmark-report.md
@@ -30,8 +30,9 @@ Both commits contain the same benchmark workflow blob,
 
 The fixed corpus contains two adjudicated `HIGH` findings, five adjudicated
 `MEDIUM` findings, and two clean controls across PRs #944, #948, #953, #954,
-#956, and #961. Each context variant ran three times. A timeout counts as no
-recalled finding because it produces no usable review.
+#956, and #961. Each context variant ran three times. Finding recall is
+calculated only across completed reviews, as required by the plan; completion
+and verified-timeout rates are reported separately.
 
 | Experiment | Run | Cases | Constant dimensions |
 | --- | --- | ---: | --- |
@@ -73,14 +74,14 @@ every per-case finalizer succeeded and produced one uniquely named artifact.
 
 ### Context experiment
 
-The recall denominators include all three trials: six expected `HIGH`
-observations and 15 expected `MEDIUM` observations per variant.
+Recall denominators include expected findings only in completed reviews. For
+example, PR #953's repeated timeouts reduce completion but do not enter recall.
 
 | Variant | Completed | Verified timeouts | `HIGH` recall | `MEDIUM` recall | Completed clean controls | Result |
 | --- | ---: | ---: | ---: | ---: | --- | --- |
-| `unified-40` | 4/18 | 14 | 3/6 | 0/15 | 1/6: `NONE` | Retain as control only |
-| `unified-10` | 4/18 | 14 | 2/6 | 0/15 | 2/6: `NONE` | Reject: insufficient completion and recall |
-| compact | 5/18 | 13 | 1/6 | 0/15 | 2/6: `NONE` | Reject: two `HIGH` downgrades |
+| `unified-40` | 4/18 | 14 | 3/3 | 0/3 | 1/6: `NONE` | Retain as control only |
+| `unified-10` | 4/18 | 14 | 2/2 | 0/2 | 2/6: `NONE` | Reject: insufficient completion and medium recall |
+| compact | 5/18 | 13 | 1/3 | 0/3 | 2/6: `NONE` | Reject: two `HIGH` downgrades |
 
 The repeats confirmed substantial model variance but did not rescue a context
 candidate. For PR #956, `unified-10` reduced the packet from 812,319 to 359,607
@@ -96,15 +97,15 @@ other candidates ran once across the six-case corpus.
 
 | Context | Effort | Prompt | Completed | Verified timeouts | `HIGH` recall | `MEDIUM` recall | Result |
 | --- | --- | --- | ---: | ---: | ---: | ---: | --- |
-| `unified-40` | `xhigh` | baseline | 4/18 | 14 | 3/6 | 0/15 | Production control; did not pass tuning gate |
-| `unified-40` | `high` | baseline | 2/6 | 4 | 1/2 | 0/5 | Reject: no completion improvement |
-| `unified-40` | `medium` | baseline | 5/6 | 1 | 1/2 | 1/5 | Reject: recall below both gates |
-| `unified-40` | `xhigh` | bounded | 2/6 | 4 | 0/2 | 0/5 | Reject: downgraded an adjudicated `HIGH` |
+| `unified-40` | `xhigh` | baseline | 4/18 | 14 | 3/3 | 0/3 | Production control; did not pass tuning gate |
+| `unified-40` | `high` | baseline | 2/6 | 4 | 1/1 | 0/1 | Reject: no completion improvement |
+| `unified-40` | `medium` | baseline | 5/6 | 1 | 1/1 | 1/4 | Reject: medium recall and validity failed |
+| `unified-40` | `xhigh` | bounded | 2/6 | 4 | 0/1 | 0/1 | Reject: downgraded an adjudicated `HIGH` |
 
-`medium` materially improved completion, but it recalled only 20% of expected
-`MEDIUM` findings, missed the `HIGH` in timed-out PR #953, and introduced an
-invalid `HIGH` on PR #948. Lower effort is therefore not safe to roll out
-despite its runtime improvement.
+`medium` materially improved completion, but it recalled only 25% of expected
+`MEDIUM` findings in completed reviews and introduced an invalid `HIGH` on PR
+#948. PR #953's timeout remains a separate completion failure. Lower effort is
+therefore not safe to roll out despite its runtime improvement.
 
 ### Completed-run metrics
 
@@ -131,8 +132,8 @@ cancellation cleanup.
 
 | Gate | Outcome |
 | --- | --- |
-| Retain every adjudicated `HIGH` without downgrade | Failed by compact context and bounded prompt; other candidates timed out on PR #953 |
-| Retain at least 90% of adjudicated `MEDIUM` findings | Failed by every tested configuration; best observed recall was 1/5 at `medium` |
+| Retain every adjudicated `HIGH` without downgrade across completed reviews | Failed by compact context and bounded prompt |
+| Retain at least 90% of adjudicated `MEDIUM` findings across completed reviews | Failed by every tested configuration; best observed recall was 1/4 at `medium` |
 | No invalid `HIGH` on completed clean controls | Passed; every completed PR #944 and PR #956 control returned `NONE` |
 | New medium-or-higher findings are valid | Failed; medium effort produced an invalid `HIGH` on PR #948 |
 | No increase in median tool calls or compactions | Not decision-bearing because recall failed |

--- a/docs/codex-security-review-benchmark-report.md
+++ b/docs/codex-security-review-benchmark-report.md
@@ -1,0 +1,127 @@
+# Codex security review benchmark report
+
+Date: 2026-08-27
+
+## Decision
+
+Keep the production reviewer on `unified=40`, `xhigh` reasoning effort, and the
+baseline prompt. None of the context, effort, or prompt candidates met the
+finding-recall and completion gates in the
+[bounded-review plan](./plans/2026-08-25-bounded-codex-security-review-plan.md).
+Do not test `medium` effort or the large-PR corpus: `high` already failed the
+adjudicated corpus, and the plan gates large-PR replay on selecting a candidate.
+
+The bounded execution and fail-closed finalizer remain useful independently of
+model tuning. Across 30 matrix cases, 22 reviews exhausted the outer budget and
+all 30 trusted finalizers uploaded either a completed-result or verified-timeout
+artifact. No ambiguous cancellation was admitted as benchmark data.
+
+Further runtime work should evaluate architecture-aware sharding rather than
+reducing context, effort, or prompt scope again. See the
+[sharded-review TDD](./plans/2026-08-27-sharded-codex-security-review-tdd.md).
+
+## Method
+
+All runs used the trusted `repository_dispatch` workflow from `main` at
+`c126c0b6bfa0947967caa5a04474503cdff5c200`. The fixed corpus contains two
+adjudicated `HIGH` findings, five adjudicated `MEDIUM` findings, and two clean
+controls across PRs #944, #948, #953, #954, #956, and #961. A timeout counts as
+no recalled finding because it produces no usable review.
+
+| Experiment | Run | Cases | Constant dimensions |
+| --- | --- | ---: | --- |
+| Context | [33009198561](https://github.com/block/proto-fleet/actions/runs/33009198561) | 18 | `xhigh`, baseline prompt |
+| Effort | [33046668278](https://github.com/block/proto-fleet/actions/runs/33046668278) | 6 | `unified=40`, baseline prompt |
+| Prompt | [33065249002](https://github.com/block/proto-fleet/actions/runs/33065249002) | 6 | `unified=40`, `xhigh` |
+
+GitHub reports each run as cancelled because timed-out matrix jobs are cancelled
+at the enforceable outer boundary. That top-level conclusion is expected here;
+every per-case finalizer succeeded and produced one uniquely named artifact.
+
+## Human adjudication
+
+- The two completed PR #956 control reviews in the context run correctly
+  returned `NONE`.
+- The PR #961 `unified=40` control recalled the adjudicated `HIGH` certificate
+  lifetime finding and missed the other adjudicated `MEDIUM` finding.
+- The compact PR #961 result described the same certificate lifetime issue as
+  `MEDIUM`, which is a downgrade of the adjudicated `HIGH`, and also missed the
+  other adjudicated `MEDIUM`.
+- Later PR #961 effort and prompt outputs were compared against the same
+  adjudicated findings: `high` retained only the `HIGH`; the bounded prompt
+  downgraded it to `MEDIUM`; both missed the other `MEDIUM`.
+
+## Results
+
+### Context experiment
+
+| Variant | Completed | Verified timeouts | `HIGH` recall | `MEDIUM` recall | Completed clean controls | Result |
+| --- | ---: | ---: | ---: | ---: | --- | --- |
+| `unified-40` | 2/6 | 4 | 1/2 | 0/5 | PR #956: `NONE` | Retain as control only |
+| `unified-10` | 1/6 | 5 | 0/2 | 0/5 | PR #956: `NONE` | Reject: insufficient completion and recall |
+| compact | 1/6 | 5 | 0/2 | 0/5 | None completed | Reject: downgraded an adjudicated `HIGH` |
+
+The smaller packet did not reliably improve completion. For PR #956,
+`unified-10` reduced the packet from 812,319 to 359,607 bytes but took 159
+seconds versus 124 seconds for `unified-40`. For PR #961, compact context reduced
+the packet from 2,347 to 849 bytes and completed 11 seconds faster, but it
+introduced a disqualifying severity downgrade.
+
+### Effort and prompt experiments
+
+| Context | Effort | Prompt | Completed | Verified timeouts | `HIGH` recall | `MEDIUM` recall | Result |
+| --- | --- | --- | ---: | ---: | ---: | ---: | --- |
+| `unified-40` | `xhigh` | baseline | 2/6 | 4 | 1/2 | 0/5 | Production control; did not pass tuning gate |
+| `unified-40` | `high` | baseline | 2/6 | 4 | 1/2 | 0/5 | Reject; do not test `medium` |
+| `unified-40` | `xhigh` | bounded | 2/6 | 4 | 0/2 | 0/5 | Reject; downgraded an adjudicated `HIGH` |
+
+Neither lower effort nor budget guidance changed which cases completed. The
+bounded prompt also regressed severity on the only completed finding-bearing
+case.
+
+### Completed-run metrics
+
+Metrics below come from the result artifacts and the Codex action logs. “Repeat”
+counts byte-identical repeated shell commands; no context-compaction marker was
+observed in any completed log.
+
+| Experiment | Case / variant | Wall time | Tool calls | Reported tokens | Repeat | Compactions | Risk |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | --- |
+| Context | PR #956 / `unified-40` | 124s | 20 | 67,165 | 0 | 0 | `NONE` |
+| Context | PR #956 / `unified-10` | 159s | 17 | 75,713 | 2 | 0 | `NONE` |
+| Context | PR #961 / `unified-40` | 102s | 13 | 43,719 | 0 | 0 | `HIGH` |
+| Context | PR #961 / compact | 91s | 4 | 36,310 | 0 | 0 | `MEDIUM` |
+| Effort | PR #956 / `unified-40` | 116s | 18 | 80,664 | 0 | 0 | `NONE` |
+| Effort | PR #961 / `unified-40` | 83s | 7 | 53,508 | 0 | 0 | `HIGH` |
+| Prompt | PR #956 / `unified-40` | 136s | 20 | 64,796 | 0 | 0 | `NONE` |
+| Prompt | PR #961 / `unified-40` | 90s | 7 | 36,375 | 0 | 0 | `MEDIUM` |
+
+These timings describe only the eight cases that completed. They are not a
+representative latency distribution because the other 22 cases reached the
+12-minute model budget and then spent approximately five minutes in Actions
+cancellation cleanup.
+
+## Gate evaluation
+
+| Gate | Outcome |
+| --- | --- |
+| Retain every adjudicated `HIGH` without downgrade | Failed by compact context and bounded prompt |
+| Retain at least 90% of adjudicated `MEDIUM` findings | Failed by every tested configuration |
+| No invalid `HIGH` on completed clean controls | Passed for completed PR #956 controls; PR #944 did not complete |
+| No increase in median tool calls or compactions | Not decision-bearing because recall failed |
+| At least 20% faster or equivalent with lower token use | Not decision-bearing because recall failed |
+
+Additional repeats cannot make the compact or bounded candidates satisfy the
+“every `HIGH`” gate because each already produced a completed severity
+downgrade. The `high` effort candidate also produced no completion improvement
+and missed the only adjudicated `MEDIUM` in its completed finding-bearing case.
+
+## Follow-up
+
+1. Keep production tuning unchanged while retaining the bounded timeout and
+   fail-closed human-review path.
+2. Complete the original plan's first-30-production-run observation window.
+3. Review the sharded-review TDD before implementing another secret-backed
+   benchmark candidate.
+4. Require a sharded candidate to pass the same adjudicated recall gates before
+   replaying PRs #957 and #964 from the large-PR corpus.

--- a/docs/plans/2026-08-25-bounded-codex-security-review-plan.md
+++ b/docs/plans/2026-08-25-bounded-codex-security-review-plan.md
@@ -282,18 +282,18 @@ of model efficiency.
 
 ## Benchmark outcome
 
-The trusted `main` workflow replayed 30 adjudicated matrix cases across context,
-effort, and prompt experiments. Eight completed and 22 reached the verified
-outer budget; every finalizer produced a distinct result or timeout artifact.
-No candidate met the recall gates: compact context and the bounded prompt each
-downgraded an adjudicated `HIGH`, while `high` effort did not improve the 2/6
-completion profile and missed the adjudicated `MEDIUM` in its completed
-finding-bearing case.
+The trusted `main` workflow replayed 72 adjudicated matrix cases across the
+initial context run, two context repeats, all three effort levels, and the prompt
+experiment. Twenty-two completed and 50 reached the verified outer budget;
+every finalizer produced a distinct result or timeout artifact. No candidate met
+the recall gates. Compact context downgraded an adjudicated `HIGH` in two of
+three completed trials. `medium` effort improved completion to 5/6 but recalled
+only one of five adjudicated `MEDIUM` findings and timed out on a case containing
+the other adjudicated `HIGH`. The bounded prompt also downgraded that `HIGH`.
 
 Production therefore remains on `unified=40`, `xhigh`, and the baseline prompt.
-The large-PR corpus is deferred because step 5 requires a selected candidate;
-`medium` effort is not tested after `high` failed. Full evidence and human
-adjudication are in the
+The large-PR corpus is deferred because step 5 requires a selected candidate.
+Full evidence and human adjudication are in the
 [benchmark report](../codex-security-review-benchmark-report.md). Further
 runtime work moves to the separate
 [sharded-review TDD](./2026-08-27-sharded-codex-security-review-tdd.md).

--- a/docs/plans/2026-08-25-bounded-codex-security-review-plan.md
+++ b/docs/plans/2026-08-25-bounded-codex-security-review-plan.md
@@ -288,8 +288,8 @@ experiment. Twenty-two completed and 50 reached the verified outer budget;
 every finalizer produced a distinct result or timeout artifact. No candidate met
 the recall gates. Compact context downgraded an adjudicated `HIGH` in two of
 three completed trials. `medium` effort improved completion to 5/6 but recalled
-only one of five adjudicated `MEDIUM` findings, timed out on a case containing
-the other adjudicated `HIGH`, and produced an invalid new `HIGH` on PR #948.
+only one of four adjudicated `MEDIUM` findings in completed reviews, left PR
+#953 incomplete, and produced an invalid new `HIGH` on PR #948.
 The bounded prompt also downgraded the known `HIGH`.
 
 Production therefore remains on `unified=40`, `xhigh`, and the baseline prompt.

--- a/docs/plans/2026-08-25-bounded-codex-security-review-plan.md
+++ b/docs/plans/2026-08-25-bounded-codex-security-review-plan.md
@@ -280,6 +280,24 @@ regresses. Keep the bounded timeout and explicit fallback unless they prevent
 artifact creation; those controls address the operational failure independently
 of model efficiency.
 
+## Benchmark outcome
+
+The trusted `main` workflow replayed 30 adjudicated matrix cases across context,
+effort, and prompt experiments. Eight completed and 22 reached the verified
+outer budget; every finalizer produced a distinct result or timeout artifact.
+No candidate met the recall gates: compact context and the bounded prompt each
+downgraded an adjudicated `HIGH`, while `high` effort did not improve the 2/6
+completion profile and missed the adjudicated `MEDIUM` in its completed
+finding-bearing case.
+
+Production therefore remains on `unified=40`, `xhigh`, and the baseline prompt.
+The large-PR corpus is deferred because step 5 requires a selected candidate;
+`medium` effort is not tested after `high` failed. Full evidence and human
+adjudication are in the
+[benchmark report](../codex-security-review-benchmark-report.md). Further
+runtime work moves to the separate
+[sharded-review TDD](./2026-08-27-sharded-codex-security-review-tdd.md).
+
 ## Risks and mitigations
 
 | Risk | Mitigation |
@@ -314,9 +332,11 @@ of model efficiency.
   merge, by executing the artifact writer against every failure mode and by
   driving `evaluate_policy` with a `HIGH` review for an otherwise-eligible
   trusted-author pull request.
-- A benchmark dispatch against `corpus: large-pr` records a timeout result and
-  uploads its artifacts through an enforceable boundary outside the composite
-  action; caller step timeout alone is not accepted as evidence.
+- If the adjudicated corpus selects a candidate, a dispatch against
+  `corpus: large-pr` records a timeout result and uploads its artifacts through
+  an enforceable boundary outside the composite action; when no candidate
+  passes, the benchmark report explicitly records why this gated run was
+  deferred. Caller step timeout alone is not accepted as evidence.
 - Broken review automation, as opposed to an exhausted outer job budget, makes
   the final `security-review` check fail without classifying the result as an
   expected timeout.

--- a/docs/plans/2026-08-25-bounded-codex-security-review-plan.md
+++ b/docs/plans/2026-08-25-bounded-codex-security-review-plan.md
@@ -288,8 +288,9 @@ experiment. Twenty-two completed and 50 reached the verified outer budget;
 every finalizer produced a distinct result or timeout artifact. No candidate met
 the recall gates. Compact context downgraded an adjudicated `HIGH` in two of
 three completed trials. `medium` effort improved completion to 5/6 but recalled
-only one of five adjudicated `MEDIUM` findings and timed out on a case containing
-the other adjudicated `HIGH`. The bounded prompt also downgraded that `HIGH`.
+only one of five adjudicated `MEDIUM` findings, timed out on a case containing
+the other adjudicated `HIGH`, and produced an invalid new `HIGH` on PR #948.
+The bounded prompt also downgraded the known `HIGH`.
 
 Production therefore remains on `unified=40`, `xhigh`, and the baseline prompt.
 The large-PR corpus is deferred because step 5 requires a selected candidate.

--- a/docs/plans/2026-08-27-sharded-codex-security-review-tdd.md
+++ b/docs/plans/2026-08-27-sharded-codex-security-review-tdd.md
@@ -128,10 +128,11 @@ A trusted aggregation job runs after every shard finalizer and does not execute
 code from the reviewed checkout. It:
 
 - Verifies the manifest, exact SHAs, run identity, and one result per shard.
-- Produces overall `HIGH` only for validated incomplete evidence, such as a
-  verified shard budget timeout, finalizer-normalized unusable model output, or
-  planner-produced `oversized-review`; the review states which domains require
-  human review.
+- Adds a synthetic `HIGH` fallback finding only for validated incomplete
+  evidence, such as a verified shard budget timeout, finalizer-normalized
+  unusable model output, or planner-produced `oversized-review`; completed shard
+  findings retain their reported severity, and the fallback states which
+  domains require human review.
 - Hard-fails the workflow when a trusted artifact is missing, corrupt,
   malformed, stale, or bound to another run. Artifact upload and finalizer
   failures never become normal aggregate findings.

--- a/docs/plans/2026-08-27-sharded-codex-security-review-tdd.md
+++ b/docs/plans/2026-08-27-sharded-codex-security-review-tdd.md
@@ -52,29 +52,42 @@ contracts or relying on a second unbounded model pass.
 ### Trusted shard planner
 
 A trusted workflow step reads the exact changed-file list and assigns files to
-stable architecture domains:
+stable architecture domains. The table is evaluated top to bottom and the first
+match wins, so ownership is deterministic and mutually exclusive:
 
-| Domain | Primary paths |
-| --- | --- |
-| Contracts and persistence | `proto/`, migrations, sqlc queries, generated API boundaries |
-| Server | `server/` excluding shared contract inputs |
-| Shared client contracts | `client/src/shared/`; replicated as context to every affected client-app shard |
-| ProtoFleet | `client/src/protoFleet/` |
-| ProtoOS | `client/src/protoOS/` |
-| Go/Python plugins | `plugin/` except `plugin/asicrs/`, generator packages |
-| ASIC-RS | `plugin/asicrs/` |
-| Delivery and infrastructure | `.github/`, Docker, deployment, monitoring, scripts, root tooling |
+| Precedence | Domain | Primary paths |
+| ---: | --- | --- |
+| 1 | Delivery and repository infrastructure | `.github/`, `deployment-files/`, `docs/`, `scripts/`, `server/monitoring/`, every `Dockerfile*` and Compose file, and root-level tooling/configuration |
+| 2 | Contracts and persistence | `proto/`, `server/migrations/`, `server/sqlc/`, `server/generated/sqlc/`, generated protobuf files, and generated API boundaries |
+| 3 | ProtoFleet | `client/src/protoFleet/` |
+| 4 | ProtoOS | `client/src/protoOS/` |
+| 5 | Shared client contracts | Remaining `client/`, including `client/src/shared/`; replicated as context to every affected client-app shard |
+| 6 | ASIC-RS | `plugin/asicrs/` |
+| 7 | Go/Python plugins | Remaining `plugin/` and plugin-generator packages |
+| 8 | Server | Remaining `server/` |
+| 9 | Cross-cutting | Every remaining path |
 
 The planner is path-based, versioned on the trusted default branch, and emits a
 machine-readable manifest containing the exact base/head SHAs, every changed
-file, its owning shard, and shared-contract membership. Unknown paths go to a
-conservative cross-cutting shard rather than being dropped.
+file, its owning shard, and shared-contract membership. The final cross-cutting
+rule ensures unknown paths are reviewed rather than dropped.
 
-Create a shard only when its primary domain has changed. Cap the first
-experiment at two shards so both model jobs can run in one bounded parallel
-wave. If more than two domains change, combine adjacent domains according to a
-checked-in deterministic merge order; never split a domain merely to equalize
-bytes.
+Within each domain, the planner forms indivisible semantic units: Go packages,
+client feature directories, protobuf packages, a migration with its sqlc
+contract, plugin modules, or one deployment surface. It never splits a file or
+hunk. It then assigns units deterministically to no more than two shard packets,
+including replicated context, with both of these hard limits:
+
+- 500,000 bytes per complete packet.
+- 8,000 lines per complete packet.
+
+These initial limits are benchmark hypotheses. They split the known 812,319-byte,
+13,926-line PR #956 control into two possible packets while keeping both model
+jobs in one parallel wave. If one semantic unit exceeds either limit, shared
+context makes a packet exceed a limit, or the units require more than two
+bounded packets, the planner does not launch an unbounded model job. It emits a
+validated `oversized-review` incomplete result that requires human review and
+records the limiting units and packet measurements.
 
 ### Shared review context
 
@@ -91,7 +104,8 @@ Each shard receives:
 The packet records primary and shared files separately so duplicated contract
 context cannot be mistaken for duplicate review ownership. Every changed file
 must appear as primary in exactly one shard. The finalizer rejects manifests
-with missing, multiply owned, stale-SHA, or out-of-range files.
+with missing, multiply owned, stale-SHA, or out-of-range files and remeasures
+each complete packet against both hard size limits.
 
 ### Bounded shard execution
 
@@ -104,8 +118,9 @@ upload inside the current 15-minute end-to-end target.
 Each shard emits the existing structured risk and Markdown contract plus trusted
 metadata identifying its shard, exact range, primary files, shared files, run
 ID, completion status, and elapsed time. Early, manual, superseded, setup, and
-ambiguous cancellation remain hard failures. A verified shard budget timeout is
-an incomplete review, not a successful empty result.
+ambiguous cancellation remain hard failures. A verified shard budget timeout or
+planner-produced `oversized-review` result is validated incomplete evidence,
+not a successful empty result.
 
 ### Deterministic aggregation
 
@@ -113,8 +128,13 @@ A trusted aggregation job runs after every shard finalizer and does not execute
 code from the reviewed checkout. It:
 
 - Verifies the manifest, exact SHAs, run identity, and one result per shard.
-- Fails closed to overall `HIGH` when any shard is incomplete, malformed, or
-  missing; the review states which domains require human review.
+- Produces overall `HIGH` only for validated incomplete evidence, such as a
+  verified shard budget timeout, finalizer-normalized unusable model output, or
+  planner-produced `oversized-review`; the review states which domains require
+  human review.
+- Hard-fails the workflow when a trusted artifact is missing, corrupt,
+  malformed, stale, or bound to another run. Artifact upload and finalizer
+  failures never become normal aggregate findings.
 - Computes overall risk as the maximum shard severity.
 - Concatenates findings in severity, shard, path, and line order.
 - Preserves potentially duplicate findings rather than using a model or fuzzy
@@ -165,10 +185,12 @@ revalidating that the PR head is current.
 | Risk | Mitigation |
 | --- | --- |
 | A cross-domain bug is hidden | Replicate changed shared contracts and include the complete changed-file manifest in every shard |
-| Replicated context increases cost | Create only affected shards, cap concurrency, and measure duplicated packet bytes |
+| Replicated context increases cost | Create only affected shards, cap concurrency, include shared bytes in the hard packet limits, and measure duplication |
 | Findings are duplicated | Preserve them by default; allow only exact deterministic fingerprint deduplication |
-| One shard timeout is masked | Any incomplete shard forces an aggregate `HIGH` human-review result |
-| Path rules silently omit files | Require exact one-to-one primary ownership and route unknown paths to a cross-cutting shard |
+| One shard timeout is masked | Any validated incomplete shard forces an aggregate `HIGH` human-review result |
+| Trusted handoff failure looks like model incompletion | Hard-fail missing, corrupt, stale, cross-run, or malformed artifacts; accept only validated incomplete evidence |
+| One semantic unit exceeds the packet bound | Skip the model and emit a measured `oversized-review` human-review result instead of running unbounded |
+| Path rules overlap or silently omit files | Apply first-match precedence, require exact one-to-one primary ownership, and route unmatched paths to a cross-cutting shard |
 | Matrix output is mixed across runs | Bind every shard artifact to run ID, shard ID, exact base/head SHAs, and manifest digest |
 | Aggregation executes untrusted code | Use inline trusted default-branch logic without a PR checkout |
 | Parallelism increases API spend | Start at `max-parallel: 2`, record per-shard tokens, and cap the number of shards |
@@ -176,12 +198,17 @@ revalidating that the PR head is current.
 
 ## Test plan
 
-- Unit-test path ownership, unknown-path fallback, deterministic domain merging,
-  shared-contract replication, and exact one-to-one changed-file coverage.
+- Unit-test first-match path ownership, unknown-path fallback, semantic-unit
+  grouping, deterministic packing, shared-contract replication, and exact
+  one-to-one changed-file coverage.
+- Test both packet limits at, below, and above the boundary, including a single
+  oversized unit, replicated context overflow, and a change requiring more than
+  two packets.
 - Assert byte-identical security boundary, schema, sandbox, model, and prompt
   between production and benchmark shard jobs.
-- Test aggregate severity, stable ordering, exact deduplication, and fail-closed
-  behavior for missing, malformed, stale, timed-out, and cross-run artifacts.
+- Test aggregate severity, stable ordering, exact deduplication, and validated
+  timeout/oversized `HIGH` behavior. Separately prove missing, corrupt,
+  malformed, stale, and cross-run artifacts hard-fail the workflow.
 - Mock Actions APIs to distinguish verified budget timeout from setup, manual,
   infrastructure, and supersession cancellation.
 - Run actionlint, Ruff, workflow-policy tests, and executable mocked posting

--- a/docs/plans/2026-08-27-sharded-codex-security-review-tdd.md
+++ b/docs/plans/2026-08-27-sharded-codex-security-review-tdd.md
@@ -15,8 +15,9 @@ showed that diff context, reasoning effort, and prompt guidance do not make the
 current single-agent review complete reliably. Only 22 of 72 adjudicated matrix
 cases completed; the other 50 exhausted the 12-minute outer budget. Compact
 context downgraded a known `HIGH` in two of three trials, `medium` effort
-recalled only one of five known `MEDIUM` findings, and the bounded prompt also
-downgraded the known `HIGH`. Production therefore remains on `unified=40`,
+recalled only one of five known `MEDIUM` findings and produced an invalid new
+`HIGH`, and the bounded prompt also downgraded the known `HIGH`. Production
+therefore remains on `unified=40`,
 `xhigh`, and the baseline prompt.
 
 The existing reviewer has one model process inspect the full exact diff and any
@@ -57,8 +58,9 @@ stable architecture domains:
 | --- | --- |
 | Contracts and persistence | `proto/`, migrations, sqlc queries, generated API boundaries |
 | Server | `server/` excluding shared contract inputs |
-| ProtoFleet and shared client | `client/src/protoFleet/` plus allowed `client/src/shared/` dependencies |
-| ProtoOS and shared client | `client/src/protoOS/` plus allowed `client/src/shared/` dependencies |
+| Shared client contracts | `client/src/shared/`; replicated as context to every affected client-app shard |
+| ProtoFleet | `client/src/protoFleet/` |
+| ProtoOS | `client/src/protoOS/` |
 | Go/Python plugins | `plugin/` except `plugin/asicrs/`, generator packages |
 | ASIC-RS | `plugin/asicrs/` |
 | Delivery and infrastructure | `.github/`, Docker, deployment, monitoring, scripts, root tooling |
@@ -146,7 +148,8 @@ revalidating that the PR head is current.
   the same 2/6 completion profile and downgraded an adjudicated `HIGH`.
 - **Lower reasoning effort:** Rejected because `high` completed 2/6 cases;
   `medium` completed 5/6 but recalled only one of five known `MEDIUM` findings
-  and one of two known `HIGH` findings.
+  and one of two known `HIGH` findings, while also producing an invalid new
+  `HIGH`.
 - **Smaller global diff context:** Rejected after three trials per variant. Every
   variant missed all 15 expected `MEDIUM` observations, and compact context
   downgraded a known `HIGH` in two trials.

--- a/docs/plans/2026-08-27-sharded-codex-security-review-tdd.md
+++ b/docs/plans/2026-08-27-sharded-codex-security-review-tdd.md
@@ -1,0 +1,186 @@
+---
+title: "Sharded Codex security review"
+date: 2026-08-27
+status: draft
+type: tdd
+tracker:
+---
+
+# Sharded Codex security review
+
+## Context
+
+The [bounded-review benchmark](../codex-security-review-benchmark-report.md)
+showed that diff context, reasoning effort, and prompt guidance do not make the
+current single-agent review complete reliably. Only 8 of 30 adjudicated matrix
+cases completed; the other 22 exhausted the 12-minute outer budget. Reduced
+context and the bounded prompt also downgraded a known `HIGH` finding, so
+production remains on `unified=40`, `xhigh`, and the baseline prompt.
+
+The existing reviewer has one model process inspect the full exact diff and any
+unchanged files it chooses. Large cross-component changes can therefore consume
+the entire budget before producing output. The next experiment should bound the
+amount of changed code assigned to each model invocation without hiding shared
+contracts or relying on a second unbounded model pass.
+
+## Goals
+
+- Complete normal and large semantic reviews within the existing end-to-end
+  production bound.
+- Preserve every adjudicated `HIGH` and at least 90% of adjudicated `MEDIUM`
+  findings without severity downgrade.
+- Preserve the exact three-dot diff, pinned SHAs, prompt-injection boundary,
+  read-only sandbox, and fail-closed artifact contract.
+- Keep cross-component contract changes visible to every affected shard.
+- Aggregate shard results deterministically without another model invocation.
+- Bound model concurrency and total API cost.
+
+## Non-goals
+
+- Arbitrary file-count or byte-count sharding that separates related code.
+- Lowering reasoning effort, reducing diff context, or adopting the bounded
+  prompt in the first sharding experiment.
+- Allowing partial shard success to authorize approval-free merge.
+- Semantic deduplication by a second model.
+- Replacing human adjudication of benchmark findings.
+
+## Design
+
+### Trusted shard planner
+
+A trusted workflow step reads the exact changed-file list and assigns files to
+stable architecture domains:
+
+| Domain | Primary paths |
+| --- | --- |
+| Contracts and persistence | `proto/`, migrations, sqlc queries, generated API boundaries |
+| Server | `server/` excluding shared contract inputs |
+| ProtoFleet and shared client | ProtoFleet plus allowed `client/shared/` dependencies |
+| ProtoOS and shared client | ProtoOS plus allowed `client/shared/` dependencies |
+| Go/Python plugins | `plugin/` except `plugin/asicrs/`, generator packages |
+| ASIC-RS | `plugin/asicrs/` |
+| Delivery and infrastructure | `.github/`, Docker, deployment, monitoring, scripts, root tooling |
+
+The planner is path-based, versioned on the trusted default branch, and emits a
+machine-readable manifest containing the exact base/head SHAs, every changed
+file, its owning shard, and shared-contract membership. Unknown paths go to a
+conservative cross-cutting shard rather than being dropped.
+
+Create a shard only when its primary domain has changed. Cap the first
+experiment at four concurrent shards. If more than four domains change, combine
+adjacent domains according to a checked-in deterministic merge order; never
+split a domain merely to equalize bytes.
+
+### Shared review context
+
+Each shard receives:
+
+1. The complete changed-file manifest and per-file diff statistics.
+2. The `unified=40` diff for files owned by that shard.
+3. Changed shared contracts relevant to that shard, even when another shard
+   owns them. Shared inputs include protobuf definitions, migrations and sqlc
+   interfaces, API types, deployment schemas, and root build/runtime contracts.
+4. The same trusted prompt, model, security boundary, output schema, and
+   read-only sandbox as production.
+
+The packet records primary and shared files separately so duplicated contract
+context cannot be mistaken for duplicate review ownership. Every changed file
+must appear as primary in exactly one shard. The finalizer rejects manifests
+with missing, multiply owned, stale-SHA, or out-of-range files.
+
+### Bounded shard execution
+
+Run shard reviewers as a matrix with bounded parallelism. The benchmark should
+start with a six-minute model budget per shard and reserve the existing
+five-minute Actions cancellation-cleanup allowance. Production timing is chosen
+only after benchmark evidence; it must keep trusted aggregation and artifact
+upload inside the current 15-minute end-to-end target.
+
+Each shard emits the existing structured risk and Markdown contract plus trusted
+metadata identifying its shard, exact range, primary files, shared files, run
+ID, completion status, and elapsed time. Early, manual, superseded, setup, and
+ambiguous cancellation remain hard failures. A verified shard budget timeout is
+an incomplete review, not a successful empty result.
+
+### Deterministic aggregation
+
+A trusted aggregation job runs after every shard finalizer and does not execute
+code from the reviewed checkout. It:
+
+- Verifies the manifest, exact SHAs, run identity, and one result per shard.
+- Fails closed to overall `HIGH` when any shard is incomplete, malformed, or
+  missing; the review states which domains require human review.
+- Computes overall risk as the maximum shard severity.
+- Concatenates findings in severity, shard, path, and line order.
+- Preserves potentially duplicate findings rather than using a model or fuzzy
+  matching to remove them. Exact duplicate structured entries may be collapsed
+  only by a documented deterministic fingerprint.
+- Emits the existing production artifact and comment contract so review policy
+  continues to consume one trusted result.
+
+No shard may post directly to a pull request. Only the aggregator posts after
+revalidating that the PR head is current.
+
+### Benchmark sequence
+
+1. Add a manual `repository_dispatch` benchmark mode that uses only fixed corpus
+   SHAs and trusted default-branch code.
+2. Replay the adjudicated corpus with `unified=40`, `xhigh`, and the baseline
+   prompt. Compare against the unsharded control in the benchmark report.
+3. Human-adjudicate the union of shard findings. Require every known `HIGH`, at
+   least 90% of known `MEDIUM` findings, and no invalid `HIGH` on either clean
+   control.
+4. Repeat only disagreements, misses, or cases within 10% of a shard budget.
+5. If the adjudicated gate passes, replay PRs #957 and #964. Require a credible
+   aggregate review or an explicit incomplete `HIGH` artifact within 15 minutes.
+6. Roll out behind a workflow-level switch that can return production to the
+   single-agent path without weakening its current timeout or fail-closed
+   behavior.
+
+## Alternatives considered
+
+- **More single-agent prompt tuning:** Rejected because the bounded prompt had
+  the same 2/6 completion profile and downgraded an adjudicated `HIGH`.
+- **Lower reasoning effort:** Rejected because `high` had the same 2/6
+  completion profile and missed the known `MEDIUM`; `medium` was therefore not
+  tested.
+- **Smaller global diff context:** Rejected because compact context downgraded a
+  known `HIGH`, while `unified-10` completed no finding-bearing case.
+- **Arbitrary equal-size shards:** Rejected because they can hide transaction,
+  API, and lifecycle relationships that cross files.
+- **Model-based aggregation:** Rejected because it adds another unbounded pass
+  and another opportunity to omit or downgrade findings.
+- **Longer timeout:** Rejected because it restores the operational failure this
+  work is intended to prevent.
+
+## Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| A cross-domain bug is hidden | Replicate changed shared contracts and include the complete changed-file manifest in every shard |
+| Replicated context increases cost | Create only affected shards, cap concurrency, and measure duplicated packet bytes |
+| Findings are duplicated | Preserve them by default; allow only exact deterministic fingerprint deduplication |
+| One shard timeout is masked | Any incomplete shard forces an aggregate `HIGH` human-review result |
+| Path rules silently omit files | Require exact one-to-one primary ownership and route unknown paths to a cross-cutting shard |
+| Matrix output is mixed across runs | Bind every shard artifact to run ID, shard ID, exact base/head SHAs, and manifest digest |
+| Aggregation executes untrusted code | Use inline trusted default-branch logic without a PR checkout |
+| Parallelism increases API spend | Start at `max-parallel: 2`, record per-shard tokens, and cap the number of shards |
+| Rollout regresses review quality | Keep the single-agent configuration as rollback and require adjudicated recall before rollout |
+
+## Test plan
+
+- Unit-test path ownership, unknown-path fallback, deterministic domain merging,
+  shared-contract replication, and exact one-to-one changed-file coverage.
+- Assert byte-identical security boundary, schema, sandbox, model, and prompt
+  between production and benchmark shard jobs.
+- Test aggregate severity, stable ordering, exact deduplication, and fail-closed
+  behavior for missing, malformed, stale, timed-out, and cross-run artifacts.
+- Mock Actions APIs to distinguish verified budget timeout from setup, manual,
+  infrastructure, and supersession cancellation.
+- Run actionlint, Ruff, workflow-policy tests, and executable mocked posting
+  tests.
+- Replay the fixed adjudicated corpus and record packet size, duplicated bytes,
+  completion, wall time, tools, tokens, compactions, and human finding recall.
+- Run the large-PR corpus only after the adjudicated recall gate passes.
+- Observe the first 30 production runs before removing the single-agent rollback
+  path.

--- a/docs/plans/2026-08-27-sharded-codex-security-review-tdd.md
+++ b/docs/plans/2026-08-27-sharded-codex-security-review-tdd.md
@@ -76,19 +76,21 @@ rule ensures unknown paths are reviewed rather than dropped.
 Within each domain, the planner forms indivisible semantic units: Go packages,
 client feature directories, protobuf packages, a migration with its sqlc
 contract, plugin modules, or one deployment surface. It never splits a file or
-hunk. It then assigns units deterministically to no more than two shard packets,
-including replicated context, with both of these hard limits:
+hunk. The planner then collects units from every domain into one review-wide
+pool and assigns that pool to no more than two shard packets total, including
+replicated context. Domains do not receive separate packet allowances. Each of
+the two review-wide packets has both of these hard limits:
 
 - 500,000 bytes per complete packet.
 - 8,000 lines per complete packet.
 
 These initial limits are benchmark hypotheses. They split the known 812,319-byte,
-13,926-line PR #956 control into two possible packets while keeping both model
-jobs in one parallel wave. If one semantic unit exceeds either limit, shared
-context makes a packet exceed a limit, or the units require more than two
-bounded packets, the planner does not launch an unbounded model job. It emits a
-validated `oversized-review` incomplete result that requires human review and
-records the limiting units and packet measurements.
+13,926-line PR #956 control into two possible packets while keeping the entire
+review in one parallel wave. If one semantic unit exceeds either limit, shared
+context makes a packet exceed a limit, or the review-wide pool requires more
+than two bounded packets, the planner does not launch an unbounded model job. It
+emits a validated `oversized-review` incomplete result that requires human
+review and records the limiting units and packet measurements.
 
 ### Shared review context
 
@@ -99,8 +101,13 @@ Each shard receives:
 3. Changed shared contracts relevant to that shard, even when another shard
    owns them. Shared inputs include protobuf definitions, migrations and sqlc
    interfaces, API types, deployment schemas, and root build/runtime contracts.
-4. The same trusted prompt, model, security boundary, output schema, and
-   read-only sandbox as production.
+4. The production model, security boundary, output schema, read-only sandbox,
+   and common review guidance.
+5. A trusted shard-scope prompt stanza stating that the packet is the complete
+   authorized scope for this shard, not the complete PR diff; primary files are
+   its review ownership and shared files are supporting cross-boundary context.
+   It instructs the model not to regenerate the full PR diff and to report only
+   findings grounded in a primary change or its interaction with shared context.
 
 The packet records primary and shared files separately so duplicated contract
 context cannot be mistaken for duplicate review ownership. Every changed file
@@ -110,11 +117,13 @@ each complete packet against both hard size limits.
 
 ### Bounded shard execution
 
-Run shard reviewers as a matrix with bounded parallelism. The benchmark should
-start with a six-minute model budget per shard and reserve the existing
-five-minute Actions cancellation-cleanup allowance. Production timing is chosen
-only after benchmark evidence; it must keep trusted aggregation and artifact
-upload inside the current 15-minute end-to-end target.
+Run shard reviewers as one matrix wave with `max-parallel: 2`. Because the
+planner emits no more than two packets for the whole review, no second model
+wave can extend the deadline. The benchmark should start with a six-minute model
+budget per shard and reserve the existing five-minute Actions
+cancellation-cleanup allowance. Production timing is chosen only after
+benchmark evidence; it must keep the single parallel wave, trusted aggregation,
+and artifact upload inside the current 15-minute end-to-end target.
 
 Each shard emits the existing structured risk and Markdown contract plus trusted
 metadata identifying its shard, exact range, primary files, shared files, run
@@ -154,17 +163,23 @@ revalidating that the PR head is current.
    SHAs and trusted default-branch code.
 2. Replay the adjudicated corpus with `unified=40`, `xhigh`, and the baseline
    prompt. Compare against the unsharded control in the benchmark report.
-3. Human-adjudicate the union of shard findings. Across completed reviews,
+3. Require a completed aggregate for all six adjudicated corpus cases in the
+   initial candidate run. Any timeout or `oversized-review` rejects the
+   candidate before recall evaluation; hard finding-bearing cases cannot
+   disappear from the denominator.
+4. Human-adjudicate the union of shard findings. Across completed reviews,
    require every known `HIGH` and at least 90% of known `MEDIUM` findings.
    Require every newly reported `MEDIUM` or `HIGH` to be valid across the full
    corpus, not only the clean controls.
-4. Repeat only disagreements, misses, or cases within 10% of a shard budget.
-5. If the adjudicated gate passes, replay PRs #957 and #964. Both must produce a
+5. Repeat only disagreements, misses, or cases within 10% of a shard budget to
+   measure model variance. Repeats cannot erase a failure of the initial 6/6
+   completion gate.
+6. If the adjudicated gates pass, replay PRs #957 and #964. Both must produce a
    credible completed aggregate within 10 minutes and the final artifact within
    15 minutes. A validated timeout or `oversized-review` artifact demonstrates
    safe fallback behavior but blocks rollout because it does not improve the
    large-PR completion failure.
-6. Only after both large-PR cases pass, roll out behind a workflow-level switch
+7. Only after both large-PR cases pass, roll out behind a workflow-level switch
    that can return production to the single-agent path without weakening its
    current timeout or fail-closed behavior.
 
@@ -190,7 +205,8 @@ revalidating that the PR head is current.
 | Risk | Mitigation |
 | --- | --- |
 | A cross-domain bug is hidden | Replicate changed shared contracts and include the complete changed-file manifest in every shard |
-| Replicated context increases cost | Create only affected shards, cap concurrency, include shared bytes in the hard packet limits, and measure duplication |
+| Replicated context increases cost | Create only affected shards, cap the whole review at two packets, include shared bytes in the hard packet limits, and measure duplication |
+| A shard regenerates the full PR diff | State trusted primary/shared scope explicitly in the prompt and test that the full-diff instruction is absent |
 | Findings are duplicated | Preserve them by default; allow only exact deterministic fingerprint deduplication |
 | One shard timeout is masked | Any validated incomplete shard forces an aggregate `HIGH` human-review result |
 | Trusted handoff failure looks like model incompletion | Hard-fail missing, corrupt, stale, cross-run, or malformed artifacts; accept only validated incomplete evidence |
@@ -209,8 +225,10 @@ revalidating that the PR head is current.
 - Test both packet limits at, below, and above the boundary, including a single
   oversized unit, replicated context overflow, and a change requiring more than
   two packets.
-- Assert byte-identical security boundary, schema, sandbox, model, and prompt
-  between production and benchmark shard jobs.
+- Assert byte-identical model, security boundary, schema, common review guidance,
+  sandbox, and shard-scope prompt stanza between production and benchmark shard
+  jobs. Test that the stanza identifies primary/shared scope and prohibits
+  regenerating the full PR diff.
 - Test aggregate severity, stable ordering, exact deduplication, and validated
   timeout/oversized `HIGH` behavior. Separately prove missing, corrupt,
   malformed, stale, and cross-run artifacts hard-fail the workflow.
@@ -218,9 +236,10 @@ revalidating that the PR head is current.
   infrastructure, and supersession cancellation.
 - Run actionlint, Ruff, workflow-policy tests, and executable mocked posting
   tests.
-- Replay the fixed adjudicated corpus and record packet size, duplicated bytes,
-  completion, wall time, tools, tokens, compactions, human finding recall across
-  completed reviews, and the validity of every new `MEDIUM` or `HIGH`.
+- Replay the fixed adjudicated corpus and require 6/6 initial completion before
+  evaluating packet size, duplicated bytes, wall time, tools, tokens,
+  compactions, human finding recall, and the validity of every new `MEDIUM` or
+  `HIGH`.
 - Run the large-PR corpus only after the adjudicated recall and finding-validity
   gates pass; require both cases to complete credibly before rollout.
 - Observe the first 30 production runs before removing the single-agent rollback

--- a/docs/plans/2026-08-27-sharded-codex-security-review-tdd.md
+++ b/docs/plans/2026-08-27-sharded-codex-security-review-tdd.md
@@ -15,8 +15,9 @@ showed that diff context, reasoning effort, and prompt guidance do not make the
 current single-agent review complete reliably. Only 22 of 72 adjudicated matrix
 cases completed; the other 50 exhausted the 12-minute outer budget. Compact
 context downgraded a known `HIGH` in two of three trials, `medium` effort
-recalled only one of five known `MEDIUM` findings and produced an invalid new
-`HIGH`, and the bounded prompt also downgraded the known `HIGH`. Production
+recalled only one of four expected `MEDIUM` findings in completed reviews and
+produced an invalid new `HIGH`, and the bounded prompt also downgraded the known
+`HIGH`. Production
 therefore remains on `unified=40`,
 `xhigh`, and the baseline prompt.
 
@@ -30,8 +31,8 @@ contracts or relying on a second unbounded model pass.
 
 - Complete normal and large semantic reviews within the existing end-to-end
   production bound.
-- Preserve every adjudicated `HIGH` and at least 90% of adjudicated `MEDIUM`
-  findings without severity downgrade.
+- Across completed reviews, preserve every adjudicated `HIGH` and at least 90%
+  of adjudicated `MEDIUM` findings without severity downgrade.
 - Preserve the exact three-dot diff, pinned SHAs, prompt-injection boundary,
   read-only sandbox, and fail-closed artifact contract.
 - Keep cross-component contract changes visible to every affected shard.
@@ -153,24 +154,27 @@ revalidating that the PR head is current.
    SHAs and trusted default-branch code.
 2. Replay the adjudicated corpus with `unified=40`, `xhigh`, and the baseline
    prompt. Compare against the unsharded control in the benchmark report.
-3. Human-adjudicate the union of shard findings. Require every known `HIGH`, at
-   least 90% of known `MEDIUM` findings, and no invalid `HIGH` on either clean
-   control.
+3. Human-adjudicate the union of shard findings. Across completed reviews,
+   require every known `HIGH` and at least 90% of known `MEDIUM` findings.
+   Require every newly reported `MEDIUM` or `HIGH` to be valid across the full
+   corpus, not only the clean controls.
 4. Repeat only disagreements, misses, or cases within 10% of a shard budget.
-5. If the adjudicated gate passes, replay PRs #957 and #964. Require a credible
-   aggregate review or an explicit incomplete `HIGH` artifact within 15 minutes.
-6. Roll out behind a workflow-level switch that can return production to the
-   single-agent path without weakening its current timeout or fail-closed
-   behavior.
+5. If the adjudicated gate passes, replay PRs #957 and #964. Both must produce a
+   credible completed aggregate within 10 minutes and the final artifact within
+   15 minutes. A validated timeout or `oversized-review` artifact demonstrates
+   safe fallback behavior but blocks rollout because it does not improve the
+   large-PR completion failure.
+6. Only after both large-PR cases pass, roll out behind a workflow-level switch
+   that can return production to the single-agent path without weakening its
+   current timeout or fail-closed behavior.
 
 ## Alternatives considered
 
 - **More single-agent prompt tuning:** Rejected because the bounded prompt had
   the same 2/6 completion profile and downgraded an adjudicated `HIGH`.
 - **Lower reasoning effort:** Rejected because `high` completed 2/6 cases;
-  `medium` completed 5/6 but recalled only one of five known `MEDIUM` findings
-  and one of two known `HIGH` findings, while also producing an invalid new
-  `HIGH`.
+  `medium` completed 5/6 but recalled only one of four expected `MEDIUM`
+  findings in completed reviews, while also producing an invalid new `HIGH`.
 - **Smaller global diff context:** Rejected after three trials per variant. Every
   variant missed all 15 expected `MEDIUM` observations, and compact context
   downgraded a known `HIGH` in two trials.
@@ -215,7 +219,9 @@ revalidating that the PR head is current.
 - Run actionlint, Ruff, workflow-policy tests, and executable mocked posting
   tests.
 - Replay the fixed adjudicated corpus and record packet size, duplicated bytes,
-  completion, wall time, tools, tokens, compactions, and human finding recall.
-- Run the large-PR corpus only after the adjudicated recall gate passes.
+  completion, wall time, tools, tokens, compactions, human finding recall across
+  completed reviews, and the validity of every new `MEDIUM` or `HIGH`.
+- Run the large-PR corpus only after the adjudicated recall and finding-validity
+  gates pass; require both cases to complete credibly before rollout.
 - Observe the first 30 production runs before removing the single-agent rollback
   path.

--- a/docs/plans/2026-08-27-sharded-codex-security-review-tdd.md
+++ b/docs/plans/2026-08-27-sharded-codex-security-review-tdd.md
@@ -12,10 +12,12 @@ tracker:
 
 The [bounded-review benchmark](../codex-security-review-benchmark-report.md)
 showed that diff context, reasoning effort, and prompt guidance do not make the
-current single-agent review complete reliably. Only 8 of 30 adjudicated matrix
-cases completed; the other 22 exhausted the 12-minute outer budget. Reduced
-context and the bounded prompt also downgraded a known `HIGH` finding, so
-production remains on `unified=40`, `xhigh`, and the baseline prompt.
+current single-agent review complete reliably. Only 22 of 72 adjudicated matrix
+cases completed; the other 50 exhausted the 12-minute outer budget. Compact
+context downgraded a known `HIGH` in two of three trials, `medium` effort
+recalled only one of five known `MEDIUM` findings, and the bounded prompt also
+downgraded the known `HIGH`. Production therefore remains on `unified=40`,
+`xhigh`, and the baseline prompt.
 
 The existing reviewer has one model process inspect the full exact diff and any
 unchanged files it chooses. Large cross-component changes can therefore consume
@@ -55,8 +57,8 @@ stable architecture domains:
 | --- | --- |
 | Contracts and persistence | `proto/`, migrations, sqlc queries, generated API boundaries |
 | Server | `server/` excluding shared contract inputs |
-| ProtoFleet and shared client | ProtoFleet plus allowed `client/shared/` dependencies |
-| ProtoOS and shared client | ProtoOS plus allowed `client/shared/` dependencies |
+| ProtoFleet and shared client | `client/src/protoFleet/` plus allowed `client/src/shared/` dependencies |
+| ProtoOS and shared client | `client/src/protoOS/` plus allowed `client/src/shared/` dependencies |
 | Go/Python plugins | `plugin/` except `plugin/asicrs/`, generator packages |
 | ASIC-RS | `plugin/asicrs/` |
 | Delivery and infrastructure | `.github/`, Docker, deployment, monitoring, scripts, root tooling |
@@ -67,9 +69,10 @@ file, its owning shard, and shared-contract membership. Unknown paths go to a
 conservative cross-cutting shard rather than being dropped.
 
 Create a shard only when its primary domain has changed. Cap the first
-experiment at four concurrent shards. If more than four domains change, combine
-adjacent domains according to a checked-in deterministic merge order; never
-split a domain merely to equalize bytes.
+experiment at two shards so both model jobs can run in one bounded parallel
+wave. If more than two domains change, combine adjacent domains according to a
+checked-in deterministic merge order; never split a domain merely to equalize
+bytes.
 
 ### Shared review context
 
@@ -141,11 +144,12 @@ revalidating that the PR head is current.
 
 - **More single-agent prompt tuning:** Rejected because the bounded prompt had
   the same 2/6 completion profile and downgraded an adjudicated `HIGH`.
-- **Lower reasoning effort:** Rejected because `high` had the same 2/6
-  completion profile and missed the known `MEDIUM`; `medium` was therefore not
-  tested.
-- **Smaller global diff context:** Rejected because compact context downgraded a
-  known `HIGH`, while `unified-10` completed no finding-bearing case.
+- **Lower reasoning effort:** Rejected because `high` completed 2/6 cases;
+  `medium` completed 5/6 but recalled only one of five known `MEDIUM` findings
+  and one of two known `HIGH` findings.
+- **Smaller global diff context:** Rejected after three trials per variant. Every
+  variant missed all 15 expected `MEDIUM` observations, and compact context
+  downgraded a known `HIGH` in two trials.
 - **Arbitrary equal-size shards:** Rejected because they can hide transaction,
   API, and lifecycle relationships that cross files.
 - **Model-based aggregation:** Rejected because it adds another unbounded pass


### PR DESCRIPTION
Reviewable diff: +424/-3 across 3 files (excludes generated, test, and story files).

## Summary

Records all 72 trusted Codex security-review benchmark cases and the human finding adjudication that followed PR #965. The evidence rejects reduced context, lower effort, and bounded-prompt candidates, keeps production on `unified=40` + `xhigh` + the baseline prompt, and scopes architecture-aware sharding as the next design experiment.

## How it works

The report ties each conclusion to the trusted `main` workflow run that produced it, summarizes completed and verified-timeout artifacts, and evaluates each candidate against the plan's recall gates. The existing plan records why `medium` effort was rejected and the large-PR corpus was gated off, while a separate draft TDD defines deterministic architecture shards, shared contract context, fail-closed aggregation, and the benchmark sequence required before rollout.

```mermaid
flowchart LR
    A["Trusted benchmark runs"] --> B["Human finding adjudication"]
    B --> C["Checked-in benchmark report"]
    C --> D["Retain production control"]
    C --> E["Draft architecture-aware sharding TDD"]
    E --> F["Future adjudicated benchmark"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `docs/codex-security-review-benchmark-report.md` | Records 72 matrix cases, run links, timing/tool/token metrics, recall and false-positive adjudication, and the production recommendation | Verify the evidence supports rejecting each candidate |
| `docs/plans/2026-08-25-bounded-codex-security-review-plan.md` | Adds the measured outcome and makes large-PR replay conditional on selecting a candidate | Verify the outcome remains consistent with the original experiment gates |
| `docs/plans/2026-08-27-sharded-codex-security-review-tdd.md` | Defines trusted planning, shared contract context, bounded execution, deterministic aggregation, and benchmark gates | Review the proposed security boundaries and cross-domain recall strategy; implementation remains out of scope |

## Key technical decisions & trade-offs

- Keep `unified=40`, `xhigh`, and the baseline prompt rather than adopting candidates that missed or downgraded adjudicated findings.
- Reject `medium` despite 5/6 completion because it recalled only one of four expected `MEDIUM` findings across completed reviews while also producing an invalid new `HIGH`.
- Require 6/6 adjudicated-corpus completion before candidate selection, then require both large cases to complete before any sharded rollout.
- Prefer architecture-aware shards with replicated shared contracts and a review-wide two-packet cap, hard 500,000-byte/8,000-line packet bounds, and a shard-aware prompt over unbounded or equal-size shards that can hide cross-component bugs.
- Use deterministic aggregation and preserve possible duplicates rather than adding another unbounded model pass.
- Treat validated timeout or oversized shards as aggregate `HIGH`; hard-fail missing, corrupt, stale, or cross-run artifacts rather than masking automation failures.

## Testing & validation

- Verified all six trusted benchmark runs completed their finalizers and uploaded one artifact for each of 72 matrix cases.
- Reconciled result artifacts with action-log wall time, tool-call, token, repeat-read, and compaction metrics.
- Confirmed local Markdown links resolve.
- Ran `git diff --check` and repository commit/push hooks.
- No workflow or production code changes are included. Sharding implementation, large-PR replay, and the first-30-production-run observation remain untested and out of scope.





