### PR TITLE
docs: record sharded Codex benchmark results

### DIFF
--- a/docs/codex-security-review-benchmark-report.md
+++ b/docs/codex-security-review-benchmark-report.md
@@ -1,6 +1,6 @@
 # Codex security review benchmark report
 
-Date: 2026-08-27
+Date: 2026-09-01
 
 ## Decision
 
@@ -16,9 +16,17 @@ model tuning. Across 72 matrix cases, 50 reviews exhausted the outer budget and
 all 72 trusted finalizers uploaded either a completed-result or verified-timeout
 artifact. No ambiguous cancellation was admitted as benchmark data.
 
-Further runtime work should evaluate architecture-aware sharding rather than
-reducing context, effort, or prompt scope again. See the
-[sharded-review TDD](./plans/2026-08-27-sharded-codex-security-review-tdd.md).
+Architecture-aware sharding also failed its initial gate. The trusted sharded
+run completed only one of six aggregates; eight of 11 active shards exhausted
+their six-minute model budget. Do not repeat the sharded candidate or run it
+against the large-PR corpus. The completed
+[sharded-review TDD](./plans/archive/2026-08-27-sharded-codex-security-review-tdd.md)
+records the design and outcome.
+
+The next independent candidate is `gpt-5.6-terra` with `high` reasoning,
+default service tier, and low verbosity. It must run through trusted
+benchmark-only code before any production consideration. Production remains on
+`gpt-5.6-sol`, `unified=40`, `xhigh`, and the baseline prompt.
 
 ## Method
 
@@ -46,6 +54,36 @@ and verified-timeout rates are reported separately.
 GitHub reports each run as cancelled because timed-out matrix jobs are cancelled
 at the enforceable outer boundary. That top-level conclusion is expected here;
 every per-case finalizer succeeded and produced one uniquely named artifact.
