### PR TITLE
ci: add trusted Terra review benchmark

### DIFF
--- a/.github/scripts/codex_sharding_test.py
+++ b/.github/scripts/codex_sharding_test.py
@@ -1095,10 +1095,8 @@ class WorkflowInvariantTest(unittest.TestCase):
         self.assertIn(
             "--corpus-file .codex-trusted/.github/codex-benchmark-corpus.json", called
         )
-        self.assertIn(
-            "github.event.action == 'codex-security-review-sharded-benchmark' && 'unified-40' || 'all'",
-            parent,
-        )
+        self.assertIn("codex-security-review-terra-benchmark", parent)
+        self.assertIn("&& 'unified-40' || 'all'", parent)
 
     def test_shard_prompt_comes_from_trusted_checkout(self):
         called = (
@@ -1128,7 +1126,6 @@ class WorkflowInvariantTest(unittest.TestCase):
         )
         for field in (
             "model",
-            "codex-args",
             "output-schema",
             "safety-strategy",
             "sandbox",
@@ -1137,6 +1134,17 @@ class WorkflowInvariantTest(unittest.TestCase):
                 self.assertEqual(
                     sharded_step["with"][field], baseline_step["with"][field]
                 )
+        # The unsharded benchmark now selects Codex arguments through a trusted
+        # profile. The policy tests execute that selector and lock its Sol output to
+        # the sharded baseline while independently locking the Terra candidate.
+        self.assertEqual(
+            baseline_step["with"]["codex-args"],
+            "${{ needs.select-cases.outputs.codex_args }}",
+        )
+        self.assertEqual(
+            sharded_step["with"]["codex-args"],
+            '["-c","model_reasoning_effort=${{ env.CODEX_REASONING_EFFORT }}"]',
+        )
 
     def test_model_job_has_no_checkout_or_corpus_labels(self):
         workflow = workflow_test_helpers.load_workflow(

--- a/.github/scripts/evaluate_review_policy_test.py
+++ b/.github/scripts/evaluate_review_policy_test.py
@@ -592,10 +592,34 @@ class ReviewPolicyTest(unittest.TestCase):
                     "types": [
                         "codex-security-review-benchmark",
                         "codex-security-review-sharded-benchmark",
+                        "codex-security-review-terra-benchmark",
                     ]
                 }
             },
         )
+        selector = find_step(workflow, "select-cases", "select")
+        self.assertEqual(
+            selector["env"]["BENCHMARK_PROFILE"],
+            "${{ github.event.action == 'codex-security-review-terra-benchmark' && 'terra-high-default-low' || 'sol' }}",
+        )
+        self.assertIn(
+            "github.event.action == 'codex-security-review-terra-benchmark' && 'high' || 'xhigh'",
+            selector["env"]["REASONING_EFFORT"],
+        )
+        self.assertIn(
+            "github.event.action == 'codex-security-review-terra-benchmark') && 'unified-40' || 'all'",
+            selector["env"]["CONTEXT_VARIANT"],
+        )
+        self.assertEqual(
+            workflow["jobs"]["sharded-benchmark-case"]["if"],
+            "${{ github.event.action == 'codex-security-review-sharded-benchmark' }}",
+        )
+        unsharded_events = (
+            "github.event.action == 'codex-security-review-benchmark' || "
+            "github.event.action == 'codex-security-review-terra-benchmark'"
+        )
+        self.assertEqual(job["if"], f"${{{{ {unsharded_events} }}}}")
+        self.assertIn(unsharded_events, workflow["jobs"]["benchmark-finalize"]["if"])
         self.assertNotIn("workflow_dispatch:", workflow_text)
         self.assertNotIn("${{ inputs", workflow_text)
         self.assertEqual(
@@ -662,7 +686,11 @@ class ReviewPolicyTest(unittest.TestCase):
             workflow["jobs"]["select-cases"]["outputs"],
             {
                 "matrix": "${{ steps.select.outputs.matrix }}",
+                "model": "${{ steps.select.outputs.model }}",
                 "reasoning_effort": "${{ steps.select.outputs.reasoning_effort }}",
+                "service_tier": "${{ steps.select.outputs.service_tier }}",
+                "verbosity": "${{ steps.select.outputs.verbosity }}",
+                "codex_args": "${{ steps.select.outputs.codex_args }}",
                 "prompt_profile": "${{ steps.select.outputs.prompt_profile }}",
                 "repeat": "${{ steps.select.outputs.repeat }}",
             },
@@ -681,7 +709,14 @@ class ReviewPolicyTest(unittest.TestCase):
             case["id"] for case in corpus["cases"] if case["corpus"] == "large-pr"
         ]
 
