### PR TITLE
fix(updater): retry process lock across a child's fork-exec window

### DIFF
--- a/server/internal/updater/manager.go
+++ b/server/internal/updater/manager.go
@@ -58,6 +58,8 @@ const (
 	maxRetainedLogBytes                    = int64(256 << 20)
 	canonicalDownloadBaseURL               = "https://github.com/block/proto-fleet/releases/download"
 	processLockFilename                    = "updater.lock"
+	processLockRetryWindow                 = 250 * time.Millisecond
+	processLockRetryInterval               = 5 * time.Millisecond
 	activationMarkerFilename               = "activation-swap.json"
 	activationMarkerTempName               = ".activation-swap.json.tmp"
 	qualificationBeforeStopBarrierName     = "qualification-pause-before-ha-stop"
@@ -873,6 +875,10 @@ func (m *Manager) Shutdown(ctx context.Context) error {
 }
 
 func acquireProcessLock(stateDir string) (*os.File, error) {
+	return acquireProcessLockWithin(stateDir, processLockRetryWindow)
+}
+
+func acquireProcessLockWithin(stateDir string, retryWindow time.Duration) (*os.File, error) {
 	lockPath := filepath.Join(stateDir, processLockFilename)
 	fd, err := syscall.Open(
 		lockPath,
@@ -901,11 +907,11 @@ func acquireProcessLock(stateDir string) (*os.File, error) {
 	if err := lockFile.Chmod(0o600); err != nil {
 		return closeWithError(fmt.Errorf("secure updater process lock: %w", err))
 	}
-	if err := syscall.Flock(fd, syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
-		if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) {
+	if err := flockExclusiveWithin(fd, retryWindow); err != nil {
+		if isLockContended(err) {
 			return closeWithError(fmt.Errorf("another updater process is already running"))
 		}
-		return closeWithError(fmt.Errorf("acquire updater process lock: %w", err))
+		return closeWithError(err)
 	}
 	// PID metadata is diagnostic only; the open-file-description lock is the
 	// authority. Failure to refresh the hint must not weaken serialization.
@@ -913,6 +919,35 @@ func acquireProcessLock(stateDir string) (*os.File, error) {
 		log.Printf("write updater process lock owner: %v", err)
 	}
 	return lockFile, nil
+}
+
+// flockExclusiveWithin takes a non-blocking exclusive flock, retrying
+// contention until retryWindow elapses.
+//
+// flock ownership belongs to the open file description, and a child this
+// process forks (docker compose, shell helpers, the candidate smoke test)
+// duplicates every descriptor until it execs. A contender arriving inside that
+// fork→exec window sees EWOULDBLOCK with no updater running, so contention only
+// counts once it outlasts the window. A real updater holds the lock for its
+// whole lifetime, far longer than any exec latency. The lock is never requested
+// in blocking mode, so a genuine holder cannot stall startup.
+func flockExclusiveWithin(fd int, retryWindow time.Duration) error {
+	deadline := time.Now().Add(retryWindow)
+	for {
+		err := syscall.Flock(fd, syscall.LOCK_EX|syscall.LOCK_NB)
+		if err == nil {
+			return nil
+		}
+		retryable := isLockContended(err) || errors.Is(err, syscall.EINTR)
+		if !retryable || !time.Now().Before(deadline) {
+			return fmt.Errorf("acquire updater process lock: %w", err)
+		}
+		time.Sleep(processLockRetryInterval)
+	}
+}
+
+func isLockContended(err error) bool {
+	return errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN)
 }
 
 func writeProcessLockPID(lockFile *os.File) error {

--- a/server/internal/updater/manager_test.go
+++ b/server/internal/updater/manager_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -3660,6 +3661,77 @@ func TestExecRunnerMarksCommandsAsUpdaterManaged(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assert.Equal(t, "1", output.String())
+}
+
+func TestAcquireProcessLockWaitsOutTransientHolder(t *testing.T) {
+	t.Parallel()
+
+	stateDir := t.TempDir()
+	holder, err := acquireProcessLock(stateDir)
+	require.NoError(t, err)
+	released := make(chan struct{})
+	go func() {
+		defer close(released)
+		time.Sleep(50 * time.Millisecond)
+		assert.NoError(t, holder.Close())
+	}()
+
+	lock, err := acquireProcessLockWithin(stateDir, 10*time.Second)
+	require.NoError(t, err, "a holder that releases inside the window is not a competing updater")
+	<-released
+	require.NoError(t, lock.Close())
+}
+
+func TestAcquireProcessLockRejectsPersistentHolder(t *testing.T) {
+	t.Parallel()
+
+	stateDir := t.TempDir()
+	holder, err := acquireProcessLock(stateDir)
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, holder.Close()) })
+
+	window := 50 * time.Millisecond
+	started := time.Now()
+	_, err = acquireProcessLockWithin(stateDir, window)
+	require.ErrorContains(t, err, "another updater process is already running")
+	assert.GreaterOrEqual(t, time.Since(started), window, "contention must outlast the window before it is reported")
+}
+
+// Regression for a flake seen in CI: a child forked by another goroutine holds
+// a duplicate of the lock descriptor until it execs, so a same-process
+// close→reacquire could observe EWOULDBLOCK with no updater running.
+func TestAcquireProcessLockToleratesForkExecWindow(t *testing.T) {
+	t.Parallel()
+
+	truePath, err := exec.LookPath("true")
+	if err != nil {
+		t.Skip("no true binary on PATH")
+	}
+	stop := make(chan struct{})
+	var forkers sync.WaitGroup
+	for range 4 {
+		forkers.Go(func() {
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					_ = exec.Command(truePath).Run()
+				}
+			}
+		})
+	}
+	t.Cleanup(func() {
+		close(stop)
+		forkers.Wait()
+	})
+
+	stateDir := t.TempDir()
+	for range 200 {
+		lock, err := acquireProcessLock(stateDir)
+		require.NoError(t, err, "a forked child mid-exec must not read as a competing updater")
+		require.NoError(t, lock.Close())
+	}
 }
 
 func newTestManager(t *testing.T, installRoot string, server *httptest.Server, runner CommandRunner) *Manager {


### PR DESCRIPTION
Reviewable diff: +38/-3 across 1 file (excludes generated, test, and story files).

## Summary

Stops the updater from reporting "another updater process is already running" when the only other holder of its `flock` is a child process that this same updater forked and that has not yet reached `execve`. The false positive surfaced as an intermittent CI failure in `server/internal/updater` (`TestManagerAcknowledgeRecordsAndPersistsTerminalDismissal` on `main` twice on 2026-08-28, `TestStatusDerivesAcknowledgementForRemediatedFailure` on #1002), but the same window exists in production whenever the updater restarts while a `docker compose` or shell child is mid-spawn. The lock stays non-blocking; contention is now confirmed only once it persists for a bounded 250 ms.

## How it works

`acquireProcessLock` opens `<state-dir>/updater.lock` with `O_CLOEXEC` and takes `flock(LOCK_EX|LOCK_NB)`. A `flock` belongs to the open file description, and on fork a child duplicates every parent descriptor; `O_CLOEXEC` only closes them when the child calls `execve`. So between fork and exec the child transiently co-owns the lock. If the parent closes its own descriptor and immediately reopens (`RepairStartup` does exactly this before constructing the manager, and several tests do it to simulate a restart), a `LOCK_NB` attempt that lands in that window gets `EWOULDBLOCK` even though no other updater exists.

The fix routes the `flock` call through `flockExclusiveWithin`, which retries `EWOULDBLOCK`/`EAGAIN` (and `EINTR`) every 5 ms until a 250 ms deadline, then returns the last error. `acquireProcessLock` maps a still-contended result to the existing "another updater process is already running" message and passes any other errno through with the existing "acquire updater process lock" wrapping, so callers and existing assertions are unchanged. A genuine competing updater holds its lock for the lifetime of the process, so the only behavioural difference for a real conflict is that the rejection arrives 250 ms later.

The mechanism was confirmed with a standalone program: 0 spurious `EWOULDBLOCK` across ~170k open→flock→close cycles with no forking, ~4,900 (about 4%) once four goroutines were forking `/usr/bin/true` concurrently. The new `TestAcquireProcessLockToleratesForkExecWindow` encodes that scenario in-tree and fails 5/5 runs when the retry window is set to zero.

## Diagrams

```mermaid
sequenceDiagram
  participant T1 as Updater thread
  participant K as Kernel
  participant T2 as Other thread
  participant C as Forked child
  T1->>K: open updater.lock, flock LOCK_EX|LOCK_NB
  K-->>T1: locked
  T2->>K: fork (docker compose / sh)
  K-->>C: duplicate of lock fd (same open file description)
  T1->>K: close lock fd
  Note over K: lock still held via child's duplicate
  T1->>K: open updater.lock, flock LOCK_NB
  K-->>T1: EWOULDBLOCK
  Note over T1: before: report "another updater process is already running"
  C->>K: execve (O_CLOEXEC closes duplicate)
  Note over K: lock released
  T1->>K: retry flock LOCK_NB (5 ms later, within 250 ms window)
  K-->>T1: locked
```

```mermaid
flowchart LR
  A["acquireProcessLock"] --> B["acquireProcessLockWithin(250 ms)"]
  B --> C["open + stat + chmod updater.lock"]
  C --> D["flockExclusiveWithin"]
  D -->|locked| E["write PID hint, return lock"]
  D -->|EWOULDBLOCK / EAGAIN / EINTR and deadline not reached| F["sleep 5 ms"] --> D
  D -->|EWOULDBLOCK / EAGAIN after deadline| G["another updater process is already running"]
  D -->|other errno| H["acquire updater process lock: errno"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/internal/updater/manager.go` | `acquireProcessLock` delegates to `acquireProcessLockWithin(stateDir, processLockRetryWindow)`; new `flockExclusiveWithin` retry loop and `isLockContended` helper; two constants (`processLockRetryWindow` 250 ms, `processLockRetryInterval` 5 ms) | Only production change. Confirm the lock is still `LOCK_NB` (no indefinite block), that the contended and non-contended error strings match the previous ones, and that the window is generous relative to fork→exec latency yet short relative to a real updater's lifetime |
| `server/internal/updater/manager_test.go` | `TestAcquireProcessLockWaitsOutTransientHolder`, `TestAcquireProcessLockRejectsPersistentHolder`, `TestAcquireProcessLockToleratesForkExecWindow` | Test-only. The third test is the regression guard: it forks `true` from four goroutines while cycling the lock 200 times |

## Key technical decisions & trade-offs

- **Bounded retry over changing the lock primitive.** POSIX `fcntl(F_SETLK)` record locks are not inherited across fork and would remove the window outright, but they are released when the process closes *any* descriptor for the file, which is a footgun for code that later opens files in the state directory. The retry keeps the existing open-file-description semantics the manager already relies on.
- **Fix the production path, not just the tests.** Dropping `t.Parallel()` from the three subprocess-spawning tests would have made CI green, but `RepairStartup` performs the same close→reopen sequence in production, so the false "already running" was reachable there too.
- **250 ms window, 5 ms poll.** Fork→exec of a small binary is on the order of a millisecond even on loaded CI runners, giving two orders of magnitude of margin; a real updater holds the lock for minutes to hours, so 250 ms cannot mask genuine contention. The cost is a 250 ms slower rejection when another updater really is running.
- **`acquireProcessLockWithin` as the seam.** Tests pass an explicit window (10 s for the transient holder, 50 ms for the persistent one) so they are deterministic rather than racing the production constant; production callers keep using `acquireProcessLock`.

## Testing & validation

- `go build ./...`, `go vet`, `gofmt`, `goimports`, and `golangci-lint run -c .golangci.yaml ./internal/updater/...` clean (0 issues).
- `go test ./internal/updater -count=5` passes; the existing genuine-contention assertions (`TestManagerProcessLockPreventsASecondDaemonFromMutatingState`, `TestManagerShutdownDuringActivationRetainsTheProcessLockUntilCompletion`, `TestRepairStartupDoesNotTouchSelfUpdateWhileManagerRuns`) still pass, now after the 250 ms window.
- Full server suite against a local TimescaleDB: 123 packages pass.
- Regression test proven effective: with the retry window forced to 0 (the previous behaviour) `TestAcquireProcessLockToleratesForkExecWindow` failed 5/5 runs locally; with the fix it passes across repeated runs.
- Not covered: no Linux-specific run beyond CI itself; the fork/flock semantics involved are identical on Linux and macOS, and the original failures were observed on Linux CI runners.
