### PR TITLE
Add topology curtailment profile E2E coverage

### DIFF
--- a/client/e2eTests/protoFleet/pages/components/curtailmentModal.ts
+++ b/client/e2eTests/protoFleet/pages/components/curtailmentModal.ts
@@ -33,7 +33,16 @@ export class CurtailmentModal {
   }
 
   async confirmRun() {
-    await this.root.getByRole("button", { name: "Run curtailment", exact: true }).click();
+    const runButton = this.root.getByRole("button", { name: "Run curtailment", exact: true });
+    if (await runButton.isVisible().catch(() => false)) {
+      await runButton.click();
+    } else {
+      await this.root.getByTestId("overflow-menu-trigger").click();
+      await this.page
+        .getByTestId("modal-overflow-sheet-content")
+        .getByRole("button", { name: "Run curtailment", exact: true })
+        .click();
+    }
 
     const forceConfirmation = this.page.getByTestId("curtailment-force-inclusion-confirmation");
     const runConfirmation = this.page.getByTestId("curtailment-run-confirmation");

--- a/client/e2eTests/protoFleet/pages/components/curtailmentModal.ts
+++ b/client/e2eTests/protoFleet/pages/components/curtailmentModal.ts
@@ -1,0 +1,67 @@
+import { expect, type Locator, type Page } from "@playwright/test";
+
+type TopologyTarget = "Buildings" | "Groups" | "Racks" | "Sites";
+
+const selectionModalTitles: Record<TopologyTarget, string> = {
+  Buildings: "Select buildings",
+  Groups: "Select groups",
+  Racks: "Select racks",
+  Sites: "Select sites",
+};
+
+export class CurtailmentModal {
+  constructor(private readonly page: Page) {}
+
+  async selectSite(siteName: string) {
+    await this.selectTarget("Sites", siteName);
+  }
+
+  async selectBuilding(buildingName: string) {
+    await this.selectTarget("Buildings", buildingName);
+  }
+
+  async selectRack(rackLabel: string) {
+    await this.selectTarget("Racks", rackLabel);
+  }
+
+  async selectGroup(groupName: string) {
+    await this.selectTarget("Groups", groupName);
+  }
+
+  async validateSelection(target: TopologyTarget, value: string) {
+    await expect(this.targetButton(target)).toHaveAccessibleName(`${target} ${value}`);
+  }
+
+  async confirmRun() {
+    await this.root.getByRole("button", { name: "Run curtailment", exact: true }).click();
+
+    const forceConfirmation = this.page.getByTestId("curtailment-force-inclusion-confirmation");
+    const runConfirmation = this.page.getByTestId("curtailment-run-confirmation");
+    await expect(forceConfirmation.or(runConfirmation)).toBeVisible();
+    if (await forceConfirmation.isVisible()) {
+      await forceConfirmation.getByRole("button", { name: "Force include", exact: true }).click();
+    }
+
+    await expect(runConfirmation).toBeVisible();
+    await runConfirmation.getByRole("button", { name: "Run curtailment", exact: true }).click();
+  }
+
+  private get root(): Locator {
+    return this.page.getByTestId("full-screen-two-pane-modal");
+  }
+
+  private targetButton(target: TopologyTarget): Locator {
+    return this.root.getByRole("button", { name: new RegExp(`^${target} `) });
+  }
+
+  private async selectTarget(target: TopologyTarget, optionLabel: string) {
+    await this.targetButton(target).click();
+
+    const modal = this.page.getByTestId("modal");
+    await expect(modal.getByText(selectionModalTitles[target], { exact: true })).toBeVisible();
+    const option = modal.getByText(optionLabel, { exact: true }).locator("xpath=ancestor::label[1]");
+    await option.getByRole("checkbox").check();
+    await modal.getByRole("button", { name: "Done", exact: true }).click();
+    await expect(modal).toBeHidden();
+  }
+}

--- a/client/e2eTests/protoFleet/pages/energy.ts
+++ b/client/e2eTests/protoFleet/pages/energy.ts
@@ -1,6 +1,7 @@
 import { expect, type Locator, type Request, type Response } from "@playwright/test";
 import { DEFAULT_INTERVAL, DEFAULT_TIMEOUT } from "../config/test.config";
 import { BasePage } from "./base";
+import { CurtailmentModal } from "./components/curtailmentModal";
 
 const stopRequestPattern = /StopCurtailment/;
 const restoreReconciliationTimeout = DEFAULT_TIMEOUT * 4;
@@ -11,11 +12,36 @@ export interface CurtailmentCleanupTarget {
   eventUuid?: string;
 }
 
+export type CurtailmentScopeJson = {
+  building?: { buildingId?: string };
+  group?: { groupId?: string };
+  rack?: { rackId?: string };
+  site?: { siteId?: string };
+  wholeOrg?: Record<string, never>;
+};
+
+export type StartCurtailmentRequestBody = {
+  fixedKw?: { targetKw?: number; toleranceKw?: number };
+  forceIncludeAllPairedMiners?: boolean;
+  forceIncludeMaintenance?: boolean;
+  includeMaintenance?: boolean;
+  mode?: string;
+  modeParams?: { fixedKw?: { targetKw?: number; toleranceKw?: number } };
+  reason?: string;
+  responseProfileId?: string;
+  responseProfileRevision?: string;
+  restoreBatchIntervalSec?: number;
+  scopeSchemaVersion?: number;
+  scopes?: CurtailmentScopeJson[];
+};
+
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 export class EnergyPage extends BasePage {
+  private readonly curtailmentModal = new CurtailmentModal(this.page);
+
   async navigateToEnergyPage() {
     await this.clickNavigationMenuIfMobile();
     await this.page.getByTestId("navigation-menu").locator('a[href="/energy"]').click();
@@ -35,6 +61,27 @@ export class EnergyPage extends BasePage {
   async openCurtailmentPlanner() {
     await this.clickButton("Run curtailment");
     await expect(this.page.getByTestId("full-screen-two-pane-modal").getByText("New curtailment")).toBeVisible();
+  }
+
+  async selectResponseProfile(profileName: string) {
+    const modal = this.page.getByTestId("full-screen-two-pane-modal");
+    await modal.getByTestId("curtailment-response-profile-select").click();
+    await this.page.getByRole("option", { name: profileName, exact: true }).click();
+    await expect(modal.getByTestId("curtailment-response-profile-select")).toContainText(profileName);
+  }
+
+  async fillCurtailmentReason(reason: string) {
+    await this.page.getByTestId("full-screen-two-pane-modal").locator("#curtailment-reason").fill(reason);
+  }
+
+  async validateGroupTargetSelected() {
+    await this.curtailmentModal.validateSelection("Groups", "1 group");
+  }
+
+  async waitForCurtailmentReady() {
+    await expect(
+      this.page.getByTestId("full-screen-two-pane-modal").getByRole("button", { name: "Run curtailment" }),
+    ).toBeEnabled({ timeout: DEFAULT_TIMEOUT * 2 });
   }
 
   async fillCurtailmentPlan({
@@ -84,16 +131,7 @@ export class EnergyPage extends BasePage {
   }
 
   async startCurtailment() {
-    await this.page.getByTestId("full-screen-two-pane-modal").getByRole("button", { name: "Run curtailment" }).click();
-    const forceInclusionConfirmation = this.page.getByTestId("curtailment-force-inclusion-confirmation");
-    const runConfirmation = this.page.getByTestId("curtailment-run-confirmation");
-
-    await expect(forceInclusionConfirmation.or(runConfirmation)).toBeVisible();
-    if (await forceInclusionConfirmation.isVisible()) {
-      await forceInclusionConfirmation.getByRole("button", { name: "Force include" }).click();
-    }
-    await expect(runConfirmation).toBeVisible();
-    await runConfirmation.getByRole("button", { name: "Run curtailment" }).click();
+    await this.curtailmentModal.confirmRun();
     await expect(this.page.getByTestId("full-screen-two-pane-modal")).toBeHidden();
   }
 
@@ -342,17 +380,8 @@ export class EnergyPage extends BasePage {
   }
 }
 
-export function getStartCurtailmentRequestBody(request: Request) {
-  return request.postDataJSON() as {
-    fixedKw?: { targetKw?: number; toleranceKw?: number };
-    forceIncludeMaintenance?: boolean;
-    includeMaintenance?: boolean;
-    mode?: string;
-    modeParams?: { fixedKw?: { targetKw?: number; toleranceKw?: number } };
-    reason?: string;
-    restoreBatchIntervalSec?: number;
-    scopes?: Array<{ wholeOrg?: Record<string, never> }>;
-  };
+export function getStartCurtailmentRequestBody(request: Request): StartCurtailmentRequestBody {
+  return request.postDataJSON() as StartCurtailmentRequestBody;
 }
 
 export async function getStartCurtailmentResponseBody(response: Response): Promise<{

--- a/client/e2eTests/protoFleet/pages/energy.ts
+++ b/client/e2eTests/protoFleet/pages/energy.ts
@@ -29,7 +29,7 @@ export type StartCurtailmentRequestBody = {
   modeParams?: { fixedKw?: { targetKw?: number; toleranceKw?: number } };
   reason?: string;
   responseProfileId?: string;
-  responseProfileRevision?: string;
+  expectedResponseProfileRevision?: string;
   restoreBatchIntervalSec?: number;
   scopeSchemaVersion?: number;
   scopes?: CurtailmentScopeJson[];

--- a/client/e2eTests/protoFleet/pages/groups.ts
+++ b/client/e2eTests/protoFleet/pages/groups.ts
@@ -151,6 +151,29 @@ export class GroupsPage extends BasePage {
     await this.modalMinerList.selectRowByCellText("ipAddress", ipAddress);
   }
 
+  async createGroupWithMiners(groupName: string, minerIps: readonly string[]): Promise<bigint> {
+    await this.navigateToGroupsPage();
+    await this.clickAddGroupButton();
+    await this.inputGroupName(groupName);
+    await this.waitForModalListToLoad();
+    for (const minerIp of minerIps) {
+      await this.selectMinerByIp(minerIp);
+    }
+
+    const responsePromise = this.page.waitForResponse(/CreateDeviceSet/);
+    await this.clickSaveInModal();
+    const response = await responsePromise;
+    expect(response.status()).toBe(200);
+    const responseBody = (await response.json()) as { deviceSet?: { id?: string } };
+    const groupId = responseBody.deviceSet?.id;
+    if (!groupId) {
+      throw new Error(`CreateDeviceSet did not return an id for group "${groupName}".`);
+    }
+
+    await this.validateSavedGroupVisible(groupName);
+    return BigInt(groupId);
+  }
+
   async validateMinerGroupsByIp(ipAddress: string, expectedGroups: string) {
     const groupCell = this.page
       .getByTestId("modal")

--- a/client/e2eTests/protoFleet/pages/settingsCurtailment.ts
+++ b/client/e2eTests/protoFleet/pages/settingsCurtailment.ts
@@ -1,6 +1,7 @@
 import { expect, Locator } from "@playwright/test";
 import { DEFAULT_INTERVAL, DEFAULT_TIMEOUT } from "../config/test.config";
 import { BasePage } from "./base";
+import { CurtailmentModal } from "./components/curtailmentModal";
 
 export type ResponseProfileFormInput = {
   name: string;
@@ -21,6 +22,8 @@ export type CurtailmentSourceFormInput = {
 };
 
 export class SettingsCurtailmentPage extends BasePage {
+  private readonly curtailmentModal = new CurtailmentModal(this.page);
+
   async validateCurtailmentSubmenuHidden() {
     await expect(this.page.getByTestId("secondary-nav").locator('a[href="/settings/curtailment"]')).toBeHidden();
   }
@@ -47,16 +50,63 @@ export class SettingsCurtailmentPage extends BasePage {
     await this.page.getByTestId("response-profile-restore-batch-interval").fill(values.restoreBatchIntervalSec);
   }
 
+  async selectSiteTarget(siteName: string) {
+    await this.curtailmentModal.selectSite(siteName);
+  }
+
+  async selectBuildingTarget(buildingName: string) {
+    await this.curtailmentModal.selectBuilding(buildingName);
+  }
+
+  async selectRackTarget(rackLabel: string) {
+    await this.curtailmentModal.selectRack(rackLabel);
+  }
+
+  async selectGroupTarget(groupName: string) {
+    await this.curtailmentModal.selectGroup(groupName);
+  }
+
+  async enableAllPairedTargeting() {
+    const checkbox = this.page.getByRole("checkbox", { name: "Target all paired miners", exact: true });
+    await checkbox.check();
+    await expect(checkbox).toBeChecked();
+  }
+
+  async validateBuildingTargetSelected() {
+    await this.curtailmentModal.validateSelection("Buildings", "1 building");
+  }
+
+  async validateRackTargetSelected() {
+    await this.curtailmentModal.validateSelection("Racks", "1 rack");
+  }
+
+  async openEditResponseProfile(name: string) {
+    const card = this.getResponseProfileCard(name);
+    await expect(card).toBeVisible();
+    await card.getByRole("button", { name: "Edit", exact: true }).click();
+    await expect(this.page.getByText("Edit response profile", { exact: true })).toBeVisible();
+  }
+
+  async reloadResponseProfiles() {
+    await this.page.reload();
+    await this.waitForResponseProfilesToLoad();
+  }
+
+  async runResponseProfileCurtailment() {
+    await this.curtailmentModal.confirmRun();
+    await expect(this.page).toHaveURL(/.*\/energy/);
+  }
+
   async saveResponseProfile() {
     await this.clickButton("Save profile");
     await expect(this.page.getByTestId("full-screen-two-pane-modal")).toBeHidden();
   }
 
-  async validateResponseProfileVisible(name: string) {
+  async validateResponseProfileVisible(name: string, target = "Whole fleet") {
     const card = this.getResponseProfileCard(name);
     await expect(card).toBeVisible();
     await expect(card.getByText("100% reduction", { exact: true })).toBeVisible();
-    await expect(card.getByText("Whole fleet", { exact: true })).toBeVisible();
+    await expect(card.getByText(target, { exact: true })).toBeVisible();
   }
 
   async deleteResponseProfilesByPrefix(prefix: string) {

--- a/client/e2eTests/protoFleet/spec/curtailmentTopology.spec.ts
+++ b/client/e2eTests/protoFleet/spec/curtailmentTopology.spec.ts
@@ -65,17 +65,25 @@ function createTopologyTestState(testInfo: TestInfo): TopologyTestState {
   };
 }
 
+function getRequestBody(request: Request): Record<string, unknown> {
+  try {
+    const body = request.postDataJSON();
+    return typeof body === "object" && body !== null ? (body as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
+}
+
 function isResponseProfileRequest(request: Request, methodName: string, profileName: string): boolean {
   if (request.method() !== "POST" || !request.url().includes(methodName)) {
     return false;
   }
 
-  const body = request.postDataJSON() as { profileName?: string };
-  return body.profileName === profileName;
+  return getRequestBody(request).profileName === profileName;
 }
 
 function expectOnlyTopologyScope(request: Request, expectedScope: CurtailmentScopeJson): ResponseProfileRequestBody {
-  const body = request.postDataJSON() as ResponseProfileRequestBody;
+  const body = getRequestBody(request) as ResponseProfileRequestBody;
   expect(body.scopeSchemaVersion).toBe(1);
   expect(body.scopes).toEqual([expectedScope]);
   return body;

--- a/client/e2eTests/protoFleet/spec/curtailmentTopology.spec.ts
+++ b/client/e2eTests/protoFleet/spec/curtailmentTopology.spec.ts
@@ -1,0 +1,283 @@
+import type { Browser, Request, Response, TestInfo } from "@playwright/test";
+import { testConfig } from "../config/test.config";
+import { expect, test } from "../fixtures/pageFixtures";
+import {
+  type BuildingsScenarioData,
+  createBuildingsScenarioData,
+  setupRackAssignedToBuilding,
+} from "../helpers/buildingsTestSetup";
+import { CommonSteps } from "../helpers/commonSteps";
+import { getSafeProjectName, getTestRunKey, installAllSitesInitScript } from "../helpers/fleetLocationsSetup";
+import { generateRandomText } from "../helpers/testDataHelper";
+import { AuthPage } from "../pages/auth";
+import {
+  type CurtailmentCleanupTarget,
+  type CurtailmentScopeJson,
+  EnergyPage,
+  getStartCurtailmentRequestBody,
+  getStartCurtailmentResponseBody,
+} from "../pages/energy";
+import { FleetLocationsPage } from "../pages/fleetLocations";
+import { GroupsPage } from "../pages/groups";
+import { MinersPage } from "../pages/miners";
+import { RacksPage } from "../pages/racks";
+import { SettingsCurtailmentPage } from "../pages/settingsCurtailment";
+
+const PROFILE_PREFIX = "curtailment_topology_profile_e2e";
+const GROUP_PREFIX = "curtailment_topology_group_e2e";
+const REASON_PREFIX = "curtailment_topology_run_e2e";
+
+type ResponseProfileRequestBody = {
+  forceIncludeAllPairedMiners?: boolean;
+  forceIncludeMaintenance?: boolean;
+  includeMaintenance?: boolean;
+  mode?: string;
+  profileName?: string;
+  scopeSchemaVersion?: number;
+  scopes?: CurtailmentScopeJson[];
+};
+
+type TopologyTestState = {
+  energyReason: string;
+  groupName: string;
+  profileName: string;
+  scenario: BuildingsScenarioData;
+};
+
+const topologyTestStates = new Map<string, TopologyTestState>();
+
+function getTopologyTestState(testInfo: TestInfo): TopologyTestState {
+  const state = topologyTestStates.get(getTestRunKey(testInfo));
+  if (!state) {
+    throw new Error("Curtailment topology E2E state was not initialized.");
+  }
+
+  return state;
+}
+
+function createTopologyTestState(testInfo: TestInfo): TopologyTestState {
+  const runSuffix = `${getSafeProjectName(testInfo)}_${testInfo.workerIndex}_${testInfo.retry}`;
+  return {
+    energyReason: generateRandomText(`${REASON_PREFIX}_${runSuffix}`),
+    groupName: generateRandomText(`${GROUP_PREFIX}_${runSuffix}`),
+    profileName: generateRandomText(`${PROFILE_PREFIX}_${runSuffix}`),
+    scenario: createBuildingsScenarioData(),
+  };
+}
+
+function isResponseProfileRequest(request: Request, methodName: string, profileName: string): boolean {
+  if (request.method() !== "POST" || !request.url().includes(methodName)) {
+    return false;
+  }
+
+  const body = request.postDataJSON() as { profileName?: string };
+  return body.profileName === profileName;
+}
+
+function expectOnlyTopologyScope(request: Request, expectedScope: CurtailmentScopeJson): ResponseProfileRequestBody {
+  const body = request.postDataJSON() as ResponseProfileRequestBody;
+  expect(body.scopeSchemaVersion).toBe(1);
+  expect(body.scopes).toEqual([expectedScope]);
+  return body;
+}
+
+function expectProfileReference(body: ReturnType<typeof getStartCurtailmentRequestBody>) {
+  expect(body.responseProfileId).toEqual(expect.stringMatching(/\S/));
+  expect(body.responseProfileRevision).toEqual(expect.stringMatching(/\S/));
+}
+
+function expectGroupProfileStart(request: Request, groupId: bigint, reason?: string) {
+  const body = getStartCurtailmentRequestBody(request);
+  expect(body.scopeSchemaVersion).toBe(1);
+  expect(body.scopes).toEqual([{ group: { groupId: groupId.toString() } }]);
+  expect(body.forceIncludeAllPairedMiners).toBe(true);
+  expectProfileReference(body);
+  if (reason) {
+    expect(body.reason).toBe(reason);
+  }
+}
+
+async function getStartedCurtailment(response: Response, expectedReason?: string): Promise<CurtailmentCleanupTarget> {
+  expect(response.status()).toBe(200);
+  const body = await getStartCurtailmentResponseBody(response);
+  expect(body.event?.eventUuid).toEqual(expect.stringMatching(/\S/));
+  expect(body.event?.reason).toEqual(expect.stringMatching(/\S/));
+  if (expectedReason) {
+    expect(body.event?.reason).toBe(expectedReason);
+  }
+
+  return { reason: body.event!.reason!, eventUuid: body.event!.eventUuid! };
+}
+
+async function cleanupTopologyTest(browser: Browser, testInfo: TestInfo, state: TopologyTestState) {
+  const context = await browser.newContext({
+    baseURL: testConfig.baseUrl,
+    viewport: testInfo.project.use?.viewport,
+  });
+
+  try {
+    const page = await context.newPage();
+    await installAllSitesInitScript(page);
+    await page.goto("/");
+
+    const isMobile = testInfo.project.use?.isMobile ?? false;
+    const authPage = new AuthPage(page, isMobile);
+    const minersPage = new MinersPage(page, isMobile);
+    const commonSteps = new CommonSteps(authPage, minersPage);
+    const energyPage = new EnergyPage(page, isMobile);
+    const settingsCurtailmentPage = new SettingsCurtailmentPage(page, isMobile);
+    const groupsPage = new GroupsPage(page, isMobile);
+    const racksPage = new RacksPage(page, isMobile);
+    const fleetLocationsPage = new FleetLocationsPage(page, isMobile);
+
+    await commonSteps.loginAsAdmin();
+    await energyPage.cleanupStartedCurtailmentsByReasonPrefix(state.profileName);
+    await energyPage.cleanupStartedCurtailmentsByReasonPrefix(state.energyReason);
+    await settingsCurtailmentPage.navigateToCurtailmentSettings();
+    await settingsCurtailmentPage.deleteResponseProfilesByPrefix(state.profileName);
+    await groupsPage.navigateToGroupsPage();
+    await groupsPage.waitForSavedGroupsListToLoad();
+    await groupsPage.deleteSavedGroupIfVisible(state.groupName);
+    await racksPage.deleteRackByLabelIfVisible(state.scenario.rackLabel);
+    await fleetLocationsPage.deleteBuildingByNameIfVisible(state.scenario.buildingName);
+    await fleetLocationsPage.deleteSiteByNameIfVisible(state.scenario.siteName);
+  } finally {
+    await context.close();
+  }
+}
+
+test.describe("Proto Fleet - Curtailment topology targets", () => {
+  test.beforeEach(async ({ commonSteps, page }, testInfo) => {
+    topologyTestStates.set(getTestRunKey(testInfo), createTopologyTestState(testInfo));
+    await installAllSitesInitScript(page);
+    await page.goto("/");
+    await commonSteps.loginAsAdmin();
+  });
+
+  test.afterEach("CLEANUP: Restore curtailments and delete topology fixtures", async ({ browser }, testInfo) => {
+    const runKey = getTestRunKey(testInfo);
+    const state = topologyTestStates.get(runKey);
+    if (!state) {
+      return;
+    }
+
+    try {
+      await cleanupTopologyTest(browser, testInfo, state);
+    } finally {
+      topologyTestStates.delete(runKey);
+    }
+  });
+
+  if (testConfig.target !== "real") {
+    test(
+      "Create, edit, test, and run a topology-scoped response profile",
+      { tag: "@smoke" },
+      async ({ energyPage, fleetLocationsPage, groupsPage, page, racksPage, settingsCurtailmentPage }, testInfo) => {
+        test.setTimeout(testConfig.testTimeout * 4);
+        const state = getTopologyTestState(testInfo);
+
+        const { buildingId, rackId, selectedMinerIps } = await setupRackAssignedToBuilding(
+          page,
+          fleetLocationsPage,
+          racksPage,
+          state.scenario,
+        );
+        const groupId = await groupsPage.createGroupWithMiners(state.groupName, selectedMinerIps);
+
+        await test.step("Create a building-scoped response profile", async () => {
+          await settingsCurtailmentPage.navigateToCurtailmentSettings();
+          await settingsCurtailmentPage.openCreateResponseProfile();
+          await settingsCurtailmentPage.fillResponseProfile({
+            name: state.profileName,
+            curtailBatchSize: "2",
+            curtailBatchIntervalSec: "1",
+            restoreBatchSize: "2",
+            restoreBatchIntervalSec: "1",
+          });
+          await settingsCurtailmentPage.selectSiteTarget(state.scenario.siteName);
+          await settingsCurtailmentPage.selectBuildingTarget(state.scenario.buildingName);
+          await settingsCurtailmentPage.enableAllPairedTargeting();
+
+          const createRequestPromise = page.waitForRequest((request) =>
+            isResponseProfileRequest(request, "CreateCurtailmentResponseProfile", state.profileName),
+          );
+          await settingsCurtailmentPage.saveResponseProfile();
+          const createRequest = await createRequestPromise;
+          const createBody = expectOnlyTopologyScope(createRequest, {
+            building: { buildingId: buildingId.toString() },
+          });
+
+          expect(createBody.mode).toBe("CURTAILMENT_MODE_FULL_FLEET");
+          expect(createBody.forceIncludeAllPairedMiners).toBe(true);
+          expect(createBody.includeMaintenance).toBe(true);
+          expect(createBody.forceIncludeMaintenance).toBe(true);
+          await settingsCurtailmentPage.validateResponseProfileVisible(state.profileName, "1 building");
+        });
+
+        await test.step("Reload the profile and replace its building scope with the selected rack", async () => {
+          await settingsCurtailmentPage.reloadResponseProfiles();
+          await settingsCurtailmentPage.openEditResponseProfile(state.profileName);
+          await settingsCurtailmentPage.validateBuildingTargetSelected();
+          await settingsCurtailmentPage.selectSiteTarget(state.scenario.siteName);
+          await settingsCurtailmentPage.selectBuildingTarget(state.scenario.buildingName);
+          await settingsCurtailmentPage.selectRackTarget(state.scenario.rackLabel);
+
+          const updateRequestPromise = page.waitForRequest((request) =>
+            isResponseProfileRequest(request, "UpdateCurtailmentResponseProfile", state.profileName),
+          );
+          await settingsCurtailmentPage.saveResponseProfile();
+          const updateRequest = await updateRequestPromise;
+          const updateBody = expectOnlyTopologyScope(updateRequest, { rack: { rackId: rackId.toString() } });
+          expect(updateBody.forceIncludeAllPairedMiners).toBe(true);
+          await settingsCurtailmentPage.validateResponseProfileVisible(state.profileName, "1 rack");
+        });
+
+        await test.step("Reload the profile, switch it to the selected group, and test it", async () => {
+          await settingsCurtailmentPage.reloadResponseProfiles();
+          await settingsCurtailmentPage.openEditResponseProfile(state.profileName);
+          await settingsCurtailmentPage.validateRackTargetSelected();
+          await settingsCurtailmentPage.selectSiteTarget(state.scenario.siteName);
+          await settingsCurtailmentPage.selectGroupTarget(state.groupName);
+
+          const updateRequestPromise = page.waitForRequest((request) =>
+            isResponseProfileRequest(request, "UpdateCurtailmentResponseProfile", state.profileName),
+          );
+          const startRequestPromise = page.waitForRequest(/StartCurtailment/);
+          const startResponsePromise = page.waitForResponse(/StartCurtailment/);
+          await settingsCurtailmentPage.runResponseProfileCurtailment();
+
+          const updateRequest = await updateRequestPromise;
+          const updateBody = expectOnlyTopologyScope(updateRequest, { group: { groupId: groupId.toString() } });
+          expect(updateBody.forceIncludeAllPairedMiners).toBe(true);
+
+          const startRequest = await startRequestPromise;
+          expectGroupProfileStart(startRequest, groupId);
+          const testedCurtailment = await getStartedCurtailment(await startResponsePromise);
+          await energyPage.validateActiveCurtailment(testedCurtailment.reason);
+          await energyPage.stopCurtailment(testedCurtailment);
+          await energyPage.waitForCurtailmentToRestore(testedCurtailment);
+        });
+
+        await test.step("Select the saved group profile from New curtailment and run it", async () => {
+          await energyPage.openCurtailmentPlanner();
+          await energyPage.selectResponseProfile(state.profileName);
+          await energyPage.validateGroupTargetSelected();
+          await energyPage.fillCurtailmentReason(state.energyReason);
+          await energyPage.waitForCurtailmentReady();
+
+          const startRequestPromise = page.waitForRequest(/StartCurtailment/);
+          const startResponsePromise = page.waitForResponse(/StartCurtailment/);
+          await energyPage.startCurtailment();
+
+          const startRequest = await startRequestPromise;
+          expectGroupProfileStart(startRequest, groupId, state.energyReason);
+          const startedCurtailment = await getStartedCurtailment(await startResponsePromise, state.energyReason);
+          await energyPage.validateActiveCurtailment(startedCurtailment.reason);
+          await energyPage.validateCurtailmentHistoryRow(startedCurtailment.reason);
+          await energyPage.stopCurtailment(startedCurtailment);
+          await energyPage.waitForCurtailmentToRestore(startedCurtailment);
+        });
+      },
+    );
+  }
+});

--- a/client/e2eTests/protoFleet/spec/curtailmentTopology.spec.ts
+++ b/client/e2eTests/protoFleet/spec/curtailmentTopology.spec.ts
@@ -91,7 +91,7 @@ function expectOnlyTopologyScope(request: Request, expectedScope: CurtailmentSco
 
 function expectProfileReference(body: ReturnType<typeof getStartCurtailmentRequestBody>) {
   expect(body.responseProfileId).toEqual(expect.stringMatching(/\S/));
-  expect(body.responseProfileRevision).toEqual(expect.stringMatching(/\S/));
+  expect(body.expectedResponseProfileRevision).toEqual(expect.stringMatching(/\S/));
 }
 
 function expectGroupProfileStart(request: Request, groupId: bigint, reason?: string) {


### PR DESCRIPTION
Reviewable diff: +192/-23 across 4 files (excludes generated, test, and story files).

## Summary

This PR adds end-to-end coverage for building-, rack-, and group-scoped curtailment response profiles across both Settings and Energy. The scenario verifies that topology scopes and the all-paired policy survive create, reload, edit, Test, profile selection, and live Run flows without widening into a multi-type union.

## How it works

The Playwright scenario provisions a site, building, rack, two assigned miners, and a group. It creates an all-paired building profile, reloads and changes the terminal scope to the rack, reloads again and changes it to the group, then tests the profile from Settings and runs the saved profile from New curtailment. Each API boundary is inspected for one typed terminal scope, schema version, profile revision, and all-paired policy; each started event is restored before fixtures are deleted in dependency order.

## Diagrams

```mermaid
flowchart TD
  A["Create site, building, rack, miners, and group"] --> B["Create building-scoped response profile"]
  B --> C["Reload and replace scope with rack"]
  C --> D["Reload and replace scope with group"]
  D --> E["Test profile from Settings"]
  E --> F["Select saved profile in New curtailment"]
  F --> G["Run and verify active event"]
  G --> H["Restore event and delete fixtures"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/e2eTests/protoFleet/pages/components/curtailmentModal.ts` | Adds shared topology selection and run-confirmation behavior. | Keeps both modal entry points on the same Schedules-style drill-down interactions and makes repeated parent selection idempotent. |
| `client/e2eTests/protoFleet/pages/energy.ts` | Adds saved-profile selection, topology assertions, and shared modal execution. | Covers the New curtailment entry point and exposes typed Start request fields. |
| `client/e2eTests/protoFleet/pages/settingsCurtailment.ts` | Adds profile edit/reload/Test and topology-target actions. | Covers create/edit response profile behavior through persisted scope changes. |
| `client/e2eTests/protoFleet/pages/groups.ts` | Adds a fixture helper that creates a group from selected miner IPs and returns its persisted ID. | Lets request assertions compare the submitted group selector with the actual created resource. |
| `client/e2eTests/protoFleet/spec/curtailmentTopology.spec.ts` | Adds the full create, reload, edit, Test, Run, restore, and cleanup scenario. | Proves the issue #909 workflow across real frontend/backend boundaries in the fake-miner environment. |

## Key technical decisions & trade-offs

- Exercise all three new terminal types in one lifecycle scenario so the test proves replacement semantics and persistence without repeating expensive fleet setup.
- Assert request IDs and policy fields at each transition instead of relying only on UI summaries, which catches accidental scope widening or profile fallback.
- Run only outside the real-miner target because the scenario intentionally starts and restores curtailment commands.
- Clean up from a fresh authenticated browser context and restore events before deleting dependent topology resources so interrupted test pages do not leave active ownership or fixtures behind.

## Testing & validation

- `cd client && ../bin/npx eslint e2eTests/protoFleet/pages/energy.ts e2eTests/protoFleet/pages/groups.ts e2eTests/protoFleet/pages/settingsCurtailment.ts e2eTests/protoFleet/pages/components/curtailmentModal.ts e2eTests/protoFleet/spec/curtailmentTopology.spec.ts`
- `cd client && ../bin/npx prettier --check ...` for the five changed files.
- `cd client && ../bin/npx tsc --noEmit`
- `cd client/e2eTests/protoFleet && ../../../bin/npx playwright test spec/curtailmentTopology.spec.ts --project=desktop --list`
- The live Playwright scenario was not run locally because the configured frontend and backend were not running; CI provides the simulator-backed execution.

Refs #909
