### PR TITLE
make Fleet Node enrollment one command

### DIFF
--- a/.github/workflows/deployment-config-checks.yml
+++ b/.github/workflows/deployment-config-checks.yml
@@ -58,7 +58,10 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Validate shell syntax
-        run: bash -n deployment-files/fleetnode/fleetnode-enroll deployment-files/fleetnode/install-fleet-node.sh deployment-files/fleetnode/tests/qualify-package.sh deployment-files/fleetnode/tests/test-install-fleetnode.sh
+        run: bash -n deployment-files/fleetnode/fleetnode-enroll deployment-files/fleetnode/install-fleet-node.sh deployment-files/fleetnode/tests/qualify-package.sh deployment-files/fleetnode/tests/test-fleetnode-enroll.sh deployment-files/fleetnode/tests/test-install-fleetnode.sh
+
+      - name: Test enrollment helper
+        run: ./deployment-files/fleetnode/tests/test-fleetnode-enroll.sh
 
       - name: Test installer
         run: ./deployment-files/fleetnode/tests/test-install-fleetnode.sh

--- a/.github/workflows/deployment-config-checks.yml
+++ b/.github/workflows/deployment-config-checks.yml
@@ -58,7 +58,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Validate shell syntax
-        run: bash -n deployment-files/fleetnode/install-fleet-node.sh deployment-files/fleetnode/tests/qualify-package.sh deployment-files/fleetnode/tests/test-install-fleetnode.sh
+        run: bash -n deployment-files/fleetnode/fleetnode-enroll deployment-files/fleetnode/install-fleet-node.sh deployment-files/fleetnode/tests/qualify-package.sh deployment-files/fleetnode/tests/test-install-fleetnode.sh
 
       - name: Test installer
         run: ./deployment-files/fleetnode/tests/test-install-fleetnode.sh

--- a/.github/workflows/proto-fleet-artifact-build.yml
+++ b/.github/workflows/proto-fleet-artifact-build.yml
@@ -302,6 +302,7 @@ jobs:
 
           mkdir -p "$package_dir/plugins"
           install -m 0755 fleetnode "$package_dir/fleetnode"
+          install -m 0755 ../deployment-files/fleetnode/fleetnode-enroll "$package_dir/fleetnode-enroll"
           install -m 0644 ../deployment-files/fleetnode/fleet-node.service "$package_dir/fleet-node.service"
           install -m 0755 proto-plugin "$package_dir/plugins/proto-plugin"
           install -m 0755 antminer-plugin "$package_dir/plugins/antminer-plugin"

