### PR TITLE
Qualify Fleet Node release artifacts

### DIFF
--- a/.github/workflows/deployment-config-checks.yml
+++ b/.github/workflows/deployment-config-checks.yml
@@ -58,7 +58,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Validate shell syntax
-        run: bash -n deployment-files/fleetnode/install-fleet-node.sh deployment-files/fleetnode/tests/test-install-fleetnode.sh
+        run: bash -n deployment-files/fleetnode/install-fleet-node.sh deployment-files/fleetnode/tests/qualify-package.sh deployment-files/fleetnode/tests/test-install-fleetnode.sh
 
       - name: Test installer
         run: ./deployment-files/fleetnode/tests/test-install-fleetnode.sh

--- a/.github/workflows/proto-fleet-artifact-build.yml
+++ b/.github/workflows/proto-fleet-artifact-build.yml
@@ -267,19 +267,6 @@ jobs:
           go build -v -o server/fleetnode ./server/cmd/fleetnode
           go build -o server/proto-plugin ./plugin/proto
           go build -o server/antminer-plugin ./plugin/antminer
-          go build -o server/virtual-plugin ./plugin/virtual
-          cp plugin/virtual/config.json server/virtual-plugin.json
-
-          for binary in fleetnode proto-plugin antminer-plugin virtual-plugin; do
-            if ! readelf -h "server/$binary" >/dev/null; then
-              echo "::error::Unable to inspect Fleet Node binary $binary"
-              exit 1
-            fi
-            if readelf -l "server/$binary" | grep INTERP >/dev/null || readelf -d "server/$binary" | grep NEEDED >/dev/null; then
-              echo "::error::Fleet Node binary $binary must be statically linked"
-              exit 1
-            fi
-          done
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
@@ -293,6 +280,33 @@ jobs:
           cp /tmp/asicrs/asicrs-plugin server/asicrs-plugin
           cp /tmp/asicrs/asicrs-config.yaml server/asicrs-config.yaml
 
+      - name: Validate Fleet Node executables
+        env:
+          EXPECTED_ARCH: ${{ matrix.arch }}
+        run: |
+          case "$EXPECTED_ARCH" in
+            amd64) expected_machine="Advanced Micro Devices X86-64" ;;
+            arm64) expected_machine="AArch64" ;;
+            *) echo "::error::Unsupported architecture $EXPECTED_ARCH"; exit 1 ;;
+          esac
+
+          for binary in fleetnode proto-plugin antminer-plugin asicrs-plugin; do
+            path="server/$binary"
+            if ! header=$(readelf -h "$path"); then
+              echo "::error::Unable to inspect Fleet Node executable $binary"
+              exit 1
+            fi
+            machine=$(awk -F: '/Machine:/{sub(/^[[:space:]]+/, "", $2); print $2}' <<< "$header")
+            if [[ "$machine" != "$expected_machine" ]]; then
+              echo "::error::$binary targets '$machine', expected '$expected_machine'"
+              exit 1
+            fi
+            if readelf -l "$path" | grep INTERP >/dev/null || readelf -d "$path" | grep NEEDED >/dev/null; then
+              echo "::error::Fleet Node executable $binary must be statically linked"
+              exit 1
+            fi
+          done
+
       - name: Package Fleet Node
         working-directory: ./server
         run: |
@@ -304,8 +318,6 @@ jobs:
           install -m 0644 ../deployment-files/fleetnode/fleet-node.service "$package_dir/fleet-node.service"
           install -m 0755 proto-plugin "$package_dir/plugins/proto-plugin"
           install -m 0755 antminer-plugin "$package_dir/plugins/antminer-plugin"
-          install -m 0755 virtual-plugin "$package_dir/plugins/virtual-plugin"
-          install -m 0644 virtual-plugin.json "$package_dir/plugins/virtual-plugin.json"
           install -m 0755 asicrs-plugin "$package_dir/plugins/asicrs-plugin"
           install -m 0644 asicrs-config.yaml "$package_dir/plugins/asicrs-config.yaml"
           printf 'version: %s\n' "$VERSION" > "$package_dir/version.txt"
@@ -313,6 +325,14 @@ jobs:
           tar -czf "$archive" "$package_dir"
           sha256sum "$archive" > "$archive.sha256"
           sha256sum -c "$archive.sha256"
