### PR TITLE
Complete the Fleet Node installer lifecycle

### DIFF
--- a/deployment-files/fleetnode/install-fleet-node.sh
+++ b/deployment-files/fleetnode/install-fleet-node.sh
@@ -9,7 +9,6 @@ USE_SUDO=0
 INSTALL_LOCK_PID=""
 INSTALL_LOCK_RELEASE_PATH=""
 ACTION=install
-PURGE=0
 VERSION=""
 
 if [[ "$TEST_MODE" != "1" ]]; then
@@ -20,14 +19,13 @@ fi
 usage() {
   cat <<'EOF'
 Usage: install-fleet-node.sh VERSION
-       install-fleet-node.sh uninstall [--purge]
+       install-fleet-node.sh uninstall
 
 Install one exact Proto Fleet Node release on Linux. VERSION must be a
 release-specific tag such as v1.2.3 or nightly-20260825-0123456789ab.
 
 uninstall removes the program and systemd unit while preserving configuration,
-state, and the service account. --purge also removes those preserved files and
-the dedicated service account.
+state, and the service account.
 
 The installer leaves a fresh installation stopped and disabled at boot. After
 installation, enroll the node and then enable and start the service.
@@ -41,12 +39,7 @@ fi
 case "${1:-}" in
   uninstall)
     ACTION=uninstall
-    case "${2:-}" in
-      "") ;;
-      --purge) PURGE=1 ;;
-      *) usage >&2; exit 2 ;;
-    esac
-    [[ $# -le 2 ]] || { usage >&2; exit 2; }
+    [[ $# -eq 1 ]] || { usage >&2; exit 2; }
     ;;
   "") usage >&2; exit 2 ;;
   *)
@@ -129,14 +122,8 @@ if [[ "$ACTION" == "install" ]] && ! command -v nmap >/dev/null 2>&1; then
   echo "required command not found: nmap; install nmap in the Fleet Node service PATH ($LINUX_SERVICE_PATH)" >&2
   exit 1
 fi
-if [[ "$TEST_MODE" != "1" ]]; then
-  account_commands=()
-  if [[ "$ACTION" == "install" ]]; then
-    account_commands=(getent id nologin runuser useradd)
-  elif [[ "$PURGE" == "1" ]]; then
-    account_commands=(getent groupdel id nologin pgrep userdel)
-  fi
-  for command in "${account_commands[@]}"; do
+if [[ "$TEST_MODE" != "1" && "$ACTION" == "install" ]]; then
+  for command in getent id nologin runuser useradd; do
     command -v "$command" >/dev/null 2>&1 || { echo "required command not found: $command" >&2; exit 1; }
   done
 fi
@@ -366,51 +353,10 @@ cleanup() {
 trap cleanup EXIT
 
 remove_fleet_node() {
-  local unit_present=0
-  local service_was_active=0
-  [[ -f "$UNIT_PATH" ]] && unit_present=1
-
-  if [[ "$PURGE" == "1" ]]; then
-    load_service_account
-    if [[ -n "$passwd_record" ]]; then
-      validate_service_account
-    elif [[ -n "$group_record" ]]; then
-      validate_group
-      local _name _password _gid members
-      IFS=: read -r _name _password _gid members <<< "$group_record"
-      [[ -z "$members" ]] || { echo "fleetnode group exists without its service account" >&2; return 1; }
-    fi
-  fi
-
-  if [[ "$unit_present" == "1" ]]; then
-    if [[ "$PURGE" == "1" ]] && as_root "$SYSTEMCTL" is-active --quiet fleet-node.service; then
-      service_was_active=1
-    fi
+  if as_root "$SYSTEMCTL" is-active --quiet fleet-node.service; then
     as_root "$SYSTEMCTL" stop fleet-node.service
   fi
-
-  if [[ "$PURGE" == "1" ]]; then
-    if [[ -e "$STATE_DIR/state.lock" ]] && ! as_root flock -n "$STATE_DIR/state.lock" true; then
-      echo "Fleet Node state is in use; refusing to purge while state.lock is held" >&2
-      if [[ "$service_was_active" == "1" ]]; then
-        as_root "$SYSTEMCTL" start fleet-node.service || echo "failed to restart Fleet Node after refusing purge" >&2
-      fi
-      return 1
-    fi
-
-    load_service_account
-    if [[ -n "$passwd_record" ]]; then
-      if as_root pgrep -u "$account_uid" >/dev/null 2>&1; then
-        echo "fleetnode account still has running processes" >&2
-        if [[ "$service_was_active" == "1" ]]; then
-          as_root "$SYSTEMCTL" start fleet-node.service || echo "failed to restart Fleet Node after refusing purge" >&2
-        fi
-        return 1
-      fi
-    fi
-  fi
-
-  if [[ "$unit_present" == "1" ]]; then
+  if as_root "$SYSTEMCTL" is-enabled --quiet fleet-node.service; then
     as_root "$SYSTEMCTL" disable fleet-node.service
   fi
 
@@ -419,23 +365,10 @@ remove_fleet_node() {
   as_root "$SYSTEMCTL" daemon-reload
   as_root "$SYSTEMCTL" reset-failed fleet-node.service >/dev/null 2>&1 || true
 
-  if [[ "$PURGE" == "1" ]]; then
-    as_root rm -rf "$CONFIG_DIR" "$STATE_DIR"
-    load_service_account
-    if [[ -n "$passwd_record" ]]; then
-      as_root userdel fleetnode
-    fi
-    load_service_account
-    if [[ -n "$group_record" ]]; then
-      as_root groupdel fleetnode
-    fi
-    echo "Fleet Node uninstalled and local state purged."
-  else
-    echo "Fleet Node uninstalled. Preserved:"
-    echo "  $CONFIG_DIR"
-    echo "  $STATE_DIR"
-    echo "  fleetnode service account"
-  fi
+  echo "Fleet Node uninstalled. Preserved:"
+  echo "  $CONFIG_DIR"
+  echo "  $STATE_DIR"
+  echo "  fleetnode service account"
 }
 
 if [[ "$ACTION" == "uninstall" ]]; then

--- a/deployment-files/fleetnode/install-fleet-node.sh
+++ b/deployment-files/fleetnode/install-fleet-node.sh
@@ -462,10 +462,21 @@ if ! grep -Fxq "version: $VERSION" "$source_dir/version.txt"; then
 fi
 
 if [[ "$fresh_install" == "0" ]]; then
-  if as_root "$SYSTEMCTL" is-active --quiet fleet-node.service; then
-    as_root "$SYSTEMCTL" stop fleet-node.service
-    service_stopped=1
-  fi
+  active_state=$(as_root "$SYSTEMCTL" show --property=ActiveState --value fleet-node.service) || {
+    echo "cannot inspect Fleet Node systemd active state" >&2
+    exit 1
+  }
+  case "$active_state" in
+    active)
+      as_root "$SYSTEMCTL" stop fleet-node.service
+      service_stopped=1
+      ;;
+    inactive|failed) ;;
+    *)
+      echo "cannot upgrade Fleet Node while service is ${active_state:-unknown}" >&2
+      exit 1
+      ;;
+  esac
 fi
 
 ensure_shared_directory "${PROGRAM_DIR%/*}"

--- a/deployment-files/fleetnode/install-fleet-node.sh
+++ b/deployment-files/fleetnode/install-fleet-node.sh
@@ -353,9 +353,16 @@ cleanup() {
 trap cleanup EXIT
 
 remove_fleet_node() {
-  if as_root "$SYSTEMCTL" is-active --quiet fleet-node.service; then
-    as_root "$SYSTEMCTL" stop fleet-node.service
-  fi
+  local load_state
+  load_state=$(as_root "$SYSTEMCTL" show --property=LoadState --value fleet-node.service) || {
+    echo "cannot inspect Fleet Node systemd unit" >&2
+    return 1
+  }
+  case "$load_state" in
+    loaded) as_root "$SYSTEMCTL" stop fleet-node.service ;;
+    not-found) ;;
+    *) echo "unexpected Fleet Node systemd unit load state: $load_state" >&2; return 1 ;;
+  esac
   if as_root "$SYSTEMCTL" is-enabled --quiet fleet-node.service; then
     as_root "$SYSTEMCTL" disable fleet-node.service
   fi
@@ -473,19 +480,12 @@ if ! getent passwd fleetnode >/dev/null 2>&1; then
 fi
 validate_service_account
 
-if [[ ! -e "$CONFIG_DIR" ]]; then
-  if [[ "$TEST_MODE" == "1" ]]; then
-    as_root install -d -m 0750 "$CONFIG_DIR"
-  else
-    as_root install -d -o root -g fleetnode -m 0750 "$CONFIG_DIR"
-  fi
-fi
-if [[ ! -e "$STATE_DIR" ]]; then
-  if [[ "$TEST_MODE" == "1" ]]; then
-    as_root install -d -m 0700 "$STATE_DIR"
-  else
-    as_root install -d -o fleetnode -g fleetnode -m 0700 "$STATE_DIR"
-  fi
+if [[ "$TEST_MODE" == "1" ]]; then
+  as_root install -d -m 0750 "$CONFIG_DIR"
+  as_root install -d -m 0700 "$STATE_DIR"
+else
+  as_root install -d -o root -g fleetnode -m 0750 "$CONFIG_DIR"
+  as_root install -d -o fleetnode -g fleetnode -m 0700 "$STATE_DIR"
 fi
 
 as_root rm -rf "$incoming" "$previous"

--- a/deployment-files/fleetnode/install-fleet-node.sh
+++ b/deployment-files/fleetnode/install-fleet-node.sh
@@ -140,6 +140,9 @@ fi
 
 for path in "${PROGRAM_DIR%/*}" "${UNIT_PATH%/*}" "$PROGRAM_DIR" "$CONFIG_DIR" "$STATE_DIR" "$UNIT_PATH" "$INSTALL_LOCK_DIR" "$INSTALL_LOCK_PATH"; do
   if [[ -L "$path" ]]; then
+    if [[ "$ACTION" == "uninstall" && "$path" == "$UNIT_PATH" && "$path" -ef /dev/null ]]; then
+      continue
+    fi
     echo "refusing to install through symlink: $path" >&2
     exit 1
   fi
@@ -360,6 +363,10 @@ remove_fleet_node() {
   }
   case "$load_state" in
     loaded) as_root "$SYSTEMCTL" stop fleet-node.service ;;
+    masked)
+      as_root "$SYSTEMCTL" stop fleet-node.service
+      as_root "$SYSTEMCTL" unmask fleet-node.service
+      ;;
     not-found) ;;
     *) echo "unexpected Fleet Node systemd unit load state: $load_state" >&2; return 1 ;;
   esac
@@ -459,6 +466,18 @@ done < <(find "$source_dir" -mindepth 1 -print0)
 if ! grep -Fxq "version: $VERSION" "$source_dir/version.txt"; then
   echo "Fleet Node archive metadata does not match requested version '$VERSION'" >&2
   exit 1
+fi
+
+if [[ "$fresh_install" == "1" ]]; then
+  load_state=$(as_root "$SYSTEMCTL" show --property=LoadState --value fleet-node.service) || {
+    echo "cannot inspect Fleet Node systemd unit load state" >&2
+    exit 1
+  }
+  case "$load_state" in
+    loaded) fresh_install=0 ;;
+    not-found) ;;
+    *) echo "unexpected Fleet Node systemd unit load state: $load_state" >&2; exit 1 ;;
+  esac
 fi
 
 if [[ "$fresh_install" == "0" ]]; then