-        def select(corpus_name, variant_name, review_mode="unsharded"):
+        def select(
+            corpus_name,
+            variant_name,
+            review_mode="unsharded",
+            benchmark_profile="sol",
+            reasoning_effort="xhigh",
+            prompt_profile="baseline",
+        ):
             with tempfile.TemporaryDirectory() as tmp:
                 target = Path(tmp) / ".github" / BENCHMARK_CORPUS_PATH.name
                 target.parent.mkdir()
@@ -692,10 +727,11 @@ class ReviewPolicyTest(unittest.TestCase):
                     body,
                     {
                         "REVIEW_MODE": review_mode,
+                        "BENCHMARK_PROFILE": benchmark_profile,
                         "CORPUS": corpus_name,
                         "CONTEXT_VARIANT": variant_name,
-                        "REASONING_EFFORT": "xhigh",
-                        "PROMPT_PROFILE": "baseline",
+                        "REASONING_EFFORT": reasoning_effort,
+                        "PROMPT_PROFILE": prompt_profile,
                         "REPEAT": "initial",
                         "GITHUB_OUTPUT": str(output),
                     },
@@ -707,7 +743,14 @@ class ReviewPolicyTest(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         outputs = dict(line.split("=", 1) for line in emitted.splitlines())
         include = json.loads(outputs["matrix"])["include"]
+        self.assertEqual(outputs["model"], "gpt-5.6-sol")
         self.assertEqual(outputs["reasoning_effort"], "xhigh")
+        self.assertEqual(outputs["service_tier"], "unspecified")
+        self.assertEqual(outputs["verbosity"], "unspecified")
+        self.assertEqual(
+            json.loads(outputs["codex_args"]),
+            ["-c", "model_reasoning_effort=xhigh"],
+        )
         self.assertEqual(outputs["prompt_profile"], "baseline")
         self.assertEqual(outputs["repeat"], "initial")
         self.assertEqual(len(include), len(adjudicated) * len(corpus["variants"]))
@@ -743,6 +786,50 @@ class ReviewPolicyTest(unittest.TestCase):
         self.assertIn("compact", result.stderr)
         self.assertEqual(emitted, "")
 
+        result, emitted = select(
+            "adjudicated",
+            "unified-40",
+            benchmark_profile="terra-high-default-low",
+            reasoning_effort="high",
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        outputs = dict(line.split("=", 1) for line in emitted.splitlines())
+        include = json.loads(outputs["matrix"])["include"]
+        self.assertEqual(len(include), len(adjudicated))
+        self.assertEqual({entry["variant"]["id"] for entry in include}, {"unified-40"})
+        self.assertEqual(outputs["model"], "gpt-5.6-terra")
+        self.assertEqual(outputs["reasoning_effort"], "high")
+        self.assertEqual(outputs["service_tier"], "default")
+        self.assertEqual(outputs["verbosity"], "low")
+        self.assertEqual(
+            json.loads(outputs["codex_args"]),
+            [
+                "-c",
+                "model_reasoning_effort=high",
+                "-c",
+                "service_tier=default",
+                "-c",
+                "model_verbosity=low",
+            ],
+        )
+
+        for variant, effort, prompt, rejected in (
+            ("unified-40", "xhigh", "baseline", "xhigh"),
+            ("compact", "high", "baseline", "compact"),
+            ("unified-40", "high", "bounded", "bounded"),
+        ):
+            with self.subTest(rejected=rejected):
+                result, emitted = select(
+                    "adjudicated",
+                    variant,
+                    benchmark_profile="terra-high-default-low",
+                    reasoning_effort=effort,
+                    prompt_profile=prompt,
+                )
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(rejected, result.stderr)
+                self.assertEqual(emitted, "")
+
     def test_codex_review_workflows_share_bounded_review_configuration(self):
         production = load_workflow("codex-security-review.yml")
         benchmark = load_workflow("codex-security-review-benchmark.yml")
@@ -772,15 +859,19 @@ class ReviewPolicyTest(unittest.TestCase):
             production_poster["env"]["CODEX_MODEL"],
             production_job["env"]["CODEX_MODEL"],
         )
-        self.assertEqual(benchmark_job["env"]["CODEX_MODEL"], "gpt-5.6-sol")
         self.assertEqual(
-            benchmark_finalizer["env"]["CODEX_MODEL"],
-            benchmark_job["env"]["CODEX_MODEL"],
+            benchmark_codex["with"]["codex-args"],
+            "${{ needs.select-cases.outputs.codex_args }}",
         )
-        self.assertEqual(
-            benchmark_finalizer["env"]["CODEX_REASONING_EFFORT"],
-            benchmark_job["env"]["CODEX_REASONING_EFFORT"],
-        )
+        for name, output in (
+            ("CODEX_MODEL", "model"),
+            ("CODEX_REASONING_EFFORT", "reasoning_effort"),
+            ("CODEX_SERVICE_TIER", "service_tier"),
+            ("CODEX_VERBOSITY", "verbosity"),
+        ):
+            expected = f"${{{{ needs.select-cases.outputs.{output} }}}}"
+            self.assertEqual(benchmark_job["env"][name], expected)
+            self.assertEqual(benchmark_finalizer["env"][name], expected)
 
         production_writer = extract_python_heredoc(
             find_step(production, "security-review", "write_review_result")["run"]
@@ -907,11 +998,13 @@ class ReviewPolicyTest(unittest.TestCase):
                             "INTER_HUNK": "0",
                             "REPEAT": "initial",
                             "PROMPT_PROFILE": "baseline",
+                            "SERVICE_TIER": "default",
+                            "VERBOSITY": "low",
                             "REVIEW_BASE_SHA": "a" * 40,
                             "REVIEW_HEAD_SHA": "b" * 40,
                             "REVIEW_COMMIT_RANGE": f"{'a' * 40}...{'b' * 40}",
-                            "CODEX_MODEL": "gpt-5.6-sol",
-                            "CODEX_REASONING_EFFORT": "xhigh",
+                            "CODEX_MODEL": "gpt-5.6-terra",
+                            "CODEX_REASONING_EFFORT": "high",
                         },
                         tmp,
                     )