+
+      - name: Qualify Fleet Node package on systemd
+        env:
+          PACKAGE_DIR: ${{ github.workspace }}/server
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes nmap
+          deployment-files/fleetnode/tests/qualify-package.sh "$VERSION" "$PACKAGE_DIR"
 
       - name: Upload Fleet Node artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/proto-fleet-artifact-build.yml
+++ b/.github/workflows/proto-fleet-artifact-build.yml
@@ -281,24 +281,11 @@ jobs:
           cp /tmp/asicrs/asicrs-config.yaml server/asicrs-config.yaml
 
       - name: Validate Fleet Node executables
-        env:
-          EXPECTED_ARCH: ${{ matrix.arch }}
         run: |
-          case "$EXPECTED_ARCH" in
-            amd64) expected_machine="Advanced Micro Devices X86-64" ;;
-            arm64) expected_machine="AArch64" ;;
-            *) echo "::error::Unsupported architecture $EXPECTED_ARCH"; exit 1 ;;
-          esac
-
           for binary in fleetnode proto-plugin antminer-plugin asicrs-plugin; do
             path="server/$binary"
-            if ! header=$(readelf -h "$path"); then
+            if ! readelf -h "$path" >/dev/null; then
               echo "::error::Unable to inspect Fleet Node executable $binary"
-              exit 1
-            fi
-            machine=$(awk -F: '/Machine:/{sub(/^[[:space:]]+/, "", $2); print $2}' <<< "$header")
-            if [[ "$machine" != "$expected_machine" ]]; then
-              echo "::error::$binary targets '$machine', expected '$expected_machine'"
               exit 1
             fi
             if readelf -l "$path" | grep INTERP >/dev/null || readelf -d "$path" | grep NEEDED >/dev/null; then
@@ -324,7 +311,6 @@ jobs:
 
           tar -czf "$archive" "$package_dir"
           sha256sum "$archive" > "$archive.sha256"
-          sha256sum -c "$archive.sha256"
 
       - name: Qualify Fleet Node package on systemd
         env:

--- a/deployment-files/fleetnode/install-fleet-node.sh
+++ b/deployment-files/fleetnode/install-fleet-node.sh
@@ -11,6 +11,11 @@ INSTALL_LOCK_RELEASE_PATH=""
 ACTION=install
 VERSION=""
 
+case "$TEST_MODE" in
+  0|1|systemd) ;;
+  *) echo "invalid FLEETNODE_TEST_MODE" >&2; exit 1 ;;
+esac
+
 if [[ "$TEST_MODE" != "1" ]]; then
   PATH="$LINUX_SERVICE_PATH"
   export PATH
@@ -51,9 +56,14 @@ case "${1:-}" in
     fi
     ;;
 esac
-if [[ "$TEST_MODE" != "1" ]]; then
+if [[ "$TEST_MODE" == "0" ]]; then
   if [[ -n "$ROOT_PREFIX" || -n "${FLEETNODE_ARCH:-}" || -n "$DOWNLOAD_BASE_URL" || -n "${FLEETNODE_SYSTEMCTL:-}" ]]; then
     echo "Fleet Node installer overrides are restricted to automated tests" >&2