--- a/client/src/protoFleet/features/settings/components/Nodes/EnrollNodeModal.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Nodes/EnrollNodeModal.test.tsx
@@ -44,7 +44,11 @@ describe("EnrollNodeModal", () => {
     const { getByText } = render(<EnrollNodeModal open onDismiss={mockOnDismiss} onUpdated={mockOnUpdated} />);
 
     await waitFor(() => {
-      expect(getByText(/fleetnode enroll --server-url=/)).toBeInTheDocument();
+      expect(
+        getByText(
+          "sudo -u fleetnode /opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode enroll --server-url=http://localhost:4000 && sudo systemctl enable --now fleet-node.service",
+        ),
+      ).toBeInTheDocument();
       expect(getByText("pf_code_123")).toBeInTheDocument();
       expect(getByText("Waiting for the node to register…")).toBeInTheDocument();
     });

--- a/client/src/protoFleet/features/settings/components/Nodes/EnrollNodeModal.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Nodes/EnrollNodeModal.test.tsx
@@ -47,10 +47,8 @@ describe("EnrollNodeModal", () => {
 
     await waitFor(() => {
       const command = getByRole("button", { name: "Copy command" }).parentElement;
-      expect(command).toHaveTextContent("sudo -u fleetnode /opt/fleetnode/fleetnode");
-      expect(command).toHaveTextContent("--state-dir /var/lib/fleetnode");
-      expect(command).toHaveTextContent("enroll --server-url=http://localhost:4000");
-      expect(command).toHaveTextContent("sudo systemctl enable --now fleet-node.service");
+      expect(command).toHaveTextContent("sudo fleetnode-enroll");
+      expect(command).toHaveTextContent("--server-url=http://localhost:4000");
       expect(getByText("pf_code_123")).toBeInTheDocument();
       expect(getByText("Waiting for the node to register…")).toBeInTheDocument();
     });

--- a/client/src/protoFleet/features/settings/components/Nodes/EnrollNodeModal.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Nodes/EnrollNodeModal.test.tsx
@@ -50,7 +50,7 @@ describe("EnrollNodeModal", () => {
       expect(command).toHaveTextContent("sudo -u fleetnode /opt/fleetnode/fleetnode");
       expect(command).toHaveTextContent("--state-dir /var/lib/fleetnode");
       expect(command).toHaveTextContent("enroll --server-url=http://localhost:4000");
-      expect(command).toHaveTextContent("sudo systemctl enable fleet-node.service");
+      expect(command).toHaveTextContent("sudo systemctl enable --now fleet-node.service");
       expect(getByText("pf_code_123")).toBeInTheDocument();
       expect(getByText("Waiting for the node to register…")).toBeInTheDocument();
     });

--- a/client/src/protoFleet/features/settings/components/Nodes/EnrollNodeModal.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Nodes/EnrollNodeModal.test.tsx
@@ -41,14 +41,16 @@ describe("EnrollNodeModal", () => {
     mockListFleetNodes.mockResolvedValue([]);
     mockCreateEnrollmentCode.mockResolvedValue({ code: "pf_code_123", pendingEnrollmentId: "11", expiresAt: null });
 
-    const { getByText } = render(<EnrollNodeModal open onDismiss={mockOnDismiss} onUpdated={mockOnUpdated} />);
+    const { getByRole, getByText } = render(
+      <EnrollNodeModal open onDismiss={mockOnDismiss} onUpdated={mockOnUpdated} />,
+    );
 
     await waitFor(() => {
-      expect(
-        getByText(
-          "sudo -u fleetnode /opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode enroll --server-url=http://localhost:4000 && sudo systemctl enable --now fleet-node.service",
-        ),
-      ).toBeInTheDocument();
+      const command = getByRole("button", { name: "Copy command" }).parentElement;
+      expect(command).toHaveTextContent("sudo -u fleetnode /opt/fleetnode/fleetnode");
+      expect(command).toHaveTextContent("--state-dir /var/lib/fleetnode");
+      expect(command).toHaveTextContent("enroll --server-url=http://localhost:4000");
+      expect(command).toHaveTextContent("sudo systemctl enable fleet-node.service");
       expect(getByText("pf_code_123")).toBeInTheDocument();
       expect(getByText("Waiting for the node to register…")).toBeInTheDocument();
     });

--- a/client/src/protoFleet/features/settings/components/Nodes/enrollNodeCommand.test.ts
+++ b/client/src/protoFleet/features/settings/components/Nodes/enrollNodeCommand.test.ts
@@ -11,7 +11,7 @@ describe("buildFleetNodeEnrollCommand", () => {
         hostname: "192.168.1.20",
       },
       expected:
-        "sudo -u fleetnode /opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode enroll --server-url=http://192.168.1.20:4000 --allow-insecure-transport && sudo systemctl enable fleet-node.service",
+        "sudo -u fleetnode /opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode enroll --server-url=http://192.168.1.20:4000 --allow-insecure-transport && sudo systemctl enable --now fleet-node.service",
     },
     {
       label: "HTTPS",
@@ -21,7 +21,7 @@ describe("buildFleetNodeEnrollCommand", () => {
         hostname: "fleet.example.com",
       },
       expected:
-        "sudo -u fleetnode /opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode enroll --server-url=https://fleet.example.com/api-proxy && sudo systemctl enable fleet-node.service",
+        "sudo -u fleetnode /opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode enroll --server-url=https://fleet.example.com/api-proxy && sudo systemctl enable --now fleet-node.service",
     },
     {
       label: "localhost HTTP",
@@ -31,7 +31,7 @@ describe("buildFleetNodeEnrollCommand", () => {
         hostname: "localhost",
       },
       expected:
-        "sudo -u fleetnode /opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode enroll --server-url=http://localhost:4000 && sudo systemctl enable fleet-node.service",
+        "sudo -u fleetnode /opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode enroll --server-url=http://localhost:4000 && sudo systemctl enable --now fleet-node.service",
     },
     {
       label: "127.0.0.1 HTTP",
@@ -41,7 +41,7 @@ describe("buildFleetNodeEnrollCommand", () => {
         hostname: "127.0.0.1",
       },
       expected:
-        "sudo -u fleetnode /opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode enroll --server-url=http://127.0.0.1:4000 && sudo systemctl enable fleet-node.service",
+        "sudo -u fleetnode /opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode enroll --server-url=http://127.0.0.1:4000 && sudo systemctl enable --now fleet-node.service",
     },
     {
       label: "::1 HTTP",
@@ -51,7 +51,7 @@ describe("buildFleetNodeEnrollCommand", () => {
         hostname: "[::1]",
       },
       expected:
-        "sudo -u fleetnode /opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode enroll --server-url=http://[::1]:4000 && sudo systemctl enable fleet-node.service",
+        "sudo -u fleetnode /opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode enroll --server-url=http://[::1]:4000 && sudo systemctl enable --now fleet-node.service",
     },
   ])("builds the enroll command for $label", ({ location, expected }) => {
     expect(buildFleetNodeEnrollCommand(location)).toBe(expected);

--- a/client/src/protoFleet/features/settings/components/Nodes/enrollNodeCommand.test.ts
+++ b/client/src/protoFleet/features/settings/components/Nodes/enrollNodeCommand.test.ts
@@ -10,8 +10,7 @@ describe("buildFleetNodeEnrollCommand", () => {
         protocol: "http:",
         hostname: "192.168.1.20",
       },
-      expected:
-        "sudo -u fleetnode /opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode enroll --server-url=http://192.168.1.20:4000 --allow-insecure-transport && sudo systemctl enable --now fleet-node.service",
+      expected: "sudo fleetnode-enroll --server-url=http://192.168.1.20:4000 --allow-insecure-transport",
     },
     {
       label: "HTTPS",
@@ -20,8 +19,7 @@ describe("buildFleetNodeEnrollCommand", () => {
         protocol: "https:",
         hostname: "fleet.example.com",
       },
-      expected:
-        "sudo -u fleetnode /opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode enroll --server-url=https://fleet.example.com/api-proxy && sudo systemctl enable --now fleet-node.service",
+      expected: "sudo fleetnode-enroll --server-url=https://fleet.example.com/api-proxy",
     },
     {
       label: "localhost HTTP",
@@ -30,8 +28,7 @@ describe("buildFleetNodeEnrollCommand", () => {
         protocol: "http:",
         hostname: "localhost",
       },
-      expected:
-        "sudo -u fleetnode /opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode enroll --server-url=http://localhost:4000 && sudo systemctl enable --now fleet-node.service",
+      expected: "sudo fleetnode-enroll --server-url=http://localhost:4000",
     },
     {
       label: "127.0.0.1 HTTP",
@@ -40,8 +37,7 @@ describe("buildFleetNodeEnrollCommand", () => {
         protocol: "http:",
         hostname: "127.0.0.1",
       },
-      expected:
-        "sudo -u fleetnode /opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode enroll --server-url=http://127.0.0.1:4000 && sudo systemctl enable --now fleet-node.service",
+      expected: "sudo fleetnode-enroll --server-url=http://127.0.0.1:4000",
     },
     {
       label: "::1 HTTP",
@@ -50,8 +46,7 @@ describe("buildFleetNodeEnrollCommand", () => {
         protocol: "http:",
         hostname: "[::1]",
       },
-      expected:
-        "sudo -u fleetnode /opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode enroll --server-url=http://[::1]:4000 && sudo systemctl enable --now fleet-node.service",
+      expected: "sudo fleetnode-enroll --server-url=http://[::1]:4000",
     },
   ])("builds the enroll command for $label", ({ location, expected }) => {
     expect(buildFleetNodeEnrollCommand(location)).toBe(expected);

--- a/client/src/protoFleet/features/settings/components/Nodes/enrollNodeCommand.test.ts
+++ b/client/src/protoFleet/features/settings/components/Nodes/enrollNodeCommand.test.ts
@@ -11,7 +11,7 @@ describe("buildFleetNodeEnrollCommand", () => {
         hostname: "192.168.1.20",
       },
       expected:
-        "sudo -u fleetnode /opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode enroll --server-url=http://192.168.1.20:4000 --allow-insecure-transport && sudo systemctl enable --now fleet-node.service",
+        "sudo -u fleetnode /opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode enroll --server-url=http://192.168.1.20:4000 --allow-insecure-transport && sudo systemctl enable fleet-node.service",
     },
     {
       label: "HTTPS",
@@ -21,7 +21,7 @@ describe("buildFleetNodeEnrollCommand", () => {
         hostname: "fleet.example.com",
       },
       expected:
-        "sudo -u fleetnode /opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode enroll --server-url=https://fleet.example.com/api-proxy && sudo systemctl enable --now fleet-node.service",
+        "sudo -u fleetnode /opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode enroll --server-url=https://fleet.example.com/api-proxy && sudo systemctl enable fleet-node.service",
     },
     {
       label: "localhost HTTP",
@@ -31,7 +31,7 @@ describe("buildFleetNodeEnrollCommand", () => {
         hostname: "localhost",
       },
       expected:
-        "sudo -u fleetnode /opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode enroll --server-url=http://localhost:4000 && sudo systemctl enable --now fleet-node.service",
+        "sudo -u fleetnode /opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode enroll --server-url=http://localhost:4000 && sudo systemctl enable fleet-node.service",
     },
     {
       label: "127.0.0.1 HTTP",
@@ -41,7 +41,7 @@ describe("buildFleetNodeEnrollCommand", () => {
         hostname: "127.0.0.1",
       },
       expected:
-        "sudo -u fleetnode /opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode enroll --server-url=http://127.0.0.1:4000 && sudo systemctl enable --now fleet-node.service",
+        "sudo -u fleetnode /opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode enroll --server-url=http://127.0.0.1:4000 && sudo systemctl enable fleet-node.service",
     },
     {
       label: "::1 HTTP",
@@ -51,7 +51,7 @@ describe("buildFleetNodeEnrollCommand", () => {
         hostname: "[::1]",
       },
       expected:
-        "sudo -u fleetnode /opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode enroll --server-url=http://[::1]:4000 && sudo systemctl enable --now fleet-node.service",
+        "sudo -u fleetnode /opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode enroll --server-url=http://[::1]:4000 && sudo systemctl enable fleet-node.service",
     },
   ])("builds the enroll command for $label", ({ location, expected }) => {
     expect(buildFleetNodeEnrollCommand(location)).toBe(expected);

--- a/client/src/protoFleet/features/settings/components/Nodes/enrollNodeCommand.test.ts
+++ b/client/src/protoFleet/features/settings/components/Nodes/enrollNodeCommand.test.ts
@@ -10,7 +10,8 @@ describe("buildFleetNodeEnrollCommand", () => {
         protocol: "http:",
         hostname: "192.168.1.20",
       },
-      expected: "fleetnode enroll --server-url=http://192.168.1.20:4000 --allow-insecure-transport",
+      expected:
+        "sudo -u fleetnode /opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode enroll --server-url=http://192.168.1.20:4000 --allow-insecure-transport && sudo systemctl enable --now fleet-node.service",
     },
     {
       label: "HTTPS",
@@ -19,7 +20,8 @@ describe("buildFleetNodeEnrollCommand", () => {
         protocol: "https:",
         hostname: "fleet.example.com",
       },
-      expected: "fleetnode enroll --server-url=https://fleet.example.com/api-proxy",
+      expected:
+        "sudo -u fleetnode /opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode enroll --server-url=https://fleet.example.com/api-proxy && sudo systemctl enable --now fleet-node.service",
     },
     {
       label: "localhost HTTP",
@@ -28,7 +30,8 @@ describe("buildFleetNodeEnrollCommand", () => {
         protocol: "http:",
         hostname: "localhost",
       },
-      expected: "fleetnode enroll --server-url=http://localhost:4000",
+      expected:
+        "sudo -u fleetnode /opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode enroll --server-url=http://localhost:4000 && sudo systemctl enable --now fleet-node.service",
     },
     {
       label: "127.0.0.1 HTTP",
@@ -37,7 +40,8 @@ describe("buildFleetNodeEnrollCommand", () => {
         protocol: "http:",
         hostname: "127.0.0.1",
       },
-      expected: "fleetnode enroll --server-url=http://127.0.0.1:4000",
+      expected:
+        "sudo -u fleetnode /opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode enroll --server-url=http://127.0.0.1:4000 && sudo systemctl enable --now fleet-node.service",
     },
     {
       label: "::1 HTTP",
@@ -46,7 +50,8 @@ describe("buildFleetNodeEnrollCommand", () => {
         protocol: "http:",
         hostname: "[::1]",
       },
-      expected: "fleetnode enroll --server-url=http://[::1]:4000",
+      expected:
+        "sudo -u fleetnode /opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode enroll --server-url=http://[::1]:4000 && sudo systemctl enable --now fleet-node.service",
     },
   ])("builds the enroll command for $label", ({ location, expected }) => {
     expect(buildFleetNodeEnrollCommand(location)).toBe(expected);

--- a/client/src/protoFleet/features/settings/components/Nodes/enrollNodeCommand.ts
+++ b/client/src/protoFleet/features/settings/components/Nodes/enrollNodeCommand.ts
@@ -2,8 +2,7 @@ import { API_PROXY_BASE } from "@/protoFleet/api/constants";
 
 const INSECURE_TRANSPORT_FLAG = "--allow-insecure-transport";
 const HTTP_FLEET_API_PORT = "4000";
-const FLEET_NODE_ENROLL_COMMAND = "sudo -u fleetnode /opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode enroll";
-const FLEET_NODE_ENABLE_COMMAND = "sudo systemctl enable --now fleet-node.service";
+const FLEET_NODE_ENROLL_COMMAND = "sudo fleetnode-enroll";
 
 const isLoopbackHostname = (hostname: string) => {
   const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, "");
@@ -27,5 +26,5 @@ export const buildFleetNodeEnrollCommand = (location: Pick<Location, "origin" | 
     ? `${enrollCommand} ${INSECURE_TRANSPORT_FLAG}`
     : enrollCommand;
 
-  return `${command} && ${FLEET_NODE_ENABLE_COMMAND}`;
+  return command;
 };

--- a/client/src/protoFleet/features/settings/components/Nodes/enrollNodeCommand.ts
+++ b/client/src/protoFleet/features/settings/components/Nodes/enrollNodeCommand.ts
@@ -3,7 +3,7 @@ import { API_PROXY_BASE } from "@/protoFleet/api/constants";
 const INSECURE_TRANSPORT_FLAG = "--allow-insecure-transport";
 const HTTP_FLEET_API_PORT = "4000";
 const FLEET_NODE_ENROLL_COMMAND = "sudo -u fleetnode /opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode enroll";
-const FLEET_NODE_ENABLE_COMMAND = "sudo systemctl enable --now fleet-node.service";
+const FLEET_NODE_ENABLE_COMMAND = "sudo systemctl enable fleet-node.service";
 
 const isLoopbackHostname = (hostname: string) => {
   const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, "");

--- a/client/src/protoFleet/features/settings/components/Nodes/enrollNodeCommand.ts
+++ b/client/src/protoFleet/features/settings/components/Nodes/enrollNodeCommand.ts
@@ -3,7 +3,7 @@ import { API_PROXY_BASE } from "@/protoFleet/api/constants";
 const INSECURE_TRANSPORT_FLAG = "--allow-insecure-transport";
 const HTTP_FLEET_API_PORT = "4000";
 const FLEET_NODE_ENROLL_COMMAND = "sudo -u fleetnode /opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode enroll";
-const FLEET_NODE_ENABLE_COMMAND = "sudo systemctl enable fleet-node.service";
+const FLEET_NODE_ENABLE_COMMAND = "sudo systemctl enable --now fleet-node.service";
 
 const isLoopbackHostname = (hostname: string) => {
   const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, "");

--- a/client/src/protoFleet/features/settings/components/Nodes/enrollNodeCommand.ts
+++ b/client/src/protoFleet/features/settings/components/Nodes/enrollNodeCommand.ts
@@ -2,6 +2,8 @@ import { API_PROXY_BASE } from "@/protoFleet/api/constants";
 
 const INSECURE_TRANSPORT_FLAG = "--allow-insecure-transport";
 const HTTP_FLEET_API_PORT = "4000";
+const FLEET_NODE_ENROLL_COMMAND = "sudo -u fleetnode /opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode enroll";
+const FLEET_NODE_ENABLE_COMMAND = "sudo systemctl enable --now fleet-node.service";
 
 const isLoopbackHostname = (hostname: string) => {
   const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, "");
@@ -20,6 +22,10 @@ const getHttpFleetApiOrigin = (origin: string) => {
 export const buildFleetNodeEnrollCommand = (location: Pick<Location, "origin" | "protocol" | "hostname">) => {
   const serverUrl =
     location.protocol === "http:" ? getHttpFleetApiOrigin(location.origin) : `${location.origin}${API_PROXY_BASE}`;
-  const command = `fleetnode enroll --server-url=${serverUrl}`;
-  return shouldAppendInsecureTransportFlag(location) ? `${command} ${INSECURE_TRANSPORT_FLAG}` : command;
+  const enrollCommand = `${FLEET_NODE_ENROLL_COMMAND} --server-url=${serverUrl}`;
+  const command = shouldAppendInsecureTransportFlag(location)
+    ? `${enrollCommand} ${INSECURE_TRANSPORT_FLAG}`
+    : enrollCommand;
+
+  return `${command} && ${FLEET_NODE_ENABLE_COMMAND}`;
 };

--- a/deployment-files/fleetnode/fleetnode-enroll
+++ b/deployment-files/fleetnode/fleetnode-enroll
@@ -4,35 +4,83 @@ set -euo pipefail
 PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 export PATH
 
+FLEETNODE_BIN="/opt/fleetnode/fleetnode"
+STATE_DIR="/var/lib/fleetnode"
+STATE_PATH="$STATE_DIR/state.yaml"
+SERVICE_NAME="fleet-node.service"
+
 usage() {
   cat <<'EOF'
 Usage: sudo fleetnode-enroll --server-url=URL [--allow-insecure-transport]
 
-Enroll the packaged Fleet Node, then enable and start fleet-node.service.
+Enroll or resume the packaged Fleet Node, then enable and start fleet-node.service.
 EOF
 }
 
-case "${1:-}" in
-  -h|--help)
-    usage
-    exit 0
-    ;;
-  "")
-    usage >&2
-    exit 2
-    ;;
-esac
+run_fleetnode() {
+  runuser -u fleetnode -- "$FLEETNODE_BIN" --state-dir "$STATE_DIR" "$@"
+}
 
-if [[ "$(id -u)" -ne 0 ]]; then
-  echo "fleetnode-enroll must run as root; use sudo fleetnode-enroll ..." >&2
-  exit 1
+has_force_flag() {
+  local arg
+  for arg in "$@"; do
+    [[ "$arg" == "--force" ]] && return 0
+  done
+  return 1
+}
+
+enroll_or_resume() {
+  if has_force_flag "$@" || [[ ! -f "$STATE_PATH" ]]; then
+    run_fleetnode enroll "$@"
+    return
+  fi
+
+  local status fleet_node_id api_key_present
+  status=$(run_fleetnode status) || return
+  fleet_node_id=$(awk '$1 == "fleet_node_id:" { print $2 }' <<<"$status")
+  api_key_present=$(awk '$1 == "api_key_present:" { print $2 }' <<<"$status")
+  if [[ ! "$fleet_node_id" =~ ^[1-9][0-9]*$ ]]; then
+    echo "Fleet Node state has no fleet_node_id; pass --force to re-enroll" >&2
+    return 1
+  fi
+
+  case "$api_key_present" in
+    false) run_fleetnode refresh ;;
+    true) return 0 ;;
+    *)
+      echo "Fleet Node status did not report whether an api_key is present" >&2
+      return 1
+      ;;
+  esac
+}
+
+main() {
+  case "${1:-}" in
+    -h|--help)
+      usage
+      return 0
+      ;;
+    "")
+      usage >&2
+      return 2
+      ;;
+  esac
+
+  if [[ "$(id -u)" -ne 0 ]]; then
+    echo "fleetnode-enroll must run as root; use sudo fleetnode-enroll ..." >&2
+    return 1
+  fi
+
+  local command
+  for command in awk runuser systemctl; do
+    command -v "$command" >/dev/null 2>&1 || { echo "required command not found: $command" >&2; return 1; }
+  done
+  [[ -x "$FLEETNODE_BIN" ]] || { echo "Fleet Node is not installed at $FLEETNODE_BIN" >&2; return 1; }
+
+  enroll_or_resume "$@" || return
+  systemctl enable --now "$SERVICE_NAME"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
 fi
-
-for command in runuser systemctl; do
-  command -v "$command" >/dev/null 2>&1 || { echo "required command not found: $command" >&2; exit 1; }
-done
-[[ -x /opt/fleetnode/fleetnode ]] || { echo "Fleet Node is not installed at /opt/fleetnode/fleetnode" >&2; exit 1; }
-
-runuser -u fleetnode -- \
-  /opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode enroll "$@"
-systemctl enable --now fleet-node.service

--- a/deployment-files/fleetnode/fleetnode-enroll
+++ b/deployment-files/fleetnode/fleetnode-enroll
@@ -11,7 +11,7 @@ SERVICE_NAME="fleet-node.service"
 
 usage() {
   cat <<'EOF'
-Usage: sudo fleetnode-enroll --server-url=URL [--allow-insecure-transport]
+Usage: sudo fleetnode-enroll --server-url=URL [--allow-insecure-transport] [--force]
 
 Enroll or resume the packaged Fleet Node, then enable and start fleet-node.service.
 EOF
@@ -29,16 +29,50 @@ has_force_flag() {
   return 1
 }
 
+requested_server_url() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --server-url=*)
+        printf '%s\n' "${1#*=}"
+        return 0
+        ;;
+      --server-url)
+        shift
+        if [[ $# -eq 0 ]]; then
+          echo "--server-url requires a URL" >&2
+          return 1
+        fi
+        printf '%s\n' "$1"
+        return 0
+        ;;
+    esac
+    shift
+  done
+  echo "fleetnode-enroll requires --server-url" >&2
+  return 1
+}
+
 enroll_or_resume() {
-  if has_force_flag "$@" || [[ ! -f "$STATE_PATH" ]]; then
+  if has_force_flag "$@"; then
+    systemctl stop "$SERVICE_NAME" || return $?
+    run_fleetnode enroll "$@"
+    return
+  fi
+  if [[ ! -f "$STATE_PATH" ]]; then
     run_fleetnode enroll "$@"
     return
   fi
 
-  local status fleet_node_id api_key_present
+  local requested_url status state_url fleet_node_id api_key_present
+  requested_url=$(requested_server_url "$@") || return
   status=$(run_fleetnode status) || return
+  state_url=$(awk '$1 == "server_url:" { print $2 }' <<<"$status")
   fleet_node_id=$(awk '$1 == "fleet_node_id:" { print $2 }' <<<"$status")
   api_key_present=$(awk '$1 == "api_key_present:" { print $2 }' <<<"$status")
+  if [[ "$state_url" != "$requested_url" ]]; then
+    echo "Fleet Node is enrolled with server_url=$state_url, not requested server_url=$requested_url; pass --force to re-enroll" >&2
+    return 1
+  fi
   if [[ ! "$fleet_node_id" =~ ^[1-9][0-9]*$ ]]; then
     echo "Fleet Node state has no fleet_node_id; pass --force to re-enroll" >&2
     return 1
@@ -46,7 +80,10 @@ enroll_or_resume() {
 
   case "$api_key_present" in
     false) run_fleetnode refresh ;;
-    true) return 0 ;;
+    true)
+      echo "Fleet Node is already enrolled (fleet_node_id=$fleet_node_id); enabling $SERVICE_NAME."
+      return 0
+      ;;
     *)
       echo "Fleet Node status did not report whether an api_key is present" >&2
       return 1

--- a/deployment-files/fleetnode/fleetnode-enroll
+++ b/deployment-files/fleetnode/fleetnode-enroll
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+export PATH
+
+usage() {
+  cat <<'EOF'
+Usage: sudo fleetnode-enroll --server-url=URL [--allow-insecure-transport]
+
+Enroll the packaged Fleet Node, then enable and start fleet-node.service.
+EOF
+}
+
+case "${1:-}" in
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  "")
+    usage >&2
+    exit 2
+    ;;
+esac
+
+if [[ "$(id -u)" -ne 0 ]]; then
+  echo "fleetnode-enroll must run as root; use sudo fleetnode-enroll ..." >&2
+  exit 1
+fi
+
+for command in runuser systemctl; do
+  command -v "$command" >/dev/null 2>&1 || { echo "required command not found: $command" >&2; exit 1; }
+done
+[[ -x /opt/fleetnode/fleetnode ]] || { echo "Fleet Node is not installed at /opt/fleetnode/fleetnode" >&2; exit 1; }
+
+runuser -u fleetnode -- \
+  /opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode enroll "$@"
+systemctl enable --now fleet-node.service

--- a/deployment-files/fleetnode/install-fleet-node.sh
+++ b/deployment-files/fleetnode/install-fleet-node.sh
@@ -103,6 +103,7 @@ PROGRAM_DIR="${ROOT_PREFIX}/opt/fleetnode"
 CONFIG_DIR="${ROOT_PREFIX}/etc/fleetnode"
 STATE_DIR="${ROOT_PREFIX}/var/lib/fleetnode"
 UNIT_PATH="${ROOT_PREFIX}/etc/systemd/system/fleet-node.service"
+ENROLL_HELPER_PATH="${ROOT_PREFIX}/usr/local/bin/fleetnode-enroll"
 INSTALL_LOCK_DIR="${ROOT_PREFIX}/run/proto-fleet"
 INSTALL_LOCK_PATH="$INSTALL_LOCK_DIR/fleetnode-installer.lock"
 SYSTEMCTL="${FLEETNODE_SYSTEMCTL:-systemctl}"
@@ -148,7 +149,7 @@ if ! as_root "$SYSTEMCTL" show --property=Version --value >/dev/null 2>&1; then
   exit 1
 fi
 
-for path in "${PROGRAM_DIR%/*}" "${UNIT_PATH%/*}" "$PROGRAM_DIR" "$CONFIG_DIR" "$STATE_DIR" "$UNIT_PATH" "$INSTALL_LOCK_DIR" "$INSTALL_LOCK_PATH"; do
+for path in "${PROGRAM_DIR%/*}" "${UNIT_PATH%/*}" "${ENROLL_HELPER_PATH%/*}" "$PROGRAM_DIR" "$CONFIG_DIR" "$STATE_DIR" "$UNIT_PATH" "$ENROLL_HELPER_PATH" "$INSTALL_LOCK_DIR" "$INSTALL_LOCK_PATH"; do
   if [[ -L "$path" ]]; then
     if [[ "$ACTION" == "uninstall" && "$path" == "$UNIT_PATH" && "$path" -ef /dev/null ]]; then
       continue
@@ -270,6 +271,18 @@ validate_preserved_access() {
   done
 }
 
+validate_existing_enroll_helper() {
+  [[ -e "$ENROLL_HELPER_PATH" || -L "$ENROLL_HELPER_PATH" ]] || return 0
+  [[ -f "$ENROLL_HELPER_PATH" && ! -L "$ENROLL_HELPER_PATH" ]] || {
+    echo "enrollment helper path is not a regular file: $ENROLL_HELPER_PATH" >&2
+    return 1
+  }
+  [[ -f "$PROGRAM_DIR/fleetnode-enroll" ]] && cmp -s "$PROGRAM_DIR/fleetnode-enroll" "$ENROLL_HELPER_PATH" || {
+    echo "refusing to replace unmanaged enrollment helper: $ENROLL_HELPER_PATH" >&2
+    return 1
+  }
+}
+
 if [[ "$ACTION" == "install" ]]; then
   validate_existing_service_account
   validate_preserved_access
@@ -311,12 +324,14 @@ fi
 incoming="${PROGRAM_DIR%/*}/.fleetnode.install.$$"
 previous="${PROGRAM_DIR%/*}/.fleetnode.previous.$$"
 unit_backup="$work_dir/fleet-node.service.previous"
+enroll_helper_backup="$work_dir/fleetnode-enroll.previous"
 fresh_install=1
 [[ -x "$PROGRAM_DIR/fleetnode" && -f "$UNIT_PATH" ]] && fresh_install=0
 service_stopped=0
 previous_saved=0
 program_replaced=0
 unit_replaced=0
+enroll_helper_replaced=0
 install_complete=0
 
 cleanup() {
@@ -330,6 +345,13 @@ cleanup() {
   if [[ "$install_complete" != "1" ]]; then
     if [[ "$service_stopped" == "1" ]]; then
       as_root "$SYSTEMCTL" stop fleet-node.service || rollback_error "stop candidate Fleet Node service"
+    fi
+    if [[ "$enroll_helper_replaced" == "1" ]]; then
+      if [[ -f "$enroll_helper_backup" ]]; then
+        as_root install -m 0755 "$enroll_helper_backup" "$ENROLL_HELPER_PATH" || rollback_error "restore previous enrollment helper"
+      else
+        as_root rm -f "$ENROLL_HELPER_PATH" || rollback_error "remove candidate enrollment helper"
+      fi
     fi
     if [[ "$unit_replaced" == "1" ]]; then
       if [[ -f "$unit_backup" ]]; then
@@ -365,6 +387,8 @@ cleanup() {
 }
 trap cleanup EXIT
 
+validate_existing_enroll_helper
+
 remove_fleet_node() {
   local load_state
   load_state=$(as_root "$SYSTEMCTL" show --property=LoadState --value fleet-node.service) || {
@@ -381,6 +405,7 @@ remove_fleet_node() {
     *) echo "unexpected Fleet Node systemd unit load state: $load_state" >&2; return 1 ;;
   esac
 
+  as_root rm -f "$ENROLL_HELPER_PATH"
   as_root rm -rf "$PROGRAM_DIR"
   as_root rm -f "${UNIT_PATH%/*}/multi-user.target.wants/fleet-node.service"
   as_root rm -f "$UNIT_PATH"
@@ -446,6 +471,7 @@ source_dir="$work_dir/extracted/$ARCHIVE_ROOT"
 [[ -d "$source_dir" && ! -L "$source_dir" ]] || { echo "archive root must be a directory" >&2; exit 1; }
 for required in \
   fleetnode \
+  fleetnode-enroll \
   version.txt \
   fleet-node.service \
   plugins/proto-plugin \
@@ -465,7 +491,7 @@ fi
 while IFS= read -r -d '' path; do
   relative_path="${path#"$source_dir"/}"
   case "$relative_path" in
-    fleetnode|version.txt|fleet-node.service|plugins|plugins/proto-plugin|plugins/antminer-plugin|plugins/asicrs-plugin|plugins/asicrs-config.yaml) ;;
+    fleetnode|fleetnode-enroll|version.txt|fleet-node.service|plugins|plugins/proto-plugin|plugins/antminer-plugin|plugins/asicrs-plugin|plugins/asicrs-config.yaml) ;;
     *) echo "archive contains an unexpected entry: $relative_path" >&2; exit 1 ;;
   esac
 done < <(find "$source_dir" -mindepth 1 -print0)
@@ -518,6 +544,7 @@ fi
 
 ensure_shared_directory "${PROGRAM_DIR%/*}"
 ensure_shared_directory "${UNIT_PATH%/*}"
+ensure_shared_directory "${ENROLL_HELPER_PATH%/*}"
 
 if ! getent passwd fleetnode >/dev/null 2>&1; then
   if getent group fleetnode >/dev/null 2>&1; then
@@ -539,6 +566,7 @@ fi
 as_root rm -rf "$incoming" "$previous"
 as_root install -d -m 0755 "$incoming" "$incoming/plugins"
 as_root install -m 0755 "$source_dir/fleetnode" "$incoming/fleetnode"
+as_root install -m 0755 "$source_dir/fleetnode-enroll" "$incoming/fleetnode-enroll"
 as_root install -m 0644 "$source_dir/version.txt" "$incoming/version.txt"
 as_root install -m 0644 "$source_dir/fleet-node.service" "$incoming/fleet-node.service"
 as_root install -m 0755 "$source_dir/plugins/proto-plugin" "$incoming/plugins/proto-plugin"
@@ -554,6 +582,12 @@ if [[ -d "$PROGRAM_DIR" ]]; then
 fi
 as_root mv "$incoming" "$PROGRAM_DIR"
 program_replaced=1
+
+if [[ -f "$ENROLL_HELPER_PATH" ]]; then
+  as_root cp -p "$ENROLL_HELPER_PATH" "$enroll_helper_backup"
+fi
+enroll_helper_replaced=1
+as_root install -m 0755 "$PROGRAM_DIR/fleetnode-enroll" "$ENROLL_HELPER_PATH"
 
 if [[ -f "$UNIT_PATH" ]]; then
   as_root cp -p "$UNIT_PATH" "$unit_backup"
@@ -581,9 +615,7 @@ echo "Configuration: $CONFIG_DIR"
 echo "Protected state: $STATE_DIR"
 echo
 echo "Enroll:"
-echo "  sudo -u fleetnode $PROGRAM_DIR/fleetnode --state-dir $STATE_DIR enroll --server-url=https://YOUR-FLEET-SERVER"
-echo "Then enable and start the service:"
-echo "  sudo systemctl enable --now fleet-node.service"
+echo "  sudo fleetnode-enroll --server-url=https://YOUR-FLEET-SERVER"
 echo "Inspect:"
 echo "  systemctl status fleet-node.service"
 echo "  journalctl -u fleet-node.service"

--- a/deployment-files/fleetnode/install-fleet-node.sh
+++ b/deployment-files/fleetnode/install-fleet-node.sh
@@ -154,6 +154,9 @@ for path in "${PROGRAM_DIR%/*}" "${UNIT_PATH%/*}" "${ENROLL_HELPER_PATH%/*}" "$P
     if [[ "$ACTION" == "uninstall" && "$path" == "$UNIT_PATH" && "$path" -ef /dev/null ]]; then
       continue
     fi
+    if [[ "$ACTION" == "uninstall" && "$path" == "$ENROLL_HELPER_PATH" ]]; then
+      continue
+    fi
     echo "refusing to install through symlink: $path" >&2
     exit 1
   fi
@@ -387,7 +390,9 @@ cleanup() {
 }
 trap cleanup EXIT
 
-validate_existing_enroll_helper
+if [[ "$ACTION" == "install" ]]; then
+  validate_existing_enroll_helper
+fi
 
 remove_fleet_node() {
   local load_state
@@ -405,7 +410,11 @@ remove_fleet_node() {
     *) echo "unexpected Fleet Node systemd unit load state: $load_state" >&2; return 1 ;;
   esac
 
-  as_root rm -f "$ENROLL_HELPER_PATH"
+  if [[ -f "$ENROLL_HELPER_PATH" && ! -L "$ENROLL_HELPER_PATH" && \
+      -f "$PROGRAM_DIR/fleetnode-enroll" ]] && \
+      cmp -s "$PROGRAM_DIR/fleetnode-enroll" "$ENROLL_HELPER_PATH"; then
+    as_root rm -f "$ENROLL_HELPER_PATH"
+  fi
   as_root rm -rf "$PROGRAM_DIR"
   as_root rm -f "${UNIT_PATH%/*}/multi-user.target.wants/fleet-node.service"
   as_root rm -f "$UNIT_PATH"

--- a/deployment-files/fleetnode/tests/qualify-package.sh
+++ b/deployment-files/fleetnode/tests/qualify-package.sh
@@ -48,7 +48,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-for path in /opt/fleetnode /etc/fleetnode /var/lib/fleetnode /etc/systemd/system/fleet-node.service; do
+for path in /opt/fleetnode /etc/fleetnode /var/lib/fleetnode /etc/systemd/system/fleet-node.service /usr/local/bin/fleetnode-enroll; do
   [[ ! -e "$path" ]] || fail "runner is not clean: $path already exists"
 done
 getent passwd fleetnode >/dev/null 2>&1 && fail "runner already has a fleetnode account"
@@ -58,6 +58,11 @@ CLEANUP_ALLOWED=1
 run_installer "$VERSION"
 sudo systemctl is-active --quiet fleet-node.service && fail "fresh install started the unenrolled service"
 sudo systemctl is-enabled --quiet fleet-node.service && fail "fresh install enabled the service"
+[[ -x /usr/local/bin/fleetnode-enroll ]] || fail "enrollment helper was not installed"
+/usr/local/bin/fleetnode-enroll --help | grep -Fq "sudo fleetnode-enroll --server-url=URL" || \
+  fail "enrollment helper did not report its supported command"
+sudo systemctl is-active --quiet fleet-node.service && fail "enrollment helper help started the service"
+sudo systemctl is-enabled --quiet fleet-node.service && fail "enrollment helper help enabled the service"
 
 sudo tee /var/lib/fleetnode/state.yaml >/dev/null <<'EOF'
 server_url: http://127.0.0.1:1
@@ -103,6 +108,7 @@ WORK_DIR=""
 run_installer uninstall
 [[ ! -e /opt/fleetnode ]] || fail "uninstall retained the program"
 [[ ! -e /etc/systemd/system/fleet-node.service ]] || fail "uninstall retained the unit"
+[[ ! -e /usr/local/bin/fleetnode-enroll ]] || fail "uninstall retained the enrollment helper"
 sudo test -f /var/lib/fleetnode/state.yaml || fail "uninstall removed state"
 getent passwd fleetnode >/dev/null || fail "uninstall removed the service account"
 

--- a/deployment-files/fleetnode/tests/qualify-package.sh
+++ b/deployment-files/fleetnode/tests/qualify-package.sh
@@ -81,7 +81,7 @@ EOF
 sudo chown fleetnode:fleetnode /var/lib/fleetnode/state.yaml
 sudo chmod 0600 /var/lib/fleetnode/state.yaml
 
-sudo systemctl enable --now fleet-node.service
+sudo fleetnode-enroll --server-url=http://127.0.0.1:1 --allow-insecure-transport
 sudo systemctl is-active --quiet fleet-node.service || fail "installed service did not report ready"
 
 original_plugin_hash=$(sha256sum /opt/fleetnode/plugins/antminer-plugin | awk '{print $1}')

--- a/deployment-files/fleetnode/tests/test-fleetnode-enroll.sh
+++ b/deployment-files/fleetnode/tests/test-fleetnode-enroll.sh
@@ -21,6 +21,7 @@ printf '%s\n' "$*" >>"$CALLS"
 printf 'fleetnode:%s\n' "$*" >>"$TRACE"
 case " $* " in
   *" status "*)
+    printf 'server_url:            %s\n' "${MOCK_STATE_SERVER_URL:-https://fleet.example.com}"
     printf 'fleet_node_id:         %s\n' "${MOCK_FLEET_NODE_ID:-42}"
     printf 'api_key_present:       %s\n' "${MOCK_API_KEY_PRESENT:-false}"
     ;;
@@ -57,7 +58,7 @@ systemctl() {
 reset_test() {
   rm -f "$CALLS" "$SYSTEMCTL_CALLS" "$TRACE"
   rm -rf "$STATE_DIR"
-  unset MOCK_API_KEY_PRESENT MOCK_ENROLL_EXIT MOCK_FLEET_NODE_ID MOCK_REFRESH_EXIT MOCK_SYSTEMCTL_FAIL_ONCE
+  unset MOCK_API_KEY_PRESENT MOCK_ENROLL_EXIT MOCK_FLEET_NODE_ID MOCK_REFRESH_EXIT MOCK_STATE_SERVER_URL MOCK_SYSTEMCTL_FAIL_ONCE
 }
 
 assert_line() {
@@ -105,7 +106,7 @@ mkdir -p "$STATE_DIR"
 touch "$STATE_PATH"
 MOCK_API_KEY_PRESENT=false
 export MOCK_API_KEY_PRESENT
-main --server-url=https://fleet.example.com
+main --server-url https://fleet.example.com
 assert_line "$CALLS" "--state-dir $STATE_DIR status"
 assert_line "$CALLS" "--state-dir $STATE_DIR refresh"
 assert_no_line "$CALLS" " enroll "
@@ -117,7 +118,11 @@ mkdir -p "$STATE_DIR"
 touch "$STATE_PATH"
 MOCK_API_KEY_PRESENT=true
 export MOCK_API_KEY_PRESENT
-main --server-url=https://fleet.example.com
+complete_output=$(main --server-url=https://fleet.example.com)
+[[ "$complete_output" == *"already enrolled (fleet_node_id=42); enabling fleet-node.service"* ]] || {
+  echo "complete-state notice omitted the fleet node ID" >&2
+  exit 1
+}
 assert_line "$CALLS" "--state-dir $STATE_DIR status"
 assert_no_line "$CALLS" " enroll "
 assert_no_line "$CALLS" " refresh "
@@ -150,7 +155,53 @@ touch "$STATE_PATH"
 main --server-url=https://fleet.example.com --force
 assert_line "$CALLS" "--state-dir $STATE_DIR enroll --server-url=https://fleet.example.com --force"
 assert_no_line "$CALLS" " status"
+assert_line "$SYSTEMCTL_CALLS" "stop fleet-node.service"
 assert_line "$SYSTEMCTL_CALLS" "enable --now fleet-node.service"
+assert_sequence \
+  "systemctl:stop fleet-node.service" \
+  "fleetnode:--state-dir $STATE_DIR enroll --server-url=https://fleet.example.com --force"
+
+# A failed stop prevents forced enrollment from racing the running service.
+reset_test
+mkdir -p "$STATE_DIR"
+touch "$STATE_PATH"
+MOCK_SYSTEMCTL_FAIL_ONCE=1
+export MOCK_SYSTEMCTL_FAIL_ONCE
+if main --server-url=https://fleet.example.com --force; then
+  echo "forced enrollment continued after service stop failed" >&2
+  exit 1
+fi
+assert_line "$SYSTEMCTL_CALLS" "stop fleet-node.service"
+[[ ! -e "$CALLS" ]] || { echo "failed service stop ran fleetnode" >&2; exit 1; }
+assert_no_line "$SYSTEMCTL_CALLS" "enable --now"
+
+# Existing state must match the requested server before refresh or activation.
+reset_test
+mkdir -p "$STATE_DIR"
+touch "$STATE_PATH"
+MOCK_API_KEY_PRESENT=false
+MOCK_STATE_SERVER_URL=https://old-fleet.example.com
+export MOCK_API_KEY_PRESENT MOCK_STATE_SERVER_URL
+if mismatch_output=$(main --server-url=https://new-fleet.example.com 2>&1); then
+  echo "mismatched server URL unexpectedly succeeded" >&2
+  exit 1
+fi
+[[ "$mismatch_output" == *"server_url=https://old-fleet.example.com"* ]] || {
+  echo "server mismatch omitted the existing URL" >&2
+  exit 1
+}
+[[ "$mismatch_output" == *"server_url=https://new-fleet.example.com"* ]] || {
+  echo "server mismatch omitted the requested URL" >&2
+  exit 1
+}
+[[ "$mismatch_output" == *"pass --force"* ]] || {
+  echo "server mismatch omitted force recovery guidance" >&2
+  exit 1
+}
+assert_line "$CALLS" "--state-dir $STATE_DIR status"
+assert_no_line "$CALLS" " enroll "
+assert_no_line "$CALLS" " refresh "
+[[ ! -e "$SYSTEMCTL_CALLS" ]] || { echo "server mismatch called systemctl" >&2; exit 1; }
 
 # Failed enrollment and refresh attempts must not activate the service.
 reset_test

--- a/deployment-files/fleetnode/tests/test-fleetnode-enroll.sh
+++ b/deployment-files/fleetnode/tests/test-fleetnode-enroll.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "$SCRIPT_DIR/../fleetnode-enroll"
+
+TEST_DIR=$(mktemp -d)
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+FLEETNODE_BIN="$TEST_DIR/fleetnode"
+STATE_DIR="$TEST_DIR/state"
+STATE_PATH="$STATE_DIR/state.yaml"
+CALLS="$TEST_DIR/calls"
+SYSTEMCTL_CALLS="$TEST_DIR/systemctl-calls"
+TRACE="$TEST_DIR/trace"
+export CALLS STATE_DIR STATE_PATH TRACE
+
+cat >"$FLEETNODE_BIN" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$CALLS"
+printf 'fleetnode:%s\n' "$*" >>"$TRACE"
+case " $* " in
+  *" status "*)
+    printf 'fleet_node_id:         %s\n' "${MOCK_FLEET_NODE_ID:-42}"
+    printf 'api_key_present:       %s\n' "${MOCK_API_KEY_PRESENT:-false}"
+    ;;
+  *" enroll "*)
+    [[ "${MOCK_ENROLL_EXIT:-0}" == "0" ]] || exit "$MOCK_ENROLL_EXIT"
+    mkdir -p "$STATE_DIR"
+    touch "$STATE_PATH"
+    ;;
+  *" refresh "*) exit "${MOCK_REFRESH_EXIT:-0}" ;;
+esac
+EOF
+chmod 0755 "$FLEETNODE_BIN"
+
+id() {
+  [[ "${1:-}" == "-u" ]] && { printf '0\n'; return; }
+  command id "$@"
+}
+
+runuser() {
+  [[ "$1" == "-u" && "$2" == "fleetnode" && "$3" == "--" ]] || return 1
+  shift 3
+  "$@"
+}
+
+systemctl() {
+  printf '%s\n' "$*" >>"$SYSTEMCTL_CALLS"
+  printf 'systemctl:%s\n' "$*" >>"$TRACE"
+  if [[ "${MOCK_SYSTEMCTL_FAIL_ONCE:-0}" == "1" ]]; then
+    MOCK_SYSTEMCTL_FAIL_ONCE=0
+    return 1
+  fi
+}
+
+reset_test() {
+  rm -f "$CALLS" "$SYSTEMCTL_CALLS" "$TRACE"
+  rm -rf "$STATE_DIR"
+  unset MOCK_API_KEY_PRESENT MOCK_ENROLL_EXIT MOCK_FLEET_NODE_ID MOCK_REFRESH_EXIT MOCK_SYSTEMCTL_FAIL_ONCE
+}
+
+assert_line() {
+  local file="$1" expected="$2"
+  grep -Fxq -- "$expected" "$file" || {
+    echo "expected line not found in $file: $expected" >&2
+    [[ ! -f "$file" ]] || sed 's/^/  /' "$file" >&2
+    exit 1
+  }
+}
+
+assert_no_line() {
+  local file="$1" unexpected="$2"
+  if [[ -f "$file" ]] && grep -Fq -- "$unexpected" "$file"; then
+    echo "unexpected text found in $file: $unexpected" >&2
+    sed 's/^/  /' "$file" >&2
+    exit 1
+  fi
+}
+
+assert_sequence() {
+  local first="$1" second="$2"
+  [[ "$(sed -n '1p' "$TRACE")" == "$first" ]] || {
+    echo "unexpected first operation: $(sed -n '1p' "$TRACE")" >&2
+    exit 1
+  }
+  [[ "$(sed -n '2p' "$TRACE")" == "$second" ]] || {
+    echo "unexpected second operation: $(sed -n '2p' "$TRACE")" >&2
+    exit 1
+  }
+}
+
+# A fresh host enrolls with every caller-supplied argument before activation.
+reset_test
+main --server-url=https://fleet.example.com --name=test-node
+assert_line "$CALLS" "--state-dir $STATE_DIR enroll --server-url=https://fleet.example.com --name=test-node"
+assert_line "$SYSTEMCTL_CALLS" "enable --now fleet-node.service"
+assert_sequence \
+  "fleetnode:--state-dir $STATE_DIR enroll --server-url=https://fleet.example.com --name=test-node" \
+  "systemctl:enable --now fleet-node.service"
+
+# Partial state resumes the supported refresh flow, then activates the service.
+reset_test
+mkdir -p "$STATE_DIR"
+touch "$STATE_PATH"
+MOCK_API_KEY_PRESENT=false
+export MOCK_API_KEY_PRESENT
+main --server-url=https://fleet.example.com
+assert_line "$CALLS" "--state-dir $STATE_DIR status"
+assert_line "$CALLS" "--state-dir $STATE_DIR refresh"
+assert_no_line "$CALLS" " enroll "
+assert_line "$SYSTEMCTL_CALLS" "enable --now fleet-node.service"
+
+# Complete state only retries service activation.
+reset_test
+mkdir -p "$STATE_DIR"
+touch "$STATE_PATH"
+MOCK_API_KEY_PRESENT=true
+export MOCK_API_KEY_PRESENT
+main --server-url=https://fleet.example.com
+assert_line "$CALLS" "--state-dir $STATE_DIR status"
+assert_no_line "$CALLS" " enroll "
+assert_no_line "$CALLS" " refresh "
+assert_line "$SYSTEMCTL_CALLS" "enable --now fleet-node.service"
+
+# A service-start failure leaves complete state that the same command can retry.
+reset_test
+MOCK_API_KEY_PRESENT=true
+MOCK_SYSTEMCTL_FAIL_ONCE=1
+export MOCK_API_KEY_PRESENT MOCK_SYSTEMCTL_FAIL_ONCE
+if main --server-url=https://fleet.example.com; then
+  echo "failed service activation unexpectedly succeeded" >&2
+  exit 1
+fi
+main --server-url=https://fleet.example.com
+[[ "$(grep -Fc ' enroll ' "$CALLS")" == "1" ]] || {
+  echo "service activation retry reran enrollment" >&2
+  exit 1
+}
+assert_line "$CALLS" "--state-dir $STATE_DIR status"
+[[ "$(grep -Fc 'enable --now fleet-node.service' "$SYSTEMCTL_CALLS")" == "2" ]] || {
+  echo "service activation was not retried" >&2
+  exit 1
+}
+
+# --force always reaches enroll with the original arguments, even with state.
+reset_test
+mkdir -p "$STATE_DIR"
+touch "$STATE_PATH"
+main --server-url=https://fleet.example.com --force
+assert_line "$CALLS" "--state-dir $STATE_DIR enroll --server-url=https://fleet.example.com --force"
+assert_no_line "$CALLS" " status"
+assert_line "$SYSTEMCTL_CALLS" "enable --now fleet-node.service"
+
+# Failed enrollment and refresh attempts must not activate the service.
+reset_test
+MOCK_ENROLL_EXIT=1
+export MOCK_ENROLL_EXIT
+if main --server-url=https://fleet.example.com; then
+  echo "failed enrollment unexpectedly succeeded" >&2
+  exit 1
+fi
+[[ ! -e "$SYSTEMCTL_CALLS" ]] || { echo "failed enrollment called systemctl" >&2; exit 1; }
+
+reset_test
+mkdir -p "$STATE_DIR"
+touch "$STATE_PATH"
+MOCK_API_KEY_PRESENT=false
+MOCK_REFRESH_EXIT=1
+export MOCK_API_KEY_PRESENT MOCK_REFRESH_EXIT
+if main --server-url=https://fleet.example.com; then
+  echo "failed refresh unexpectedly succeeded" >&2
+  exit 1
+fi
+[[ ! -e "$SYSTEMCTL_CALLS" ]] || { echo "failed refresh called systemctl" >&2; exit 1; }
+
+echo "Fleet Node enrollment helper tests passed"

--- a/deployment-files/fleetnode/tests/test-install-fleetnode.sh
+++ b/deployment-files/fleetnode/tests/test-install-fleetnode.sh
@@ -40,6 +40,9 @@ create_release() {
 
   printf '#!/usr/bin/env bash\nexit 0\n' > "$release_dir/$archive_root/fleetnode"
   chmod 0755 "$release_dir/$archive_root/fleetnode"
+  cp "$FLEETNODE_DIR/fleetnode-enroll" "$release_dir/$archive_root/fleetnode-enroll"
+  printf '# fixture version: %s\n' "$version" >> "$release_dir/$archive_root/fleetnode-enroll"
+  chmod 0755 "$release_dir/$archive_root/fleetnode-enroll"
   printf 'version: %s\n' "$version" > "$release_dir/$archive_root/version.txt"
   cp "$FLEETNODE_DIR/fleet-node.service" "$release_dir/$archive_root/fleet-node.service"
   if [[ -n "$unit_marker" ]]; then
@@ -363,7 +366,7 @@ if grep -Eq '^(stop|start) fleet-node.service$' "$SYSTEMCTL_LOG"; then
 fi
 rm -f "$ROOT_PREFIX/etc/systemd/system/fleet-node.service"
 
-CURL_HOME="$TEST_DIR/curl-home" FAKE_FLEETNODE_ENABLED=1 run_installer v1.0.0
+CURL_HOME="$TEST_DIR/curl-home" FAKE_FLEETNODE_ENABLED=1 run_installer v1.0.0 > "$TEST_DIR/fresh-install.out"
 
 [[ "$(file_mode "$ROOT_PREFIX/opt")" == "711" ]] || fail "installer changed /opt mode"
 [[ "$(file_mode "$ROOT_PREFIX/etc/systemd/system")" == "751" ]] || fail "installer changed systemd directory mode"
@@ -374,6 +377,14 @@ assert_file_contains "$FLEETNODE_DIR/install-fleet-node.sh" "--retry-delay 2"
 assert_file_contains "$FLEETNODE_DIR/install-fleet-node.sh" "--retry-connrefused"
 
 [[ -x "$ROOT_PREFIX/opt/fleetnode/fleetnode" ]] || fail "Fleet Node binary was not installed"
+[[ -x "$ROOT_PREFIX/usr/local/bin/fleetnode-enroll" ]] || fail "Fleet Node enrollment helper was not installed"
+cmp -s "$ROOT_PREFIX/opt/fleetnode/fleetnode-enroll" "$ROOT_PREFIX/usr/local/bin/fleetnode-enroll" || \
+  fail "installed enrollment helper differs from packaged helper"
+assert_file_contains "$ROOT_PREFIX/usr/local/bin/fleetnode-enroll" "# fixture version: v1.0.0"
+assert_file_contains "$TEST_DIR/fresh-install.out" "sudo fleetnode-enroll --server-url=https://YOUR-FLEET-SERVER"
+if grep -Fq "sudo -u fleetnode" "$TEST_DIR/fresh-install.out"; then
+  fail "installer still printed the internal enrollment command"
+fi
 [[ ! -e "$ROOT_PREFIX/opt/fleetnode/plugins/virtual-plugin" ]] || fail "customer package installed the virtual test plugin"
 assert_file_contains "$ROOT_PREFIX/opt/fleetnode/version.txt" "version: v1.0.0"
 [[ -f "$ROOT_PREFIX/etc/systemd/system/fleet-node.service" ]] || fail "systemd unit was not installed"
@@ -406,6 +417,19 @@ fi
 printf 'operator config\n' > "$ROOT_PREFIX/etc/fleetnode/config.yaml"
 printf 'identity material\n' > "$ROOT_PREFIX/var/lib/fleetnode/state.yaml"
 printf 'stale program file\n' > "$ROOT_PREFIX/opt/fleetnode/stale.txt"
+
+printf 'unmanaged helper\n' > "$ROOT_PREFIX/usr/local/bin/fleetnode-enroll"
+: > "$SYSTEMCTL_LOG"
+if run_installer v1.1.0 > "$TEST_DIR/unmanaged-helper.out" 2>&1; then
+  fail "installer replaced an unmanaged enrollment helper"
+fi
+assert_file_contains "$TEST_DIR/unmanaged-helper.out" "refusing to replace unmanaged enrollment helper"
+assert_file_contains "$ROOT_PREFIX/opt/fleetnode/version.txt" "version: v1.0.0"
+if grep -Fq 'stop fleet-node.service' "$SYSTEMCTL_LOG"; then
+  fail "installer stopped the service before validating the enrollment helper"
+fi
+cp "$ROOT_PREFIX/opt/fleetnode/fleetnode-enroll" "$ROOT_PREFIX/usr/local/bin/fleetnode-enroll"
+chmod 0755 "$ROOT_PREFIX/usr/local/bin/fleetnode-enroll"
 
 : > "$SYSTEMCTL_LOG"
 if FAKE_PRIMARY_GID_USER=operator run_installer v1.1.0 > "$TEST_DIR/shared-primary-gid-install.out" 2>&1; then
@@ -441,6 +465,7 @@ chmod 0777 "$ROOT_PREFIX/etc/fleetnode" "$ROOT_PREFIX/var/lib/fleetnode"
 run_installer v1.1.0
 
 assert_file_contains "$ROOT_PREFIX/opt/fleetnode/version.txt" "version: v1.1.0"
+assert_file_contains "$ROOT_PREFIX/usr/local/bin/fleetnode-enroll" "# fixture version: v1.1.0"
 [[ ! -e "$ROOT_PREFIX/opt/fleetnode/stale.txt" ]] || fail "upgrade retained stale program files"
 assert_file_contains "$ROOT_PREFIX/etc/fleetnode/config.yaml" "operator config"
 assert_file_contains "$ROOT_PREFIX/var/lib/fleetnode/state.yaml" "identity material"
@@ -456,6 +481,7 @@ if FAKE_SYSTEMCTL_FAIL_START_ONCE="$FAIL_START_ONCE" run_installer v1.3.0 > "$TE
   fail "installer accepted an upgrade whose service did not become ready"
 fi
 assert_file_contains "$ROOT_PREFIX/opt/fleetnode/version.txt" "version: v1.1.0"
+assert_file_contains "$ROOT_PREFIX/usr/local/bin/fleetnode-enroll" "# fixture version: v1.1.0"
 if grep -Fq '# candidate unit v1.3.0' "$ROOT_PREFIX/etc/systemd/system/fleet-node.service"; then
   fail "failed upgrade retained the candidate systemd unit"
 fi
@@ -627,6 +653,7 @@ rm -f "$ROOT_PREFIX/etc/systemd/system/fleet-node.service"
 FAKE_FLEETNODE_LOAD_STATE=loaded run_uninstaller
 [[ ! -e "$ROOT_PREFIX/opt/fleetnode" ]] || fail "uninstall retained the program"
 [[ ! -e "$ROOT_PREFIX/etc/systemd/system/fleet-node.service" ]] || fail "uninstall retained the unit"
+[[ ! -e "$ROOT_PREFIX/usr/local/bin/fleetnode-enroll" ]] || fail "uninstall retained the enrollment helper"
 [[ -e "$ROOT_PREFIX/etc/fleetnode/config.yaml" ]] || fail "uninstall removed configuration"
 [[ -e "$ROOT_PREFIX/var/lib/fleetnode/state.yaml" ]] || fail "uninstall removed state"
 [[ -e "$ACCOUNT_DB/user" && -e "$ACCOUNT_DB/group" ]] || fail "uninstall removed the service account"

--- a/deployment-files/fleetnode/tests/test-install-fleetnode.sh
+++ b/deployment-files/fleetnode/tests/test-install-fleetnode.sh
@@ -659,6 +659,33 @@ FAKE_FLEETNODE_LOAD_STATE=loaded run_uninstaller
 [[ -e "$ACCOUNT_DB/user" && -e "$ACCOUNT_DB/group" ]] || fail "uninstall removed the service account"
 assert_file_contains "$SYSTEMCTL_LOG" "stop fleet-node.service"
 
+rm -f "$ROOT_PREFIX/usr/local/bin/fleetnode-enroll"
+run_installer v1.3.0
+rm -f "$ROOT_PREFIX/opt/fleetnode/fleetnode-enroll"
+printf 'unrelated helper\n' > "$ROOT_PREFIX/usr/local/bin/fleetnode-enroll"
+
+: > "$SYSTEMCTL_LOG"
+FAKE_FLEETNODE_LOAD_STATE=loaded run_uninstaller
+[[ ! -e "$ROOT_PREFIX/opt/fleetnode" ]] || fail "damaged uninstall retained the program"
+[[ ! -e "$ROOT_PREFIX/etc/systemd/system/fleet-node.service" ]] || fail "damaged uninstall retained the unit"
+assert_file_contains "$ROOT_PREFIX/usr/local/bin/fleetnode-enroll" "unrelated helper"
+[[ -e "$ROOT_PREFIX/etc/fleetnode/config.yaml" ]] || fail "damaged uninstall removed configuration"
+[[ -e "$ROOT_PREFIX/var/lib/fleetnode/state.yaml" ]] || fail "damaged uninstall removed state"
+[[ -e "$ACCOUNT_DB/user" && -e "$ACCOUNT_DB/group" ]] || fail "damaged uninstall removed the service account"
+
+rm -f "$ROOT_PREFIX/usr/local/bin/fleetnode-enroll"
+run_installer v1.3.0
+rm -f "$ROOT_PREFIX/usr/local/bin/fleetnode-enroll"
+printf 'unrelated helper target\n' > "$TEST_DIR/unrelated-fleetnode-enroll"
+ln -s "$TEST_DIR/unrelated-fleetnode-enroll" "$ROOT_PREFIX/usr/local/bin/fleetnode-enroll"
+
+: > "$SYSTEMCTL_LOG"
+FAKE_FLEETNODE_LOAD_STATE=loaded run_uninstaller
+[[ ! -e "$ROOT_PREFIX/opt/fleetnode" ]] || fail "symlink-helper uninstall retained the program"
+[[ ! -e "$ROOT_PREFIX/etc/systemd/system/fleet-node.service" ]] || fail "symlink-helper uninstall retained the unit"
+[[ -L "$ROOT_PREFIX/usr/local/bin/fleetnode-enroll" ]] || fail "uninstall removed an unmanaged helper symlink"
+assert_file_contains "$ROOT_PREFIX/usr/local/bin/fleetnode-enroll" "unrelated helper target"
+
 : > "$SYSTEMCTL_LOG"
 mkdir -p "$ROOT_PREFIX/etc/systemd/system/multi-user.target.wants"
 ln -s "$ROOT_PREFIX/etc/systemd/system/fleet-node.service" \


### PR DESCRIPTION
Reviewable diff: +84/-8 across 5 files (excludes generated, test, and story files).

## Summary

Fleet Node enrollment is now a single copy/paste command: `sudo fleetnode-enroll --server-url=...`. The packaged helper owns the service-account, state-directory, and systemd details, so operators no longer need the verbose internal command or a separate service-start step.

**Stack:** [#990 Make Fleet Node startup readiness explicit](https://github.com/block/proto-fleet/pull/990) → [#991 Complete the Fleet Node installer lifecycle](https://github.com/block/proto-fleet/pull/991) → [#992 Qualify Fleet Node release artifacts](https://github.com/block/proto-fleet/pull/992) → **#989 (this PR)**. This diff is relative to #992. The upstream PRs establish the service-readiness, transactional installer, and clean-host qualification contracts that this helper extends; broader release/distribution work remains outside this PR.

## How it works

The release artifact includes `fleetnode-enroll`, and the installer places a managed copy at `/usr/local/bin/fleetnode-enroll`. The operator UI builds the server URL exactly as before, but now displays the short helper command. The helper runs the installed Fleet Node binary as the `fleetnode` service account with `/var/lib/fleetnode` as its state directory, then enables and starts `fleet-node.service` only after enrollment succeeds.

Installer upgrades treat the helper like the binary and unit: an existing managed copy is backed up and restored if installation fails, while an unrelated file at the global path is rejected rather than overwritten. Uninstall and purge remove the managed helper.

## Diagrams

```mermaid
flowchart LR
    A["Operator copies sudo fleetnode-enroll command"] --> B["Managed helper in /usr/local/bin"]
    B --> C["Fleet Node runs as fleetnode user"]
    C --> D["Enrollment state is written to /var/lib/fleetnode"]
    D --> E["systemd enables and starts fleet-node.service"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `deployment-files/fleetnode/fleetnode-enroll` | Adds the operator-facing enrollment entry point | Confirm privilege boundaries, argument forwarding, and start-after-success ordering |
| `deployment-files/fleetnode/install-fleet-node.sh` | Installs, validates, rolls back, and removes the helper | Confirm upgrades remain transactional and do not overwrite unmanaged files |
| `.github/workflows/` | Packages the helper and syntax-checks it in deployment CI | Confirms every published Fleet Node artifact contains the command shown by the UI |
| `client/.../Nodes/enrollNodeCommand.ts` | Produces the concise command while retaining existing URL and HTTP transport rules | Confirm UI output matches the installed package contract |
| Installer, qualification, and client tests | Cover install/upgrade/removal behavior and exact UI output | Prevents packaging and operator guidance from drifting apart |

## Key technical decisions & trade-offs

- Install a dedicated `fleetnode-enroll` helper instead of placing the raw `fleetnode` binary on `PATH`; this keeps the full CLI privilege model explicit while making the supported enrollment workflow concise.
- Keep the helper root-owned and switch only the enrollment process to the `fleetnode` account; systemd enablement still has the privilege it requires.
- Start the service only after successful enrollment; a canceled or failed enrollment leaves lifecycle state unchanged.
- Reject an unrelated `/usr/local/bin/fleetnode-enroll` instead of overwriting it, trading automatic replacement for safe host ownership boundaries.

## Testing & validation

- `bash deployment-files/fleetnode/tests/test-install-fleetnode.sh`
- `bash -n` for the helper, installer, installer tests, and package qualification script
- `vitest --run` for `enrollNodeCommand.test.ts` and `EnrollNodeModal.test.tsx`: 13 tests passed
- Client ESLint passed with zero warnings; targeted Prettier check passed
- Workflow YAML parsed successfully; `git diff --check` passed
- Not manually exercised against a live Fleet server; clean-host package qualification verifies installation and non-mutating helper help, while CI performs the architecture-specific artifact checks
