### PR TITLE
Debounce HA readiness alerts for one minute

### DIFF
--- a/server/internal/infrastructure/timescaledb/ha_readiness_rule_test.go
+++ b/server/internal/infrastructure/timescaledb/ha_readiness_rule_test.go
@@ -1,14 +1,41 @@
 package timescaledb_test
 
 import (
+	"os"
 	"testing"
 	"time"
 
 	"github.com/block/proto-fleet/server/internal/testutil"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 const haRuleFile = "../../../monitoring/grafana/ha/proto-fleet-ha-rules.yaml"
+
+func TestHAReadinessRuleRequiresMinuteOfDegradation(t *testing.T) {
+	raw, err := os.ReadFile(haRuleFile)
+	require.NoError(t, err)
+
+	var doc struct {
+		Groups []struct {
+			Rules []struct {
+				Title string `yaml:"title"`
+				For   string `yaml:"for"`
+			} `yaml:"rules"`
+		} `yaml:"groups"`
+	}
+	require.NoError(t, yaml.Unmarshal(raw, &doc))
+
+	for _, group := range doc.Groups {
+		for _, rule := range group.Rules {
+			if rule.Title == "HA Failover Readiness Degraded" {
+				require.Equal(t, "1m", rule.For)
+				return
+			}
+		}
+	}
+	t.Fatal("HA readiness rule not found")
+}
 
 func TestHAReadinessRuleUsesLatestValueAndFreshness(t *testing.T) {
 	if testing.Short() {

--- a/server/monitoring/grafana/ha/proto-fleet-ha-rules.yaml
+++ b/server/monitoring/grafana/ha/proto-fleet-ha-rules.yaml
@@ -46,9 +46,9 @@ groups:
         # samples still return one row per live org through the LEFT JOIN.
         noDataState: OK
         execErrState: Error
-        # Notify on the first failed readiness sample. Fleet's 30s collector
-        # remains the debounce boundary, avoiding extra status-probe load.
-        for: 0s
+        # Require one minute of continuous degradation so transient failures
+        # from Fleet's 30s readiness sampler do not flap notifications.
+        for: 1m
         labels:
           proto_fleet_rule_uid: protofleet-ha-readiness
           proto_fleet_scope: shared

--- a/server/monitoring/grafana/provisioning/alerting/notification-policies.yaml
+++ b/server/monitoring/grafana/provisioning/alerting/notification-policies.yaml
@@ -12,8 +12,8 @@ policies:
     group_interval: 5m
     repeat_interval: 1h
     routes:
-      # HA readiness is already debounced by Fleet's 30s status sampler. Flush
-      # its first failed sample quickly instead of adding the root 30s wait.
+      # The alert rule already requires one minute of continuous degradation.
+      # Flush the confirmed failure quickly instead of adding the root 30s wait.
       - receiver: protofleet-internal
         object_matchers:
           - ["template", "=", "ha-readiness"]


### PR DESCRIPTION
Reviewable diff: +5/-5 across 2 files (excludes generated, test, and story files).

## Summary

HA readiness notifications now require one minute of continuous degradation before reaching operators. This suppresses the observed single-sample alert flapping while preserving warnings for sustained loss of safe failover readiness.

## How it works

Fleet continues to sample the complete HA readiness predicate every 30 seconds and persist the result. Grafana evaluates that value on the same cadence, but now keeps a failed evaluation pending for one minute; only continuously degraded readiness becomes firing and enters the existing fast HA notification route. A passing evaluation during the pending minute resets the timer without sending a firing or resolved Slack pair.

## Diagrams

```mermaid
flowchart LR
    A["Fleet HA status sampler every 30 seconds"] --> B["Persist failover-ready value"]
    B --> C["Grafana evaluates HA readiness"]
    C --> D{"Continuously degraded for one minute?"}
    D -->|"No"| E["Remain pending or return to normal"]
    D -->|"Yes"| F["Send confirmed warning through HA route"]
```

```mermaid
sequenceDiagram
    participant Fleet as Fleet sampler
    participant Grafana as Grafana rule
    participant Slack as Slack notification
    Fleet->>Grafana: Failed readiness sample
    Grafana->>Grafana: Start one-minute pending period
    Fleet->>Grafana: Next readiness sample
    alt Readiness recovered
        Grafana->>Grafana: Clear pending state
    else Degradation remains for one minute
        Grafana->>Slack: Send HA readiness warning
    end
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/monitoring/grafana/ha/proto-fleet-ha-rules.yaml` | Changed the HA readiness pending period from zero to one minute. | Defines the operator-visible hysteresis and warning delay. |
| `server/monitoring/grafana/provisioning/alerting/notification-policies.yaml` | Updated route documentation to reflect rule-level hysteresis. | Confirms the existing five-second delivery wait applies only after degradation is established. |
| `server/internal/infrastructure/timescaledb/ha_readiness_rule_test.go` | Added a provisioning regression test for the one-minute pending period. | Prevents the alert from silently returning to immediate firing. |

## Key technical decisions & trade-offs

- Apply hysteresis in the Grafana rule instead of changing the 30-second HA sampler, preserving current probe frequency and stored readiness history.
- Require one continuous minute instead of changing Slack batching, suppressing both sides of short firing/resolved cycles while delaying sustained warnings by one minute.
- Keep the HA notification route five-second group wait, so confirmed degradation is delivered promptly after the pending period.

## Testing & validation

- `go test ./internal/infrastructure/timescaledb -run "^TestHAReadinessRuleRequiresMinuteOfDegradation$" -count=1`
- `go test ./internal/infrastructure/timescaledb -short -count=1`
- `just lint`
- `git diff --check`
- Pre-commit and pre-push hooks passed, including server and plugin lint plus client type checking.
- Live Grafana provisioning was not exercised locally.