+    exit 1
+  fi
+elif [[ "$TEST_MODE" == "systemd" ]]; then
+  if [[ -n "$ROOT_PREFIX" || -n "${FLEETNODE_ARCH:-}" || -n "${FLEETNODE_SYSTEMCTL:-}" || "$DOWNLOAD_BASE_URL" != file://* ]]; then
+    echo "systemd qualification mode only accepts a local file:// download URL" >&2
     exit 1
   fi
 fi
@@ -402,7 +412,7 @@ curl_options=(
   --retry-delay 2
   --retry-connrefused
 )
-if [[ "$TEST_MODE" != "1" ]]; then
+if [[ "$TEST_MODE" == "0" ]]; then
   curl_options+=(--proto '=https' --proto-redir '=https')
 fi
 curl "${curl_options[@]}" \
@@ -440,8 +450,6 @@ for required in \
   fleet-node.service \
   plugins/proto-plugin \
   plugins/antminer-plugin \
-  plugins/virtual-plugin \
-  plugins/virtual-plugin.json \
   plugins/asicrs-plugin \
   plugins/asicrs-config.yaml; do
   [[ -f "$source_dir/$required" ]] || { echo "archive is missing $required" >&2; exit 1; }
@@ -457,7 +465,7 @@ fi
 while IFS= read -r -d '' path; do
   relative_path="${path#"$source_dir"/}"
   case "$relative_path" in
-    fleetnode|version.txt|fleet-node.service|plugins|plugins/proto-plugin|plugins/antminer-plugin|plugins/virtual-plugin|plugins/virtual-plugin.json|plugins/asicrs-plugin|plugins/asicrs-config.yaml) ;;
+    fleetnode|version.txt|fleet-node.service|plugins|plugins/proto-plugin|plugins/antminer-plugin|plugins/asicrs-plugin|plugins/asicrs-config.yaml) ;;
     *) echo "archive contains an unexpected entry: $relative_path" >&2; exit 1 ;;
   esac
 done < <(find "$source_dir" -mindepth 1 -print0)
@@ -535,8 +543,6 @@ as_root install -m 0644 "$source_dir/version.txt" "$incoming/version.txt"
 as_root install -m 0644 "$source_dir/fleet-node.service" "$incoming/fleet-node.service"
 as_root install -m 0755 "$source_dir/plugins/proto-plugin" "$incoming/plugins/proto-plugin"
 as_root install -m 0755 "$source_dir/plugins/antminer-plugin" "$incoming/plugins/antminer-plugin"
-as_root install -m 0755 "$source_dir/plugins/virtual-plugin" "$incoming/plugins/virtual-plugin"
-as_root install -m 0644 "$source_dir/plugins/virtual-plugin.json" "$incoming/plugins/virtual-plugin.json"
 as_root install -m 0755 "$source_dir/plugins/asicrs-plugin" "$incoming/plugins/asicrs-plugin"
 as_root install -m 0644 "$source_dir/plugins/asicrs-config.yaml" "$incoming/plugins/asicrs-config.yaml"
 if [[ "$TEST_MODE" != "1" ]]; then

--- a/deployment-files/fleetnode/tests/qualify-package.sh
+++ b/deployment-files/fleetnode/tests/qualify-package.sh
@@ -102,7 +102,7 @@ WORK_DIR=""
 run_installer uninstall
 [[ ! -e /opt/fleetnode ]] || fail "uninstall retained the program"
 [[ ! -e /etc/systemd/system/fleet-node.service ]] || fail "uninstall retained the unit"
-[[ -e /var/lib/fleetnode/state.yaml ]] || fail "uninstall removed state"
+sudo test -f /var/lib/fleetnode/state.yaml || fail "uninstall removed state"
 getent passwd fleetnode >/dev/null || fail "uninstall removed the service account"
 
 trap - EXIT