@@ -933,6 +1026,10 @@ class ReviewPolicyTest(unittest.TestCase):
                     "completed" if expected_reason is None else "incomplete",
                 )
                 self.assertEqual(scope["completed"], expected_reason is None)
+                self.assertEqual(scope["model"], "gpt-5.6-terra")
+                self.assertEqual(scope["reasoning_effort"], "high")
+                self.assertEqual(scope["service_tier"], "default")
+                self.assertEqual(scope["verbosity"], "low")
 
         self.assertEqual(
             {reason for reason, _, _, _ in cases if reason},
@@ -1064,8 +1161,8 @@ class ReviewPolicyTest(unittest.TestCase):
                 body,
                 {
                     "CODEX_TIMEOUT_MINUTES": "12",
-                    "CODEX_MODEL": "gpt-5.6-sol",
-                    "CODEX_REASONING_EFFORT": "xhigh",
+                    "CODEX_MODEL": "gpt-5.6-terra",
+                    "CODEX_REASONING_EFFORT": "high",
                     "REVIEW_BASE_SHA": "a" * 40,
                     "REVIEW_HEAD_SHA": "b" * 40,
                     "REVIEW_COMMIT_RANGE": f"{'a' * 40}...{'b' * 40}",
@@ -1080,6 +1177,8 @@ class ReviewPolicyTest(unittest.TestCase):
                     "INTER_HUNK": "0",
                     "REPEAT": "initial",
                     "PROMPT_PROFILE": "baseline",
+                    "SERVICE_TIER": "default",
+                    "VERBOSITY": "low",
                 },
                 tmp,
             )
@@ -1097,6 +1196,10 @@ class ReviewPolicyTest(unittest.TestCase):
         self.assertEqual(scope["incomplete_reason"], "codex-job-timeout")
         self.assertIsNone(scope["elapsed_seconds"])
         self.assertEqual(scope["timeout_budget_seconds"], 720)
+        self.assertEqual(scope["model"], "gpt-5.6-terra")
+        self.assertEqual(scope["reasoning_effort"], "high")
+        self.assertEqual(scope["service_tier"], "default")
+        self.assertEqual(scope["verbosity"], "low")
         self.assertEqual(elapsed_text, "unknown\n")
 
     def test_codex_benchmark_serializes_repeat_dispatches(self):

--- a/.github/scripts/evaluate_review_policy_test.py
+++ b/.github/scripts/evaluate_review_policy_test.py
@@ -1219,6 +1219,24 @@ class ReviewPolicyTest(unittest.TestCase):
             "repeat",
         ):
             self.assertIn(name, group)
+        # Concurrency is evaluated before the trusted selector. Canonicalize every
+        # caller-controlled value so malformed dispatches cannot create arbitrary
+        # groups and fan out runner or model work.
+        self.assertNotIn("client_payload.corpus ||", group)
+        self.assertNotIn("client_payload['context-variant'] ||", group)
+        self.assertNotIn("client_payload['reasoning-effort'] ||", group)
+        self.assertNotIn("client_payload['prompt-profile'] ||", group)
+        self.assertNotIn("client_payload.repeat ||", group)
+        self.assertIn("client_payload.corpus == 'large-pr'", group)
+        self.assertIn("client_payload.repeat == 'repeat-2'", group)
+        self.assertIn(
+            "github.event.action == 'codex-security-review-terra-benchmark' && 'high'",
+            group,
+        )
+        self.assertIn(
+            "github.event.action == 'codex-security-review-sharded-benchmark' && 'xhigh'",
+            group,
+        )
 
     def test_incomplete_codex_review_cannot_take_approval_free_path(self):
         workflow = load_workflow("codex-security-review.yml")

