### PR TITLE
Make Fleet Node startup readiness explicit

### DIFF
--- a/deployment-files/fleetnode/fleet-node.service
+++ b/deployment-files/fleetnode/fleet-node.service
@@ -5,7 +5,8 @@ Wants=network-online.target
 After=network-online.target
 
 [Service]
-Type=simple
+Type=notify
+NotifyAccess=main
 User=fleetnode
 Group=fleetnode
 Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
@@ -13,6 +14,8 @@ EnvironmentFile=-/etc/fleetnode/fleetnode.env
 ExecStart=/usr/bin/env PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin /opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode run
 Restart=on-failure
 RestartSec=5s
+RestartPreventExitStatus=78
+TimeoutStartSec=120s
 TimeoutStopSec=90s
 NoNewPrivileges=true
 PrivateTmp=true

--- a/deployment-files/fleetnode/fleet-node.service
+++ b/deployment-files/fleetnode/fleet-node.service
@@ -15,7 +15,7 @@ ExecStart=/usr/bin/env PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/s
 Restart=on-failure
 RestartSec=5s
 RestartPreventExitStatus=78
-TimeoutStartSec=120s
+TimeoutStartSec=180s
 TimeoutStopSec=90s
 NoNewPrivileges=true
 PrivateTmp=true

--- a/deployment-files/fleetnode/fleet-node.service
+++ b/deployment-files/fleetnode/fleet-node.service
@@ -15,7 +15,7 @@ ExecStart=/usr/bin/env PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/s
 Restart=on-failure
 RestartSec=5s
 RestartPreventExitStatus=78
-TimeoutStartSec=180s
+TimeoutStartSec=300s
 TimeoutStopSec=90s
 NoNewPrivileges=true
 PrivateTmp=true

--- a/deployment-files/fleetnode/install-fleet-node.sh
+++ b/deployment-files/fleetnode/install-fleet-node.sh
@@ -174,6 +174,9 @@ cleanup() {
     rollback_failed=1
   }
   if [[ "$install_complete" != "1" ]]; then
+    if [[ "$service_stopped" == "1" ]]; then
+      as_root "$SYSTEMCTL" stop fleet-node.service || rollback_error "stop candidate Fleet Node service"
+    fi
     if [[ "$unit_replaced" == "1" ]]; then
       if [[ -f "$unit_backup" ]]; then
         as_root install -m 0644 "$unit_backup" "$UNIT_PATH" || rollback_error "restore previous systemd unit"
@@ -275,8 +278,10 @@ if ! grep -Fxq "version: $VERSION" "$source_dir/version.txt"; then
 fi
 
 if [[ "$fresh_install" == "0" ]]; then
-  as_root "$SYSTEMCTL" stop fleet-node.service
-  service_stopped=1
+  if as_root "$SYSTEMCTL" is-active --quiet fleet-node.service; then
+    as_root "$SYSTEMCTL" stop fleet-node.service
+    service_stopped=1
+  fi
 fi
 
 as_root install -d -m 0755 "${PROGRAM_DIR%/*}" "${UNIT_PATH%/*}"
@@ -332,7 +337,9 @@ else
   # Type=notify keeps this call blocked until Fleet Node finishes local
   # initialization and reports READY=1, so the previous payload remains
   # available to the EXIT trap until the candidate is actually runnable.
-  as_root "$SYSTEMCTL" start fleet-node.service
+  if [[ "$service_stopped" == "1" ]]; then
+    as_root "$SYSTEMCTL" start fleet-node.service
+  fi
 fi
 
 install_complete=1

--- a/deployment-files/fleetnode/install-fleet-node.sh
+++ b/deployment-files/fleetnode/install-fleet-node.sh
@@ -21,8 +21,8 @@ Usage: install-fleet-node.sh VERSION
 Install one exact Proto Fleet Node release on Linux. VERSION must be a
 release-specific tag such as v1.2.3 or nightly-20260825-0123456789ab.
 
-The installer starts the service but leaves a fresh installation disabled at
-boot. After installation, enroll the node and then enable the service.
+The installer leaves a fresh installation stopped and disabled at boot. After
+installation, enroll the node and then enable and start the service.
 EOF
 }
 
