### PR TITLE
docs: record Terra Codex benchmark results

### DIFF
--- a/docs/codex-security-review-benchmark-report.md
+++ b/docs/codex-security-review-benchmark-report.md
@@ -23,10 +23,12 @@ against the large-PR corpus. The completed
 [sharded-review TDD](./plans/archive/2026-08-27-sharded-codex-security-review-tdd.md)
 records the design and outcome.
 
-The next independent candidate is `gpt-5.6-terra` with `high` reasoning,
-default service tier, and low verbosity. It must run through trusted
-benchmark-only code before any production consideration. Production remains on
-`gpt-5.6-sol`, `unified=40`, `xhigh`, and the baseline prompt.
+The independent `gpt-5.6-terra` candidate also failed. It completed five of six
+cases and recalled both adjudicated `HIGH` findings, but recalled none of the
+five adjudicated `MEDIUM` findings and produced one invalid new `MEDIUM`. The
+completed [Terra benchmark plan](./plans/archive/2026-09-01-terra-codex-security-review-benchmark-plan.md)
+records the fixed profile and outcome. Production remains on `gpt-5.6-sol`,
+`unified=40`, `xhigh`, and the baseline prompt.
 
 ## Method
 
@@ -50,6 +52,7 @@ and verified-timeout rates are reported separately.
 | Effort, `high` | [33046668278](https://github.com/block/proto-fleet/actions/runs/33046668278) | 6 | `unified=40`, baseline prompt |
 | Effort, `medium` | [33092678963](https://github.com/block/proto-fleet/actions/runs/33092678963) | 6 | `unified=40`, baseline prompt |
 | Prompt | [33065249002](https://github.com/block/proto-fleet/actions/runs/33065249002) | 6 | `unified=40`, `xhigh` |
+| Terra | [33551271863](https://github.com/block/proto-fleet/actions/runs/33551271863) | 6 | `unified=40`, `high`, default service tier, low verbosity, baseline prompt |
 
 GitHub reports each run as cancelled because timed-out matrix jobs are cancelled
 at the enforceable outer boundary. That top-level conclusion is expected here;
@@ -85,6 +88,39 @@ failed both the mandatory initial 6/6 completion gate and the only recall check
 available from a completed aggregate. Per the accepted sequence, repeats cannot
 erase the completion failure, and PRs #957 and #964 were not run.
 
+### Terra candidate
+
+The initial Terra run
+[33551271863](https://github.com/block/proto-fleet/actions/runs/33551271863)
+loaded trusted `main` at
+`603ed457a23e9fe6c23ca8792b6aaad2e01722d1`. It used
+`gpt-5.6-terra`, `unified=40`, `high` reasoning, explicit `default` service
+tier, low verbosity, the baseline prompt, and the existing 12-minute outer
+budget.
+
+| Case | Outcome | Risk | Adjudicated result | Recall |
+| --- | --- | --- | --- | --- |
+| PR #944 | Verified timeout | — | Clean control | Not evaluated |
+| PR #948 | Completed at 150s | `NONE` | One `MEDIUM` | Missed |
+| PR #953 | Completed at 160s | `HIGH` | One `HIGH`, one `MEDIUM` | `HIGH` recalled; `MEDIUM` missed |
+| PR #954 | Completed at 174s | `NONE` | Two `MEDIUM` findings | Both missed |
+| PR #956 | Completed at 85s | `NONE` | Clean control | Correct |
+| PR #961 | Completed at 56s | `HIGH` | One `HIGH`, one `MEDIUM` | `HIGH` recalled; `MEDIUM` missed |
+
+The five completed cases had a 150-second median wall time (56–174 seconds) and
+reported a median 102,377 tokens (42,354–192,784). PR #944 reached a verified
+outer-budget timeout; every trusted finalizer succeeded.
+
+Terra recalled 2/2 adjudicated `HIGH` findings and 0/5 adjudicated `MEDIUM`
+findings. Its additional PR #953 `MEDIUM` claimed legacy site-scoped profile
+requests reach the envelope builder with empty scope JSON. That finding is
+invalid: [`validateAndNormalize`](https://github.com/block/proto-fleet/blob/586901c2c4b2ca21057202bac398718204ea6435/server/internal/domain/curtailment/response_profile.go#L220-L276)
+resolves the legacy `SiteID`, marshals the effective scope, and assigns canonical
+non-empty `ScopeJSON` before calling the store. The candidate therefore failed
+completion, recall, and new-finding
+validity. Repeats cannot repair the initial 6/6 failure, so PRs #957 and #964
+were not run.
+
 ## Human adjudication
 
 - Every completed PR #944 and PR #956 clean-control review correctly returned
@@ -107,6 +143,14 @@ erase the completion failure, and PRs #957 and #964 were not run.
   out in every experiment.
 - The bounded prompt downgraded PR #961's expected `HIGH` to `MEDIUM` and missed
   its expected `MEDIUM`.
+- Terra recalled the expected `HIGH` findings on PR #953 and PR #961. It missed
+  PR #948's topology-preview `MEDIUM`, PR #953's conflicting-lock-order
+  `MEDIUM`, both PR #954 database-harness `MEDIUM` findings, and PR #961's
+  existing-deployment compatibility `MEDIUM`.
+- Terra's new PR #953 legacy-site-profile `MEDIUM` is invalid. At the reviewed
+  head, the response-profile service resolves `SiteID` through
+  `ResponseProfileScope`, marshals it to canonical scope JSON, and replaces
+  `profile.ScopeJSON` before the SQL store invokes the envelope builder.
 
 ## Results
 
@@ -170,12 +214,13 @@ cancellation cleanup.
 
 | Gate | Outcome |
 | --- | --- |
-| Retain every adjudicated `HIGH` without downgrade across completed reviews | Failed by compact context and bounded prompt |
-| Retain at least 90% of adjudicated `MEDIUM` findings across completed reviews | Failed by every tested configuration; best observed recall was 1/4 at `medium` |
+| Initial candidate completion | Failed: sharding completed 1/6 aggregates; Terra completed 5/6 cases |
+| Retain every adjudicated `HIGH` without downgrade across completed reviews | Terra passed at 2/2; compact context and the bounded prompt failed |
+| Retain at least 90% of adjudicated `MEDIUM` findings across completed reviews | Failed by every tested configuration; Terra recalled 0/5, and the best observed result was 1/4 at `medium` effort |
 | No invalid `HIGH` on completed clean controls | Passed; every completed PR #944 and PR #956 control returned `NONE` |
-| New medium-or-higher findings are valid | Failed; medium effort produced an invalid `HIGH` on PR #948 |
-| No increase in median tool calls or compactions | Not decision-bearing because recall failed |
-| At least 20% faster or equivalent with lower token use | `medium` improved completion, but recall failed |
+| New medium-or-higher findings are valid | Failed: medium effort produced an invalid `HIGH` on PR #948, and Terra produced an invalid `MEDIUM` on PR #953 |
+| No increase in median tool calls or compactions | Not decision-bearing because completion and recall failed |
+| At least 20% faster or equivalent with lower token use | Terra improved completion, and `medium` effort also improved completion, but both failed recall and validity gates |
 
 The planned repeats showed that compact severity varies, but two completed
 trials still downgraded an adjudicated `HIGH`. Testing `medium` closed the effort
@@ -185,11 +230,9 @@ matrix and showed that its completion gain comes with unacceptable recall.
 
 1. Keep production on `gpt-5.6-sol`, `unified=40`, `xhigh`, and the baseline
    prompt while retaining the bounded timeout and fail-closed human-review path.
-2. Do not repeat the rejected sharded candidate or replay PRs #957 and #964.
-3. Add trusted benchmark-only support for `gpt-5.6-terra` with `high` reasoning,
-   default service tier, and low verbosity.
-4. After that support lands on `main`, run Terra independently across the fixed
-   adjudicated corpus. Require 6/6 completion, every adjudicated `HIGH`, at
-   least 90% of the five adjudicated `MEDIUM` findings, and no invalid new
-   `MEDIUM` or `HIGH` before any large-PR or production evaluation.
-5. Complete the original plan's first-30-production-run observation window.
+2. Do not repeat the rejected sharded or Terra candidates, and do not replay PRs
+   #957 and #964 for either candidate.
+3. Complete the original plan's first-30-production-run observation window.
+4. Require any future candidate to use trusted default-branch benchmark code and
+   pass the same initial completion, recall, and finding-validity gates before
+   production evaluation.

--- a/docs/codex-security-review-benchmark-report.md
+++ b/docs/codex-security-review-benchmark-report.md
@@ -223,7 +223,7 @@ cancellation cleanup.
 | No invalid `HIGH` on completed clean controls | Passed; every completed PR #944 and PR #956 control returned `NONE` |
 | New medium-or-higher findings are valid | Failed: medium effort produced an invalid `HIGH` on PR #948, and Terra produced an invalid `MEDIUM` on PR #953 |
 | No increase in median tool calls or compactions | Not decision-bearing because completion and recall failed |
-| At least 20% faster or equivalent with lower token use | Terra improved completion, and `medium` effort also improved completion, but both failed recall and validity gates |
+| At least 20% faster or equivalent with lower token use | Not evaluated for Terra: quality gates failed, and its completed-case set is not case-matched to the Sol timing samples; completion rate is not a latency comparison |
 
 The planned repeats showed that compact severity varies, but two completed
 trials still downgraded an adjudicated `HIGH`. Testing `medium` closed the effort

--- a/docs/codex-security-review-benchmark-report.md
+++ b/docs/codex-security-review-benchmark-report.md
@@ -142,8 +142,8 @@ were not run.
   against automation changes, and unit and integration tests cover the case.
 - The medium-effort PR #954 review recalled the abandoned-staging-database
   `MEDIUM` and missed the connection-retry/deadline `MEDIUM`.
-- PR #953, which contains one expected `HIGH` and one expected `MEDIUM`, timed
-  out in every experiment.
+- In the pre-Terra context, effort, and prompt experiments, PR #953 timed out
+  every time. It contains one expected `HIGH` and one expected `MEDIUM`.
 - The bounded prompt downgraded PR #961's expected `HIGH` to `MEDIUM` and missed
   its expected `MEDIUM`.
 - Terra recalled the expected `HIGH` findings on PR #953 and PR #961. It missed

--- a/docs/codex-security-review-benchmark-report.md
+++ b/docs/codex-security-review-benchmark-report.md
@@ -92,8 +92,9 @@ erase the completion failure, and PRs #957 and #964 were not run.
 
 The initial Terra run
 [33551271863](https://github.com/block/proto-fleet/actions/runs/33551271863)
-loaded trusted `main` at
-`603ed457a23e9fe6c23ca8792b6aaad2e01722d1`. It used
+loaded trusted workflow code from `main` at
+`603ed457a23e9fe6c23ca8792b6aaad2e01722d1`. Each case still checked out its
+fixed historical head from the corpus. The run used
 `gpt-5.6-terra`, `unified=40`, `high` reasoning, explicit `default` service
 tier, low verbosity, the baseline prompt, and the existing 12-minute outer
 budget.
@@ -116,7 +117,9 @@ findings. Its additional PR #953 `MEDIUM` claimed legacy site-scoped profile
 requests reach the envelope builder with empty scope JSON. That finding is
 invalid: [`validateAndNormalize`](https://github.com/block/proto-fleet/blob/586901c2c4b2ca21057202bac398718204ea6435/server/internal/domain/curtailment/response_profile.go#L220-L276)
 resolves the legacy `SiteID`, marshals the effective scope, and assigns canonical
-non-empty `ScopeJSON` before calling the store. The candidate therefore failed
+non-empty `ScopeJSON` before calling the store. That link intentionally targets
+PR #953's benchmarked historical head; `603ed457a` identifies the trusted
+workflow revision, not the code under review. The candidate therefore failed
 completion, recall, and new-finding
 validity. Repeats cannot repair the initial 6/6 failure, so PRs #957 and #964
 were not run.

--- a/docs/plans/archive/2026-09-01-terra-codex-security-review-benchmark-plan.md
+++ b/docs/plans/archive/2026-09-01-terra-codex-security-review-benchmark-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "Terra Codex security review benchmark"
 date: 2026-09-01
-status: implementing
+status: completed
 type: plan
 tracker: https://github.com/block/proto-fleet/pull/987
 ---
@@ -22,6 +22,24 @@ quality, latency, and cost. The current Codex configuration schema supports
 Codex action accepts these as trusted `codex-args` overrides. This experiment
 tests Terra independently so a model change is not mixed with sharding or
 prompt changes.
+
+## Outcome
+
+The benchmark-only implementation landed in PR #987 and ran from trusted `main`
+at `603ed457a23e9fe6c23ca8792b6aaad2e01722d1`. The initial adjudicated run
+[33551271863](https://github.com/block/proto-fleet/actions/runs/33551271863)
+completed five of six cases. PR #944 exhausted the 12-minute outer budget; its
+trusted finalizer produced a verified timeout artifact.
+
+Across the five completed cases, Terra recalled both adjudicated `HIGH`
+findings and none of the five adjudicated `MEDIUM` findings. It also reported a
+new `MEDIUM` on PR #953 that was adjudicated invalid: the response-profile
+service converts legacy `SiteID` requests to canonical, non-empty scope JSON
+before the SQL store builds the authorization envelope.
+
+The candidate failed the initial 6/6 completion gate, the medium-recall gate,
+and the new-finding validity gate. Repeats and the large-PR corpus were not run,
+and Terra did not advance to production.
 
 ## Goals
 


### PR DESCRIPTION
Reviewable diff: +84/-20 across 2 files (excludes generated, test, and story files).

## Summary

Records the live Terra security-review benchmark and rejects the candidate before production or large-PR evaluation. Terra materially improved completion to 5/6 and recalled both known `HIGH` findings, but missed all five known `MEDIUM` findings, timed out on PR #944, and introduced one invalid new `MEDIUM`.

## How it works

The report binds the evidence to trusted `main` commit `603ed457a`, Actions run 33551271863, and the fixed Terra/high/default/low profile. It separates completion from recall, compares each completed output with the adjudicated corpus, and documents why the new PR #953 finding is invalid. The completed plan moves to `docs/plans/archive/`; repeats and PRs #957/#964 remain skipped because the initial gate failed.

## Diagrams

```mermaid
flowchart LR
  A["Trusted Terra benchmark"] --> B["5 of 6 cases completed"]
  B --> C["2 of 2 HIGH recalled"]
  B --> D["0 of 5 MEDIUM recalled"]
  B --> E["1 invalid new MEDIUM"]
  C --> F["Reject candidate"]
  D --> F
  E --> F
  F --> G["Keep production Sol/xhigh"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `docs/codex-security-review-benchmark-report.md` | Added Terra run metadata, per-case outcomes, timing/token metrics, adjudication, gate results, and decision | Verify the evidence supports rejection and the false-positive analysis is grounded in the historical code |
| `docs/plans/archive/2026-09-01-terra-codex-security-review-benchmark-plan.md` | Marked the plan completed, archived it, and recorded the outcome | Confirms the accepted sequence stopped before repeats, large PRs, or rollout |

## Key technical decisions & trade-offs

- Reject Terra despite improved completion because completion cannot compensate for 0/5 `MEDIUM` recall.
- Count PR #944 separately as a verified timeout rather than excluding it from the initial 6/6 gate.
- Reject the new PR #953 `MEDIUM`; the domain service canonicalizes legacy site scope before the changed SQL-store envelope builder receives it.
- Skip repeats because they cannot erase an initial completion failure.
- Skip PRs #957 and #964 because the adjudicated completion, recall, and validity gates did not pass.
- Keep production on `gpt-5.6-sol`, `unified=40`, `xhigh`, and the baseline prompt.

## Testing & validation

- Cross-checked six trusted artifacts and all finalizer outcomes from Actions run 33551271863.
- Compared completed outputs with the five source review comments containing the two known `HIGH` and five known `MEDIUM` findings.
- Inspected historical PR #953 domain and SQL-store code to adjudicate the new `MEDIUM` as invalid.
- Verified local Markdown links after archiving the plan.
- Ran `git diff --check`.
- No application or workflow behavior changes.


