### PR TITLE
Enable topology response profiles for curtailment automation

### DIFF
--- a/client/src/protoFleet/api/useCurtailmentResponseProfiles.test.tsx
+++ b/client/src/protoFleet/api/useCurtailmentResponseProfiles.test.tsx
@@ -494,7 +494,7 @@ describe("useCurtailmentResponseProfiles", () => {
     expect(result.current.responseProfiles[0]).toMatchObject({
       scope: "2 buildings",
       isReadOnly: false,
-      isAutomationReady: false,
+      isAutomationReady: true,
       formValues: expect.objectContaining({ scopeType: "building", buildingTargetIds: ["7", "8"] }),
     });
   });
@@ -888,6 +888,7 @@ describe("useCurtailmentResponseProfiles", () => {
       scope: "Unknown scope",
       formValues: undefined,
       isReadOnly: true,
+      isAutomationReady: false,
     });
   });
 
@@ -912,8 +913,20 @@ describe("useCurtailmentResponseProfiles", () => {
     });
 
     expect(result.current.responseProfiles).toEqual([
-      expect.objectContaining({ id: "8", scope: "Unknown scope", formValues: undefined, isReadOnly: true }),
-      expect.objectContaining({ id: "9", scope: "Unknown scope", formValues: undefined, isReadOnly: true }),
+      expect.objectContaining({
+        id: "8",
+        scope: "Unknown scope",
+        formValues: undefined,
+        isReadOnly: true,
+        isAutomationReady: false,
+      }),
+      expect.objectContaining({
+        id: "9",
+        scope: "Unknown scope",
+        formValues: undefined,
+        isReadOnly: true,
+        isAutomationReady: false,
+      }),
     ]);
   });
 
@@ -977,21 +990,21 @@ describe("useCurtailmentResponseProfiles", () => {
           name: "Buildings",
           scope: "2 buildings",
           isReadOnly: false,
-          isAutomationReady: false,
+          isAutomationReady: true,
           formValues: expect.objectContaining({ scopeType: "building", buildingTargetIds: ["7", "8"] }),
         }),
         expect.objectContaining({
           name: "Rack",
           scope: "1 rack",
           isReadOnly: false,
-          isAutomationReady: false,
+          isAutomationReady: true,
           formValues: expect.objectContaining({ scopeType: "rack", rackTargetIds: ["9"] }),
         }),
         expect.objectContaining({
           name: "Groups",
           scope: "2 groups",
           isReadOnly: false,
-          isAutomationReady: false,
+          isAutomationReady: true,
           formValues: expect.objectContaining({ scopeType: "group", groupTargetIds: ["10", "11"] }),
         }),
       ]),

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentAutomations.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentAutomations.test.tsx
@@ -211,12 +211,17 @@ describe("CurtailmentAutomationsContent", () => {
     expect(responseProfileSelect).toHaveTextContent("Facility fan shed");
   });
 