--- a/.github/workflows/codex-security-review-benchmark.yml
+++ b/.github/workflows/codex-security-review-benchmark.yml
@@ -21,17 +21,23 @@ concurrency:
     codex-security-review-benchmark-${{
       github.event.action
     }}-${{
-      github.event.client_payload.corpus || 'adjudicated'
+      github.event.client_payload.corpus == 'large-pr' && 'large-pr' || 'adjudicated'
     }}-${{
-      github.event.client_payload['context-variant'] ||
-      ((github.event.action == 'codex-security-review-sharded-benchmark' || github.event.action == 'codex-security-review-terra-benchmark') && 'unified-40' || 'all')
+      (github.event.action == 'codex-security-review-sharded-benchmark' || github.event.action == 'codex-security-review-terra-benchmark') && 'unified-40' ||
+      github.event.client_payload['context-variant'] == 'unified-40' && 'unified-40' ||
+      github.event.client_payload['context-variant'] == 'unified-10' && 'unified-10' ||
+      github.event.client_payload['context-variant'] == 'compact' && 'compact' || 'all'
     }}-${{
-      github.event.client_payload['reasoning-effort'] ||
-      (github.event.action == 'codex-security-review-terra-benchmark' && 'high' || 'xhigh')
+      github.event.action == 'codex-security-review-terra-benchmark' && 'high' ||
+      github.event.action == 'codex-security-review-sharded-benchmark' && 'xhigh' ||
+      github.event.client_payload['reasoning-effort'] == 'high' && 'high' ||
+      github.event.client_payload['reasoning-effort'] == 'medium' && 'medium' || 'xhigh'
     }}-${{
-      github.event.client_payload['prompt-profile'] || 'baseline'
+      (github.event.action == 'codex-security-review-sharded-benchmark' || github.event.action == 'codex-security-review-terra-benchmark') && 'baseline' ||
+      github.event.client_payload['prompt-profile'] == 'bounded' && 'bounded' || 'baseline'
     }}-${{
-      github.event.client_payload.repeat || 'initial'
+      github.event.client_payload.repeat == 'repeat-1' && 'repeat-1' ||
+      github.event.client_payload.repeat == 'repeat-2' && 'repeat-2' || 'initial'
     }}
   cancel-in-progress: false
 

--- a/.github/workflows/codex-security-review-benchmark.yml
+++ b/.github/workflows/codex-security-review-benchmark.yml
@@ -8,6 +8,7 @@ on:
     types:
       - codex-security-review-benchmark
       - codex-security-review-sharded-benchmark
+      - codex-security-review-terra-benchmark
 
 permissions:
   actions: read
