### PR TITLE
Update vendored proto-rig-api to proto-apps-1.8.5

### DIFF
--- a/client/src/protoOS/api/generatedApi.ts
+++ b/client/src/protoOS/api/generatedApi.ts
@@ -107,12 +107,12 @@ export interface AsicTelemetry {
 export interface AuthTokens {
   /**
    * JWT access token.
-   * @example "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+   * @example "example.jwt.token"
    */
   access_token: string;
   /**
    * JWT refresh token.
-   * @example "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+   * @example "example.jwt.token"
    */
   refresh_token: string;
 }
@@ -1789,7 +1789,7 @@ export interface PsusInfo {
 export interface RefreshRequest {
   /**
    * The JWT refresh token to be validated.
-   * @example "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+   * @example "example.jwt.token"
    */
   refresh_token: string;
 }
@@ -1798,7 +1798,7 @@ export interface RefreshRequest {
 export interface RefreshResponse {
   /**
    * A new JWT access token.
-   * @example "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+   * @example "example.jwt.token"
    */
   access_token: string;
 }

--- a/proto-rig-api/VERSION.md
+++ b/proto-rig-api/VERSION.md
@@ -2,14 +2,14 @@
 
 ## Source
 - Repository: miner-firmware (private)
-  - Commit SHA: b8c6575ea1cc32498cd18616865964b7e816dcea
-  - Commit Date: 2026-08-13
-  - Extraction Date: 2026-08-17
+  - Commit SHA: 89ef557cbec85ebe7aced9fc47d0bdfde744e913
+  - Commit Date: 2026-08-27
+  - Extraction Date: 2026-08-31
 
-This snapshot tracks the `proto-apps-1.8.4` source revision. The REST pool
-contract adds native Stratum V2 configuration through `v2_authority_pubkey`
-and protocol-default ports. The ProtoOS REST client and fake-proto-rig
-simulator are updated with these OpenAPI changes.
+This snapshot tracks the `proto-apps-1.8.5` source revision. The
+`POST /api/v1/system/update/check` contract drops its unreachable `400`,
+`422`, and `500` responses (the endpoint only returns `200`, `409`, or
+`401`), and JWT examples are replaced with a neutral placeholder string.
 
 ## Files Extracted
 

--- a/proto-rig-api/openapi/MDK-API.json
+++ b/proto-rig-api/openapi/MDK-API.json
@@ -1270,17 +1270,8 @@
           "200": {
             "description": "The mining device has successfully started system update check."
           },
-          "400": {
-            "$ref": "#/components/responses/BadRequest"
-          },
-          "422": {
-            "$ref": "#/components/responses/UnprocessableEntity"
-          },
           "409": {
             "$ref": "#/components/responses/UpdateAlreadyInProgress"
-          },
-          "500": {
-            "$ref": "#/components/responses/InternalServerError"
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
@@ -4437,12 +4428,12 @@
           "refresh_token": {
             "type": "string",
             "description": "JWT refresh token.",
-            "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+            "example": "example.jwt.token"
           },
           "access_token": {
             "type": "string",
             "description": "JWT access token.",
-            "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+            "example": "example.jwt.token"
           }
         },
         "required": [
@@ -4457,7 +4448,7 @@
           "refresh_token": {
             "type": "string",
             "description": "The JWT refresh token to be validated.",
-            "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+            "example": "example.jwt.token"
           }
         },
         "required": [
@@ -4471,7 +4462,7 @@
           "access_token": {
             "type": "string",
             "description": "A new JWT access token.",
-            "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+            "example": "example.jwt.token"
           }
         },
         "required": [


### PR DESCRIPTION
Reviewable diff: +12/-21 across 2 files (excludes generated, test, and story files).

## Summary

Re-vendors the Proto miner OpenAPI contract (`proto-rig-api/openapi/MDK-API.json`) from miner-firmware `proto-apps-1.8.5` (commit `89ef557c`, 2026-08-27), replacing the previous `proto-apps-1.8.4` snapshot. The upstream change removes unreachable error responses from the update-check endpoint and sanitizes JWT examples, so downstream docs and generated types now match what the device actually returns.

## How it works

The vendored spec is the single source of truth for the miner REST contract inside this repo. This PR copies the new spec byte-for-byte from `crates/miner-api-server/docs/` in miner-firmware, records the new source commit in `VERSION.md`, and regenerates the ProtoOS TypeScript client via `npm run generate-api-types`. Upstream (miner-firmware PR #3470) made two changes:

- `POST /api/v1/system/update/check` no longer documents `400`, `422`, and `500` responses — those exit codes are unreachable in the firmware implementation; the endpoint returns only `200`, `409` (update already in progress), or `401`.
- JWT example strings were replaced with a neutral `example.jwt.token` placeholder to stop secret scanners flagging the spec.

Neither change affects behavior in this repo: the fake-proto-rig simulator never emitted the removed error responses for that endpoint, the server miner proxy only maps the path to permissions, and the ProtoOS firmware-update hook handles non-2xx responses generically. The regenerated client diff is doc comments only.

## Diagrams

```mermaid
flowchart LR
    FW["miner-firmware<br/>proto-apps-1.8.5"] -->|"vendor MDK-API.json"| SPEC["proto-rig-api/openapi/MDK-API.json"]
    SPEC -->|"npm run generate-api-types"| TS["client/src/protoOS/api/generatedApi.ts"]
    SPEC -.->|"hand-maintained reference"| SIM["server/fake-proto-rig<br/>(no change needed)"]
    SPEC -.->|"CI docs build"| DOCS["Redocly API docs"]
```

## Areas of the code involved

| Area / file | What changed | Why it matters for review |
| --- | --- | --- |
| `proto-rig-api/openapi/MDK-API.json` | Byte-for-byte copy of the 1.8.5 spec: update-check error responses removed, JWT examples sanitized | The vendored contract — verify the diff matches the described upstream change |
| `proto-rig-api/VERSION.md` | New source SHA, dates, and change summary | Version-tracking source of truth for the snapshot |
| `client/src/protoOS/api/generatedApi.ts` | Regenerated from the new spec (JSDoc example comments only) | Generated — skip |

## Key technical decisions & trade-offs

- No simulator change: the fake-proto-rig `handleUpdateCheck` already returns only `200`/`405` (plus `401` via middleware), so it stays conformant without edits — chosen over adding speculative `409` simulation, which is pre-existing scope.
- `VERSION.md` records the `proto-apps-1.8.5` tag commit (`89ef557c`), matching the existing convention of tracking the release tag rather than the last spec-touching commit.

## Testing & validation

- Verified the vendored file is byte-identical to the firmware source (`cmp`).
- `npx tsc --noEmit` in `client/` passes (also enforced by the pre-push hook).
- `go test ./...` in `server/fake-proto-rig/` passes.
- Not covered: E2E suites — no runtime behavior changed in this repo.