### PR TITLE
Pre-bake ProtoFleet E2E runner dependencies

### DIFF
--- a/.github/actions/protofleet-e2e-runner/action.yml
+++ b/.github/actions/protofleet-e2e-runner/action.yml
@@ -1,0 +1,40 @@
+name: Restore ProtoFleet E2E runner content
+description: Use hash-matched dependencies and Docker images from the custom runner image
+
+inputs:
+  server-hash:
+    description: GitHub hashFiles digest for server/**
+    required: true
+  client-lock-hash:
+    description: GitHub hashFiles digest for client/package-lock.json
+    required: true
+  allow-docker-images:
+    description: Whether pre-baked Docker images may be used for this run
+    required: false
+    default: "true"
+
+outputs:
+  image-version:
+    description: Source commit recorded in the runner image
+    value: ${{ steps.restore.outputs.image-version }}
+  client-dependencies:
+    description: Whether client/node_modules was restored from the runner image
+    value: ${{ steps.restore.outputs.client-dependencies }}
+  playwright-browsers:
+    description: Whether Playwright will use browsers from the runner image
+    value: ${{ steps.restore.outputs.playwright-browsers }}
+  docker-images:
+    description: Whether every required Docker image is present and hash-matched
+    value: ${{ steps.restore.outputs.docker-images }}
+
+runs:
+  using: composite
+  steps:
+    - name: Inspect and restore pre-baked content
+      id: restore
+      shell: bash
+      env:
+        PROTOFLEET_CURRENT_SERVER_HASH: ${{ inputs.server-hash }}
+        PROTOFLEET_CURRENT_CLIENT_LOCK_HASH: ${{ inputs.client-lock-hash }}
+        PROTOFLEET_ALLOW_PREBAKED_DOCKER: ${{ inputs.allow-docker-images }}
+      run: "$GITHUB_ACTION_PATH/../../scripts/restore_protofleet_e2e_runner.sh"

--- a/.github/scripts/analyze_ci_timings.py
+++ b/.github/scripts/analyze_ci_timings.py
@@ -1,0 +1,1065 @@
+#!/usr/bin/env python3
+r"""Analyze GitHub Actions runner time by step category.
+
+The default selection reproduces the CI investigation performed on 2026-08-31:
+the latest 100 completed PR Gate runs, with detailed job data for up to the
+newest three successful runs per pull request. GitHub's API returns rerun jobs
+separately, so the analyzer requests only the latest attempt for each run.
+
+Examples:
+
+    GITHUB_TOKEN=... python3 .github/scripts/analyze_ci_timings.py \
+      --json-out /tmp/proto-fleet-ci-baseline.json
+
+    GITHUB_TOKEN=... python3 .github/scripts/analyze_ci_timings.py \
+      --baseline .github/scripts/ci_timing_baseline.json \
+      --json-out /tmp/proto-fleet-ci-after.json \
+      --fail-on-regression-pct 10
+
+Use ``--max-runs-per-pr 0 --detail-limit 100 --conclusions
+success,failure,cancelled,startup_failure`` for job-level detail across every
+attempt. That mode requires an authenticated token because it makes at least
+one API request per workflow run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import datetime as dt
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Iterable
+
+API_ROOT = "https://api.github.com"
+API_VERSION = "2022-11-28"
+SCHEMA_VERSION = 1
+TRANSIENT_HTTP_STATUSES = {429, 500, 502, 503, 504}
+
+CATEGORY_PLATFORM = "platform"
+CATEGORY_SETUP = "setup"
+CATEGORY_TEST = "test"
+CATEGORY_VALIDATION = "validation_build"
+CATEGORY_ORCHESTRATION = "orchestration"
+CATEGORY_REPORTING = "reporting_teardown"
+CATEGORY_UNCLASSIFIED = "unclassified"
+
+OVERHEAD_CATEGORIES = {
+    CATEGORY_PLATFORM,
+    CATEGORY_SETUP,
+    CATEGORY_ORCHESTRATION,
+    CATEGORY_REPORTING,
+}
+
+COMPARISON_METRICS = {
+    "full_mean_runner_minutes": "Full-run mean runner minutes",
+    "full_mean_overhead_minutes": "Full-run mean overhead minutes",
+    "full_median_wall_minutes": "Full-run median wall minutes",
+    "overall_overhead_percent": "Overall overhead share",
+    "protofleet_e2e_mean_job_minutes": "ProtoFleet E2E mean shard minutes",
+    "protofleet_e2e_mean_overhead_minutes": (
+        "ProtoFleet E2E mean shard overhead minutes"
+    ),
+}
+
+
+class AnalysisError(RuntimeError):
+    """A user-actionable error while collecting or analyzing timings."""
+
+
+class GitHubClient:
+    def __init__(self, token: str | None, timeout: float = 30.0) -> None:
+        self.token = token
+        self.timeout = timeout
+
+    def get_json(self, path: str) -> Any:
+        url = path if path.startswith("https://") else API_ROOT + path
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "proto-fleet-ci-timing-analyzer",
+            "X-GitHub-Api-Version": API_VERSION,
+        }
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+
+        for attempt in range(4):
+            request = urllib.request.Request(url, headers=headers, method="GET")
+            try:
+                with urllib.request.urlopen(request, timeout=self.timeout) as response:
+                    return json.loads(response.read().decode("utf-8"))
+            except urllib.error.HTTPError as error:
+                body = error.read().decode("utf-8", errors="replace")
+                if error.code in TRANSIENT_HTTP_STATUSES and attempt < 3:
+                    time.sleep(2**attempt)
+                    continue
+                if error.code == 403 and "rate limit" in body.casefold():
+                    reset = error.headers.get("X-RateLimit-Reset")
+                    reset_hint = ""
+                    if reset and reset.isdigit():
+                        instant = dt.datetime.fromtimestamp(
+                            int(reset), tz=dt.timezone.utc
+                        ).isoformat()
+                        reset_hint = f" The anonymous quota resets at {instant}."
+                    auth_hint = (
+                        " Set GITHUB_TOKEN or GH_TOKEN to raise the API limit."
+                        if not self.token
+                        else " The configured token also exhausted its API quota."
+                    )
+                    raise AnalysisError(
+                        f"GitHub API rate limit exceeded.{reset_hint}{auth_hint}"
+                    ) from error
+                raise AnalysisError(
+                    f"GitHub API GET {url} failed with HTTP {error.code}: {body}"
+                ) from error
+            except urllib.error.URLError as error:
+                if attempt < 3:
+                    time.sleep(2**attempt)
+                    continue
+                raise AnalysisError(f"GitHub API GET {url} failed: {error}") from error
+        raise AssertionError("unreachable")
+
+
+def paginate_key(
+    client: GitHubClient, path: str, key: str, limit: int
+) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    page = 1
+    separator = "&" if "?" in path else "?"
+    while len(items) < limit:
+        response = client.get_json(
+            f"{path}{separator}per_page={min(100, limit - len(items))}&page={page}"
+        )
+        if not isinstance(response, dict) or not isinstance(response.get(key), list):
+            raise AnalysisError(f"Expected a {key!r} list from GitHub API path {path}")
+        batch = response[key]
+        items.extend(batch)
+        if len(batch) < 100:
+            break
+        page += 1
+    return items[:limit]
+
+
+def paginate_list(client: GitHubClient, path: str, limit: int) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    page = 1
+    separator = "&" if "?" in path else "?"
+    while len(items) < limit:
+        response = client.get_json(
+            f"{path}{separator}per_page={min(100, limit - len(items))}&page={page}"
+        )
+        if not isinstance(response, list):
+            raise AnalysisError(f"Expected a list from GitHub API path {path}")
+        items.extend(response)
+        if len(response) < 100:
+            break
+        page += 1
+    return items[:limit]
+
+
+def infer_repository() -> str:
+    result = subprocess.run(
+        ["git", "config", "--get", "remote.origin.url"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    remote = result.stdout.strip()
+    patterns = (
+        r"git@github\.com:([^/]+/[^/]+?)(?:\.git)?$",
+        r"https://github\.com/([^/]+/[^/]+?)(?:\.git)?$",
+        r"ssh://git@github\.com/([^/]+/[^/]+?)(?:\.git)?$",
+    )
+    for pattern in patterns:
+        match = re.fullmatch(pattern, remote)
+        if match:
+            return match.group(1)
+    raise AnalysisError(
+        "Could not infer owner/repository from origin; pass --repo OWNER/REPO"
+    )
+
+
+def parse_timestamp(value: str | None) -> dt.datetime | None:
+    if not value:
+        return None
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    return dt.datetime.fromisoformat(value)
+
+
+def duration_seconds(start: str | None, end: str | None) -> float:
+    started = parse_timestamp(start)
+    completed = parse_timestamp(end)
+    if started is None or completed is None:
+        return 0.0
+    return max(0.0, (completed - started).total_seconds())
+
+
+def quantile(values: Iterable[float], percentile: float) -> float:
+    ordered = sorted(values)
+    if not ordered:
+        return 0.0
+    index = (len(ordered) - 1) * percentile
+    lower = int(index)
+    upper = min(lower + 1, len(ordered) - 1)
+    fraction = index - lower
+    return ordered[lower] + (ordered[upper] - ordered[lower]) * fraction
+
+
+def normalize_step_name(name: str) -> str:
+    normalized = re.sub(r"shard\s+\d+", "shard N", name, flags=re.IGNORECASE)
+    normalized = re.sub(
+        r"\(\d+,\s*(mobile|desktop)\)",
+        r"(N, \1)",
+        normalized,
+        flags=re.IGNORECASE,
+    )
+    return re.sub(r"\s+", " ", normalized).strip()
+
+
+def classify_step(name: str) -> str:
+    lowered = name.casefold()
+    if re.search(r"^(set up job|complete job)$", lowered):
+        return CATEGORY_PLATFORM
+    if re.search(
+        r"^post |upload|merge .*report|submit .*result|dump .*log|cleanup|"
+        r"tear.?down|^stop |archive|note report|collect .*log|publish .*report",
+        lowered,
+    ):
+        return CATEGORY_REPORTING
+    if re.search(r"build e2e docker images|build fake-proto-rig simulator", lowered):
+        return CATEGORY_SETUP
+    if re.search(
+        r"checkout|setup |set up |cache|restore|save|install|configure|download|"
+        r"load .*image|export .*image|start |make .*executable|compute .*cache|"
+        r"expose .*runtime|wait for|prepare|initiali[sz]e|create .*database|"
+        r"seed |copy .*artifact|fetch|pull |chmod|enable .*cache|activate|"
+        r"add .*path|show \.net sdk info",
+        lowered,
+    ):
+        return CATEGORY_SETUP
+    if re.search(
+        r"detect changed|evaluate gate|skip on|set output|determine .*changed|"
+        r"gate input|changed areas|detect migration changes",
+        lowered,
+    ):
+        return CATEGORY_ORCHESTRATION
+    if re.search(
+        r"test|playwright|pytest|nextest|contract|integration|unit suite|e2e|"
+        r"smoke|visual spec|spec suite",
+        lowered,
+    ):
+        return CATEGORY_TEST
+    if re.search(
+        r"lint|format|type.?check|validate|verify|check|review|scan|zizmor|"
+        r"semgrep|build|generate|compile|vet|clippy|audit|benchmark|"
+        r"shell syntax|analyzer rule|parse powershell|guard |enforce ",
+        lowered,
+    ):
+        return CATEGORY_VALIDATION
+    return CATEGORY_UNCLASSIFIED
+
+
+def associate_runs_with_pull_requests(
+    runs: list[dict[str, Any]], pulls: list[dict[str, Any]]
+) -> None:
+    pulls_by_number = {pull["number"]: pull for pull in pulls}
+    pulls_by_branch = {
+        pull.get("head", {}).get("ref"): pull
+        for pull in pulls
+        if pull.get("head", {}).get("ref")
+    }
+    for run in runs:
+        direct_numbers = [
+            item.get("number") for item in run.get("pull_requests", []) if item
+        ]
+        direct_number = next((number for number in direct_numbers if number), None)
+        pull = pulls_by_number.get(direct_number) or pulls_by_branch.get(
+            run.get("head_branch")
+        )
+        number = direct_number or (pull or {}).get("number")
+        run["_pr_number"] = number
+        run["_pr_title"] = (pull or {}).get("title")
+        run["_group_key"] = (
+            f"pr:{number}"
+            if number
+            else f"branch:{run.get('head_branch', '<unknown>')}"
+        )
+
+
+def select_detailed_runs(
+    runs: list[dict[str, Any]],
+    conclusions: set[str],
+    max_runs_per_pr: int,
+    detail_limit: int,
+) -> list[dict[str, Any]]:
+    groups: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for run in runs:
+        if run.get("conclusion") in conclusions:
+            groups[run["_group_key"]].append(run)
+
+    ordered_groups = sorted(
+        groups.values(),
+        key=lambda group: max(item.get("run_number", 0) for item in group),
+        reverse=True,
+    )
+    selected: list[dict[str, Any]] = []
+    for group in ordered_groups:
+        ordered = sorted(
+            group, key=lambda item: item.get("run_number", 0), reverse=True
+        )
+        selected.extend(ordered[:max_runs_per_pr] if max_runs_per_pr else ordered)
+    selected.sort(key=lambda item: item.get("run_number", 0), reverse=True)
+    return selected[:detail_limit] if detail_limit else selected
+
+
+def jobs_cache_path(cache_dir: Path, run: dict[str, Any]) -> Path:
+    return cache_dir / (
+        f"run-{run['id']}-attempt-{run.get('run_attempt', 1)}-jobs.json"
+    )
+
+
+def fetch_jobs(
+    client: GitHubClient,
+    repository: str,
+    run: dict[str, Any],
+    cache_dir: Path | None,
+    refresh: bool,
+) -> list[dict[str, Any]]:
+    cache_path = jobs_cache_path(cache_dir, run) if cache_dir else None
+    if cache_path and cache_path.exists() and not refresh:
+        cached = json.loads(cache_path.read_text(encoding="utf-8"))
+        if isinstance(cached, list):
+            return cached
+
+    jobs = paginate_key(
+        client,
+        f"/repos/{repository}/actions/runs/{run['id']}/jobs?filter=latest",
+        "jobs",
+        500,
+    )
+    if cache_path:
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_text(json.dumps(jobs, indent=2) + "\n", encoding="utf-8")
+    return jobs
+
+
+def summarize_profile(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    if not rows:
+        return {
+            "runs": 0,
+            "median_jobs": 0.0,
+            "mean_runner_minutes": 0.0,
+            "median_runner_minutes": 0.0,
+            "median_wall_minutes": 0.0,
+            "mean_test_minutes": 0.0,
+            "mean_validation_minutes": 0.0,
+            "mean_overhead_minutes": 0.0,
+            "test_percent": 0.0,
+            "validation_percent": 0.0,
+            "overhead_percent": 0.0,
+        }
+
+    runner = sum(row["runner_seconds"] for row in rows)
+    test = sum(row["test_seconds"] for row in rows)
+    validation = sum(row["validation_seconds"] for row in rows)
+    overhead = sum(row["overhead_seconds"] for row in rows)
+    count = len(rows)
+    return {
+        "runs": count,
+        "median_jobs": round(quantile((row["jobs"] for row in rows), 0.5), 1),
+        "mean_runner_minutes": round(runner / count / 60, 2),
+        "median_runner_minutes": round(
+            quantile((row["runner_seconds"] for row in rows), 0.5) / 60, 2
+        ),
+        "median_wall_minutes": round(
+            quantile((row["wall_seconds"] for row in rows), 0.5) / 60, 2
+        ),
+        "mean_test_minutes": round(test / count / 60, 2),
+        "mean_validation_minutes": round(validation / count / 60, 2),
+        "mean_overhead_minutes": round(overhead / count / 60, 2),
+        "test_percent": round(100 * test / runner, 2) if runner else 0.0,
+        "validation_percent": round(100 * validation / runner, 2) if runner else 0.0,
+        "overhead_percent": round(100 * overhead / runner, 2) if runner else 0.0,
+    }
+
+
+def summarize_e2e_jobs(
+    job_records: list[dict[str, Any]], step_records: list[dict[str, Any]]
+) -> dict[str, Any]:
+    e2e_jobs = [
+        job for job in job_records if re.search(r"E2E Tests / e2e-tests", job["name"])
+    ]
+    e2e_job_ids = {job["id"] for job in e2e_jobs}
+    steps_by_job: dict[int, list[dict[str, Any]]] = defaultdict(list)
+    for step in step_records:
+        if step["job_id"] in e2e_job_ids:
+            steps_by_job[step["job_id"]].append(step)
+
+    suites: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for job in e2e_jobs:
+        suites[job["name"].split(" / ", 1)[0]].append(job)
+
+    def summarize(jobs: list[dict[str, Any]]) -> dict[str, Any]:
+        runner = sum(job["duration_seconds"] for job in jobs)
+        test = 0.0
+        validation = 0.0
+        overhead = sum(job["unattributed_seconds"] for job in jobs)
+        for job in jobs:
+            for step in steps_by_job[job["id"]]:
+                if step["category"] == CATEGORY_TEST:
+                    test += step["duration_seconds"]
+                elif step["category"] == CATEGORY_VALIDATION:
+                    validation += step["duration_seconds"]
+                elif step["category"] in OVERHEAD_CATEGORIES:
+                    overhead += step["duration_seconds"]
+        return {
+            "jobs": len(jobs),
+            "runner_minutes": round(runner / 60, 2),
+            "mean_job_minutes": round(runner / len(jobs) / 60, 2) if jobs else 0.0,
+            "test_minutes": round(test / 60, 2),
+            "validation_minutes": round(validation / 60, 2),
+            "overhead_minutes": round(overhead / 60, 2),
+            "mean_overhead_minutes": round(overhead / len(jobs) / 60, 2)
+            if jobs
+            else 0.0,
+            "test_percent": round(100 * test / runner, 2) if runner else 0.0,
+            "overhead_percent": round(100 * overhead / runner, 2) if runner else 0.0,
+        }
+
+    return {
+        "all": summarize(e2e_jobs),
+        "suites": {name: summarize(jobs) for name, jobs in sorted(suites.items())},
+    }
+
+
+def analyze(
+    repository: str,
+    workflow: str,
+    history_runs: list[dict[str, Any]],
+    selected_runs: list[dict[str, Any]],
+    jobs_by_run: dict[int, list[dict[str, Any]]],
+) -> dict[str, Any]:
+    job_records: list[dict[str, Any]] = []
+    step_records: list[dict[str, Any]] = []
+    run_rows: list[dict[str, Any]] = []
+
+    for run in selected_runs:
+        current_jobs: list[dict[str, Any]] = []
+        current_steps: list[dict[str, Any]] = []
+        for job_index, job in enumerate(jobs_by_run[run["id"]]):
+            job_duration = duration_seconds(
+                job.get("started_at"), job.get("completed_at")
+            )
+            if job_duration <= 0:
+                continue
+            job_id = int(job.get("id") or (run["id"] * 1000 + job_index))
+            step_sum = 0.0
+            for step in job.get("steps", []):
+                step_duration = duration_seconds(
+                    step.get("started_at"), step.get("completed_at")
+                )
+                if step_duration <= 0:
+                    continue
+                step_sum += step_duration
+                record = {
+                    "run_id": run["id"],
+                    "job_id": job_id,
+                    "job_name": job.get("name", "<unnamed job>"),
+                    "name": step.get("name", "<unnamed step>"),
+                    "normalized_name": normalize_step_name(
+                        step.get("name", "<unnamed step>")
+                    ),
+                    "category": classify_step(step.get("name", "")),
+                    "duration_seconds": step_duration,
+                }
+                current_steps.append(record)
+                step_records.append(record)
+            job_record = {
+                "id": job_id,
+                "run_id": run["id"],
+                "name": job.get("name", "<unnamed job>"),
+                "duration_seconds": job_duration,
+                "unattributed_seconds": max(0.0, job_duration - step_sum),
+                "started_at": job.get("started_at"),
+                "completed_at": job.get("completed_at"),
+            }
+            current_jobs.append(job_record)
+            job_records.append(job_record)
+
+        category_seconds: dict[str, float] = defaultdict(float)
+        for step in current_steps:
+            category_seconds[step["category"]] += step["duration_seconds"]
+        runner_seconds = sum(job["duration_seconds"] for job in current_jobs)
+        unattributed = sum(job["unattributed_seconds"] for job in current_jobs)
+        overhead = unattributed + sum(
+            category_seconds[category] for category in OVERHEAD_CATEGORIES
+        )
+        completed = [
+            parse_timestamp(job["completed_at"])
+            for job in current_jobs
+            if job["completed_at"]
+        ]
+        run_started = parse_timestamp(run.get("run_started_at"))
+        wall_seconds = 0.0
+        if completed and run_started:
+            wall_seconds = max(0.0, (max(completed) - run_started).total_seconds())
+        run_rows.append(
+            {
+                "run_id": run["id"],
+                "run_number": run.get("run_number"),
+                "run_url": run.get("html_url"),
+                "pr_number": run.get("_pr_number"),
+                "pr_title": run.get("_pr_title"),
+                "branch": run.get("head_branch"),
+                "conclusion": run.get("conclusion"),
+                "jobs": len(current_jobs),
+                "runner_seconds": runner_seconds,
+                "wall_seconds": wall_seconds,
+                "test_seconds": category_seconds[CATEGORY_TEST],
+                "validation_seconds": category_seconds[CATEGORY_VALIDATION],
+                "overhead_seconds": overhead,
+                "unclassified_seconds": category_seconds[CATEGORY_UNCLASSIFIED],
+            }
+        )
+
+    total_runner = sum(job["duration_seconds"] for job in job_records)
+    total_unattributed = sum(job["unattributed_seconds"] for job in job_records)
+    category_seconds: dict[str, float] = defaultdict(float)
+    for step in step_records:
+        category_seconds[step["category"]] += step["duration_seconds"]
+    overhead_seconds = total_unattributed + sum(
+        category_seconds[category] for category in OVERHEAD_CATEGORIES
+    )
+
+    categories = {
+        category: {
+            "minutes": round(seconds / 60, 2),
+            "percent_runner": round(100 * seconds / total_runner, 2)
+            if total_runner
+            else 0.0,
+        }
+        for category, seconds in sorted(category_seconds.items())
+    }
+    categories["unattributed"] = {
+        "minutes": round(total_unattributed / 60, 2),
+        "percent_runner": round(100 * total_unattributed / total_runner, 2)
+        if total_runner
+        else 0.0,
+    }
+
+    step_groups: dict[str, dict[str, Any]] = {}
+    for step in step_records:
+        key = step["normalized_name"]
+        if key not in step_groups:
+            step_groups[key] = {
+                "name": key,
+                "category": step["category"],
+                "durations": [],
+            }
+        step_groups[key]["durations"].append(step["duration_seconds"])
+    step_stats = []
+    for item in step_groups.values():
+        durations = item.pop("durations")
+        total = sum(durations)
+        step_stats.append(
+            {
+                **item,
+                "count": len(durations),
+                "total_minutes": round(total / 60, 2),
+                "mean_seconds": round(total / len(durations), 2),
+                "p50_seconds": round(quantile(durations, 0.5), 2),
+                "p95_seconds": round(quantile(durations, 0.95), 2),
+            }
+        )
+    step_stats.sort(key=lambda item: item["total_minutes"], reverse=True)
+
+    profiles = {
+        "light": summarize_profile([row for row in run_rows if row["jobs"] < 10]),
+        "partial": summarize_profile(
+            [row for row in run_rows if 10 <= row["jobs"] < 40]
+        ),
+        "full": summarize_profile([row for row in run_rows if row["jobs"] >= 40]),
+    }
+    e2e = summarize_e2e_jobs(job_records, step_records)
+
+    outcomes: dict[str, dict[str, Any]] = {}
+    history_by_conclusion: dict[str, list[float]] = defaultdict(list)
+    for run in history_runs:
+        history_by_conclusion[run.get("conclusion") or "unknown"].append(
+            duration_seconds(run.get("run_started_at"), run.get("updated_at"))
+        )
+    for conclusion, durations in sorted(history_by_conclusion.items()):
+        outcomes[conclusion] = {
+            "runs": len(durations),
+            "median_wall_minutes": round(quantile(durations, 0.5) / 60, 2),
+            "p95_wall_minutes": round(quantile(durations, 0.95) / 60, 2),
+        }
+
+    protofleet = e2e["suites"].get("ProtoFleet E2E Tests", {})
+    full = profiles["full"]
+    metrics = {
+        "full_mean_runner_minutes": full["mean_runner_minutes"],
+        "full_mean_overhead_minutes": full["mean_overhead_minutes"],
+        "full_median_wall_minutes": full["median_wall_minutes"],
+        "overall_overhead_percent": round(100 * overhead_seconds / total_runner, 2)
+        if total_runner
+        else 0.0,
+        "protofleet_e2e_mean_job_minutes": protofleet.get("mean_job_minutes", 0.0),
+        "protofleet_e2e_mean_overhead_minutes": protofleet.get(
+            "mean_overhead_minutes", 0.0
+        ),
+    }
+
+    started = [
+        run.get("run_started_at") for run in history_runs if run.get("run_started_at")
+    ]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "generated_at": dt.datetime.now(tz=dt.timezone.utc).isoformat(),
+        "repository": repository,
+        "workflow": workflow,
+        "history": {
+            "runs": len(history_runs),
+            "pull_requests_or_branches": len(
+                {run["_group_key"] for run in history_runs}
+            ),
+            "from": min(started) if started else None,
+            "to": max(started) if started else None,
+            "outcomes": outcomes,
+        },
+        "detail": {
+            "runs": len(selected_runs),
+            "pull_requests_or_branches": len(
+                {run["_group_key"] for run in selected_runs}
+            ),
+            "jobs": len(job_records),
+            "positive_duration_steps": len(step_records),
+            "runner_minutes": round(total_runner / 60, 2),
+            "categories": categories,
+            "headline": {
+                "test_minutes": round(category_seconds[CATEGORY_TEST] / 60, 2),
+                "test_percent": round(
+                    100 * category_seconds[CATEGORY_TEST] / total_runner, 2
+                )
+                if total_runner
+                else 0.0,
+                "validation_minutes": round(
+                    category_seconds[CATEGORY_VALIDATION] / 60, 2
+                ),
+                "validation_percent": round(
+                    100 * category_seconds[CATEGORY_VALIDATION] / total_runner, 2
+                )
+                if total_runner
+                else 0.0,
+                "overhead_minutes": round(overhead_seconds / 60, 2),
+                "overhead_percent": metrics["overall_overhead_percent"],
+                "unclassified_minutes": round(
+                    category_seconds[CATEGORY_UNCLASSIFIED] / 60, 2
+                ),
+            },
+            "profiles": profiles,
+            "e2e": e2e,
+            "steps": step_stats,
+            "runs_detail": run_rows,
+        },
+        "metrics": metrics,
+    }
+
+
+def compare_with_baseline(
+    current: dict[str, Any], baseline: dict[str, Any]
+) -> dict[str, Any]:
+    rows = []
+    for key, label in COMPARISON_METRICS.items():
+        before = baseline.get("metrics", {}).get(key)
+        after = current.get("metrics", {}).get(key)
+        if not isinstance(before, (int, float)) or not isinstance(after, (int, float)):
+            continue
+        delta = after - before
+        delta_percent = 100 * delta / before if before else None
+        rows.append(
+            {
+                "metric": key,
+                "label": label,
+                "baseline": round(before, 2),
+                "current": round(after, 2),
+                "delta": round(delta, 2),
+                "delta_percent": round(delta_percent, 2)
+                if delta_percent is not None
+                else None,
+            }
+        )
+    return {
+        "same_repository": baseline.get("repository") == current.get("repository"),
+        "same_workflow": baseline.get("workflow") == current.get("workflow"),
+        "same_selection": baseline.get("selection") == current.get("selection"),
+        "metrics": rows,
+    }
+
+
+def markdown_table(headers: list[str], rows: list[list[Any]]) -> list[str]:
+    def cell(value: Any) -> str:
+        return str(value).replace("|", r"\|").replace("\n", " ")
+
+    lines = [
+        "| " + " | ".join(cell(header) for header in headers) + " |",
+        "| " + " | ".join("---" for _ in headers) + " |",
+    ]
+    lines.extend("| " + " | ".join(cell(value) for value in row) + " |" for row in rows)
+    return lines
+
+
+def render_markdown(
+    analysis: dict[str, Any], top_steps: int, comparison: dict[str, Any] | None
+) -> str:
+    history = analysis["history"]
+    detail = analysis["detail"]
+    headline = detail["headline"]
+    lines = [
+        "# GitHub Actions timing analysis",
+        "",
+        f"Repository: `{analysis['repository']}`  ",
+        f"Workflow: `{analysis['workflow']}`  ",
+        (
+            f"History: {history['runs']} completed runs across "
+            f"{history['pull_requests_or_branches']} PRs/branches "
+            f"({history['from']} to {history['to']})  "
+        ),
+        (
+            f"Detailed sample: {detail['runs']} runs, {detail['jobs']} jobs, "
+            f"{detail['positive_duration_steps']} positive-duration steps"
+        ),
+        "",
+        "## Outcome history",
+        "",
+    ]
+    outcome_rows = [
+        [
+            conclusion,
+            values["runs"],
+            f"{values['median_wall_minutes']:.1f}",
+            f"{values['p95_wall_minutes']:.1f}",
+        ]
+        for conclusion, values in history["outcomes"].items()
+    ]
+    lines.extend(
+        markdown_table(
+            ["Conclusion", "Runs", "Median wall min", "p95 wall min"], outcome_rows
+        )
+    )
+    lines.extend(["", "## Runner-time split", ""])
+    lines.extend(
+        markdown_table(
+            ["Bucket", "Runner minutes", "Share"],
+            [
+                [
+                    "Actual tests",
+                    f"{headline['test_minutes']:.1f}",
+                    f"{headline['test_percent']:.1f}%",
+                ],
+                [
+                    "Build/static validation",
+                    f"{headline['validation_minutes']:.1f}",
+                    f"{headline['validation_percent']:.1f}%",
+                ],
+                [
+                    "Overhead",
+                    f"{headline['overhead_minutes']:.1f}",
+                    f"{headline['overhead_percent']:.1f}%",
+                ],
+                [
+                    "Unclassified",
+                    f"{headline['unclassified_minutes']:.1f}",
+                    "review",
+                ],
+            ],
+        )
+    )
+    lines.extend(["", "## Run profiles", ""])
+    profile_rows = []
+    for name, profile in detail["profiles"].items():
+        profile_rows.append(
+            [
+                name,
+                profile["runs"],
+                f"{profile['mean_runner_minutes']:.1f}",
+                f"{profile['median_wall_minutes']:.1f}",
+                f"{profile['mean_test_minutes']:.1f}",
+                f"{profile['mean_overhead_minutes']:.1f}",
+            ]
+        )
+    lines.extend(
+        markdown_table(
+            [
+                "Profile",
+                "Runs",
+                "Mean runner min",
+                "Median wall min",
+                "Mean test min",
+                "Mean overhead min",
+            ],
+            profile_rows,
+        )
+    )
+    lines.extend(["", "## E2E shard jobs", ""])
+    e2e_rows = []
+    for name, suite in detail["e2e"]["suites"].items():
+        e2e_rows.append(
+            [
+                name,
+                suite["jobs"],
+                f"{suite['runner_minutes']:.1f}",
+                f"{suite['mean_job_minutes']:.2f}",
+                f"{suite['test_percent']:.1f}%",
+                f"{suite['overhead_percent']:.1f}%",
+            ]
+        )
+    lines.extend(
+        markdown_table(
+            ["Suite", "Jobs", "Runner min", "Mean job min", "Test", "Overhead"],
+            e2e_rows,
+        )
+    )
+    lines.extend(["", f"## Top {top_steps} steps by runner time", ""])
+    step_rows = [
+        [
+            step["name"],
+            step["category"],
+            step["count"],
+            f"{step['total_minutes']:.1f}",
+            f"{step['mean_seconds']:.1f}",
+            f"{step['p95_seconds']:.1f}",
+        ]
+        for step in detail["steps"][:top_steps]
+    ]
+    lines.extend(
+        markdown_table(
+            ["Step", "Category", "Count", "Total min", "Mean sec", "p95 sec"],
+            step_rows,
+        )
+    )
+
+    unclassified = [
+        step for step in detail["steps"] if step["category"] == CATEGORY_UNCLASSIFIED
+    ]
+    if unclassified:
+        lines.extend(["", "## Unclassified steps", ""])
+        lines.extend(
+            f"- `{step['name']}`: {step['total_minutes']:.2f} runner-minutes"
+            for step in unclassified
+        )
+
+    if comparison:
+        lines.extend(["", "## Baseline comparison", ""])
+        if (
+            not comparison["same_repository"]
+            or not comparison["same_workflow"]
+            or not comparison["same_selection"]
+        ):
+            lines.append(
+                "> Warning: the baseline repository, workflow, or selection does not "
+                "match this run."
+            )
+            lines.append("")
+        comparison_rows = []
+        for item in comparison["metrics"]:
+            delta_percent = item["delta_percent"]
+            comparison_rows.append(
+                [
+                    item["label"],
+                    f"{item['baseline']:.2f}",
+                    f"{item['current']:.2f}",
+                    f"{item['delta']:+.2f}",
+                    f"{delta_percent:+.1f}%" if delta_percent is not None else "n/a",
+                ]
+            )
+        lines.extend(
+            markdown_table(
+                ["Metric", "Baseline", "Current", "Delta", "Delta %"],
+                comparison_rows,
+            )
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--repo", help="GitHub repository as OWNER/REPO")
+    parser.add_argument("--workflow", default="pr-gate.yml")
+    parser.add_argument("--history-runs", type=int, default=100)
+    parser.add_argument(
+        "--conclusions",
+        default="success",
+        help="Comma-separated conclusions to fetch detailed jobs for",
+    )
+    parser.add_argument(
+        "--max-runs-per-pr",
+        type=int,
+        default=3,
+        help="Newest detailed runs per PR/branch; 0 means unlimited",
+    )
+    parser.add_argument(
+        "--detail-limit",
+        type=int,
+        default=0,
+        help="Total detailed run cap; 0 unlimited",
+    )
+    parser.add_argument("--workers", type=int, default=6)
+    parser.add_argument("--timeout", type=float, default=30.0)
+    parser.add_argument("--cache-dir", type=Path)
+    parser.add_argument("--refresh", action="store_true")
+    parser.add_argument("--top-steps", type=int, default=20)
+    parser.add_argument("--json-out", type=Path)
+    parser.add_argument("--markdown-out", type=Path)
+    parser.add_argument("--baseline", type=Path)
+    parser.add_argument(
+        "--fail-on-regression-pct",
+        type=float,
+        help="Exit 3 if any lower-is-better comparison metric regresses by this percent",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    if args.history_runs <= 0:
+        raise AnalysisError("--history-runs must be positive")
+    if args.max_runs_per_pr < 0 or args.detail_limit < 0:
+        raise AnalysisError("run limits cannot be negative")
+    if args.workers <= 0:
+        raise AnalysisError("--workers must be positive")
+    if args.timeout <= 0:
+        raise AnalysisError("--timeout must be positive")
+    if args.top_steps <= 0:
+        raise AnalysisError("--top-steps must be positive")
+    if args.fail_on_regression_pct is not None and args.fail_on_regression_pct < 0:
+        raise AnalysisError("--fail-on-regression-pct cannot be negative")
+
+    repository = args.repo or infer_repository()
+    workflow = urllib.parse.quote(args.workflow, safe="")
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    client = GitHubClient(token, timeout=args.timeout)
+
+    runs = paginate_key(
+        client,
+        (
+            f"/repos/{repository}/actions/workflows/{workflow}/runs"
+            "?event=pull_request&status=completed"
+        ),
+        "workflow_runs",
+        args.history_runs,
+    )
+    pull_limit = max(100, min(500, args.history_runs * 2))
+    pulls = paginate_list(
+        client,
+        f"/repos/{repository}/pulls?state=all&sort=updated&direction=desc",
+        pull_limit,
+    )
+    associate_runs_with_pull_requests(runs, pulls)
+    conclusions = {
+        value.strip() for value in args.conclusions.split(",") if value.strip()
+    }
+    selected = select_detailed_runs(
+        runs, conclusions, args.max_runs_per_pr, args.detail_limit
+    )
+    if not selected:
+        raise AnalysisError("No workflow runs matched the detailed-run selection")
+    if not token and len(selected) > 50:
+        print(
+            "warning: this selection is likely to exceed GitHub's anonymous API limit; "
+            "set GITHUB_TOKEN or GH_TOKEN",
+            file=sys.stderr,
+        )
+    print(
+        f"Fetching jobs for {len(selected)} of {len(runs)} runs with "
+        f"{args.workers} workers...",
+        file=sys.stderr,
+    )
+
+    jobs_by_run: dict[int, list[dict[str, Any]]] = {}
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.workers) as executor:
+        futures = {
+            executor.submit(
+                fetch_jobs,
+                client,
+                repository,
+                run,
+                args.cache_dir,
+                args.refresh,
+            ): run
+            for run in selected
+        }
+        completed_count = 0
+        for future in concurrent.futures.as_completed(futures):
+            run = futures[future]
+            jobs_by_run[run["id"]] = future.result()
+            completed_count += 1
+            if completed_count % 10 == 0 or completed_count == len(selected):
+                print(
+                    f"Fetched {completed_count}/{len(selected)} runs",
+                    file=sys.stderr,
+                )
+
+    analysis = analyze(repository, args.workflow, runs, selected, jobs_by_run)
+    analysis["selection"] = {
+        "history_runs": args.history_runs,
+        "event": "pull_request",
+        "status": "completed",
+        "conclusions": sorted(conclusions),
+        "max_runs_per_pr": args.max_runs_per_pr,
+        "detail_limit": args.detail_limit,
+    }
+    comparison = None
+    if args.baseline:
+        baseline = json.loads(args.baseline.read_text(encoding="utf-8"))
+        comparison = compare_with_baseline(analysis, baseline)
+        analysis["comparison"] = comparison
+
+    if args.json_out:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(
+            json.dumps(analysis, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+    markdown = render_markdown(analysis, args.top_steps, comparison)
+    if args.markdown_out:
+        args.markdown_out.parent.mkdir(parents=True, exist_ok=True)
+        args.markdown_out.write_text(markdown, encoding="utf-8")
+    else:
+        print(markdown, end="")
+
+    if args.fail_on_regression_pct is not None and comparison:
+        regressions = [
+            item
+            for item in comparison["metrics"]
+            if item["delta_percent"] is not None
+            and item["delta_percent"] > args.fail_on_regression_pct
+        ]
+        if regressions:
+            labels = ", ".join(item["label"] for item in regressions)
+            print(
+                f"regression threshold exceeded ({args.fail_on_regression_pct}%): "
+                f"{labels}",
+                file=sys.stderr,
+            )
+            return 3
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except AnalysisError as error:
+        print(f"error: {error}", file=sys.stderr)
+        raise SystemExit(2) from error

--- a/.github/scripts/analyze_ci_timings_test.py
+++ b/.github/scripts/analyze_ci_timings_test.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import unittest
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).with_name("analyze_ci_timings.py")
+BASELINE_PATH = Path(__file__).with_name("ci_timing_baseline.json")
+SPEC = importlib.util.spec_from_file_location("analyze_ci_timings", SCRIPT_PATH)
+assert SPEC is not None and SPEC.loader is not None
+timings = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = timings
+SPEC.loader.exec_module(timings)
+
+
+def timestamp(seconds: int) -> str:
+    return f"2026-01-01T00:{seconds // 60:02d}:{seconds % 60:02d}Z"
+
+
+def step(name: str, start: int, end: int) -> dict:
+    return {
+        "name": name,
+        "started_at": timestamp(start),
+        "completed_at": timestamp(end),
+    }
+
+
+def job(job_id: int, name: str, start: int, end: int, steps: list[dict]) -> dict:
+    return {
+        "id": job_id,
+        "name": name,
+        "started_at": timestamp(start),
+        "completed_at": timestamp(end),
+        "steps": steps,
+    }
+
+
+class ClassificationTest(unittest.TestCase):
+    def test_normalizes_matrix_shards(self):
+        self.assertEqual(
+            timings.normalize_step_name("Run Playwright tests (mobile - shard 14)"),
+            "Run Playwright tests (mobile - shard N)",
+        )
+
+    def test_classifies_representative_steps(self):
+        cases = {
+            "Set up job": timings.CATEGORY_PLATFORM,
+            "Install client dependencies": timings.CATEGORY_SETUP,
+            "Build E2E Docker images": timings.CATEGORY_SETUP,
+            "Export pre-baked Docker images": timings.CATEGORY_SETUP,
+            "Run Playwright tests (desktop - shard 3)": timings.CATEGORY_TEST,
+            "Run onboarding visual spec (mobile)": timings.CATEGORY_TEST,
+            "Generate code": timings.CATEGORY_VALIDATION,
+            "Detect changed areas": timings.CATEGORY_ORCHESTRATION,
+            "Upload blob report": timings.CATEGORY_REPORTING,
+            "A new unexplained phase": timings.CATEGORY_UNCLASSIFIED,
+        }
+        for name, expected in cases.items():
+            with self.subTest(name=name):
+                self.assertEqual(timings.classify_step(name), expected)
+
+
+class SelectionTest(unittest.TestCase):
+    def test_associates_empty_run_pull_lists_by_branch(self):
+        runs = [
+            {
+                "id": 1,
+                "head_branch": "feature/a",
+                "pull_requests": [],
+                "conclusion": "success",
+                "run_number": 10,
+            }
+        ]
+        pulls = [{"number": 42, "title": "Feature A", "head": {"ref": "feature/a"}}]
+        timings.associate_runs_with_pull_requests(runs, pulls)
+        self.assertEqual(runs[0]["_pr_number"], 42)
+        self.assertEqual(runs[0]["_group_key"], "pr:42")
+
+    def test_limits_detailed_runs_per_pr(self):
+        runs = []
+        for number in range(1, 5):
+            runs.append(
+                {
+                    "id": number,
+                    "run_number": number,
+                    "conclusion": "success",
+                    "_group_key": "pr:42",
+                }
+            )
+        selected = timings.select_detailed_runs(runs, {"success"}, 2, 0)
+        self.assertEqual([run["run_number"] for run in selected], [4, 3])
+
+
+class AnalysisTest(unittest.TestCase):
+    def make_fixture(self):
+        run = {
+            "id": 100,
+            "run_number": 7,
+            "run_attempt": 1,
+            "run_started_at": timestamp(0),
+            "updated_at": timestamp(200),
+            "head_branch": "feature/ci",
+            "html_url": "https://example.invalid/run/100",
+            "conclusion": "success",
+            "_pr_number": 9,
+            "_pr_title": "CI change",
+            "_group_key": "pr:9",
+        }
+        jobs = [
+            job(
+                1,
+                "ProtoFleet E2E Tests / e2e-tests (0, mobile)",
+                0,
+                100,
+                [
+                    step("Set up job", 0, 10),
+                    step("Install client dependencies", 10, 30),
+                    step("Run Playwright tests (mobile - shard 0)", 30, 90),
+                ],
+            ),
+            job(
+                2,
+                "Client Checks / Build",
+                0,
+                50,
+                [step("Checkout code", 0, 5), step("Build", 5, 45)],
+            ),
+        ]
+        for job_id in range(3, 41):
+            jobs.append(
+                job(job_id, f"small-{job_id}", 0, 1, [step("Set up job", 0, 1)])
+            )
+        return run, jobs
+
+    def test_analyzes_runner_time_and_e2e_overhead(self):
+        run, jobs = self.make_fixture()
+        analysis = timings.analyze(
+            "block/proto-fleet", "pr-gate.yml", [run], [run], {run["id"]: jobs}
+        )
+        headline = analysis["detail"]["headline"]
+        self.assertEqual(analysis["detail"]["jobs"], 40)
+        self.assertAlmostEqual(analysis["detail"]["runner_minutes"], 3.13)
+        self.assertAlmostEqual(headline["test_minutes"], 1.0)
+        self.assertAlmostEqual(headline["validation_minutes"], 0.67)
+        self.assertAlmostEqual(headline["overhead_minutes"], 1.47)
+        self.assertEqual(analysis["detail"]["profiles"]["full"]["runs"], 1)
+        protofleet = analysis["detail"]["e2e"]["suites"]["ProtoFleet E2E Tests"]
+        self.assertAlmostEqual(protofleet["test_percent"], 60.0)
+        self.assertAlmostEqual(protofleet["overhead_percent"], 40.0)
+        self.assertAlmostEqual(protofleet["mean_overhead_minutes"], 0.67)
+
+    def test_compares_and_renders_baseline(self):
+        run, jobs = self.make_fixture()
+        current = timings.analyze(
+            "block/proto-fleet", "pr-gate.yml", [run], [run], {run["id"]: jobs}
+        )
+        current["selection"] = {"history_runs": 1}
+        baseline = {**current, "metrics": dict(current["metrics"])}
+        baseline["metrics"]["full_mean_overhead_minutes"] = 1.0
+        comparison = timings.compare_with_baseline(current, baseline)
+        metric = next(
+            item
+            for item in comparison["metrics"]
+            if item["metric"] == "full_mean_overhead_minutes"
+        )
+        self.assertEqual(metric["delta_percent"], 47.0)
+        report = timings.render_markdown(current, 5, comparison)
+        self.assertIn("Runner-time split", report)
+        self.assertIn("Baseline comparison", report)
+        self.assertIn("Run Playwright tests (mobile - shard N)", report)
+
+    def test_checked_in_baseline_matches_current_schema(self):
+        baseline = json.loads(BASELINE_PATH.read_text(encoding="utf-8"))
+        self.assertEqual(baseline["schema_version"], timings.SCHEMA_VERSION)
+        self.assertEqual(set(baseline["metrics"]), set(timings.COMPARISON_METRICS))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/ci_timing_baseline.json
+++ b/.github/scripts/ci_timing_baseline.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-08-31T17:30:00+00:00",
+  "repository": "block/proto-fleet",
+  "workflow": "pr-gate.yml",
+  "selection": {
+    "history_runs": 100,
+    "event": "pull_request",
+    "status": "completed",
+    "conclusions": [
+      "success"
+    ],
+    "max_runs_per_pr": 3,
+    "detail_limit": 0
+  },
+  "snapshot": {
+    "workflow_runs": "6222-6321",
+    "history_from": "2026-08-26T07:00:13Z",
+    "history_to": "2026-08-31T16:56:31Z",
+    "detailed_runs": 32,
+    "pull_requests": 17,
+    "jobs": 1508,
+    "positive_duration_steps": 16966
+  },
+  "metrics": {
+    "full_mean_runner_minutes": 167.18,
+    "full_mean_overhead_minutes": 79.6,
+    "full_median_wall_minutes": 9.6,
+    "overall_overhead_percent": 47.58,
+    "protofleet_e2e_mean_job_minutes": 4.09,
+    "protofleet_e2e_mean_overhead_minutes": 1.94
+  }
+}

--- a/.github/scripts/prepare_protofleet_e2e_runner.sh
+++ b/.github/scripts/prepare_protofleet_e2e_runner.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly INSTALL_ROOT="${PROTOFLEET_E2E_INSTALL_ROOT:-/opt/protofleet-e2e}"
+readonly REPOSITORY_ROOT="${GITHUB_WORKSPACE:-$(pwd)}"
+readonly JQ="${REPOSITORY_ROOT}/bin/jq"
+readonly NPM="${REPOSITORY_ROOT}/bin/npm"
+readonly NPX="${REPOSITORY_ROOT}/bin/npx"
+
+require_hash() {
+  local name="$1"
+  local value="$2"
+  if [[ ! "${value}" =~ ^[0-9a-f]{64}$ ]]; then
+    echo "${name} must be a non-empty GitHub hashFiles SHA-256 digest." >&2
+    exit 1
+  fi
+}
+
+as_root() {
+  if [[ "${EUID}" -eq 0 ]]; then
+    "$@"
+  else
+    sudo "$@"
+  fi
+}
+
+if [[ "$(uname -s)" != "Linux" ]] || [[ "$(uname -m)" != "x86_64" ]]; then
+  echo "ProtoFleet E2E runner images must be generated on Linux x64." >&2
+  exit 1
+fi
+
+: "${PROTOFLEET_SERVER_HASH:?PROTOFLEET_SERVER_HASH is required}"
+: "${PROTOFLEET_CLIENT_LOCK_HASH:?PROTOFLEET_CLIENT_LOCK_HASH is required}"
+: "${PROTOFLEET_IMAGE_SOURCE_SHA:?PROTOFLEET_IMAGE_SOURCE_SHA is required}"
+require_hash PROTOFLEET_SERVER_HASH "${PROTOFLEET_SERVER_HASH}"
+require_hash PROTOFLEET_CLIENT_LOCK_HASH "${PROTOFLEET_CLIENT_LOCK_HASH}"
+if [[ ! "${PROTOFLEET_IMAGE_SOURCE_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "PROTOFLEET_IMAGE_SOURCE_SHA must be a Git commit SHA." >&2
+  exit 1
+fi
+
+if [[ -e "${INSTALL_ROOT}" ]]; then
+  echo "${INSTALL_ROOT} already exists; generate from a clean GitHub-owned base image." >&2
+  exit 1
+fi
+
+for command in docker "${JQ}" "${NPM}" "${NPX}"; do
+  if ! command -v "${command}" >/dev/null 2>&1; then
+    echo "Required command is unavailable: ${command}" >&2
+    exit 1
+  fi
+done
+
+staging_root="$(mktemp -d)"
+cleanup() {
+  rm -rf -- "${staging_root}"
+  rm -rf -- "${REPOSITORY_ROOT}/client/node_modules"
+}
+trap cleanup EXIT
+
+cd "${REPOSITORY_ROOT}"
+
+echo "Installing the lockfile-exact client dependency tree..."
+"${NPM}" --prefix client ci --include=optional
+
+echo "Installing Chromium and its operating-system dependencies..."
+(
+  cd client/e2eTests/protoFleet
+  PLAYWRIGHT_BROWSERS_PATH="${staging_root}/ms-playwright" \
+    "${NPX}" playwright install --with-deps chromium
+)
+
+echo "Building and pulling the Docker images used by ProtoFleet E2E..."
+(
+  cd server
+  docker compose pull --ignore-buildable
+  docker compose build --pull
+)
+
+docker_images=()
+while IFS= read -r image; do
+  docker_images+=("${image}")
+done < <(cd server && docker compose config --images | sort -u)
+if [[ "${#docker_images[@]}" -eq 0 ]]; then
+  echo "Docker Compose did not report any E2E images." >&2
+  exit 1
+fi
+for image in "${docker_images[@]}"; do
+  docker image inspect "${image}" >/dev/null
+done
+
+printf '%s\n' "${docker_images[@]}" | "${JQ}" -Rn '[inputs]' > "${staging_root}/docker-images.json"
+"${JQ}" -n \
+  --arg source_sha "${PROTOFLEET_IMAGE_SOURCE_SHA}" \
+  --arg generated_at "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+  --arg server_hash "${PROTOFLEET_SERVER_HASH}" \
+  --arg client_lock_hash "${PROTOFLEET_CLIENT_LOCK_HASH}" \
+  --argjson docker_images "$(< "${staging_root}/docker-images.json")" \
+  '{
+    schema_version: 1,
+    source_sha: $source_sha,
+    generated_at: $generated_at,
+    server_hash: $server_hash,
+    client_lock_hash: $client_lock_hash,
+    docker_images: $docker_images
+  }' > "${staging_root}/manifest.json"
+
+echo "Installing reusable content at ${INSTALL_ROOT}..."
+as_root install -d -m 0755 "${INSTALL_ROOT}"
+as_root cp -R "${REPOSITORY_ROOT}/client/node_modules" "${INSTALL_ROOT}/client-node-modules"
+as_root cp -R "${staging_root}/ms-playwright" "${INSTALL_ROOT}/ms-playwright"
+as_root install -m 0644 "${staging_root}/manifest.json" "${INSTALL_ROOT}/manifest.json"
+as_root chmod -R a+rX "${INSTALL_ROOT}"
+
+echo "Pre-baked $("${JQ}" '.docker_images | length' "${INSTALL_ROOT}/manifest.json") Docker images for source ${PROTOFLEET_IMAGE_SOURCE_SHA}."

--- a/.github/scripts/protofleet_e2e_runner_test.py
+++ b/.github/scripts/protofleet_e2e_runner_test.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).with_name("restore_protofleet_e2e_runner.sh")
+
+
+class RestoreRunnerImageTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary_directory.name)
+        self.install_root = self.root / "image"
+        self.workspace = self.root / "workspace"
+        self.fake_bin = self.root / "bin"
+        self.output = self.root / "output"
+        self.environment = self.root / "environment"
+        (self.workspace / "client").mkdir(parents=True)
+        self.fake_bin.mkdir()
+        docker = self.fake_bin / "docker"
+        docker.write_text(
+            "#!/bin/sh\n"
+            'if [ "$1" = image ] && [ "$2" = inspect ] && '
+            '[ "$3" != missing:latest ]; then exit 0; fi\n'
+            "exit 1\n",
+            encoding="utf-8",
+        )
+        docker.chmod(0o755)
+        self.server_hash = "a" * 64
+        self.client_hash = "b" * 64
+
+    def tearDown(self):
+        self.temporary_directory.cleanup()
+
+    def write_image(self, docker_images=None):
+        dependencies = self.install_root / "client-node-modules" / "package"
+        browser = self.install_root / "ms-playwright" / "chromium-1"
+        dependencies.mkdir(parents=True)
+        browser.mkdir(parents=True)
+        (dependencies / "index.js").write_text("export {};\n", encoding="utf-8")
+        (browser / "chrome").write_text("browser\n", encoding="utf-8")
+        manifest = {
+            "schema_version": 1,
+            "source_sha": "c" * 40,
+            "server_hash": self.server_hash,
+            "client_lock_hash": self.client_hash,
+            "docker_images": docker_images or ["present:latest"],
+        }
+        (self.install_root / "manifest.json").write_text(
+            json.dumps(manifest), encoding="utf-8"
+        )
+
+    def run_restore(self, **overrides):
+        environment = {
+            **os.environ,
+            "PATH": f"{self.fake_bin}:{os.environ['PATH']}",
+            "GITHUB_WORKSPACE": str(self.workspace),
+            "GITHUB_OUTPUT": str(self.output),
+            "GITHUB_ENV": str(self.environment),
+            "PROTOFLEET_E2E_INSTALL_ROOT": str(self.install_root),
+            "PROTOFLEET_JQ": shutil.which("jq") or "jq",
+            "PROTOFLEET_CURRENT_SERVER_HASH": self.server_hash,
+            "PROTOFLEET_CURRENT_CLIENT_LOCK_HASH": self.client_hash,
+            "PROTOFLEET_ALLOW_PREBAKED_DOCKER": "true",
+            **overrides,
+        }
+        result = subprocess.run(
+            ["bash", str(SCRIPT)],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=environment,
+        )
+        outputs = {}
+        if self.output.exists():
+            for line in self.output.read_text(encoding="utf-8").splitlines():
+                key, value = line.split("=", 1)
+                outputs[key] = value
+        return result, outputs
+
+    def test_restores_every_hash_matched_component(self):
+        self.write_image()
+        result, outputs = self.run_restore()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(outputs["client-dependencies"], "true")
+        self.assertEqual(outputs["playwright-browsers"], "true")
+        self.assertEqual(outputs["docker-images"], "true")
+        self.assertTrue(
+            (self.workspace / "client/node_modules/package/index.js").is_file()
+        )
+        self.assertIn(
+            f"PLAYWRIGHT_BROWSERS_PATH={self.install_root}/ms-playwright",
+            self.environment.read_text(encoding="utf-8"),
+        )
+
+    def test_lockfile_mismatch_falls_back_but_docker_can_still_hit(self):
+        self.write_image()
+        result, outputs = self.run_restore(PROTOFLEET_CURRENT_CLIENT_LOCK_HASH="d" * 64)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(outputs["client-dependencies"], "false")
+        self.assertEqual(outputs["playwright-browsers"], "false")
+        self.assertEqual(outputs["docker-images"], "true")
+
+    def test_missing_docker_image_falls_back(self):
+        self.write_image(["present:latest", "missing:latest"])
+        result, outputs = self.run_restore()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(outputs["docker-images"], "false")
+        self.assertIn("missing:latest", result.stdout)
+
+    def test_scheduled_run_can_disable_prebaked_docker(self):
+        self.write_image()
+        result, outputs = self.run_restore(PROTOFLEET_ALLOW_PREBAKED_DOCKER="false")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(outputs["client-dependencies"], "true")
+        self.assertEqual(outputs["docker-images"], "false")
+
+    def test_missing_manifest_is_a_clean_miss(self):
+        result, outputs = self.run_restore()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(outputs["client-dependencies"], "false")
+        self.assertEqual(outputs["playwright-browsers"], "false")
+        self.assertEqual(outputs["docker-images"], "false")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/restore_protofleet_e2e_runner.sh
+++ b/.github/scripts/restore_protofleet_e2e_runner.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly INSTALL_ROOT="${PROTOFLEET_E2E_INSTALL_ROOT:-/opt/protofleet-e2e}"
+readonly MANIFEST="${INSTALL_ROOT}/manifest.json"
+readonly JQ="${PROTOFLEET_JQ:-${GITHUB_WORKSPACE}/bin/jq}"
+
+emit_output() {
+  printf '%s=%s\n' "$1" "$2" >> "${GITHUB_OUTPUT}"
+}
+
+image_version=unavailable
+client_dependencies=false
+playwright_browsers=false
+docker_images_available=false
+
+finish() {
+  emit_output image-version "${image_version}"
+  emit_output client-dependencies "${client_dependencies}"
+  emit_output playwright-browsers "${playwright_browsers}"
+  emit_output docker-images "${docker_images_available}"
+  echo "ProtoFleet E2E runner image ${image_version}: client dependencies=${client_dependencies}, Playwright=${playwright_browsers}, Docker=${docker_images_available}"
+}
+
+if [[ ! -f "${MANIFEST}" ]]; then
+  echo "No ProtoFleet E2E runner manifest found; using normal setup paths."
+  finish
+  exit 0
+fi
+
+if ! "${JQ}" -e '
+  .schema_version == 1 and
+  (.source_sha | type == "string") and
+  (.server_hash | type == "string") and
+  (.client_lock_hash | type == "string") and
+  (.docker_images | type == "array")
+' "${MANIFEST}" >/dev/null; then
+  echo "::warning::Ignoring an invalid ProtoFleet E2E runner manifest."
+  finish
+  exit 0
+fi
+
+image_version="$("${JQ}" -r '.source_sha' "${MANIFEST}")"
+manifest_server_hash="$("${JQ}" -r '.server_hash' "${MANIFEST}")"
+manifest_client_lock_hash="$("${JQ}" -r '.client_lock_hash' "${MANIFEST}")"
+
+if [[ "${manifest_client_lock_hash}" == "${PROTOFLEET_CURRENT_CLIENT_LOCK_HASH}" ]]; then
+  dependency_source="${INSTALL_ROOT}/client-node-modules"
+  dependency_target="${GITHUB_WORKSPACE}/client/node_modules"
+  if [[ -d "${dependency_source}" ]] &&
+    [[ -n "$(find "${dependency_source}" -mindepth 1 -print -quit)" ]]; then
+    if [[ -e "${dependency_target}" ]]; then
+      echo "::error::Refusing to overlay an existing client/node_modules directory."
+      exit 1
+    fi
+    cp -R "${dependency_source}" "${dependency_target}"
+    client_dependencies=true
+  else
+    echo "::warning::The runner manifest matches the client lockfile, but its dependency tree is missing."
+  fi
+
+  browser_root="${INSTALL_ROOT}/ms-playwright"
+  if [[ -d "${browser_root}" ]] &&
+    [[ -n "$(find "${browser_root}" -mindepth 1 -print -quit)" ]]; then
+    printf 'PLAYWRIGHT_BROWSERS_PATH=%s\n' "${browser_root}" >> "${GITHUB_ENV}"
+    playwright_browsers=true
+  else
+    echo "::warning::The runner manifest matches the client lockfile, but its Playwright browsers are missing."
+  fi
+fi
+
+if [[ "${PROTOFLEET_ALLOW_PREBAKED_DOCKER}" == "true" ]] &&
+  [[ "${manifest_server_hash}" == "${PROTOFLEET_CURRENT_SERVER_HASH}" ]]; then
+  docker_images=()
+  while IFS= read -r image; do
+    docker_images+=("${image}")
+  done < <("${JQ}" -r '.docker_images[]' "${MANIFEST}")
+  docker_images_available=true
+  if [[ "${#docker_images[@]}" -eq 0 ]]; then
+    docker_images_available=false
+  fi
+  for image in "${docker_images[@]}"; do
+    if ! docker image inspect "${image}" >/dev/null 2>&1; then
+      echo "::warning::Pre-baked Docker image is missing: ${image}"
+      docker_images_available=false
+    fi
+  done
+fi
+
+finish

--- a/.github/workflows/protofleet-e2e-runner-image.yml
+++ b/.github/workflows/protofleet-e2e-runner-image.yml
@@ -1,0 +1,49 @@
+name: ProtoFleet E2E Runner Image
+
+on:
+  schedule:
+    # Weekly refresh picks up operating-system and upstream image patches.
+    - cron: "0 8 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: protofleet-e2e-runner-image
+  cancel-in-progress: false
+
+jobs:
+  build-image:
+    name: Build runner image
+    if: >-
+      vars.PROTOFLEET_E2E_IMAGE_BUILDER_RUNNER != '' &&
+      github.ref_name == github.event.repository.default_branch
+    runs-on: ${{ vars.PROTOFLEET_E2E_IMAGE_BUILDER_RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 180
+    snapshot:
+      image-name: protofleet-e2e
+      version: "1.*"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Hermit
+        uses: ./.github/actions/hermit-setup
+
+      - name: Prepare E2E runner image
+        env:
+          PROTOFLEET_SERVER_HASH: ${{ hashFiles('server/**') }}
+          PROTOFLEET_CLIENT_LOCK_HASH: ${{ hashFiles('client/package-lock.json') }}
+          PROTOFLEET_IMAGE_SOURCE_SHA: ${{ github.sha }}
+        run: .github/scripts/prepare_protofleet_e2e_runner.sh
+
+      - name: Summarize image
+        run: |
+          echo "## ProtoFleet E2E runner image" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo '```json' >> "$GITHUB_STEP_SUMMARY"
+          bin/jq . /opt/protofleet-e2e/manifest.json >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/protofleet-e2e-tests.yml
+++ b/.github/workflows/protofleet-e2e-tests.yml
@@ -78,7 +78,7 @@ jobs:
 
   build:
     name: Build client and plugins
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.PROTOFLEET_E2E_RUNNER || 'ubuntu-latest' }}
     permissions:
       contents: read
     steps:
@@ -90,14 +90,24 @@ jobs:
       - name: Setup Hermit
         uses: ./.github/actions/hermit-setup
 
+      - name: Restore pre-baked runner content
+        id: runner-image
+        uses: ./.github/actions/protofleet-e2e-runner
+        with:
+          server-hash: ${{ hashFiles('server/**') }}
+          client-lock-hash: ${{ hashFiles('client/package-lock.json') }}
+          # Scheduled runs deliberately refresh upstream Docker base images.
+          allow-docker-images: ${{ github.event_name != 'schedule' }}
+
       - name: Configure Go cache
         uses: ./.github/actions/go-cache-setup
 
-      # Cache the npm download cache (~/.npm), not a built node_modules:
-      # restoring node_modules from cache corrupts native optional deps (e.g.
-      # Rolldown's Linux binding), so we always run a clean `npm ci` and just
-      # keep its downloads warm. This is also the pattern Client Checks uses.
+      # Standard runners cache only npm downloads because cross-image
+      # node_modules caches corrupt native optional dependencies. The custom
+      # runner may instead restore an exact-lockfile dependency tree built in
+      # the same VM image.
       - name: Cache npm dependencies
+        if: steps.runner-image.outputs.client-dependencies != 'true'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.npm
@@ -106,6 +116,7 @@ jobs:
             ${{ runner.os }}-npm-
 
       - name: Install client dependencies
+        if: steps.runner-image.outputs.client-dependencies != 'true'
         working-directory: client
         run: npm ci --include=optional
 
@@ -136,7 +147,9 @@ jobs:
           key: ${{ runner.os }}-protofleet-e2e-docker-${{ hashFiles('server/**') }}
 
       - name: Build E2E Docker images
-        if: steps.docker-image-cache.outputs.cache-hit != 'true'
+        if: >-
+          steps.runner-image.outputs.docker-images != 'true' &&
+          steps.docker-image-cache.outputs.cache-hit != 'true'
         working-directory: server
         run: |
           mkdir -p /tmp/docker-images
@@ -157,6 +170,18 @@ jobs:
           docker save "${images[@]}" | gzip > /tmp/docker-images/e2e-images.tar.gz
           ls -lh /tmp/docker-images/
           echo "::endgroup::"
+
+      # The artifact remains available even when the custom image is used, so
+      # a shard that lands on an older runner image can fall back safely.
+      - name: Export pre-baked Docker images
+        if: >-
+          steps.runner-image.outputs.docker-images == 'true' &&
+          steps.docker-image-cache.outputs.cache-hit != 'true'
+        working-directory: server
+        run: |
+          mkdir -p /tmp/docker-images
+          mapfile -t images < <(docker compose config --images | sort -u)
+          docker save "${images[@]}" | gzip > /tmp/docker-images/e2e-images.tar.gz
 
       - name: Save Docker image cache
         if: github.event_name != 'schedule' && steps.docker-image-cache.outputs.cache-hit != 'true'
@@ -205,7 +230,7 @@ jobs:
   e2e-tests:
     needs: [detect-specs, build]
     timeout-minutes: 40
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.PROTOFLEET_E2E_RUNNER || 'ubuntu-latest' }}
     permissions:
       contents: read
     env:
@@ -229,9 +254,18 @@ jobs:
         with:
           preinstall: "false"
 
-      # See the build job: cache ~/.npm and run a clean `npm ci` rather than
-      # caching a built node_modules.
+      - name: Restore pre-baked runner content
+        id: runner-image
+        uses: ./.github/actions/protofleet-e2e-runner
+        with:
+          server-hash: ${{ hashFiles('server/**') }}
+          client-lock-hash: ${{ hashFiles('client/package-lock.json') }}
+          allow-docker-images: ${{ github.event_name != 'schedule' }}
+
+      # See the build job: the normal path caches ~/.npm and runs npm ci; the
+      # custom runner uses only its exact-lockfile dependency tree.
       - name: Cache npm dependencies
+        if: steps.runner-image.outputs.client-dependencies != 'true'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.npm
@@ -241,6 +275,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: playwright-cache
+        if: steps.runner-image.outputs.playwright-browsers != 'true'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/ms-playwright
@@ -249,11 +284,14 @@ jobs:
             ${{ runner.os }}-playwright-
 
       - name: Install client dependencies
+        if: steps.runner-image.outputs.client-dependencies != 'true'
         working-directory: client
         run: npm ci --include=optional
 
       - name: Install Playwright browser
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        if: >-
+          steps.runner-image.outputs.playwright-browsers != 'true' &&
+          steps.playwright-cache.outputs.cache-hit != 'true'
         working-directory: client/e2eTests/protoFleet
         run: |
           # ubuntu-latest already includes Chromium's runtime libraries. Avoid
@@ -278,12 +316,14 @@ jobs:
         run: chmod +x server/plugins/proto-plugin server/plugins/antminer-plugin
 
       - name: Download prebuilt Docker images
+        if: steps.runner-image.outputs.docker-images != 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: protofleet-e2e-docker-images
           path: /tmp/docker-images
 
       - name: Load Docker images
+        if: steps.runner-image.outputs.docker-images != 'true'
         run: |
           gunzip < /tmp/docker-images/e2e-images.tar.gz | docker load
 
@@ -394,7 +434,7 @@ jobs:
     name: Visual Tests
     needs: [build]
     timeout-minutes: 40
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.PROTOFLEET_E2E_RUNNER || 'ubuntu-latest' }}
     permissions:
       contents: read
     strategy:
@@ -413,7 +453,16 @@ jobs:
         with:
           preinstall: "false"
 
+      - name: Restore pre-baked runner content
+        id: runner-image
+        uses: ./.github/actions/protofleet-e2e-runner
+        with:
+          server-hash: ${{ hashFiles('server/**') }}
+          client-lock-hash: ${{ hashFiles('client/package-lock.json') }}
+          allow-docker-images: ${{ github.event_name != 'schedule' }}
+
       - name: Cache npm dependencies
+        if: steps.runner-image.outputs.client-dependencies != 'true'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.npm
@@ -423,6 +472,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: playwright-cache
+        if: steps.runner-image.outputs.playwright-browsers != 'true'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/ms-playwright
@@ -431,11 +481,14 @@ jobs:
             ${{ runner.os }}-playwright-
 
       - name: Install client dependencies
+        if: steps.runner-image.outputs.client-dependencies != 'true'
         working-directory: client
         run: npm ci --include=optional
 
       - name: Install Playwright browser
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        if: >-
+          steps.runner-image.outputs.playwright-browsers != 'true' &&
+          steps.playwright-cache.outputs.cache-hit != 'true'
         working-directory: client/e2eTests/protoFleet
         run: npx playwright install chromium
 
@@ -455,12 +508,14 @@ jobs:
         run: chmod +x server/plugins/proto-plugin server/plugins/antminer-plugin
 
       - name: Download prebuilt Docker images
+        if: steps.runner-image.outputs.docker-images != 'true'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: protofleet-e2e-docker-images
           path: /tmp/docker-images
 
       - name: Load Docker images
+        if: steps.runner-image.outputs.docker-images != 'true'
         run: |
           gunzip < /tmp/docker-images/e2e-images.tar.gz | docker load
 

--- a/docs/plans/2026-08-31-protofleet-e2e-prebaked-runner-plan.md
+++ b/docs/plans/2026-08-31-protofleet-e2e-prebaked-runner-plan.md
@@ -1,0 +1,93 @@
+---
+title: "Pre-baked ProtoFleet E2E runner"
+date: 2026-08-31
+status: implementing
+type: plan
+---
+
+# Pre-baked ProtoFleet E2E runner
+
+## Context
+
+The August 2026 CI timing baseline found that successful ProtoFleet E2E jobs
+spend 47.5% of their runner time outside tests. Downloading and loading the
+Docker Compose image bundle accounts for 1,013 runner-minutes in the sampled
+runs, or about 66 seconds per shard. Repeating npm and Playwright setup adds
+more overhead across the 32 functional shards and two visual jobs.
+
+A GitHub Actions job container cannot remove the largest cost: the Compose
+stack runs through the runner host's Docker daemon, whose image store is not
+populated by layers in the job container. The supported pre-warmed topology is
+therefore a GitHub-hosted larger runner using a custom VM image.
+
+## Repository implementation
+
+The `ProtoFleet E2E Runner Image` workflow generates the `protofleet-e2e`
+custom image from the default branch. It installs:
+
+- the exact `client/package-lock.json` dependency tree;
+- the matching Playwright Chromium build and operating-system dependencies;
+- all pulled and locally built images reported by `server/docker-compose.yaml`.
+
+The image records the GitHub `hashFiles` digests for `server/**` and the client
+lockfile. E2E jobs use a component only when its digest matches. They also
+verify that every recorded Docker image still exists in the host daemon. A
+miss uses the existing Actions cache, artifact, and install path.
+
+Scheduled E2E runs deliberately ignore pre-baked Docker images so the existing
+daily rebuild against fresh upstream bases remains intact. The build job still
+publishes a Docker image artifact on a hit, allowing a shard on an older runner
+image to fall back safely during image rollouts.
+
+## Organization setup
+
+An organization or CI/CD administrator must complete these steps after the
+repository changes land:
+
+1. Enable GitHub-hosted custom images for the organization.
+2. Create a dedicated Linux x64 image-generation larger runner from a
+   GitHub-owned Ubuntu image. Give only this repository access to its runner
+   group and enable custom-image generation.
+3. Set the repository or organization variable
+   `PROTOFLEET_E2E_IMAGE_BUILDER_RUNNER` to that runner's name.
+4. Run `ProtoFleet E2E Runner Image` from the default branch. Its successful
+   `snapshot` job creates image `protofleet-e2e` version `1.x`.
+5. Create a Linux x64 larger runner using the latest `protofleet-e2e` image.
+   Its maximum concurrency must accommodate the build, 32 functional shards,
+   and two visual jobs without serializing the existing matrix.
+6. Give this repository access and set `PROTOFLEET_E2E_RUNNER` to the runtime
+   runner's name. Until this variable exists, all jobs continue using
+   `ubuntu-latest`.
+
+Use a dedicated image-generation runner group. The image workflow refuses to
+run from a non-default branch, and the runtime runner contains no credentials.
+
+## Verification and rollout
+
+1. Leave `PROTOFLEET_E2E_RUNNER` unset while the image is generated.
+2. Confirm the image manifest summary lists every Compose image and that a
+   manually configured runtime runner reports Docker, Playwright, and client
+   dependency hits.
+3. Set the runtime variable and exercise the same commit with the stock and
+   custom runner configurations. Compare at least ten full E2E runs with:
+
+   ```bash
+   GITHUB_TOKEN=... .github/scripts/analyze_ci_timings.py \
+     --baseline .github/scripts/ci_timing_baseline.json \
+     --json-out /tmp/protofleet-e2e-runner-after.json \
+     --markdown-out /tmp/protofleet-e2e-runner-after.md
+   ```
+
+4. Check failure and cancellation rates in addition to timing. The primary
+   target is to reduce mean ProtoFleet shard overhead from the 1.94-minute
+   baseline without increasing E2E failures.
+
+Rollback is immediate: delete or clear `PROTOFLEET_E2E_RUNNER`. The workflow
+then resolves `runs-on` to `ubuntu-latest`, and every cache probe becomes a
+normal miss.
+
+## Remaining external dependency
+
+Repository code cannot create or grant access to organization-level larger
+runners. The custom image remains inactive until an administrator provisions
+the image-generation and runtime runners and sets the two variables above.


### PR DESCRIPTION
Reviewable diff: +1552/-12 across 8 files (excludes generated, test, and story files).

## Summary

ProtoFleet E2E can now run on an opt-in GitHub-hosted custom VM image that preloads the exact client dependency tree, matching Playwright browser, and Docker Compose images. Hash and presence checks keep stale image components from being used, while the existing `ubuntu-latest`, Actions cache, and Docker artifact paths remain the default and fallback. This also checks in the timing analyzer and baseline used to measure whether the runner reduces overhead or causes regressions.

## How it works

A trusted weekly or manual workflow on the default branch prepares a Linux x64 image-generation runner, writes a manifest containing the source SHA plus `hashFiles` digests, and snapshots it as `protofleet-e2e`. Once an administrator provisions a runtime larger runner and sets `PROTOFLEET_E2E_RUNNER`, the E2E build, 32 functional shards, and two visual jobs land on that image.

After checkout, a local action compares the current server and lockfile hashes with the manifest. Matching client dependencies are copied into the workspace, Playwright is pointed at the baked Chromium tree, and Docker images are accepted only if every recorded image is still present in the host daemon. Each component falls back independently; scheduled E2E runs always rebuild Docker images against fresh upstream bases, and the build job still publishes an image artifact so older runner instances can fall back safely during image rollouts.

The timing analyzer reads completed PR Gate runs and latest-attempt job data from GitHub, groups the newest successful runs per PR, classifies step time as test, validation/build, or overhead, and emits Markdown/JSON plus a regression comparison against the checked-in baseline.

## Diagrams

```mermaid
flowchart LR
  A["Trusted default-branch image workflow"] --> B["Image-generation larger runner"]
  B --> C["Install Node dependencies and Chromium"]
  B --> D["Pull and build Compose images"]
  C --> E["Write hash manifest"]
  D --> E
  E --> F["Snapshot protofleet-e2e"]
  F --> G["Runtime larger runner"]
  H["PR E2E job"] --> I["Hash-aware restore action"]
  G --> I
  I --> J{"Component matches and exists?"}
  J -->|"Yes"| K["Use pre-baked component"]
  J -->|"No"| L["Use existing cache or artifact path"]
  K --> M["Build, functional shards, and visual tests"]
  L --> M
```

```mermaid
sequenceDiagram
  participant Admin as "CI administrator"
  participant Builder as "Image workflow"
  participant GitHub as "Custom image store"
  participant E2E as "PR E2E job"
  Admin->>Builder: "Configure builder variable and run on main"
  Builder->>GitHub: "Snapshot tools, dependencies, Docker images, and manifest"
  Admin->>E2E: "Configure runtime runner variable"
  E2E->>E2E: "Compare current hashes and inspect Docker images"
  alt "Valid pre-baked component"
    E2E->>E2E: "Restore or reuse local component"
  else "Missing or stale component"
    E2E->>E2E: "Restore Actions cache/artifact or rebuild"
  end
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `.github/workflows/protofleet-e2e-runner-image.yml` | Adds trusted weekly/manual custom-image generation with GitHub `snapshot` | Verify the image lifecycle, default-branch restriction, and organization runner dependency |
| `.github/actions/protofleet-e2e-runner/` | Exposes independently validated client, Playwright, and Docker hits | This is the boundary that decides whether setup steps may be skipped |
| `.github/scripts/prepare_protofleet_e2e_runner.sh` | Installs exact dependencies and Compose images, then writes the root-owned manifest | Review image contents, hash inputs, and snapshot safety |
| `.github/scripts/restore_protofleet_e2e_runner.sh` | Validates the manifest, restores dependencies, and inspects host Docker images | Review fail-safe behavior for stale, missing, and partially available content |
| `.github/workflows/protofleet-e2e-tests.yml` | Selects the configured runner and conditionally skips redundant setup | Verify the normal runner path is unchanged on misses and scheduled rebuilds stay fresh |
| `.github/scripts/analyze_ci_timings.py` and baseline | Adds repeatable historical step timing, Markdown/JSON reports, caching, and regression thresholds | Review sampling semantics and name-based timing classification |
| `docs/plans/2026-08-31-protofleet-e2e-prebaked-runner-plan.md` | Documents administrator activation, canary measurement, and rollback | Organization-level runners cannot be provisioned by repository code |
| Python tests | Covers run selection/classification and runner hit/miss/fallback behavior | Test-only — focus on edge-case coverage |

## Key technical decisions & trade-offs

- Use a custom runner VM rather than a job container, because the measured hotspot is hydrating the host Docker daemon used by Compose.
- Validate server and client inputs independently rather than invalidating the entire image, so client-only and server-only changes retain safe partial hits.
- Keep publishing the Docker artifact on a pre-baked hit rather than maximizing the single build-job saving, so mixed image versions can fall back during rollout.
- Force scheduled runs down the Docker rebuild path rather than using a weekly snapshot, preserving the existing fresh-upstream-base behavior.
- Keep `ubuntu-latest` as the variable fallback rather than requiring organization infrastructure at merge time; activation and rollback are configuration-only.
- Classify timing by normalized step name rather than workflow-specific IDs, which supports reusable workflows but surfaces unmatched steps explicitly for review.

## Testing & validation

- `server/sdk/v1/python/.venv/bin/python -B .github/scripts/protofleet_e2e_runner_test.py` — 5 tests passed.
- `server/sdk/v1/python/.venv/bin/python -B .github/scripts/analyze_ci_timings_test.py` — 7 tests passed.
- `server/sdk/v1/python/.venv/bin/python -B .github/scripts/evaluate_review_policy_test.py` — 72 tests passed.
- Ruff check/format, shell syntax, YAML parsing, Prettier, and `git diff --check` passed.
- Pre-commit hooks passed Ruff and protected-branch checks; pre-push hooks passed client typecheck and server lint.
- Not covered yet: generating the real GitHub custom image and running the E2E canary. Those require an organization administrator to provision the image-generation/runtime larger runners and set the two documented variables.