--- a/deployment-files/fleetnode/install-fleet-node.sh
+++ b/deployment-files/fleetnode/install-fleet-node.sh
@@ -194,9 +194,9 @@ load_service_account() {
 
 validate_group() {
   [[ -n "$group_record" ]] || { echo "fleetnode user exists without a fleetnode group" >&2; return 1; }
-  local _name _password _gid members member
+  local _name _password _uid _rest group_gid members member passwd_entries passwd_name passwd_gid
   local -a group_members=()
-  IFS=: read -r _name _password _gid members <<< "$group_record"
+  IFS=: read -r _name _password group_gid members <<< "$group_record"
   if [[ -n "$members" ]]; then
     IFS=, read -ra group_members <<< "$members"
     for member in "${group_members[@]}"; do
@@ -206,6 +206,14 @@ validate_group() {
       }
     done
   fi
+
+  passwd_entries=$(getent passwd) || { echo "cannot inspect primary group ownership for fleetnode group" >&2; return 1; }
+  while IFS=: read -r passwd_name _password _uid passwd_gid _rest; do
+    if [[ "$passwd_gid" == "$group_gid" && "$passwd_name" != "fleetnode" ]]; then
+      echo "fleetnode group is the primary group for unrelated account: $passwd_name" >&2
+      return 1
+    fi
+  done <<< "$passwd_entries"
 }
 
 validate_service_account() {

--- a/deployment-files/fleetnode/install-fleet-node.sh
+++ b/deployment-files/fleetnode/install-fleet-node.sh
@@ -8,6 +8,9 @@ LINUX_SERVICE_PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 USE_SUDO=0
 INSTALL_LOCK_PID=""
 INSTALL_LOCK_RELEASE_PATH=""
+ACTION=install
+PURGE=0
+VERSION=""
 
 if [[ "$TEST_MODE" != "1" ]]; then
   PATH="$LINUX_SERVICE_PATH"
@@ -17,9 +20,14 @@ fi
 usage() {
   cat <<'EOF'
 Usage: install-fleet-node.sh VERSION
+       install-fleet-node.sh uninstall [--purge]
 
 Install one exact Proto Fleet Node release on Linux. VERSION must be a
 release-specific tag such as v1.2.3 or nightly-20260825-0123456789ab.
+
+uninstall removes the program and systemd unit while preserving configuration,
+state, and the service account. --purge also removes those preserved files and
+the dedicated service account.
 
 The installer leaves a fresh installation stopped and disabled at boot. After
 installation, enroll the node and then enable and start the service.
@@ -30,16 +38,26 @@ if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
   usage
   exit 0
 fi
-if [[ $# -ne 1 ]]; then
-  usage >&2
-  exit 2
-fi
-VERSION="$1"
-
-if [[ ! "$VERSION" =~ ^[A-Za-z0-9_][A-Za-z0-9._-]{0,127}$ ]] || [[ "$VERSION" == "latest" ]]; then
-  echo "version must be an explicit release identifier (1-128 letters, numbers, dots, underscores, or hyphens; not latest)" >&2
-  exit 2
-fi
+case "${1:-}" in
+  uninstall)
+    ACTION=uninstall
+    case "${2:-}" in
+      "") ;;
+      --purge) PURGE=1 ;;
+      *) usage >&2; exit 2 ;;
+    esac
+    [[ $# -le 2 ]] || { usage >&2; exit 2; }
+    ;;
+  "") usage >&2; exit 2 ;;
+  *)
+    [[ $# -eq 1 ]] || { usage >&2; exit 2; }
+    VERSION="$1"
+    if [[ ! "$VERSION" =~ ^[A-Za-z0-9_][A-Za-z0-9._-]{0,127}$ ]] || [[ "$VERSION" == "latest" ]]; then
+      echo "version must be an explicit release identifier (1-128 letters, numbers, dots, underscores, or hyphens; not latest)" >&2
+      exit 2
+    fi
+    ;;
+esac
 if [[ "$TEST_MODE" != "1" ]]; then
   if [[ -n "$ROOT_PREFIX" || -n "${FLEETNODE_ARCH:-}" || -n "$DOWNLOAD_BASE_URL" || -n "${FLEETNODE_SYSTEMCTL:-}" ]]; then
     echo "Fleet Node installer overrides are restricted to automated tests" >&2
@@ -63,11 +81,13 @@ as_root() {
   fi
 }
 
-case "${FLEETNODE_ARCH:-$(uname -m)}" in
-  x86_64|amd64) ARCH=amd64 ;;
-  aarch64|arm64) ARCH=arm64 ;;
-  *) echo "unsupported Linux architecture: ${FLEETNODE_ARCH:-$(uname -m)}" >&2; exit 1 ;;
-esac
+if [[ "$ACTION" == "install" ]]; then
+  case "${FLEETNODE_ARCH:-$(uname -m)}" in
+    x86_64|amd64) ARCH=amd64 ;;
+    aarch64|arm64) ARCH=arm64 ;;
+    *) echo "unsupported Linux architecture: ${FLEETNODE_ARCH:-$(uname -m)}" >&2; exit 1 ;;
+  esac
+fi
 
 if [[ "$TEST_MODE" == "1" ]]; then
   [[ -n "$ROOT_PREFIX" && "$ROOT_PREFIX" == /* && "$ROOT_PREFIX" != "/" ]] || {
@@ -83,45 +103,171 @@ UNIT_PATH="${ROOT_PREFIX}/etc/systemd/system/fleet-node.service"
 INSTALL_LOCK_DIR="${ROOT_PREFIX}/run/proto-fleet"
 INSTALL_LOCK_PATH="$INSTALL_LOCK_DIR/fleetnode-installer.lock"
 SYSTEMCTL="${FLEETNODE_SYSTEMCTL:-systemctl}"
-ARCHIVE_ROOT="fleetnode-${VERSION}-linux-${ARCH}"
-ARCHIVE_NAME="${ARCHIVE_ROOT}.tar.gz"
-if [[ -z "$DOWNLOAD_BASE_URL" ]]; then
+ARCHIVE_ROOT=""
+ARCHIVE_NAME=""
+if [[ "$ACTION" == "install" ]]; then
+  ARCHIVE_ROOT="fleetnode-${VERSION}-linux-${ARCH}"
+  ARCHIVE_NAME="${ARCHIVE_ROOT}.tar.gz"
+fi
+if [[ "$ACTION" == "install" && -z "$DOWNLOAD_BASE_URL" ]]; then
   DOWNLOAD_BASE_URL="https://github.com/block/proto-fleet/releases/download/${VERSION}"
 fi
 
-for command in curl sha256sum tar install flock "$SYSTEMCTL"; do
+for command in install flock "$SYSTEMCTL"; do
   command -v "$command" >/dev/null 2>&1 || { echo "required command not found: $command" >&2; exit 1; }
 done
+if [[ "$ACTION" == "install" ]]; then
+  for command in curl sha256sum tar; do
+    command -v "$command" >/dev/null 2>&1 || { echo "required command not found: $command" >&2; exit 1; }
+  done
+fi
 if [[ "$TEST_MODE" != "1" && ! -x /usr/bin/env ]]; then
   echo "required command not found: /usr/bin/env" >&2
   exit 1
 fi
-if ! command -v nmap >/dev/null 2>&1; then
+if [[ "$ACTION" == "install" ]] && ! command -v nmap >/dev/null 2>&1; then
   echo "required command not found: nmap; install nmap in the Fleet Node service PATH ($LINUX_SERVICE_PATH)" >&2
   exit 1
 fi
 if [[ "$TEST_MODE" != "1" ]]; then
-  for command in getent useradd nologin; do
+  account_commands=()
+  if [[ "$ACTION" == "install" ]]; then
+    account_commands=(getent id nologin runuser useradd)
+  elif [[ "$PURGE" == "1" ]]; then
+    account_commands=(getent groupdel id nologin pgrep userdel)
+  fi
+  for command in "${account_commands[@]}"; do
     command -v "$command" >/dev/null 2>&1 || { echo "required command not found: $command" >&2; exit 1; }
   done
 fi
 
-for path in "$PROGRAM_DIR" "$CONFIG_DIR" "$STATE_DIR" "$UNIT_PATH" "$INSTALL_LOCK_DIR" "$INSTALL_LOCK_PATH"; do
+SYSTEMD_RUNTIME_DIR="${ROOT_PREFIX}/run/systemd/system"
+if [[ ! -d "$SYSTEMD_RUNTIME_DIR" || -L "$SYSTEMD_RUNTIME_DIR" ]]; then
+  echo "Fleet Node installation requires a running systemd system manager" >&2
+  exit 1
+fi
+if ! as_root "$SYSTEMCTL" show --property=Version --value >/dev/null 2>&1; then
+  echo "Fleet Node installation requires a running systemd system manager" >&2
+  exit 1
+fi
+
+for path in "${PROGRAM_DIR%/*}" "${UNIT_PATH%/*}" "$PROGRAM_DIR" "$CONFIG_DIR" "$STATE_DIR" "$UNIT_PATH" "$INSTALL_LOCK_DIR" "$INSTALL_LOCK_PATH"; do
   if [[ -L "$path" ]]; then
     echo "refusing to install through symlink: $path" >&2
     exit 1
   fi
 done
-if [[ -e "$PROGRAM_DIR" && ! -d "$PROGRAM_DIR" ]]; then
-  echo "program path exists but is not a directory: $PROGRAM_DIR" >&2
-  exit 1
+for path in "${PROGRAM_DIR%/*}" "${UNIT_PATH%/*}" "$PROGRAM_DIR" "$CONFIG_DIR" "$STATE_DIR"; do
+  if [[ -e "$path" && ! -d "$path" ]]; then
+    echo "directory path exists but is not a directory: $path" >&2
+    exit 1
+  fi
+done
+
+ensure_shared_directory() {
+  local path="$1"
+  if [[ -e "$path" ]]; then
+    [[ -d "$path" && ! -L "$path" ]] || { echo "shared path is not a directory: $path" >&2; return 1; }
+    return
+  fi
+  if [[ "$TEST_MODE" == "1" ]]; then
+    as_root install -d -m 0755 "$path"
+  else
+    as_root install -d -o root -g root -m 0755 "$path"
+  fi
+}
+
+group_record=""
+passwd_record=""
+account_uid=""
+
+load_service_account() {
+  passwd_record=""
+  group_record=""
+  if getent passwd fleetnode >/dev/null 2>&1; then
+    passwd_record=$(getent passwd fleetnode)
+  fi
+  if getent group fleetnode >/dev/null 2>&1; then
+    group_record=$(getent group fleetnode)
+  fi
+}
+
+validate_group() {
+  [[ -n "$group_record" ]] || { echo "fleetnode user exists without a fleetnode group" >&2; return 1; }
+  local _name _password _gid members member
+  local -a group_members=()
+  IFS=: read -r _name _password _gid members <<< "$group_record"
+  if [[ -n "$members" ]]; then
+    IFS=, read -ra group_members <<< "$members"
+    for member in "${group_members[@]}"; do
+      [[ "$member" == "fleetnode" ]] || {
+        echo "fleetnode group contains unrelated member: $member" >&2
+        return 1
+      }
+    done
+  fi
+}
+
+validate_service_account() {
+  load_service_account
+  [[ -n "$passwd_record" ]] || { echo "fleetnode account does not exist" >&2; return 1; }
+  validate_group
+
+  local _name _password primary_gid _gecos home shell group_gid groups group
+  IFS=: read -r _name _password account_uid primary_gid _gecos home shell <<< "$passwd_record"
+  IFS=: read -r _name _password group_gid _ <<< "$group_record"
+  [[ "$account_uid" != "0" ]] || { echo "fleetnode account must not be root" >&2; return 1; }
+  [[ "$primary_gid" == "$group_gid" ]] || { echo "fleetnode account must use the fleetnode group as its primary group" >&2; return 1; }
+  [[ "$home" == "/var/lib/fleetnode" ]] || { echo "fleetnode account must use home /var/lib/fleetnode" >&2; return 1; }
+  [[ "$shell" == "$(command -v nologin)" ]] || { echo "fleetnode account must use the system nologin shell" >&2; return 1; }
+  groups=$(id -nG fleetnode) || { echo "cannot inspect fleetnode group membership" >&2; return 1; }
+  for group in $groups; do
+    [[ "$group" == "fleetnode" ]] || { echo "fleetnode account belongs to unrelated group: $group" >&2; return 1; }
+  done
+  [[ " $groups " == *" fleetnode "* ]] || { echo "fleetnode account is not a member of fleetnode group" >&2; return 1; }
+}
+
+validate_existing_service_account() {
+  load_service_account
+  if [[ -n "$passwd_record" ]]; then
+    validate_service_account
+  elif [[ -n "$group_record" ]]; then
+    validate_group
+    local _name _password _gid members
+    IFS=: read -r _name _password _gid members <<< "$group_record"
+    [[ -z "$members" ]] || { echo "fleetnode group exists without its service account" >&2; return 1; }
+  elif [[ -e "$STATE_DIR" || -e "$CONFIG_DIR" ]]; then
+    echo "preserved Fleet Node data exists without the fleetnode service account" >&2
+    return 1
+  fi
+}
+
+validate_preserved_access() {
+  load_service_account
+  [[ -n "$passwd_record" ]] || return 0
+  if [[ -e "$STATE_DIR" ]]; then
+    [[ -d "$STATE_DIR" && ! -L "$STATE_DIR" ]] || { echo "state path is not a directory: $STATE_DIR" >&2; return 1; }
+    as_root runuser -u fleetnode -- test -x "$STATE_DIR" && \
+      as_root runuser -u fleetnode -- test -w "$STATE_DIR" || {
+        echo "fleetnode cannot traverse and write preserved state directory: $STATE_DIR" >&2
+        return 1
+      }
+  fi
+  local path
+  for path in "$STATE_DIR/state.yaml" "$CONFIG_DIR/config.yaml" "$CONFIG_DIR/fleetnode.env"; do
+    if [[ -e "$path" ]] && ! as_root runuser -u fleetnode -- test -r "$path"; then
+      echo "fleetnode cannot read preserved file: $path" >&2
+      return 1
+    fi
+  done
+}
+
+if [[ "$ACTION" == "install" ]]; then
+  validate_existing_service_account
+  validate_preserved_access
 fi
 
-if [[ "$TEST_MODE" == "1" ]]; then
-  as_root install -d -m 0755 "$INSTALL_LOCK_DIR"
-else
-  as_root install -d -o root -g root -m 0755 "$INSTALL_LOCK_DIR"
-fi
+ensure_shared_directory "$INSTALL_LOCK_DIR"
 as_root touch "$INSTALL_LOCK_PATH"
 if [[ "$TEST_MODE" != "1" ]]; then
   as_root chown root:root "$INSTALL_LOCK_PATH"
@@ -211,8 +357,98 @@ cleanup() {
 }
 trap cleanup EXIT
 
+remove_fleet_node() {
+  local unit_present=0
+  local service_was_active=0
+  [[ -f "$UNIT_PATH" ]] && unit_present=1
+
+  if [[ "$PURGE" == "1" ]]; then
+    load_service_account
+    if [[ -n "$passwd_record" ]]; then
+      validate_service_account
+    elif [[ -n "$group_record" ]]; then
+      validate_group
+      local _name _password _gid members
+      IFS=: read -r _name _password _gid members <<< "$group_record"
+      [[ -z "$members" ]] || { echo "fleetnode group exists without its service account" >&2; return 1; }
+    fi
+  fi
+
+  if [[ "$unit_present" == "1" ]]; then
+    if [[ "$PURGE" == "1" ]] && as_root "$SYSTEMCTL" is-active --quiet fleet-node.service; then
+      service_was_active=1
+    fi
+    as_root "$SYSTEMCTL" stop fleet-node.service
+  fi
+
+  if [[ "$PURGE" == "1" ]]; then
+    if [[ -e "$STATE_DIR/state.lock" ]] && ! as_root flock -n "$STATE_DIR/state.lock" true; then
+      echo "Fleet Node state is in use; refusing to purge while state.lock is held" >&2
+      if [[ "$service_was_active" == "1" ]]; then
+        as_root "$SYSTEMCTL" start fleet-node.service || echo "failed to restart Fleet Node after refusing purge" >&2
+      fi
+      return 1
+    fi
+
+    load_service_account
+    if [[ -n "$passwd_record" ]]; then
+      if as_root pgrep -u "$account_uid" >/dev/null 2>&1; then
+        echo "fleetnode account still has running processes" >&2
+        if [[ "$service_was_active" == "1" ]]; then
+          as_root "$SYSTEMCTL" start fleet-node.service || echo "failed to restart Fleet Node after refusing purge" >&2
+        fi
+        return 1
+      fi
+    fi
+  fi
+
+  if [[ "$unit_present" == "1" ]]; then
+    as_root "$SYSTEMCTL" disable fleet-node.service
+  fi
+
+  as_root rm -rf "$PROGRAM_DIR"
+  as_root rm -f "$UNIT_PATH"
+  as_root "$SYSTEMCTL" daemon-reload
+  as_root "$SYSTEMCTL" reset-failed fleet-node.service >/dev/null 2>&1 || true
+
+  if [[ "$PURGE" == "1" ]]; then
+    as_root rm -rf "$CONFIG_DIR" "$STATE_DIR"
+    load_service_account
+    if [[ -n "$passwd_record" ]]; then
+      as_root userdel fleetnode
+    fi
+    load_service_account
+    if [[ -n "$group_record" ]]; then
+      as_root groupdel fleetnode
+    fi
+    echo "Fleet Node uninstalled and local state purged."
+  else
+    echo "Fleet Node uninstalled. Preserved:"
+    echo "  $CONFIG_DIR"
+    echo "  $STATE_DIR"
+    echo "  fleetnode service account"
+  fi
+}
+
+if [[ "$ACTION" == "uninstall" ]]; then
+  remove_fleet_node
+  install_complete=1
+  exit 0
+fi
+
 echo "Downloading Fleet Node $VERSION for linux/$ARCH..."
-curl_options=(--disable --fail --location --silent --show-error)
+curl_options=(
+  --disable
+  --fail
+  --location
+  --silent
+  --show-error
+  --connect-timeout 10
+  --max-time 300
+  --retry 3
+  --retry-delay 2
+  --retry-connrefused
+)
 if [[ "$TEST_MODE" != "1" ]]; then
   curl_options+=(--proto '=https' --proto-redir '=https')
 fi
@@ -284,21 +520,31 @@ if [[ "$fresh_install" == "0" ]]; then
   fi
 fi
 
-as_root install -d -m 0755 "${PROGRAM_DIR%/*}" "${UNIT_PATH%/*}"
-if [[ "$TEST_MODE" == "1" ]]; then
-  as_root install -d -m 0750 "$CONFIG_DIR"
-  as_root install -d -m 0700 "$STATE_DIR"
-else
-  if ! getent passwd fleetnode >/dev/null; then
-    if getent group fleetnode >/dev/null; then
-      as_root useradd --system --gid fleetnode --home-dir /var/lib/fleetnode --shell "$(command -v nologin)" fleetnode
-    else
-      as_root useradd --system --user-group --home-dir /var/lib/fleetnode --shell "$(command -v nologin)" fleetnode
-    fi
+ensure_shared_directory "${PROGRAM_DIR%/*}"
+ensure_shared_directory "${UNIT_PATH%/*}"
+
+if ! getent passwd fleetnode >/dev/null 2>&1; then
+  if getent group fleetnode >/dev/null 2>&1; then
+    as_root useradd --system --gid fleetnode --home-dir /var/lib/fleetnode --shell "$(command -v nologin)" fleetnode
+  else
+    as_root useradd --system --user-group --home-dir /var/lib/fleetnode --shell "$(command -v nologin)" fleetnode
   fi
-  getent group fleetnode >/dev/null || { echo "fleetnode user exists without a fleetnode group" >&2; exit 1; }
-  as_root install -d -o root -g fleetnode -m 0750 "$CONFIG_DIR"
-  as_root install -d -o fleetnode -g fleetnode -m 0700 "$STATE_DIR"
+fi
+validate_service_account
+
+if [[ ! -e "$CONFIG_DIR" ]]; then
+  if [[ "$TEST_MODE" == "1" ]]; then
+    as_root install -d -m 0750 "$CONFIG_DIR"
+  else
+    as_root install -d -o root -g fleetnode -m 0750 "$CONFIG_DIR"
+  fi
+fi
+if [[ ! -e "$STATE_DIR" ]]; then
+  if [[ "$TEST_MODE" == "1" ]]; then
+    as_root install -d -m 0700 "$STATE_DIR"
+  else
+    as_root install -d -o fleetnode -g fleetnode -m 0700 "$STATE_DIR"
+  fi
 fi
 
 as_root rm -rf "$incoming" "$previous"
@@ -325,8 +571,8 @@ program_replaced=1
 if [[ -f "$UNIT_PATH" ]]; then
   as_root cp -p "$UNIT_PATH" "$unit_backup"
 fi
-as_root install -m 0644 "$PROGRAM_DIR/fleet-node.service" "$UNIT_PATH"
 unit_replaced=1
+as_root install -m 0644 "$PROGRAM_DIR/fleet-node.service" "$UNIT_PATH"
 as_root "$SYSTEMCTL" daemon-reload
 
 if [[ "$fresh_install" == "1" ]]; then

--- a/deployment-files/fleetnode/install-fleet-node.sh
+++ b/deployment-files/fleetnode/install-fleet-node.sh
@@ -370,11 +370,9 @@ remove_fleet_node() {
     not-found) ;;
     *) echo "unexpected Fleet Node systemd unit load state: $load_state" >&2; return 1 ;;
   esac
-  if as_root "$SYSTEMCTL" is-enabled --quiet fleet-node.service; then
-    as_root "$SYSTEMCTL" disable fleet-node.service
-  fi
 
   as_root rm -rf "$PROGRAM_DIR"
+  as_root rm -f "${UNIT_PATH%/*}/multi-user.target.wants/fleet-node.service"
   as_root rm -f "$UNIT_PATH"
   as_root "$SYSTEMCTL" daemon-reload
   as_root "$SYSTEMCTL" reset-failed fleet-node.service >/dev/null 2>&1 || true

--- a/deployment-files/fleetnode/install-fleet-node.sh
+++ b/deployment-files/fleetnode/install-fleet-node.sh
@@ -474,7 +474,19 @@ if [[ "$fresh_install" == "1" ]]; then
     exit 1
   }
   case "$load_state" in
-    loaded) fresh_install=0 ;;
+    loaded)
+      active_state=$(as_root "$SYSTEMCTL" show --property=ActiveState --value fleet-node.service) || {
+        echo "cannot inspect Fleet Node systemd active state" >&2
+        exit 1
+      }
+      case "$active_state" in
+        inactive|failed) ;;
+        *)
+          echo "cannot install Fleet Node over an incomplete installation while service is ${active_state:-unknown}" >&2
+          exit 1
+          ;;
+      esac
+      ;;
     not-found) ;;
     *) echo "unexpected Fleet Node systemd unit load state: $load_state" >&2; exit 1 ;;
   esac

--- a/deployment-files/fleetnode/tests/test-install-fleetnode.sh
+++ b/deployment-files/fleetnode/tests/test-install-fleetnode.sh
@@ -4,14 +4,16 @@ set -euo pipefail
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 FLEETNODE_DIR=$(cd "$SCRIPT_DIR/.." && pwd)
 TEST_DIR=$(mktemp -d)
-trap 'rm -rf "$TEST_DIR"' EXIT
+trap 'status=$?; if [[ "$status" == "0" ]]; then rm -rf "$TEST_DIR"; else echo "test artifacts: $TEST_DIR" >&2; fi; exit "$status"' EXIT
 
 ASSETS_DIR="$TEST_DIR/assets"
 ROOT_PREFIX="$TEST_DIR/root"
 SYSTEMCTL_LOG="$TEST_DIR/systemctl.log"
 SUDO_LOG="$TEST_DIR/sudo.log"
+ACCOUNT_LOG="$TEST_DIR/account.log"
+ACCOUNT_DB="$TEST_DIR/account-db"
 LINUX_SERVICE_PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-mkdir -p "$ASSETS_DIR" "$ROOT_PREFIX" "$TEST_DIR/bin"
+mkdir -p "$ASSETS_DIR" "$ROOT_PREFIX/run/systemd/system" "$TEST_DIR/bin" "$ACCOUNT_DB"
 
 fail() {
   echo "FAIL: $*" >&2
@@ -21,7 +23,11 @@ fail() {
 assert_file_contains() {
   local path="$1"
   local expected="$2"
-  grep -Fq "$expected" "$path" || fail "$path does not contain: $expected"
+  grep -Fq -- "$expected" "$path" || fail "$path does not contain: $expected"
+}
+
+file_mode() {
+  stat -c %a "$1" 2>/dev/null || stat -f %Lp "$1"
 }
 
 create_release() {
@@ -49,7 +55,8 @@ create_release() {
   printf 'plugin: {}\nminers: {}\n' > "$release_dir/$archive_root/plugins/asicrs-config.yaml"
   if [[ -n "$extra_entry" ]]; then
     printf '#!/usr/bin/env bash\nexit 0\n' > "$release_dir/$archive_root/$extra_entry"
-    chmod 4755 "$release_dir/$archive_root/$extra_entry"
+    chmod 4755 "$release_dir/$archive_root/$extra_entry" 2>/dev/null || \
+      chmod 0755 "$release_dir/$archive_root/$extra_entry"
   fi
 
   (
@@ -65,6 +72,10 @@ cat > "$TEST_DIR/bin/id" <<'EOF'
 set -euo pipefail
 if [[ "${1:-}" == "-u" ]]; then
   echo 1000
+  exit 0
+fi
+if [[ "${1:-}" == "-nG" && "${2:-}" == "fleetnode" && -e "$FAKE_ACCOUNT_DB/user" ]]; then
+  echo "${FAKE_ACCOUNT_GROUPS:-fleetnode}"
   exit 0
 fi
 exit 1
@@ -83,6 +94,9 @@ cat > "$TEST_DIR/bin/systemctl" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >> "$SYSTEMCTL_LOG"
+if [[ "${1:-}" == "show" && "${FAKE_SYSTEMCTL_FAIL_SHOW:-0}" == "1" ]]; then
+  exit 1
+fi
 if [[ "${1:-}" == "stop" && -n "${FAKE_FLEETNODE_LOCK_READY:-}" ]]; then
   : > "$FAKE_FLEETNODE_LOCK_READY"
   while [[ -e "${FAKE_FLEETNODE_LOCK_BLOCK:-}" ]]; do
@@ -110,6 +124,77 @@ exit 0
 EOF
 chmod 0755 "$TEST_DIR/bin/systemctl"
 
+cat > "$TEST_DIR/bin/getent" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}:${2:-}" in
+  passwd:fleetnode)
+    [[ -e "$FAKE_ACCOUNT_DB/user" ]] || exit 2
+    printf 'fleetnode:x:995:%s::%s:%s\n' \
+      "${FAKE_ACCOUNT_PRIMARY_GID:-995}" \
+      "${FAKE_ACCOUNT_HOME:-/var/lib/fleetnode}" \
+      "${FAKE_ACCOUNT_SHELL:-$FAKE_NOLOGIN_PATH}"
+    ;;
+  group:fleetnode)
+    [[ -e "$FAKE_ACCOUNT_DB/group" ]] || exit 2
+    printf 'fleetnode:x:%s:%s\n' \
+      "${FAKE_GROUP_GID:-995}" "${FAKE_GROUP_MEMBERS:-}"
+    ;;
+  *) exit 2 ;;
+esac
+EOF
+chmod 0755 "$TEST_DIR/bin/getent"
+
+cat > "$TEST_DIR/bin/useradd" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'useradd %s\n' "$*" >> "$ACCOUNT_LOG"
+touch "$FAKE_ACCOUNT_DB/user"
+if [[ " $* " == *" --user-group "* ]]; then
+  touch "$FAKE_ACCOUNT_DB/group"
+fi
+EOF
+chmod 0755 "$TEST_DIR/bin/useradd"
+
+cat > "$TEST_DIR/bin/userdel" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'userdel %s\n' "$*" >> "$ACCOUNT_LOG"
+rm -f "$FAKE_ACCOUNT_DB/user"
+EOF
+chmod 0755 "$TEST_DIR/bin/userdel"
+
+cat > "$TEST_DIR/bin/groupdel" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'groupdel %s\n' "$*" >> "$ACCOUNT_LOG"
+rm -f "$FAKE_ACCOUNT_DB/group"
+EOF
+chmod 0755 "$TEST_DIR/bin/groupdel"
+
+cat > "$TEST_DIR/bin/runuser" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+shift 3
+if [[ -n "${FAKE_RUNUSER_DENY:-}" && " $* " == *" $FAKE_RUNUSER_DENY "* ]]; then
+  exit 1
+fi
+exec "$@"
+EOF
+chmod 0755 "$TEST_DIR/bin/runuser"
+
+cat > "$TEST_DIR/bin/pgrep" <<'EOF'
+#!/usr/bin/env bash
+[[ "${FAKE_ACCOUNT_BUSY:-0}" == "1" ]]
+EOF
+chmod 0755 "$TEST_DIR/bin/pgrep"
+
+cat > "$TEST_DIR/bin/nologin" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod 0755 "$TEST_DIR/bin/nologin"
+
 cat > "$TEST_DIR/bin/nmap" <<'EOF'
 #!/usr/bin/env bash
 exit 0
@@ -121,6 +206,9 @@ cat > "$TEST_DIR/bin/flock" <<'EOF'
 set -euo pipefail
 if [[ -n "${REAL_FLOCK:-}" ]]; then
   exec "$REAL_FLOCK" "$@"
+fi
+if [[ "${FAKE_STATE_LOCK_HELD:-0}" == "1" && " $* " == *"state.lock"* ]]; then
+  exit 1
 fi
 if [[ "${1:-}" == "-n" ]]; then
   shift 2
@@ -185,6 +273,19 @@ run_installer() {
   FAKE_FLEETNODE_LOCK_BLOCK="${FAKE_FLEETNODE_LOCK_BLOCK:-}" \
   FAKE_SYSTEMCTL_FAIL_START="${FAKE_SYSTEMCTL_FAIL_START:-0}" \
   FAKE_SYSTEMCTL_FAIL_START_ONCE="${FAKE_SYSTEMCTL_FAIL_START_ONCE:-}" \
+  FAKE_SYSTEMCTL_FAIL_SHOW="${FAKE_SYSTEMCTL_FAIL_SHOW:-0}" \
+  FAKE_ACCOUNT_DB="$ACCOUNT_DB" \
+  FAKE_NOLOGIN_PATH="$TEST_DIR/bin/nologin" \
+  FAKE_ACCOUNT_HOME="${FAKE_ACCOUNT_HOME:-/var/lib/fleetnode}" \
+  FAKE_ACCOUNT_SHELL="${FAKE_ACCOUNT_SHELL:-$TEST_DIR/bin/nologin}" \
+  FAKE_ACCOUNT_GROUPS="${FAKE_ACCOUNT_GROUPS:-fleetnode}" \
+  FAKE_ACCOUNT_PRIMARY_GID="${FAKE_ACCOUNT_PRIMARY_GID:-995}" \
+  FAKE_GROUP_GID="${FAKE_GROUP_GID:-995}" \
+  FAKE_GROUP_MEMBERS="${FAKE_GROUP_MEMBERS:-}" \
+  FAKE_RUNUSER_DENY="${FAKE_RUNUSER_DENY:-}" \
+  FAKE_ACCOUNT_BUSY="${FAKE_ACCOUNT_BUSY:-0}" \
+  FAKE_STATE_LOCK_HELD="${FAKE_STATE_LOCK_HELD:-0}" \
+  ACCOUNT_LOG="$ACCOUNT_LOG" \
   REAL_FLOCK="${REAL_FLOCK:-}" \
   SYSTEMCTL_LOG="$SYSTEMCTL_LOG" \
   SUDO_LOG="$SUDO_LOG" \
@@ -197,6 +298,29 @@ run_installer() {
     bash <(curl --disable --fail --silent --show-error "file://$FLEETNODE_DIR/install-fleet-node.sh") "$version"
 }
 
+run_uninstaller() {
+  FAKE_FLEETNODE_ENABLED="${FAKE_FLEETNODE_ENABLED:-0}" \
+  FAKE_FLEETNODE_ACTIVE="${FAKE_FLEETNODE_ACTIVE:-0}" \
+  FAKE_ACCOUNT_DB="$ACCOUNT_DB" \
+  FAKE_NOLOGIN_PATH="$TEST_DIR/bin/nologin" \
+  FAKE_ACCOUNT_HOME="${FAKE_ACCOUNT_HOME:-/var/lib/fleetnode}" \
+  FAKE_ACCOUNT_SHELL="${FAKE_ACCOUNT_SHELL:-$TEST_DIR/bin/nologin}" \
+  FAKE_ACCOUNT_GROUPS="${FAKE_ACCOUNT_GROUPS:-fleetnode}" \
+  FAKE_ACCOUNT_PRIMARY_GID="${FAKE_ACCOUNT_PRIMARY_GID:-995}" \
+  FAKE_GROUP_GID="${FAKE_GROUP_GID:-995}" \
+  FAKE_GROUP_MEMBERS="${FAKE_GROUP_MEMBERS:-}" \
+  FAKE_ACCOUNT_BUSY="${FAKE_ACCOUNT_BUSY:-0}" \
+  FAKE_STATE_LOCK_HELD="${FAKE_STATE_LOCK_HELD:-0}" \
+  ACCOUNT_LOG="$ACCOUNT_LOG" \
+  SYSTEMCTL_LOG="$SYSTEMCTL_LOG" \
+  SUDO_LOG="$SUDO_LOG" \
+  PATH="$TEST_DIR/bin:$PATH" \
+  FLEETNODE_TEST_MODE=1 \
+  FLEETNODE_ROOT_PREFIX="$ROOT_PREFIX" \
+  FLEETNODE_SYSTEMCTL="$TEST_DIR/bin/systemctl" \
+    /bin/bash "$FLEETNODE_DIR/install-fleet-node.sh" uninstall "$@"
+}
+
 start_installer() {
   local version="$1"
   local output_path="$2"
@@ -204,6 +328,16 @@ start_installer() {
   FAKE_FLEETNODE_ACTIVE="${FAKE_FLEETNODE_ACTIVE:-1}" \
   FAKE_FLEETNODE_LOCK_READY="${FAKE_FLEETNODE_LOCK_READY:-}" \
   FAKE_FLEETNODE_LOCK_BLOCK="${FAKE_FLEETNODE_LOCK_BLOCK:-}" \
+  FAKE_ACCOUNT_DB="$ACCOUNT_DB" \
+  FAKE_NOLOGIN_PATH="$TEST_DIR/bin/nologin" \
+  FAKE_ACCOUNT_HOME="${FAKE_ACCOUNT_HOME:-/var/lib/fleetnode}" \
+  FAKE_ACCOUNT_SHELL="${FAKE_ACCOUNT_SHELL:-$TEST_DIR/bin/nologin}" \
+  FAKE_ACCOUNT_GROUPS="${FAKE_ACCOUNT_GROUPS:-fleetnode}" \
+  FAKE_ACCOUNT_PRIMARY_GID="${FAKE_ACCOUNT_PRIMARY_GID:-995}" \
+  FAKE_GROUP_GID="${FAKE_GROUP_GID:-995}" \
+  FAKE_GROUP_MEMBERS="${FAKE_GROUP_MEMBERS:-}" \
+  FAKE_RUNUSER_DENY="${FAKE_RUNUSER_DENY:-}" \
+  ACCOUNT_LOG="$ACCOUNT_LOG" \
   REAL_FLOCK="${REAL_FLOCK:-}" \
   SYSTEMCTL_LOG="$SYSTEMCTL_LOG" \
   SUDO_LOG="$SUDO_LOG" \
@@ -220,9 +354,21 @@ start_installer() {
 
 : > "$SYSTEMCTL_LOG"
 : > "$SUDO_LOG"
+: > "$ACCOUNT_LOG"
 mkdir -p "$ROOT_PREFIX/etc/systemd/system"
+mkdir -p "$ROOT_PREFIX/opt"
+chmod 0711 "$ROOT_PREFIX/opt"
+chmod 0751 "$ROOT_PREFIX/etc/systemd/system"
 printf 'legacy unit\n' > "$ROOT_PREFIX/etc/systemd/system/fleetnode.service"
 CURL_HOME="$TEST_DIR/curl-home" FAKE_FLEETNODE_ENABLED=1 run_installer v1.0.0
+
+[[ "$(file_mode "$ROOT_PREFIX/opt")" == "711" ]] || fail "installer changed /opt mode"
+[[ "$(file_mode "$ROOT_PREFIX/etc/systemd/system")" == "751" ]] || fail "installer changed systemd directory mode"
+assert_file_contains "$FLEETNODE_DIR/install-fleet-node.sh" "--connect-timeout 10"
+assert_file_contains "$FLEETNODE_DIR/install-fleet-node.sh" "--max-time 300"
+assert_file_contains "$FLEETNODE_DIR/install-fleet-node.sh" "--retry 3"
+assert_file_contains "$FLEETNODE_DIR/install-fleet-node.sh" "--retry-delay 2"
+assert_file_contains "$FLEETNODE_DIR/install-fleet-node.sh" "--retry-connrefused"
 
 [[ -x "$ROOT_PREFIX/opt/fleetnode/fleetnode" ]] || fail "Fleet Node binary was not installed"
 assert_file_contains "$ROOT_PREFIX/opt/fleetnode/version.txt" "version: v1.0.0"
@@ -256,6 +402,25 @@ fi
 printf 'operator config\n' > "$ROOT_PREFIX/etc/fleetnode/config.yaml"
 printf 'identity material\n' > "$ROOT_PREFIX/var/lib/fleetnode/state.yaml"
 printf 'stale program file\n' > "$ROOT_PREFIX/opt/fleetnode/stale.txt"
+
+: > "$SYSTEMCTL_LOG"
+if FAKE_ACCOUNT_HOME=/tmp/not-fleetnode run_installer v1.1.0 > "$TEST_DIR/bad-account.out" 2>&1; then
+  fail "installer reused an account with the wrong home"
+fi
+assert_file_contains "$TEST_DIR/bad-account.out" "fleetnode account must use home /var/lib/fleetnode"
+if grep -Fq 'stop fleet-node.service' "$SYSTEMCTL_LOG"; then
+  fail "installer stopped the service before validating its account"
+fi
+
+: > "$SYSTEMCTL_LOG"
+if FAKE_RUNUSER_DENY="$ROOT_PREFIX/var/lib/fleetnode/state.yaml" \
+    run_installer v1.1.0 > "$TEST_DIR/unreadable-state.out" 2>&1; then
+  fail "installer accepted unreadable preserved state"
+fi
+assert_file_contains "$TEST_DIR/unreadable-state.out" "fleetnode cannot read preserved file"
+if grep -Fq 'stop fleet-node.service' "$SYSTEMCTL_LOG"; then
+  fail "installer stopped the service before validating preserved state"
+fi
 
 : > "$SYSTEMCTL_LOG"
 run_installer v1.1.0
@@ -368,6 +533,11 @@ if FLEETNODE_TEST_MODE=1 \
   FLEETNODE_ARCH=amd64 \
   FLEETNODE_SYSTEMCTL="$TEST_DIR/bin/systemctl" \
   FLEETNODE_DOWNLOAD_BASE_URL="file://$ASSETS_DIR/bad-checksum" \
+  FAKE_ACCOUNT_DB="$ACCOUNT_DB" \
+  FAKE_NOLOGIN_PATH="$TEST_DIR/bin/nologin" \
+  FAKE_ACCOUNT_SHELL="$TEST_DIR/bin/nologin" \
+  FAKE_ACCOUNT_GROUPS=fleetnode \
+  ACCOUNT_LOG="$ACCOUNT_LOG" \
   SYSTEMCTL_LOG="$SYSTEMCTL_LOG" \
   SUDO_LOG="$SUDO_LOG" \
   PATH="$TEST_DIR/bin:$PATH" \
@@ -386,5 +556,51 @@ assert_file_contains "$SYSTEMCTL_LOG" "is-active --quiet fleet-node.service"
 if grep -Eq '^(stop|start) fleet-node.service$' "$SYSTEMCTL_LOG"; then
   fail "inactive upgrade changed the Fleet Node service state"
 fi
+
+run_uninstaller
+[[ ! -e "$ROOT_PREFIX/opt/fleetnode" ]] || fail "uninstall retained the program"
+[[ ! -e "$ROOT_PREFIX/etc/systemd/system/fleet-node.service" ]] || fail "uninstall retained the unit"
+[[ -e "$ROOT_PREFIX/etc/fleetnode/config.yaml" ]] || fail "uninstall removed configuration"
+[[ -e "$ROOT_PREFIX/var/lib/fleetnode/state.yaml" ]] || fail "uninstall removed state"
+[[ -e "$ACCOUNT_DB/user" && -e "$ACCOUNT_DB/group" ]] || fail "uninstall removed the service account"
+assert_file_contains "$SYSTEMCTL_LOG" "stop fleet-node.service"
+assert_file_contains "$SYSTEMCTL_LOG" "disable fleet-node.service"
+
+run_uninstaller
+run_installer v1.1.0
+
+: > "$ROOT_PREFIX/var/lib/fleetnode/state.lock"
+: > "$SYSTEMCTL_LOG"
+if FAKE_FLEETNODE_ACTIVE=1 FAKE_FLEETNODE_ENABLED=1 FAKE_STATE_LOCK_HELD=1 run_uninstaller --purge > "$TEST_DIR/locked-purge.out" 2>&1; then
+  fail "purge accepted an active state lock"
+fi
+assert_file_contains "$TEST_DIR/locked-purge.out" "Fleet Node state is in use"
+[[ -e "$ROOT_PREFIX/var/lib/fleetnode/state.yaml" ]] || fail "failed purge removed state"
+assert_file_contains "$SYSTEMCTL_LOG" "stop fleet-node.service"
+assert_file_contains "$SYSTEMCTL_LOG" "start fleet-node.service"
+if grep -Fq "disable fleet-node.service" "$SYSTEMCTL_LOG"; then
+  fail "refused locked purge disabled the service"
+fi
+
+: > "$SYSTEMCTL_LOG"
+if FAKE_FLEETNODE_ACTIVE=1 FAKE_FLEETNODE_ENABLED=1 FAKE_ACCOUNT_BUSY=1 run_uninstaller --purge > "$TEST_DIR/busy-purge.out" 2>&1; then
+  fail "purge accepted a service account with running processes"
+fi
+assert_file_contains "$TEST_DIR/busy-purge.out" "fleetnode account still has running processes"
+[[ -e "$ROOT_PREFIX/var/lib/fleetnode/state.yaml" ]] || fail "busy purge removed state"
+assert_file_contains "$SYSTEMCTL_LOG" "stop fleet-node.service"
+assert_file_contains "$SYSTEMCTL_LOG" "start fleet-node.service"
+if grep -Fq "disable fleet-node.service" "$SYSTEMCTL_LOG"; then
+  fail "refused busy purge disabled the service"
+fi
+
+run_uninstaller --purge
+[[ ! -e "$ROOT_PREFIX/opt/fleetnode" ]] || fail "purge retained the program"
+[[ ! -e "$ROOT_PREFIX/etc/fleetnode" ]] || fail "purge retained configuration"
+[[ ! -e "$ROOT_PREFIX/var/lib/fleetnode" ]] || fail "purge retained state"
+[[ ! -e "$ACCOUNT_DB/user" && ! -e "$ACCOUNT_DB/group" ]] || fail "purge retained the service account"
+assert_file_contains "$ACCOUNT_LOG" "userdel fleetnode"
+assert_file_contains "$ACCOUNT_LOG" "groupdel fleetnode"
+run_uninstaller --purge
 
 echo "Fleet Node installer tests passed"

--- a/deployment-files/fleetnode/tests/test-install-fleetnode.sh
+++ b/deployment-files/fleetnode/tests/test-install-fleetnode.sh
@@ -128,6 +128,18 @@ cat > "$TEST_DIR/bin/getent" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 case "${1:-}:${2:-}" in
+  passwd:)
+    if [[ -e "$FAKE_ACCOUNT_DB/user" ]]; then
+      printf 'fleetnode:x:995:%s::%s:%s\n' \
+        "${FAKE_ACCOUNT_PRIMARY_GID:-995}" \
+        "${FAKE_ACCOUNT_HOME:-/var/lib/fleetnode}" \
+        "${FAKE_ACCOUNT_SHELL:-$FAKE_NOLOGIN_PATH}"
+    fi
+    if [[ -n "${FAKE_PRIMARY_GID_USER:-}" ]]; then
+      printf '%s:x:996:%s::/home/%s:/bin/sh\n' \
+        "$FAKE_PRIMARY_GID_USER" "${FAKE_GROUP_GID:-995}" "$FAKE_PRIMARY_GID_USER"
+    fi
+    ;;
   passwd:fleetnode)
     [[ -e "$FAKE_ACCOUNT_DB/user" ]] || exit 2
     printf 'fleetnode:x:995:%s::%s:%s\n' \
@@ -282,6 +294,7 @@ run_installer() {
   FAKE_ACCOUNT_PRIMARY_GID="${FAKE_ACCOUNT_PRIMARY_GID:-995}" \
   FAKE_GROUP_GID="${FAKE_GROUP_GID:-995}" \
   FAKE_GROUP_MEMBERS="${FAKE_GROUP_MEMBERS:-}" \
+  FAKE_PRIMARY_GID_USER="${FAKE_PRIMARY_GID_USER:-}" \
   FAKE_RUNUSER_DENY="${FAKE_RUNUSER_DENY:-}" \
   FAKE_ACCOUNT_BUSY="${FAKE_ACCOUNT_BUSY:-0}" \
   FAKE_STATE_LOCK_HELD="${FAKE_STATE_LOCK_HELD:-0}" \
@@ -309,6 +322,7 @@ run_uninstaller() {
   FAKE_ACCOUNT_PRIMARY_GID="${FAKE_ACCOUNT_PRIMARY_GID:-995}" \
   FAKE_GROUP_GID="${FAKE_GROUP_GID:-995}" \
   FAKE_GROUP_MEMBERS="${FAKE_GROUP_MEMBERS:-}" \
+  FAKE_PRIMARY_GID_USER="${FAKE_PRIMARY_GID_USER:-}" \
   FAKE_ACCOUNT_BUSY="${FAKE_ACCOUNT_BUSY:-0}" \
   FAKE_STATE_LOCK_HELD="${FAKE_STATE_LOCK_HELD:-0}" \
   ACCOUNT_LOG="$ACCOUNT_LOG" \
@@ -336,6 +350,7 @@ start_installer() {
   FAKE_ACCOUNT_PRIMARY_GID="${FAKE_ACCOUNT_PRIMARY_GID:-995}" \
   FAKE_GROUP_GID="${FAKE_GROUP_GID:-995}" \
   FAKE_GROUP_MEMBERS="${FAKE_GROUP_MEMBERS:-}" \
+  FAKE_PRIMARY_GID_USER="${FAKE_PRIMARY_GID_USER:-}" \
   FAKE_RUNUSER_DENY="${FAKE_RUNUSER_DENY:-}" \
   ACCOUNT_LOG="$ACCOUNT_LOG" \
   REAL_FLOCK="${REAL_FLOCK:-}" \
@@ -402,6 +417,16 @@ fi
 printf 'operator config\n' > "$ROOT_PREFIX/etc/fleetnode/config.yaml"
 printf 'identity material\n' > "$ROOT_PREFIX/var/lib/fleetnode/state.yaml"
 printf 'stale program file\n' > "$ROOT_PREFIX/opt/fleetnode/stale.txt"
+
+: > "$SYSTEMCTL_LOG"
+if FAKE_PRIMARY_GID_USER=operator run_installer v1.1.0 > "$TEST_DIR/shared-primary-gid-install.out" 2>&1; then
+  fail "installer reused a fleetnode group that is another account's primary group"
+fi
+assert_file_contains "$TEST_DIR/shared-primary-gid-install.out" "fleetnode group is the primary group for unrelated account: operator"
+assert_file_contains "$ROOT_PREFIX/opt/fleetnode/version.txt" "version: v1.0.0"
+if grep -Fq 'stop fleet-node.service' "$SYSTEMCTL_LOG"; then
+  fail "installer stopped the service before validating primary group ownership"
+fi
 
 : > "$SYSTEMCTL_LOG"
 if FAKE_ACCOUNT_HOME=/tmp/not-fleetnode run_installer v1.1.0 > "$TEST_DIR/bad-account.out" 2>&1; then
@@ -568,6 +593,21 @@ assert_file_contains "$SYSTEMCTL_LOG" "disable fleet-node.service"
 
 run_uninstaller
 run_installer v1.1.0
+
+: > "$SYSTEMCTL_LOG"
+: > "$ACCOUNT_LOG"
+if FAKE_PRIMARY_GID_USER=operator run_uninstaller --purge > "$TEST_DIR/shared-primary-gid-purge.out" 2>&1; then
+  fail "purge accepted a fleetnode group that is another account's primary group"
+fi
+assert_file_contains "$TEST_DIR/shared-primary-gid-purge.out" "fleetnode group is the primary group for unrelated account: operator"
+[[ -e "$ROOT_PREFIX/opt/fleetnode/fleetnode" ]] || fail "refused purge removed the program"
+[[ -e "$ROOT_PREFIX/var/lib/fleetnode/state.yaml" ]] || fail "refused purge removed state"
+if grep -Eq '(^| )(stop|disable) fleet-node.service($| )' "$SYSTEMCTL_LOG"; then
+  fail "purge mutated the service before validating primary group ownership"
+fi
+if [[ -s "$ACCOUNT_LOG" ]]; then
+  fail "purge mutated accounts before validating primary group ownership"
+fi
 
 : > "$ROOT_PREFIX/var/lib/fleetnode/state.lock"
 : > "$SYSTEMCTL_LOG"

--- a/deployment-files/fleetnode/tests/test-install-fleetnode.sh
+++ b/deployment-files/fleetnode/tests/test-install-fleetnode.sh
@@ -168,22 +168,6 @@ fi
 EOF
 chmod 0755 "$TEST_DIR/bin/useradd"
 
-cat > "$TEST_DIR/bin/userdel" <<'EOF'
-#!/usr/bin/env bash
-set -euo pipefail
-printf 'userdel %s\n' "$*" >> "$ACCOUNT_LOG"
-rm -f "$FAKE_ACCOUNT_DB/user"
-EOF
-chmod 0755 "$TEST_DIR/bin/userdel"
-
-cat > "$TEST_DIR/bin/groupdel" <<'EOF'
-#!/usr/bin/env bash
-set -euo pipefail
-printf 'groupdel %s\n' "$*" >> "$ACCOUNT_LOG"
-rm -f "$FAKE_ACCOUNT_DB/group"
-EOF
-chmod 0755 "$TEST_DIR/bin/groupdel"
-
 cat > "$TEST_DIR/bin/runuser" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -194,12 +178,6 @@ fi
 exec "$@"
 EOF
 chmod 0755 "$TEST_DIR/bin/runuser"
-
-cat > "$TEST_DIR/bin/pgrep" <<'EOF'
-#!/usr/bin/env bash
-[[ "${FAKE_ACCOUNT_BUSY:-0}" == "1" ]]
-EOF
-chmod 0755 "$TEST_DIR/bin/pgrep"
 
 cat > "$TEST_DIR/bin/nologin" <<'EOF'
 #!/usr/bin/env bash
@@ -218,9 +196,6 @@ cat > "$TEST_DIR/bin/flock" <<'EOF'
 set -euo pipefail
 if [[ -n "${REAL_FLOCK:-}" ]]; then
   exec "$REAL_FLOCK" "$@"
-fi
-if [[ "${FAKE_STATE_LOCK_HELD:-0}" == "1" && " $* " == *"state.lock"* ]]; then
-  exit 1
 fi
 if [[ "${1:-}" == "-n" ]]; then
   shift 2
@@ -296,8 +271,6 @@ run_installer() {
   FAKE_GROUP_MEMBERS="${FAKE_GROUP_MEMBERS:-}" \
   FAKE_PRIMARY_GID_USER="${FAKE_PRIMARY_GID_USER:-}" \
   FAKE_RUNUSER_DENY="${FAKE_RUNUSER_DENY:-}" \
-  FAKE_ACCOUNT_BUSY="${FAKE_ACCOUNT_BUSY:-0}" \
-  FAKE_STATE_LOCK_HELD="${FAKE_STATE_LOCK_HELD:-0}" \
   ACCOUNT_LOG="$ACCOUNT_LOG" \
   REAL_FLOCK="${REAL_FLOCK:-}" \
   SYSTEMCTL_LOG="$SYSTEMCTL_LOG" \
@@ -314,18 +287,6 @@ run_installer() {
 run_uninstaller() {
   FAKE_FLEETNODE_ENABLED="${FAKE_FLEETNODE_ENABLED:-0}" \
   FAKE_FLEETNODE_ACTIVE="${FAKE_FLEETNODE_ACTIVE:-0}" \
-  FAKE_ACCOUNT_DB="$ACCOUNT_DB" \
-  FAKE_NOLOGIN_PATH="$TEST_DIR/bin/nologin" \
-  FAKE_ACCOUNT_HOME="${FAKE_ACCOUNT_HOME:-/var/lib/fleetnode}" \
-  FAKE_ACCOUNT_SHELL="${FAKE_ACCOUNT_SHELL:-$TEST_DIR/bin/nologin}" \
-  FAKE_ACCOUNT_GROUPS="${FAKE_ACCOUNT_GROUPS:-fleetnode}" \
-  FAKE_ACCOUNT_PRIMARY_GID="${FAKE_ACCOUNT_PRIMARY_GID:-995}" \
-  FAKE_GROUP_GID="${FAKE_GROUP_GID:-995}" \
-  FAKE_GROUP_MEMBERS="${FAKE_GROUP_MEMBERS:-}" \
-  FAKE_PRIMARY_GID_USER="${FAKE_PRIMARY_GID_USER:-}" \
-  FAKE_ACCOUNT_BUSY="${FAKE_ACCOUNT_BUSY:-0}" \
-  FAKE_STATE_LOCK_HELD="${FAKE_STATE_LOCK_HELD:-0}" \
-  ACCOUNT_LOG="$ACCOUNT_LOG" \
   SYSTEMCTL_LOG="$SYSTEMCTL_LOG" \
   SUDO_LOG="$SUDO_LOG" \
   PATH="$TEST_DIR/bin:$PATH" \
@@ -573,6 +534,13 @@ assert_file_contains "$TEST_DIR/bad-checksum.err" "checksum sidecar is not bound
 assert_file_contains "$ROOT_PREFIX/opt/fleetnode/version.txt" "version: v1.1.0"
 assert_file_contains "$ROOT_PREFIX/var/lib/fleetnode/state.yaml" "identity material"
 
+if run_uninstaller --purge > "$TEST_DIR/purge.out" 2>&1; then
+  fail "uninstaller accepted the unsupported --purge option"
+fi
+assert_file_contains "$TEST_DIR/purge.out" "Usage: install-fleet-node.sh VERSION"
+[[ -e "$ROOT_PREFIX/opt/fleetnode/fleetnode" ]] || fail "rejected purge removed the program"
+[[ -e "$ROOT_PREFIX/var/lib/fleetnode/state.yaml" ]] || fail "rejected purge removed state"
+
 : > "$SYSTEMCTL_LOG"
 FAKE_FLEETNODE_ACTIVE=0 run_installer v1.3.0
 assert_file_contains "$ROOT_PREFIX/opt/fleetnode/version.txt" "version: v1.3.0"
@@ -582,7 +550,8 @@ if grep -Eq '^(stop|start) fleet-node.service$' "$SYSTEMCTL_LOG"; then
   fail "inactive upgrade changed the Fleet Node service state"
 fi
 
-run_uninstaller
+rm -f "$ROOT_PREFIX/etc/systemd/system/fleet-node.service"
+FAKE_FLEETNODE_ACTIVE=1 FAKE_FLEETNODE_ENABLED=1 run_uninstaller
 [[ ! -e "$ROOT_PREFIX/opt/fleetnode" ]] || fail "uninstall retained the program"
 [[ ! -e "$ROOT_PREFIX/etc/systemd/system/fleet-node.service" ]] || fail "uninstall retained the unit"
 [[ -e "$ROOT_PREFIX/etc/fleetnode/config.yaml" ]] || fail "uninstall removed configuration"
@@ -592,55 +561,5 @@ assert_file_contains "$SYSTEMCTL_LOG" "stop fleet-node.service"
 assert_file_contains "$SYSTEMCTL_LOG" "disable fleet-node.service"
 
 run_uninstaller
-run_installer v1.1.0
-
-: > "$SYSTEMCTL_LOG"
-: > "$ACCOUNT_LOG"
-if FAKE_PRIMARY_GID_USER=operator run_uninstaller --purge > "$TEST_DIR/shared-primary-gid-purge.out" 2>&1; then
-  fail "purge accepted a fleetnode group that is another account's primary group"
-fi
-assert_file_contains "$TEST_DIR/shared-primary-gid-purge.out" "fleetnode group is the primary group for unrelated account: operator"
-[[ -e "$ROOT_PREFIX/opt/fleetnode/fleetnode" ]] || fail "refused purge removed the program"
-[[ -e "$ROOT_PREFIX/var/lib/fleetnode/state.yaml" ]] || fail "refused purge removed state"
-if grep -Eq '(^| )(stop|disable) fleet-node.service($| )' "$SYSTEMCTL_LOG"; then
-  fail "purge mutated the service before validating primary group ownership"
-fi
-if [[ -s "$ACCOUNT_LOG" ]]; then
-  fail "purge mutated accounts before validating primary group ownership"
-fi
-
-: > "$ROOT_PREFIX/var/lib/fleetnode/state.lock"
-: > "$SYSTEMCTL_LOG"
-if FAKE_FLEETNODE_ACTIVE=1 FAKE_FLEETNODE_ENABLED=1 FAKE_STATE_LOCK_HELD=1 run_uninstaller --purge > "$TEST_DIR/locked-purge.out" 2>&1; then
-  fail "purge accepted an active state lock"
-fi
-assert_file_contains "$TEST_DIR/locked-purge.out" "Fleet Node state is in use"
-[[ -e "$ROOT_PREFIX/var/lib/fleetnode/state.yaml" ]] || fail "failed purge removed state"
-assert_file_contains "$SYSTEMCTL_LOG" "stop fleet-node.service"
-assert_file_contains "$SYSTEMCTL_LOG" "start fleet-node.service"
-if grep -Fq "disable fleet-node.service" "$SYSTEMCTL_LOG"; then
-  fail "refused locked purge disabled the service"
-fi
-
-: > "$SYSTEMCTL_LOG"
-if FAKE_FLEETNODE_ACTIVE=1 FAKE_FLEETNODE_ENABLED=1 FAKE_ACCOUNT_BUSY=1 run_uninstaller --purge > "$TEST_DIR/busy-purge.out" 2>&1; then
-  fail "purge accepted a service account with running processes"
-fi
-assert_file_contains "$TEST_DIR/busy-purge.out" "fleetnode account still has running processes"
-[[ -e "$ROOT_PREFIX/var/lib/fleetnode/state.yaml" ]] || fail "busy purge removed state"
-assert_file_contains "$SYSTEMCTL_LOG" "stop fleet-node.service"
-assert_file_contains "$SYSTEMCTL_LOG" "start fleet-node.service"
-if grep -Fq "disable fleet-node.service" "$SYSTEMCTL_LOG"; then
-  fail "refused busy purge disabled the service"
-fi
-
-run_uninstaller --purge
-[[ ! -e "$ROOT_PREFIX/opt/fleetnode" ]] || fail "purge retained the program"
-[[ ! -e "$ROOT_PREFIX/etc/fleetnode" ]] || fail "purge retained configuration"
-[[ ! -e "$ROOT_PREFIX/var/lib/fleetnode" ]] || fail "purge retained state"
-[[ ! -e "$ACCOUNT_DB/user" && ! -e "$ACCOUNT_DB/group" ]] || fail "purge retained the service account"
-assert_file_contains "$ACCOUNT_LOG" "userdel fleetnode"
-assert_file_contains "$ACCOUNT_LOG" "groupdel fleetnode"
-run_uninstaller --purge
 
 echo "Fleet Node installer tests passed"

--- a/deployment-files/fleetnode/tests/test-install-fleetnode.sh
+++ b/deployment-files/fleetnode/tests/test-install-fleetnode.sh
@@ -102,6 +102,10 @@ if [[ "${1:-}" == "show" && "${2:-}" == "--property=LoadState" ]]; then
   printf '%s\n' "${FAKE_FLEETNODE_LOAD_STATE:-not-found}"
   exit 0
 fi
+if [[ "${1:-}" == "show" && "${2:-}" == "--property=ActiveState" ]]; then
+  printf '%s\n' "${FAKE_FLEETNODE_ACTIVE_STATE:-active}"
+  exit 0
+fi
 if [[ "${1:-}" == "stop" && -n "${FAKE_FLEETNODE_LOCK_READY:-}" ]]; then
   : > "$FAKE_FLEETNODE_LOCK_READY"
   while [[ -e "${FAKE_FLEETNODE_LOCK_BLOCK:-}" ]]; do
@@ -110,10 +114,6 @@ if [[ "${1:-}" == "stop" && -n "${FAKE_FLEETNODE_LOCK_READY:-}" ]]; then
 fi
 if [[ "${1:-}" == "is-enabled" ]]; then
   [[ "${FAKE_FLEETNODE_ENABLED:-0}" == "1" ]]
-  exit
-fi
-if [[ "${1:-}" == "is-active" ]]; then
-  [[ "${FAKE_FLEETNODE_ACTIVE:-0}" == "1" ]]
   exit
 fi
 if [[ "${1:-}" == "start" ]]; then
@@ -238,7 +238,7 @@ assert_file_contains "$TEST_DIR/missing-nmap.err" "required command not found: n
 assert_file_contains "$FLEETNODE_DIR/install-fleet-node.sh" "LINUX_SERVICE_PATH=\"$LINUX_SERVICE_PATH\""
 assert_file_contains "$FLEETNODE_DIR/install-fleet-node.sh" "PATH=\"\$LINUX_SERVICE_PATH\""
 assert_file_contains "$FLEETNODE_DIR/install-fleet-node.sh" "as_root flock -n \"\$INSTALL_LOCK_PATH\""
-assert_file_contains "$FLEETNODE_DIR/install-fleet-node.sh" 'is-active --quiet fleet-node.service'
+assert_file_contains "$FLEETNODE_DIR/install-fleet-node.sh" '--property=ActiveState --value fleet-node.service'
 if grep -Fq 'fleetnode.service' "$FLEETNODE_DIR/install-fleet-node.sh"; then
   fail "installer contains a migration path for the old systemd unit"
 fi
@@ -260,7 +260,7 @@ printf 'proto = "=https"\n' > "$TEST_DIR/curl-home/.curlrc"
 run_installer() {
   local version="$1"
   FAKE_FLEETNODE_ENABLED="${FAKE_FLEETNODE_ENABLED:-0}" \
-  FAKE_FLEETNODE_ACTIVE="${FAKE_FLEETNODE_ACTIVE:-1}" \
+  FAKE_FLEETNODE_ACTIVE_STATE="${FAKE_FLEETNODE_ACTIVE_STATE:-active}" \
   FAKE_FLEETNODE_LOCK_READY="${FAKE_FLEETNODE_LOCK_READY:-}" \
   FAKE_FLEETNODE_LOCK_BLOCK="${FAKE_FLEETNODE_LOCK_BLOCK:-}" \
   FAKE_SYSTEMCTL_FAIL_START="${FAKE_SYSTEMCTL_FAIL_START:-0}" \
@@ -306,7 +306,7 @@ start_installer() {
   local version="$1"
   local output_path="$2"
   FAKE_FLEETNODE_ENABLED="${FAKE_FLEETNODE_ENABLED:-0}" \
-  FAKE_FLEETNODE_ACTIVE="${FAKE_FLEETNODE_ACTIVE:-1}" \
+  FAKE_FLEETNODE_ACTIVE_STATE="${FAKE_FLEETNODE_ACTIVE_STATE:-active}" \
   FAKE_FLEETNODE_LOCK_READY="${FAKE_FLEETNODE_LOCK_READY:-}" \
   FAKE_FLEETNODE_LOCK_BLOCK="${FAKE_FLEETNODE_LOCK_BLOCK:-}" \
   FAKE_ACCOUNT_DB="$ACCOUNT_DB" \
@@ -439,8 +439,8 @@ if grep -Fq '# candidate unit v1.3.0' "$ROOT_PREFIX/etc/systemd/system/fleet-nod
 fi
 [[ "$(grep -Fc 'start fleet-node.service' "$SYSTEMCTL_LOG")" == "2" ]] || \
   fail "failed upgrade did not start the candidate and then restart the previous service"
-[[ "$(grep -E '^(is-active --quiet|stop|start) fleet-node.service$' "$SYSTEMCTL_LOG")" == \
-  $'is-active --quiet fleet-node.service\nstop fleet-node.service\nstart fleet-node.service\nstop fleet-node.service\nstart fleet-node.service' ]] || \
+[[ "$(grep -E '^(show --property=ActiveState --value|stop|start) fleet-node.service$' "$SYSTEMCTL_LOG")" == \
+  $'show --property=ActiveState --value fleet-node.service\nstop fleet-node.service\nstart fleet-node.service\nstop fleet-node.service\nstart fleet-node.service' ]] || \
   fail "failed upgrade did not stop the candidate before restarting the previous service"
 
 : > "$SYSTEMCTL_LOG"
@@ -551,10 +551,24 @@ assert_file_contains "$TEST_DIR/purge.out" "Usage: install-fleet-node.sh VERSION
 [[ -e "$ROOT_PREFIX/var/lib/fleetnode/state.yaml" ]] || fail "rejected purge removed state"
 
 : > "$SYSTEMCTL_LOG"
-FAKE_FLEETNODE_ACTIVE=0 run_installer v1.3.0
+if FAKE_FLEETNODE_ACTIVE_STATE=activating \
+    run_installer v1.3.0 > "$TEST_DIR/activating-upgrade.out" 2>&1; then
+  fail "installer accepted an upgrade while the service was activating"
+fi
+assert_file_contains "$TEST_DIR/activating-upgrade.out" "cannot upgrade Fleet Node while service is activating"
+assert_file_contains "$ROOT_PREFIX/opt/fleetnode/version.txt" "version: v1.1.0"
+if grep -Fq '# candidate unit v1.3.0' "$ROOT_PREFIX/etc/systemd/system/fleet-node.service"; then
+  fail "activating upgrade replaced the Fleet Node systemd unit"
+fi
+if grep -Eq '^(stop|start) fleet-node.service$' "$SYSTEMCTL_LOG"; then
+  fail "activating upgrade changed the Fleet Node service state"
+fi
+
+: > "$SYSTEMCTL_LOG"
+FAKE_FLEETNODE_ACTIVE_STATE=inactive run_installer v1.3.0
 assert_file_contains "$ROOT_PREFIX/opt/fleetnode/version.txt" "version: v1.3.0"
 assert_file_contains "$ROOT_PREFIX/etc/systemd/system/fleet-node.service" "# candidate unit v1.3.0"
-assert_file_contains "$SYSTEMCTL_LOG" "is-active --quiet fleet-node.service"
+assert_file_contains "$SYSTEMCTL_LOG" "show --property=ActiveState --value fleet-node.service"
 if grep -Eq '^(stop|start) fleet-node.service$' "$SYSTEMCTL_LOG"; then
   fail "inactive upgrade changed the Fleet Node service state"
 fi

--- a/deployment-files/fleetnode/tests/test-install-fleetnode.sh
+++ b/deployment-files/fleetnode/tests/test-install-fleetnode.sh
@@ -260,6 +260,7 @@ printf 'proto = "=https"\n' > "$TEST_DIR/curl-home/.curlrc"
 run_installer() {
   local version="$1"
   FAKE_FLEETNODE_ENABLED="${FAKE_FLEETNODE_ENABLED:-0}" \
+  FAKE_FLEETNODE_LOAD_STATE="${FAKE_FLEETNODE_LOAD_STATE:-not-found}" \
   FAKE_FLEETNODE_ACTIVE_STATE="${FAKE_FLEETNODE_ACTIVE_STATE:-active}" \
   FAKE_FLEETNODE_LOCK_READY="${FAKE_FLEETNODE_LOCK_READY:-}" \
   FAKE_FLEETNODE_LOCK_BLOCK="${FAKE_FLEETNODE_LOCK_BLOCK:-}" \
@@ -380,6 +381,19 @@ fi
 if grep -Fq 'install-fleet-node.sh' "$SUDO_LOG"; then
   fail "installer asked sudo to rerun the whole script"
 fi
+
+: > "$SYSTEMCTL_LOG"
+rm -f "$ROOT_PREFIX/opt/fleetnode/fleetnode"
+printf '# incomplete installation\n' >> "$ROOT_PREFIX/etc/systemd/system/fleet-node.service"
+FAKE_FLEETNODE_LOAD_STATE=loaded run_installer v1.0.0
+[[ -x "$ROOT_PREFIX/opt/fleetnode/fleetnode" ]] || fail "partial install did not restore the Fleet Node binary"
+if grep -Fq '# incomplete installation' "$ROOT_PREFIX/etc/systemd/system/fleet-node.service"; then
+  fail "partial install did not replace the Fleet Node systemd unit"
+fi
+assert_file_contains "$ROOT_PREFIX/opt/fleetnode/version.txt" "version: v1.0.0"
+assert_file_contains "$SYSTEMCTL_LOG" "show --property=LoadState --value fleet-node.service"
+assert_file_contains "$SYSTEMCTL_LOG" "stop fleet-node.service"
+assert_file_contains "$SYSTEMCTL_LOG" "start fleet-node.service"
 
 printf 'operator config\n' > "$ROOT_PREFIX/etc/fleetnode/config.yaml"
 printf 'identity material\n' > "$ROOT_PREFIX/var/lib/fleetnode/state.yaml"
@@ -585,6 +599,21 @@ if FAKE_FLEETNODE_LOAD_STATE=error run_uninstaller > "$TEST_DIR/unexpected-load-
 fi
 assert_file_contains "$TEST_DIR/unexpected-load-state.out" "unexpected Fleet Node systemd unit load state: error"
 [[ -e "$ROOT_PREFIX/opt/fleetnode/fleetnode" ]] || fail "unexpected systemd state removed the program"
+
+: > "$SYSTEMCTL_LOG"
+rm -f "$ROOT_PREFIX/etc/systemd/system/fleet-node.service"
+ln -s /dev/null "$ROOT_PREFIX/etc/systemd/system/fleet-node.service"
+FAKE_FLEETNODE_LOAD_STATE=masked FAKE_FLEETNODE_ENABLED=1 run_uninstaller
+[[ ! -e "$ROOT_PREFIX/opt/fleetnode" ]] || fail "masked uninstall retained the program"
+[[ ! -e "$ROOT_PREFIX/etc/systemd/system/fleet-node.service" ]] || fail "masked uninstall retained the unit mask"
+[[ -e "$ROOT_PREFIX/etc/fleetnode/config.yaml" ]] || fail "masked uninstall removed configuration"
+[[ -e "$ROOT_PREFIX/var/lib/fleetnode/state.yaml" ]] || fail "masked uninstall removed state"
+[[ -e "$ACCOUNT_DB/user" && -e "$ACCOUNT_DB/group" ]] || fail "masked uninstall removed the service account"
+assert_file_contains "$SYSTEMCTL_LOG" "stop fleet-node.service"
+assert_file_contains "$SYSTEMCTL_LOG" "unmask fleet-node.service"
+assert_file_contains "$SYSTEMCTL_LOG" "disable fleet-node.service"
+
+run_installer v1.3.0
 
 : > "$SYSTEMCTL_LOG"
 rm -f "$ROOT_PREFIX/etc/systemd/system/fleet-node.service"

--- a/deployment-files/fleetnode/tests/test-install-fleetnode.sh
+++ b/deployment-files/fleetnode/tests/test-install-fleetnode.sh
@@ -343,6 +343,22 @@ mkdir -p "$ROOT_PREFIX/opt"
 chmod 0711 "$ROOT_PREFIX/opt"
 chmod 0751 "$ROOT_PREFIX/etc/systemd/system"
 printf 'legacy unit\n' > "$ROOT_PREFIX/etc/systemd/system/fleetnode.service"
+
+: > "$SYSTEMCTL_LOG"
+printf '# incomplete installation\n' > "$ROOT_PREFIX/etc/systemd/system/fleet-node.service"
+if CURL_HOME="$TEST_DIR/curl-home" FAKE_FLEETNODE_LOAD_STATE=loaded \
+    run_installer v1.0.0 > "$TEST_DIR/active-partial-install.out" 2>&1; then
+  fail "installer accepted an active incomplete installation"
+fi
+assert_file_contains "$TEST_DIR/active-partial-install.out" \
+  "cannot install Fleet Node over an incomplete installation while service is active"
+[[ ! -e "$ROOT_PREFIX/opt/fleetnode" ]] || fail "active partial install created the Fleet Node payload"
+assert_file_contains "$ROOT_PREFIX/etc/systemd/system/fleet-node.service" "# incomplete installation"
+if grep -Eq '^(stop|start) fleet-node.service$' "$SYSTEMCTL_LOG"; then
+  fail "active partial install changed the Fleet Node service state"
+fi
+rm -f "$ROOT_PREFIX/etc/systemd/system/fleet-node.service"
+
 CURL_HOME="$TEST_DIR/curl-home" FAKE_FLEETNODE_ENABLED=1 run_installer v1.0.0
 
 [[ "$(file_mode "$ROOT_PREFIX/opt")" == "711" ]] || fail "installer changed /opt mode"
@@ -381,19 +397,6 @@ fi
 if grep -Fq 'install-fleet-node.sh' "$SUDO_LOG"; then
   fail "installer asked sudo to rerun the whole script"
 fi
-
-: > "$SYSTEMCTL_LOG"
-rm -f "$ROOT_PREFIX/opt/fleetnode/fleetnode"
-printf '# incomplete installation\n' >> "$ROOT_PREFIX/etc/systemd/system/fleet-node.service"
-FAKE_FLEETNODE_LOAD_STATE=loaded run_installer v1.0.0
-[[ -x "$ROOT_PREFIX/opt/fleetnode/fleetnode" ]] || fail "partial install did not restore the Fleet Node binary"
-if grep -Fq '# incomplete installation' "$ROOT_PREFIX/etc/systemd/system/fleet-node.service"; then
-  fail "partial install did not replace the Fleet Node systemd unit"
-fi
-assert_file_contains "$ROOT_PREFIX/opt/fleetnode/version.txt" "version: v1.0.0"
-assert_file_contains "$SYSTEMCTL_LOG" "show --property=LoadState --value fleet-node.service"
-assert_file_contains "$SYSTEMCTL_LOG" "stop fleet-node.service"
-assert_file_contains "$SYSTEMCTL_LOG" "start fleet-node.service"
 
 printf 'operator config\n' > "$ROOT_PREFIX/etc/fleetnode/config.yaml"
 printf 'identity material\n' > "$ROOT_PREFIX/var/lib/fleetnode/state.yaml"

--- a/deployment-files/fleetnode/tests/test-install-fleetnode.sh
+++ b/deployment-files/fleetnode/tests/test-install-fleetnode.sh
@@ -606,7 +606,7 @@ assert_file_contains "$TEST_DIR/unexpected-load-state.out" "unexpected Fleet Nod
 : > "$SYSTEMCTL_LOG"
 rm -f "$ROOT_PREFIX/etc/systemd/system/fleet-node.service"
 ln -s /dev/null "$ROOT_PREFIX/etc/systemd/system/fleet-node.service"
-FAKE_FLEETNODE_LOAD_STATE=masked FAKE_FLEETNODE_ENABLED=1 run_uninstaller
+FAKE_FLEETNODE_LOAD_STATE=masked run_uninstaller
 [[ ! -e "$ROOT_PREFIX/opt/fleetnode" ]] || fail "masked uninstall retained the program"
 [[ ! -e "$ROOT_PREFIX/etc/systemd/system/fleet-node.service" ]] || fail "masked uninstall retained the unit mask"
 [[ -e "$ROOT_PREFIX/etc/fleetnode/config.yaml" ]] || fail "masked uninstall removed configuration"
@@ -614,23 +614,26 @@ FAKE_FLEETNODE_LOAD_STATE=masked FAKE_FLEETNODE_ENABLED=1 run_uninstaller
 [[ -e "$ACCOUNT_DB/user" && -e "$ACCOUNT_DB/group" ]] || fail "masked uninstall removed the service account"
 assert_file_contains "$SYSTEMCTL_LOG" "stop fleet-node.service"
 assert_file_contains "$SYSTEMCTL_LOG" "unmask fleet-node.service"
-assert_file_contains "$SYSTEMCTL_LOG" "disable fleet-node.service"
 
 run_installer v1.3.0
 
 : > "$SYSTEMCTL_LOG"
 rm -f "$ROOT_PREFIX/etc/systemd/system/fleet-node.service"
-FAKE_FLEETNODE_LOAD_STATE=loaded FAKE_FLEETNODE_ENABLED=1 run_uninstaller
+FAKE_FLEETNODE_LOAD_STATE=loaded run_uninstaller
 [[ ! -e "$ROOT_PREFIX/opt/fleetnode" ]] || fail "uninstall retained the program"
 [[ ! -e "$ROOT_PREFIX/etc/systemd/system/fleet-node.service" ]] || fail "uninstall retained the unit"
 [[ -e "$ROOT_PREFIX/etc/fleetnode/config.yaml" ]] || fail "uninstall removed configuration"
 [[ -e "$ROOT_PREFIX/var/lib/fleetnode/state.yaml" ]] || fail "uninstall removed state"
 [[ -e "$ACCOUNT_DB/user" && -e "$ACCOUNT_DB/group" ]] || fail "uninstall removed the service account"
 assert_file_contains "$SYSTEMCTL_LOG" "stop fleet-node.service"
-assert_file_contains "$SYSTEMCTL_LOG" "disable fleet-node.service"
 
 : > "$SYSTEMCTL_LOG"
+mkdir -p "$ROOT_PREFIX/etc/systemd/system/multi-user.target.wants"
+ln -s "$ROOT_PREFIX/etc/systemd/system/fleet-node.service" \
+  "$ROOT_PREFIX/etc/systemd/system/multi-user.target.wants/fleet-node.service"
 run_uninstaller
+[[ ! -L "$ROOT_PREFIX/etc/systemd/system/multi-user.target.wants/fleet-node.service" ]] || \
+  fail "uninstall retained a dangling enablement link"
 if grep -Fq 'stop fleet-node.service' "$SYSTEMCTL_LOG"; then
   fail "idempotent uninstall stopped a unit that systemd could not find"
 fi

--- a/deployment-files/fleetnode/tests/test-install-fleetnode.sh
+++ b/deployment-files/fleetnode/tests/test-install-fleetnode.sh
@@ -97,6 +97,11 @@ printf '%s\n' "$*" >> "$SYSTEMCTL_LOG"
 if [[ "${1:-}" == "show" && "${FAKE_SYSTEMCTL_FAIL_SHOW:-0}" == "1" ]]; then
   exit 1
 fi
+if [[ "${1:-}" == "show" && "${2:-}" == "--property=LoadState" ]]; then
+  [[ "${FAKE_SYSTEMCTL_FAIL_LOAD_STATE:-0}" == "0" ]] || exit 1
+  printf '%s\n' "${FAKE_FLEETNODE_LOAD_STATE:-not-found}"
+  exit 0
+fi
 if [[ "${1:-}" == "stop" && -n "${FAKE_FLEETNODE_LOCK_READY:-}" ]]; then
   : > "$FAKE_FLEETNODE_LOCK_READY"
   while [[ -e "${FAKE_FLEETNODE_LOCK_BLOCK:-}" ]]; do
@@ -286,7 +291,8 @@ run_installer() {
 
 run_uninstaller() {
   FAKE_FLEETNODE_ENABLED="${FAKE_FLEETNODE_ENABLED:-0}" \
-  FAKE_FLEETNODE_ACTIVE="${FAKE_FLEETNODE_ACTIVE:-0}" \
+  FAKE_FLEETNODE_LOAD_STATE="${FAKE_FLEETNODE_LOAD_STATE:-not-found}" \
+  FAKE_SYSTEMCTL_FAIL_LOAD_STATE="${FAKE_SYSTEMCTL_FAIL_LOAD_STATE:-0}" \
   SYSTEMCTL_LOG="$SYSTEMCTL_LOG" \
   SUDO_LOG="$SUDO_LOG" \
   PATH="$TEST_DIR/bin:$PATH" \
@@ -409,12 +415,15 @@ if grep -Fq 'stop fleet-node.service' "$SYSTEMCTL_LOG"; then
 fi
 
 : > "$SYSTEMCTL_LOG"
+chmod 0777 "$ROOT_PREFIX/etc/fleetnode" "$ROOT_PREFIX/var/lib/fleetnode"
 run_installer v1.1.0
 
 assert_file_contains "$ROOT_PREFIX/opt/fleetnode/version.txt" "version: v1.1.0"
 [[ ! -e "$ROOT_PREFIX/opt/fleetnode/stale.txt" ]] || fail "upgrade retained stale program files"
 assert_file_contains "$ROOT_PREFIX/etc/fleetnode/config.yaml" "operator config"
 assert_file_contains "$ROOT_PREFIX/var/lib/fleetnode/state.yaml" "identity material"
+[[ "$(file_mode "$ROOT_PREFIX/etc/fleetnode")" == "750" ]] || fail "upgrade did not restore config directory mode"
+[[ "$(file_mode "$ROOT_PREFIX/var/lib/fleetnode")" == "700" ]] || fail "upgrade did not restore state directory mode"
 assert_file_contains "$SYSTEMCTL_LOG" "stop fleet-node.service"
 assert_file_contains "$SYSTEMCTL_LOG" "start fleet-node.service"
 
@@ -550,8 +559,22 @@ if grep -Eq '^(stop|start) fleet-node.service$' "$SYSTEMCTL_LOG"; then
   fail "inactive upgrade changed the Fleet Node service state"
 fi
 
+if FAKE_SYSTEMCTL_FAIL_LOAD_STATE=1 run_uninstaller > "$TEST_DIR/load-state-query-failed.out" 2>&1; then
+  fail "uninstaller removed Fleet Node after its systemd unit query failed"
+fi
+assert_file_contains "$TEST_DIR/load-state-query-failed.out" "cannot inspect Fleet Node systemd unit"
+[[ -e "$ROOT_PREFIX/opt/fleetnode/fleetnode" ]] || fail "failed systemd query removed the program"
+
+: > "$SYSTEMCTL_LOG"
+if FAKE_FLEETNODE_LOAD_STATE=error run_uninstaller > "$TEST_DIR/unexpected-load-state.out" 2>&1; then
+  fail "uninstaller accepted an unexpected systemd unit load state"
+fi
+assert_file_contains "$TEST_DIR/unexpected-load-state.out" "unexpected Fleet Node systemd unit load state: error"
+[[ -e "$ROOT_PREFIX/opt/fleetnode/fleetnode" ]] || fail "unexpected systemd state removed the program"
+
+: > "$SYSTEMCTL_LOG"
 rm -f "$ROOT_PREFIX/etc/systemd/system/fleet-node.service"
-FAKE_FLEETNODE_ACTIVE=1 FAKE_FLEETNODE_ENABLED=1 run_uninstaller
+FAKE_FLEETNODE_LOAD_STATE=loaded FAKE_FLEETNODE_ENABLED=1 run_uninstaller
 [[ ! -e "$ROOT_PREFIX/opt/fleetnode" ]] || fail "uninstall retained the program"
 [[ ! -e "$ROOT_PREFIX/etc/systemd/system/fleet-node.service" ]] || fail "uninstall retained the unit"
 [[ -e "$ROOT_PREFIX/etc/fleetnode/config.yaml" ]] || fail "uninstall removed configuration"
@@ -560,6 +583,10 @@ FAKE_FLEETNODE_ACTIVE=1 FAKE_FLEETNODE_ENABLED=1 run_uninstaller
 assert_file_contains "$SYSTEMCTL_LOG" "stop fleet-node.service"
 assert_file_contains "$SYSTEMCTL_LOG" "disable fleet-node.service"
 
+: > "$SYSTEMCTL_LOG"
 run_uninstaller
+if grep -Fq 'stop fleet-node.service' "$SYSTEMCTL_LOG"; then
+  fail "idempotent uninstall stopped a unit that systemd could not find"
+fi
 
 echo "Fleet Node installer tests passed"


### PR DESCRIPTION
Reviewable diff: +234/-47 across 1 file (excludes generated, test, and story files).

## Summary

Fleet Node installations can now be repeated, upgraded, and removed without losing the node's identity or configuration. The installer validates the host before disruption, serializes lifecycle operations, and restores the previous runnable version when an upgrade fails. Uninstall is intentionally non-destructive; destructive purge is not supported.

**Stack**

1. [#990](https://github.com/block/proto-fleet/pull/990) — startup readiness and the safe upgrade boundary
2. **[#991](https://github.com/block/proto-fleet/pull/991) — this PR: installer lifecycle**
3. [#992](https://github.com/block/proto-fleet/pull/992) — native package qualification before artifact upload
4. [#989](https://github.com/block/proto-fleet/pull/989) — concise enrollment command

This diff is relative to [#990](https://github.com/block/proto-fleet/pull/990). It relies on that PR's blocking `systemctl start` contract so an upgrade commits only after the replacement reports ready. [#992](https://github.com/block/proto-fleet/pull/992) owns native systemd package qualification, and [#989](https://github.com/block/proto-fleet/pull/989) owns the one-command enrollment flow. Destructive purge, runbooks, and broader distribution design remain out of scope.

## How it works

1. The installer accepts one exact version or `uninstall`, then verifies Linux, a running systemd manager, supported architecture, required commands, and safe installation paths.
2. Before an install or upgrade can stop the service, it verifies the existing `fleetnode` account and proves that account can access preserved configuration and state.
3. A root-owned lock prevents install, upgrade, and uninstall operations from overlapping.
4. Install and upgrade downloads use bounded HTTPS retries. The installer checks the checksum, archive paths, exact manifest, link safety, and embedded version before changing the running installation.
5. A fresh install creates the service account and directories, installs the payload and unit, and leaves the service stopped for enrollment. An upgrade stages the replacement, saves the previous payload and unit, and waits for the replacement to report ready. Any failure restores and restarts the previous version.
6. Uninstall checks systemd even when the unit file is already missing, stops and disables the loaded service, and removes only the program and unit. It preserves `/etc/fleetnode`, `/var/lib/fleetnode`, and the `fleetnode` account, and can be run repeatedly. `uninstall --purge` is rejected.

```mermaid
flowchart TD
  A["Installer invocation"] --> B["Validate host and paths"]
  B --> C["Acquire lifecycle lock"]
  C --> D{"Action"}
  D -->|"Install or upgrade"| E["Validate account and preserved data"]
  E --> F["Download and verify exact release"]
  F --> G{"Existing installation"}
  G -->|"No"| H["Install payload and unit; leave stopped"]
  G -->|"Yes"| I["Save current version and install candidate"]
  I --> J{"Candidate reports ready"}
  J -->|"Yes"| K["Discard backup"]
  J -->|"No"| L["Restore previous version and service"]
  D -->|"Uninstall"| M["Stop and disable loaded service"]
  M --> N["Remove payload and unit"]
  N --> O["Preserve configuration, state, and account"]
```

```mermaid
sequenceDiagram
  actor Operator
  participant Installer
  participant Release as Release assets
  participant Systemd
  participant Disk as Installation paths

  Operator->>Installer: Install exact version
  Installer->>Release: Download archive and checksum
  Installer->>Installer: Validate archive and preserved access
  Installer->>Systemd: Stop current service
  Installer->>Disk: Save current payload and unit
  Installer->>Disk: Install candidate payload and unit
  Installer->>Systemd: Start candidate and wait for readiness
  alt Candidate reports ready
    Installer->>Disk: Delete previous payload and unit backup
    Installer-->>Operator: Upgrade complete
  else Start or readiness fails
    Installer->>Disk: Restore previous payload and unit
    Installer->>Systemd: Restart previous service
    Installer-->>Operator: Upgrade failed
  end
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `deployment-files/fleetnode/install-fleet-node.sh` | Adds host and account preflight, bounded artifact validation, lifecycle locking, transactional upgrades, and state-preserving uninstall | This is the operator-facing lifecycle and its privilege boundary |
| `deployment-files/fleetnode/tests/test-install-fleetnode.sh` | Expands the fake-host harness across install, upgrade, rollback, concurrency, and uninstall paths | Confirms failure handling without requiring a privileged systemd host; review-light |

## Key technical decisions & trade-offs

- Require an exact release identifier rather than a moving `latest` target, so repeated installation is deterministic.
- Reject unexpected account, group, path, or preserved-data state rather than silently taking ownership of an existing host setup.
- Download and validate the candidate before stopping a running node, then keep the previous payload until the candidate reports ready.
- Preserve state, configuration, and the service account on every uninstall. A future purge flow can define its own explicit safety contract.
- Leave fresh installations stopped and disabled so enrollment happens before the long-running service starts.
- Preserve existing shared parent-directory modes instead of broadening installer ownership outside Fleet Node paths.

## Testing & validation

- The exact PR head passes `Deployment Config Checks / Fleet Node installer`, which runs shell syntax validation and the installer harness.
- The harness covers fresh and repeated installation, upgrade success and rollback, rollback-restart failure reporting, concurrent installer rejection, orphaned lock recovery, unsafe archives, invalid preserved state, missing-unit uninstall, repeated uninstall, and purge rejection.
- `git diff --check` passes for the PR range.
- Native amd64 and arm64 systemd installation is intentionally deferred to [#992](https://github.com/block/proto-fleet/pull/992); this PR's harness uses a fake host and fake systemd.