--- a/deployment-files/fleetnode/tests/qualify-package.sh
+++ b/deployment-files/fleetnode/tests/qualify-package.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: qualify-package.sh VERSION PACKAGE_DIR" >&2
+  exit 2
+fi
+
+VERSION="$1"
+PACKAGE_DIR="$2"
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+INSTALLER="$SCRIPT_DIR/../install-fleet-node.sh"
+DOWNLOAD_URL="file://$PACKAGE_DIR"
+CLEANUP_ALLOWED=0
+WORK_DIR=""
+
+case "$(uname -m)" in
+  x86_64|amd64) ARCH=amd64 ;;
+  aarch64|arm64) ARCH=arm64 ;;
+  *) echo "unsupported qualification architecture: $(uname -m)" >&2; exit 1 ;;
+esac
+ARCHIVE="fleetnode-${VERSION}-linux-${ARCH}.tar.gz"
+
+fail() {
+  echo "Fleet Node package qualification failed: $*" >&2
+  exit 1
+}
+
+run_installer() {
+  env \
+    FLEETNODE_TEST_MODE=systemd \
+    FLEETNODE_DOWNLOAD_BASE_URL="$DOWNLOAD_URL" \
+    bash "$INSTALLER" "$@"
+}
+
+cleanup() {
+  status=$?
+  trap - EXIT
+  if [[ "$status" -ne 0 ]]; then
+    sudo systemctl status --no-pager fleet-node.service || true
+    sudo journalctl --no-pager -u fleet-node.service || true
+  fi
+  if [[ "$CLEANUP_ALLOWED" == "1" ]]; then
+    run_installer uninstall --purge >/dev/null 2>&1 || true
+  fi
+  [[ -z "$WORK_DIR" ]] || rm -rf "$WORK_DIR"
+  exit "$status"
+}
+trap cleanup EXIT
+
+for path in /opt/fleetnode /etc/fleetnode /var/lib/fleetnode /etc/systemd/system/fleet-node.service; do
+  [[ ! -e "$path" ]] || fail "runner is not clean: $path already exists"
+done
+getent passwd fleetnode >/dev/null 2>&1 && fail "runner already has a fleetnode account"
+
+CLEANUP_ALLOWED=1
+run_installer "$VERSION"
+sudo systemctl is-active --quiet fleet-node.service && fail "fresh install started the unenrolled service"
+sudo systemctl is-enabled --quiet fleet-node.service && fail "fresh install enabled the service"
+grep -Fxq "version: $VERSION" /opt/fleetnode/version.txt || fail "installed version metadata is wrong"
+
+sudo tee /var/lib/fleetnode/state.yaml >/dev/null <<'EOF'
+server_url: http://127.0.0.1:1
+allow_insecure_transport: true
+fleet_node_id: 1
+identity_fingerprint: qualification
+identity_private_key_hex: 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+identity_public_key_hex: 0000000000000000000000000000000000000000000000000000000000000000
+encryption_private_key_hex: 0000000000000000000000000000000000000000000000000000000000000000
+encryption_public_key_hex: 0000000000000000000000000000000000000000000000000000000000000000
+credential_key_hex: 0000000000000000000000000000000000000000000000000000000000000000
+api_key: qualification
+session_token: qualification
+session_expires_at: 2099-01-01T00:00:00Z
+EOF
+sudo chown fleetnode:fleetnode /var/lib/fleetnode/state.yaml
+sudo chmod 0600 /var/lib/fleetnode/state.yaml
+
+sudo systemctl enable --now fleet-node.service
+sudo systemctl is-active --quiet fleet-node.service || fail "installed service did not report ready"
+
+run_installer "$VERSION"
+sudo systemctl is-active --quiet fleet-node.service || fail "same-version upgrade did not return to ready"
+
+original_plugin_hash=$(sha256sum /opt/fleetnode/plugins/antminer-plugin | awk '{print $1}')
+WORK_DIR=$(mktemp -d)
+tar -xzf "$PACKAGE_DIR/$ARCHIVE" -C "$WORK_DIR"
+printf '#!/usr/bin/env bash\nexit 1\n' > "$WORK_DIR/${ARCHIVE%.tar.gz}/plugins/antminer-plugin"
+(
+  cd "$WORK_DIR"
+  tar -czf "$ARCHIVE" "${ARCHIVE%.tar.gz}"
+  sha256sum "$ARCHIVE" > "$ARCHIVE.sha256"
+)
+if DOWNLOAD_URL="file://$WORK_DIR" run_installer "$VERSION"; then
+  fail "upgrade accepted a plugin that exited during startup"
+fi
+sudo systemctl is-active --quiet fleet-node.service || fail "failed upgrade did not restore the running service"
+restored_plugin_hash=$(sha256sum /opt/fleetnode/plugins/antminer-plugin | awk '{print $1}')
+[[ "$restored_plugin_hash" == "$original_plugin_hash" ]] || fail "failed upgrade did not restore the previous payload"
+rm -rf "$WORK_DIR"
+WORK_DIR=""
+
+run_installer uninstall
+[[ ! -e /opt/fleetnode ]] || fail "uninstall retained the program"
+[[ ! -e /etc/systemd/system/fleet-node.service ]] || fail "uninstall retained the unit"
+[[ -e /var/lib/fleetnode/state.yaml ]] || fail "uninstall removed state"
+getent passwd fleetnode >/dev/null || fail "uninstall removed the service account"
+
+run_installer "$VERSION"
+sudo systemctl is-active --quiet fleet-node.service && fail "reinstall started the service"
+run_installer uninstall --purge
+
+[[ ! -e /opt/fleetnode ]] || fail "purge retained the program"
+[[ ! -e /etc/fleetnode ]] || fail "purge retained configuration"
+[[ ! -e /var/lib/fleetnode ]] || fail "purge retained state"
+getent passwd fleetnode >/dev/null 2>&1 && fail "purge retained the service account"
+
+trap - EXIT
+echo "Fleet Node package qualification passed"