@@ -23,9 +24,10 @@ concurrency:
       github.event.client_payload.corpus || 'adjudicated'
     }}-${{
       github.event.client_payload['context-variant'] ||
-      (github.event.action == 'codex-security-review-sharded-benchmark' && 'unified-40' || 'all')
+      ((github.event.action == 'codex-security-review-sharded-benchmark' || github.event.action == 'codex-security-review-terra-benchmark') && 'unified-40' || 'all')
     }}-${{
-      github.event.client_payload['reasoning-effort'] || 'xhigh'
+      github.event.client_payload['reasoning-effort'] ||
+      (github.event.action == 'codex-security-review-terra-benchmark' && 'high' || 'xhigh')
     }}-${{
       github.event.client_payload['prompt-profile'] || 'baseline'
     }}-${{
@@ -40,7 +42,11 @@ jobs:
     timeout-minutes: 5
     outputs:
       matrix: ${{ steps.select.outputs.matrix }}
+      model: ${{ steps.select.outputs.model }}
       reasoning_effort: ${{ steps.select.outputs.reasoning_effort }}
+      service_tier: ${{ steps.select.outputs.service_tier }}
+      verbosity: ${{ steps.select.outputs.verbosity }}
+      codex_args: ${{ steps.select.outputs.codex_args }}
       prompt_profile: ${{ steps.select.outputs.prompt_profile }}
       repeat: ${{ steps.select.outputs.repeat }}
     steps:
@@ -56,9 +62,10 @@ jobs:
         id: select
         env:
           REVIEW_MODE: ${{ github.event.action == 'codex-security-review-sharded-benchmark' && 'sharded' || 'unsharded' }}
+          BENCHMARK_PROFILE: ${{ github.event.action == 'codex-security-review-terra-benchmark' && 'terra-high-default-low' || 'sol' }}
           CORPUS: ${{ github.event.client_payload.corpus || 'adjudicated' }}
-          CONTEXT_VARIANT: ${{ github.event.client_payload['context-variant'] || (github.event.action == 'codex-security-review-sharded-benchmark' && 'unified-40' || 'all') }}
-          REASONING_EFFORT: ${{ github.event.client_payload['reasoning-effort'] || 'xhigh' }}
+          CONTEXT_VARIANT: ${{ github.event.client_payload['context-variant'] || ((github.event.action == 'codex-security-review-sharded-benchmark' || github.event.action == 'codex-security-review-terra-benchmark') && 'unified-40' || 'all') }}
+          REASONING_EFFORT: ${{ github.event.client_payload['reasoning-effort'] || (github.event.action == 'codex-security-review-terra-benchmark' && 'high' || 'xhigh') }}
           PROMPT_PROFILE: ${{ github.event.client_payload['prompt-profile'] || 'baseline' }}
           REPEAT: ${{ github.event.client_payload.repeat || 'initial' }}
         run: |
@@ -68,6 +75,7 @@ jobs:
           from pathlib import Path
 
           review_mode = os.environ["REVIEW_MODE"]
+          benchmark_profile = os.environ["BENCHMARK_PROFILE"]
           corpus_name = os.environ["CORPUS"]
           variant_name = os.environ["CONTEXT_VARIANT"]
           reasoning_effort = os.environ["REASONING_EFFORT"]
@@ -81,7 +89,21 @@ jobs:
                   "prompt-profile": ({"baseline"}, prompt_profile),
                   "repeat": ({"initial", "repeat-1", "repeat-2"}, repeat),
               }
-          else:
+              model = "gpt-5.6-sol"
+              service_tier = "unspecified"
+              verbosity = "unspecified"
+          elif benchmark_profile == "terra-high-default-low":
+              allowed = {
+                  "corpus": ({"adjudicated", "large-pr"}, corpus_name),
+                  "context-variant": ({"unified-40"}, variant_name),
+                  "reasoning-effort": ({"high"}, reasoning_effort),
+                  "prompt-profile": ({"baseline"}, prompt_profile),
+                  "repeat": ({"initial", "repeat-1", "repeat-2"}, repeat),
+              }
+              model = "gpt-5.6-terra"
+              service_tier = "default"
+              verbosity = "low"
+          elif benchmark_profile == "sol":
               allowed = {
                   "corpus": ({"adjudicated", "large-pr"}, corpus_name),
                   "context-variant": ({"all", "unified-40", "unified-10", "compact"}, variant_name),
@@ -89,6 +111,11 @@ jobs:
                   "prompt-profile": ({"baseline", "bounded"}, prompt_profile),
                   "repeat": ({"initial", "repeat-1", "repeat-2"}, repeat),
               }
+              model = "gpt-5.6-sol"
+              service_tier = "unspecified"
+              verbosity = "unspecified"
+          else:
+              raise SystemExit(f"Invalid trusted benchmark profile {benchmark_profile!r}")
           for name, (choices, value) in allowed.items():
               if value not in choices:
                   raise SystemExit(f"Invalid benchmark {name} {value!r}; expected one of {sorted(choices)}")
@@ -114,9 +141,18 @@ jobs:
                   for variant in variants
               ]
           }
+          codex_args = ["-c", f"model_reasoning_effort={reasoning_effort}"]
+          if service_tier != "unspecified":
+              codex_args.extend(["-c", f"service_tier={service_tier}"])
+          if verbosity != "unspecified":
+              codex_args.extend(["-c", f"model_verbosity={verbosity}"])
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as handle:
               handle.write(f"matrix={json.dumps(matrix, separators=(',', ':'))}\n")
+              handle.write(f"model={model}\n")
               handle.write(f"reasoning_effort={reasoning_effort}\n")
+              handle.write(f"service_tier={service_tier}\n")
+              handle.write(f"verbosity={verbosity}\n")
+              handle.write(f"codex_args={json.dumps(codex_args, separators=(',', ':'))}\n")
               handle.write(f"prompt_profile={prompt_profile}\n")
               handle.write(f"repeat={repeat}\n")
           for entry in matrix["include"]:
@@ -145,7 +181,7 @@ jobs:
   benchmark-review:
     name: ${{ matrix.case.id }} / ${{ matrix.variant.id }} / ${{ needs.select-cases.outputs.repeat }}
     needs: select-cases
-    if: ${{ github.event.action == 'codex-security-review-benchmark' }}
+    if: ${{ github.event.action == 'codex-security-review-benchmark' || github.event.action == 'codex-security-review-terra-benchmark' }}
     runs-on: ubuntu-latest
     # The composite action ignored its caller step timeout in production, so the
     # matrix job itself is the enforceable model budget. A separate matrix finalizer
@@ -157,9 +193,11 @@ jobs:
       matrix: ${{ fromJSON(needs.select-cases.outputs.matrix) }}
     env:
       OPENAI_API_KEY_PRESENT: ${{ secrets.OPENAI_API_KEY != '' }}