+
+### Sharded candidate
+
+The initial sharded run
+[33534337325](https://github.com/block/proto-fleet/actions/runs/33534337325)
+loaded trusted `main` at
+`bfbc12bb61dd6372ddd25c05107a1fb41c94dfec`. It used `gpt-5.6-sol`,
+`unified=40`, `xhigh`, and the baseline prompt. Each review had at most two
+parallel packets and each active model job had a six-minute outer budget.
+
+| Case | Shard outcomes | Aggregate | Adjudicated result |
+| --- | --- | --- | --- |
+| PR #944 | timeout at 351s / timeout at 354s | Incomplete | Clean control |
+| PR #948 | timeout at 353s / timeout at 352s | Incomplete | One `MEDIUM` |
+| PR #953 | timeout at 355s / timeout at 355s | Incomplete | One `HIGH`, one `MEDIUM` |
+| PR #954 | timeout at 354s / completed at 105s | Incomplete | Two `MEDIUM` findings |
+| PR #956 | timeout at 351s / completed at 45s | Incomplete | Clean control |
+| PR #961 | completed at 82s / inactive | Completed | One `HIGH`, one `MEDIUM` |
+
+Three active shards completed and eight produced verified budget-timeout
+artifacts. All trusted preparation and finalizer jobs succeeded. Each incomplete
+aggregate uploaded fail-closed `HIGH` evidence and then failed its completion
+gate. No timeout was reclassified as an automation failure.
+
+PR #961's completed aggregate recalled the adjudicated `HIGH` about the shared
+824-day certificate lifetime. It missed the adjudicated `MEDIUM` that existing
+deployments do not receive the compatibility fix. The candidate therefore
+failed both the mandatory initial 6/6 completion gate and the only recall check
+available from a completed aggregate. Per the accepted sequence, repeats cannot
+erase the completion failure, and PRs #957 and #964 were not run.
 
 ## Human adjudication
 
@@ -145,10 +183,13 @@ matrix and showed that its completion gain comes with unacceptable recall.
 
 ## Follow-up
 
-1. Keep production tuning unchanged while retaining the bounded timeout and
-   fail-closed human-review path.
-2. Complete the original plan's first-30-production-run observation window.
-3. Review the sharded-review TDD before implementing another secret-backed
-   benchmark candidate.
-4. Require a sharded candidate to pass the same adjudicated recall gates before
-   replaying PRs #957 and #964 from the large-PR corpus.
+1. Keep production on `gpt-5.6-sol`, `unified=40`, `xhigh`, and the baseline
+   prompt while retaining the bounded timeout and fail-closed human-review path.
+2. Do not repeat the rejected sharded candidate or replay PRs #957 and #964.
+3. Add trusted benchmark-only support for `gpt-5.6-terra` with `high` reasoning,
+   default service tier, and low verbosity.
+4. After that support lands on `main`, run Terra independently across the fixed
+   adjudicated corpus. Require 6/6 completion, every adjudicated `HIGH`, at
+   least 90% of the five adjudicated `MEDIUM` findings, and no invalid new
+   `MEDIUM` or `HIGH` before any large-PR or production evaluation.
+5. Complete the original plan's first-30-production-run observation window.

--- a/docs/plans/2026-08-25-bounded-codex-security-review-plan.md
+++ b/docs/plans/2026-08-25-bounded-codex-security-review-plan.md
@@ -297,7 +297,7 @@ The large-PR corpus is deferred because step 5 requires a selected candidate.
 Full evidence and human adjudication are in the
 [benchmark report](../codex-security-review-benchmark-report.md). Further
 runtime work moves to the separate
-[sharded-review TDD](./2026-08-27-sharded-codex-security-review-tdd.md).
+[sharded-review TDD](./archive/2026-08-27-sharded-codex-security-review-tdd.md).
 
 ## Risks and mitigations
 

--- a/docs/plans/archive/2026-08-27-sharded-codex-security-review-tdd.md
+++ b/docs/plans/archive/2026-08-27-sharded-codex-security-review-tdd.md
@@ -1,7 +1,7 @@
 ---
 title: "Sharded Codex security review"
 date: 2026-08-27
-status: accepted
+status: completed
 type: tdd
 tracker: https://github.com/block/proto-fleet/pull/980
 ---
@@ -10,7 +10,7 @@ tracker: https://github.com/block/proto-fleet/pull/980
 
 ## Context
 
-The [bounded-review benchmark](../codex-security-review-benchmark-report.md)
+The [bounded-review benchmark](../../codex-security-review-benchmark-report.md)
 showed that diff context, reasoning effort, and prompt guidance do not make the
 current single-agent review complete reliably. Only 22 of 72 adjudicated matrix
 cases completed; the other 50 exhausted the 12-minute outer budget. Compact
@@ -25,6 +25,22 @@ unchanged files it chooses. Large cross-component changes can therefore consume
 the entire budget before producing output. The next experiment should bound the
 amount of changed code assigned to each model invocation without hiding shared
 contracts or relying on a second unbounded model pass.
+
+## Outcome
+
+The benchmark-only implementation landed in PR #980 and ran from trusted `main`
+at `bfbc12bb61dd6372ddd25c05107a1fb41c94dfec`. The initial adjudicated run
+[33534337325](https://github.com/block/proto-fleet/actions/runs/33534337325)
+produced one completed aggregate across six cases. Eight of 11 active shards
+exhausted their six-minute model budget; trusted finalizers classified every
+cancellation as a verified timeout, and all five incomplete aggregates failed
+closed.
+
+The only completed case, PR #961, recalled its adjudicated `HIGH` certificate
+expiry finding but missed its adjudicated `MEDIUM` upgrade-compatibility
+finding. The candidate therefore failed the required initial 6/6 completion
+gate before corpus-wide recall evaluation. Repeats and the large-PR corpus were
+not run, and sharding did not advance to production.
 
 ## Goals
 


### PR DESCRIPTION
Reviewable diff: +71/-14 across 3 files (excludes generated, test, and story files).

## Summary

Records the live architecture-aware sharding benchmark and closes the completed TDD. The initial candidate produced only one completed aggregate across six adjudicated cases, so sharding remains out of production and the large-PR stage is intentionally skipped.

## How it works

The report binds the evidence to the trusted default-branch commit and Actions run, summarizes each shard and aggregate outcome, and applies the accepted completion gate. The archived TDD records the rejected outcome, while the bounded-review plan now links to the archived design. Follow-up moves to an independent Terra benchmark without changing production Sol settings.

## Diagrams

```mermaid
flowchart LR
  A["Trusted main workflow"] --> B["Six adjudicated cases"]
  B --> C["Two bounded shards per case"]
  C --> D["1 of 6 completed aggregates"]
  D --> E["Reject sharding candidate"]
  E --> F["Keep production Sol/xhigh"]
  E --> G["Evaluate Terra independently"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `docs/codex-security-review-benchmark-report.md` | Added run metadata, per-case outcomes, gate decision, and follow-up | Confirms the evidence supports rejecting sharding |
| `docs/plans/archive/2026-08-27-sharded-codex-security-review-tdd.md` | Archived the completed TDD and recorded its outcome | Preserves the implemented design and why rollout stopped |
| `docs/plans/2026-08-25-bounded-codex-security-review-plan.md` | Updated the cross-reference to the archived TDD | Keeps planning links valid |

## Key technical decisions & trade-offs

- Reject the candidate at the mandatory 6/6 completion gate rather than using repeats to hide initial timeouts.
- Skip PRs #957 and #964 because the adjudicated gate did not pass.
- Retain production `gpt-5.6-sol`, `unified=40`, `xhigh`, and the baseline prompt rather than rolling out partial shard success.
- Evaluate Terra as a separate benchmark candidate rather than mixing model and architecture changes.

## Testing & validation

- Verified all local Markdown links resolve after archiving the TDD.
- Ran `git diff --check`.
- Cross-checked the report against trusted artifacts and job metadata from Actions run 33534337325.
- No application code or production workflow behavior changes.
