### PR TITLE
test(fleetnode): fix two timing races in control-stream and telemetry tests

### DIFF
--- a/server/cmd/fleetnode/control_test.go
+++ b/server/cmd/fleetnode/control_test.go
@@ -716,13 +716,30 @@ func (f *controlFakeGateway) ControlStream(ctx context.Context, stream *connect.
 	}
 }
 
-func newControlClient(t *testing.T, fake *controlFakeGateway) gatewayClient {
+// newControlClient serves fake over h2c. Optional wrap middlewares are applied
+// server-side around the connect handler, outermost last.
+func newControlClient(t *testing.T, fake *controlFakeGateway, wrap ...func(http.Handler) http.Handler) gatewayClient {
 	t.Helper()
 	mux := http.NewServeMux()
 	path, h := fleetnodegatewayv1connect.NewFleetNodeGatewayServiceHandler(fake)
+	for _, w := range wrap {
+		h = w(h)
+	}
 	mux.Handle(path, h)
 	srv := testutil.NewH2CServer(t, mux)
 	return fleetnodegatewayv1connect.NewFleetNodeGatewayServiceClient(testutil.NewH2CClient(), srv.URL, connect.WithGRPC())
+}
+
+// dropGRPCDeadline strips Grpc-Timeout so the fake handler's context never
+// expires on its own. connect-go copies the client context deadline into that
+// header, so without this the server would close the stream at the same
+// instant the client's credential context expires and race the client-side
+// errControlSessionExpired cause with a plain EOF.
+func dropGRPCDeadline(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Header.Del("Grpc-Timeout")
+		next.ServeHTTP(w, r)
+	})
 }
 
 type reconnectControlGateway struct {

--- a/server/cmd/fleetnode/run_test.go
+++ b/server/cmd/fleetnode/run_test.go
@@ -313,7 +313,8 @@ func TestRunCmd_RefreshFailureCannotExtendControlStreamPastExpiry(t *testing.T) 
 	require.NoError(t, bootstrap.SaveState(statePath, state))
 
 	controlGateway := &controlFakeGateway{}
-	client := newControlClient(t, controlGateway)
+	// The client must be the only party enforcing expiry here; see dropGRPCDeadline.
+	client := newControlClient(t, controlGateway, dropGRPCDeadline)
 	cmd := &RunCmd{}
 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()

--- a/server/cmd/fleetnode/telemetry_test.go
+++ b/server/cmd/fleetnode/telemetry_test.go
@@ -450,7 +450,17 @@ func TestCloseTelemetryDeviceAsyncDoesNotBlock(t *testing.T) {
 		started: make(chan struct{}),
 		release: make(chan struct{}),
 	}
-	t.Cleanup(func() { close(closer.release) })
+	// Runs before the token-channel restore above (cleanups are LIFO). The
+	// worker reads the package-level knobs right up to its exit, so wait for
+	// it to hand its token back or it races the next test's setup.
+	t.Cleanup(func() {
+		close(closer.release)
+		select {
+		case tokens <- struct{}{}:
+		case <-time.After(time.Second):
+			t.Error("async close worker did not release its token")
+		}
+	})
 
 	start := time.Now()
 	require.True(t, closeTelemetryDeviceAsync(closer))


### PR DESCRIPTION
Reviewable diff: +0/-0 across 0 files (excludes generated, test, and story files). All 3 changed files are `*_test.go` (+31/-3).

## Summary

Makes two intermittently failing tests in `server/cmd/fleetnode` deterministic. `TestRunCmd_RefreshFailureCannotExtendControlStreamPastExpiry` failed `Server Checks / Test` on #999 with `control stream closed by server: unknown: EOF` instead of the expected `control session credentials expired`; `TestCloseTelemetryDeviceAsyncDoesNotBlock` leaked a worker goroutine that races the next test and trips `-race` on every full-package run. No production code changes; `runControlLoop` already treats both control-stream error shapes identically (warn, back off, reconnect).

## How it works

**Control-stream expiry race.** `runControlSession` opens the stream with `credentialCtx`, whose deadline is the session token expiry (`beginControlSession`, `control.go:311`). The test client uses `connect.WithGRPC()`, and connect-go copies the client deadline into the `Grpc-Timeout` request header (`protocol_grpc.go:273-276`); the server handler then wraps its ctx in `context.WithTimeout` with that value (`protocol_grpc.go:137`). So the fake handler and the client expire at the same instant, and whichever fires first decides the error the receive loop returns:

- client timer first → `context.Cause(credentialCtx)` = `errControlSessionExpired` (`control.go:267`)
- server timer first → handler returns on `ctx.Done()` → client sees `EOF` (`control.go:270`)

The fix adds an optional server-side middleware hook to `newControlClient` and a `dropGRPCDeadline` middleware that deletes `Grpc-Timeout` before the connect handler sees it. The fake server then never expires on its own, so the client's credential deadline is the only thing that can end the stream, which is what the test is meant to verify (the client enforces expiry even when refresh fails). Existing `newControlClient(t, fake)` call sites are unchanged.

**Telemetry close-worker race.** `closeTelemetryDeviceAsync` spawns a worker whose deferred `<-telemetryDeviceCloseTokens` reads the package variable only when it exits (`telemetry.go:271`). `TestCloseTelemetryDeviceAsyncDoesNotBlock` returned as soon as `closer.started` fired, while the worker was still running. Its cleanup then restored the package globals under the worker (the data race), and if the next test had already installed its pre-filled token channel, the leaked worker drained that token, so `closeTelemetryDeviceAsync` saw free capacity and returned `true`, failing `assert.False` at `telemetry_test.go:488`. The fix makes the release cleanup wait until it can push a token back into the test's channel (i.e. the worker has returned its token) before the outer cleanup restores the globals.

## Diagrams

```mermaid
sequenceDiagram
  participant C as Client runControlSession
  participant S as Fake server handler
  Note over C,S: Before: Grpc-Timeout propagates the deadline
  C->>S: ControlStream (Grpc-Timeout = expiry)
  par at expiry
    C-->>C: credentialCtx deadline → errControlSessionExpired
  and
    S-->>C: handler ctx deadline → close stream (EOF)
  end
  Note over C: Whichever lands first wins → flaky
  Note over C,S: After: dropGRPCDeadline strips the header
  C->>S: ControlStream (no server deadline)
  C-->>C: credentialCtx deadline → close stream
  C-->>C: Cause = errControlSessionExpired (deterministic)
```

```mermaid
flowchart LR
  A["Test A: closeTelemetryDeviceAsync"] --> W["Worker goroutine"]
  A --> E["Test A ends on closer.started"]
  E --> B["Test B installs pre-filled tokens chan"]
  W -.->|"drains B's token (before)"| B
  E --> F["Fix: cleanup waits for token return"]
  F --> B
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/cmd/fleetnode/control_test.go` | `newControlClient` gains variadic `wrap ...func(http.Handler) http.Handler`; new `dropGRPCDeadline` middleware | Shared helper used by ~40 tests; behavior is unchanged when no wrappers are passed |
| `server/cmd/fleetnode/run_test.go` | `TestRunCmd_RefreshFailureCannotExtendControlStreamPastExpiry` passes `dropGRPCDeadline` | Confirm the assertion still tests what was intended: client-side expiry enforcement |
| `server/cmd/fleetnode/telemetry_test.go` | `TestCloseTelemetryDeviceAsyncDoesNotBlock` cleanup waits for the worker to return its token before globals are restored | Confirm cleanup ordering (LIFO) is correct: release+wait runs before the token-channel restore |

## Key technical decisions & trade-offs

- Fix the tests, not `control.go`: the receive loop could prefer the expiry cause when the deadline has passed, but production already handles both errors identically, so changing it would only reshape a log line.
- Strip `Grpc-Timeout` server-side rather than accept either error in the assertion: keeps the test's intent (the client must enforce expiry on its own) instead of weakening it.
- Wait for the worker in the test rather than capture the token channel in `closeTelemetryDeviceAsync`: capturing would fix the channel race but not the worker's reads of `telemetryDeviceCloseTimeout`/`Grace`, which the next test also mutates.

## Testing & validation

- Reproduced the control-stream race deterministically with a throwaway middleware that *shortened* `Grpc-Timeout` by 500ms: 3/3 runs failed with the exact CI message. With `dropGRPCDeadline` added, 3/3 pass with `control session credentials expired` at the 2s expiry. Scratch test not committed.
- `TestRunCmd_RefreshFailureCannotExtendControlStreamPastExpiry`: 20/20 pass.
- `TestCloseTelemetryDeviceAsync*` pair under `-race`: 10/10 pass (previously the data race reproduced 3/3 on clean `main`).
- Full `./cmd/fleetnode` package: 3/3 under `-race`, 8/8 in CI mode (`go test` without `-race`). On clean `main`, the same package failed 3/3 under `-race` and 1/5 in CI mode.
- `golangci-lint` 0 issues; `goimports` clean; lefthook pre-commit and pre-push hooks passed.
- Not covered: CI does not run `-race`, so the telemetry race is only guarded by the flaky-in-CI-mode symptom going away.