-      CODEX_MODEL: gpt-5.6-sol
+      CODEX_MODEL: ${{ needs.select-cases.outputs.model }}
       CODEX_TIMEOUT_MINUTES: "12"
       CODEX_REASONING_EFFORT: ${{ needs.select-cases.outputs.reasoning_effort }}
+      CODEX_SERVICE_TIER: ${{ needs.select-cases.outputs.service_tier }}
+      CODEX_VERBOSITY: ${{ needs.select-cases.outputs.verbosity }}
       REVIEW_BASE_SHA: ${{ matrix.case.base }}
       REVIEW_HEAD_SHA: ${{ matrix.case.head }}
       REVIEW_COMMIT_RANGE: ${{ format('{0}...{1}', matrix.case.base, matrix.case.head) }}
@@ -228,7 +266,7 @@ jobs:
         with:
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           model: ${{ env.CODEX_MODEL }}
-          codex-args: '["-c","model_reasoning_effort=${{ env.CODEX_REASONING_EFFORT }}"]'
+          codex-args: ${{ needs.select-cases.outputs.codex_args }}
           output-schema: |
             {
               "type": "object",
@@ -373,6 +411,8 @@ jobs:
           INTER_HUNK: ${{ matrix.variant['inter-hunk'] }}
           REPEAT: ${{ needs.select-cases.outputs.repeat }}
           PROMPT_PROFILE: ${{ needs.select-cases.outputs.prompt_profile }}
+          SERVICE_TIER: ${{ needs.select-cases.outputs.service_tier }}
+          VERBOSITY: ${{ needs.select-cases.outputs.verbosity }}
         run: |
           python3 - <<'PY'
           import json
@@ -504,6 +544,8 @@ jobs:
               "repeat": os.environ["REPEAT"],
               "model": os.environ["CODEX_MODEL"],
               "reasoning_effort": os.environ["CODEX_REASONING_EFFORT"],
+              "service_tier": os.environ["SERVICE_TIER"],
+              "verbosity": os.environ["VERBOSITY"],
               "prompt_profile": os.environ["PROMPT_PROFILE"],
               "diff": {
                   "unified": int(os.environ["UNIFIED"]),
@@ -547,7 +589,7 @@ jobs:
   benchmark-finalize:
     name: Finalize ${{ matrix.case.id }} / ${{ matrix.variant.id }} / ${{ needs.select-cases.outputs.repeat }}
     needs: [select-cases, benchmark-review]
-    if: ${{ always() && github.event.action == 'codex-security-review-benchmark' && needs.select-cases.result == 'success' }}
+    if: ${{ always() && (github.event.action == 'codex-security-review-benchmark' || github.event.action == 'codex-security-review-terra-benchmark') && needs.select-cases.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:
@@ -560,8 +602,10 @@ jobs:
       AGENT_JOB_NAME: ${{ format('{0} / {1} / {2}', matrix.case.id, matrix.variant.id, needs.select-cases.outputs.repeat) }}
       RESULT_ARTIFACT_NAME: benchmark-result-${{ matrix.case.id }}-${{ matrix.variant.id }}-${{ needs.select-cases.outputs.repeat }}-${{ github.run_id }}-${{ github.run_attempt }}
       TIMEOUT_ARTIFACT_NAME: benchmark-timeout-${{ matrix.case.id }}-${{ matrix.variant.id }}-${{ needs.select-cases.outputs.repeat }}-${{ github.run_id }}-${{ github.run_attempt }}
-      CODEX_MODEL: gpt-5.6-sol
+      CODEX_MODEL: ${{ needs.select-cases.outputs.model }}
       CODEX_REASONING_EFFORT: ${{ needs.select-cases.outputs.reasoning_effort }}
+      CODEX_SERVICE_TIER: ${{ needs.select-cases.outputs.service_tier }}
+      CODEX_VERBOSITY: ${{ needs.select-cases.outputs.verbosity }}
       CODEX_TIMEOUT_MINUTES: "12"
       CODEX_CANCELLATION_CLEANUP_SECONDS: "300"
       REVIEW_BASE_SHA: ${{ matrix.case.base }}
@@ -685,6 +729,8 @@ jobs:
           INTER_HUNK: ${{ matrix.variant['inter-hunk'] }}
           REPEAT: ${{ needs.select-cases.outputs.repeat }}
           PROMPT_PROFILE: ${{ needs.select-cases.outputs.prompt_profile }}
+          SERVICE_TIER: ${{ needs.select-cases.outputs.service_tier }}
+          VERBOSITY: ${{ needs.select-cases.outputs.verbosity }}
         run: |
           python3 - <<'PY'
           import json
@@ -717,6 +763,8 @@ jobs:
               "repeat": os.environ["REPEAT"],
               "model": os.environ["CODEX_MODEL"],
               "reasoning_effort": os.environ["CODEX_REASONING_EFFORT"],
+              "service_tier": os.environ["SERVICE_TIER"],
+              "verbosity": os.environ["VERBOSITY"],
               "prompt_profile": os.environ["PROMPT_PROFILE"],
               "diff": {
                   "unified": int(os.environ["UNIFIED"]),

--- a/docs/plans/2026-09-01-terra-codex-security-review-benchmark-plan.md
+++ b/docs/plans/2026-09-01-terra-codex-security-review-benchmark-plan.md
@@ -59,7 +59,9 @@ to the existing trusted benchmark workflow. The event maps to one fixed profile:
 
 The event type, not caller-controlled profile data, selects the model and Codex
 arguments. The trusted selector rejects a Terra dispatch that requests another
-context, effort, or prompt. Existing Sol and sharded event behavior remains
+context, effort, or prompt. Concurrency keys canonicalize every payload value to
+an allowed option before selection, so malformed dispatches cannot create
+arbitrary parallel groups. Existing Sol and sharded event behavior remains
 unchanged.
 
 Both normal and timeout scope artifacts record model, reasoning effort, service

--- a/docs/plans/2026-09-01-terra-codex-security-review-benchmark-plan.md
+++ b/docs/plans/2026-09-01-terra-codex-security-review-benchmark-plan.md
@@ -1,0 +1,110 @@
+---
+title: "Terra Codex security review benchmark"
+date: 2026-09-01
+status: implementing
+type: plan
+---
+
+# Terra Codex security review benchmark
+
+## Context
+
+The bounded Sol benchmark completed 22 of 72 matrix cases, and the initial
+architecture-aware sharding candidate completed only one of six aggregates.
+Neither runtime approach passed its completion and recall gates. Production
+therefore remains on `gpt-5.6-sol`, `unified=40`, `xhigh`, and the baseline
+prompt.
+
+OpenAI's current model documentation describes `gpt-5.6-terra` as balancing
+quality, latency, and cost. The current Codex configuration schema supports
+`model_reasoning_effort`, `service_tier`, and `model_verbosity`; the pinned
+Codex action accepts these as trusted `codex-args` overrides. This experiment
+tests Terra independently so a model change is not mixed with sharding or
+prompt changes.
+
+## Goals
+
+- Measure Terra completion and finding recall against the fixed adjudicated
+  corpus.
+- Hold diff context, prompt, output schema, sandbox, timeout, and trusted
+  finalization constant with the retained Sol control.
+- Bind Terra to `high` reasoning, explicit `default` service tier, and `low`
+  verbosity through trusted default-branch code.
+- Preserve uniquely named completed-result and verified-timeout artifacts for
+  manual adjudication.
+
+## Non-goals
+
+- Changing the production review model or settings.
+- Repeating the rejected sharding candidate.
+- Allowing repository-dispatch payloads to choose arbitrary models, service
+  tiers, or verbosity values.
+- Running the large-PR corpus before the adjudicated gate passes.
+
+## Design
+
+Add the typed `codex-security-review-terra-benchmark` repository-dispatch event
+to the existing trusted benchmark workflow. The event maps to one fixed profile:
+
+| Setting | Value |
+| --- | --- |
+| Model | `gpt-5.6-terra` |
+| Context | `unified=40` |
+| Reasoning effort | `high` |
+| Service tier | `default` |
+| Verbosity | `low` |
+| Prompt | Baseline |
+| Outer model budget | 12 minutes |
+
+The event type, not caller-controlled profile data, selects the model and Codex
+arguments. The trusted selector rejects a Terra dispatch that requests another
+context, effort, or prompt. Existing Sol and sharded event behavior remains
+unchanged.
+
+Both normal and timeout scope artifacts record model, reasoning effort, service
+tier, and verbosity. The model action pin, output schema, safety strategy,
+read-only sandbox, exact three-dot diff, cancellation classifier, and finalizer
+remain shared with the existing unsharded benchmark.
+
+## Acceptance gates
+
+1. The initial adjudicated run must complete all six cases. Any verified timeout
+   or automation failure rejects the candidate before recall evaluation.
+2. Human adjudication must recall both known `HIGH` findings without downgrade
+   and at least 90% of the five known `MEDIUM` findings. With five findings, the
+   threshold requires 5/5.
+3. Every new `MEDIUM`, `HIGH`, or `CRITICAL` finding must be valid. Completed
+   clean controls must not report an invalid material finding.
+4. Repeat only disagreements, misses, or cases within 10% of the model budget.
+   Repeats cannot erase an initial completion failure.
+5. Run PRs #957 and #964 only if the adjudicated gates pass. Both must complete
+   credibly before production evaluation.
+6. Any production change requires a separate reviewed rollout with the current
+   Sol configuration retained as rollback.
+
+## Test plan
+
+- Execute the trusted selector and assert the exact Terra model and Codex
+  argument array.
+- Assert Terra rejects non-`unified-40` context, non-`high` effort, and a
+  non-baseline prompt.
+- Assert the typed event routes to the unsharded bounded reviewer and finalizer,
+  never the sharded workflow.
+- Keep production and benchmark output schema, safety strategy, sandbox, exact
+  diff generation, and timeout classification tests passing.
+- Assert completed and timeout artifacts record service tier and verbosity.
+- Run Ruff, the review-policy and sharding suites, Actionlint, and
+  `git diff --check`.
+- After this workflow lands on `main`, dispatch the initial adjudicated Terra
+  run and adjudicate its artifacts manually.
+
+## Verified upstream behavior
+
+Verified on 2026-09-01 against OpenAI's live model documentation, the current
+`openai/codex` configuration schema, and the pinned `openai/codex-action`
+README:
+
+- [`gpt-5.6-terra` model](https://developers.openai.com/api/docs/models/gpt-5.6-terra)
+- [Latest model guide](https://developers.openai.com/api/docs/guides/latest-model)
+- [Codex configuration schema](https://github.com/openai/codex/blob/main/codex-rs/core/config.schema.json)
+- [Codex action arguments](https://github.com/openai/codex-action/blob/86365089eb2b84e0a8fb0717b304f8bdcb13b20e/README.md)

--- a/docs/plans/2026-09-01-terra-codex-security-review-benchmark-plan.md
+++ b/docs/plans/2026-09-01-terra-codex-security-review-benchmark-plan.md
@@ -3,6 +3,7 @@ title: "Terra Codex security review benchmark"
 date: 2026-09-01
 status: implementing
 type: plan
+tracker: https://github.com/block/proto-fleet/pull/987
 ---
 
 # Terra Codex security review benchmark


### PR DESCRIPTION
Reviewable diff: +181/-14 across 2 files (excludes generated, test, and story files).

## Summary

Adds a trusted benchmark-only path for evaluating `gpt-5.6-terra` with high reasoning, default service tier, and low verbosity. The fixed profile replays the existing adjudicated corpus without changing the production Sol reviewer, sharding behavior, prompt, sandbox, output contract, or timeout policy.

## How it works

A caller sends the typed `codex-security-review-terra-benchmark` repository dispatch. Because repository dispatch loads workflow code from `main`, the trusted selector—not caller payload—chooses Terra and its fixed model arguments, then runs the existing exact-range unsharded benchmark matrix. Completed and verified-timeout artifacts record every model setting so manual adjudication can bind results to the candidate. Invalid context, effort, or prompt combinations stop before model execution.

## Diagrams

```mermaid
flowchart LR
  A["Typed Terra dispatch"] --> B["Trusted main selector"]
  B --> C["Fixed Terra/high/default/low profile"]
  C --> D["Six exact-range benchmark cases"]
  D --> E["Trusted result or timeout finalizer"]
  E --> F["Manual completion and recall gate"]
  F -->|"Pass"| G["Separate rollout evaluation"]
  F -->|"Reject"| H["Keep production Sol/xhigh"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `.github/workflows/codex-security-review-benchmark.yml` | Added the typed Terra profile, trusted selection, Codex arguments, routing, and artifact metadata | Verify untrusted payloads cannot choose model settings and production behavior is unchanged |
| `.github/scripts/evaluate_review_policy_test.py` | Added selector, routing, rejection, parity, and metadata coverage | Test file—verify the executable assertions cover load-bearing workflow fields |
| `.github/scripts/codex_sharding_test.py` | Preserved sharded Sol contract assertions after trusted profile selection | Test file—verify Terra does not weaken sharding invariants |
| `docs/plans/2026-09-01-terra-codex-security-review-benchmark-plan.md` | Defined scope, upstream verification, acceptance gates, and run order | Verify the benchmark decision criteria are explicit before secret-backed execution |

## Key technical decisions & trade-offs

- Use a dedicated typed event rather than a caller-controlled model profile; this is less flexible but keeps model, service tier, and verbosity trusted.
- Keep the existing 12-minute unsharded outer budget rather than combining Terra with the rejected sharding architecture.
- Pass `service_tier=default` and `model_verbosity=low` explicitly so artifacts represent one reproducible candidate.
- Preserve historical Sol dispatch behavior by emitting its original reasoning-only Codex argument array.
- Require 6/6 initial completion and effectively 5/5 known `MEDIUM` recall before large-PR evaluation.

## Testing & validation

- 72 review-policy tests pass.
- 52 sharding tests pass.
- Ruff formatting and checks pass.
- Actionlint passes for the benchmark and PR-gate workflows.
- `git diff --check` passes.
- Verified the model and configuration keys against live OpenAI model docs, the current Codex configuration schema, and the pinned Codex action README.
- No secret-backed Terra run is possible from this branch; the workflow must land on `main` first.
