### PR TITLE
Complete curtailment topology targets plan

### DIFF
--- a/docs/plans/archive/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
+++ b/docs/plans/archive/2026-08-11-curtailment-building-rack-and-group-targets-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "Curtailment building, rack, and group targets"
 date: 2026-08-11
-status: implementing
+status: completed
 type: plan
 tracker: https://github.com/block/proto-fleet/issues/909
 ---


### PR DESCRIPTION
Reviewable diff: +1/-1 across 1 file (excludes generated, test, and story files).

## Summary

This PR records completion of the building, rack, and group curtailment targeting work after the final end-to-end coverage merged in PR #981. It archives the accepted implementation plan and closes the tracking issue when merged.

## How it works

The plan frontmatter moves from `implementing` to `completed`, and the document moves from the active plans directory into `docs/plans/archive/`. The closing reference below lets GitHub close issue #909 when this lifecycle update merges.

## Diagrams

```mermaid
flowchart LR
  A["Issue #909 implementation"] --> B["Final E2E coverage merged"]
  B --> C["Plan marked completed and archived"]
  C --> D["Issue #909 closes"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `docs/plans/archive/2026-08-11-curtailment-building-rack-and-group-targets-plan.md` | Marks the plan completed and moves it into the plan archive. | Keeps the planning lifecycle and issue status aligned with the merged implementation. |

## Key technical decisions & trade-offs

- Archive the existing plan rather than adding a separate completion note, preserving its full design history under the repository's documented lifecycle convention.

## Testing & validation

- `git diff --check`
- Verified the archived document has `status: completed` and the active-plan path no longer exists.
- Runtime tests were not run because this change only updates planning-document lifecycle metadata and location.

Closes #909