-  it("excludes profiles whose target scope is not ready for automation", () => {
+  it("includes topology-scoped profiles whose target scope is ready for automation", () => {
     const topologyProfile: ResponseProfile = {
       ...testResponseProfiles[0],
       id: "building-shed",
       name: "Building shed",
-      isAutomationReady: false,
+      scope: "1 building",
+      formValues: {
+        scopeType: "building",
+        buildingTargetIds: ["7"],
+      } as NonNullable<ResponseProfile["formValues"]>,
+      isAutomationReady: true,
     };
     render(
       <CurtailmentAutomationsContent
@@ -228,27 +233,29 @@ describe("CurtailmentAutomationsContent", () => {
     fireEvent.click(screen.getByRole("button", { name: "Create automation" }));
     const responseProfileSelect = screen.getByTestId("automation-response-profile-select");
 
-    expect(responseProfileSelect).toHaveTextContent("Standard shed");
-    expect(responseProfileSelect).not.toHaveTextContent("Building shed");
+    expect(responseProfileSelect).toHaveTextContent("Building shed");
   });
 
   it("prevents enabling an automation whose response profile is not automation-ready", () => {
-    const topologyProfile: ResponseProfile = {
+    const unsupportedProfile: ResponseProfile = {
       ...testResponseProfiles[0],
-      id: "building-shed",
-      name: "Building shed",
+      id: "unsupported-profile",
+      name: "Unsupported profile",
+      scope: "Unknown scope",
+      formValues: undefined,
+      isReadOnly: true,
       isAutomationReady: false,
     };
-    const topologyRule: AutomationRule = {
+    const unsupportedRule: AutomationRule = {
       ...testAutomationRules[0],
-      responseProfileId: topologyProfile.id,
+      responseProfileId: unsupportedProfile.id,
       enabled: false,
     };
     render(
       <CurtailmentAutomationsContent
-        initialAutomationRules={[topologyRule]}
+        initialAutomationRules={[unsupportedRule]}
         sources={testSources}
-        responseProfiles={[topologyProfile]}
+        responseProfiles={[unsupportedProfile]}
       />,
     );
 

--- a/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Curtailment/CurtailmentSettingsPage.test.tsx
@@ -1376,7 +1376,7 @@ describe("CurtailmentSettingsPage", () => {
         siteIds: [],
       },
       isReadOnly: false,
-      isAutomationReady: false,
+      isAutomationReady: true,
     };
 
     render(<CurtailmentSettingsContent initialResponseProfiles={[topologyProfile]} />);

--- a/client/src/protoFleet/features/settings/components/Curtailment/types.ts
+++ b/client/src/protoFleet/features/settings/components/Curtailment/types.ts
@@ -1,4 +1,4 @@
-import { type CurtailmentTerminalScopeType, isCurtailmentTopologyScopeType } from "@/protoFleet/api/curtailmentScopes";
+import { type CurtailmentTerminalScopeType } from "@/protoFleet/api/curtailmentScopes";
 
 export type CurtailmentHealth = "connected" | "waitingForSignal" | "noSignal" | "offline";
 export type AutomationTriggerType = "MQTT";
@@ -45,7 +45,7 @@ export type ResponseProfileSiteSelection = "none" | "allSites" | "site";
 export type ResponseProfileScopeType = CurtailmentTerminalScopeType;
 
 export function isResponseProfileAutomationReady(scopeType: ResponseProfileScopeType | undefined): boolean {
-  return scopeType !== undefined && !isCurtailmentTopologyScopeType(scopeType);
+  return scopeType !== undefined;
 }
 
 export type ResponseProfileFormValues = {

--- a/server/generated/sqlc/curtailment_automation.sql.go
+++ b/server/generated/sqlc/curtailment_automation.sql.go
@@ -683,20 +683,25 @@ SELECT rule.id
 FROM curtailment_automation_rule AS rule
 JOIN curtailment_automation_rule_profile_revision AS rule_revision
   ON rule_revision.automation_rule_id = rule.id
+JOIN curtailment_mqtt_source_config AS source
+  ON source.id = rule.mqtt_source_id
+ AND source.organization_id = rule.org_id
 WHERE rule.id = $1
   AND rule.org_id = $2
   AND rule.enabled = TRUE
   AND rule.trigger_type = 'MQTT'
   AND rule.mqtt_source_id = $3
-  AND rule.response_profile_id = $4
-  AND rule_revision.response_profile_revision = $5
-FOR UPDATE OF rule, rule_revision
+  AND source.service_user_id = $4
+  AND rule.response_profile_id = $5
+  AND rule_revision.response_profile_revision = $6
+FOR UPDATE OF rule, rule_revision, source
 `
 
 type LockCurtailmentAutomationRuleForExecutionParams struct {
 	ID                      int64
 	OrgID                   int64
 	MqttSourceID            int64
+	ServiceUserID           int64
 	ResponseProfileID       int64
 	ResponseProfileRevision uuid.UUID
 }
@@ -706,6 +711,7 @@ func (q *Queries) LockCurtailmentAutomationRuleForExecution(ctx context.Context,
 		arg.ID,
 		arg.OrgID,
 		arg.MqttSourceID,
+		arg.ServiceUserID,
 		arg.ResponseProfileID,
 		arg.ResponseProfileRevision,
 	)

--- a/server/generated/sqlc/db.go
+++ b/server/generated/sqlc/db.go
@@ -864,6 +864,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.getUserRoleNameStmt, err = db.PrepareContext(ctx, getUserRoleName); err != nil {
 		return nil, fmt.Errorf("error preparing query GetUserRoleName: %w", err)
 	}
+	if q.getUserRoleNameForUpdateStmt, err = db.PrepareContext(ctx, getUserRoleNameForUpdate); err != nil {
+		return nil, fmt.Errorf("error preparing query GetUserRoleNameForUpdate: %w", err)
+	}
 	if q.getUsersForOrganizationStmt, err = db.PrepareContext(ctx, getUsersForOrganization); err != nil {
 		return nil, fmt.Errorf("error preparing query GetUsersForOrganization: %w", err)
 	}
@@ -3121,6 +3124,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing getUserRoleNameStmt: %w", cerr)
 		}
 	}
+	if q.getUserRoleNameForUpdateStmt != nil {
+		if cerr := q.getUserRoleNameForUpdateStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getUserRoleNameForUpdateStmt: %w", cerr)
+		}
+	}
 	if q.getUsersForOrganizationStmt != nil {
 		if cerr := q.getUsersForOrganizationStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing getUsersForOrganizationStmt: %w", cerr)
@@ -4860,6 +4868,7 @@ type Queries struct {
 	getUserByUsernameStmt                                        *sql.Stmt
 	getUserRoleInOrganizationStmt                                *sql.Stmt
 	getUserRoleNameStmt                                          *sql.Stmt
+	getUserRoleNameForUpdateStmt                                 *sql.Stmt
 	getUsersForOrganizationStmt                                  *sql.Stmt
 	hasUserStmt                                                  *sql.Stmt
 	insertActivityLogStmt                                        *sql.Stmt
@@ -5430,6 +5439,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		getUserByUsernameStmt:                                        q.getUserByUsernameStmt,
 		getUserRoleInOrganizationStmt:                                q.getUserRoleInOrganizationStmt,
 		getUserRoleNameStmt:                                          q.getUserRoleNameStmt,
+		getUserRoleNameForUpdateStmt:                                 q.getUserRoleNameForUpdateStmt,
 		getUsersForOrganizationStmt:                                  q.getUsersForOrganizationStmt,
 		hasUserStmt:                                                  q.hasUserStmt,
 		insertActivityLogStmt:                                        q.insertActivityLogStmt,

--- a/server/generated/sqlc/querier.go
+++ b/server/generated/sqlc/querier.go
@@ -769,6 +769,7 @@ type Querier interface {
 	GetUserByUsername(ctx context.Context, username string) (User, error)
 	GetUserRoleInOrganization(ctx context.Context, arg GetUserRoleInOrganizationParams) (Role, error)
 	GetUserRoleName(ctx context.Context, arg GetUserRoleNameParams) (string, error)
+	GetUserRoleNameForUpdate(ctx context.Context, arg GetUserRoleNameForUpdateParams) (string, error)
 	GetUsersForOrganization(ctx context.Context, organizationID int64) ([]User, error)
 	HasUser(ctx context.Context) (bool, error)
 	// The unique partial index on (batch_id, event_type) for '*.completed' event

--- a/server/generated/sqlc/retrying_querier.gen.go
+++ b/server/generated/sqlc/retrying_querier.gen.go
@@ -3246,6 +3246,18 @@ func (q *retryingQuerier) GetUserRoleName(ctx context.Context, arg GetUserRoleNa
 	return result, err
 }
 
+func (q *retryingQuerier) GetUserRoleNameForUpdate(ctx context.Context, arg GetUserRoleNameForUpdateParams) (string, error) {
+	var result string
+	err := q.retrier.RetryQuery(ctx, "GetUserRoleNameForUpdate", func() error {
+		callResult, callErr := q.next.GetUserRoleNameForUpdate(ctx, arg)
+		if callErr == nil {
+			result = callResult
+		}
+		return callErr
+	})
+	return result, err
+}
+
 func (q *retryingQuerier) GetUsersForOrganization(ctx context.Context, organizationID int64) ([]User, error) {
 	var result []User
 	err := q.retrier.RetryQuery(ctx, "GetUsersForOrganization", func() error {

--- a/server/generated/sqlc/user_organization.sql.go
+++ b/server/generated/sqlc/user_organization.sql.go
@@ -113,6 +113,28 @@ func (q *Queries) GetUserRoleName(ctx context.Context, arg GetUserRoleNameParams
 	return name, err
 }
 
+const getUserRoleNameForUpdate = `-- name: GetUserRoleNameForUpdate :one
+SELECT r.name
+FROM role r
+JOIN user_organization uo ON r.id = uo.role_id
+WHERE uo.user_id = $1
+  AND uo.organization_id = $2
+  AND uo.deleted_at IS NULL
+FOR UPDATE OF uo
+`
+
+type GetUserRoleNameForUpdateParams struct {
+	UserID         int64
+	OrganizationID int64
+}
+
+func (q *Queries) GetUserRoleNameForUpdate(ctx context.Context, arg GetUserRoleNameForUpdateParams) (string, error) {
+	row := q.queryRow(ctx, q.getUserRoleNameForUpdateStmt, getUserRoleNameForUpdate, arg.UserID, arg.OrganizationID)
+	var name string
+	err := row.Scan(&name)
+	return name, err
+}
+
 const getUsersForOrganization = `-- name: GetUsersForOrganization :many
 SELECT u.id, u.user_id, u.username, u.password_hash, u.password_updated_at, u.last_login_at, u.requires_password_change, u.created_at, u.updated_at, u.deleted_at
 FROM "user" u

--- a/server/internal/domain/curtailment/authorization_envelope.go
+++ b/server/internal/domain/curtailment/authorization_envelope.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/block/proto-fleet/server/internal/domain/authz"
 	"github.com/block/proto-fleet/server/internal/domain/curtailment/models"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 )
@@ -16,6 +17,55 @@ var authorizationEnvelopeFields = [...]string{
 	"miner_scope_unbounded",
 	"facility_fan_site_ids",
 	"facility_fan_scope_unbounded",
+}
+
+// AuthorizationEnvelopeAllows reports whether the current permission snapshot
+// covers both the persisted authorization envelope and any current topology
+// coverage discovered at a later execution fence.
+func AuthorizationEnvelopeAllows(
+	effective *authz.EffectivePermissions,
+	envelope models.AuthorizationEnvelope,
+	currentSelectedResourceSiteIDs []int64,
+	currentMemberSiteIDs []int64,
+	currentRequiresOrgWide bool,
+) bool {
+	if effective == nil {
+		return false
+	}
+	requireOrgWideManage := envelope.MinerScopeUnbounded ||
+		envelope.FacilityFanScopeUnbounded ||
+		currentRequiresOrgWide
+	if requireOrgWideManage && !effective.HasOrgWide(authz.PermCurtailmentManage) {
+		return false
+	}
+	manageSites := make(map[int64]struct{})
+	for _, sites := range [][]int64{
+		envelope.SelectedResourceSiteIDs,
+		envelope.CurrentMemberSiteIDs,
+		envelope.FacilityFanSiteIDs,
+		currentSelectedResourceSiteIDs,
+		currentMemberSiteIDs,
+	} {
+		for _, siteID := range sites {
+			manageSites[siteID] = struct{}{}
+		}
+	}
+	for siteID := range manageSites {
+		id := siteID
+		if !effective.Has(authz.PermCurtailmentManage, authz.ResourceContext{SiteID: &id}) {
+			return false
+		}
+	}
+	if envelope.FacilityFanScopeUnbounded && !effective.HasOrgWide(authz.PermSiteRead) {
+		return false
+	}
+	for _, siteID := range envelope.FacilityFanSiteIDs {
+		id := siteID
+		if !effective.Has(authz.PermSiteRead, authz.ResourceContext{SiteID: &id}) {
+			return false
+		}
+	}
+	return true
 }
 
 // AuthorizationEnvelopeFromJSON parses the persisted authorization snapshot.

--- a/server/internal/domain/curtailment/automation.go
+++ b/server/internal/domain/curtailment/automation.go
@@ -367,7 +367,7 @@ func (s *AutomationService) handleRuleOff(ctx context.Context, rule *models.Auto
 		}
 		return s.store.SetAutomationActiveEvent(ctx, rule.ID, signal.Source.ID, replayEvent.EventUUID, at)
 	}
-	if err := validateBoundAutomationProfile(rule, profile); err != nil {
+	if _, err := s.currentBoundAutomationProfile(ctx, rule); err != nil {
 		return err
 	}
 	plan, err := s.curtailment.Start(ctx, startReq)
@@ -536,7 +536,7 @@ func (s *AutomationService) validateAndNormalize(
 			"curtailment response profile changed before automation rule save; retry",
 		)
 	}
-	if err := validateAutomationProfileBinding(profile, canUseAdminControls); err != nil {
+	if err := s.validateAutomationProfileBinding(ctx, profile, canUseAdminControls); err != nil {
 		return models.AutomationRule{}, models.ResponseProfileFanSettings{}, err
 	}
 	if !sameResponseProfileFanSettings(responseProfileFanSettings(profile), expectedFanSettings) {
@@ -580,7 +580,7 @@ func (s *AutomationService) ensureProfileCanBeAutomated(
 			"curtailment response profile changed before automation rule save; retry",
 		)
 	}
-	if err := validateAutomationProfileBinding(profile, canUseAdminControls); err != nil {
+	if err := s.validateAutomationProfileBinding(ctx, profile, canUseAdminControls); err != nil {
 		return models.ResponseProfileFanSettings{}, err
 	}
 	if !sameResponseProfileFanSettings(responseProfileFanSettings(profile), expectedFanSettings) {
@@ -605,6 +605,9 @@ func (s *AutomationService) currentBoundAutomationProfile(
 	if err := validateBoundAutomationProfile(rule, profile); err != nil {
 		return nil, err
 	}
+	if err := s.profiles.ValidateAutomationScope(ctx, profile); err != nil {
+		return nil, err
+	}
 	return profile, nil
 }
 
@@ -622,18 +625,16 @@ func validateBoundAutomationProfile(rule *models.AutomationRule, profile *models
 	return nil
 }
 
-func validateAutomationProfileBinding(profile *models.ResponseProfile, canUseAdminControls bool) error {
+func (s *AutomationService) validateAutomationProfileBinding(
+	ctx context.Context,
+	profile *models.ResponseProfile,
+	canUseAdminControls bool,
+) error {
 	if profile == nil {
 		return nil
 	}
-	scope, err := ResponseProfileScope(*profile)
-	if err != nil {
+	if err := s.profiles.ValidateAutomationScope(ctx, profile); err != nil {
 		return err
-	}
-	if hasTopologySelectors(scope) {
-		return fleeterror.NewFailedPreconditionError(
-			"topology-scoped response profiles cannot be used by automation until topology curtailment execution is supported",
-		)
 	}
 	if canUseAdminControls || !responseProfileRequiresAdminControls(*profile) {
 		return nil

--- a/server/internal/domain/curtailment/automation.go
+++ b/server/internal/domain/curtailment/automation.go
@@ -608,9 +608,6 @@ func (s *AutomationService) currentBoundAutomationProfile(
 	if err := validateBoundAutomationProfile(rule, profile); err != nil {
 		return nil, err
 	}
-	if err := s.profiles.ValidateAutomationScope(ctx, profile); err != nil {
-		return nil, err
-	}
 	return profile, nil
 }
 

--- a/server/internal/domain/curtailment/automation.go
+++ b/server/internal/domain/curtailment/automation.go
@@ -323,7 +323,7 @@ func (s *AutomationService) handleRuleOff(ctx context.Context, rule *models.Auto
 		case event.State.IsTerminal():
 			// Stale terminal state; start a fresh event below.
 		case event.State == models.EventStateRestoring:
-			return s.recurtailAutomationEvent(ctx, rule, signal.Source.ID, event, at)
+			return s.recurtailAutomationEvent(ctx, rule, signal.Source, event, at)
 		default:
 			return nil
 		}
@@ -363,7 +363,7 @@ func (s *AutomationService) handleRuleOff(ctx context.Context, rule *models.Auto
 			return err
 		}
 		if replayEvent.State == models.EventStateRestoring {
-			return s.recurtailAutomationEvent(ctx, rule, signal.Source.ID, replayEvent, at)
+			return s.recurtailAutomationEvent(ctx, rule, signal.Source, replayEvent, at)
 		}
 		return s.store.SetAutomationActiveEvent(ctx, rule.ID, signal.Source.ID, replayEvent.EventUUID, at)
 	}
@@ -403,7 +403,7 @@ func (s *AutomationService) handleRuleOff(ctx context.Context, rule *models.Auto
 func (s *AutomationService) recurtailAutomationEvent(
 	ctx context.Context,
 	rule *models.AutomationRule,
-	mqttSourceID int64,
+	mqttSource mqttingest.SourceConfig,
 	event *models.Event,
 	at time.Time,
 ) error {
@@ -418,11 +418,14 @@ func (s *AutomationService) recurtailAutomationEvent(
 		EventUUID:               event.EventUUID,
 		ResponseProfileID:       rule.ResponseProfileID,
 		ResponseProfileRevision: rule.ResponseProfileRevision,
+		AutomationRuleID:        rule.ID,
+		AutomationMQTTSourceID:  mqttSource.ID,
+		AutomationServiceUserID: mqttSource.ServiceUserID,
 	})
 	if err != nil {
 		return err
 	}
-	return s.store.SetAutomationActiveEvent(ctx, rule.ID, mqttSourceID, recurtailed.EventUUID, at)
+	return s.store.SetAutomationActiveEvent(ctx, rule.ID, mqttSource.ID, recurtailed.EventUUID, at)
 }
 
 func (s *AutomationService) handleRuleOn(ctx context.Context, rule *models.AutomationRule, at time.Time) error {
@@ -786,15 +789,21 @@ func validateAutomationReplayOwnership(event *models.Event, rule *models.Automat
 	if err != nil || event == nil {
 		return err
 	}
-	externalReference, idempotencyKey := automationRuleEventReference(rule.ID)
-	if event.OrgID != rule.OrgID ||
+	return ValidateAutomationEventOwnership(event, rule.OrgID, rule.ID)
+}
+
+// ValidateAutomationEventOwnership verifies that a persisted event carries
+// every immutable ownership marker for the expected automation rule.
+func ValidateAutomationEventOwnership(event *models.Event, orgID, ruleID int64) error {
+	externalReference, idempotencyKey := automationRuleEventReference(ruleID)
+	if event == nil || event.OrgID != orgID ||
 		event.SourceActorType != models.SourceActorAutomation ||
 		event.ExternalSource == nil || *event.ExternalSource != automationExternalSource ||
 		event.ExternalReference == nil || *event.ExternalReference != externalReference ||
 		event.IdempotencyKey == nil || *event.IdempotencyKey != idempotencyKey ||
 		event.SourceActorID == nil || *event.SourceActorID != externalReference {
 		return fleeterror.NewFailedPreconditionError(
-			"automation idempotency replay resolved to an event not owned by this automation rule",
+			"curtailment event is not owned by this automation rule",
 		)
 	}
 	return nil

--- a/server/internal/domain/curtailment/automation_test.go
+++ b/server/internal/domain/curtailment/automation_test.go
@@ -204,7 +204,85 @@ func TestAutomationService_CreateRejectsStaleResponseProfileRevision(t *testing.
 	assert.Equal(t, 0, h.rules.createCalls)
 }
 
-func TestAutomationService_RejectsTopologyProfileAcrossBindingMutations(t *testing.T) {
+func TestAutomationService_AllowsTopologyProfileAcrossBindingMutations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		wantName string
+		run      func(*automationHarness) (*models.AutomationRule, error)
+	}{
+		{
+			name:     "create",
+			wantName: "Topology automation",
+			run: func(h *automationHarness) (*models.AutomationRule, error) {
+				return h.automation.Create(h.t.Context(), SaveAutomationRuleRequest{
+					Rule: models.AutomationRule{
+						OrgID:             h.orgID,
+						RuleName:          "Topology automation",
+						MQTTSourceID:      h.source.ID,
+						ResponseProfileID: h.profile.ID,
+					},
+					CanUseAdminControls:             true,
+					ExpectedResponseProfileRevision: h.profile.Revision,
+				})
+			},
+		},
+		{
+			name:     "update",
+			wantName: "Topology automation",
+			run: func(h *automationHarness) (*models.AutomationRule, error) {
+				return h.automation.Update(h.t.Context(), SaveAutomationRuleRequest{
+					Rule: models.AutomationRule{
+						ID:                h.rule.ID,
+						OrgID:             h.orgID,
+						RuleName:          "Topology automation",
+						MQTTSourceID:      h.source.ID,
+						ResponseProfileID: h.profile.ID,
+					},
+					CanUseAdminControls:             true,
+					ExpectedResponseProfileRevision: h.profile.Revision,
+				})
+			},
+		},
+		{
+			name:     "enable",
+			wantName: "MaestroOS curtailment",
+			run: func(h *automationHarness) (*models.AutomationRule, error) {
+				h.rule.Enabled = false
+				return h.automation.SetEnabled(
+					h.t.Context(),
+					h.orgID,
+					h.rule.ID,
+					true,
+					h.profile.Revision,
+					true,
+					models.ResponseProfileFanSettings{},
+				)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			h := newAutomationHarness(t)
+			h.profile.SiteID = nil
+			h.profile.ScopeJSON = []byte(`{"scope_schema_version":1,"building_ids":[7]}`)
+
+			updated, err := tt.run(h)
+
+			require.NoError(t, err)
+			require.NotNil(t, updated)
+			assert.Equal(t, tt.wantName, updated.RuleName)
+			assert.Equal(t, h.profile.ID, updated.ResponseProfileID)
+			assert.Equal(t, h.profile.Revision, updated.ResponseProfileRevision)
+		})
+	}
+}
+
+func TestAutomationService_RejectsUnavailableTopologyProfile(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -260,6 +338,15 @@ func TestAutomationService_RejectsTopologyProfileAcrossBindingMutations(t *testi
 				return err
 			},
 		},
+		{
+			name: "execute",
+			run: func(h *automationHarness) error {
+				return h.automation.HandleMQTTSignal(h.t.Context(), mqttingest.SignalEdge{
+					Source: h.source,
+					Target: mqttingest.TargetOff,
+				})
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -269,14 +356,16 @@ func TestAutomationService_RejectsTopologyProfileAcrossBindingMutations(t *testi
 			h := newAutomationHarness(t)
 			h.profile.SiteID = nil
 			h.profile.ScopeJSON = []byte(`{"scope_schema_version":1,"building_ids":[7]}`)
+			h.profiles.topologyCoverageErr = fleeterror.NewNotFoundError("buildings not found in caller's org: [7]")
 
 			err := tt.run(h)
 
 			require.Error(t, err)
-			assert.True(t, fleeterror.IsFailedPreconditionError(err))
-			assert.Contains(t, err.Error(), "topology-scoped response profiles cannot be used by automation")
-			assert.Equal(t, "MaestroOS curtailment", h.rule.RuleName)
+			assert.True(t, fleeterror.IsNotFoundError(err))
 			assert.Equal(t, 0, h.rules.createCalls)
+			assert.Equal(t, 0, h.rules.updateCalls)
+			assert.Equal(t, 0, h.rules.setEnabledCalls)
+			assert.Equal(t, 0, h.curtailments.insertEventCalls)
 		})
 	}
 }
@@ -697,12 +786,12 @@ func TestAutomationService_HandleMQTTSignal_OffRejectsRestoringReplayAfterProfil
 	assert.Equal(t, 0, h.rules.setActiveCalls)
 }
 
-func TestAutomationService_HandleMQTTSignal_OffRejectsStaleTopologyProfileBinding(t *testing.T) {
+func TestAutomationService_HandleMQTTSignal_OffStartsTopologyProfile(t *testing.T) {
 	t.Parallel()
 
 	h := newAutomationHarness(t)
 	h.profile.Mode = models.ModeFixedKw
-	targetKW := 5.0
+	targetKW := 2.0
 	h.profile.TargetKW = &targetKW
 	h.profile.SiteID = nil
 	h.profile.ScopeJSON = []byte(`{"scope_schema_version":1,"building_ids":[7]}`)
@@ -720,11 +809,41 @@ func TestAutomationService_HandleMQTTSignal_OffRejectsStaleTopologyProfileBindin
 		Target: mqttingest.TargetOff,
 	})
 
-	require.Error(t, err)
-	assert.True(t, fleeterror.IsFailedPreconditionError(err))
-	assert.Contains(t, err.Error(), "topology-scoped Start is not available for automation")
-	assert.Equal(t, 0, h.curtailments.insertEventCalls)
-	assert.Equal(t, 0, h.rules.setActiveCalls)
+	require.NoError(t, err)
+	assert.Equal(t, 1, h.curtailments.insertEventCalls)
+	assert.Equal(t, 1, h.rules.setActiveCalls)
+	assert.Equal(t, models.ScopeTypeMixed, h.curtailments.lastInsertEvent.ScopeType)
+	assert.JSONEq(t, `{"scope_schema_version":1,"building_ids":[7]}`, string(h.curtailments.lastInsertEvent.ScopeJSON))
+}
+
+func TestAutomationService_HandleMQTTSignal_OffStartsClosedLoopTopologyProfile(t *testing.T) {
+	t.Parallel()
+
+	h := newAutomationHarness(t)
+	h.profile.SiteID = nil
+	h.profile.ScopeJSON = []byte(`{"scope_schema_version":1,"building_ids":[7]}`)
+	h.curtailments.orgConfigByOrg[h.orgID] = defaultOrgConfig(h.orgID)
+	h.curtailments.topologyCoverage = interfaces.CurtailmentTopologyScopeCoverage{
+		SelectedResourceSiteIDs: []int64{7},
+		CurrentMemberSiteIDs:    []int64{7},
+	}
+	h.curtailments.candidatesByBuilding[h.orgID] = map[int64][]*models.Candidate{
+		7: {minerWithEff("miner-a", 3000, 100, 50)},
+	}
+
+	err := h.automation.HandleMQTTSignal(t.Context(), mqttingest.SignalEdge{
+		Source: h.source,
+		Target: mqttingest.TargetOff,
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, h.curtailments.lastInsertEvent)
+	assert.Equal(t, models.LoopTypeClosed, h.curtailments.lastInsertEvent.LoopType)
+	assert.True(t, h.curtailments.lastInsertEvent.AllowUnbounded)
+	assert.Equal(t, h.rule.ID, h.curtailments.lastInsertEvent.AutomationRuleID)
+	assert.Equal(t, h.profile.Revision, h.curtailments.lastInsertEvent.ResponseProfileRevision)
+	assert.Equal(t, h.source.ServiceUserID, h.curtailments.lastInsertEvent.CreatedByUserID)
+	assert.JSONEq(t, `{"scope_schema_version":1,"building_ids":[7]}`, string(h.curtailments.lastInsertEvent.ScopeJSON))
 }
 
 func TestAutomationService_HandleMQTTSignal_OffSnapshotsExplicitMinerSites(t *testing.T) {
@@ -1439,6 +1558,8 @@ type automationFakeStore struct {
 	rules                             []*models.AutomationRule
 	created                           *models.AutomationRule
 	createCalls                       int
+	updateCalls                       int
+	setEnabledCalls                   int
 	lastCreateExpectedFanSettings     models.ResponseProfileFanSettings
 	lastUpdateExpectedFanSettings     models.ResponseProfileFanSettings
 	lastSetEnabledExpectedFanSettings models.ResponseProfileFanSettings
@@ -1513,6 +1634,7 @@ func (f *automationFakeStore) CreateAutomationRule(_ context.Context, rule model
 func (f *automationFakeStore) UpdateAutomationRule(_ context.Context, rule models.AutomationRule, expectedFanSettings models.ResponseProfileFanSettings) (*models.AutomationRule, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.updateCalls++
 	f.lastUpdateExpectedFanSettings = cloneResponseProfileFanSettings(expectedFanSettings)
 	for i, existing := range f.rules {
 		if existing.OrgID == rule.OrgID && existing.ID == rule.ID {
@@ -1526,6 +1648,7 @@ func (f *automationFakeStore) UpdateAutomationRule(_ context.Context, rule model
 func (f *automationFakeStore) SetAutomationRuleEnabled(_ context.Context, orgID, ruleID int64, enabled bool, responseProfileRevision uuid.UUID, expectedFanSettings models.ResponseProfileFanSettings) (*models.AutomationRule, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.setEnabledCalls++
 	f.lastSetEnabledExpectedFanSettings = cloneResponseProfileFanSettings(expectedFanSettings)
 	for _, rule := range f.rules {
 		if rule.OrgID == orgID && rule.ID == ruleID {

--- a/server/internal/domain/curtailment/automation_test.go
+++ b/server/internal/domain/curtailment/automation_test.go
@@ -743,6 +743,9 @@ func TestAutomationService_HandleMQTTSignal_OffRecurtailsRestoringReplayBeforeRe
 	assert.Equal(t, replayEvent.EventUUID, h.curtailments.beginRecurtailLastEventID)
 	assert.Equal(t, h.rule.ResponseProfileID, h.curtailments.beginRecurtailProfileID)
 	assert.Equal(t, h.rule.ResponseProfileRevision, h.curtailments.beginRecurtailRevision)
+	assert.Equal(t, h.rule.ID, h.curtailments.beginRecurtailRuleID)
+	assert.Equal(t, h.source.ID, h.curtailments.beginRecurtailSourceID)
+	assert.Equal(t, h.source.ServiceUserID, h.curtailments.beginRecurtailServiceUser)
 	assert.Equal(t, 1, h.rules.setActiveCalls)
 	assert.Equal(t, replayEvent.EventUUID, h.rules.lastActiveEvent)
 }

--- a/server/internal/domain/curtailment/automation_test.go
+++ b/server/internal/domain/curtailment/automation_test.go
@@ -356,7 +356,12 @@ func TestAutomationService_RejectsUnavailableTopologyProfile(t *testing.T) {
 			h := newAutomationHarness(t)
 			h.profile.SiteID = nil
 			h.profile.ScopeJSON = []byte(`{"scope_schema_version":1,"building_ids":[7]}`)
-			h.profiles.topologyCoverageErr = fleeterror.NewNotFoundError("buildings not found in caller's org: [7]")
+			topologyErr := fleeterror.NewNotFoundError("buildings not found in caller's org: [7]")
+			if tt.name == "execute" {
+				h.curtailments.topologyCoverageErr = topologyErr
+			} else {
+				h.profiles.topologyCoverageErr = topologyErr
+			}
 
 			err := tt.run(h)
 
@@ -817,6 +822,63 @@ func TestAutomationService_HandleMQTTSignal_OffStartsTopologyProfile(t *testing.
 	assert.Equal(t, 1, h.rules.setActiveCalls)
 	assert.Equal(t, models.ScopeTypeMixed, h.curtailments.lastInsertEvent.ScopeType)
 	assert.JSONEq(t, `{"scope_schema_version":1,"building_ids":[7]}`, string(h.curtailments.lastInsertEvent.ScopeJSON))
+}
+
+func TestValidateAutomationEventOwnership(t *testing.T) {
+	t.Parallel()
+
+	const (
+		orgID  = int64(42)
+		ruleID = int64(9001)
+	)
+	externalReference, idempotencyKey := automationRuleEventReference(ruleID)
+	validEvent := func() *models.Event {
+		return &models.Event{
+			OrgID:             orgID,
+			SourceActorType:   models.SourceActorAutomation,
+			SourceActorID:     stringPtr(externalReference),
+			ExternalSource:    stringPtr(automationExternalSource),
+			ExternalReference: stringPtr(externalReference),
+			IdempotencyKey:    stringPtr(idempotencyKey),
+		}
+	}
+	tests := []struct {
+		name   string
+		event  func() *models.Event
+		mutate func(*models.Event)
+		wantOK bool
+	}{
+		{name: "valid", event: validEvent, wantOK: true},
+		{name: "nil event", event: func() *models.Event { return nil }},
+		{name: "organization", event: validEvent, mutate: func(event *models.Event) { event.OrgID++ }},
+		{name: "actor type", event: validEvent, mutate: func(event *models.Event) { event.SourceActorType = models.SourceActorWebhook }},
+		{name: "missing external source", event: validEvent, mutate: func(event *models.Event) { event.ExternalSource = nil }},
+		{name: "external source", event: validEvent, mutate: func(event *models.Event) { event.ExternalSource = stringPtr("other") }},
+		{name: "missing external reference", event: validEvent, mutate: func(event *models.Event) { event.ExternalReference = nil }},
+		{name: "external reference", event: validEvent, mutate: func(event *models.Event) { event.ExternalReference = stringPtr("other") }},
+		{name: "missing idempotency key", event: validEvent, mutate: func(event *models.Event) { event.IdempotencyKey = nil }},
+		{name: "idempotency key", event: validEvent, mutate: func(event *models.Event) { event.IdempotencyKey = stringPtr("other") }},
+		{name: "missing actor ID", event: validEvent, mutate: func(event *models.Event) { event.SourceActorID = nil }},
+		{name: "actor ID", event: validEvent, mutate: func(event *models.Event) { event.SourceActorID = stringPtr("other") }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			event := tt.event()
+			if tt.mutate != nil {
+				tt.mutate(event)
+			}
+
+			err := ValidateAutomationEventOwnership(event, orgID, ruleID)
+			if tt.wantOK {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.True(t, fleeterror.IsFailedPreconditionError(err))
+		})
+	}
 }
 
 func TestAutomationService_HandleMQTTSignal_OffStartsClosedLoopTopologyProfile(t *testing.T) {

--- a/server/internal/domain/curtailment/reconciler/dispatch_authorization.go
+++ b/server/internal/domain/curtailment/reconciler/dispatch_authorization.go
@@ -298,39 +298,11 @@ func authorizationEnvelopeAllowsDispatch(
 	envelope models.AuthorizationEnvelope,
 	coverage interfaces.CurtailmentTopologyScopeCoverage,
 ) bool {
-	if effective == nil {
-		return false
-	}
-	requireOrgWideManage := envelope.MinerScopeUnbounded || envelope.FacilityFanScopeUnbounded || coverage.RequireOrgWide
-	if requireOrgWideManage && !effective.HasOrgWide(authz.PermCurtailmentManage) {
-		return false
-	}
-	manageSites := make(map[int64]struct{})
-	for _, sites := range [][]int64{
-		envelope.SelectedResourceSiteIDs,
-		envelope.CurrentMemberSiteIDs,
-		envelope.FacilityFanSiteIDs,
+	return curtailment.AuthorizationEnvelopeAllows(
+		effective,
+		envelope,
 		coverage.SelectedResourceSiteIDs,
 		coverage.CurrentMemberSiteIDs,
-	} {
-		for _, siteID := range sites {
-			manageSites[siteID] = struct{}{}
-		}
-	}
-	for siteID := range manageSites {
-		id := siteID
-		if !effective.Has(authz.PermCurtailmentManage, authz.ResourceContext{SiteID: &id}) {
-			return false
-		}
-	}
-	if envelope.FacilityFanScopeUnbounded && !effective.HasOrgWide(authz.PermSiteRead) {
-		return false
-	}
-	for _, siteID := range envelope.FacilityFanSiteIDs {
-		id := siteID
-		if !effective.Has(authz.PermSiteRead, authz.ResourceContext{SiteID: &id}) {
-			return false
-		}
-	}
-	return true
+		coverage.RequireOrgWide,
+	)
 }

--- a/server/internal/domain/curtailment/reconciler/reconciler_test.go
+++ b/server/internal/domain/curtailment/reconciler/reconciler_test.go
@@ -867,7 +867,12 @@ func (f *fakeStore) BeginRestoreTransition(_ context.Context, _ int64, eventUUID
 
 // BeginRecurtailTransition satisfies the store interface; the reconciler never
 // calls it (the MQTT subscriber's watchdog drives re-curtail).
-func (f *fakeStore) BeginRecurtailTransition(_ context.Context, _ int64, eventUUID uuid.UUID, _ int64, _ uuid.UUID) (*models.Event, error) {
+func (f *fakeStore) BeginRecurtailTransition(
+	_ context.Context,
+	_ int64,
+	eventUUID uuid.UUID,
+	_ interfaces.BeginRecurtailTransitionParams,
+) (*models.Event, error) {
 	for _, ev := range f.events {
 		if ev.EventUUID == eventUUID {
 			ev.State = models.EventStatePending

--- a/server/internal/domain/curtailment/response_profile.go
+++ b/server/internal/domain/curtailment/response_profile.go
@@ -74,6 +74,27 @@ func (s *ResponseProfileService) Get(ctx context.Context, orgID, profileID int64
 	return s.store.GetResponseProfile(ctx, orgID, profileID)
 }
 
+// ValidateAutomationScope strictly resolves topology selectors before an
+// automation binding or execution is accepted. Get intentionally returns
+// persisted profiles even when their selected topology was later deleted, so
+// callers that can execute a profile must opt into this live validation.
+func (s *ResponseProfileService) ValidateAutomationScope(ctx context.Context, profile *models.ResponseProfile) error {
+	if s == nil || s.store == nil {
+		return fleeterror.NewUnimplementedError("curtailment response profile service is not configured")
+	}
+	if profile == nil {
+		return fleeterror.NewNotFoundError("curtailment response profile not found")
+	}
+	scope, err := ResponseProfileScope(*profile)
+	if err != nil {
+		return err
+	}
+	if !IsTopologyScope(scope) {
+		return nil
+	}
+	return s.validateResponseProfileScope(ctx, profile.OrgID, scope)
+}
+
 func (s *ResponseProfileService) ListDeviceSites(ctx context.Context, orgID int64, deviceIdentifiers []string) (map[string]*int64, error) {
 	if s == nil || s.store == nil {
 		return nil, fleeterror.NewUnimplementedError("curtailment response profile service is not configured")
@@ -148,9 +169,6 @@ func (s *ResponseProfileService) Update(ctx context.Context, req SaveResponsePro
 	if err != nil {
 		return nil, err
 	}
-	if err := s.validateTopologyProfileAutomationBinding(ctx, profile); err != nil {
-		return nil, err
-	}
 	return s.store.UpdateResponseProfile(
 		ctx,
 		profile,
@@ -159,29 +177,6 @@ func (s *ResponseProfileService) Update(ctx context.Context, req SaveResponsePro
 		req.ExpectedSiteID,
 		req.ExpectedScopeJSON,
 		req.ExpectedFacilityFanSettings,
-	)
-}
-
-func (s *ResponseProfileService) validateTopologyProfileAutomationBinding(
-	ctx context.Context,
-	profile models.ResponseProfile,
-) error {
-	scope, err := ResponseProfileScope(profile)
-	if err != nil {
-		return err
-	}
-	if !hasTopologySelectors(scope) {
-		return nil
-	}
-	count, err := s.store.CountAutomationRulesByResponseProfile(ctx, profile.OrgID, profile.ID)
-	if err != nil {
-		return err
-	}
-	if count == 0 {
-		return nil
-	}
-	return fleeterror.NewFailedPreconditionError(
-		"topology-scoped response profiles cannot be used by automation until topology curtailment execution is supported; update the automation rules first",
 	)
 }
 

--- a/server/internal/domain/curtailment/response_profile_test.go
+++ b/server/internal/domain/curtailment/response_profile_test.go
@@ -648,14 +648,14 @@ func TestResponseProfileService_UpdateAllowsFacilityFansWhenProfileHasAutomation
 	assert.Equal(t, []int64{31}, store.updated.FacilityFanDeviceIDs)
 }
 
-func TestResponseProfileService_UpdateRejectsTopologyScopeWhenProfileHasAutomationRules(t *testing.T) {
+func TestResponseProfileService_UpdateAllowsTopologyScopeWhenProfileHasAutomationRules(t *testing.T) {
 	t.Parallel()
 
 	targetKW := 2500.0
 	store := newResponseProfileFakeStore()
 	store.automationRuleCount = 1
 
-	_, err := NewResponseProfileService(store).Update(t.Context(), SaveResponseProfileRequest{
+	updated, err := NewResponseProfileService(store).Update(t.Context(), SaveResponseProfileRequest{
 		Profile: models.ResponseProfile{
 			ID:          101,
 			Revision:    responseProfileTestRevision,
@@ -667,10 +667,9 @@ func TestResponseProfileService_UpdateRejectsTopologyScopeWhenProfileHasAutomati
 		},
 	})
 
-	require.Error(t, err)
-	assert.True(t, fleeterror.IsFailedPreconditionError(err))
-	assert.Contains(t, err.Error(), "topology-scoped response profiles cannot be used by automation")
-	assert.Nil(t, store.updated)
+	require.NoError(t, err)
+	require.NotNil(t, updated)
+	assert.JSONEq(t, `{"scope_schema_version":1,"building_ids":[7]}`, string(updated.ScopeJSON))
 }
 
 func TestResponseProfileService_CreateRejectsUnknownSite(t *testing.T) {

--- a/server/internal/domain/curtailment/service.go
+++ b/server/internal/domain/curtailment/service.go
@@ -201,11 +201,6 @@ func (s *Service) Start(ctx context.Context, req StartRequest) (*Plan, error) {
 	if err := validateStartRequest(req); err != nil {
 		return nil, err
 	}
-	if hasTopologySelectors(req.Scope) && req.SourceActorType == models.SourceActorAutomation {
-		return nil, fleeterror.NewFailedPreconditionError(
-			"topology-scoped Start is not available for automation",
-		)
-	}
 	req.PostEventCooldownSec = effectivePostEventCooldownSec(req.PreviewRequest)
 
 	// Idempotent-replay lookup: a prior persisted match short-circuits

--- a/server/internal/domain/curtailment/service.go
+++ b/server/internal/domain/curtailment/service.go
@@ -2467,6 +2467,9 @@ type RecurtailRequest struct {
 	EventUUID               uuid.UUID
 	ResponseProfileID       int64
 	ResponseProfileRevision uuid.UUID
+	AutomationRuleID        int64
+	AutomationMQTTSourceID  int64
+	AutomationServiceUserID int64
 }
 
 // Recurtail flips a restoring event back to pending and reclaims restore
@@ -2487,12 +2490,31 @@ func (s *Service) Recurtail(ctx context.Context, req RecurtailRequest) (*models.
 	if req.ResponseProfileID < 0 {
 		return nil, fleeterror.NewInvalidArgumentError("response_profile_id must be non-negative")
 	}
+	if req.AutomationRuleID < 0 || req.AutomationMQTTSourceID < 0 || req.AutomationServiceUserID < 0 {
+		return nil, fleeterror.NewInvalidArgumentError("automation execution fence IDs must be non-negative")
+	}
+	if (req.AutomationRuleID > 0) != (req.AutomationMQTTSourceID > 0) ||
+		(req.AutomationRuleID > 0) != (req.AutomationServiceUserID > 0) {
+		return nil, fleeterror.NewInvalidArgumentError(
+			"automation execution fence requires rule, MQTT source, and service user IDs",
+		)
+	}
+	if req.AutomationRuleID > 0 && req.ResponseProfileID == 0 {
+		return nil, fleeterror.NewInvalidArgumentError(
+			"automation execution fence requires a response profile ID and revision",
+		)
+	}
 	return s.store.BeginRecurtailTransition(
 		ctx,
 		req.OrgID,
 		req.EventUUID,
-		req.ResponseProfileID,
-		req.ResponseProfileRevision,
+		interfaces.BeginRecurtailTransitionParams{
+			ResponseProfileID:       req.ResponseProfileID,
+			ResponseProfileRevision: req.ResponseProfileRevision,
+			AutomationRuleID:        req.AutomationRuleID,
+			AutomationMQTTSourceID:  req.AutomationMQTTSourceID,
+			AutomationServiceUserID: req.AutomationServiceUserID,
+		},
 	)
 }
 

--- a/server/internal/domain/curtailment/service_recurtail_test.go
+++ b/server/internal/domain/curtailment/service_recurtail_test.go
@@ -3,6 +3,7 @@ package curtailment
 import (
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -21,6 +22,29 @@ func TestService_Recurtail_HappyPath(t *testing.T) {
 	assert.Equal(t, f.event.EventUUID, f.store.beginRecurtailLastEventID)
 }
 
+func TestService_Recurtail_ForwardsAutomationExecutionFence(t *testing.T) {
+	t.Parallel()
+	f := newStopFixture(t, func(ev *models.Event) { ev.State = models.EventStateRestoring })
+	revision := uuid.New()
+
+	_, err := f.svc.Recurtail(t.Context(), RecurtailRequest{
+		OrgID:                   1,
+		EventUUID:               f.event.EventUUID,
+		ResponseProfileID:       41,
+		ResponseProfileRevision: revision,
+		AutomationRuleID:        42,
+		AutomationMQTTSourceID:  43,
+		AutomationServiceUserID: 44,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, int64(41), f.store.beginRecurtailProfileID)
+	assert.Equal(t, revision, f.store.beginRecurtailRevision)
+	assert.Equal(t, int64(42), f.store.beginRecurtailRuleID)
+	assert.Equal(t, int64(43), f.store.beginRecurtailSourceID)
+	assert.Equal(t, int64(44), f.store.beginRecurtailServiceUser)
+}
+
 func TestService_Recurtail_ValidatesRequest(t *testing.T) {
 	t.Parallel()
 	f := newStopFixture(t, nil)
@@ -31,6 +55,20 @@ func TestService_Recurtail_ValidatesRequest(t *testing.T) {
 	}{
 		{"missing org", RecurtailRequest{EventUUID: f.event.EventUUID}},
 		{"missing event", RecurtailRequest{OrgID: 1}},
+		{
+			"partial automation fence",
+			RecurtailRequest{OrgID: 1, EventUUID: f.event.EventUUID, AutomationRuleID: 42},
+		},
+		{
+			"automation without profile binding",
+			RecurtailRequest{
+				OrgID:                   1,
+				EventUUID:               f.event.EventUUID,
+				AutomationRuleID:        42,
+				AutomationMQTTSourceID:  43,
+				AutomationServiceUserID: 44,
+			},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/server/internal/domain/curtailment/service_test.go
+++ b/server/internal/domain/curtailment/service_test.go
@@ -90,6 +90,9 @@ type fakeStore struct {
 	beginRecurtailLastEventID uuid.UUID
 	beginRecurtailProfileID   int64
 	beginRecurtailRevision    uuid.UUID
+	beginRecurtailRuleID      int64
+	beginRecurtailSourceID    int64
+	beginRecurtailServiceUser int64
 
 	// List-history fakes. eventsHistory is the slice the fake's ListEvents
 	// paginates over (callers seed it newest-first to match the SQL impl).
@@ -932,11 +935,19 @@ func (f *fakeStore) guardAutomationDemandForRestore(eventUUID uuid.UUID, guard *
 	)
 }
 
-func (f *fakeStore) BeginRecurtailTransition(_ context.Context, _ int64, eventUUID uuid.UUID, profileID int64, revision uuid.UUID) (*models.Event, error) {
+func (f *fakeStore) BeginRecurtailTransition(
+	_ context.Context,
+	_ int64,
+	eventUUID uuid.UUID,
+	params interfaces.BeginRecurtailTransitionParams,
+) (*models.Event, error) {
 	f.beginRecurtailCalls++
 	f.beginRecurtailLastEventID = eventUUID
-	f.beginRecurtailProfileID = profileID
-	f.beginRecurtailRevision = revision
+	f.beginRecurtailProfileID = params.ResponseProfileID
+	f.beginRecurtailRevision = params.ResponseProfileRevision
+	f.beginRecurtailRuleID = params.AutomationRuleID
+	f.beginRecurtailSourceID = params.AutomationMQTTSourceID
+	f.beginRecurtailServiceUser = params.AutomationServiceUserID
 	if f.beginRecurtailErr != nil {
 		return nil, f.beginRecurtailErr
 	}

--- a/server/internal/domain/stores/interfaces/curtailment.go
+++ b/server/internal/domain/stores/interfaces/curtailment.go
@@ -152,6 +152,17 @@ type BeginRestoreTransitionParams struct {
 	KnownUnsentDeviceIdentifiers []string
 }
 
+// BeginRecurtailTransitionParams binds an automation-owned re-curtail to the
+// current rule, MQTT source principal, and response-profile revision. Manual
+// re-curtail calls leave the automation fields zero.
+type BeginRecurtailTransitionParams struct {
+	ResponseProfileID       int64
+	ResponseProfileRevision uuid.UUID
+	AutomationRuleID        int64
+	AutomationMQTTSourceID  int64
+	AutomationServiceUserID int64
+}
+
 type AutomationDemandGuard struct {
 	ExternalReference *string
 }
@@ -596,7 +607,6 @@ type CurtailmentStore interface {
 		ctx context.Context,
 		orgID int64,
 		eventUUID uuid.UUID,
-		responseProfileID int64,
-		responseProfileRevision uuid.UUID,
+		params BeginRecurtailTransitionParams,
 	) (*models.Event, error)
 }

--- a/server/internal/domain/stores/sqlstores/curtailment.go
+++ b/server/internal/domain/stores/sqlstores/curtailment.go
@@ -1289,6 +1289,7 @@ func authorizeAutomationExecution(
 	ruleID int64,
 	serviceUserID int64,
 	event *models.Event,
+	currentTopology *interfaces.CurtailmentTopologyScopeCoverage,
 ) error {
 	if ruleID == 0 {
 		return nil
@@ -1298,13 +1299,26 @@ func authorizeAutomationExecution(
 	}
 	effective, err := authz.LoadEffectiveForUpdate(ctx, q, serviceUserID, event.OrgID)
 	if err != nil {
-		return fleeterror.NewInternalErrorf("failed to reload automation source user permissions: %v", err)
+		return fleeterror.NewInternalErrorf("failed to reload automation source user permissions: %w", err)
 	}
 	envelope, err := domainCurtailment.AuthorizationEnvelopeFromJSON(event.AuthorizationEnvelopeJSON)
 	if err != nil {
 		return err
 	}
-	if !domainCurtailment.AuthorizationEnvelopeAllows(effective, envelope, nil, nil, false) {
+	var currentSelectedResourceSiteIDs, currentMemberSiteIDs []int64
+	currentRequiresOrgWide := false
+	if currentTopology != nil {
+		currentSelectedResourceSiteIDs = currentTopology.SelectedResourceSiteIDs
+		currentMemberSiteIDs = currentTopology.CurrentMemberSiteIDs
+		currentRequiresOrgWide = currentTopology.RequireOrgWide
+	}
+	if !domainCurtailment.AuthorizationEnvelopeAllows(
+		effective,
+		envelope,
+		currentSelectedResourceSiteIDs,
+		currentMemberSiteIDs,
+		currentRequiresOrgWide,
+	) {
 		return fleeterror.NewForbiddenError(
 			"automation source user no longer has permission to manage the response profile scope",
 		)
@@ -1332,7 +1346,7 @@ func authorizeAutomationExecution(
 		return fleeterror.NewForbiddenError("automation source user no longer has an active organization role")
 	}
 	if err != nil {
-		return fleeterror.NewInternalErrorf("failed to reload automation source user role: %v", err)
+		return fleeterror.NewInternalErrorf("failed to reload automation source user role: %w", err)
 	}
 	if roleName != domainAuth.AdminRoleName && roleName != domainAuth.SuperAdminRoleName {
 		return fleeterror.NewForbiddenError(
@@ -1541,6 +1555,7 @@ func (s *SQLCurtailmentStore) InsertEventWithTargets(
 			event.AutomationRuleID,
 			event.CreatedByUserID,
 			insertEventForAutomationAuthorization(event),
+			nil,
 		); err != nil {
 			return nil, err
 		}
@@ -3509,16 +3524,8 @@ func (s *SQLCurtailmentStore) BeginRecurtailTransition(
 		); err != nil {
 			return nil, err
 		}
-		if err := lockResponseProfileRevisionForExecution(
-			ctx,
-			q,
-			orgID,
-			params.ResponseProfileID,
-			params.ResponseProfileRevision,
-		); err != nil {
-			return nil, err
-		}
 		event := convertEventRow(current)
+		var currentTopology *interfaces.CurtailmentTopologyScopeCoverage
 		if params.AutomationRuleID > 0 {
 			if err := domainCurtailment.ValidateAutomationEventOwnership(
 				event,
@@ -3527,6 +3534,24 @@ func (s *SQLCurtailmentStore) BeginRecurtailTransition(
 			); err != nil {
 				return nil, err
 			}
+			if event.CreatedByUserID != params.AutomationServiceUserID {
+				return nil, fleeterror.NewFailedPreconditionError(
+					"automation source principal changed since event creation",
+				)
+			}
+			currentTopology, err = lockCurrentTopologyAuthorizationCoverage(ctx, q, event)
+			if err != nil {
+				return nil, err
+			}
+		}
+		if err := lockResponseProfileRevisionForExecution(
+			ctx,
+			q,
+			orgID,
+			params.ResponseProfileID,
+			params.ResponseProfileRevision,
+		); err != nil {
+			return nil, err
 		}
 		if err := lockAutomationRuleForExecution(
 			ctx,
@@ -3546,6 +3571,7 @@ func (s *SQLCurtailmentStore) BeginRecurtailTransition(
 			params.AutomationRuleID,
 			params.AutomationServiceUserID,
 			event,
+			currentTopology,
 		); err != nil {
 			return nil, err
 		}

--- a/server/internal/domain/stores/sqlstores/curtailment.go
+++ b/server/internal/domain/stores/sqlstores/curtailment.go
@@ -1149,13 +1149,21 @@ func validateResponseProfileExecutionFence(profileID int64, revision uuid.UUID) 
 	return nil
 }
 
-func validateAutomationExecutionFence(ruleID, mqttSourceID, profileID int64, revision uuid.UUID) error {
-	if ruleID < 0 || mqttSourceID < 0 {
+func validateAutomationExecutionFence(ruleID, mqttSourceID, serviceUserID, profileID int64, revision uuid.UUID) error {
+	if ruleID < 0 || mqttSourceID < 0 || serviceUserID < 0 {
 		return fleeterror.NewInvalidArgumentError("automation execution fence IDs must be non-negative")
 	}
-	if (ruleID > 0) != (mqttSourceID > 0) {
+	if ruleID == 0 {
+		if mqttSourceID > 0 {
+			return fleeterror.NewInvalidArgumentError(
+				"automation execution fence requires a rule ID with the MQTT source ID",
+			)
+		}
+		return nil
+	}
+	if mqttSourceID == 0 || serviceUserID == 0 {
 		return fleeterror.NewInvalidArgumentError(
-			"automation execution fence requires both rule ID and MQTT source ID",
+			"automation execution fence requires rule, MQTT source, and service user IDs",
 		)
 	}
 	if ruleID > 0 && (profileID <= 0 || revision == uuid.Nil) {
@@ -1275,22 +1283,20 @@ func lockAutomationRuleForExecution(
 	return nil
 }
 
-func authorizeTopologyAutomationExecution(
+func authorizeAutomationExecution(
 	ctx context.Context,
 	q sqlc.Querier,
-	event models.InsertEventParams,
+	ruleID int64,
+	serviceUserID int64,
+	event *models.Event,
 ) error {
-	if event.AutomationRuleID == 0 {
+	if ruleID == 0 {
 		return nil
 	}
-	scope, hasScope, err := domainCurtailment.ScopeFromJSON(event.ScopeJSON)
-	if err != nil {
-		return err
+	if event == nil {
+		return fleeterror.NewInternalError("automation execution authorization requires an event")
 	}
-	if !hasScope || !domainCurtailment.IsTopologyScope(scope) {
-		return nil
-	}
-	effective, err := authz.LoadEffectiveForUpdate(ctx, q, event.CreatedByUserID, event.OrgID)
+	effective, err := authz.LoadEffectiveForUpdate(ctx, q, serviceUserID, event.OrgID)
 	if err != nil {
 		return fleeterror.NewInternalErrorf("failed to reload automation source user permissions: %v", err)
 	}
@@ -1319,7 +1325,7 @@ func authorizeTopologyAutomationExecution(
 		return nil
 	}
 	roleName, err := q.GetUserRoleNameForUpdate(ctx, sqlc.GetUserRoleNameForUpdateParams{
-		UserID:         event.CreatedByUserID,
+		UserID:         serviceUserID,
 		OrganizationID: event.OrgID,
 	})
 	if errors.Is(err, sql.ErrNoRows) {
@@ -1336,6 +1342,20 @@ func authorizeTopologyAutomationExecution(
 	return nil
 }
 
+func insertEventForAutomationAuthorization(event models.InsertEventParams) *models.Event {
+	return &models.Event{
+		OrgID:                       event.OrgID,
+		AuthorizationEnvelopeJSON:   event.AuthorizationEnvelopeJSON,
+		AllowUnbounded:              event.AllowUnbounded,
+		ForceIncludeMaintenance:     event.ForceIncludeMaintenance,
+		ForceIncludeAllPairedMiners: event.ForceIncludeAllPairedMiners,
+		CurtailBatchIntervalSec:     event.CurtailBatchIntervalSec,
+		RestoreBatchIntervalSec:     event.RestoreBatchIntervalSec,
+		MaxDurationSeconds:          event.MaxDurationSeconds,
+		DecisionSnapshotJSON:        event.DecisionSnapshotJSON,
+	}
+}
+
 // InsertEventWithTargets writes event + targets in one transaction.
 func (s *SQLCurtailmentStore) InsertEventWithTargets(
 	ctx context.Context,
@@ -1348,6 +1368,7 @@ func (s *SQLCurtailmentStore) InsertEventWithTargets(
 	if err := validateAutomationExecutionFence(
 		event.AutomationRuleID,
 		event.AutomationMQTTSourceID,
+		event.CreatedByUserID,
 		event.ResponseProfileID,
 		event.ResponseProfileRevision,
 	); err != nil {
@@ -1514,7 +1535,13 @@ func (s *SQLCurtailmentStore) InsertEventWithTargets(
 		); err != nil {
 			return nil, err
 		}
-		if err := authorizeTopologyAutomationExecution(ctx, q, event); err != nil {
+		if err := authorizeAutomationExecution(
+			ctx,
+			q,
+			event.AutomationRuleID,
+			event.CreatedByUserID,
+			insertEventForAutomationAuthorization(event),
+		); err != nil {
 			return nil, err
 		}
 		// pq.Array encodes a nil slice as SQL NULL. Keep the empty fan list
@@ -3439,10 +3466,18 @@ func (s *SQLCurtailmentStore) BeginRecurtailTransition(
 	ctx context.Context,
 	orgID int64,
 	eventUUID uuid.UUID,
-	responseProfileID int64,
-	responseProfileRevision uuid.UUID,
+	params interfaces.BeginRecurtailTransitionParams,
 ) (*models.Event, error) {
-	if err := validateResponseProfileExecutionFence(responseProfileID, responseProfileRevision); err != nil {
+	if err := validateResponseProfileExecutionFence(params.ResponseProfileID, params.ResponseProfileRevision); err != nil {
+		return nil, err
+	}
+	if err := validateAutomationExecutionFence(
+		params.AutomationRuleID,
+		params.AutomationMQTTSourceID,
+		params.AutomationServiceUserID,
+		params.ResponseProfileID,
+		params.ResponseProfileRevision,
+	); err != nil {
 		return nil, err
 	}
 	return db.WithTransaction(ctx, s.conn.DB, func(q sqlc.Querier) (*models.Event, error) {
@@ -3469,8 +3504,8 @@ func (s *SQLCurtailmentStore) BeginRecurtailTransition(
 		}
 		if err := validateEventResponseProfileBinding(
 			current.DecisionSnapshotJsonb,
-			responseProfileID,
-			responseProfileRevision,
+			params.ResponseProfileID,
+			params.ResponseProfileRevision,
 		); err != nil {
 			return nil, err
 		}
@@ -3478,8 +3513,39 @@ func (s *SQLCurtailmentStore) BeginRecurtailTransition(
 			ctx,
 			q,
 			orgID,
-			responseProfileID,
-			responseProfileRevision,
+			params.ResponseProfileID,
+			params.ResponseProfileRevision,
+		); err != nil {
+			return nil, err
+		}
+		event := convertEventRow(current)
+		if params.AutomationRuleID > 0 {
+			if err := domainCurtailment.ValidateAutomationEventOwnership(
+				event,
+				orgID,
+				params.AutomationRuleID,
+			); err != nil {
+				return nil, err
+			}
+		}
+		if err := lockAutomationRuleForExecution(
+			ctx,
+			q,
+			orgID,
+			params.AutomationRuleID,
+			params.AutomationMQTTSourceID,
+			params.ResponseProfileID,
+			params.ResponseProfileRevision,
+			params.AutomationServiceUserID,
+		); err != nil {
+			return nil, err
+		}
+		if err := authorizeAutomationExecution(
+			ctx,
+			q,
+			params.AutomationRuleID,
+			params.AutomationServiceUserID,
+			event,
 		); err != nil {
 			return nil, err
 		}

--- a/server/internal/domain/stores/sqlstores/curtailment.go
+++ b/server/internal/domain/stores/sqlstores/curtailment.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"log/slog"
 	"slices"
 	"sort"
@@ -17,6 +16,8 @@ import (
 	"github.com/sqlc-dev/pqtype"
 
 	"github.com/block/proto-fleet/server/generated/sqlc"
+	domainAuth "github.com/block/proto-fleet/server/internal/domain/auth"
+	"github.com/block/proto-fleet/server/internal/domain/authz"
 	domainCurtailment "github.com/block/proto-fleet/server/internal/domain/curtailment"
 	"github.com/block/proto-fleet/server/internal/domain/curtailment/models"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
@@ -290,9 +291,6 @@ func (s *SQLCurtailmentStore) UpdateResponseProfile(
 	normalizedExpectedScopeJSON := normalizedResponseProfileScopeJSON(expectedScopeJSON)
 	row, err := db.WithTransaction(ctx, s.conn.DB, func(q sqlc.Querier) (sqlc.CurtailmentResponseProfileWithRevision, error) {
 		if err := lockResponseProfileAutomationMutation(ctx, q, profile.OrgID, profile.ID); err != nil {
-			return sqlc.CurtailmentResponseProfileWithRevision{}, err
-		}
-		if err := rejectTopologyProfileWithAutomationRules(ctx, q, profile); err != nil {
 			return sqlc.CurtailmentResponseProfileWithRevision{}, err
 		}
 		if err := lockResponseProfileSitesForWrite(
@@ -1003,18 +1001,12 @@ func requireResponseProfileForAutomation(
 	if err != nil {
 		return fleeterror.NewInternalErrorf("failed to get response profile during automation mutation: %v", err)
 	}
+	if err := lockResponseProfileTopologyForAutomation(ctx, q, orgID, profile.ScopeJson); err != nil {
+		return err
+	}
 	if profile.Revision != expectedRevision {
 		return fleeterror.NewFailedPreconditionError(
 			"curtailment response profile changed before automation rule save; retry",
-		)
-	}
-	hasTopology, err := responseProfileScopeHasTopology(profile.ScopeJson)
-	if err != nil {
-		return fleeterror.NewInternalErrorf("invalid response profile scope during automation mutation: %v", err)
-	}
-	if hasTopology {
-		return fleeterror.NewFailedPreconditionError(
-			"topology-scoped response profiles cannot be used by automation until topology curtailment execution is supported",
 		)
 	}
 	if !responseProfileFanSettingsMatch(profile, expectedFanSettings) {
@@ -1023,49 +1015,29 @@ func requireResponseProfileForAutomation(
 	return nil
 }
 
-func rejectTopologyProfileWithAutomationRules(
+func lockResponseProfileTopologyForAutomation(
 	ctx context.Context,
 	q sqlc.Querier,
-	profile models.ResponseProfile,
+	orgID int64,
+	scopeJSON []byte,
 ) error {
-	hasTopology, err := responseProfileScopeHasTopology(profile.ScopeJSON)
+	scope, hasScope, err := domainCurtailment.ScopeFromJSON(scopeJSON)
 	if err != nil {
-		return fleeterror.NewInvalidArgumentErrorf("invalid curtailment response profile scope_json: %v", err)
+		return fleeterror.NewInvalidArgumentErrorf("invalid response profile scope during automation mutation: %v", err)
 	}
-	if !hasTopology {
+	if !hasScope || !domainCurtailment.IsTopologyScope(scope) {
 		return nil
 	}
-	count, err := q.CountCurtailmentAutomationRulesByResponseProfile(
-		ctx,
-		sqlc.CountCurtailmentAutomationRulesByResponseProfileParams{
-			OrgID:             profile.OrgID,
-			ResponseProfileID: profile.ID,
-		},
-	)
+	filter, err := domainCurtailment.ListCandidatesParamsForScope(scope)
 	if err != nil {
-		return fleeterror.NewInternalErrorf("failed to count automation rules for response profile: %v", err)
+		return err
 	}
-	if count == 0 {
-		return nil
+	filter.OrgID = orgID
+	if err := lockTopologySelectorResourcesForWrite(ctx, q, filter); err != nil {
+		return err
 	}
-	return fleeterror.NewFailedPreconditionError(
-		"topology-scoped response profiles cannot be used by automation until topology curtailment execution is supported; update the automation rules first",
-	)
-}
-
-func responseProfileScopeHasTopology(scopeJSON []byte) (bool, error) {
-	if len(scopeJSON) == 0 {
-		return false, nil
-	}
-	var payload struct {
-		BuildingIDs []int64 `json:"building_ids"`
-		RackIDs     []int64 `json:"rack_ids"`
-		GroupIDs    []int64 `json:"group_ids"`
-	}
-	if err := json.Unmarshal(scopeJSON, &payload); err != nil {
-		return false, fmt.Errorf("decode response profile scope: %w", err)
-	}
-	return len(payload.BuildingIDs) > 0 || len(payload.RackIDs) > 0 || len(payload.GroupIDs) > 0, nil
+	_, err = resolveCurtailmentTopologyScope(ctx, q, filter)
+	return err
 }
 
 func responseProfileFanSettingsMatch(
@@ -1270,6 +1242,7 @@ func lockAutomationRuleForExecution(
 	mqttSourceID int64,
 	profileID int64,
 	profileRevision uuid.UUID,
+	serviceUserID int64,
 ) error {
 	if ruleID == 0 {
 		return nil
@@ -1283,6 +1256,7 @@ func lockAutomationRuleForExecution(
 			ID:                      ruleID,
 			OrgID:                   orgID,
 			MqttSourceID:            mqttSourceID,
+			ServiceUserID:           serviceUserID,
 			ResponseProfileID:       profileID,
 			ResponseProfileRevision: profileRevision,
 		},
@@ -1296,6 +1270,67 @@ func lockAutomationRuleForExecution(
 		return fleeterror.NewInternalErrorf(
 			"failed to lock curtailment automation rule for execution: %v",
 			err,
+		)
+	}
+	return nil
+}
+
+func authorizeTopologyAutomationExecution(
+	ctx context.Context,
+	q sqlc.Querier,
+	event models.InsertEventParams,
+) error {
+	if event.AutomationRuleID == 0 {
+		return nil
+	}
+	scope, hasScope, err := domainCurtailment.ScopeFromJSON(event.ScopeJSON)
+	if err != nil {
+		return err
+	}
+	if !hasScope || !domainCurtailment.IsTopologyScope(scope) {
+		return nil
+	}
+	effective, err := authz.LoadEffectiveForUpdate(ctx, q, event.CreatedByUserID, event.OrgID)
+	if err != nil {
+		return fleeterror.NewInternalErrorf("failed to reload automation source user permissions: %v", err)
+	}
+	envelope, err := domainCurtailment.AuthorizationEnvelopeFromJSON(event.AuthorizationEnvelopeJSON)
+	if err != nil {
+		return err
+	}
+	if !domainCurtailment.AuthorizationEnvelopeAllows(effective, envelope, nil, nil, false) {
+		return fleeterror.NewForbiddenError(
+			"automation source user no longer has permission to manage the response profile scope",
+		)
+	}
+	requiresAdmin, err := domainCurtailment.EventRequiresAdminControls(&models.Event{
+		AllowUnbounded:              event.AllowUnbounded,
+		ForceIncludeMaintenance:     event.ForceIncludeMaintenance,
+		ForceIncludeAllPairedMiners: event.ForceIncludeAllPairedMiners,
+		CurtailBatchIntervalSec:     event.CurtailBatchIntervalSec,
+		RestoreBatchIntervalSec:     event.RestoreBatchIntervalSec,
+		MaxDurationSeconds:          event.MaxDurationSeconds,
+		DecisionSnapshotJSON:        event.DecisionSnapshotJSON,
+	}, nil)
+	if err != nil {
+		return fleeterror.NewInvalidArgumentErrorf("invalid automation decision snapshot: %v", err)
+	}
+	if !requiresAdmin {
+		return nil
+	}
+	roleName, err := q.GetUserRoleNameForUpdate(ctx, sqlc.GetUserRoleNameForUpdateParams{
+		UserID:         event.CreatedByUserID,
+		OrganizationID: event.OrgID,
+	})
+	if errors.Is(err, sql.ErrNoRows) {
+		return fleeterror.NewForbiddenError("automation source user no longer has an active organization role")
+	}
+	if err != nil {
+		return fleeterror.NewInternalErrorf("failed to reload automation source user role: %v", err)
+	}
+	if roleName != domainAuth.AdminRoleName && roleName != domainAuth.SuperAdminRoleName {
+		return fleeterror.NewForbiddenError(
+			"automation source user no longer has the admin role required by the response profile",
 		)
 	}
 	return nil
@@ -1475,7 +1510,11 @@ func (s *SQLCurtailmentStore) InsertEventWithTargets(
 			event.AutomationMQTTSourceID,
 			event.ResponseProfileID,
 			event.ResponseProfileRevision,
+			event.CreatedByUserID,
 		); err != nil {
+			return nil, err
+		}
+		if err := authorizeTopologyAutomationExecution(ctx, q, event); err != nil {
 			return nil, err
 		}
 		// pq.Array encodes a nil slice as SQL NULL. Keep the empty fan list

--- a/server/internal/domain/stores/sqlstores/curtailment_authorization_envelope.go
+++ b/server/internal/domain/stores/sqlstores/curtailment_authorization_envelope.go
@@ -122,6 +122,42 @@ func buildAuthorizationEnvelopeJSON(
 	return encoded, nil
 }
 
+func lockCurrentTopologyAuthorizationCoverage(
+	ctx context.Context,
+	q sqlc.Querier,
+	event *models.Event,
+) (*interfaces.CurtailmentTopologyScopeCoverage, error) {
+	if event == nil {
+		return nil, fleeterror.NewInternalError("topology authorization coverage requires an event")
+	}
+	scope, hasScope, err := domainCurtailment.ScopeFromJSON(event.ScopeJSON)
+	if err != nil {
+		return nil, fleeterror.NewInternalErrorf("invalid persisted automation scope: %v", err)
+	}
+	if !hasScope || !domainCurtailment.IsTopologyScope(scope) {
+		return nil, nil
+	}
+	params, err := domainCurtailment.ListCandidatesParamsForScope(scope)
+	if err != nil {
+		return nil, fleeterror.NewInternalErrorf("invalid persisted automation topology scope: %v", err)
+	}
+	params.OrgID = event.OrgID
+	lockedMemberSiteIDs, lockedRequiresOrgWide, err := lockTopologyScopeCoverage(ctx, q, params, nil)
+	if err != nil {
+		return nil, err
+	}
+	coverage, err := resolveCurtailmentTopologyScope(ctx, q, params)
+	if err != nil {
+		return nil, err
+	}
+	coverage.CurrentMemberSiteIDs = uniqueSortedInt64s(append(
+		append([]int64(nil), coverage.CurrentMemberSiteIDs...),
+		lockedMemberSiteIDs...,
+	))
+	coverage.RequireOrgWide = coverage.RequireOrgWide || lockedRequiresOrgWide
+	return &coverage, nil
+}
+
 func lockSiteScopeTargets(
 	ctx context.Context,
 	q sqlc.Querier,

--- a/server/internal/domain/stores/sqlstores/curtailment_recurtail_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/curtailment_recurtail_integration_test.go
@@ -66,7 +66,12 @@ func TestSQLCurtailmentStore_BeginRecurtailTransition_OverlapRollsBack(t *testin
 	)
 	require.NoError(t, err)
 
-	_, err = store.BeginRecurtailTransition(ctx, user.OrganizationID, sourceEventUUID, 0, uuid.Nil)
+	_, err = store.BeginRecurtailTransition(
+		ctx,
+		user.OrganizationID,
+		sourceEventUUID,
+		interfaces.BeginRecurtailTransitionParams{},
+	)
 	require.Error(t, err)
 	assert.True(t, fleeterror.IsAlreadyExistsError(err), "overlap must be retryable, got %v", err)
 
@@ -276,7 +281,12 @@ func TestSQLCurtailmentStore_BeginRecurtailTransition_ReopensResolvedTarget(t *t
 	`, source.ID, deviceID, uuid.New().String())
 	require.NoError(t, err)
 
-	got, err := store.BeginRecurtailTransition(ctx, user.OrganizationID, sourceEventUUID, 0, uuid.Nil)
+	got, err := store.BeginRecurtailTransition(
+		ctx,
+		user.OrganizationID,
+		sourceEventUUID,
+		interfaces.BeginRecurtailTransitionParams{},
+	)
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	assert.Equal(t, models.EventStatePending, got.State)

--- a/server/internal/domain/stores/sqlstores/response_profile_automation_scope_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/response_profile_automation_scope_integration_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/block/proto-fleet/server/internal/testutil"
 )
 
-func TestSQLCurtailmentStore_TopologyProfilesCannotBeAutomated(t *testing.T) {
+func TestSQLCurtailmentStore_TopologyProfilesCanBeAutomated(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping database integration test in short mode")
 	}
@@ -25,16 +25,23 @@ func TestSQLCurtailmentStore_TopologyProfilesCannotBeAutomated(t *testing.T) {
 	ctx := t.Context()
 	database := testContext.DatabaseService.DB
 	store := sqlstores.NewSQLCurtailmentStore(database)
+	buildingStore := sqlstores.NewSQLBuildingStore(database)
 	orgID := user.OrganizationID
 	site, err := sqlstores.NewSQLSiteStore(database).CreateSite(ctx, sitesmodels.CreateSiteParams{
 		OrgID: orgID,
 		Name:  "Topology profile site",
 	})
 	require.NoError(t, err)
-	building, err := sqlstores.NewSQLBuildingStore(database).CreateBuilding(ctx, buildingsmodels.CreateParams{
+	building, err := buildingStore.CreateBuilding(ctx, buildingsmodels.CreateParams{
 		OrgID:  orgID,
 		SiteID: &site.ID,
 		Name:   "Topology profile building",
+	})
+	require.NoError(t, err)
+	replacementBuilding, err := buildingStore.CreateBuilding(ctx, buildingsmodels.CreateParams{
+		OrgID:  orgID,
+		SiteID: &site.ID,
+		Name:   "Replacement topology profile building",
 	})
 	require.NoError(t, err)
 	sourceID := seedMQTTSourceConfig(t, database, orgID, user.DatabaseID, "topology-profile-source", true)
@@ -54,7 +61,7 @@ func TestSQLCurtailmentStore_TopologyProfilesCannotBeAutomated(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	_, err = store.CreateAutomationRule(ctx, models.AutomationRule{
+	createdRule, err := store.CreateAutomationRule(ctx, models.AutomationRule{
 		OrgID:                   orgID,
 		RuleName:                "topology-create",
 		TriggerType:             models.AutomationTriggerTypeMQTT,
@@ -63,12 +70,13 @@ func TestSQLCurtailmentStore_TopologyProfilesCannotBeAutomated(t *testing.T) {
 		ResponseProfileRevision: topologyProfile.Revision,
 		Enabled:                 true,
 	}, models.ResponseProfileFanSettings{})
-	require.Error(t, err)
-	assert.True(t, fleeterror.IsFailedPreconditionError(err))
+	require.NoError(t, err)
+	require.NotNil(t, createdRule)
+	assert.Equal(t, topologyProfile.Revision, createdRule.ResponseProfileRevision)
 
 	cleanProfileID := seedResponseProfile(t, database, orgID, "clean-profile")
 	ruleID := seedAutomationRule(t, database, orgID, sourceID, cleanProfileID, "clean-rule", false)
-	_, err = store.UpdateAutomationRule(ctx, models.AutomationRule{
+	updatedRule, err := store.UpdateAutomationRule(ctx, models.AutomationRule{
 		ID:                      ruleID,
 		OrgID:                   orgID,
 		RuleName:                "topology-update",
@@ -76,31 +84,46 @@ func TestSQLCurtailmentStore_TopologyProfilesCannotBeAutomated(t *testing.T) {
 		ResponseProfileID:       topologyProfileID,
 		ResponseProfileRevision: topologyProfile.Revision,
 	}, models.ResponseProfileFanSettings{})
-	require.Error(t, err)
-	assert.True(t, fleeterror.IsFailedPreconditionError(err))
+	require.NoError(t, err)
+	require.NotNil(t, updatedRule)
+	assert.Equal(t, topologyProfileID, updatedRule.ResponseProfileID)
+	assert.Equal(t, topologyProfile.Revision, updatedRule.ResponseProfileRevision)
 
 	topologyRuleID := seedAutomationRule(t, database, orgID, sourceID, topologyProfileID, "topology-enable", false)
-	_, err = store.SetAutomationRuleEnabled(ctx, orgID, topologyRuleID, true, topologyProfile.Revision, models.ResponseProfileFanSettings{})
-	require.Error(t, err)
-	assert.True(t, fleeterror.IsFailedPreconditionError(err))
-
-	cleanProfile, err := store.GetResponseProfile(ctx, orgID, cleanProfileID)
+	enabledRule, err := store.SetAutomationRuleEnabled(ctx, orgID, topologyRuleID, true, topologyProfile.Revision, models.ResponseProfileFanSettings{})
 	require.NoError(t, err)
-	expectedCleanScopeJSON := append([]byte(nil), cleanProfile.ScopeJSON...)
-	cleanProfile.ScopeJSON = []byte(`{"scope_schema_version":1,"rack_ids":[8]}`)
-	_, err = store.UpdateResponseProfile(
+	require.NotNil(t, enabledRule)
+	assert.True(t, enabledRule.Enabled)
+	assert.Equal(t, topologyProfile.Revision, enabledRule.ResponseProfileRevision)
+
+	expectedTopologyScopeJSON = append([]byte(nil), topologyProfile.ScopeJSON...)
+	topologyProfile.ScopeJSON = []byte(fmt.Sprintf(`{"scope_schema_version":1,"building_ids":[%d]}`, replacementBuilding.ID))
+	updatedProfile, err := store.UpdateResponseProfile(
 		ctx,
-		*cleanProfile,
+		*topologyProfile,
 		nil,
 		nil,
-		cleanProfile.SiteID,
-		expectedCleanScopeJSON,
+		topologyProfile.SiteID,
+		expectedTopologyScopeJSON,
 		models.ResponseProfileFanSettings{},
 	)
-	require.Error(t, err)
-	assert.True(t, fleeterror.IsFailedPreconditionError(err))
-
-	unchanged, err := store.GetResponseProfile(ctx, orgID, cleanProfileID)
 	require.NoError(t, err)
-	assert.JSONEq(t, string(expectedCleanScopeJSON), string(unchanged.ScopeJSON))
+	require.NotNil(t, updatedProfile)
+	assert.JSONEq(t, string(topologyProfile.ScopeJSON), string(updatedProfile.ScopeJSON))
+	assert.NotEqual(t, topologyProfile.Revision, updatedProfile.Revision)
+
+	_, found, err := buildingStore.SoftDeleteBuilding(ctx, orgID, replacementBuilding.ID)
+	require.NoError(t, err)
+	require.True(t, found)
+	_, err = store.CreateAutomationRule(ctx, models.AutomationRule{
+		OrgID:                   orgID,
+		RuleName:                "deleted-topology-create",
+		TriggerType:             models.AutomationTriggerTypeMQTT,
+		MQTTSourceID:            sourceID,
+		ResponseProfileID:       topologyProfileID,
+		ResponseProfileRevision: updatedProfile.Revision,
+		Enabled:                 true,
+	}, models.ResponseProfileFanSettings{})
+	require.Error(t, err)
+	assert.True(t, fleeterror.IsNotFoundError(err))
 }

--- a/server/internal/domain/stores/sqlstores/response_profile_revision_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/response_profile_revision_integration_test.go
@@ -571,7 +571,7 @@ func TestSQLCurtailmentStore_AutomationExecutionRevalidatesSourceUser(t *testing
 				profile.ScopeJSON = []byte(fmt.Sprintf(`{"scope_schema_version":1,"building_ids":[%d]}`, building.ID))
 				profile.SiteID = nil
 			} else {
-				profile.ScopeJSON = nil
+				profile.ScopeJSON = []byte(`{}`)
 				profile.SiteID = &site.ID
 			}
 			profile, err = store.UpdateResponseProfile(

--- a/server/internal/domain/stores/sqlstores/response_profile_revision_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/response_profile_revision_integration_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/block/proto-fleet/server/generated/sqlc"
 	"github.com/block/proto-fleet/server/internal/domain/authz"
 	buildingsmodels "github.com/block/proto-fleet/server/internal/domain/buildings/models"
+	domainCurtailment "github.com/block/proto-fleet/server/internal/domain/curtailment"
 	"github.com/block/proto-fleet/server/internal/domain/curtailment/models"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 	sitesmodels "github.com/block/proto-fleet/server/internal/domain/sites/models"
@@ -507,6 +508,10 @@ func TestSQLCurtailmentStore_AutomationExecutionRevalidatesSourceUser(t *testing
 		wantErrorSubstring string
 	}{
 		{
+			name:          "authorized topology scope",
+			topologyScope: true,
+		},
+		{
 			name:               "revoked scope permission",
 			topologyScope:      true,
 			demoteAssignments:  true,
@@ -663,7 +668,20 @@ func TestSQLCurtailmentStore_AutomationExecutionRevalidatesSourceUser(t *testing
 				tt.requiresAdminRole,
 			))
 
-			_, err = store.InsertEventWithTargets(ctx, execution, nil)
+			inserted, err := store.InsertEventWithTargets(ctx, execution, nil)
+			if tt.wantErrorSubstring == "" {
+				require.NoError(t, err)
+				require.NotNil(t, inserted)
+				stored, getErr := store.GetEventByUUID(ctx, user.OrganizationID, execution.EventUUID)
+				require.NoError(t, getErr)
+				assert.JSONEq(t, string(profile.ScopeJSON), string(stored.ScopeJSON))
+				envelope, parseErr := domainCurtailment.AuthorizationEnvelopeFromJSON(stored.AuthorizationEnvelopeJSON)
+				require.NoError(t, parseErr)
+				assert.Equal(t, []int64{site.ID}, envelope.SelectedResourceSiteIDs)
+				assert.Empty(t, envelope.CurrentMemberSiteIDs)
+				assert.False(t, envelope.MinerScopeUnbounded)
+				return
+			}
 
 			require.Error(t, err)
 			if tt.wantForbidden {
@@ -702,7 +720,18 @@ func TestSQLCurtailmentStore_AutomationRecurtailRevalidatesExecutionFence(t *tes
 		{
 			name:               "changed MQTT source principal",
 			mutation:           "source",
-			wantErrorSubstring: "automation rule changed before execution",
+			wantErrorSubstring: "source principal changed since event creation",
+		},
+		{
+			name:               "changed ownership marker",
+			mutation:           "ownership",
+			wantErrorSubstring: "not owned by this automation rule",
+		},
+		{
+			name:               "topology coverage moved outside permissions",
+			mutation:           "topology",
+			wantForbidden:      true,
+			wantErrorSubstring: "no longer has permission",
 		},
 	}
 
@@ -717,9 +746,65 @@ func TestSQLCurtailmentStore_AutomationRecurtailRevalidatesExecutionFence(t *tes
 			database := testContext.DatabaseService.DB
 			store := sqlstores.NewSQLCurtailmentStore(database)
 			ctx := t.Context()
+			queries := sqlc.New(database)
 			profileID := seedResponseProfile(t, database, user.OrganizationID, "automation-recurtail-profile")
 			profile, err := store.GetResponseProfile(ctx, user.OrganizationID, profileID)
 			require.NoError(t, err)
+			var topologyBuildingID, topologyNewSiteID int64
+			if tt.mutation == "topology" {
+				originalSite, createErr := sqlstores.NewSQLSiteStore(database).CreateSite(ctx, sitesmodels.CreateSiteParams{
+					OrgID: user.OrganizationID,
+					Name:  "Automation re-curtail original site",
+				})
+				require.NoError(t, createErr)
+				newSite, createErr := sqlstores.NewSQLSiteStore(database).CreateSite(ctx, sitesmodels.CreateSiteParams{
+					OrgID: user.OrganizationID,
+					Name:  "Automation re-curtail new site",
+				})
+				require.NoError(t, createErr)
+				building, createErr := sqlstores.NewSQLBuildingStore(database).CreateBuilding(ctx, buildingsmodels.CreateParams{
+					OrgID:  user.OrganizationID,
+					SiteID: &originalSite.ID,
+					Name:   "Automation re-curtail building",
+				})
+				require.NoError(t, createErr)
+				topologyBuildingID = building.ID
+				topologyNewSiteID = newSite.ID
+				expectedSiteID := profile.SiteID
+				expectedScopeJSON := append([]byte(nil), profile.ScopeJSON...)
+				profile.SiteID = nil
+				profile.ScopeJSON = []byte(fmt.Sprintf(`{"scope_schema_version":1,"building_ids":[%d]}`, building.ID))
+				profile, err = store.UpdateResponseProfile(
+					ctx,
+					*profile,
+					nil,
+					nil,
+					expectedSiteID,
+					expectedScopeJSON,
+					models.ResponseProfileFanSettings{},
+				)
+				require.NoError(t, err)
+
+				admin, roleErr := queries.GetBuiltinRoleForOrg(ctx, sqlc.GetBuiltinRoleForOrgParams{
+					OrganizationID: sql.NullInt64{Int64: user.OrganizationID, Valid: true},
+					BuiltinKey:     sql.NullString{String: string(authz.BuiltinKeyAdmin), Valid: true},
+				})
+				require.NoError(t, roleErr)
+				assignment, assignmentErr := queries.GetOrgScopeAssignmentForUser(ctx, sqlc.GetOrgScopeAssignmentForUserParams{
+					UserID:         user.DatabaseID,
+					OrganizationID: user.OrganizationID,
+				})
+				require.NoError(t, assignmentErr)
+				require.NoError(t, queries.UnassignRole(ctx, assignment.AssignmentID))
+				_, assignmentErr = queries.AssignRole(ctx, sqlc.AssignRoleParams{
+					UserID:         user.DatabaseID,
+					OrganizationID: user.OrganizationID,
+					RoleID:         admin.ID,
+					ScopeType:      string(authz.ScopeSite),
+					ScopeID:        sql.NullInt64{Int64: originalSite.ID, Valid: true},
+				})
+				require.NoError(t, assignmentErr)
+			}
 			sourceID := seedMQTTSourceConfig(
 				t,
 				database,
@@ -751,7 +836,11 @@ func TestSQLCurtailmentStore_AutomationRecurtailRevalidatesExecutionFence(t *tes
 				0,
 				reference,
 			)
-			execution.AllowUnbounded = true
+			execution.AllowUnbounded = tt.mutation != "topology"
+			if tt.mutation == "topology" {
+				execution.ScopeType = models.ScopeTypeMixed
+				execution.ScopeJSON = append([]byte(nil), profile.ScopeJSON...)
+			}
 			execution.SourceActorType = models.SourceActorAutomation
 			execution.SourceActorID = &reference
 			execution.ExternalSource = &externalSource
@@ -761,24 +850,34 @@ func TestSQLCurtailmentStore_AutomationRecurtailRevalidatesExecutionFence(t *tes
 			execution.ResponseProfileRevision = profile.Revision
 			execution.AutomationRuleID = rule.ID
 			execution.AutomationMQTTSourceID = sourceID
+			if tt.mutation == "ownership" {
+				differentRule := "different-rule"
+				execution.SourceActorID = &differentRule
+			}
 			execution.DecisionSnapshotJSON = []byte(fmt.Sprintf(
-				`{"response_profile_id":%d,"response_profile_revision":%q,"requires_admin_controls":true}`,
+				`{"response_profile_id":%d,"response_profile_revision":%q,"requires_admin_controls":%t}`,
 				profile.ID,
 				profile.Revision.String(),
+				tt.mutation != "topology",
 			))
 			inserted, err := store.InsertEventWithTargets(ctx, execution, nil)
 			require.NoError(t, err)
-			_, err = database.ExecContext(ctx, `UPDATE curtailment_event SET state = 'restoring' WHERE id = $1`, inserted.ID)
+			updatedRows, err := queries.UpdateCurtailmentEventState(ctx, sqlc.UpdateCurtailmentEventStateParams{
+				State:         string(models.EventStateRestoring),
+				ID:            inserted.ID,
+				ExpectedState: string(models.EventStateActive),
+			})
 			require.NoError(t, err)
+			require.Equal(t, int64(1), updatedRows)
 
-			queries := sqlc.New(database)
 			fieldTech, err := queries.GetBuiltinRoleForOrg(ctx, sqlc.GetBuiltinRoleForOrgParams{
 				OrganizationID: sql.NullInt64{Int64: user.OrganizationID, Valid: true},
 				BuiltinKey:     sql.NullString{String: string(authz.BuiltinKeyFieldTech), Valid: true},
 			})
 			require.NoError(t, err)
+			automationServiceUserID := user.DatabaseID
 			switch tt.mutation {
-			case "none":
+			case "none", "ownership":
 			case "permissions":
 				assignment, assignmentErr := queries.GetOrgScopeAssignmentForUser(ctx, sqlc.GetOrgScopeAssignmentForUserParams{
 					UserID:         user.DatabaseID,
@@ -802,11 +901,34 @@ func TestSQLCurtailmentStore_AutomationRecurtailRevalidatesExecutionFence(t *tes
 				}))
 			case "source":
 				replacement := testContext.DatabaseService.CreateSuperAdminUser2()
-				_, err = database.ExecContext(
+				source, sourceErr := queries.GetMQTTSourceConfigByOrg(ctx, sqlc.GetMQTTSourceConfigByOrgParams{
+					ID:             sourceID,
+					OrganizationID: user.OrganizationID,
+				})
+				require.NoError(t, sourceErr)
+				_, err = queries.UpdateMQTTSourceConfig(ctx, sqlc.UpdateMQTTSourceConfigParams{
+					ServiceUserID:         replacement.DatabaseID,
+					SourceName:            source.SourceName,
+					Topic:                 source.Topic,
+					BrokerPrimaryHost:     source.BrokerPrimaryHost,
+					BrokerSecondaryHost:   source.BrokerSecondaryHost,
+					BrokerPort:            source.BrokerPort,
+					BrokerTransport:       source.BrokerTransport,
+					MqttUsername:          source.MqttUsername,
+					MqttPasswordEnc:       source.MqttPasswordEnc,
+					PayloadFormat:         source.PayloadFormat,
+					StalenessThresholdSec: source.StalenessThresholdSec,
+					ID:                    source.ID,
+					OrganizationID:        source.OrganizationID,
+				})
+				require.NoError(t, err)
+				automationServiceUserID = replacement.DatabaseID
+			case "topology":
+				_, err = sqlstores.NewSQLSiteStore(database).AssignBuildingsToSiteBulk(
 					ctx,
-					`UPDATE curtailment_mqtt_source_config SET service_user_id = $1 WHERE id = $2`,
-					replacement.DatabaseID,
-					sourceID,
+					user.OrganizationID,
+					[]int64{topologyBuildingID},
+					&topologyNewSiteID,
 				)
 				require.NoError(t, err)
 			default:
@@ -822,7 +944,7 @@ func TestSQLCurtailmentStore_AutomationRecurtailRevalidatesExecutionFence(t *tes
 					ResponseProfileRevision: profile.Revision,
 					AutomationRuleID:        rule.ID,
 					AutomationMQTTSourceID:  sourceID,
-					AutomationServiceUserID: user.DatabaseID,
+					AutomationServiceUserID: automationServiceUserID,
 				},
 			)
 

--- a/server/internal/domain/stores/sqlstores/response_profile_revision_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/response_profile_revision_integration_test.go
@@ -12,8 +12,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/block/proto-fleet/server/generated/sqlc"
+	"github.com/block/proto-fleet/server/internal/domain/authz"
+	buildingsmodels "github.com/block/proto-fleet/server/internal/domain/buildings/models"
 	"github.com/block/proto-fleet/server/internal/domain/curtailment/models"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
+	sitesmodels "github.com/block/proto-fleet/server/internal/domain/sites/models"
 	"github.com/block/proto-fleet/server/internal/domain/stores/sqlstores"
 	"github.com/block/proto-fleet/server/internal/testutil"
 )
@@ -482,6 +485,159 @@ func TestSQLCurtailmentStore_AutomationExecutionRejectsReboundRule(t *testing.T)
 	currentExecution.ResponseProfileRevision = profileB.Revision
 	_, err = store.InsertEventWithTargets(ctx, currentExecution, nil)
 	require.NoError(t, err)
+}
+
+func TestSQLCurtailmentStore_TopologyAutomationExecutionRevalidatesSourceUser(t *testing.T) {
+	tests := []struct {
+		name               string
+		demoteAssignments  bool
+		requiresAdminRole  bool
+		useDifferentActor  bool
+		wantForbidden      bool
+		wantErrorSubstring string
+	}{
+		{
+			name:               "revoked scope permission",
+			demoteAssignments:  true,
+			wantForbidden:      true,
+			wantErrorSubstring: "no longer has permission",
+		},
+		{
+			name:               "demoted admin role",
+			requiresAdminRole:  true,
+			wantForbidden:      true,
+			wantErrorSubstring: "no longer has the admin role",
+		},
+		{
+			name:               "changed MQTT source principal",
+			useDifferentActor:  true,
+			wantErrorSubstring: "automation rule changed before execution",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if testing.Short() {
+				t.Skip("skipping database integration test in short mode")
+			}
+
+			testContext := testutil.InitializeDBServiceInfrastructure(t)
+			user := testContext.DatabaseService.CreateSuperAdminUser()
+			database := testContext.DatabaseService.DB
+			store := sqlstores.NewSQLCurtailmentStore(database)
+			ctx := t.Context()
+			site, err := sqlstores.NewSQLSiteStore(database).CreateSite(ctx, sitesmodels.CreateSiteParams{
+				OrgID: user.OrganizationID,
+				Name:  "Automation authorization site",
+			})
+			require.NoError(t, err)
+			building, err := sqlstores.NewSQLBuildingStore(database).CreateBuilding(ctx, buildingsmodels.CreateParams{
+				OrgID:  user.OrganizationID,
+				SiteID: &site.ID,
+				Name:   "Automation authorization building",
+			})
+			require.NoError(t, err)
+			profileID := seedResponseProfile(t, database, user.OrganizationID, "automation-authorization-profile")
+			profile, err := store.GetResponseProfile(ctx, user.OrganizationID, profileID)
+			require.NoError(t, err)
+			expectedSiteID := profile.SiteID
+			expectedScopeJSON := append([]byte(nil), profile.ScopeJSON...)
+			profile.ScopeJSON = []byte(fmt.Sprintf(`{"scope_schema_version":1,"building_ids":[%d]}`, building.ID))
+			profile.SiteID = nil
+			profile, err = store.UpdateResponseProfile(
+				ctx,
+				*profile,
+				nil,
+				nil,
+				expectedSiteID,
+				expectedScopeJSON,
+				models.ResponseProfileFanSettings{},
+			)
+			require.NoError(t, err)
+			sourceID := seedMQTTSourceConfig(
+				t,
+				database,
+				user.OrganizationID,
+				user.DatabaseID,
+				"automation-authorization-source",
+				true,
+			)
+			rule, err := store.CreateAutomationRule(ctx, models.AutomationRule{
+				OrgID:                   user.OrganizationID,
+				RuleName:                "automation-authorization-rule",
+				TriggerType:             models.AutomationTriggerTypeMQTT,
+				MQTTSourceID:            sourceID,
+				ResponseProfileID:       profile.ID,
+				ResponseProfileRevision: profile.Revision,
+				Enabled:                 true,
+			}, models.ResponseProfileFanSettings{})
+			require.NoError(t, err)
+
+			queries := sqlc.New(database)
+			if tt.demoteAssignments || tt.requiresAdminRole {
+				fieldTech, roleErr := queries.GetBuiltinRoleForOrg(ctx, sqlc.GetBuiltinRoleForOrgParams{
+					OrganizationID: sql.NullInt64{Int64: user.OrganizationID, Valid: true},
+					BuiltinKey:     sql.NullString{String: string(authz.BuiltinKeyFieldTech), Valid: true},
+				})
+				require.NoError(t, roleErr)
+				require.NoError(t, queries.UpdateUserRole(ctx, sqlc.UpdateUserRoleParams{
+					RoleID:         fieldTech.ID,
+					UserID:         user.DatabaseID,
+					OrganizationID: user.OrganizationID,
+				}))
+				if tt.demoteAssignments {
+					assignment, assignmentErr := queries.GetOrgScopeAssignmentForUser(ctx, sqlc.GetOrgScopeAssignmentForUserParams{
+						UserID:         user.DatabaseID,
+						OrganizationID: user.OrganizationID,
+					})
+					require.NoError(t, assignmentErr)
+					require.NoError(t, queries.UnassignRole(ctx, assignment.AssignmentID))
+					_, assignmentErr = queries.AssignRole(ctx, sqlc.AssignRoleParams{
+						UserID:         user.DatabaseID,
+						OrganizationID: user.OrganizationID,
+						RoleID:         fieldTech.ID,
+						ScopeType:      "org",
+						ScopeID:        sql.NullInt64{},
+					})
+					require.NoError(t, assignmentErr)
+				}
+			}
+			createdByUserID := user.DatabaseID
+			if tt.useDifferentActor {
+				createdByUserID = testContext.DatabaseService.CreateSuperAdminUser2().DatabaseID
+			}
+
+			execution := curtailmentStoreClosedLoopFullFleetEvent(
+				user.OrganizationID,
+				createdByUserID,
+				uuid.New(),
+				models.ScopeTypeMixed,
+				0,
+				fmt.Sprintf("%d", rule.ID),
+			)
+			execution.ScopeJSON = append([]byte(nil), profile.ScopeJSON...)
+			execution.SourceActorType = models.SourceActorAutomation
+			execution.ResponseProfileID = profile.ID
+			execution.ResponseProfileRevision = profile.Revision
+			execution.AutomationRuleID = rule.ID
+			execution.AutomationMQTTSourceID = sourceID
+			execution.ForceIncludeAllPairedMiners = tt.requiresAdminRole
+			execution.DecisionSnapshotJSON = []byte(fmt.Sprintf(
+				`{"requires_admin_controls":%t}`,
+				tt.requiresAdminRole,
+			))
+
+			_, err = store.InsertEventWithTargets(ctx, execution, nil)
+
+			require.Error(t, err)
+			if tt.wantForbidden {
+				assert.True(t, fleeterror.IsForbiddenError(err))
+			} else {
+				assert.True(t, fleeterror.IsFailedPreconditionError(err))
+			}
+			assert.Contains(t, err.Error(), tt.wantErrorSubstring)
+		})
+	}
 }
 
 func TestSQLCurtailmentStore_AutomationExecutionSerializesConcurrentRebind(t *testing.T) {

--- a/server/internal/domain/stores/sqlstores/response_profile_revision_integration_test.go
+++ b/server/internal/domain/stores/sqlstores/response_profile_revision_integration_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/block/proto-fleet/server/internal/domain/curtailment/models"
 	"github.com/block/proto-fleet/server/internal/domain/fleeterror"
 	sitesmodels "github.com/block/proto-fleet/server/internal/domain/sites/models"
+	"github.com/block/proto-fleet/server/internal/domain/stores/interfaces"
 	"github.com/block/proto-fleet/server/internal/domain/stores/sqlstores"
 	"github.com/block/proto-fleet/server/internal/testutil"
 )
@@ -113,7 +114,10 @@ func TestSQLCurtailmentStore_RecurtailRequiresMatchingEventProfileBinding(t *tes
 	`, inserted.ID)
 	require.NoError(t, err)
 
-	_, err = store.BeginRecurtailTransition(ctx, user.OrganizationID, eventUUID, profile.ID, profile.Revision)
+	_, err = store.BeginRecurtailTransition(ctx, user.OrganizationID, eventUUID, interfaces.BeginRecurtailTransitionParams{
+		ResponseProfileID:       profile.ID,
+		ResponseProfileRevision: profile.Revision,
+	})
 	require.Error(t, err)
 	assert.True(t, fleeterror.IsFailedPreconditionError(err), "unstamped replay must fail closed, got %v", err)
 
@@ -127,7 +131,10 @@ func TestSQLCurtailmentStore_RecurtailRequiresMatchingEventProfileBinding(t *tes
 	`, inserted.ID, profile.ID+1, profile.Revision.String())
 	require.NoError(t, err)
 
-	_, err = store.BeginRecurtailTransition(ctx, user.OrganizationID, eventUUID, profile.ID, profile.Revision)
+	_, err = store.BeginRecurtailTransition(ctx, user.OrganizationID, eventUUID, interfaces.BeginRecurtailTransitionParams{
+		ResponseProfileID:       profile.ID,
+		ResponseProfileRevision: profile.Revision,
+	})
 	require.Error(t, err)
 	assert.True(t, fleeterror.IsFailedPreconditionError(err), "mismatched replay must fail closed, got %v", err)
 
@@ -145,8 +152,10 @@ func TestSQLCurtailmentStore_RecurtailRequiresMatchingEventProfileBinding(t *tes
 		ctx,
 		user.OrganizationID,
 		eventUUID,
-		profile.ID,
-		profile.Revision,
+		interfaces.BeginRecurtailTransitionParams{
+			ResponseProfileID:       profile.ID,
+			ResponseProfileRevision: profile.Revision,
+		},
 	)
 	require.NoError(t, err)
 	require.NotNil(t, recurtailed)
@@ -487,9 +496,10 @@ func TestSQLCurtailmentStore_AutomationExecutionRejectsReboundRule(t *testing.T)
 	require.NoError(t, err)
 }
 
-func TestSQLCurtailmentStore_TopologyAutomationExecutionRevalidatesSourceUser(t *testing.T) {
+func TestSQLCurtailmentStore_AutomationExecutionRevalidatesSourceUser(t *testing.T) {
 	tests := []struct {
 		name               string
+		topologyScope      bool
 		demoteAssignments  bool
 		requiresAdminRole  bool
 		useDifferentActor  bool
@@ -498,20 +508,35 @@ func TestSQLCurtailmentStore_TopologyAutomationExecutionRevalidatesSourceUser(t 
 	}{
 		{
 			name:               "revoked scope permission",
+			topologyScope:      true,
 			demoteAssignments:  true,
 			wantForbidden:      true,
 			wantErrorSubstring: "no longer has permission",
 		},
 		{
 			name:               "demoted admin role",
+			topologyScope:      true,
 			requiresAdminRole:  true,
 			wantForbidden:      true,
 			wantErrorSubstring: "no longer has the admin role",
 		},
 		{
 			name:               "changed MQTT source principal",
+			topologyScope:      true,
 			useDifferentActor:  true,
 			wantErrorSubstring: "automation rule changed before execution",
+		},
+		{
+			name:               "revoked site scope permission",
+			demoteAssignments:  true,
+			wantForbidden:      true,
+			wantErrorSubstring: "no longer has permission",
+		},
+		{
+			name:               "demoted admin role for site scope",
+			requiresAdminRole:  true,
+			wantForbidden:      true,
+			wantErrorSubstring: "no longer has the admin role",
 		},
 	}
 
@@ -542,8 +567,13 @@ func TestSQLCurtailmentStore_TopologyAutomationExecutionRevalidatesSourceUser(t 
 			require.NoError(t, err)
 			expectedSiteID := profile.SiteID
 			expectedScopeJSON := append([]byte(nil), profile.ScopeJSON...)
-			profile.ScopeJSON = []byte(fmt.Sprintf(`{"scope_schema_version":1,"building_ids":[%d]}`, building.ID))
-			profile.SiteID = nil
+			if tt.topologyScope {
+				profile.ScopeJSON = []byte(fmt.Sprintf(`{"scope_schema_version":1,"building_ids":[%d]}`, building.ID))
+				profile.SiteID = nil
+			} else {
+				profile.ScopeJSON = nil
+				profile.SiteID = &site.ID
+			}
 			profile, err = store.UpdateResponseProfile(
 				ctx,
 				*profile,
@@ -607,15 +637,21 @@ func TestSQLCurtailmentStore_TopologyAutomationExecutionRevalidatesSourceUser(t 
 				createdByUserID = testContext.DatabaseService.CreateSuperAdminUser2().DatabaseID
 			}
 
+			scopeType := models.ScopeTypeSite
+			if tt.topologyScope {
+				scopeType = models.ScopeTypeMixed
+			}
 			execution := curtailmentStoreClosedLoopFullFleetEvent(
 				user.OrganizationID,
 				createdByUserID,
 				uuid.New(),
-				models.ScopeTypeMixed,
-				0,
+				scopeType,
+				site.ID,
 				fmt.Sprintf("%d", rule.ID),
 			)
-			execution.ScopeJSON = append([]byte(nil), profile.ScopeJSON...)
+			if tt.topologyScope {
+				execution.ScopeJSON = append([]byte(nil), profile.ScopeJSON...)
+			}
 			execution.SourceActorType = models.SourceActorAutomation
 			execution.ResponseProfileID = profile.ID
 			execution.ResponseProfileRevision = profile.Revision
@@ -636,6 +672,178 @@ func TestSQLCurtailmentStore_TopologyAutomationExecutionRevalidatesSourceUser(t 
 				assert.True(t, fleeterror.IsFailedPreconditionError(err))
 			}
 			assert.Contains(t, err.Error(), tt.wantErrorSubstring)
+		})
+	}
+}
+
+func TestSQLCurtailmentStore_AutomationRecurtailRevalidatesExecutionFence(t *testing.T) {
+	tests := []struct {
+		name               string
+		mutation           string
+		wantForbidden      bool
+		wantErrorSubstring string
+	}{
+		{
+			name:     "valid execution",
+			mutation: "none",
+		},
+		{
+			name:               "revoked scope permission",
+			mutation:           "permissions",
+			wantForbidden:      true,
+			wantErrorSubstring: "no longer has permission",
+		},
+		{
+			name:               "demoted admin role",
+			mutation:           "role",
+			wantForbidden:      true,
+			wantErrorSubstring: "no longer has the admin role",
+		},
+		{
+			name:               "changed MQTT source principal",
+			mutation:           "source",
+			wantErrorSubstring: "automation rule changed before execution",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if testing.Short() {
+				t.Skip("skipping database integration test in short mode")
+			}
+
+			testContext := testutil.InitializeDBServiceInfrastructure(t)
+			user := testContext.DatabaseService.CreateSuperAdminUser()
+			database := testContext.DatabaseService.DB
+			store := sqlstores.NewSQLCurtailmentStore(database)
+			ctx := t.Context()
+			profileID := seedResponseProfile(t, database, user.OrganizationID, "automation-recurtail-profile")
+			profile, err := store.GetResponseProfile(ctx, user.OrganizationID, profileID)
+			require.NoError(t, err)
+			sourceID := seedMQTTSourceConfig(
+				t,
+				database,
+				user.OrganizationID,
+				user.DatabaseID,
+				"automation-recurtail-source",
+				true,
+			)
+			rule, err := store.CreateAutomationRule(ctx, models.AutomationRule{
+				OrgID:                   user.OrganizationID,
+				RuleName:                "automation-recurtail-rule",
+				TriggerType:             models.AutomationTriggerTypeMQTT,
+				MQTTSourceID:            sourceID,
+				ResponseProfileID:       profile.ID,
+				ResponseProfileRevision: profile.Revision,
+				Enabled:                 true,
+			}, models.ResponseProfileFanSettings{})
+			require.NoError(t, err)
+
+			reference := fmt.Sprintf("%d", rule.ID)
+			externalSource := "curtailment_automation"
+			idempotencyKey := "curtailment_automation_rule:" + reference
+			eventUUID := uuid.New()
+			execution := curtailmentStoreClosedLoopFullFleetEvent(
+				user.OrganizationID,
+				user.DatabaseID,
+				eventUUID,
+				models.ScopeTypeWholeOrg,
+				0,
+				reference,
+			)
+			execution.AllowUnbounded = true
+			execution.SourceActorType = models.SourceActorAutomation
+			execution.SourceActorID = &reference
+			execution.ExternalSource = &externalSource
+			execution.ExternalReference = &reference
+			execution.IdempotencyKey = &idempotencyKey
+			execution.ResponseProfileID = profile.ID
+			execution.ResponseProfileRevision = profile.Revision
+			execution.AutomationRuleID = rule.ID
+			execution.AutomationMQTTSourceID = sourceID
+			execution.DecisionSnapshotJSON = []byte(fmt.Sprintf(
+				`{"response_profile_id":%d,"response_profile_revision":%q,"requires_admin_controls":true}`,
+				profile.ID,
+				profile.Revision.String(),
+			))
+			inserted, err := store.InsertEventWithTargets(ctx, execution, nil)
+			require.NoError(t, err)
+			_, err = database.ExecContext(ctx, `UPDATE curtailment_event SET state = 'restoring' WHERE id = $1`, inserted.ID)
+			require.NoError(t, err)
+
+			queries := sqlc.New(database)
+			fieldTech, err := queries.GetBuiltinRoleForOrg(ctx, sqlc.GetBuiltinRoleForOrgParams{
+				OrganizationID: sql.NullInt64{Int64: user.OrganizationID, Valid: true},
+				BuiltinKey:     sql.NullString{String: string(authz.BuiltinKeyFieldTech), Valid: true},
+			})
+			require.NoError(t, err)
+			switch tt.mutation {
+			case "none":
+			case "permissions":
+				assignment, assignmentErr := queries.GetOrgScopeAssignmentForUser(ctx, sqlc.GetOrgScopeAssignmentForUserParams{
+					UserID:         user.DatabaseID,
+					OrganizationID: user.OrganizationID,
+				})
+				require.NoError(t, assignmentErr)
+				require.NoError(t, queries.UnassignRole(ctx, assignment.AssignmentID))
+				_, assignmentErr = queries.AssignRole(ctx, sqlc.AssignRoleParams{
+					UserID:         user.DatabaseID,
+					OrganizationID: user.OrganizationID,
+					RoleID:         fieldTech.ID,
+					ScopeType:      "org",
+					ScopeID:        sql.NullInt64{},
+				})
+				require.NoError(t, assignmentErr)
+			case "role":
+				require.NoError(t, queries.UpdateUserRole(ctx, sqlc.UpdateUserRoleParams{
+					RoleID:         fieldTech.ID,
+					UserID:         user.DatabaseID,
+					OrganizationID: user.OrganizationID,
+				}))
+			case "source":
+				replacement := testContext.DatabaseService.CreateSuperAdminUser2()
+				_, err = database.ExecContext(
+					ctx,
+					`UPDATE curtailment_mqtt_source_config SET service_user_id = $1 WHERE id = $2`,
+					replacement.DatabaseID,
+					sourceID,
+				)
+				require.NoError(t, err)
+			default:
+				t.Fatalf("unknown mutation %q", tt.mutation)
+			}
+
+			_, err = store.BeginRecurtailTransition(
+				ctx,
+				user.OrganizationID,
+				eventUUID,
+				interfaces.BeginRecurtailTransitionParams{
+					ResponseProfileID:       profile.ID,
+					ResponseProfileRevision: profile.Revision,
+					AutomationRuleID:        rule.ID,
+					AutomationMQTTSourceID:  sourceID,
+					AutomationServiceUserID: user.DatabaseID,
+				},
+			)
+
+			if tt.wantErrorSubstring == "" {
+				require.NoError(t, err)
+				stored, getErr := store.GetEventByUUID(ctx, user.OrganizationID, eventUUID)
+				require.NoError(t, getErr)
+				assert.Equal(t, models.EventStatePending, stored.State)
+				return
+			}
+
+			require.Error(t, err)
+			if tt.wantForbidden {
+				assert.True(t, fleeterror.IsForbiddenError(err))
+			} else {
+				assert.True(t, fleeterror.IsFailedPreconditionError(err))
+			}
+			assert.Contains(t, err.Error(), tt.wantErrorSubstring)
+			stored, getErr := store.GetEventByUUID(ctx, user.OrganizationID, eventUUID)
+			require.NoError(t, getErr)
+			assert.Equal(t, models.EventStateRestoring, stored.State)
 		})
 	}
 }

--- a/server/internal/handlers/curtailment/handler_admin_terminate_test.go
+++ b/server/internal/handlers/curtailment/handler_admin_terminate_test.go
@@ -189,7 +189,7 @@ func (s *adminTerminateStubStore) GetTargetRollupByEvent(context.Context, int64,
 func (s *adminTerminateStubStore) BeginRestoreTransition(context.Context, int64, uuid.UUID, interfaces.BeginRestoreTransitionParams) (*models.Event, error) {
 	panic("BeginRestoreTransition not exercised by AdminTerminate handler tests")
 }
-func (s *adminTerminateStubStore) BeginRecurtailTransition(context.Context, int64, uuid.UUID, int64, uuid.UUID) (*models.Event, error) {
+func (s *adminTerminateStubStore) BeginRecurtailTransition(context.Context, int64, uuid.UUID, interfaces.BeginRecurtailTransitionParams) (*models.Event, error) {
 	panic("BeginRecurtailTransition not exercised by AdminTerminate handler tests")
 }
 func (s *adminTerminateStubStore) GetHeartbeat(context.Context) (*models.Heartbeat, error) {

--- a/server/internal/handlers/curtailment/handler_list_test.go
+++ b/server/internal/handlers/curtailment/handler_list_test.go
@@ -242,7 +242,7 @@ func (s *listStubStore) GetTargetRollupByEvent(_ context.Context, _ int64, event
 func (s *listStubStore) BeginRestoreTransition(context.Context, int64, uuid.UUID, interfaces.BeginRestoreTransitionParams) (*models.Event, error) {
 	panic("BeginRestoreTransition not exercised by List handler tests")
 }
-func (s *listStubStore) BeginRecurtailTransition(context.Context, int64, uuid.UUID, int64, uuid.UUID) (*models.Event, error) {
+func (s *listStubStore) BeginRecurtailTransition(context.Context, int64, uuid.UUID, interfaces.BeginRecurtailTransitionParams) (*models.Event, error) {
 	panic("BeginRecurtailTransition not exercised by List handler tests")
 }
 func (s *listStubStore) GetHeartbeat(context.Context) (*models.Heartbeat, error) {

--- a/server/internal/handlers/curtailment/handler_start_test.go
+++ b/server/internal/handlers/curtailment/handler_start_test.go
@@ -220,7 +220,7 @@ func (s *startStubStore) UpsertHeartbeat(context.Context, interfaces.UpsertCurta
 func (s *startStubStore) BeginRestoreTransition(context.Context, int64, uuid.UUID, interfaces.BeginRestoreTransitionParams) (*models.Event, error) {
 	panic("BeginRestoreTransition not exercised by handler Start tests")
 }
-func (s *startStubStore) BeginRecurtailTransition(context.Context, int64, uuid.UUID, int64, uuid.UUID) (*models.Event, error) {
+func (s *startStubStore) BeginRecurtailTransition(context.Context, int64, uuid.UUID, interfaces.BeginRecurtailTransitionParams) (*models.Event, error) {
 	panic("BeginRecurtailTransition not exercised by handler Start tests")
 }
 

--- a/server/internal/handlers/curtailment/handler_stop_test.go
+++ b/server/internal/handlers/curtailment/handler_stop_test.go
@@ -168,7 +168,7 @@ func (s *stopStubStore) BeginRestoreTransition(_ context.Context, _ int64, event
 	}
 	return &updated, nil
 }
-func (s *stopStubStore) BeginRecurtailTransition(context.Context, int64, uuid.UUID, int64, uuid.UUID) (*models.Event, error) {
+func (s *stopStubStore) BeginRecurtailTransition(context.Context, int64, uuid.UUID, interfaces.BeginRecurtailTransitionParams) (*models.Event, error) {
 	panic("BeginRecurtailTransition not exercised (no gRPC re-curtail endpoint)")
 }
 func (s *stopStubStore) GetHeartbeat(context.Context) (*models.Heartbeat, error) {

--- a/server/internal/handlers/curtailment/handler_update_test.go
+++ b/server/internal/handlers/curtailment/handler_update_test.go
@@ -192,7 +192,7 @@ func (s *updateStubStore) GetTargetRollupByEvent(context.Context, int64, uuid.UU
 func (s *updateStubStore) BeginRestoreTransition(context.Context, int64, uuid.UUID, interfaces.BeginRestoreTransitionParams) (*models.Event, error) {
 	panic("BeginRestoreTransition not exercised by Update handler tests")
 }
-func (s *updateStubStore) BeginRecurtailTransition(context.Context, int64, uuid.UUID, int64, uuid.UUID) (*models.Event, error) {
+func (s *updateStubStore) BeginRecurtailTransition(context.Context, int64, uuid.UUID, interfaces.BeginRecurtailTransitionParams) (*models.Event, error) {
 	panic("BeginRecurtailTransition not exercised by Update handler tests")
 }
 func (s *updateStubStore) GetHeartbeat(context.Context) (*models.Heartbeat, error) {

--- a/server/sqlc/queries/curtailment_automation.sql
+++ b/server/sqlc/queries/curtailment_automation.sql
@@ -72,14 +72,18 @@ SELECT rule.id
 FROM curtailment_automation_rule AS rule
 JOIN curtailment_automation_rule_profile_revision AS rule_revision
   ON rule_revision.automation_rule_id = rule.id
+JOIN curtailment_mqtt_source_config AS source
+  ON source.id = rule.mqtt_source_id
+ AND source.organization_id = rule.org_id
 WHERE rule.id = sqlc.arg('id')
   AND rule.org_id = sqlc.arg('org_id')
   AND rule.enabled = TRUE
   AND rule.trigger_type = 'MQTT'
   AND rule.mqtt_source_id = sqlc.arg('mqtt_source_id')
+  AND source.service_user_id = sqlc.arg('service_user_id')
   AND rule.response_profile_id = sqlc.arg('response_profile_id')
   AND rule_revision.response_profile_revision = sqlc.arg('response_profile_revision')
-FOR UPDATE OF rule, rule_revision;
+FOR UPDATE OF rule, rule_revision, source;
 
 -- name: ListEnabledCurtailmentAutomationRulesByMQTTSource :many
 SELECT

--- a/server/sqlc/queries/user_organization.sql
+++ b/server/sqlc/queries/user_organization.sql
@@ -40,3 +40,12 @@ JOIN user_organization uo ON r.id = uo.role_id
 WHERE uo.user_id = $1
   AND uo.organization_id = $2
   AND uo.deleted_at IS NULL;
+
+-- name: GetUserRoleNameForUpdate :one
+SELECT r.name
+FROM role r
+JOIN user_organization uo ON r.id = uo.role_id
+WHERE uo.user_id = $1
+  AND uo.organization_id = $2
+  AND uo.deleted_at IS NULL
+FOR UPDATE OF uo;


### PR DESCRIPTION
Reviewable diff: +377/-146 across 11 files (excludes generated, test, and story files).

## Summary

Topology-scoped response profiles can now be bound to and executed by MQTT curtailment automation. Building, rack, and group selectors remain logical scopes, so each trigger resolves current membership while every automation scope fails closed if the selector, source principal, permissions, or required admin role changed. This is the automation-enablement slice of #909; the remaining picker/UI and E2E work stays tracked there.

## How it works

When a rule is created, updated, enabled, or triggered, the response profile service strictly resolves its persisted topology selector. A new automation event enters the existing SQL execution transaction, which locks the rule, profile revision, MQTT source, current topology, effective permission assignments, and primary role before persisting any event or target reservation. If an OFF signal reasserts demand while an event is restoring, the re-curtail transaction applies the same rule, source-principal, permission, admin-role, profile, and event-ownership checks before it reclaims targets. The authorization-envelope evaluator is shared with the reconciler's pre-dispatch fence, keeping admission, re-curtail, and physical dispatch aligned.

```mermaid
flowchart LR
    A["MQTT OFF signal"] --> B["Load bound response profile"]
    B --> C{"Existing event is restoring?"}
    C -->|"No"| D["Resolve current building, rack, or group scope"]
    D --> E["Build curtailment plan"]
    E --> F["Transactional start fence"]
    C -->|"Yes"| G["Transactional re-curtail fence"]
    F --> H{"Binding and authorization still valid?"}
    G --> H
    H -->|"Yes"| I["Persist event or reclaim targets"]
    H -->|"No"| J["Reject without changing ownership"]
    I --> K["Reconciler revalidates before Curtail dispatch"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/` curtailment profile types | Marks every recognized terminal scope as automation-ready | Building, rack, and group profiles are selectable without treating unknown scopes as valid |
| `server/internal/domain/curtailment` | Removes topology staging gates, adds strict live selector validation, and carries the automation execution fence through re-curtail | Binding and trigger paths preserve logical selectors and re-curtail cannot bypass current rule ownership |
| Authorization envelope | Extracts the shared current-permission coverage check | Start, re-curtail, and dispatch use the same site/org-wide authorization semantics for every scope |
| `server/internal/domain/stores/sqlstores` | Adds transactional source-principal, permission, role, topology, profile, rule, and event-ownership fences | Unauthorized automation cannot reserve or reclaim miners before dispatch |
| `server/sqlc/queries/` | Locks and verifies the current MQTT source user and primary role | Concurrent source edits or role demotions serialize with event creation |
| `server/generated/sqlc/` | Regenerated SQL bindings — skip | Generated from the reviewed query sources |

## Key technical decisions & trade-offs

- Keep topology selectors logical and resolve them live instead of snapshotting miner IDs into the automation rule.
- Recheck authorization inside start and re-curtail transactions instead of relying only on the later dispatch fence, preventing unauthorized reservations from being persisted or reclaimed.
- Apply permission and admin-role checks to every automation scope, including site, whole-org, and explicit-miner profiles.
- Preserve idempotent replay recovery even when a profile later changes; strict current-profile validation applies only before creating or re-curtailing an event.
- Keep profile reads tolerant of stale topology for settings/history, while execution-capable paths opt into strict resolution.

## Testing & validation

- `go test ./internal/domain/curtailment/... ./internal/handlers/curtailment`
- `go test ./internal/domain/stores/sqlstores -run '^$'`
- `go build ./...` from `server/`
- `just _lint-server`
- `go test ./cmd/fleetnode -run '^TestRunCmd_RefreshFailureCannotExtendControlStreamPastExpiry$' -count=10`
- `npx vitest run` for the response-profile hook, automation settings, and curtailment settings suites (89 tests)
- `npx tsc --noEmit`
- `npm run build:protoFleet`
- `just _lint-client`
- Added SQL integration coverage for deleted selectors; topology and site permission revocation; admin demotion; changed MQTT source principals; and successful or rejected transactional re-curtail. The local integration database could not authenticate the configured `fleet` user, so those cases are compiled locally and will execute in CI.

Refs #909
