### PR TITLE
chore(ci): align docker/setup-buildx-action pin to v4.3.0

### DIFF
--- a/.github/workflows/mdk-api-docs.yml
+++ b/.github/workflows/mdk-api-docs.yml
@@ -53,4 +53,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}proto-api-docs/
     steps:
       - id: deployment
-        uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5.0.1
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/mdk-api-docs.yml
+++ b/.github/workflows/mdk-api-docs.yml
@@ -53,4 +53,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}proto-api-docs/
     steps:
       - id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+        uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5.0.1

--- a/.github/workflows/proto-fleet-artifact-build.yml
+++ b/.github/workflows/proto-fleet-artifact-build.yml
@@ -282,7 +282,7 @@ jobs:
           done
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Build asicrs plugin
         run: |


### PR DESCRIPTION
Reviewable diff: +1/-1 across 1 file (excludes generated, test, and story files).

## Summary

Aligns the one remaining `docker/setup-buildx-action` pin still on v4.2.0 (introduced by the Linux installer work after #955) with the v4.3.0 SHA already used by every other workflow, preserving the repository's immutable SHA-pin convention. Workflow inputs and job behavior are unchanged.

An `actions/deploy-pages` v5.0.0 -> v5.0.1 bump was originally included and has been dropped: v5.0.1 was published 2026-09-01, inside the 7-day `github-actions` cooldown in `.github/dependabot.yml`. It can move once the cooldown elapses.

## How it works

GitHub Actions resolves each external action by an immutable 40-character commit SHA, with a trailing `# vX.Y.Z` comment for readability. The new SHA was resolved from the upstream `v4.3.0` release tag through the GitHub API and confirmed to exist as a commit in `docker/setup-buildx-action`. All 17 distinct external actions across `.github/workflows/`, `.github/actions/`, and `.github/client-e2e-tests.yml` were audited against both `releases/latest` and the full tag list; this was the only stale pin that also satisfies the cooldown policy.

## Diagrams

```mermaid
flowchart LR
  A["Workflow trigger"] --> B["Immutable action SHA"]
  B --> C["Existing workflow inputs"]
  C --> D["Existing Buildx build job"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `.github/workflows/proto-fleet-artifact-build.yml` (asicrs plugin job) | `docker/setup-buildx-action` v4.2.0 -> v4.3.0 | Aligns with the five other Buildx usages already on v4.3.0; every action version now maps to exactly one SHA |

## Key technical decisions & trade-offs

- Keep immutable commit SHAs over mutable version tags; the comment retains the human-readable release version.
- Update only the stale pin rather than touching workflow structure, minimizing CI behavior risk.
- Respect the Dependabot cooldown window: `docker/setup-buildx-action` v4.3.0 was published 2026-08-19 (14 days before this PR), so it is eligible; `actions/deploy-pages` v5.0.1 (published 2026-09-01) is not and was left at v5.0.0.

## Testing & validation

- Verified the new SHA resolves to a real commit at the upstream `v4.3.0` tag via the GitHub API, and that its release date satisfies the 7-day cooldown.
- Confirmed all other external action pins already match their newest cooldown-eligible upstream tag (checked `releases/latest` and full tag lists, including repos like `openai/codex-action` and `cashapp/activate-hermit` that tag without publishing releases).
- Parsed all 33 workflow and composite-action YAML files successfully.
- Pin-consistency check: every `action@version` maps to a single SHA.
- `git diff --check` passed; lefthook pre-commit and pre-push hooks passed (code-specific hooks correctly skipped this workflow-only diff).
- Not covered: the asicrs plugin build job is exercised by the artifact-build workflow on the default branch, not on this PR.