@@ -167,23 +167,29 @@ install_complete=0
 
 cleanup() {
   status=$?
+  set +e
+  rollback_failed=0
+  rollback_error() {
+    echo "rollback failed: $*" >&2
+    rollback_failed=1
+  }
   if [[ "$install_complete" != "1" ]]; then
     if [[ "$unit_replaced" == "1" ]]; then
       if [[ -f "$unit_backup" ]]; then
-        as_root install -m 0644 "$unit_backup" "$UNIT_PATH"
+        as_root install -m 0644 "$unit_backup" "$UNIT_PATH" || rollback_error "restore previous systemd unit"
       else
-        as_root rm -f "$UNIT_PATH"
+        as_root rm -f "$UNIT_PATH" || rollback_error "remove candidate systemd unit"
       fi
-      as_root "$SYSTEMCTL" daemon-reload >/dev/null 2>&1 || true
+      as_root "$SYSTEMCTL" daemon-reload || rollback_error "reload systemd after restoring previous unit"
     fi
     if [[ "$program_replaced" == "1" ]]; then
-      as_root rm -rf "$PROGRAM_DIR"
+      as_root rm -rf "$PROGRAM_DIR" || rollback_error "remove candidate Fleet Node payload"
     fi
     if [[ "$previous_saved" == "1" && -d "$previous" ]]; then
-      as_root mv "$previous" "$PROGRAM_DIR"
+      as_root mv "$previous" "$PROGRAM_DIR" || rollback_error "restore previous Fleet Node payload"
     fi
     if [[ "$service_stopped" == "1" ]]; then
-      as_root "$SYSTEMCTL" start fleet-node.service >/dev/null 2>&1 || true
+      as_root "$SYSTEMCTL" start fleet-node.service || rollback_error "restart previous Fleet Node service"
     fi
   fi
   if [[ -n "$INSTALL_LOCK_PID" ]]; then
@@ -194,6 +200,9 @@ cleanup() {
   as_root rm -rf "$work_dir" "$incoming"
   if [[ "$install_complete" == "1" ]]; then
     as_root rm -rf "$previous"
+  fi
+  if [[ "$rollback_failed" == "1" ]]; then
+    status=1
   fi
   exit "$status"
 }
@@ -319,8 +328,12 @@ if [[ "$fresh_install" == "1" ]]; then
   if as_root "$SYSTEMCTL" is-enabled --quiet fleet-node.service; then
     as_root "$SYSTEMCTL" disable fleet-node.service
   fi
+else
+  # Type=notify keeps this call blocked until Fleet Node finishes local
+  # initialization and reports READY=1, so the previous payload remains
+  # available to the EXIT trap until the candidate is actually runnable.
+  as_root "$SYSTEMCTL" start fleet-node.service
 fi
-as_root "$SYSTEMCTL" start fleet-node.service
 
 install_complete=1
 echo "Fleet Node $VERSION installed."
@@ -329,8 +342,8 @@ echo "Protected state: $STATE_DIR"
 echo
 echo "Enroll:"
 echo "  sudo -u fleetnode $PROGRAM_DIR/fleetnode --state-dir $STATE_DIR enroll --server-url=https://YOUR-FLEET-SERVER"
-echo "Then enable at boot:"
-echo "  sudo systemctl enable fleet-node.service"
+echo "Then enable and start the service:"
+echo "  sudo systemctl enable --now fleet-node.service"
 echo "Inspect:"
 echo "  systemctl status fleet-node.service"
 echo "  journalctl -u fleet-node.service"

--- a/deployment-files/fleetnode/tests/test-install-fleetnode.sh
+++ b/deployment-files/fleetnode/tests/test-install-fleetnode.sh
@@ -229,7 +229,7 @@ assert_file_contains "$ROOT_PREFIX/etc/systemd/system/fleet-node.service" "Type=
 assert_file_contains "$ROOT_PREFIX/etc/systemd/system/fleet-node.service" "NotifyAccess=main"
 assert_file_contains "$ROOT_PREFIX/etc/systemd/system/fleet-node.service" "Restart=on-failure"
 assert_file_contains "$ROOT_PREFIX/etc/systemd/system/fleet-node.service" "RestartPreventExitStatus=78"
-assert_file_contains "$ROOT_PREFIX/etc/systemd/system/fleet-node.service" "TimeoutStartSec=180s"
+assert_file_contains "$ROOT_PREFIX/etc/systemd/system/fleet-node.service" "TimeoutStartSec=300s"
 assert_file_contains "$ROOT_PREFIX/etc/systemd/system/fleet-node.service" "RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK"
 assert_file_contains "$ROOT_PREFIX/etc/systemd/system/fleetnode.service" "legacy unit"
 if grep -Eq '(^| )enable( |$)|(^| )stop( |$)' "$SYSTEMCTL_LOG"; then

--- a/deployment-files/fleetnode/tests/test-install-fleetnode.sh
+++ b/deployment-files/fleetnode/tests/test-install-fleetnode.sh
@@ -27,6 +27,7 @@ assert_file_contains() {
 create_release() {
   local version="$1"
   local extra_entry="${2:-}"
+  local unit_marker="${3:-}"
   local release_dir="$ASSETS_DIR/$version"
   local archive_root="fleetnode-${version}-linux-amd64"
   mkdir -p "$release_dir/$archive_root/plugins"
@@ -35,6 +36,9 @@ create_release() {
   chmod 0755 "$release_dir/$archive_root/fleetnode"
   printf 'version: %s\n' "$version" > "$release_dir/$archive_root/version.txt"
   cp "$FLEETNODE_DIR/fleet-node.service" "$release_dir/$archive_root/fleet-node.service"
+  if [[ -n "$unit_marker" ]]; then
+    printf '%s\n' "$unit_marker" >> "$release_dir/$archive_root/fleet-node.service"
+  fi
 
   local plugin
   for plugin in proto-plugin antminer-plugin virtual-plugin asicrs-plugin; do
@@ -88,6 +92,15 @@ fi
 if [[ "${1:-}" == "is-enabled" ]]; then
   [[ "${FAKE_FLEETNODE_ENABLED:-0}" == "1" ]]
   exit
+fi
+if [[ "${1:-}" == "start" ]]; then
+  if [[ "${FAKE_SYSTEMCTL_FAIL_START:-0}" == "1" ]]; then
+    exit 1
+  fi
+  if [[ -n "${FAKE_SYSTEMCTL_FAIL_START_ONCE:-}" && -e "$FAKE_SYSTEMCTL_FAIL_START_ONCE" ]]; then
+    rm -f "$FAKE_SYSTEMCTL_FAIL_START_ONCE"
+    exit 1
+  fi
 fi
 exit 0
 EOF
@@ -157,6 +170,7 @@ assert_file_contains "$TEST_DIR/systemctl-override.err" "installer overrides are
 create_release v1.0.0
 create_release v1.1.0
 create_release v1.2.0 unexpected-setuid
+create_release v1.3.0 "" "# candidate unit v1.3.0"
 
 mkdir -p "$TEST_DIR/curl-home"
 printf 'proto = "=https"\n' > "$TEST_DIR/curl-home/.curlrc"
@@ -166,6 +180,8 @@ run_installer() {
   FAKE_FLEETNODE_ENABLED="${FAKE_FLEETNODE_ENABLED:-0}" \
   FAKE_FLEETNODE_LOCK_READY="${FAKE_FLEETNODE_LOCK_READY:-}" \
   FAKE_FLEETNODE_LOCK_BLOCK="${FAKE_FLEETNODE_LOCK_BLOCK:-}" \
+  FAKE_SYSTEMCTL_FAIL_START="${FAKE_SYSTEMCTL_FAIL_START:-0}" \
+  FAKE_SYSTEMCTL_FAIL_START_ONCE="${FAKE_SYSTEMCTL_FAIL_START_ONCE:-}" \
   REAL_FLOCK="${REAL_FLOCK:-}" \
   SYSTEMCTL_LOG="$SYSTEMCTL_LOG" \
   SUDO_LOG="$SUDO_LOG" \
@@ -209,7 +225,11 @@ assert_file_contains "$ROOT_PREFIX/opt/fleetnode/version.txt" "version: v1.0.0"
 [[ -f "$ROOT_PREFIX/etc/systemd/system/fleet-node.service" ]] || fail "systemd unit was not installed"
 assert_file_contains "$ROOT_PREFIX/etc/systemd/system/fleet-node.service" "Environment=PATH=$LINUX_SERVICE_PATH"
 assert_file_contains "$ROOT_PREFIX/etc/systemd/system/fleet-node.service" "ExecStart=/usr/bin/env PATH=$LINUX_SERVICE_PATH /opt/fleetnode/fleetnode --state-dir /var/lib/fleetnode run"
+assert_file_contains "$ROOT_PREFIX/etc/systemd/system/fleet-node.service" "Type=notify"
+assert_file_contains "$ROOT_PREFIX/etc/systemd/system/fleet-node.service" "NotifyAccess=main"
 assert_file_contains "$ROOT_PREFIX/etc/systemd/system/fleet-node.service" "Restart=on-failure"
+assert_file_contains "$ROOT_PREFIX/etc/systemd/system/fleet-node.service" "RestartPreventExitStatus=78"
+assert_file_contains "$ROOT_PREFIX/etc/systemd/system/fleet-node.service" "TimeoutStartSec=120s"
 assert_file_contains "$ROOT_PREFIX/etc/systemd/system/fleet-node.service" "RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK"
 assert_file_contains "$ROOT_PREFIX/etc/systemd/system/fleetnode.service" "legacy unit"
 if grep -Eq '(^| )enable( |$)|(^| )stop( |$)' "$SYSTEMCTL_LOG"; then
@@ -219,8 +239,12 @@ if grep -Fq 'fleetnode.service' "$SYSTEMCTL_LOG"; then
   fail "installer operated on the old systemd unit"
 fi
 assert_file_contains "$SYSTEMCTL_LOG" "disable fleet-node.service"
-assert_file_contains "$SYSTEMCTL_LOG" "start fleet-node.service"
-assert_file_contains "$SUDO_LOG" "$TEST_DIR/bin/systemctl start fleet-node.service"
+if grep -Fq 'start fleet-node.service' "$SYSTEMCTL_LOG"; then
+  fail "fresh install started the unenrolled service"
+fi
+if grep -Fq "$TEST_DIR/bin/systemctl start fleet-node.service" "$SUDO_LOG"; then
+  fail "fresh install asked sudo to start the unenrolled service"
+fi
 if grep -Fq 'install-fleet-node.sh' "$SUDO_LOG"; then
   fail "installer asked sudo to rerun the whole script"
 fi
@@ -238,6 +262,26 @@ assert_file_contains "$ROOT_PREFIX/etc/fleetnode/config.yaml" "operator config"
 assert_file_contains "$ROOT_PREFIX/var/lib/fleetnode/state.yaml" "identity material"
 assert_file_contains "$SYSTEMCTL_LOG" "stop fleet-node.service"
 assert_file_contains "$SYSTEMCTL_LOG" "start fleet-node.service"
+
+FAIL_START_ONCE="$TEST_DIR/fail-upgrade-start-once"
+: > "$FAIL_START_ONCE"
+: > "$SYSTEMCTL_LOG"
+if FAKE_SYSTEMCTL_FAIL_START_ONCE="$FAIL_START_ONCE" run_installer v1.3.0 > "$TEST_DIR/failed-upgrade.out" 2>&1; then
+  fail "installer accepted an upgrade whose service did not become ready"
+fi
+assert_file_contains "$ROOT_PREFIX/opt/fleetnode/version.txt" "version: v1.1.0"
+if grep -Fq '# candidate unit v1.3.0' "$ROOT_PREFIX/etc/systemd/system/fleet-node.service"; then
+  fail "failed upgrade retained the candidate systemd unit"
+fi
+[[ "$(grep -Fc 'start fleet-node.service' "$SYSTEMCTL_LOG")" == "2" ]] || \
+  fail "failed upgrade did not start the candidate and then restart the previous service"
+
+: > "$SYSTEMCTL_LOG"
+if FAKE_SYSTEMCTL_FAIL_START=1 run_installer v1.3.0 > "$TEST_DIR/failed-rollback.out" 2>&1; then
+  fail "installer accepted an upgrade whose candidate and rollback restart both failed"
+fi
+assert_file_contains "$TEST_DIR/failed-rollback.out" "rollback failed: restart previous Fleet Node service"
+assert_file_contains "$ROOT_PREFIX/opt/fleetnode/version.txt" "version: v1.1.0"
 
 if REAL_FLOCK_BINARY=$(command -v flock 2>/dev/null); then
   LOCK_READY="$TEST_DIR/installer-lock.ready"

--- a/deployment-files/fleetnode/tests/test-install-fleetnode.sh
+++ b/deployment-files/fleetnode/tests/test-install-fleetnode.sh
@@ -229,7 +229,7 @@ assert_file_contains "$ROOT_PREFIX/etc/systemd/system/fleet-node.service" "Type=
 assert_file_contains "$ROOT_PREFIX/etc/systemd/system/fleet-node.service" "NotifyAccess=main"
 assert_file_contains "$ROOT_PREFIX/etc/systemd/system/fleet-node.service" "Restart=on-failure"
 assert_file_contains "$ROOT_PREFIX/etc/systemd/system/fleet-node.service" "RestartPreventExitStatus=78"
-assert_file_contains "$ROOT_PREFIX/etc/systemd/system/fleet-node.service" "TimeoutStartSec=120s"
+assert_file_contains "$ROOT_PREFIX/etc/systemd/system/fleet-node.service" "TimeoutStartSec=180s"
 assert_file_contains "$ROOT_PREFIX/etc/systemd/system/fleet-node.service" "RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK"
 assert_file_contains "$ROOT_PREFIX/etc/systemd/system/fleetnode.service" "legacy unit"
 if grep -Eq '(^| )enable( |$)|(^| )stop( |$)' "$SYSTEMCTL_LOG"; then

--- a/deployment-files/fleetnode/tests/test-install-fleetnode.sh
+++ b/deployment-files/fleetnode/tests/test-install-fleetnode.sh
@@ -93,6 +93,10 @@ if [[ "${1:-}" == "is-enabled" ]]; then
   [[ "${FAKE_FLEETNODE_ENABLED:-0}" == "1" ]]
   exit
 fi
+if [[ "${1:-}" == "is-active" ]]; then
+  [[ "${FAKE_FLEETNODE_ACTIVE:-0}" == "1" ]]
+  exit
+fi
 if [[ "${1:-}" == "start" ]]; then
   if [[ "${FAKE_SYSTEMCTL_FAIL_START:-0}" == "1" ]]; then
     exit 1
@@ -154,9 +158,7 @@ assert_file_contains "$TEST_DIR/missing-nmap.err" "required command not found: n
 assert_file_contains "$FLEETNODE_DIR/install-fleet-node.sh" "LINUX_SERVICE_PATH=\"$LINUX_SERVICE_PATH\""
 assert_file_contains "$FLEETNODE_DIR/install-fleet-node.sh" "PATH=\"\$LINUX_SERVICE_PATH\""
 assert_file_contains "$FLEETNODE_DIR/install-fleet-node.sh" "as_root flock -n \"\$INSTALL_LOCK_PATH\""
-if grep -Fq 'is-active' "$FLEETNODE_DIR/install-fleet-node.sh"; then
-  fail "installer checks active state before restarting"
-fi
+assert_file_contains "$FLEETNODE_DIR/install-fleet-node.sh" 'is-active --quiet fleet-node.service'
 if grep -Fq 'fleetnode.service' "$FLEETNODE_DIR/install-fleet-node.sh"; then
   fail "installer contains a migration path for the old systemd unit"
 fi
@@ -178,6 +180,7 @@ printf 'proto = "=https"\n' > "$TEST_DIR/curl-home/.curlrc"
 run_installer() {
   local version="$1"
   FAKE_FLEETNODE_ENABLED="${FAKE_FLEETNODE_ENABLED:-0}" \
+  FAKE_FLEETNODE_ACTIVE="${FAKE_FLEETNODE_ACTIVE:-1}" \
   FAKE_FLEETNODE_LOCK_READY="${FAKE_FLEETNODE_LOCK_READY:-}" \
   FAKE_FLEETNODE_LOCK_BLOCK="${FAKE_FLEETNODE_LOCK_BLOCK:-}" \
   FAKE_SYSTEMCTL_FAIL_START="${FAKE_SYSTEMCTL_FAIL_START:-0}" \
@@ -198,6 +201,7 @@ start_installer() {
   local version="$1"
   local output_path="$2"
   FAKE_FLEETNODE_ENABLED="${FAKE_FLEETNODE_ENABLED:-0}" \
+  FAKE_FLEETNODE_ACTIVE="${FAKE_FLEETNODE_ACTIVE:-1}" \
   FAKE_FLEETNODE_LOCK_READY="${FAKE_FLEETNODE_LOCK_READY:-}" \
   FAKE_FLEETNODE_LOCK_BLOCK="${FAKE_FLEETNODE_LOCK_BLOCK:-}" \
   REAL_FLOCK="${REAL_FLOCK:-}" \
@@ -275,6 +279,9 @@ if grep -Fq '# candidate unit v1.3.0' "$ROOT_PREFIX/etc/systemd/system/fleet-nod
 fi
 [[ "$(grep -Fc 'start fleet-node.service' "$SYSTEMCTL_LOG")" == "2" ]] || \
   fail "failed upgrade did not start the candidate and then restart the previous service"
+[[ "$(grep -E '^(is-active --quiet|stop|start) fleet-node.service$' "$SYSTEMCTL_LOG")" == \
+  $'is-active --quiet fleet-node.service\nstop fleet-node.service\nstart fleet-node.service\nstop fleet-node.service\nstart fleet-node.service' ]] || \
+  fail "failed upgrade did not stop the candidate before restarting the previous service"
 
 : > "$SYSTEMCTL_LOG"
 if FAKE_SYSTEMCTL_FAIL_START=1 run_installer v1.3.0 > "$TEST_DIR/failed-rollback.out" 2>&1; then
@@ -370,5 +377,14 @@ fi
 assert_file_contains "$TEST_DIR/bad-checksum.err" "checksum sidecar is not bound"
 assert_file_contains "$ROOT_PREFIX/opt/fleetnode/version.txt" "version: v1.1.0"
 assert_file_contains "$ROOT_PREFIX/var/lib/fleetnode/state.yaml" "identity material"
+
+: > "$SYSTEMCTL_LOG"
+FAKE_FLEETNODE_ACTIVE=0 run_installer v1.3.0
+assert_file_contains "$ROOT_PREFIX/opt/fleetnode/version.txt" "version: v1.3.0"
+assert_file_contains "$ROOT_PREFIX/etc/systemd/system/fleet-node.service" "# candidate unit v1.3.0"
+assert_file_contains "$SYSTEMCTL_LOG" "is-active --quiet fleet-node.service"
+if grep -Eq '^(stop|start) fleet-node.service$' "$SYSTEMCTL_LOG"; then
+  fail "inactive upgrade changed the Fleet Node service state"
+fi
 
 echo "Fleet Node installer tests passed"

--- a/server/cmd/fleetnode/control.go
+++ b/server/cmd/fleetnode/control.go
@@ -135,7 +135,7 @@ func (r *RunCmd) runControlLoop(ctx context.Context, client gatewayClient, st *b
 			return nil
 		}
 		if errors.Is(err, bootstrap.ErrBeginAuthRejected) || connect.CodeOf(err) == connect.CodeNotFound {
-			return err
+			return operatorActionRequired(err)
 		}
 		if connect.CodeOf(err) == connect.CodeUnimplemented {
 			// Old server: drop to heartbeat-only instead of looping forever.

--- a/server/cmd/fleetnode/control_test.go
+++ b/server/cmd/fleetnode/control_test.go
@@ -410,6 +410,7 @@ func TestControlLoop_PermanentErrorPropagates(t *testing.T) {
 
 	// Assert
 	require.Error(t, err)
+	requireOperatorActionExit(t, err)
 	assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
 }
 

--- a/server/cmd/fleetnode/exitcode.go
+++ b/server/cmd/fleetnode/exitcode.go
@@ -2,6 +2,7 @@ package main
 
 import "errors"
 
+// EX_CONFIG; keep in sync with RestartPreventExitStatus in deployment-files/fleetnode/fleet-node.service.
 const operatorActionExitCode = 78
 
 type operatorActionError struct {

--- a/server/cmd/fleetnode/exitcode.go
+++ b/server/cmd/fleetnode/exitcode.go
@@ -1,0 +1,24 @@
+package main
+
+import "errors"
+
+const operatorActionExitCode = 78
+
+type operatorActionError struct {
+	err error
+}
+
+func (e operatorActionError) Error() string { return e.err.Error() }
+func (e operatorActionError) Unwrap() error { return e.err }
+func (e operatorActionError) ExitCode() int { return operatorActionExitCode }
+
+func operatorActionRequired(err error) error {
+	if err == nil {
+		return nil
+	}
+	var existing operatorActionError
+	if errors.As(err, &existing) {
+		return err
+	}
+	return operatorActionError{err: err}
+}

--- a/server/cmd/fleetnode/fake_gateway_test.go
+++ b/server/cmd/fleetnode/fake_gateway_test.go
@@ -25,15 +25,18 @@ import (
 type fakeFleetNodeGateway struct {
 	fleetnodegatewayv1connect.UnimplementedFleetNodeGatewayServiceHandler
 
-	expectedCode     string
-	expectedAPIKey   string
-	fleetNodeID      int64
-	identityPub      ed25519.PublicKey
-	challenge        []byte
-	sessionToken     string
-	sessionExpiresAt time.Time
-	registerError    error
-	beginAuthError   error
+	expectedCode          string
+	expectedAPIKey        string
+	fleetNodeID           int64
+	identityPub           ed25519.PublicKey
+	challenge             []byte
+	sessionToken          string
+	sessionExpiresAt      time.Time
+	registerError         error
+	beginAuthError        error
+	completeAuthMu        sync.Mutex
+	completeAuthCalls     int
+	completeAuthResponder func(call int) error
 
 	registered        bool
 	signatureVerified bool
@@ -91,10 +94,26 @@ func (f *fakeFleetNodeGateway) CompleteAuthHandshake(_ context.Context, req *con
 		return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("bad signature"))
 	}
 	f.signatureVerified = true
+	f.completeAuthMu.Lock()
+	f.completeAuthCalls++
+	call := f.completeAuthCalls
+	responder := f.completeAuthResponder
+	f.completeAuthMu.Unlock()
+	if responder != nil {
+		if err := responder(call); err != nil {
+			return nil, err
+		}
+	}
 	return connect.NewResponse(&pb.CompleteAuthHandshakeResponse{
 		SessionToken: f.sessionToken,
 		ExpiresAt:    timestamppb.New(f.sessionExpiresAt),
 	}), nil
+}
+
+func (f *fakeFleetNodeGateway) completeAuthCount() int {
+	f.completeAuthMu.Lock()
+	defer f.completeAuthMu.Unlock()
+	return f.completeAuthCalls
 }
 
 func (f *fakeFleetNodeGateway) UploadHeartbeat(_ context.Context, req *connect.Request[pb.UploadHeartbeatRequest]) (*connect.Response[pb.UploadHeartbeatResponse], error) {

--- a/server/cmd/fleetnode/run.go
+++ b/server/cmd/fleetnode/run.go
@@ -147,6 +147,7 @@ func (r *RunCmd) run(c *Context, logOutput io.Writer) error {
 	var runErr error
 	if err := bootstrap.WithStateLock(c.StateDir, func() error {
 		runErr = r.runLocked(ctx, c, resolvedPluginsDir, logger)
+		// Keep runLocked's exit classification separate from lock acquisition errors.
 		return nil
 	}); err != nil {
 		return operatorActionRequired(err)
@@ -335,7 +336,13 @@ func (r *RunCmd) refreshAndSave(ctx context.Context, st *bootstrap.State, path s
 	// stall the control loop's token reads.
 	next := *st
 	if err := bootstrap.Refresh(ctx, &next); err != nil {
-		return err
+		if errors.Is(err, bootstrap.ErrBeginAuthRejected) || connect.CodeOf(err) != connect.CodeUnauthenticated {
+			return err
+		}
+		logger.Warn("session refresh completion rejected; retrying handshake once", "fleet_node_id", st.FleetNodeID, "err", err)
+		if err := bootstrap.Refresh(ctx, &next); err != nil {
+			return err
+		}
 	}
 	r.stateMu.Lock()
 	st.SessionToken = next.SessionToken
@@ -369,6 +376,8 @@ func isRetryableRefreshError(err error) bool {
 		code == connect.CodeResourceExhausted ||
 		code == connect.CodeAborted ||
 		code == connect.CodeInternal ||
+		code == connect.CodeUnknown ||
+		code == connect.CodeUnimplemented ||
 		code == connect.CodeUnavailable
 }
 

--- a/server/cmd/fleetnode/run.go
+++ b/server/cmd/fleetnode/run.go
@@ -183,7 +183,7 @@ func (r *RunCmd) runLocked(ctx context.Context, c *Context, resolvedPluginsDir s
 		}
 		disc, prr, tf, cleanup, bootstrapErr := newPluginComponents(ctx, resolvedPluginsDir, st.FleetNodeID, credentials)
 		if bootstrapErr != nil {
-			return operatorActionRequired(fmt.Errorf("bootstrap plugins: %w", bootstrapErr))
+			return fmt.Errorf("bootstrap plugins: %w", bootstrapErr)
 		}
 		defer cleanup()
 		r.discoverer = disc
@@ -352,6 +352,14 @@ func (r *RunCmd) refreshAndSave(ctx context.Context, st *bootstrap.State, path s
 	return nil
 }
 
+func isRetryableRefreshError(err error) bool {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var connectErr *connect.Error
+	return errors.As(err, &connectErr)
+}
+
 // tick runs one heartbeat cycle. A non-nil return is a permanent condition
 // (revoked credential / deleted fleet_node) that requires re-enrollment;
 // transient errors return nil so the next tick retries.
@@ -360,6 +368,9 @@ func (r *RunCmd) tick(ctx context.Context, client gatewayClient, st *bootstrap.S
 		if err := r.refreshAndSave(ctx, st, path, logger); err != nil {
 			if errors.Is(err, bootstrap.ErrBeginAuthRejected) {
 				return operatorActionRequired(fmt.Errorf("%w. The server returns Unauthenticated for any of: revoked api_key, identity_pubkey mismatch, expired challenge, or server clock drift. Exiting; local credentials are preserved, re-enroll once the operator-side cause is resolved", bootstrap.ErrBeginAuthRejected))
+			}
+			if !isRetryableRefreshError(err) {
+				return operatorActionRequired(fmt.Errorf("session refresh requires operator action: %w", err))
 			}
 			logger.Error("session refresh failed; will retry on next tick", "fleet_node_id", st.FleetNodeID, "err", err)
 			return nil
@@ -383,6 +394,9 @@ func (r *RunCmd) tick(ctx context.Context, client gatewayClient, st *bootstrap.S
 	if refreshErr := r.refreshAndSave(ctx, st, path, logger); refreshErr != nil {
 		if errors.Is(refreshErr, bootstrap.ErrBeginAuthRejected) {
 			return operatorActionRequired(fmt.Errorf("%w. The server returns Unauthenticated for any of: revoked api_key, identity_pubkey mismatch, expired challenge, or server clock drift. Exiting; re-enroll once the operator-side cause is resolved", bootstrap.ErrBeginAuthRejected))
+		}
+		if !isRetryableRefreshError(refreshErr) {
+			return operatorActionRequired(fmt.Errorf("session refresh requires operator action: %w", refreshErr))
 		}
 		logger.Error("post-Unauthenticated refresh failed; will retry on next tick", "fleet_node_id", st.FleetNodeID, "err", refreshErr)
 		return nil

--- a/server/cmd/fleetnode/run.go
+++ b/server/cmd/fleetnode/run.go
@@ -94,7 +94,10 @@ func (r *RunCmd) run(c *Context, logOutput io.Writer) error {
 	if r.notifyReady == nil {
 		r.notifyReady = func() error {
 			_, err := daemon.SdNotify(false, daemon.SdNotifyReady)
-			return err
+			if err != nil {
+				return fmt.Errorf("send systemd readiness notification: %w", err)
+			}
+			return nil
 		}
 	}
 

--- a/server/cmd/fleetnode/run.go
+++ b/server/cmd/fleetnode/run.go
@@ -360,7 +360,16 @@ func isRetryableRefreshError(err error) bool {
 		return true
 	}
 	var connectErr *connect.Error
-	return errors.As(err, &connectErr)
+	if !errors.As(err, &connectErr) {
+		return false
+	}
+	code := connectErr.Code()
+	return code == connect.CodeCanceled ||
+		code == connect.CodeDeadlineExceeded ||
+		code == connect.CodeResourceExhausted ||
+		code == connect.CodeAborted ||
+		code == connect.CodeInternal ||
+		code == connect.CodeUnavailable
 }
 
 // tick runs one heartbeat cycle. A non-nil return is a permanent condition

--- a/server/cmd/fleetnode/run.go
+++ b/server/cmd/fleetnode/run.go
@@ -141,9 +141,14 @@ func (r *RunCmd) run(c *Context, logOutput io.Writer) error {
 	// concurrent enroll/refresh that rewrites state.yaml while we wait for the lock
 	// can't leave the discoverer scoped to a stale fleet_node_id.
 	logger.Info("acquiring state lock", "state_dir", c.StateDir)
-	return bootstrap.WithStateLock(c.StateDir, func() error {
-		return r.runLocked(ctx, c, resolvedPluginsDir, logger)
-	})
+	var runErr error
+	if err := bootstrap.WithStateLock(c.StateDir, func() error {
+		runErr = r.runLocked(ctx, c, resolvedPluginsDir, logger)
+		return nil
+	}); err != nil {
+		return operatorActionRequired(err)
+	}
+	return runErr
 }
 
 func (r *RunCmd) runLocked(ctx context.Context, c *Context, resolvedPluginsDir string, logger *slog.Logger) error {

--- a/server/cmd/fleetnode/run.go
+++ b/server/cmd/fleetnode/run.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
+	"github.com/coreos/go-systemd/v22/daemon"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pb "github.com/block/proto-fleet/server/generated/grpc/fleetnodegateway/v1"
@@ -46,6 +47,7 @@ type RunCmd struct {
 	resolver                 ipResolver                                                               `kong:"-"`
 	localSubnets             func() ([]string, error)                                                 `kong:"-"` // test seam for local-subnet detection
 	firmwareTempRoot         string                                                                   `kong:"-"`
+	notifyReady              func() error                                                             `kong:"-"`
 
 	stateMu sync.Mutex `kong:"-"` // guards session state and the active control-session cancel func.
 	pairMu  sync.Mutex `kong:"-"` // serializes pair commands; held until every pair worker exits (see handlePairCommand).
@@ -89,6 +91,12 @@ func (r *RunCmd) run(c *Context, logOutput io.Writer) error {
 	if r.parentCtx == nil {
 		r.parentCtx = context.Background()
 	}
+	if r.notifyReady == nil {
+		r.notifyReady = func() error {
+			_, err := daemon.SdNotify(false, daemon.SdNotifyReady)
+			return err
+		}
+	}
 
 	// Wire signals before plugin work so a SIGTERM during the up-to-60s
 	// plugin load aborts cleanly instead of orphaning subprocesses.
@@ -102,20 +110,20 @@ func (r *RunCmd) run(c *Context, logOutput io.Writer) error {
 	if r.discoverer == nil {
 		resolved, resolveErr := resolvePluginsDir(exeDir)
 		if resolveErr != nil {
-			return resolveErr
+			return operatorActionRequired(resolveErr)
 		}
 		resolvedPluginsDir = resolved
 	}
 	path := bootstrap.StatePath(c.StateDir)
 	st, exists, err := bootstrap.LoadState(path)
 	if err != nil {
-		return err
+		return operatorActionRequired(err)
 	}
 	if !exists || st.FleetNodeID == 0 {
-		return fmt.Errorf("no state at %s; run `fleetnode enroll` first", path)
+		return operatorActionRequired(fmt.Errorf("no state at %s; run `fleetnode enroll` first", path))
 	}
 	if st.APIKey == "" {
-		return fmt.Errorf("state at %s has no api_key; complete enrollment via `fleetnode refresh` before running the daemon", path)
+		return operatorActionRequired(fmt.Errorf("state at %s has no api_key; complete enrollment via `fleetnode refresh` before running the daemon", path))
 	}
 
 	logger := slog.New(slog.NewTextHandler(logOutput, nil))
@@ -142,20 +150,20 @@ func (r *RunCmd) runLocked(ctx context.Context, c *Context, resolvedPluginsDir s
 	path := bootstrap.StatePath(c.StateDir)
 	st, exists, err := bootstrap.LoadState(path)
 	if err != nil {
-		return err
+		return operatorActionRequired(err)
 	}
 	if !exists || st.FleetNodeID == 0 || st.APIKey == "" {
-		return fmt.Errorf("state at %s became invalid between checks; re-run after `fleetnode enroll`", path)
+		return operatorActionRequired(fmt.Errorf("state at %s became invalid between checks; re-run after `fleetnode enroll`", path))
 	}
 	// Re-validate on every entry so a tampered state.yaml can't redirect
 	// bearer heartbeats to a plaintext non-loopback URL while the cached
 	// session_token is still fresh.
 	if err := bootstrap.ValidateServerURL(st.ServerURL, st.AllowInsecureTransport); err != nil {
-		return err
+		return operatorActionRequired(err)
 	}
 	r.firmwareTempRoot = filepath.Join(c.StateDir, firmwareArtifactTempDirName)
 	if err := prepareFirmwareArtifactTempRoot(r.firmwareTempRoot); err != nil {
-		return fmt.Errorf("prepare firmware temp dir: %w", err)
+		return operatorActionRequired(fmt.Errorf("prepare firmware temp dir: %w", err))
 	}
 
 	// Reap + spawn inside the lock, from the state loaded under it, so the
@@ -166,11 +174,11 @@ func (r *RunCmd) runLocked(ctx context.Context, c *Context, resolvedPluginsDir s
 		reapOrphanedPlugins(ctx, resolvedPluginsDir, logger)
 		credentials, credentialErr := ensureCredentialCodec(path, st)
 		if credentialErr != nil {
-			return fmt.Errorf("prepare credential key: %w", credentialErr)
+			return operatorActionRequired(fmt.Errorf("prepare credential key: %w", credentialErr))
 		}
 		disc, prr, tf, cleanup, bootstrapErr := newPluginComponents(ctx, resolvedPluginsDir, st.FleetNodeID, credentials)
 		if bootstrapErr != nil {
-			return fmt.Errorf("bootstrap plugins: %w", bootstrapErr)
+			return operatorActionRequired(fmt.Errorf("bootstrap plugins: %w", bootstrapErr))
 		}
 		defer cleanup()
 		r.discoverer = disc
@@ -185,21 +193,12 @@ func (r *RunCmd) runLocked(ctx context.Context, c *Context, resolvedPluginsDir s
 		if r.passwordUpdatePrivateKey == nil {
 			privateKey, err := decodePasswordUpdatePrivateKey(st)
 			if err != nil {
-				return err
+				return operatorActionRequired(err)
 			}
 			r.passwordUpdatePrivateKey = privateKey
 		}
 		r.pairer = prr
 		r.telemetry = tf
-	}
-
-	if r.sessionNeedsRefresh(st) {
-		if err := r.refreshAndSave(ctx, st, path, logger); err != nil {
-			if errors.Is(err, bootstrap.ErrBeginAuthRejected) {
-				return fmt.Errorf("%w. The server returns Unauthenticated for any of: revoked api_key, identity_pubkey mismatch, expired challenge, or server clock drift. Verify the api_key matches the one minted in the UI and retry; local credentials are preserved", bootstrap.ErrBeginAuthRejected)
-			}
-			return fmt.Errorf("initial session refresh: %w", err)
-		}
 	}
 
 	tokenSource := func() string {
@@ -222,6 +221,12 @@ func (r *RunCmd) runLocked(ctx context.Context, c *Context, resolvedPluginsDir s
 
 	if err := r.tick(ctx, client, st, path, logger); err != nil {
 		return err
+	}
+	if ctx.Err() != nil {
+		return nil
+	}
+	if err := r.notifyReady(); err != nil {
+		return fmt.Errorf("notify systemd ready: %w", err)
 	}
 
 	loopCtx, cancelLoops := context.WithCancel(ctx)
@@ -349,7 +354,7 @@ func (r *RunCmd) tick(ctx context.Context, client gatewayClient, st *bootstrap.S
 	if r.sessionNeedsRefresh(st) {
 		if err := r.refreshAndSave(ctx, st, path, logger); err != nil {
 			if errors.Is(err, bootstrap.ErrBeginAuthRejected) {
-				return fmt.Errorf("%w. The server returns Unauthenticated for any of: revoked api_key, identity_pubkey mismatch, expired challenge, or server clock drift. Exiting; re-enroll once the operator-side cause is resolved", bootstrap.ErrBeginAuthRejected)
+				return operatorActionRequired(fmt.Errorf("%w. The server returns Unauthenticated for any of: revoked api_key, identity_pubkey mismatch, expired challenge, or server clock drift. Exiting; local credentials are preserved, re-enroll once the operator-side cause is resolved", bootstrap.ErrBeginAuthRejected))
 			}
 			logger.Error("session refresh failed; will retry on next tick", "fleet_node_id", st.FleetNodeID, "err", err)
 			return nil
@@ -362,7 +367,7 @@ func (r *RunCmd) tick(ctx context.Context, client gatewayClient, st *bootstrap.S
 		return nil
 	}
 	if code := connect.CodeOf(err); code == connect.CodeNotFound {
-		return fmt.Errorf("fleet_node not found server-side (revoked or deleted); exiting, re-enroll on this host: %w", err)
+		return operatorActionRequired(fmt.Errorf("fleet_node not found server-side (revoked or deleted); exiting, re-enroll on this host: %w", err))
 	}
 	if connect.CodeOf(err) != connect.CodeUnauthenticated {
 		logger.Error("heartbeat failed", "fleet_node_id", st.FleetNodeID, "err", err)
@@ -372,7 +377,7 @@ func (r *RunCmd) tick(ctx context.Context, client gatewayClient, st *bootstrap.S
 	logger.Warn("heartbeat rejected as Unauthenticated; refreshing session and retrying", "fleet_node_id", st.FleetNodeID, "err", err)
 	if refreshErr := r.refreshAndSave(ctx, st, path, logger); refreshErr != nil {
 		if errors.Is(refreshErr, bootstrap.ErrBeginAuthRejected) {
-			return fmt.Errorf("%w. The server returns Unauthenticated for any of: revoked api_key, identity_pubkey mismatch, expired challenge, or server clock drift. Exiting; re-enroll once the operator-side cause is resolved", bootstrap.ErrBeginAuthRejected)
+			return operatorActionRequired(fmt.Errorf("%w. The server returns Unauthenticated for any of: revoked api_key, identity_pubkey mismatch, expired challenge, or server clock drift. Exiting; re-enroll once the operator-side cause is resolved", bootstrap.ErrBeginAuthRejected))
 		}
 		logger.Error("post-Unauthenticated refresh failed; will retry on next tick", "fleet_node_id", st.FleetNodeID, "err", refreshErr)
 		return nil
@@ -383,7 +388,7 @@ func (r *RunCmd) tick(ctx context.Context, client gatewayClient, st *bootstrap.S
 		return nil
 	}
 	if code := connect.CodeOf(retryErr); code == connect.CodeNotFound {
-		return fmt.Errorf("fleet_node not found server-side (revoked or deleted); exiting, re-enroll on this host: %w", retryErr)
+		return operatorActionRequired(fmt.Errorf("fleet_node not found server-side (revoked or deleted); exiting, re-enroll on this host: %w", retryErr))
 	}
 	logger.Error("heartbeat retry after refresh failed", "fleet_node_id", st.FleetNodeID, "err", retryErr)
 	return nil

--- a/server/cmd/fleetnode/run_test.go
+++ b/server/cmd/fleetnode/run_test.go
@@ -210,6 +210,86 @@ func TestRunCmd_TransientInitialRefreshFailureStillBecomesReady(t *testing.T) {
 	assert.True(t, notified, "Fleet Server unavailability must not block local readiness")
 }
 
+func TestRunCmd_LocalRefreshFailureRequiresOperatorAction(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	state := freshState(t, dir, time.Now().Add(30*time.Minute))
+	state.IdentityPrivateKeyHex = "not-hex"
+	require.NoError(t, bootstrap.SaveState(bootstrap.StatePath(dir), state))
+
+	notified := false
+	parent, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
+	defer cancel()
+	cmd := &RunCmd{parentCtx: parent, notifyReady: func() error {
+		notified = true
+		return nil
+	}}
+
+	err := cmd.run(&Context{StateDir: dir}, &bytes.Buffer{})
+
+	require.Error(t, err)
+	requireOperatorActionExit(t, err)
+	assert.Contains(t, err.Error(), "decode identity private key")
+	assert.False(t, notified, "unrecoverable local state must not report ready")
+}
+
+func TestRunCmd_StateSaveFailureRequiresOperatorAction(t *testing.T) {
+	t.Parallel()
+
+	pubKey, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	fake := &fakeFleetNodeGateway{
+		expectedAPIKey:   "fleet_known_key",
+		identityPub:      pubKey,
+		challenge:        bytes.Repeat([]byte{0x35}, 32),
+		sessionToken:     "session-2",
+		sessionExpiresAt: time.Now().Add(24 * time.Hour),
+	}
+	srv := newFakeServer(t, fake)
+	state := &bootstrap.State{
+		ServerURL:              srv.URL,
+		AllowInsecureTransport: true,
+		FleetNodeID:            42,
+		IdentityPrivateKeyHex:  hex.EncodeToString(priv),
+		IdentityPublicKeyHex:   hex.EncodeToString(pubKey),
+		APIKey:                 "fleet_known_key",
+		SessionToken:           "session-1",
+		SessionExpiresAt:       time.Now().Add(30 * time.Minute),
+	}
+	blockedParent := filepath.Join(t.TempDir(), "not-a-directory")
+	require.NoError(t, os.WriteFile(blockedParent, []byte("blocked"), 0o600))
+	statePath := filepath.Join(blockedParent, "state.yaml")
+	cmd := &RunCmd{now: func() time.Time { return time.Now().UTC() }}
+
+	err = cmd.tick(t.Context(), &stubGatewayClient{}, state, statePath, discardLogger(t))
+
+	require.Error(t, err)
+	requireOperatorActionExit(t, err)
+	assert.Contains(t, err.Error(), "save state after refresh")
+}
+
+func TestRunLocked_PluginBootstrapFailureRemainsRetryable(t *testing.T) {
+	t.Parallel()
+
+	stateDir := t.TempDir()
+	freshState(t, stateDir, time.Now().Add(24*time.Hour))
+	pluginsDir := t.TempDir()
+	badPlugin := filepath.Join(pluginsDir, "bad-plugin")
+	require.NoError(t, os.WriteFile(badPlugin, []byte("#!/usr/bin/env bash\nexit 1\n"), 0o755))
+	cmd := &RunCmd{
+		clientFactory: func(_ string, _ func() string) (gatewayClient, error) {
+			return &stubGatewayClient{}, nil
+		},
+	}
+
+	err := cmd.runLocked(t.Context(), &Context{StateDir: stateDir}, pluginsDir, discardLogger(t))
+
+	require.Error(t, err)
+	var exitCoder interface{ ExitCode() int }
+	assert.False(t, errors.As(err, &exitCoder), "transient plugin startup failures must remain restartable")
+}
+
 func TestRunCmd_StateLockErrorClassification(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Windows does not use the filesystem state lock")

--- a/server/cmd/fleetnode/run_test.go
+++ b/server/cmd/fleetnode/run_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -207,6 +208,38 @@ func TestRunCmd_TransientInitialRefreshFailureStillBecomesReady(t *testing.T) {
 
 	require.NoError(t, cmd.run(&Context{StateDir: dir}, &bytes.Buffer{}))
 	assert.True(t, notified, "Fleet Server unavailability must not block local readiness")
+}
+
+func TestRunCmd_StateLockErrorClassification(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not use the filesystem state lock")
+	}
+
+	t.Run("lock preparation error requires operator action", func(t *testing.T) {
+		realStateDir := t.TempDir()
+		freshState(t, realStateDir, time.Now().Add(24*time.Hour))
+		stateDir := filepath.Join(t.TempDir(), "state")
+		require.NoError(t, os.Symlink(realStateDir, stateDir))
+
+		err := (&RunCmd{}).run(&Context{StateDir: stateDir}, &bytes.Buffer{})
+
+		require.Error(t, err)
+		requireOperatorActionExit(t, err)
+		assert.Contains(t, err.Error(), "symlink")
+	})
+
+	t.Run("callback error keeps its original classification", func(t *testing.T) {
+		stateDir := t.TempDir()
+		freshState(t, stateDir, time.Now().Add(24*time.Hour))
+		notifyErr := errors.New("notify failed")
+		cmd := &RunCmd{notifyReady: func() error { return notifyErr }}
+
+		err := cmd.run(&Context{StateDir: stateDir}, &bytes.Buffer{})
+
+		require.ErrorIs(t, err, notifyErr)
+		var exitCoder interface{ ExitCode() int }
+		assert.False(t, errors.As(err, &exitCoder), "callback errors must not inherit lock-error classification")
+	})
 }
 
 func TestRunCmd_ControlWorkerShutdownWaitIsBounded(t *testing.T) {

--- a/server/cmd/fleetnode/run_test.go
+++ b/server/cmd/fleetnode/run_test.go
@@ -41,6 +41,13 @@ type authRecordingControlGateway struct {
 	authHeaders []string
 }
 
+func requireOperatorActionExit(t *testing.T, err error) {
+	t.Helper()
+	var exitCoder interface{ ExitCode() int }
+	require.ErrorAs(t, err, &exitCoder)
+	assert.Equal(t, operatorActionExitCode, exitCoder.ExitCode())
+}
+
 func (f *authRecordingControlGateway) ControlStream(ctx context.Context, stream *connect.BidiStream[pb.ControlStreamRequest, pb.ControlStreamResponse]) error {
 	f.authMu.Lock()
 	f.authHeaders = append(f.authHeaders, stream.RequestHeader().Get("Authorization"))
@@ -154,6 +161,52 @@ func TestRunCmd_HappyPathThreeTicks(t *testing.T) {
 	// Assert
 	calls, _ := stub.snapshot()
 	assert.GreaterOrEqual(t, calls, 3, "daemon must send at least 3 heartbeats before shutdown")
+}
+
+func TestRunCmd_NotifiesReadyAfterFirstHeartbeatAttempt(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	freshState(t, dir, time.Now().Add(24*time.Hour))
+
+	parent, cancel := context.WithCancel(context.Background())
+	stub := &stubGatewayClient{}
+	notified := false
+	cmd := &RunCmd{
+		parentCtx:     parent,
+		clientFactory: func(_ string, _ func() string) (gatewayClient, error) { return stub, nil },
+		notifyReady: func() error {
+			notified = true
+			cancel()
+			return nil
+		},
+	}
+
+	require.NoError(t, cmd.run(&Context{StateDir: dir}, &bytes.Buffer{}))
+	assert.True(t, notified)
+	calls, _ := stub.snapshot()
+	assert.Equal(t, 1, calls, "readiness must follow the first heartbeat attempt")
+}
+
+func TestRunCmd_TransientInitialRefreshFailureStillBecomesReady(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	freshState(t, dir, time.Now().Add(30*time.Minute))
+
+	parent, cancel := context.WithCancel(context.Background())
+	notified := false
+	cmd := &RunCmd{
+		parentCtx: parent,
+		notifyReady: func() error {
+			notified = true
+			cancel()
+			return nil
+		},
+	}
+
+	require.NoError(t, cmd.run(&Context{StateDir: dir}, &bytes.Buffer{}))
+	assert.True(t, notified, "Fleet Server unavailability must not block local readiness")
 }
 
 func TestRunCmd_ControlWorkerShutdownWaitIsBounded(t *testing.T) {
@@ -407,6 +460,7 @@ func TestRunCmd_FailsWhenStateIsMissing(t *testing.T) {
 
 	// Assert
 	require.Error(t, err)
+	requireOperatorActionExit(t, err)
 	assert.Contains(t, err.Error(), "fleetnode enroll")
 	_, statErr := os.Stat(stateDir)
 	assert.True(t, os.IsNotExist(statErr), "state dir must not be created when run bails out on missing state")
@@ -434,6 +488,7 @@ func TestRunCmd_FailsWhenApiKeyIsMissing(t *testing.T) {
 
 	// Assert
 	require.Error(t, err)
+	requireOperatorActionExit(t, err)
 	assert.Contains(t, err.Error(), "fleetnode refresh")
 }
 
@@ -469,6 +524,7 @@ func TestRunCmd_BailsOutWhenInitialRefreshHitsBeginAuthRejected(t *testing.T) {
 
 	// Assert
 	require.Error(t, err)
+	requireOperatorActionExit(t, err)
 	assert.ErrorIs(t, err, bootstrap.ErrBeginAuthRejected)
 	assert.Contains(t, err.Error(), "local credentials are preserved")
 }
@@ -533,6 +589,7 @@ func TestRunCmd_ExitsOnCodeNotFoundHeartbeat(t *testing.T) {
 	select {
 	case err := <-done:
 		require.Error(t, err)
+		requireOperatorActionExit(t, err)
 		assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
 		assert.Contains(t, err.Error(), "re-enroll")
 	case <-time.After(2 * time.Second):
@@ -580,6 +637,7 @@ func TestRunCmd_ExitsWhenTickRefreshHitsBeginAuthRejected(t *testing.T) {
 	select {
 	case err := <-done:
 		require.Error(t, err)
+		requireOperatorActionExit(t, err)
 		assert.ErrorIs(t, err, bootstrap.ErrBeginAuthRejected)
 		assert.Contains(t, err.Error(), "Exiting")
 	case <-time.After(3 * time.Second):

--- a/server/cmd/fleetnode/run_test.go
+++ b/server/cmd/fleetnode/run_test.go
@@ -226,6 +226,8 @@ func TestIsRetryableRefreshError(t *testing.T) {
 		{name: "connect resource exhausted", err: connect.NewError(connect.CodeResourceExhausted, errors.New("resource exhausted")), retryable: true},
 		{name: "connect aborted", err: connect.NewError(connect.CodeAborted, errors.New("aborted")), retryable: true},
 		{name: "connect internal", err: connect.NewError(connect.CodeInternal, errors.New("internal")), retryable: true},
+		{name: "connect unknown", err: connect.NewError(connect.CodeUnknown, errors.New("unknown")), retryable: true},
+		{name: "connect unimplemented", err: connect.NewError(connect.CodeUnimplemented, errors.New("unimplemented")), retryable: true},
 		{name: "wrapped connect unavailable", err: fmt.Errorf("refresh: %w", connect.NewError(connect.CodeUnavailable, errors.New("unavailable"))), retryable: true},
 		{name: "connect unauthenticated", err: connect.NewError(connect.CodeUnauthenticated, errors.New("unauthenticated")), retryable: false},
 		{name: "connect invalid argument", err: connect.NewError(connect.CodeInvalidArgument, errors.New("invalid argument")), retryable: false},
@@ -297,6 +299,82 @@ func TestRunCmd_StateSaveFailureRequiresOperatorAction(t *testing.T) {
 	require.Error(t, err)
 	requireOperatorActionExit(t, err)
 	assert.Contains(t, err.Error(), "save state after refresh")
+}
+
+func TestRunCmd_RefreshRetriesOneCompleteAuthRejection(t *testing.T) {
+	t.Parallel()
+
+	pubKey, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	fake := &fakeFleetNodeGateway{
+		expectedAPIKey:   "fleet_known_key",
+		identityPub:      pubKey,
+		challenge:        bytes.Repeat([]byte{0x36}, 32),
+		sessionToken:     "session-2",
+		sessionExpiresAt: time.Now().Add(24 * time.Hour),
+		completeAuthResponder: func(call int) error {
+			if call == 1 {
+				return connect.NewError(connect.CodeUnauthenticated, errors.New("expired challenge"))
+			}
+			return nil
+		},
+	}
+	srv := newFakeServer(t, fake)
+	state := &bootstrap.State{
+		ServerURL:              srv.URL,
+		AllowInsecureTransport: true,
+		FleetNodeID:            42,
+		IdentityPrivateKeyHex:  hex.EncodeToString(priv),
+		IdentityPublicKeyHex:   hex.EncodeToString(pubKey),
+		APIKey:                 "fleet_known_key",
+		SessionToken:           "session-1",
+		SessionExpiresAt:       time.Now().Add(30 * time.Minute),
+	}
+	statePath := bootstrap.StatePath(t.TempDir())
+	cmd := &RunCmd{}
+
+	err = cmd.refreshAndSave(t.Context(), state, statePath, discardLogger(t))
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, fake.completeAuthCount())
+	assert.Equal(t, "session-2", state.SessionToken)
+}
+
+func TestRunCmd_RepeatedCompleteAuthRejectionRequiresOperatorAction(t *testing.T) {
+	t.Parallel()
+
+	pubKey, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	fake := &fakeFleetNodeGateway{
+		expectedAPIKey:   "fleet_known_key",
+		identityPub:      pubKey,
+		challenge:        bytes.Repeat([]byte{0x37}, 32),
+		sessionToken:     "session-2",
+		sessionExpiresAt: time.Now().Add(24 * time.Hour),
+		completeAuthResponder: func(int) error {
+			return connect.NewError(connect.CodeUnauthenticated, errors.New("expired challenge"))
+		},
+	}
+	srv := newFakeServer(t, fake)
+	state := &bootstrap.State{
+		ServerURL:              srv.URL,
+		AllowInsecureTransport: true,
+		FleetNodeID:            42,
+		IdentityPrivateKeyHex:  hex.EncodeToString(priv),
+		IdentityPublicKeyHex:   hex.EncodeToString(pubKey),
+		APIKey:                 "fleet_known_key",
+		SessionToken:           "session-1",
+		SessionExpiresAt:       time.Now().Add(30 * time.Minute),
+	}
+	cmd := &RunCmd{now: func() time.Time { return time.Now().UTC() }}
+
+	err = cmd.tick(t.Context(), &stubGatewayClient{}, state, bootstrap.StatePath(t.TempDir()), discardLogger(t))
+
+	require.Error(t, err)
+	requireOperatorActionExit(t, err)
+	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+	assert.Equal(t, 2, fake.completeAuthCount())
+	assert.Equal(t, "session-1", state.SessionToken)
 }
 
 func TestRunLocked_PluginBootstrapFailureRemainsRetryable(t *testing.T) {

--- a/server/cmd/fleetnode/run_test.go
+++ b/server/cmd/fleetnode/run_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -208,6 +209,35 @@ func TestRunCmd_TransientInitialRefreshFailureStillBecomesReady(t *testing.T) {
 
 	require.NoError(t, cmd.run(&Context{StateDir: dir}, &bytes.Buffer{}))
 	assert.True(t, notified, "Fleet Server unavailability must not block local readiness")
+}
+
+func TestIsRetryableRefreshError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		err       error
+		retryable bool
+	}{
+		{name: "context canceled", err: context.Canceled, retryable: true},
+		{name: "context deadline exceeded", err: context.DeadlineExceeded, retryable: true},
+		{name: "connect canceled", err: connect.NewError(connect.CodeCanceled, errors.New("canceled")), retryable: true},
+		{name: "connect deadline exceeded", err: connect.NewError(connect.CodeDeadlineExceeded, errors.New("deadline exceeded")), retryable: true},
+		{name: "connect resource exhausted", err: connect.NewError(connect.CodeResourceExhausted, errors.New("resource exhausted")), retryable: true},
+		{name: "connect aborted", err: connect.NewError(connect.CodeAborted, errors.New("aborted")), retryable: true},
+		{name: "connect internal", err: connect.NewError(connect.CodeInternal, errors.New("internal")), retryable: true},
+		{name: "wrapped connect unavailable", err: fmt.Errorf("refresh: %w", connect.NewError(connect.CodeUnavailable, errors.New("unavailable"))), retryable: true},
+		{name: "connect unauthenticated", err: connect.NewError(connect.CodeUnauthenticated, errors.New("unauthenticated")), retryable: false},
+		{name: "connect invalid argument", err: connect.NewError(connect.CodeInvalidArgument, errors.New("invalid argument")), retryable: false},
+		{name: "plain error", err: errors.New("local failure"), retryable: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.retryable, isRetryableRefreshError(tt.err))
+		})
+	}
 }
 
 func TestRunCmd_LocalRefreshFailureRequiresOperatorAction(t *testing.T) {

--- a/server/go.mod
+++ b/server/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/alecthomas/kong-yaml v0.2.0
 	github.com/btcsuite/btcd/btcec/v2 v2.5.0
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.2.0
+	github.com/coreos/go-systemd/v22 v22.7.0
 	github.com/eclipse/paho.mqtt.golang v1.5.1
 	github.com/fatih/color v1.19.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
@@ -64,7 +65,6 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/coreos/go-semver v0.3.1 // indirect
-	github.com/coreos/go-systemd/v22 v22.7.0 // indirect
 	github.com/decred/dcrd/crypto/blake256 v1.1.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.1 // indirect
 	github.com/docker/docker v28.5.2+incompatible // indirect


### PR DESCRIPTION
Reviewable diff: +91/-41 across 6 files (excludes generated, test, and story files).

## Summary

Fleet Node now exposes a real systemd readiness boundary and stops restart loops when operator action is required. Fresh installs remain stopped until enrollment, while upgrades only succeed after the replacement process finishes local initialization and reports ready.

**Stack**

1. **[#990](https://github.com/block/proto-fleet/pull/990) — this PR: startup readiness and safe upgrade boundary**
2. [#991](https://github.com/block/proto-fleet/pull/991) — installer lifecycle: preflight, uninstall, purge, and idempotency
3. [#992](https://github.com/block/proto-fleet/pull/992) — native package qualification before artifact upload

The later PRs build on this readiness contract. Installer lifecycle breadth and release-artifact qualification are intentionally deferred to [#991](https://github.com/block/proto-fleet/pull/991) and [#992](https://github.com/block/proto-fleet/pull/992); runbooks and broader distribution work remain out of this stack.

## How it works

1. `fleetnode run` validates local state, initializes plugins, and makes its first gateway attempt.
2. Once local startup is usable, it sends `READY=1` to systemd. A temporarily unavailable Fleet server does not prevent the local daemon from becoming ready and retrying.
3. Invalid local state, revoked enrollment, missing server-side identity, or permanent plugin/bootstrap failures exit with code 78.
4. The unit uses `Type=notify`, waits up to 300 seconds for readiness, and does not restart exit code 78.
5. During an upgrade, the installer starts the replacement synchronously. If it never becomes ready, the prior payload and unit are restored and restarted.
6. A fresh install is left stopped and disabled so the operator can enroll before enabling it.

```mermaid
flowchart TD
  A["systemd starts Fleet Node"] --> B["Validate state and initialize plugins"]
  B --> C{"Local startup usable?"}
  C -->|"Yes"| D["Send READY=1"]
  D --> E["Run heartbeat and control loops"]
  C -->|"Operator action required"| F["Exit 78"]
  C -->|"Other startup failure"| G["Exit non-zero"]
  F --> H["systemd leaves service stopped"]
  G --> I["systemd may restart service"]
```

```mermaid
sequenceDiagram
  participant Installer
  participant Systemd
  participant Candidate as Fleet Node candidate
  participant Previous as Previous payload
  Installer->>Systemd: start fleet-node.service
  Systemd->>Candidate: launch
  Candidate-->>Systemd: READY=1 after local initialization
  Systemd-->>Installer: start succeeded
  alt candidate cannot become ready
    Systemd-->>Installer: start failed or timed out
    Installer->>Previous: restore payload and unit
    Installer->>Systemd: start previous service
  end
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/cmd/fleetnode/` | Added readiness notification and an operator-action exit classification | Defines when Fleet Node is safe to consider started and when retries must stop |
| `deployment-files/fleetnode/fleet-node.service` | Switched to `Type=notify`, added startup timeout and exit-78 restart prevention | Establishes the service-manager contract |
| `deployment-files/fleetnode/install-fleet-node.sh` | Leaves fresh installs stopped and blocks upgrades on systemd readiness | Makes installer success mean the replacement is locally runnable |
| `server/go.mod` | Promoted the existing systemd module to a direct dependency | Supports native readiness notification |
| Tests | Added readiness, permanent-error, fresh-install, and rollback coverage | Guards the lifecycle boundary; review-light |

## Key technical decisions & trade-offs

- Readiness means local initialization completed, not that the Fleet server is currently reachable; transient network outages continue retrying after startup.
- Exit code 78 is reserved for states that need enrollment or operator repair, preventing an unbounded restart loop while preserving ordinary restart-on-failure behavior.
- Fresh installation does not auto-start because an unenrolled node cannot run successfully; upgrades still start synchronously so rollback remains possible.

## Testing & validation

- `go test ./server/cmd/fleetnode`
- `bash deployment-files/fleetnode/tests/test-install-fleetnode.sh`
- Shell syntax and diff checks
- Native amd64/arm64 package installation is intentionally covered by PR 3, not this PR.