--- a/deployment-files/fleetnode/tests/qualify-package.sh
+++ b/deployment-files/fleetnode/tests/qualify-package.sh
@@ -41,7 +41,7 @@ cleanup() {
     sudo journalctl --no-pager -u fleet-node.service || true
   fi
   if [[ "$CLEANUP_ALLOWED" == "1" ]]; then
-    run_installer uninstall --purge >/dev/null 2>&1 || true
+    run_installer uninstall >/dev/null 2>&1 || true
   fi
   [[ -z "$WORK_DIR" ]] || rm -rf "$WORK_DIR"
   exit "$status"
@@ -108,12 +108,7 @@ getent passwd fleetnode >/dev/null || fail "uninstall removed the service accoun
 
 run_installer "$VERSION"
 sudo systemctl is-active --quiet fleet-node.service && fail "reinstall started the service"
-run_installer uninstall --purge
-
-[[ ! -e /opt/fleetnode ]] || fail "purge retained the program"
-[[ ! -e /etc/fleetnode ]] || fail "purge retained configuration"
-[[ ! -e /var/lib/fleetnode ]] || fail "purge retained state"
-getent passwd fleetnode >/dev/null 2>&1 && fail "purge retained the service account"
+run_installer uninstall
 
 trap - EXIT
 echo "Fleet Node package qualification passed"

--- a/deployment-files/fleetnode/tests/qualify-package.sh
+++ b/deployment-files/fleetnode/tests/qualify-package.sh
@@ -57,7 +57,6 @@ CLEANUP_ALLOWED=1
 run_installer "$VERSION"
 sudo systemctl is-active --quiet fleet-node.service && fail "fresh install started the unenrolled service"
 sudo systemctl is-enabled --quiet fleet-node.service && fail "fresh install enabled the service"
-grep -Fxq "version: $VERSION" /opt/fleetnode/version.txt || fail "installed version metadata is wrong"
 
 sudo tee /var/lib/fleetnode/state.yaml >/dev/null <<'EOF'
 server_url: http://127.0.0.1:1
@@ -78,9 +77,6 @@ sudo chmod 0600 /var/lib/fleetnode/state.yaml
 
 sudo systemctl enable --now fleet-node.service
 sudo systemctl is-active --quiet fleet-node.service || fail "installed service did not report ready"
-
-run_installer "$VERSION"
-sudo systemctl is-active --quiet fleet-node.service || fail "same-version upgrade did not return to ready"
 
 original_plugin_hash=$(sha256sum /opt/fleetnode/plugins/antminer-plugin | awk '{print $1}')
 WORK_DIR=$(mktemp -d)
@@ -105,10 +101,6 @@ run_installer uninstall
 [[ ! -e /etc/systemd/system/fleet-node.service ]] || fail "uninstall retained the unit"
 [[ -e /var/lib/fleetnode/state.yaml ]] || fail "uninstall removed state"
 getent passwd fleetnode >/dev/null || fail "uninstall removed the service account"
-
-run_installer "$VERSION"
-sudo systemctl is-active --quiet fleet-node.service && fail "reinstall started the service"
-run_installer uninstall
 
 trap - EXIT
 echo "Fleet Node package qualification passed"

--- a/deployment-files/fleetnode/tests/qualify-package.sh
+++ b/deployment-files/fleetnode/tests/qualify-package.sh
@@ -53,6 +53,7 @@ for path in /opt/fleetnode /etc/fleetnode /var/lib/fleetnode /etc/systemd/system
 done
 getent passwd fleetnode >/dev/null 2>&1 && fail "runner already has a fleetnode account"
 
+sudo chmod go-w /opt
 CLEANUP_ALLOWED=1
 run_installer "$VERSION"
 sudo systemctl is-active --quiet fleet-node.service && fail "fresh install started the unenrolled service"

--- a/deployment-files/fleetnode/tests/qualify-package.sh
+++ b/deployment-files/fleetnode/tests/qualify-package.sh
@@ -79,6 +79,9 @@ sudo systemctl enable --now fleet-node.service
 sudo systemctl is-active --quiet fleet-node.service || fail "installed service did not report ready"
 
 original_plugin_hash=$(sha256sum /opt/fleetnode/plugins/antminer-plugin | awk '{print $1}')
+run_installer "$VERSION"
+sudo systemctl is-active --quiet fleet-node.service || fail "known-good upgrade did not leave the service active"
+
 WORK_DIR=$(mktemp -d)
 tar -xzf "$PACKAGE_DIR/$ARCHIVE" -C "$WORK_DIR"
 printf '#!/usr/bin/env bash\nexit 1\n' > "$WORK_DIR/${ARCHIVE%.tar.gz}/plugins/antminer-plugin"

--- a/deployment-files/fleetnode/tests/test-install-fleetnode.sh
+++ b/deployment-files/fleetnode/tests/test-install-fleetnode.sh
@@ -47,11 +47,10 @@ create_release() {
   fi
 
   local plugin
-  for plugin in proto-plugin antminer-plugin virtual-plugin asicrs-plugin; do
+  for plugin in proto-plugin antminer-plugin asicrs-plugin; do
     printf '#!/usr/bin/env bash\nexit 0\n' > "$release_dir/$archive_root/plugins/$plugin"
     chmod 0755 "$release_dir/$archive_root/plugins/$plugin"
   done
-  printf '{}\n' > "$release_dir/$archive_root/plugins/virtual-plugin.json"
   printf 'plugin: {}\nminers: {}\n' > "$release_dir/$archive_root/plugins/asicrs-config.yaml"
   if [[ -n "$extra_entry" ]]; then
     printf '#!/usr/bin/env bash\nexit 0\n' > "$release_dir/$archive_root/$extra_entry"
@@ -335,6 +334,11 @@ start_installer() {
   STARTED_INSTALLER_PID=$!
 }
 
+if FAKE_SYSTEMCTL_FAIL_SHOW=1 run_installer v1.0.0 > "$TEST_DIR/no-systemd.out" 2>&1; then
+  fail "installer accepted a host without a live systemd manager"
+fi
+assert_file_contains "$TEST_DIR/no-systemd.out" "requires a running systemd system manager"
+
 : > "$SYSTEMCTL_LOG"
 : > "$SUDO_LOG"
 : > "$ACCOUNT_LOG"
@@ -370,6 +374,7 @@ assert_file_contains "$FLEETNODE_DIR/install-fleet-node.sh" "--retry-delay 2"
 assert_file_contains "$FLEETNODE_DIR/install-fleet-node.sh" "--retry-connrefused"
 
 [[ -x "$ROOT_PREFIX/opt/fleetnode/fleetnode" ]] || fail "Fleet Node binary was not installed"
+[[ ! -e "$ROOT_PREFIX/opt/fleetnode/plugins/virtual-plugin" ]] || fail "customer package installed the virtual test plugin"
 assert_file_contains "$ROOT_PREFIX/opt/fleetnode/version.txt" "version: v1.0.0"
 [[ -f "$ROOT_PREFIX/etc/systemd/system/fleet-node.service" ]] || fail "systemd unit was not installed"
 assert_file_contains "$ROOT_PREFIX/etc/systemd/system/fleet-node.service" "Environment=PATH=$LINUX_SERVICE_PATH"


### PR DESCRIPTION
Reviewable diff: +36/-24 across 3 files (excludes generated, test, and story files).

## Summary

Fleet Node release artifacts are installed and exercised on native amd64 and arm64 systemd runners before upload. The customer archive contains only production plugins, and each executable must be a valid, statically linked ELF. The qualification stays intentionally narrow: it proves local startup, failed-upgrade rollback, and state-preserving uninstall without duplicating the full installer test suite.

**Stack**

1. [#990](https://github.com/block/proto-fleet/pull/990) — startup readiness and safe upgrade boundary (merged)
2. [#991](https://github.com/block/proto-fleet/pull/991) — installer lifecycle (merged)
3. **[#992](https://github.com/block/proto-fleet/pull/992) — this PR: native release-artifact qualification**
4. [#989](https://github.com/block/proto-fleet/pull/989) — one-command enrollment helper

With #990 and #991 merged, this PR's current diff is against `main`. It exercises their explicit readiness and rollback contracts using the packaged artifact. The enrollment helper remains isolated in #989; signing, release publication policy, and runbooks remain out of scope here.

## How it works

1. The artifact matrix builds directly on native `ubuntu-latest` amd64 and `ubuntu-24.04-arm` runners.
2. CI verifies that Fleet Node and all production plugins are valid ELF executables without dynamic interpreters or shared-library dependencies.
3. Packaging omits the virtual test plugin while retaining Fleet Node, Proto, Antminer, and asicrs binaries plus required configuration and unit files.
4. Before upload, the runner invokes the real installer as a non-root user. Only installer mutations cross `sudo`, matching the customer privilege boundary.
5. Qualification verifies that a fresh installation stays stopped, starts the service using synthetic local state, injects a broken plugin into an upgrade, and requires the previous running payload to be restored byte-for-byte.
6. A final uninstall must remove the program and unit while preserving Fleet Node state and its service account.
7. The exact archive and checksum are uploaded only after qualification succeeds.

```mermaid
flowchart LR
  A["Native amd64 or arm64 runner"] --> B["Build Fleet Node and production plugins"]
  B --> C["Validate ELF and static linkage"]
  C --> D["Create exact-version archive and checksum"]
  D --> E["Install through the customer installer"]
  E --> F["Start with real systemd"]
  F --> G["Inject failed upgrade and verify rollback"]
  G --> H["Uninstall while preserving state"]
  H --> I["Upload qualified artifact"]
```

```mermaid
sequenceDiagram
  participant CI
  participant Installer
  participant Systemd
  CI->>Installer: fresh install exact archive
  Installer-->>CI: stopped and disabled
  CI->>Systemd: start with synthetic local state
  Systemd-->>CI: active after local readiness
  CI->>Installer: upgrade with broken plugin
  Installer->>Systemd: candidate start fails
  Installer->>Systemd: restore and start previous payload
  Systemd-->>CI: previous service active
  CI->>Installer: uninstall
  Installer-->>CI: program removed and state preserved
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `.github/workflows/proto-fleet-artifact-build.yml` | Builds on native runners, validates static executables, packages production contents, and qualifies before upload | Defines the release gate and exact customer artifact |
| `.github/workflows/deployment-config-checks.yml` | Syntax-checks the qualification script during PR CI | Catches shell parse failures before nightly or tagged builds |
| `deployment-files/fleetnode/install-fleet-node.sh` | Adds a constrained local-file systemd qualification mode and removes the virtual plugin from the accepted manifest | Reuses the customer installer without exposing production override hooks |
| `deployment-files/fleetnode/tests/qualify-package.sh` | Adds the focused native systemd lifecycle scenario | Proves the packaged binaries, unit, installer, and rollback work together; review-light |
| Installer tests | Updates the package fixture and qualification-mode guards | Prevents test-only content or broader override behavior from returning; review-light |

## Key technical decisions & trade-offs

- Native execution replaces explicit ELF machine-string matching: wrong-architecture binaries fail by running, while CI avoids maintaining architecture-specific output text.
- Static-link validation remains explicit because a dynamically linked executable may work on the runner but fail on a customer host missing that library.
- The qualification seam accepts only a local `file://` source and rejects root-path, architecture, and systemctl overrides.
- The native scenario covers the high-value systemd and rollback boundary; successful upgrade variants and reinstall permutations remain in the fast installer suite.
- Synthetic state proves local daemon and plugin readiness, not real Fleet enrollment or server connectivity.

## Testing & validation

- `bash -n deployment-files/fleetnode/install-fleet-node.sh deployment-files/fleetnode/tests/qualify-package.sh deployment-files/fleetnode/tests/test-install-fleetnode.sh`
- `./deployment-files/fleetnode/tests/test-install-fleetnode.sh`
- `source ./bin/activate-hermit && just lint`
- Restacked #989: installer suite plus 13 focused enrollment-command client tests
- `git diff --check` for both stack layers
- Native amd64/arm64 systemd execution runs in nightly and tagged artifact workflows; it cannot be reproduced on this macOS workstation.
