### PR TITLE
Honor feature flags in HA installs and updates

### DIFF
--- a/deployment-files/ha/README.md
+++ b/deployment-files/ha/README.md
@@ -63,6 +63,44 @@ ssh -A -t admin@10.40.0.11 'curl -fsSL https://fleet.proto.xyz/install.sh | sudo
 makes it available to the peer checks after `sudo`. Normal password and
 host-key prompts still work when the agent has no applicable key.
 
+The HA installer persists the same deployment feature flags used by the
+standalone profile. `ENABLE_BETA_ALERTS` defaults to `true` for HA so the
+failover-readiness alert remains enabled; `ENABLE_SYSTEM_MONITORING` and
+`ENABLE_TRACING` default to `false`. To override them, export the selected
+`ENABLE_*` values before `sudo` and add them to `--preserve-env`. Tracing also
+requires `DD_API_KEY` to be preserved. To keep that secret out of command
+history and process arguments, open an interactive shell on `ha-a` and read it
+without echo before starting the installer:
+
+```bash
+ssh -A -t admin@10.40.0.11
+read -rsp 'Datadog API key: ' DD_API_KEY < /dev/tty && printf '\n'
+export ENABLE_TRACING=true DD_API_KEY
+curl -fsSL https://fleet.proto.xyz/install.sh | sudo --preserve-env=SSH_AUTH_SOCK,ENABLE_TRACING,DD_API_KEY bash -s -- --ha
+unset DD_API_KEY
+```
+
+The public installer removes the preserved key from its exported environment
+before running any setup or download subprocesses. It exposes the captured
+value only to `fleet-ha`, which immediately moves it into the protected
+in-memory deployment profile and clears its own environment before host work.
+
+For a non-US1 Datadog account, preserve `DD_SITE` too. HA accepts Datadog's
+published site parameters: `datadoghq.com`, `us3.datadoghq.com`,
+`us5.datadoghq.com`, `datadoghq.eu`, `ap1.datadoghq.com`,
+`ap2.datadoghq.com`, `uk1.datadoghq.com`, `ddog-gov.com`, and
+`us2.ddog-gov.com`.
+
+The installer validates these values before changing the hosts and records
+them in the protected `/etc/proto-fleet/ha/fleet.env`. Host updates reuse that
+file, so every stop, preflight, and restart uses the same overlays. Setting
+`ENABLE_BETA_ALERTS=false` also disables the HA readiness
+Grafana sidecar; `fleet-ha status` remains the authoritative readiness check.
+System monitoring is configured on both database hosts, but its runtime job
+runs only on the host that currently owns Fleet. This keeps the shared metric
+series single-writer while preserving monitoring across failover. Its disk
+gauge watches the active host's filesystem containing `/var/lib/proto-fleet/ha`.
+
 The wizard asks for the `ha-b` address, `ha-c` address, VIP, and the SSH
 username shared by the peer hosts. It derives `ha-a`'s local address and
 interface, validates the release and all three addresses, and shows the

--- a/deployment-files/ha/fleet-compose.alerts.yaml
+++ b/deployment-files/ha/fleet-compose.alerts.yaml
@@ -1,0 +1,47 @@
+services:
+  fleet-api:
+    environment:
+      FLEET_ALERTS_GRAFANA_USER: "admin"
+      FLEET_ALERTS_GRAFANA_PASSWORD: "${GRAFANA_ADMIN_PASSWORD}"
+
+  grafana:
+    # HA keeps Grafana intentionally local: the file-provisioned readiness
+    # rule is identical on both hosts, while each instance keeps standalone
+    # SQLite state in its own grafana-data volume.
+    # Pin the verified multi-architecture manifest because HA release installs
+    # otherwise pull this image outside the checksummed release archive.
+    image: grafana/grafana:13.0@sha256:e78917cdd3336d0d679d345b2e6d0f60a0fe85ed7ac3882b68f089fdb6ff2ace
+    depends_on: !reset []
+    network_mode: host
+    ports: !reset []
+    expose: !reset []
+    networks: !reset []
+    extra_hosts: !override
+      - "fleet-api:127.0.0.1"
+    environment:
+      HA_NODE_IP: "${HA_NODE_IP}"
+      HA_DB_A_IP: "${HA_DB_A_IP}"
+      HA_DB_B_IP: "${HA_DB_B_IP}"
+      GRAFANA_DB_NAME: "fleet"
+      GRAFANA_DB_USERNAME: "grafana_ha_ro"
+      GF_SERVER_HTTP_ADDR: "127.0.0.1"
+      GF_SERVER_HTTP_PORT: "3030"
+    volumes: !override
+      - grafana-data:/var/lib/grafana
+      - "./server/monitoring/grafana/grafana.ini:/etc/grafana/grafana.ini:ro"
+      - "./server/monitoring/grafana/provisioning/alerting/contact-points.yaml:/etc/grafana/provisioning/alerting/contact-points.yaml:ro"
+      - "./server/monitoring/grafana/provisioning/alerting/notification-policies.yaml:/etc/grafana/provisioning/alerting/notification-policies.yaml:ro"
+      - "${HA_SECRETS_DIR}/service-ca.crt:/etc/grafana/proto-fleet-ha/service-ca.crt:ro"
+      - "./server/monitoring/grafana/ha/timescaledb.yaml:/etc/grafana/provisioning/datasources/timescaledb.yaml:ro"
+      - "./server/monitoring/grafana/ha/proto-fleet-ha-rules.yaml:/etc/grafana/provisioning/alerting/proto-fleet-ha-rules.yaml:ro"
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >-
+          { credential="$$(printf 'admin:%s' "$${GF_SECURITY_ADMIN_PASSWORD}" | base64 | tr -d '\n')" &&
+          wget -q -O /dev/null http://127.0.0.1:3030/api/health &&
+          wget -q -O /dev/null --header "Authorization: Basic $${credential}"
+          http://127.0.0.1:3030/api/v1/provisioning/alert-rules/protofleet-ha-readiness; }
+          >/dev/null 2>&1
+    # Keep Docker restarts behind the same systemd start gate as Fleet.
+    restart: on-failure

--- a/deployment-files/ha/fleet-compose.system-monitoring.yaml
+++ b/deployment-files/ha/fleet-compose.system-monitoring.yaml
@@ -1,0 +1,6 @@
+services:
+  fleet-api:
+    volumes:
+      # Replace the standalone Docker-volume sentinel with an empty directory
+      # on the filesystem that holds the HA database.
+      - "${HA_DATA_DIR}/system-monitoring:/hostfs:ro"

--- a/deployment-files/ha/fleet-compose.tracing.yaml
+++ b/deployment-files/ha/fleet-compose.tracing.yaml
@@ -1,0 +1,13 @@
+services:
+  fleet-api:
+    # Tracing is best-effort in HA and must not gate control-plane startup.
+    depends_on: !reset []
+
+  otel-collector:
+    # Pin the verified multi-architecture manifest because HA release installs
+    # pull this sidecar outside the checksummed release archive.
+    image: otel/opentelemetry-collector-contrib:0.150.1@sha256:a516c26968aa1feb5e5fc0562e3338ea13755cb4f373603226bcc4e276374ad0
+    ports:
+      - "127.0.0.1:13133:13133"
+    # Let systemd reapply the HA start gate after Docker restarts.
+    restart: on-failure

--- a/deployment-files/ha/fleet-compose.yaml
+++ b/deployment-files/ha/fleet-compose.yaml
@@ -19,8 +19,6 @@ services:
       FLEET_HA_ENDPOINT_IP: "${HA_VIRTUAL_IP}"
       FLEET_HA_ENDPOINT_INTERFACE: "${HA_NETWORK_INTERFACE}"
       FLEET_PUBLIC_URL: "https://${HA_VIRTUAL_IP}"
-      FLEET_ALERTS_GRAFANA_USER: "admin"
-      FLEET_ALERTS_GRAFANA_PASSWORD: "${GRAFANA_ADMIN_PASSWORD}"
     volumes:
       - "${HA_SECRETS_DIR}/service-ca.crt:/etc/proto-fleet/ha/service-ca.crt:ro"
       - "${HA_SECRETS_DIR}/fleet-etcd-password:/etc/proto-fleet/ha/fleet-etcd-password:ro"
@@ -33,45 +31,3 @@ services:
       - "${HA_SECRETS_DIR}/fleet-client.crt:/etc/nginx/ssl/cert.pem:ro"
       - "${HA_SECRETS_DIR}/fleet-client.key:/etc/nginx/ssl/key.pem:ro"
       - "${HA_SECRETS_DIR}/service-ca.crt:/usr/share/nginx/html/proto-fleet-ha-service-ca.crt:ro"
-
-  grafana:
-    # HA keeps Grafana intentionally local: the file-provisioned readiness
-    # rule is identical on both hosts, while each instance keeps standalone
-    # SQLite state in its own grafana-data volume.
-    # Pin the verified multi-architecture manifest because HA release installs
-    # otherwise pull this image outside the checksummed release archive.
-    image: grafana/grafana:13.0@sha256:e78917cdd3336d0d679d345b2e6d0f60a0fe85ed7ac3882b68f089fdb6ff2ace
-    depends_on: !reset []
-    network_mode: host
-    ports: !reset []
-    expose: !reset []
-    networks: !reset []
-    extra_hosts: !override
-      - "fleet-api:127.0.0.1"
-    environment:
-      HA_NODE_IP: "${HA_NODE_IP}"
-      HA_DB_A_IP: "${HA_DB_A_IP}"
-      HA_DB_B_IP: "${HA_DB_B_IP}"
-      GRAFANA_DB_NAME: "fleet"
-      GRAFANA_DB_USERNAME: "grafana_ha_ro"
-      GF_SERVER_HTTP_ADDR: "127.0.0.1"
-      GF_SERVER_HTTP_PORT: "3030"
-    volumes: !override
-      - grafana-data:/var/lib/grafana
-      - "./server/monitoring/grafana/grafana.ini:/etc/grafana/grafana.ini:ro"
-      - "./server/monitoring/grafana/provisioning/alerting/contact-points.yaml:/etc/grafana/provisioning/alerting/contact-points.yaml:ro"
-      - "./server/monitoring/grafana/provisioning/alerting/notification-policies.yaml:/etc/grafana/provisioning/alerting/notification-policies.yaml:ro"
-      - "${HA_SECRETS_DIR}/service-ca.crt:/etc/grafana/proto-fleet-ha/service-ca.crt:ro"
-      - "./server/monitoring/grafana/ha/timescaledb.yaml:/etc/grafana/provisioning/datasources/timescaledb.yaml:ro"
-      - "./server/monitoring/grafana/ha/proto-fleet-ha-rules.yaml:/etc/grafana/provisioning/alerting/proto-fleet-ha-rules.yaml:ro"
-    healthcheck:
-      test:
-        - CMD-SHELL
-        - >-
-          { credential="$$(printf 'admin:%s' "$${GF_SECURITY_ADMIN_PASSWORD}" | base64 | tr -d '\n')" &&
-          wget -q -O /dev/null http://127.0.0.1:3030/api/health &&
-          wget -q -O /dev/null --header "Authorization: Basic $${credential}"
-          http://127.0.0.1:3030/api/v1/provisioning/alert-rules/protofleet-ha-readiness; }
-          >/dev/null 2>&1
-    # Keep Docker restarts behind the same systemd start gate as Fleet.
-    restart: on-failure

--- a/deployment-files/ha/tests/test-profile.sh
+++ b/deployment-files/ha/tests/test-profile.sh
@@ -26,6 +26,55 @@ assert_not_contains() {
     fi
 }
 
+render_fleet_profile() {
+    local release_dir="$1"
+    local profile="$2"
+
+    local -a environment=(
+        AUTH_CLIENT_SECRET_KEY=test-auth-secret
+        DB_USERNAME=fleet
+        DB_PASSWORD=test-db-password
+        DB_DSN=postgresql://fleet:test@10.40.0.11:5432/fleet
+        ENCRYPT_SERVICE_MASTER_KEY=test-master-key
+        GRAFANA_ADMIN_PASSWORD=test-grafana-admin-password
+        GRAFANA_DB_PASSWORD=test-grafana-db-password
+        GRAFANA_SECRET_KEY=test-grafana-secret-key
+        FLEET_ALERTS_WEBHOOK_TOKEN=test-alert-webhook-token
+        DD_HOSTNAME=ha-a
+        HA_NODE_NAME=ha-a
+        HA_NODE_IP=10.40.0.11
+        HA_DB_A_IP=10.40.0.11
+        HA_DB_B_IP=10.40.0.12
+        HA_DCS_C_IP=10.40.0.13
+        HA_VIRTUAL_IP=10.40.0.100
+        HA_NETWORK_INTERFACE=eth0
+        HA_DATA_DIR=/var/lib/proto-fleet/ha
+        HA_SECRETS_DIR=/etc/proto-fleet/ha
+    )
+    local -a compose_files=(--file "${release_dir}/docker-compose.yaml")
+    local -a services=(fleet-api fleet-client)
+    if [[ "$profile" != "disabled" ]]; then
+        compose_files+=(--file "${release_dir}/docker-compose.alerts.yaml")
+        services+=(grafana)
+    fi
+    compose_files+=(--file "${release_dir}/ha/fleet-compose.yaml")
+    if [[ "$profile" != "disabled" ]]; then
+        compose_files+=(--file "${release_dir}/ha/fleet-compose.alerts.yaml")
+    fi
+    if [[ "$profile" == "tracing" ]]; then
+        environment+=(DD_API_KEY=test-datadog-key)
+        services+=(otel-collector)
+        compose_files+=(
+            --file "${release_dir}/docker-compose.system-monitoring.yaml"
+            --file "${release_dir}/ha/fleet-compose.system-monitoring.yaml"
+            --file "${release_dir}/docker-compose.tracing.yaml"
+            --file "${release_dir}/ha/fleet-compose.tracing.yaml"
+        )
+    fi
+
+    env "${environment[@]}" docker compose "${compose_files[@]}" config "${services[@]}"
+}
+
 test_compose_uses_one_host_identity() {
     local rendered
     rendered="$(mktemp)"
@@ -99,32 +148,17 @@ test_fleet_ha_contract() {
     mkdir -p "${release_dir}/ha" "${release_dir}/server"
     cp "${HA_DIR}/../docker-compose.yaml" "${release_dir}/docker-compose.yaml"
     cp "${HA_DIR}/../docker-compose.alerts.yaml" "${release_dir}/docker-compose.alerts.yaml"
+    cp "${HA_DIR}/../docker-compose.system-monitoring.yaml" "${release_dir}/docker-compose.system-monitoring.yaml"
+    cp "${HA_DIR}/../docker-compose.tracing.yaml" "${release_dir}/docker-compose.tracing.yaml"
     cp "${HA_DIR}/fleet-compose.yaml" "${release_dir}/ha/fleet-compose.yaml"
+    cp "${HA_DIR}/fleet-compose.alerts.yaml" "${release_dir}/ha/fleet-compose.alerts.yaml"
+    cp "${HA_DIR}/fleet-compose.system-monitoring.yaml" "${release_dir}/ha/fleet-compose.system-monitoring.yaml"
+    cp "${HA_DIR}/fleet-compose.tracing.yaml" "${release_dir}/ha/fleet-compose.tracing.yaml"
     cp "${HA_DIR}/../../server/docker-compose.base.yaml" "${release_dir}/server/docker-compose.base.yaml"
+    cp "${HA_DIR}/../server/otel-collector-config.datadog.yaml" "${release_dir}/server/otel-collector-config.datadog.yaml"
     cp -r "${HA_DIR}/../../server/monitoring" "${release_dir}/server/monitoring"
 
-    AUTH_CLIENT_SECRET_KEY=test-auth-secret \
-    DB_USERNAME=fleet \
-    DB_PASSWORD=test-db-password \
-    DB_DSN=postgresql://fleet:test@10.40.0.11:5432/fleet \
-    ENCRYPT_SERVICE_MASTER_KEY=test-master-key \
-    GRAFANA_ADMIN_PASSWORD=test-grafana-admin-password \
-    GRAFANA_DB_PASSWORD=test-grafana-db-password \
-    GRAFANA_SECRET_KEY=test-grafana-secret-key \
-    FLEET_ALERTS_WEBHOOK_TOKEN=test-alert-webhook-token \
-    UPDATES_ENABLED=true \
-    HA_NODE_IP=10.40.0.11 \
-    HA_DB_A_IP=10.40.0.11 \
-    HA_DB_B_IP=10.40.0.12 \
-    HA_DCS_C_IP=10.40.0.13 \
-    HA_VIRTUAL_IP=10.40.0.100 \
-    HA_NETWORK_INTERFACE=eth0 \
-    HA_SECRETS_DIR=/etc/proto-fleet/ha \
-        docker compose \
-        --file "${release_dir}/docker-compose.yaml" \
-        --file "${release_dir}/docker-compose.alerts.yaml" \
-        --file "${release_dir}/ha/fleet-compose.yaml" \
-        config fleet-api fleet-client grafana >"$rendered"
+    UPDATES_ENABLED=true render_fleet_profile "$release_dir" base >"$rendered"
 
     if grep -q '^  timescaledb:$' "$rendered"; then
         fail "HA Fleet targets must not include the standalone database service"
@@ -178,6 +212,34 @@ test_fleet_ha_contract() {
     ' "$notification_policies" || fail "HA readiness notifications must use a five-second group wait"
     secret_mount_count="$(grep -c 'source: /etc/proto-fleet/ha/' "$rendered")"
     [[ "$secret_mount_count" -eq 7 ]] || fail "Fleet services must mount only their required HA secret files"
+
+    render_fleet_profile "$release_dir" disabled >"$rendered"
+    assert_not_contains "$rendered" "grafana:"
+    assert_not_contains "$rendered" "grafana-data"
+    assert_not_contains "$rendered" "FLEET_ALERTS_GRAFANA_PASSWORD"
+
+    render_fleet_profile "$release_dir" tracing >"$rendered"
+
+    assert_contains "$rendered" "FLEET_SYSTEM_MONITORING_ENABLED: \"true\""
+    assert_contains "$rendered" "source: /var/lib/proto-fleet/ha/system-monitoring"
+    assert_contains "$rendered" "target: /hostfs"
+    assert_contains "$rendered" "FLEET_TELEMETRY_ENABLED: \"true\""
+    assert_contains "$rendered" "DD_HOSTNAME: ha-a"
+    awk '
+        /^  fleet-api:$/ { f = 1; next }
+        f && /^  [[:alnum:]_-]+:$/ { exit }
+        f && /^      otel-collector:$/ { exit 1 }
+    ' "$rendered" || fail "HA tracing collector must not gate Fleet startup"
+    assert_contains "$rendered" 'published: "13133"'
+    assert_contains "$rendered" "image: otel/opentelemetry-collector-contrib:0.150.1@sha256:a516c26968aa1feb5e5fc0562e3338ea13755cb4f373603226bcc4e276374ad0"
+    assert_contains "${release_dir}/server/otel-collector-config.datadog.yaml" "fail_on_invalid_key: true"
+    assert_contains "$rendered" "target: /etc/grafana/provisioning/alerting/proto-fleet-system-rules.yaml"
+    awk '
+        /^  otel-collector:$/ { in_collector = 1; next }
+        in_collector && /^  [[:alnum:]_-]+:$/ { exit }
+        in_collector && /^[[:space:]]+restart: on-failure$/ { found = 1 }
+        END { exit !found }
+    ' "$rendered" || fail "HA tracing collector must remain behind the systemd start gate"
     assert_not_contains "$rendered" "source: ${release_dir}/ssl"
     assert_not_contains "$rendered" "/run/proto-fleet-updater"
 

--- a/deployment-files/install.sh
+++ b/deployment-files/install.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 DEPLOYMENT_DIR="deployment"
 HA_BUNDLE_PATH="/var/tmp/proto-fleet-ha-host.json"
+unset HA_DD_API_KEY_CAPTURED
 DOWNLOAD_DIR=""
 UPDATER_BOOTSTRAP_DIR=""
 UPDATER_CLEANUP_FAILED=0
@@ -1546,6 +1547,27 @@ service_docker_id_with() {
   fi
 }
 
+capture_ha_datadog_api_key() {
+  if [ "${DD_API_KEY+x}" = "x" ]; then
+    HA_DD_API_KEY_CAPTURED="$DD_API_KEY"
+    unset DD_API_KEY
+  fi
+}
+
+run_fleet_ha() {
+  local fleet_ha="$1"
+  shift
+  local status=0
+
+  if [ "${HA_DD_API_KEY_CAPTURED+x}" = "x" ]; then
+    DD_API_KEY="$HA_DD_API_KEY_CAPTURED" "$fleet_ha" "$@" || status=$?
+  else
+    "$fleet_ha" "$@" || status=$?
+  fi
+  unset HA_DD_API_KEY_CAPTURED
+  return "$status"
+}
+
 run_ha_install() {
   local tar_path="$1"
   local download_dir="$2"
@@ -1585,14 +1607,14 @@ run_ha_install() {
     if [ "$(id -u)" -eq 0 ]; then
       chown 0:0 "$HA_BUNDLE_PATH"
     fi
-    "$fleet_ha" install "$HA_BUNDLE_PATH"
+    run_fleet_ha "$fleet_ha" install "$HA_BUNDLE_PATH"
     return
   fi
   if [ ! -r /dev/tty ]; then
     echo "❌ HA cluster preparation requires an interactive terminal." >&2
     return 1
   fi
-  "$fleet_ha" install </dev/tty
+  run_fleet_ha "$fleet_ha" install </dev/tty
 }
 
 # END INSTALLER TESTABLE HELPERS
@@ -1787,6 +1809,13 @@ fi
 if [ "$HA_INSTALL" = "1" ] && { [ -n "$REQUESTED_INSTALL_DIR" ] || [ "$NON_INTERACTIVE" = "1" ]; }; then
   echo "Error: --ha cannot be combined with --install-dir or --non-interactive." >&2
   usage
+fi
+
+if [ "$HA_INSTALL" = "1" ]; then
+  # Preserve the key only in this shell, not its setup/download subprocesses.
+  # run_fleet_ha exposes it solely to the fleet-ha process, which captures and
+  # clears it before invoking any host commands.
+  capture_ha_datadog_api_key
 fi
 
 check_page_size

--- a/deployment-files/server/otel-collector-config.datadog.yaml
+++ b/deployment-files/server/otel-collector-config.datadog.yaml
@@ -36,6 +36,8 @@ exporters:
     api:
       key: ${env:DD_API_KEY}
       site: ${env:DD_SITE}
+      # Refuse to start when Datadog rejects the credential so the HA health probe reports degraded tracing.
+      fail_on_invalid_key: true
     # Fallback for the resource attribute above, which a whole-value env reference types as int for an all-numeric hostname.
     hostname: "${env:DD_HOSTNAME}"
 

--- a/deployment-files/tests/test-install-overlay-migration.sh
+++ b/deployment-files/tests/test-install-overlay-migration.sh
@@ -85,9 +85,12 @@ make_ha_release_archive() {
   local release_root="$1"
   local tar_path="$2"
   mkdir -p "$release_root/deployment/ha"
-  cat > "$release_root/deployment/ha/fleet-ha" <<'EOF'
+cat > "$release_root/deployment/ha/fleet-ha" <<'EOF'
 #!/usr/bin/env bash
 printf '%s\n' "$*" > "$HA_TEST_LOG"
+if [ -n "${HA_TEST_ENV_LOG:-}" ]; then
+  printf '%s\n' "${DD_API_KEY-unset}" > "$HA_TEST_ENV_LOG"
+fi
 EOF
   chmod 755 "$release_root/deployment/ha/fleet-ha"
   tar -czf "$tar_path" -C "$release_root" deployment
@@ -1513,7 +1516,11 @@ if (
   tar_path="$TEST_TMP/proto-fleet-v0.2.10-arm64.tar.gz"
   make_ha_release_archive "$release_root" "$tar_path"
   HA_TEST_LOG="$TEST_TMP/ha-invocation"
-  export HA_TEST_LOG
+  HA_TEST_ENV_LOG="$TEST_TMP/ha-environment"
+  export HA_TEST_LOG HA_TEST_ENV_LOG
+  DD_API_KEY=isolated-datadog-key
+  export DD_API_KEY
+  capture_ha_datadog_api_key
   HA_BUNDLE_PATH="$TEST_TMP/proto-fleet-ha-host.json"
   printf '%s' '{"prepared":true}' > "$HA_BUNDLE_PATH"
   chmod 600 "$HA_BUNDLE_PATH"
@@ -1523,13 +1530,16 @@ if (
   chown() { printf '%s\n' "$*" > "$TEST_TMP/ha-chown"; }
   download_dir="$TEST_TMP/ha-download"
   mkdir -m 700 "$download_dir"
-  run_ha_install "$tar_path" "$download_dir" \
+  ! env | grep -q '^DD_API_KEY=' \
+    && run_ha_install "$tar_path" "$download_dir" \
     && grep -Fxq "install $HA_BUNDLE_PATH" "$HA_TEST_LOG" \
+    && grep -Fxq "isolated-datadog-key" "$HA_TEST_ENV_LOG" \
+    && [ "${HA_DD_API_KEY_CAPTURED+x}" != x ] \
     && grep -Fxq "0:0 $HA_BUNDLE_PATH" "$TEST_TMP/ha-chown"
 ); then
-  pass "sudo HA installs accept the invoking administrator's prepared peer bundle"
+  pass "sudo HA installs isolate the Datadog key and accept the invoking administrator's prepared peer bundle"
 else
-  fail "sudo HA install rejected the invoking administrator's prepared peer bundle"
+  fail "sudo HA install leaked the Datadog key or rejected the invoking administrator's prepared peer bundle"
 fi
 
 if (

--- a/server/internal/ha/deployment/application_profile.go
+++ b/server/internal/ha/deployment/application_profile.go
@@ -1,0 +1,176 @@
+package deployment
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"os"
+	"strconv"
+	"strings"
+)
+
+var fleetDeploymentEnvironmentKeys = []string{
+	"DD_API_KEY",
+	"DD_ENV",
+	"DD_SITE",
+	"ENABLE_BETA_ALERTS",
+	"ENABLE_SYSTEM_MONITORING",
+	"ENABLE_TRACING",
+	"FLEET_TELEMETRY_SAMPLE_RATE",
+	"FLEET_TELEMETRY_TRUST_INCOMING_TRACES",
+}
+
+type fleetApplicationProfile map[string]string
+
+func fleetApplicationEnvironment(lookup func(string) (string, bool)) (fleetApplicationProfile, error) {
+	values := make(map[string]string, len(fleetDeploymentEnvironmentKeys))
+	for _, key := range fleetDeploymentEnvironmentKeys {
+		value, ok := lookup(key)
+		if !ok {
+			continue
+		}
+		if !envLine.MatchString(key + "=" + value) {
+			return nil, fmt.Errorf("%s contains an unsupported value", key)
+		}
+		values[key] = value
+	}
+	return fleetApplicationProfileFromValues(values, true)
+}
+
+func captureFleetApplicationEnvironment() (fleetApplicationProfile, error) {
+	profile, profileErr := fleetApplicationEnvironment(os.LookupEnv)
+	unsetErr := os.Unsetenv("DD_API_KEY")
+	if profileErr != nil {
+		return nil, profileErr
+	}
+	if unsetErr != nil {
+		return nil, fmt.Errorf("clear DD_API_KEY after capture: %w", unsetErr)
+	}
+	return profile, nil
+}
+
+func loadFleetApplicationProfileFile(path string, defaultBetaAlerts bool) (fleetApplicationProfile, error) {
+	values, err := loadFleetEnvironment(path)
+	if err != nil {
+		return nil, fmt.Errorf("Fleet environment rejected: %w", err)
+	}
+	return fleetApplicationProfileFromValues(values, defaultBetaAlerts)
+}
+
+func parseFleetDeploymentEnvironment(contents []byte) (fleetApplicationProfile, error) {
+	values, err := parseFleetEnvironment(strings.NewReader(string(contents)))
+	if err != nil {
+		return nil, fmt.Errorf("Fleet environment %w", err)
+	}
+	return fleetApplicationProfileFromValues(values, true)
+}
+
+func fleetApplicationProfileFromValues(values map[string]string, defaultBetaAlerts bool) (fleetApplicationProfile, error) {
+	profile := make(fleetApplicationProfile, len(fleetDeploymentEnvironmentKeys))
+	for _, key := range fleetDeploymentEnvironmentKeys {
+		if value, ok := values[key]; ok {
+			profile[key] = value
+		}
+	}
+	betaAlerts, err := fleetFeatureFlagOrDefault(profile, "ENABLE_BETA_ALERTS", defaultBetaAlerts)
+	if err != nil {
+		return nil, err
+	}
+	systemMonitoring, err := fleetFeatureFlagOrDefault(profile, "ENABLE_SYSTEM_MONITORING", false)
+	if err != nil {
+		return nil, err
+	}
+	tracing, err := fleetFeatureFlagOrDefault(profile, "ENABLE_TRACING", false)
+	if err != nil {
+		return nil, err
+	}
+	if !tracing {
+		delete(profile, "DD_API_KEY")
+	}
+	if systemMonitoring && !betaAlerts {
+		return nil, errors.New("ENABLE_SYSTEM_MONITORING=true requires ENABLE_BETA_ALERTS=true")
+	}
+	if site := profile["DD_SITE"]; site != "" && !validDatadogSite(site) {
+		return nil, errors.New("DD_SITE must be an official Datadog site")
+	}
+	if tracing && profile["DD_API_KEY"] == "" {
+		return nil, errors.New("ENABLE_TRACING=true requires DD_API_KEY")
+	}
+	if tracing {
+		if value, ok := profile["FLEET_TELEMETRY_SAMPLE_RATE"]; ok {
+			sampleRate, parseErr := strconv.ParseFloat(value, 64)
+			if parseErr != nil || math.IsNaN(sampleRate) || sampleRate < 0 || sampleRate > 1 {
+				return nil, errors.New("FLEET_TELEMETRY_SAMPLE_RATE must be a number from 0.0 to 1.0")
+			}
+		}
+		if _, ok := profile["FLEET_TELEMETRY_TRUST_INCOMING_TRACES"]; ok {
+			trustIncoming, parseErr := fleetFeatureFlagOrDefault(profile, "FLEET_TELEMETRY_TRUST_INCOMING_TRACES", false)
+			if parseErr != nil {
+				return nil, parseErr
+			}
+			profile["FLEET_TELEMETRY_TRUST_INCOMING_TRACES"] = strconv.FormatBool(trustIncoming)
+		}
+	}
+	profile["ENABLE_BETA_ALERTS"] = strconv.FormatBool(betaAlerts)
+	profile["ENABLE_SYSTEM_MONITORING"] = strconv.FormatBool(systemMonitoring)
+	profile["ENABLE_TRACING"] = strconv.FormatBool(tracing)
+	return profile, nil
+}
+
+func validDatadogSite(site string) bool {
+	switch site {
+	case "datadoghq.com",
+		"us3.datadoghq.com",
+		"us5.datadoghq.com",
+		"datadoghq.eu",
+		"ap1.datadoghq.com",
+		"ap2.datadoghq.com",
+		"uk1.datadoghq.com",
+		"ddog-gov.com",
+		"us2.ddog-gov.com":
+		return true
+	default:
+		return false
+	}
+}
+
+func fleetFeatureFlagOrDefault(values map[string]string, name string, fallback bool) (bool, error) {
+	value, ok := values[name]
+	if !ok {
+		return fallback, nil
+	}
+	switch strings.ToLower(value) {
+	case "true":
+		return true, nil
+	case "false":
+		return false, nil
+	default:
+		return false, fmt.Errorf("%s must be true or false", name)
+	}
+}
+
+func renderFleetDeploymentEnvironment(profile fleetApplicationProfile) []byte {
+	var environment strings.Builder
+	for _, key := range fleetDeploymentEnvironmentKeys {
+		value, ok := profile[key]
+		if ok {
+			fmt.Fprintf(&environment, "%s=%s\n", key, value)
+		}
+	}
+	return []byte(environment.String())
+}
+
+func (profile fleetApplicationProfile) sidecars() []string {
+	var services []string
+	if profile.enabled("ENABLE_BETA_ALERTS") {
+		services = append(services, "grafana")
+	}
+	if profile.enabled("ENABLE_TRACING") {
+		services = append(services, "otel-collector")
+	}
+	return services
+}
+
+func (profile fleetApplicationProfile) enabled(key string) bool {
+	return profile[key] == "true"
+}

--- a/server/internal/ha/deployment/application_profile_test.go
+++ b/server/internal/ha/deployment/application_profile_test.go
@@ -1,0 +1,139 @@
+package deployment
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFleetApplicationComposeArgsRespectPersistedFeatureFlags(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		environment  string
+		composeFiles []string
+		services     []string
+	}{
+		{
+			name: "optional features disabled",
+			environment: "ENABLE_BETA_ALERTS=false\n" +
+				"ENABLE_SYSTEM_MONITORING=false\n" +
+				"ENABLE_TRACING=false\n",
+			composeFiles: []string{"ha/fleet-compose.yaml"},
+			services:     []string{"fleet-api", "fleet-client"},
+		},
+		{
+			name: "optional features enabled",
+			environment: "DD_API_KEY=test-key\n" +
+				"ENABLE_BETA_ALERTS=true\n" +
+				"ENABLE_SYSTEM_MONITORING=true\n" +
+				"ENABLE_TRACING=true\n",
+			composeFiles: []string{
+				"docker-compose.alerts.yaml",
+				"ha/fleet-compose.yaml",
+				"ha/fleet-compose.alerts.yaml",
+				"docker-compose.system-monitoring.yaml",
+				"ha/fleet-compose.system-monitoring.yaml",
+				"docker-compose.tracing.yaml",
+				"ha/fleet-compose.tracing.yaml",
+			},
+			services: []string{"fleet-api", "fleet-client", "grafana", "otel-collector"},
+		},
+		{
+			name:         "legacy deployment defaults to alerts",
+			composeFiles: []string{"docker-compose.alerts.yaml", "ha/fleet-compose.yaml", "ha/fleet-compose.alerts.yaml"},
+			services:     []string{"fleet-api", "fleet-client", "grafana"},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			root := t.TempDir()
+			environmentPath := filepath.Join(root, fleetEnvironmentFile)
+			require.NoError(t, os.WriteFile(environmentPath, []byte(test.environment), 0o600))
+
+			profile, err := loadFleetApplicationProfileFile(environmentPath, true)
+			require.NoError(t, err)
+			args := fleetApplicationComposeArgsAtProfile(root, environmentPath, profile, "config", "--quiet")
+
+			expected := []string{
+				"--project-name", fleetComposeProject,
+				"--env-file", filepath.Join(configRoot, "base.env"),
+				"--env-file", environmentPath,
+				"--env-file", filepath.Join(configRoot, "node.env"),
+				"--file", filepath.Join(root, "docker-compose.yaml"),
+			}
+			for _, composeFile := range test.composeFiles {
+				expected = append(expected, "--file", filepath.Join(root, composeFile))
+			}
+			expected = append(expected, "config", "--quiet")
+			expected = append(expected, test.services...)
+			require.Equal(t, expected, args)
+		})
+	}
+}
+
+func TestFleetApplicationProfileRejectsInvalidFeatureCombinations(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		environment string
+		error       string
+	}{
+		{name: "invalid boolean", environment: "ENABLE_TRACING=maybe\n", error: "must be true or false"},
+		{name: "monitoring without alerts", environment: "ENABLE_BETA_ALERTS=false\nENABLE_SYSTEM_MONITORING=true\n", error: "requires ENABLE_BETA_ALERTS"},
+		{name: "tracing without API key", environment: "ENABLE_TRACING=true\n", error: "requires DD_API_KEY"},
+		{name: "unapproved Datadog site", environment: "DD_SITE=example.com\n", error: "official Datadog site"},
+		{name: "invalid tracing sample rate", environment: "ENABLE_TRACING=true\nDD_API_KEY=test-key\nFLEET_TELEMETRY_SAMPLE_RATE=abc\n", error: "must be a number from 0.0 to 1.0"},
+		{name: "out-of-range tracing sample rate", environment: "ENABLE_TRACING=true\nDD_API_KEY=test-key\nFLEET_TELEMETRY_SAMPLE_RATE=1.1\n", error: "must be a number from 0.0 to 1.0"},
+		{name: "NaN tracing sample rate", environment: "ENABLE_TRACING=true\nDD_API_KEY=test-key\nFLEET_TELEMETRY_SAMPLE_RATE=NaN\n", error: "must be a number from 0.0 to 1.0"},
+		{name: "invalid incoming trace trust", environment: "ENABLE_TRACING=true\nDD_API_KEY=test-key\nFLEET_TELEMETRY_TRUST_INCOMING_TRACES=maybe\n", error: "must be true or false"},
+		{name: "unknown key", environment: "DB_PASSWORD=unexpected\n", error: "unknown key"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := parseFleetDeploymentEnvironment([]byte(test.environment))
+			require.ErrorContains(t, err, test.error)
+		})
+	}
+}
+
+func TestRenderedFleetDeploymentEnvironmentNormalizesFeatureFlags(t *testing.T) {
+	values, err := fleetApplicationEnvironment(func(key string) (string, bool) {
+		value, ok := map[string]string{
+			"DD_API_KEY":                            "test-key",
+			"ENABLE_TRACING":                        "TRUE",
+			"ENABLE_BETA_ALERTS":                    "true",
+			"ENABLE_SYSTEM_MONITORING":              "true",
+			"FLEET_TELEMETRY_SAMPLE_RATE":           "0.25",
+			"FLEET_TELEMETRY_TRUST_INCOMING_TRACES": "TRUE",
+		}[key]
+		return value, ok
+	})
+	require.NoError(t, err)
+
+	environment := renderFleetDeploymentEnvironment(values)
+	require.Equal(t, "DD_API_KEY=test-key\nENABLE_BETA_ALERTS=true\nENABLE_SYSTEM_MONITORING=true\nENABLE_TRACING=true\nFLEET_TELEMETRY_SAMPLE_RATE=0.25\nFLEET_TELEMETRY_TRUST_INCOMING_TRACES=true\n", string(environment))
+}
+
+func TestFleetDeploymentEnvironmentOmitsDatadogAPIKeyWhenTracingIsDisabled(t *testing.T) {
+	profile, err := fleetApplicationEnvironment(func(key string) (string, bool) {
+		value, ok := map[string]string{
+			"DD_API_KEY":     "ambient-secret",
+			"ENABLE_TRACING": "false",
+		}[key]
+		return value, ok
+	})
+	require.NoError(t, err)
+	require.NotContains(t, profile, "DD_API_KEY")
+	require.NotContains(t, string(renderFleetDeploymentEnvironment(profile)), "DD_API_KEY")
+}
+
+func TestCaptureFleetApplicationEnvironmentClearsDatadogAPIKey(t *testing.T) {
+	t.Setenv("ENABLE_TRACING", "true")
+	t.Setenv("DD_API_KEY", "captured-secret")
+
+	profile, err := captureFleetApplicationEnvironment()
+
+	require.NoError(t, err)
+	require.Equal(t, "captured-secret", profile["DD_API_KEY"])
+	_, stillExported := os.LookupEnv("DD_API_KEY")
+	require.False(t, stillExported)
+}

--- a/server/internal/ha/deployment/compose.go
+++ b/server/internal/ha/deployment/compose.go
@@ -5,35 +5,118 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"slices"
+	"time"
 )
 
 const localDockerHost = "unix:///var/run/docker.sock"
 
-func fleetApplicationComposeArgs(operation string, flags ...string) []string {
-	return fleetApplicationComposeArgsAt(installRoot, operation, flags...)
+const installedFleetEnvironment = configRoot + "/" + fleetEnvironmentFile
+
+const (
+	haTracingHealthTimeout = 15 * time.Second
+	haTracingHealthRetry   = 250 * time.Millisecond
+)
+
+type fleetApplicationStartDependencies struct {
+	environmentPath string
+	runCompose      func(context.Context, []string) error
+	collectorReady  func(context.Context) error
+	warnings        io.Writer
 }
 
-func fleetApplicationComposeArgsAt(root, operation string, flags ...string) []string {
-	args := slices.Clone(flags)
-	args = append(args, "fleet-api", "fleet-client", "grafana")
-	return fleetComposeArgsAt(root, operation, args...)
+func fleetApplicationComposeArgsAtProfile(root, environmentPath string, profile fleetApplicationProfile, operation string, flags ...string) []string {
+	return fleetComposeArgsAtProfile(root, environmentPath, profile, operation, slices.Concat(flags, []string{"fleet-api", "fleet-client"}, profile.sidecars())...)
 }
 
-func fleetComposeArgsForInstalledProfile(operation string, flags ...string) ([]string, error) {
-	return fleetComposeArgsForInstalledProfileAt(installRoot, haGrafanaVolumeOwnershipMarker, operation, flags...)
+func startFleetApplication(ctx context.Context, root string, flags ...string) error {
+	return startFleetApplicationWith(ctx, root, fleetApplicationStartDependencies{
+		environmentPath: installedFleetEnvironment,
+		runCompose:      RunCompose,
+		collectorReady:  waitForTracingCollector,
+		warnings:        os.Stderr,
+	}, flags...)
 }
 
-func fleetComposeArgsForInstalledProfileAt(root, ownershipMarker, operation string, flags ...string) ([]string, error) {
-	if _, err := os.Stat(ownershipMarker); err == nil {
-		return fleetComposeArgsAtProfile(root, true, operation, flags...), nil
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return nil, fmt.Errorf("inspect installed HA Grafana ownership marker: %w", err)
+func startFleetApplicationWith(ctx context.Context, root string, deps fleetApplicationStartDependencies, flags ...string) error {
+	profile, err := loadFleetApplicationProfileFile(deps.environmentPath, true)
+	if err != nil {
+		return fmt.Errorf("load application profile: %w", err)
 	}
-	return fleetComposeArgsAtProfile(root, false, operation, flags...), nil
+	services := []string{"fleet-api", "fleet-client"}
+	if profile.enabled("ENABLE_BETA_ALERTS") {
+		services = append(services, "grafana")
+	}
+	args := fleetComposeArgsAtProfile(root, deps.environmentPath, profile, "up", slices.Concat(flags, []string{"--remove-orphans"}, services)...)
+	if err := deps.runCompose(ctx, args); err != nil {
+		return err
+	}
+	if profile.enabled("ENABLE_TRACING") {
+		collectorArgs := fleetComposeArgsAtProfile(root, deps.environmentPath, profile, "up", "-d", "--no-deps", "--no-build", "--pull", "never", "otel-collector")
+		collectorErr := deps.runCompose(ctx, collectorArgs)
+		if collectorErr == nil {
+			collectorErr = deps.collectorReady(ctx)
+		}
+		if collectorErr != nil {
+			_, _ = fmt.Fprintf(deps.warnings, "[warning] Fleet is running, but tracing is degraded: %v\n", collectorErr)
+		}
+	}
+	return nil
+}
+
+func waitForTracingCollector(ctx context.Context) error {
+	healthCtx, cancel := context.WithTimeout(ctx, haTracingHealthTimeout)
+	defer cancel()
+	client, cleanup := newProbeHTTPClient(nil, nil)
+	defer cleanup()
+	endpoint := fmt.Sprintf("http://127.0.0.1:%d/", haTracingHealthHostPort)
+	if err := waitForHTTPEndpoint(healthCtx, client, endpoint, haTracingHealthRetry); err != nil {
+		return fmt.Errorf("collector health endpoint did not become ready: %w", err)
+	}
+	return nil
+}
+
+func waitForHTTPEndpoint(ctx context.Context, client *http.Client, endpoint string, retryInterval time.Duration) error {
+	for {
+		if endpointReadyWithClient(ctx, client, endpoint) {
+			return nil
+		}
+		timer := time.NewTimer(retryInterval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return fmt.Errorf("wait for %s: %w", endpoint, ctx.Err())
+		case <-timer.C:
+		}
+	}
+}
+
+func fleetApplicationDownArgsAt(root, environmentPath, ownershipMarker string, flags ...string) ([]string, error) {
+	return fleetComposeArgsForInstalledProfileAt(root, environmentPath, ownershipMarker, "down", slices.Concat(flags, []string{"--remove-orphans"})...)
+}
+
+func fleetSidecarPullArgs(root, environmentPath string, profile fleetApplicationProfile) []string {
+	sidecars := profile.sidecars()
+	if len(sidecars) == 0 {
+		return nil
+	}
+	return fleetComposeArgsAtProfile(root, environmentPath, profile, "pull", sidecars...)
+}
+
+func fleetComposeArgsForInstalledProfileAt(root, environmentPath, ownershipMarker, operation string, flags ...string) ([]string, error) {
+	_, markerErr := os.Stat(ownershipMarker)
+	if markerErr != nil && !errors.Is(markerErr, os.ErrNotExist) {
+		return nil, fmt.Errorf("inspect installed HA Grafana ownership marker: %w", markerErr)
+	}
+	profile, err := loadFleetApplicationProfileFile(environmentPath, markerErr == nil)
+	if err != nil {
+		return nil, err
+	}
+	return fleetComposeArgsAtProfile(root, environmentPath, profile, operation, flags...), nil
 }
 
 // ResetSuperAdminPassword runs the offline fleetd recovery command against the
@@ -48,49 +131,32 @@ func ResetSuperAdminPassword(ctx context.Context, passwordInput io.Reader) error
 		return errors.New("HA password reset must run on ha-a or ha-b")
 	}
 
-	args, err := resetSuperAdminPasswordComposeArgsAt(installRoot, haGrafanaVolumeOwnershipMarker)
+	args, err := resetSuperAdminPasswordComposeArgsAt(installRoot, installedFleetEnvironment, haGrafanaVolumeOwnershipMarker)
 	if err != nil {
 		return err
 	}
 	return runCompose(ctx, args, passwordInput)
 }
 
-func resetSuperAdminPasswordComposeArgsAt(root, ownershipMarker string) ([]string, error) {
+func resetSuperAdminPasswordComposeArgsAt(root, environmentPath, ownershipMarker string) ([]string, error) {
 	command := []string{"--rm", "--no-deps", "-T", "fleet-api", "/app/fleetd", "admin", "reset-password", "--password-stdin"}
-	return fleetComposeArgsForInstalledProfileAt(root, ownershipMarker, "run", command...)
+	return fleetComposeArgsForInstalledProfileAt(root, environmentPath, ownershipMarker, "run", command...)
 }
 
-// RunCompose prevents parent variables from overriding generated HA identity and secrets.
+// RunCompose isolates Compose from parent variables so only installed HA configuration is interpolated.
 func RunCompose(ctx context.Context, args []string) error {
 	return runCompose(ctx, args, os.Stdin)
 }
 
 func runCompose(ctx context.Context, args []string, stdin io.Reader) error {
-	protected := []string{
-		"AUTH_CLIENT_SECRET_KEY",
-		"COMPOSE_PROJECT_NAME",
-		"DB_DSN",
-		"ENCRYPT_SERVICE_MASTER_KEY",
-		"FLEET_ALERTS_ENABLED",
-		"FLEET_ALERTS_GRAFANA_TOKEN",
-		"FLEET_ALERTS_GRAFANA_URL",
-		"FLEET_ALERTS_WEBHOOK_TOKEN",
-		"GRAFANA_ADMIN_PASSWORD",
-		"GRAFANA_DB_PASSWORD",
-		"GRAFANA_SECRET_KEY",
-	}
-	for key := range allowedEnvKeys {
-		protected = append(protected, key)
-	}
-	slices.Sort(protected)
-	for _, key := range protected {
-		if _, ok := os.LookupEnv(key); ok {
-			return fmt.Errorf("parent environment must not set %s; unset it before running Fleet", key)
-		}
+	environment, err := composeEnvironment(args)
+	if err != nil {
+		return err
 	}
 
 	commandArgs := append([]string{"--host", localDockerHost, "compose"}, args...)
 	command := exec.CommandContext(ctx, "docker", commandArgs...)
+	command.Env = environment
 	command.Stdin = stdin
 	command.Stdout = os.Stdout
 	command.Stderr = os.Stderr
@@ -98,4 +164,26 @@ func runCompose(ctx context.Context, args []string, stdin io.Reader) error {
 		return fmt.Errorf("run Docker Compose: %w", err)
 	}
 	return nil
+}
+
+func composeEnvironment(args []string) ([]string, error) {
+	// Docker needs PATH to find its Compose plugin. All Compose interpolation
+	// inputs come from the explicit, protected env files below.
+	environment := []string{"PATH=" + os.Getenv("PATH")}
+	for index := 0; index+1 < len(args); index++ {
+		if args[index] != "--env-file" || filepath.Base(args[index+1]) != "node.env" {
+			continue
+		}
+		config, err := loadNodeConfig(args[index+1])
+		if err != nil {
+			return nil, err
+		}
+		if err := validateNodeConfig(config); err != nil {
+			return nil, fmt.Errorf("HA node environment rejected: %w", err)
+		}
+		// The shared tracing overlay requires DD_HOSTNAME during interpolation.
+		// Derive it from the validated HA identity instead of persisting a second hostname.
+		return append(environment, "DD_HOSTNAME="+config.NodeName), nil
+	}
+	return environment, nil
 }

--- a/server/internal/ha/deployment/compose_test.go
+++ b/server/internal/ha/deployment/compose_test.go
@@ -1,12 +1,20 @@
 package deployment
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestInstalledFleetComposeArgsSupportLegacyAndGrafanaProfiles(t *testing.T) {
@@ -19,6 +27,10 @@ func TestInstalledFleetComposeArgsSupportLegacyAndGrafanaProfiles(t *testing.T) 
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			root := t.TempDir()
+			environmentPath := filepath.Join(root, fleetEnvironmentFile)
+			if err := os.WriteFile(environmentPath, nil, 0o600); err != nil {
+				t.Fatal(err)
+			}
 			alertsPath := filepath.Join(root, "docker-compose.alerts.yaml")
 			if err := os.WriteFile(alertsPath, []byte("services: {}\n"), 0o600); err != nil {
 				t.Fatal(err)
@@ -30,7 +42,7 @@ func TestInstalledFleetComposeArgsSupportLegacyAndGrafanaProfiles(t *testing.T) 
 				}
 			}
 
-			args, err := fleetComposeArgsForInstalledProfileAt(root, ownershipMarker, "down")
+			args, err := fleetComposeArgsForInstalledProfileAt(root, environmentPath, ownershipMarker, "down")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -44,9 +56,13 @@ func TestInstalledFleetComposeArgsSupportLegacyAndGrafanaProfiles(t *testing.T) 
 
 func TestResetSuperAdminPasswordComposeArgsUseInstalledHAProfile(t *testing.T) {
 	root := t.TempDir()
+	environmentPath := filepath.Join(root, fleetEnvironmentFile)
+	if err := os.WriteFile(environmentPath, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
 	ownershipMarker := filepath.Join(root, "grafana-volume-owned")
 
-	args, err := resetSuperAdminPasswordComposeArgsAt(root, ownershipMarker)
+	args, err := resetSuperAdminPasswordComposeArgsAt(root, environmentPath, ownershipMarker)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -54,7 +70,7 @@ func TestResetSuperAdminPasswordComposeArgsUseInstalledHAProfile(t *testing.T) {
 	for _, expected := range []string{
 		"--project-name deployment",
 		"--env-file /etc/proto-fleet/ha/base.env",
-		"--env-file /etc/proto-fleet/ha/fleet.env",
+		"--env-file " + environmentPath,
 		"--env-file /etc/proto-fleet/ha/node.env",
 		"--file " + filepath.Join(root, "docker-compose.yaml"),
 		"--file " + filepath.Join(root, "ha/fleet-compose.yaml"),
@@ -71,7 +87,7 @@ func TestResetSuperAdminPasswordComposeArgsUseInstalledHAProfile(t *testing.T) {
 	if err := os.WriteFile(ownershipMarker, nil, 0o600); err != nil {
 		t.Fatal(err)
 	}
-	args, err = resetSuperAdminPasswordComposeArgsAt(root, ownershipMarker)
+	args, err = resetSuperAdminPasswordComposeArgsAt(root, environmentPath, ownershipMarker)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -84,23 +100,93 @@ func TestResetSuperAdminPasswordComposeArgsUseInstalledHAProfile(t *testing.T) {
 	}
 }
 
-func TestRunComposeRejectsParentOverrides(t *testing.T) {
-	for _, key := range []string{"AUTH_CLIENT_SECRET_KEY", "COMPOSE_PROJECT_NAME", "DB_DSN", "HA_NODE_IP", "GRAFANA_DB_PASSWORD", "FLEET_ALERTS_GRAFANA_URL"} {
-		t.Run(key, func(t *testing.T) {
-			// Arrange
-			const value = "must-not-appear-in-errors"
-			t.Setenv(key, value)
-
-			// Act
-			err := RunCompose(context.Background(), []string{"config"})
-
-			// Assert
-			if err == nil || !strings.Contains(err.Error(), key) {
-				t.Fatalf("RunCompose() error = %v", err)
-			}
-			if strings.Contains(err.Error(), value) {
-				t.Fatal("RunCompose() exposed the parent value")
-			}
-		})
+func TestComposeEnvironmentDropsParentOverrides(t *testing.T) {
+	for _, key := range []string{"AUTH_CLIENT_SECRET_KEY", "COMPOSE_PROJECT_NAME", "DB_DSN", "HA_NODE_IP", "GRAFANA_DB_PASSWORD", "FLEET_ALERTS_GRAFANA_URL", "ENABLE_TRACING", "DD_API_KEY", "DD_HOSTNAME", "SESSION_COOKIE_SECURE", "INFRASTRUCTURE_OT_CONTROL_SUBNETS"} {
+		t.Setenv(key, "parent-value")
 	}
+
+	environment, err := composeEnvironment([]string{"config"})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(environment) != 1 || !strings.HasPrefix(environment[0], "PATH=") {
+		t.Fatalf("compose environment = %q, want only PATH", environment)
+	}
+}
+
+func TestComposeEnvironmentDerivesDatadogHostnameFromNodeIdentity(t *testing.T) {
+	nodeEnvironment := testNodeEnv(t, t.TempDir(), t.TempDir(), t.TempDir())
+
+	environment, err := composeEnvironment([]string{"--env-file", nodeEnvironment})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Contains(environment, "DD_HOSTNAME=ha-a") {
+		t.Fatalf("compose environment does not contain the derived Datadog hostname: %q", environment)
+	}
+	if len(environment) != 2 {
+		t.Fatalf("compose environment contains ambient values: %q", environment)
+	}
+}
+
+func TestFleetApplicationStartReconcilesOrphansAndReportsCollectorHealthFailure(t *testing.T) {
+	root := t.TempDir()
+	environmentPath := filepath.Join(root, fleetEnvironmentFile)
+	require.NoError(t, os.WriteFile(environmentPath, []byte("DD_API_KEY=test-key\nENABLE_BETA_ALERTS=false\nENABLE_TRACING=true\n"), 0o600))
+	var calls [][]string
+	var warnings bytes.Buffer
+	healthErr := errors.New("collector rejected its configuration")
+	deps := fleetApplicationStartDependencies{
+		environmentPath: environmentPath,
+		runCompose: func(_ context.Context, args []string) error {
+			calls = append(calls, slices.Clone(args))
+			return nil
+		},
+		collectorReady: func(context.Context) error { return healthErr },
+		warnings:       &warnings,
+	}
+
+	err := startFleetApplicationWith(t.Context(), root, deps, "-d")
+
+	require.NoError(t, err)
+	require.Len(t, calls, 2)
+	criticalStart := calls[0][slices.Index(calls[0], "up"):]
+	require.Equal(t, []string{"up", "-d", "--remove-orphans", "fleet-api", "fleet-client"}, criticalStart)
+	collectorStart := calls[1][slices.Index(calls[1], "up"):]
+	require.Equal(t, []string{"up", "-d", "--no-deps", "--no-build", "--pull", "never", "otel-collector"}, collectorStart)
+	require.Contains(t, warnings.String(), healthErr.Error())
+}
+
+func TestFleetApplicationDownRemovesDisabledSidecarOrphans(t *testing.T) {
+	root := t.TempDir()
+	environmentPath := filepath.Join(root, fleetEnvironmentFile)
+	require.NoError(t, os.WriteFile(environmentPath, []byte("ENABLE_BETA_ALERTS=false\nENABLE_TRACING=false\n"), 0o600))
+	ownershipMarker := filepath.Join(root, "grafana-volume-owned")
+
+	args, err := fleetApplicationDownArgsAt(root, environmentPath, ownershipMarker, "--timeout", "1")
+
+	require.NoError(t, err)
+	down := args[slices.Index(args, "down"):]
+	require.Equal(t, []string{"down", "--timeout", "1", "--remove-orphans"}, down)
+	require.NotContains(t, args, "fleet-api")
+	require.NotContains(t, args, "fleet-client")
+	require.NotContains(t, args, "grafana")
+	require.NotContains(t, args, "otel-collector")
+}
+
+func TestWaitForHTTPEndpointRetriesUntilHealthy(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		if requests.Add(1) == 1 {
+			response.WriteHeader(http.StatusServiceUnavailable)
+		}
+	}))
+	defer server.Close()
+
+	err := waitForHTTPEndpoint(t.Context(), server.Client(), server.URL, time.Millisecond)
+
+	require.NoError(t, err)
+	require.Equal(t, int32(2), requests.Load())
 }

--- a/server/internal/ha/deployment/deployment_test.go
+++ b/server/internal/ha/deployment/deployment_test.go
@@ -126,7 +126,7 @@ func TestGenerateSecrets(t *testing.T) {
 		if err := verifyEndpointCertificate(filepath.Join(dir, "fleet-client.crt"), testVirtualIP, roots, x509.ExtKeyUsageServerAuth); err != nil {
 			t.Errorf("verify %s Fleet client certificate: %v", node, err)
 		}
-		if err := validateFleetEnvironment(filepath.Join(dir, fleetEnvironmentFile)); err != nil {
+		if _, err := loadValidatedFleetApplicationProfile(filepath.Join(dir, fleetEnvironmentFile)); err != nil {
 			t.Errorf("validate %s Fleet environment: %v", node, err)
 		}
 	}
@@ -298,6 +298,34 @@ func TestPreflight(t *testing.T) {
 		if _, err := preflight(context.Background(), envPath, firewallTemplatePath, host); err == nil || !strings.Contains(err.Error(), fmt.Sprintf("TCP port %d is already occupied", port)) {
 			t.Fatalf("preflight(occupied Fleet port %d) error = %v", port, err)
 		}
+	}
+	listeners = ""
+	fleetEnvironmentPath := filepath.Join(generated, "ha-a", fleetEnvironmentFile)
+	fleetEnvironment, err := os.ReadFile(fleetEnvironmentPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fleetEnvironment = append(fleetEnvironment, []byte("DD_API_KEY=test-key\nENABLE_TRACING=true\n")...)
+	if err := os.WriteFile(fleetEnvironmentPath, fleetEnvironment, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, port := range []int{haTracingHostPort, haTracingHealthHostPort} {
+		listeners = fmt.Sprintf("LISTEN 0 4096 127.0.0.1:%d 0.0.0.0:*\n", port)
+		firewallApplied = false
+		if _, err := preflight(context.Background(), envPath, firewallTemplatePath, host); err == nil || !strings.Contains(err.Error(), fmt.Sprintf("TCP port %d is already occupied", port)) {
+			t.Fatalf("preflight(occupied tracing port %d) error = %v", port, err)
+		}
+		if firewallApplied {
+			t.Fatal("preflight applied the firewall after finding an occupied tracing port")
+		}
+	}
+	fleetEnvironment = append(fleetEnvironment, []byte("ENABLE_BETA_ALERTS=false\n")...)
+	if err := os.WriteFile(fleetEnvironmentPath, fleetEnvironment, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	listeners = "LISTEN 0 4096 127.0.0.1:3030 0.0.0.0:*\n"
+	if _, err := preflight(context.Background(), envPath, firewallTemplatePath, host); err != nil {
+		t.Fatalf("preflight(alerts disabled with occupied Grafana port) error = %v", err)
 	}
 	listeners = ""
 

--- a/server/internal/ha/deployment/guided_install.go
+++ b/server/internal/ha/deployment/guided_install.go
@@ -78,7 +78,7 @@ type guidedInstallDependencies struct {
 	operatorUsername func() string
 	checkPeer        func(context.Context, string, string) error
 	transferBundle   func(context.Context, string, string, string) error
-	inspect          func(context.Context, string, NodeConfig) (installedDependencies, error)
+	inspect          func(context.Context, string, NodeConfig, fleetApplicationProfile) (installedDependencies, error)
 	install          func(context.Context, InstallOptions) error
 }
 
@@ -122,12 +122,15 @@ func defaultGuidedInstallDependencies() guidedInstallDependencies {
 			defer bundle.Close()
 			return runSSH(ctx, localUsername, bundle, target, remoteBundleInstallCommand)
 		},
-		inspect: func(ctx context.Context, source string, config NodeConfig) (installedDependencies, error) {
+		inspect: func(ctx context.Context, source string, config NodeConfig, profile fleetApplicationProfile) (installedDependencies, error) {
 			host := hostEnvironment{
 				goos: runtime.GOOS, localIPs: localAddresses, interfacePrefixes: interfaceIPv4Prefixes,
 				runCommand: runCommand,
 			}
-			if err := validateHostConfiguration(ctx, config, host, false); err != nil {
+			if err := validateNodeConfig(config); err != nil {
+				return installedDependencies{}, fmt.Errorf("HA preflight failed: %w", err)
+			}
+			if err := validateHostEnvironment(ctx, config, host, false, profile); err != nil {
 				return installedDependencies{}, err
 			}
 			_, installed, err := inspectInstallBase(ctx, source, defaultInstallDependencies())
@@ -140,6 +143,11 @@ func defaultGuidedInstallDependencies() guidedInstallDependencies {
 }
 
 func guidedInstall(ctx context.Context, bundlePath string, deps guidedInstallDependencies) error {
+	if bundlePath != "" {
+		if err := os.Unsetenv("DD_API_KEY"); err != nil {
+			return fmt.Errorf("clear DD_API_KEY before prepared host installation: %w", err)
+		}
+	}
 	source, err := deps.sourceRoot()
 	if err != nil {
 		return err
@@ -160,7 +168,10 @@ func guidedInstall(ctx context.Context, bundlePath string, deps guidedInstallDep
 
 func prepareAndInstallCluster(ctx context.Context, source string, release clusterMetadata, scanner *bufio.Scanner, deps guidedInstallDependencies) error {
 	metadata := release
-	var err error
+	applicationProfile, err := captureFleetApplicationEnvironment()
+	if err != nil {
+		return fmt.Errorf("validate HA feature configuration: %w", err)
+	}
 	if metadata.DatabaseBIP, err = readPrompt(scanner, deps.prompts, "ha-b IPv4 address: "); err != nil {
 		return err
 	}
@@ -194,7 +205,7 @@ func prepareAndInstallCluster(ctx context.Context, source string, release cluste
 		DatabaseBIP: metadata.DatabaseBIP, WitnessIP: metadata.WitnessIP, VirtualIP: metadata.VirtualIP,
 		NetworkInterface: identity.networkInterface, DataDir: dataRoot, SecretsDir: configRoot,
 	}
-	installed, err := deps.inspect(ctx, source, config)
+	installed, err := deps.inspect(ctx, source, config, applicationProfile)
 	if err != nil {
 		return err
 	}
@@ -216,7 +227,7 @@ func prepareAndInstallCluster(ctx context.Context, source string, release cluste
 	if err != nil {
 		return err
 	}
-	if err := prepareInstallBundles(exportDir, metadata); err != nil {
+	if err := prepareInstallBundles(exportDir, metadata, applicationProfile); err != nil {
 		return fmt.Errorf("bundle generation failed; partial exports remain at %s: %w", exportDir, err)
 	}
 	haABundle := filepath.Join(exportDir, hostBundleName("ha-a"))
@@ -312,7 +323,14 @@ func installPreparedHost(ctx context.Context, source, bundlePath string, release
 		if err := writeInstallerOutput(deps.output, "[validation] Checking the bundle, release, network, and dedicated host...\n"); err != nil {
 			return err
 		}
-		installed, err := deps.inspect(ctx, source, config)
+		profile := fleetApplicationProfile{}
+		if config.isDatabaseNode() {
+			profile, err = loadValidatedFleetApplicationProfile(filepath.Join(config.SecretsDir, fleetEnvironmentFile))
+			if err != nil {
+				return err
+			}
+		}
+		installed, err := deps.inspect(ctx, source, config, profile)
 		if err != nil {
 			return err
 		}
@@ -364,7 +382,7 @@ func stageHostBundle(bundle preparedHostBundle, stagingDir, networkInterface str
 	return options, nil
 }
 
-func prepareInstallBundles(exportDir string, metadata clusterMetadata) (err error) {
+func prepareInstallBundles(exportDir string, metadata clusterMetadata, environment fleetApplicationProfile) (err error) {
 	generated, err := os.MkdirTemp("", "proto-fleet-ha-secrets-")
 	if err != nil {
 		return fmt.Errorf("create secret generation workspace: %w", err)
@@ -374,6 +392,7 @@ func prepareInstallBundles(exportDir string, metadata clusterMetadata) (err erro
 	if err := GenerateSecrets(secretsRoot, [3]string{metadata.DatabaseAIP, metadata.DatabaseBIP, metadata.WitnessIP}, metadata.VirtualIP); err != nil {
 		return err
 	}
+	deploymentEnvironment := renderFleetDeploymentEnvironment(environment)
 
 	for _, role := range []string{"ha-a", "ha-b", "ha-c"} {
 		nodeIP := map[string]string{"ha-a": metadata.DatabaseAIP, "ha-b": metadata.DatabaseBIP, "ha-c": metadata.WitnessIP}[role]
@@ -389,6 +408,9 @@ func prepareInstallBundles(exportDir string, metadata clusterMetadata) (err erro
 			contents, err := os.ReadFile(filepath.Join(secretsRoot, role, name))
 			if err != nil {
 				return fmt.Errorf("read generated %s secret %s: %w", role, name, err)
+			}
+			if name == fleetEnvironmentFile {
+				contents = append(contents, deploymentEnvironment...)
 			}
 			bundle.Secrets[name] = contents
 		}
@@ -438,7 +460,8 @@ func decodeHostBundle(contents []byte) (preparedHostBundle, error) {
 	if err := validateBundleMetadata(bundle.Metadata); err != nil {
 		return preparedHostBundle{}, fmt.Errorf("host bundle rejected: %w", err)
 	}
-	expectedSecrets := copiedSecretFiles(NodeConfig{NodeName: bundle.Metadata.Role})
+	config := NodeConfig{NodeName: bundle.Metadata.Role}
+	expectedSecrets := copiedSecretFiles(config)
 	for _, name := range expectedSecrets {
 		if len(bundle.Secrets[name]) == 0 {
 			return preparedHostBundle{}, fmt.Errorf("host bundle rejected: missing secret %s", name)
@@ -452,6 +475,11 @@ func decodeHostBundle(contents []byte) (preparedHostBundle, error) {
 	}
 	if bundle.Metadata.Role != "ha-a" && len(bundle.EtcdRootPassword) != 0 {
 		return preparedHostBundle{}, errors.New("host bundle rejected: etcd root password is only valid for ha-a")
+	}
+	if config.isDatabaseNode() {
+		if _, err := parseFleetDeploymentEnvironment(bundle.Secrets[fleetEnvironmentFile]); err != nil {
+			return preparedHostBundle{}, fmt.Errorf("host bundle rejected: %w", err)
+		}
 	}
 	return bundle, nil
 }

--- a/server/internal/ha/deployment/guided_install_test.go
+++ b/server/internal/ha/deployment/guided_install_test.go
@@ -56,9 +56,10 @@ func TestGuidedInstallPreparesClusterAndInstallsHAA(t *testing.T) {
 	deps.makeExportDir = func() (string, error) {
 		return exportDir, os.Mkdir(exportDir, 0o700)
 	}
-	deps.inspect = func(_ context.Context, _ string, config NodeConfig) (installedDependencies, error) {
+	deps.inspect = func(_ context.Context, _ string, config NodeConfig, profile fleetApplicationProfile) (installedDependencies, error) {
 		require.Equal(t, testHostIPs[0], config.NodeIP)
 		require.Equal(t, "enp1s0", config.NetworkInterface)
+		require.True(t, profile.enabled("ENABLE_BETA_ALERTS"))
 		inspected = true
 		return installedDependencies{docker: true}, nil
 	}
@@ -213,6 +214,10 @@ func TestBundleExportDirectoryIsOutsideRelease(t *testing.T) {
 
 func TestPrepareInstallBundlesCreatesRoleScopedBundles(t *testing.T) {
 	// Arrange
+	t.Setenv("ENABLE_BETA_ALERTS", "true")
+	t.Setenv("ENABLE_SYSTEM_MONITORING", "true")
+	t.Setenv("ENABLE_TRACING", "true")
+	t.Setenv("DD_API_KEY", "test-datadog-key")
 	exportDir := filepath.Join(t.TempDir(), "exports")
 	require.NoError(t, os.Mkdir(exportDir, 0o700))
 	metadata := clusterMetadata{
@@ -221,20 +226,31 @@ func TestPrepareInstallBundlesCreatesRoleScopedBundles(t *testing.T) {
 	}
 
 	// Act
-	err := prepareInstallBundles(exportDir, metadata)
+	profile, err := fleetApplicationEnvironment(os.LookupEnv)
+	require.NoError(t, err)
+	err = prepareInstallBundles(exportDir, metadata, profile)
 
 	// Assert
 	require.NoError(t, err)
 	for _, role := range []string{"ha-a", "ha-b", "ha-c"} {
-		bundle, err := readHostBundle(filepath.Join(exportDir, hostBundleName(role)))
+		bundlePath := filepath.Join(exportDir, hostBundleName(role))
+		bundle, err := readHostBundle(bundlePath)
 		require.NoError(t, err)
+		requireMode(t, bundlePath, 0o600)
+		require.NoFileExists(t, bundlePath+".sha256")
 		require.Equal(t, role, bundle.Metadata.Role)
 		require.NotContains(t, bundle.Secrets, "service-ca.key")
 		require.Equal(t, role == "ha-a", len(bundle.EtcdRootPassword) != 0)
-	}
-	for _, name := range []string{hostBundleName("ha-a"), hostBundleName("ha-b"), hostBundleName("ha-c")} {
-		requireMode(t, filepath.Join(exportDir, name), 0o600)
-		require.NoFileExists(t, filepath.Join(exportDir, name+".sha256"))
+		if role == "ha-c" {
+			require.NotContains(t, bundle.Secrets, fleetEnvironmentFile)
+			continue
+		}
+		profile, err := parseFleetDeploymentEnvironment(bundle.Secrets[fleetEnvironmentFile])
+		require.NoError(t, err)
+		require.True(t, profile.enabled("ENABLE_BETA_ALERTS"))
+		require.True(t, profile.enabled("ENABLE_SYSTEM_MONITORING"))
+		require.True(t, profile.enabled("ENABLE_TRACING"))
+		require.Equal(t, "test-datadog-key", profile["DD_API_KEY"])
 	}
 }
 
@@ -331,6 +347,7 @@ func TestInstallHostBundleConsumption(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Arrange
+			t.Setenv("DD_API_KEY", "ambient-secret")
 			source := testGuidedRelease(t, "v0.2.10", "abc123")
 			bundlePath := filepath.Join(t.TempDir(), hostBundleName("ha-c"))
 			writeValidTestBundle(t, bundlePath, testBundleMetadata("ha-c"))
@@ -338,8 +355,10 @@ func TestInstallHostBundleConsumption(t *testing.T) {
 			deps := testGuidedDependencies(source, strings.NewReader(""), &bytes.Buffer{}, &prompts)
 			deps.terminal = func() bool { return false }
 			inspected := false
-			deps.inspect = func(context.Context, string, NodeConfig) (installedDependencies, error) {
+			deps.inspect = func(context.Context, string, NodeConfig, fleetApplicationProfile) (installedDependencies, error) {
 				inspected = true
+				_, stillExported := os.LookupEnv("DD_API_KEY")
+				require.False(t, stillExported)
 				return installedDependencies{}, nil
 			}
 			deps.install = func(context.Context, InstallOptions) error { return tt.installErr }
@@ -374,6 +393,9 @@ func writeValidTestBundle(t *testing.T, path string, metadata bundleMetadata) {
 	secrets := make(map[string][]byte)
 	for _, name := range copiedSecretFiles(NodeConfig{NodeName: metadata.Role}) {
 		secrets[name] = []byte("test")
+		if name == fleetEnvironmentFile {
+			secrets[name] = []byte(testFleetEnvironment)
+		}
 	}
 	writeTestBundle(t, path, metadata, secrets)
 }
@@ -408,7 +430,7 @@ func testGuidedDependencies(source string, input *strings.Reader, output, prompt
 		operatorUsername: func() string { return "operator" },
 		checkPeer:        func(context.Context, string, string) error { return nil },
 		transferBundle:   func(context.Context, string, string, string) error { return nil },
-		inspect: func(context.Context, string, NodeConfig) (installedDependencies, error) {
+		inspect: func(context.Context, string, NodeConfig, fleetApplicationProfile) (installedDependencies, error) {
 			return installedDependencies{}, nil
 		},
 		install: func(context.Context, InstallOptions) error { return nil },

--- a/server/internal/ha/deployment/install.go
+++ b/server/internal/ha/deployment/install.go
@@ -21,32 +21,35 @@ import (
 )
 
 const (
-	installBase           = "/opt/proto-fleet"
-	installRoot           = "/opt/proto-fleet/deployment"
-	configRoot            = "/etc/proto-fleet/ha"
-	dataRoot              = "/var/lib/proto-fleet/ha"
-	infrastructureCompose = configRoot + "/compose.yaml"
-	serviceUnit           = "/etc/systemd/system/proto-fleet-ha.service"
-	firewallUnit          = "/etc/systemd/system/proto-fleet-ha-firewall.service"
-	nftablesDropIn        = "/etc/systemd/system/nftables.service.d/proto-fleet-ha.conf"
-	nftablesReloadConfig  = configRoot + "/nftables-reload.conf"
-	firewallReplaceConfig = configRoot + "/firewall-replace.nft"
-	dockerDropIn          = "/etc/systemd/system/docker.service.d/proto-fleet-ha.conf"
-	dockerRecoveryDropIn  = "/etc/systemd/system/docker.service.d/proto-fleet-ha-recovery.conf"
-	fleetComposeProject   = "deployment"
-	minimumComposeVersion = "v2.24.4" // fleet-compose.yaml uses !override, added in this Compose release.
-	updaterDropIn         = "/etc/systemd/system/proto-fleet-updater.service.d/proto-fleet-ha.conf"
-	haUpdaterDropIn       = "/etc/systemd/system/proto-fleet-ha.service.d/proto-fleet-updater.conf"
-	updaterBinary         = "/usr/local/libexec/proto-fleet/proto-fleet-updater"
-	updaterUnit           = "/etc/systemd/system/proto-fleet-updater.service"
-	updaterEnvironment    = "/etc/proto-fleet/updater.env"
-	updaterStateRoot      = "/var/lib/proto-fleet-updater"
-	updaterRuntimeRoot    = "/run/proto-fleet-updater"
-	updaterLock           = updaterStateRoot + "/updater.lock"
-	keepalivedConfig      = "/etc/keepalived/keepalived.conf"
-	keepalivedOverride    = "/etc/systemd/system/keepalived.service.d/override.conf"
-	keepalivedHealthCheck = "/usr/local/libexec/proto-fleet/check-fleet-active"
-	haActiveInstallMarker = configRoot + "/active-install"
+	installBase             = "/opt/proto-fleet"
+	installRoot             = "/opt/proto-fleet/deployment"
+	configRoot              = "/etc/proto-fleet/ha"
+	dataRoot                = "/var/lib/proto-fleet/ha"
+	infrastructureCompose   = configRoot + "/compose.yaml"
+	serviceUnit             = "/etc/systemd/system/proto-fleet-ha.service"
+	firewallUnit            = "/etc/systemd/system/proto-fleet-ha-firewall.service"
+	nftablesDropIn          = "/etc/systemd/system/nftables.service.d/proto-fleet-ha.conf"
+	nftablesReloadConfig    = configRoot + "/nftables-reload.conf"
+	firewallReplaceConfig   = configRoot + "/firewall-replace.nft"
+	dockerDropIn            = "/etc/systemd/system/docker.service.d/proto-fleet-ha.conf"
+	dockerRecoveryDropIn    = "/etc/systemd/system/docker.service.d/proto-fleet-ha-recovery.conf"
+	fleetComposeProject     = "deployment"
+	minimumComposeVersion   = "v2.24.4" // fleet-compose.yaml uses !override, added in this Compose release.
+	updaterDropIn           = "/etc/systemd/system/proto-fleet-updater.service.d/proto-fleet-ha.conf"
+	haUpdaterDropIn         = "/etc/systemd/system/proto-fleet-ha.service.d/proto-fleet-updater.conf"
+	updaterBinary           = "/usr/local/libexec/proto-fleet/proto-fleet-updater"
+	updaterUnit             = "/etc/systemd/system/proto-fleet-updater.service"
+	updaterEnvironment      = "/etc/proto-fleet/updater.env"
+	updaterStateRoot        = "/var/lib/proto-fleet-updater"
+	updaterRuntimeRoot      = "/run/proto-fleet-updater"
+	updaterLock             = updaterStateRoot + "/updater.lock"
+	keepalivedConfig        = "/etc/keepalived/keepalived.conf"
+	keepalivedOverride      = "/etc/systemd/system/keepalived.service.d/override.conf"
+	keepalivedHealthCheck   = "/usr/local/libexec/proto-fleet/check-fleet-active"
+	haActiveInstallMarker   = configRoot + "/active-install"
+	haSystemMonitoringDir   = dataRoot + "/system-monitoring"
+	haTracingHostPort       = 4319
+	haTracingHealthHostPort = 13133
 )
 
 var errInstallConverging = errors.New("HA service remains enabled and is still converging")
@@ -97,7 +100,7 @@ type installDependencies struct {
 	lstat        func(string) (os.FileInfo, error)
 	lookPath     func(string) (string, error)
 	requireEmpty func(string, string) error
-	validateHost func(context.Context, string) (NodeConfig, error)
+	validateHost func(context.Context, string) (NodeConfig, fleetApplicationProfile, error)
 	run          func(context.Context, string, ...string) ([]byte, error)
 	runInput     func(context.Context, string, string, ...string) error
 	sourceRoot   func() (string, error)
@@ -110,7 +113,7 @@ type installDependencies struct {
 func defaultInstallDependencies() installDependencies {
 	return installDependencies{
 		goos: runtime.GOOS, goarch: runtime.GOARCH, pageSize: os.Getpagesize(),
-		readFile: os.ReadFile, lstat: os.Lstat, lookPath: exec.LookPath, requireEmpty: requireEmptyDir, validateHost: ValidateHost,
+		readFile: os.ReadFile, lstat: os.Lstat, lookPath: exec.LookPath, requireEmpty: requireEmptyDir, validateHost: validateInstallHost,
 		run: runCommand, runInput: runWithInput,
 		sourceRoot: ReleaseRoot, verifyVIP: verifyInstallVirtualIP,
 		localReady: waitForLocalEtcd, vipReady: probeInstalledActiveVIP, sleep: time.Sleep,
@@ -127,7 +130,7 @@ func install(ctx context.Context, options InstallOptions, deps installDependenci
 	if err != nil {
 		return err
 	}
-	config, err := deps.validateHost(ctx, options.NodeEnvPath)
+	config, applicationProfile, err := deps.validateHost(ctx, options.NodeEnvPath)
 	if err != nil {
 		return err
 	}
@@ -136,7 +139,6 @@ func install(ctx context.Context, options InstallOptions, deps installDependenci
 			return fmt.Errorf("validate etcd root password file: %w", err)
 		}
 	}
-
 	fmt.Println("[package setup] Installing missing host dependencies...")
 	if err := installValidationPrerequisites(ctx, config.isDatabaseNode(), deps); err != nil {
 		return err
@@ -176,7 +178,7 @@ func install(ctx context.Context, options InstallOptions, deps installDependenci
 		return err
 	}
 	fmt.Println("[image preparation] Loading and building the packaged service images...")
-	if err := prepareImages(ctx, source, config, deps); err != nil {
+	if err := prepareImages(ctx, source, config, applicationProfile, deps); err != nil {
 		return err
 	}
 	// Install the Docker recovery dependency before etcd first starts so a
@@ -415,14 +417,16 @@ func parseOSRelease(contents string) map[string]string {
 
 func validateRelease(source string, readFile func(string) ([]byte, error)) error {
 	required := []string{
-		"version.txt", "docker-compose.yaml", "docker-compose.alerts.yaml", "server/docker-compose.base.yaml", "images/fleet.tar.gz", "images/timescaledb.tar.gz",
+		"version.txt", "docker-compose.yaml", "docker-compose.alerts.yaml", "docker-compose.system-monitoring.yaml", "docker-compose.tracing.yaml", "server/docker-compose.base.yaml", "images/fleet.tar.gz", "images/timescaledb.tar.gz",
+		"server/otel-collector-config.datadog.yaml",
 		"server/monitoring/grafana/grafana.ini", "server/monitoring/grafana/provisioning/alerting/notification-policies.yaml",
 		"server/monitoring/grafana/ha/proto-fleet-ha-rules.yaml", "server/monitoring/grafana/ha/timescaledb.yaml",
+		"server/monitoring/grafana/system-monitoring/proto-fleet-system-rules.yaml", "server/monitoring/grafana/system-monitoring/dashboards.yaml", "server/monitoring/grafana/system-monitoring/dashboards/system-monitoring.json",
 		"server/Dockerfile", "server/fleetd", "server/proto-plugin", "server/antminer-plugin", "server/asicrs-plugin", "server/asicrs-config.yaml", "server/virtual-plugin", "server/virtual-plugin.json",
 		"client/Dockerfile", "client/nginx.https.conf", "client/protoFleet/index.html", "client/docker-entrypoint.d/40-render-runtime-config.sh",
 		"updater/proto-fleet-updater", "updater/proto-fleet-updater.service",
 		"ha/updater-systemd.conf", "ha/ha-updater-systemd.conf",
-		"ha/fleet-ha", "ha/compose.yaml", "ha/fleet-compose.yaml", "ha/firewall.nft.tmpl", "ha/firewall-replace.nft",
+		"ha/fleet-ha", "ha/compose.yaml", "ha/fleet-compose.alerts.yaml", "ha/fleet-compose.system-monitoring.yaml", "ha/fleet-compose.tracing.yaml", "ha/fleet-compose.yaml", "ha/firewall.nft.tmpl", "ha/firewall-replace.nft",
 		"ha/keepalived.conf.tmpl", "ha/keepalived-systemd.conf.tmpl", "ha/proto-fleet-ha.service", "ha/proto-fleet-ha-keepalived.conf",
 		"ha/proto-fleet-ha-firewall.service", "ha/nftables-systemd.conf", "ha/nftables-reload.conf", "ha/docker-systemd.conf", "ha/docker-ha-recovery-systemd.conf", "ha/scripts/check-fleet-active.sh",
 	}
@@ -685,6 +689,10 @@ func installRelease(ctx context.Context, config NodeConfig, deps installDependen
 		return err
 	}
 	if config.isDatabaseNode() {
+		if err := sudoStep(ctx, deps, "install HA system monitoring mount point",
+			"install", "-d", "-o", "root", "-g", "root", "-m", "0755", haSystemMonitoringDir); err != nil {
+			return err
+		}
 		if err := sudoStep(ctx, deps, "record HA Grafana volume ownership",
 			"install", "-o", "root", "-g", "root", "-m", "0600", "/dev/null", haGrafanaVolumeOwnershipMarker); err != nil {
 			return err
@@ -804,14 +812,15 @@ func installKeepalived(ctx context.Context, source string, config NodeConfig, de
 	return placeFile(ctx, deps, "install keepalived service dependency", filepath.Join(source, "ha", "proto-fleet-ha-keepalived.conf"), "/etc/systemd/system/proto-fleet-ha.service.d/keepalived.conf", "0644")
 }
 
-func prepareImages(ctx context.Context, source string, config NodeConfig, deps installDependencies) error {
+func prepareImages(ctx context.Context, source string, config NodeConfig, profile fleetApplicationProfile, deps installDependencies) error {
 	if output, err := deps.run(ctx, "sudo", filepath.Join(installRoot, "ha", "fleet-ha"), "compose", "--env-file", filepath.Join(configRoot, "node.env"), "--file", infrastructureCompose, "pull", "etcd"); err != nil {
 		return fmt.Errorf("pull etcd image: %s", commandError(output, err))
 	}
 	if config.isDatabaseNode() {
-		pullArgs := fleetComposeArgs("pull", "grafana")
-		if output, err := deps.run(ctx, "sudo", append([]string{filepath.Join(installRoot, "ha", "fleet-ha"), "compose"}, pullArgs...)...); err != nil {
-			return fmt.Errorf("pull Grafana image: %s", commandError(output, err))
+		if pullArgs := fleetSidecarPullArgs(installRoot, installedFleetEnvironment, profile); pullArgs != nil {
+			if output, err := deps.run(ctx, "sudo", append([]string{filepath.Join(installRoot, "ha", "fleet-ha"), "compose"}, pullArgs...)...); err != nil {
+				return fmt.Errorf("pull HA application sidecar images: %s", commandError(output, err))
+			}
 		}
 		for _, archive := range []string{"timescaledb.tar.gz", "fleet.tar.gz"} {
 			if output, err := deps.run(ctx, "sudo", "docker", "load", "--input", filepath.Join(installRoot, "images", archive)); err != nil {
@@ -976,27 +985,36 @@ func stopIncompleteHA(ctx context.Context, deps installDependencies, cause error
 	return errors.Join(cause, errors.Join(cleanupErrs...))
 }
 
-func fleetComposeArgs(operation string, services ...string) []string {
-	return fleetComposeArgsAt(installRoot, operation, services...)
-}
-
-func fleetComposeArgsAt(root, operation string, services ...string) []string {
-	return fleetComposeArgsAtProfile(root, true, operation, services...)
-}
-
-func fleetComposeArgsAtProfile(root string, includeAlerts bool, operation string, services ...string) []string {
+func fleetComposeArgsAtProfile(root, environmentPath string, profile fleetApplicationProfile, operation string, commandArgs ...string) []string {
 	args := []string{
 		"--project-name", fleetComposeProject,
 		"--env-file", filepath.Join(configRoot, "base.env"),
-		"--env-file", filepath.Join(configRoot, fleetEnvironmentFile),
+		"--env-file", environmentPath,
 		"--env-file", filepath.Join(configRoot, "node.env"),
 		"--file", filepath.Join(root, "docker-compose.yaml"),
 	}
-	if includeAlerts {
+	if profile.enabled("ENABLE_BETA_ALERTS") {
 		args = append(args, "--file", filepath.Join(root, "docker-compose.alerts.yaml"))
 	}
-	args = append(args, "--file", filepath.Join(root, "ha", "fleet-compose.yaml"), operation)
-	return append(args, services...)
+	args = append(args, "--file", filepath.Join(root, "ha", "fleet-compose.yaml"))
+	if profile.enabled("ENABLE_BETA_ALERTS") {
+		args = append(args, "--file", filepath.Join(root, "ha", "fleet-compose.alerts.yaml"))
+	}
+	if profile.enabled("ENABLE_SYSTEM_MONITORING") {
+		args = append(args,
+			"--file", filepath.Join(root, "docker-compose.system-monitoring.yaml"),
+			"--file", filepath.Join(root, "ha", "fleet-compose.system-monitoring.yaml"),
+		)
+	}
+	if profile.enabled("ENABLE_TRACING") {
+		args = append(args,
+			"--file", filepath.Join(root, "docker-compose.tracing.yaml"),
+			"--file", filepath.Join(root, "ha", "fleet-compose.tracing.yaml"),
+		)
+	}
+	args = append(args, operation)
+	args = append(args, commandArgs...)
+	return args
 }
 
 func writeInstallTemp(name, contents string, mode os.FileMode) (string, error) {

--- a/server/internal/ha/deployment/install_test.go
+++ b/server/internal/ha/deployment/install_test.go
@@ -78,6 +78,7 @@ func TestInstallGoldenPathOrdersFirewallBeforeServices(t *testing.T) {
 	require.Contains(t, joined, "sudo install -D -o root -g root -m 0644 "+filepath.Join(secrets, "service-ca.crt")+" "+filepath.Join(configRoot, "service-ca.crt"))
 	require.Contains(t, joined, "sudo install -D -o root -g root -m 0600 "+filepath.Join(secrets, "fleet-client.key")+" "+filepath.Join(configRoot, "fleet-client.key"))
 	require.Contains(t, joined, "sudo install -o root -g root -m 0600 /dev/null "+haGrafanaVolumeOwnershipMarker)
+	require.Contains(t, joined, "sudo install -d -o root -g root -m 0755 "+haSystemMonitoringDir)
 }
 
 func TestInstallDoesNotRecordActiveMarkerWhenStartupFails(t *testing.T) {
@@ -465,7 +466,7 @@ func TestPrepareImagesRejectsMissingReleaseImage(t *testing.T) {
 			}
 
 			// Act
-			err := prepareImages(t.Context(), source, config, deps)
+			err := prepareImages(t.Context(), source, config, fleetApplicationProfile{"ENABLE_BETA_ALERTS": "true"}, deps)
 
 			// Assert
 			require.ErrorContains(t, err, "archive did not load required image "+image)
@@ -867,15 +868,22 @@ func TestReleaseSnapshotCleanupOutlivesInstallCancellation(t *testing.T) {
 }
 
 func TestValidateReleaseRejectsMissingRuntimeAsset(t *testing.T) {
-	// Arrange
-	source := testInstallRelease(t)
-	require.NoError(t, os.Remove(filepath.Join(source, "images", "fleet.tar.gz")))
+	for _, asset := range []string{
+		"images/fleet.tar.gz",
+		"server/otel-collector-config.datadog.yaml",
+		"server/monitoring/grafana/system-monitoring/proto-fleet-system-rules.yaml",
+		"server/monitoring/grafana/system-monitoring/dashboards.yaml",
+		"server/monitoring/grafana/system-monitoring/dashboards/system-monitoring.json",
+	} {
+		t.Run(asset, func(t *testing.T) {
+			source := testInstallRelease(t)
+			require.NoError(t, os.Remove(filepath.Join(source, asset)))
 
-	// Act
-	err := validateRelease(source, os.ReadFile)
+			err := validateRelease(source, os.ReadFile)
 
-	// Assert
-	require.ErrorContains(t, err, "release is missing images/fleet.tar.gz")
+			require.ErrorContains(t, err, "release is missing "+asset)
+		})
+	}
 }
 
 func TestInstallVIPConflictLeavesDockerUninstalled(t *testing.T) {
@@ -926,7 +934,9 @@ func testInstallerDependencies(source string, config NodeConfig, calls *[]string
 			return "", fmt.Errorf("not found")
 		},
 		requireEmpty: func(string, string) error { return nil },
-		validateHost: func(context.Context, string) (NodeConfig, error) { return config, nil },
+		validateHost: func(context.Context, string) (NodeConfig, fleetApplicationProfile, error) {
+			return config, fleetApplicationProfile{"ENABLE_BETA_ALERTS": "true"}, nil
+		},
 		verifyVIP: func(context.Context, NodeConfig) error {
 			record("verify-vip")
 			return nil
@@ -971,14 +981,20 @@ func testInstallRelease(t *testing.T) string {
 	t.Helper()
 	root := t.TempDir()
 	required := map[string]string{
-		"version.txt":                           "version: test\n",
-		"docker-compose.yaml":                   "services:\n  fleet-api:\n    image: proto-fleet-api:test\n  fleet-client:\n    image: proto-fleet-client:test\n",
-		"docker-compose.alerts.yaml":            "services:\n  grafana:\n    image: grafana/grafana:13.0\n",
-		"server/docker-compose.base.yaml":       "services: {}\n",
-		"server/monitoring/grafana/grafana.ini": "[unified_alerting]\nenabled = true\n",
-		"server/monitoring/grafana/provisioning/alerting/notification-policies.yaml": "apiVersion: 1\n",
-		"server/monitoring/grafana/ha/proto-fleet-ha-rules.yaml":                     "apiVersion: 1\n",
-		"server/monitoring/grafana/ha/timescaledb.yaml":                              "apiVersion: 1\n",
+		"version.txt":                               "version: test\n",
+		"docker-compose.yaml":                       "services:\n  fleet-api:\n    image: proto-fleet-api:test\n  fleet-client:\n    image: proto-fleet-client:test\n",
+		"docker-compose.alerts.yaml":                "services:\n  grafana:\n    image: grafana/grafana:13.0\n",
+		"docker-compose.system-monitoring.yaml":     "services: {}\n",
+		"docker-compose.tracing.yaml":               "services: {}\n",
+		"server/docker-compose.base.yaml":           "services: {}\n",
+		"server/otel-collector-config.datadog.yaml": "receivers: {}\n",
+		"server/monitoring/grafana/grafana.ini":     "[unified_alerting]\nenabled = true\n",
+		"server/monitoring/grafana/provisioning/alerting/notification-policies.yaml":    "apiVersion: 1\n",
+		"server/monitoring/grafana/ha/proto-fleet-ha-rules.yaml":                        "apiVersion: 1\n",
+		"server/monitoring/grafana/ha/timescaledb.yaml":                                 "apiVersion: 1\n",
+		"server/monitoring/grafana/system-monitoring/proto-fleet-system-rules.yaml":     "apiVersion: 1\n",
+		"server/monitoring/grafana/system-monitoring/dashboards.yaml":                   "apiVersion: 1\n",
+		"server/monitoring/grafana/system-monitoring/dashboards/system-monitoring.json": "{}\n",
 		"server/Dockerfile":                                      "FROM scratch\n",
 		"server/fleetd":                                          "binary",
 		"server/proto-plugin":                                    "binary",
@@ -992,6 +1008,9 @@ func testInstallRelease(t *testing.T) string {
 		"ha/fleet-ha":                                            "binary",
 		"ha/compose.yaml":                                        "services:\n  patroni:\n    image: proto-fleet-timescaledb-ha:test\n",
 		"ha/fleet-compose.yaml":                                  "services: {}\n",
+		"ha/fleet-compose.alerts.yaml":                           "services: {}\n",
+		"ha/fleet-compose.system-monitoring.yaml":                "services: {}\n",
+		"ha/fleet-compose.tracing.yaml":                          "services: {}\n",
 		"ha/firewall.nft.tmpl":                                   "${HA_NODE_IP} ${HA_DB_A_IP} ${HA_DB_B_IP} ${HA_DCS_C_IP} ${HA_NETWORK_INTERFACE}\n",
 		"ha/firewall-replace.nft":                                "delete table inet proto_fleet_ha\ninclude \"/etc/proto-fleet/ha/firewall.nft\"\n",
 		"ha/keepalived.conf.tmpl":                                "${HA_NODE_IP} ${HA_PEER_IP} ${HA_VIRTUAL_IP} ${HA_NETWORK_INTERFACE} ${HA_ENDPOINT_HEARTBEAT_FILE} ${HA_SECRETS_DIR}\n",
@@ -1031,17 +1050,19 @@ func writeTestSecretBundle(t *testing.T, config NodeConfig) {
 	for _, name := range copiedSecretFiles(config) {
 		contents := "test"
 		if name == fleetEnvironmentFile {
-			contents = "AUTH_CLIENT_SECRET_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n" +
-				"ENCRYPT_SERVICE_MASTER_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\n" +
-				"DB_DSN=postgresql://fleet:test@db/fleet\n" +
-				"GRAFANA_ADMIN_PASSWORD=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n" +
-				"GRAFANA_DB_PASSWORD=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n" +
-				"GRAFANA_SECRET_KEY=cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\n" +
-				"FLEET_ALERTS_WEBHOOK_TOKEN=dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\n"
+			contents = testFleetEnvironment
 		}
 		require.NoError(t, os.WriteFile(filepath.Join(config.SecretsDir, name), []byte(contents), 0o600))
 	}
 }
+
+const testFleetEnvironment = "AUTH_CLIENT_SECRET_KEY=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n" +
+	"ENCRYPT_SERVICE_MASTER_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\n" +
+	"DB_DSN=postgresql://fleet:test@db/fleet\n" +
+	"GRAFANA_ADMIN_PASSWORD=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n" +
+	"GRAFANA_DB_PASSWORD=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n" +
+	"GRAFANA_SECRET_KEY=cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\n" +
+	"FLEET_ALERTS_WEBHOOK_TOKEN=dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd\n"
 
 func callIndex(calls []string, needle string) int {
 	for index, call := range calls {

--- a/server/internal/ha/deployment/preflight.go
+++ b/server/internal/ha/deployment/preflight.go
@@ -26,8 +26,7 @@ type hostEnvironment struct {
 	applyFirewall     func(context.Context, NodeConfig, string) error
 }
 
-// ValidateHost verifies the immutable host inputs before installation changes the machine.
-func ValidateHost(ctx context.Context, envPath string) (NodeConfig, error) {
+func validateInstallHost(ctx context.Context, envPath string) (NodeConfig, fleetApplicationProfile, error) {
 	host := hostEnvironment{
 		goos:              runtime.GOOS,
 		localIPs:          localAddresses,
@@ -50,7 +49,7 @@ func Preflight(ctx context.Context, envPath, firewallTemplatePath string) (NodeC
 }
 
 func preflight(ctx context.Context, envPath, firewallTemplatePath string, host hostEnvironment) (NodeConfig, error) {
-	config, err := validateHost(ctx, envPath, host, true)
+	config, _, err := validateHost(ctx, envPath, host, true)
 	if err != nil {
 		return NodeConfig{}, err
 	}
@@ -60,24 +59,25 @@ func preflight(ctx context.Context, envPath, firewallTemplatePath string, host h
 	return config, nil
 }
 
-func validateHost(ctx context.Context, envPath string, host hostEnvironment, probeVirtualIP bool) (NodeConfig, error) {
+func validateHost(ctx context.Context, envPath string, host hostEnvironment, probeVirtualIP bool) (NodeConfig, fleetApplicationProfile, error) {
 	config, err := loadNodeConfig(envPath)
 	if err != nil {
-		return NodeConfig{}, err
+		return NodeConfig{}, nil, err
 	}
-	if err := validateHostConfiguration(ctx, config, host, probeVirtualIP); err != nil {
-		return NodeConfig{}, err
+	if err := validateNodeConfig(config); err != nil {
+		return NodeConfig{}, nil, fmt.Errorf("HA preflight failed: %w", err)
 	}
-	if err := validateSecrets(config); err != nil {
-		return NodeConfig{}, fmt.Errorf("HA preflight failed: %w", err)
+	profile, err := validateSecrets(config)
+	if err != nil {
+		return NodeConfig{}, nil, fmt.Errorf("HA preflight failed: %w", err)
 	}
-	return config, nil
+	if err := validateHostEnvironment(ctx, config, host, probeVirtualIP, profile); err != nil {
+		return NodeConfig{}, nil, err
+	}
+	return config, profile, nil
 }
 
-func validateHostConfiguration(ctx context.Context, config NodeConfig, host hostEnvironment, probeVirtualIP bool) error {
-	if err := validateNodeConfig(config); err != nil {
-		return fmt.Errorf("HA preflight failed: %w", err)
-	}
+func validateHostEnvironment(ctx context.Context, config NodeConfig, host hostEnvironment, probeVirtualIP bool, profile fleetApplicationProfile) error {
 	if host.goos != "linux" {
 		return errors.New("HA preflight failed: the HA profile requires Linux host networking")
 	}
@@ -146,13 +146,19 @@ func validateHostConfiguration(ctx context.Context, config NodeConfig, host host
 			}
 		}
 	}
+	ports := []int{2379, 2380}
+	if config.isDatabaseNode() {
+		ports = append(ports, 80, 443, 4000, 5432, 8008)
+		if profile.enabled("ENABLE_BETA_ALERTS") {
+			ports = append(ports, 3030)
+		}
+		if profile.enabled("ENABLE_TRACING") {
+			ports = append(ports, haTracingHostPort, haTracingHealthHostPort)
+		}
+	}
 	listeners, err := host.runCommand(ctx, "ss", "-H", "-lnt")
 	if err != nil {
 		return fmt.Errorf("HA preflight failed: inspect listening ports: %s", commandError(listeners, err))
-	}
-	ports := []int{2379, 2380}
-	if config.isDatabaseNode() {
-		ports = append(ports, 80, 443, 3030, 4000, 5432, 8008)
 	}
 	for _, port := range ports {
 		if portIsListening(string(listeners), port) {
@@ -232,16 +238,16 @@ func validateNodeConfig(config NodeConfig) error {
 	return nil
 }
 
-func validateSecrets(config NodeConfig) error {
+func validateSecrets(config NodeConfig) (fleetApplicationProfile, error) {
 	dirInfo, err := os.Lstat(config.SecretsDir)
 	if err != nil || !dirInfo.IsDir() || dirInfo.Mode()&os.ModeSymlink != 0 {
-		return fmt.Errorf("secrets directory must be a non-symlink directory: %s", config.SecretsDir)
+		return nil, fmt.Errorf("secrets directory must be a non-symlink directory: %s", config.SecretsDir)
 	}
 	if err := requireCurrentOwner(dirInfo, "secrets directory"); err != nil {
-		return err
+		return nil, err
 	}
 	if dirInfo.Mode().Perm()&0o022 != 0 {
-		return errors.New("secrets directory must not be group/world writable")
+		return nil, errors.New("secrets directory must not be group/world writable")
 	}
 
 	publicFiles := []string{"service-ca.crt", "etcd-server.crt", "etcd-peer.crt", "etcd-jwt.pub"}
@@ -255,58 +261,60 @@ func validateSecrets(config NodeConfig) error {
 	for _, name := range publicFiles {
 		info, err := secureFileInfo(filepath.Join(config.SecretsDir, name), 0)
 		if err != nil {
-			return fmt.Errorf("required identity file %s: %w", name, err)
+			return nil, fmt.Errorf("required identity file %s: %w", name, err)
 		}
 		if err := requireCurrentOwner(info, name); err != nil {
-			return err
+			return nil, err
 		}
 		if info.Mode().Perm()&0o022 != 0 {
-			return fmt.Errorf("%s must not be group/world writable", name)
+			return nil, fmt.Errorf("%s must not be group/world writable", name)
 		}
 	}
 	for _, name := range keyFiles {
 		info, err := secureFileInfo(filepath.Join(config.SecretsDir, name), 0)
 		if err != nil {
-			return fmt.Errorf("required identity file %s: %w", name, err)
+			return nil, fmt.Errorf("required identity file %s: %w", name, err)
 		}
 		if err := requireCurrentOwner(info, name); err != nil {
-			return err
+			return nil, err
 		}
 		if info.Mode().Perm() != 0o600 {
-			return fmt.Errorf("%s must have mode 0600", name)
+			return nil, fmt.Errorf("%s must have mode 0600", name)
 		}
 	}
 	if _, err := readPassword(filepath.Join(config.SecretsDir, fleetEtcdPasswordFile)); err != nil {
-		return fmt.Errorf("required password file %s: %w", fleetEtcdPasswordFile, err)
+		return nil, fmt.Errorf("required password file %s: %w", fleetEtcdPasswordFile, err)
 	}
+	var profile fleetApplicationProfile
 	if config.isDatabaseNode() {
-		if err := validateFleetEnvironment(filepath.Join(config.SecretsDir, fleetEnvironmentFile)); err != nil {
-			return fmt.Errorf("required Fleet environment file %s: %w", fleetEnvironmentFile, err)
+		profile, err = loadValidatedFleetApplicationProfile(filepath.Join(config.SecretsDir, fleetEnvironmentFile))
+		if err != nil {
+			return nil, fmt.Errorf("required Fleet environment file %s: %w", fleetEnvironmentFile, err)
 		}
 		for _, name := range databasePasswordFiles {
 			if _, err := readPassword(filepath.Join(config.SecretsDir, name)); err != nil {
-				return fmt.Errorf("required password file %s: %w", name, err)
+				return nil, fmt.Errorf("required password file %s: %w", name, err)
 			}
 		}
 	}
 
-	return nil
+	return profile, nil
 }
 
-func validateFleetEnvironment(path string) error {
+func loadValidatedFleetApplicationProfile(path string) (fleetApplicationProfile, error) {
 	values, err := loadFleetEnvironment(path)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if values["DB_DSN"] == "" {
-		return errors.New("DB_DSN is required")
+		return nil, errors.New("DB_DSN is required")
 	}
 	if len(values["AUTH_CLIENT_SECRET_KEY"]) < 32 {
-		return errors.New("AUTH_CLIENT_SECRET_KEY must contain at least 32 characters")
+		return nil, errors.New("AUTH_CLIENT_SECRET_KEY must contain at least 32 characters")
 	}
 	masterKey, err := base64.StdEncoding.DecodeString(values["ENCRYPT_SERVICE_MASTER_KEY"])
 	if err != nil || len(masterKey) != 32 {
-		return errors.New("ENCRYPT_SERVICE_MASTER_KEY must be a base64-encoded 32-byte key")
+		return nil, errors.New("ENCRYPT_SERVICE_MASTER_KEY must be a base64-encoded 32-byte key")
 	}
 	for _, key := range []string{
 		"GRAFANA_ADMIN_PASSWORD",
@@ -315,10 +323,20 @@ func validateFleetEnvironment(path string) error {
 		"FLEET_ALERTS_WEBHOOK_TOKEN",
 	} {
 		if len(values[key]) < 32 {
-			return fmt.Errorf("%s must contain at least 32 characters", key)
+			return nil, fmt.Errorf("%s must contain at least 32 characters", key)
 		}
 	}
-	return nil
+	return fleetApplicationProfileFromValues(values, true)
+}
+
+var fleetSecretEnvironmentKeys = []string{
+	"AUTH_CLIENT_SECRET_KEY",
+	"DB_DSN",
+	"ENCRYPT_SERVICE_MASTER_KEY",
+	"FLEET_ALERTS_WEBHOOK_TOKEN",
+	"GRAFANA_ADMIN_PASSWORD",
+	"GRAFANA_DB_PASSWORD",
+	"GRAFANA_SECRET_KEY",
 }
 
 func loadFleetEnvironment(path string) (map[string]string, error) {
@@ -336,20 +354,19 @@ func loadFleetEnvironment(path string) (map[string]string, error) {
 	}
 	defer file.Close()
 
-	allowed := map[string]struct{}{
-		"AUTH_CLIENT_SECRET_KEY": {}, "ENCRYPT_SERVICE_MASTER_KEY": {}, "DB_DSN": {},
-		"GRAFANA_ADMIN_PASSWORD": {}, "GRAFANA_DB_PASSWORD": {}, "GRAFANA_SECRET_KEY": {},
-		"FLEET_ALERTS_WEBHOOK_TOKEN": {},
-	}
-	values := make(map[string]string, len(allowed))
-	scanner := bufio.NewScanner(file)
+	return parseFleetEnvironment(file)
+}
+
+func parseFleetEnvironment(reader io.Reader) (map[string]string, error) {
+	values := make(map[string]string, len(fleetSecretEnvironmentKeys)+len(fleetDeploymentEnvironmentKeys))
+	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {
 		match := envLine.FindStringSubmatch(scanner.Text())
 		if match == nil {
 			return nil, errors.New("contains a malformed entry")
 		}
 		key := match[1]
-		if _, ok := allowed[key]; !ok {
+		if !slices.Contains(fleetSecretEnvironmentKeys, key) && !slices.Contains(fleetDeploymentEnvironmentKeys, key) {
 			return nil, fmt.Errorf("contains unknown key: %s", key)
 		}
 		if _, duplicate := values[key]; duplicate {

--- a/server/internal/ha/deployment/start.go
+++ b/server/internal/ha/deployment/start.go
@@ -67,7 +67,7 @@ func StartInstalledServices(ctx context.Context, envPath, rootPasswordFile strin
 	if err := RunCompose(ctx, []string{"--env-file", envPath, "--file", infrastructureCompose, "--profile", "database", "up", "-d", "--no-build", "--pull", "never", "patroni"}); err != nil {
 		return fmt.Errorf("start Patroni: %w", err)
 	}
-	if err := RunCompose(ctx, fleetApplicationComposeArgs("up", "-d", "--no-build", "--pull", "never", "--wait", "--wait-timeout", "60")); err != nil {
+	if err := startFleetApplication(ctx, installRoot, "-d", "--no-build", "--pull", "never", "--wait", "--wait-timeout", "60"); err != nil {
 		return fmt.Errorf("start Fleet: %w", err)
 	}
 	return nil
@@ -168,7 +168,7 @@ func StopInstalledServices(ctx context.Context, envPath string) error {
 	}
 	var stopFleetErr error
 	if config.isDatabaseNode() {
-		args, err := fleetComposeArgsForInstalledProfile("down")
+		args, err := fleetApplicationDownArgsAt(installRoot, installedFleetEnvironment, haGrafanaVolumeOwnershipMarker)
 		if err != nil {
 			stopFleetErr = fmt.Errorf("stop Fleet: %w", err)
 		} else if err := RunCompose(ctx, args); err != nil {

--- a/server/internal/ha/deployment/update.go
+++ b/server/internal/ha/deployment/update.go
@@ -103,28 +103,32 @@ func ValidateActiveUpdate(ctx context.Context, envPath, targetVersion string) er
 
 // PrepareApplicationUpdate loads the HA application from a verified release.
 func PrepareApplicationUpdate(ctx context.Context, root string) error {
-	if err := requireUpdateCompatibleProfile(filepath.Join(configRoot, fleetEnvironmentFile)); err != nil {
+	profile, err := loadUpdateCompatibleProfile(filepath.Join(configRoot, fleetEnvironmentFile))
+	if err != nil {
 		return err
 	}
-	return prepareApplicationUpdate(ctx, root, defaultInstallDependencies(), RunCompose)
+	return prepareApplicationUpdate(ctx, root, profile, defaultInstallDependencies(), RunCompose)
 }
 
-func requireUpdateCompatibleProfile(path string) error {
-	if err := validateFleetEnvironment(path); err != nil {
-		return fmt.Errorf("installed HA profile is incompatible with this release; reinstall both database hosts before updating: %w", err)
+func loadUpdateCompatibleProfile(path string) (fleetApplicationProfile, error) {
+	profile, err := loadValidatedFleetApplicationProfile(path)
+	if err != nil {
+		return nil, fmt.Errorf("installed HA profile is incompatible with this release; reinstall both database hosts before updating: %w", err)
 	}
-	return nil
+	return profile, nil
 }
 
-func prepareApplicationUpdate(ctx context.Context, root string, deps installDependencies, runCompose func(context.Context, []string) error) error {
+func prepareApplicationUpdate(ctx context.Context, root string, profile fleetApplicationProfile, deps installDependencies, runCompose func(context.Context, []string) error) error {
 	if err := validateRelease(root, deps.readFile); err != nil {
 		return err
 	}
-	if err := runCompose(ctx, fleetApplicationComposeArgsAt(root, "config", "--quiet")); err != nil {
+	if err := runCompose(ctx, fleetApplicationComposeArgsAtProfile(root, installedFleetEnvironment, profile, "config", "--quiet")); err != nil {
 		return fmt.Errorf("validate HA application update Compose model: %w", err)
 	}
-	if err := runCompose(ctx, fleetComposeArgsAt(root, "pull", "grafana")); err != nil {
-		return fmt.Errorf("stage HA Grafana image: %w", err)
+	if pullArgs := fleetSidecarPullArgs(root, installedFleetEnvironment, profile); pullArgs != nil {
+		if err := runCompose(ctx, pullArgs); err != nil {
+			return fmt.Errorf("stage HA application sidecar images: %w", err)
+		}
 	}
 	if output, err := deps.run(ctx, "docker", "load", "--input", filepath.Join(root, "images", "fleet.tar.gz")); err != nil {
 		return fmt.Errorf("load HA application update images: %s", commandError(output, err))
@@ -158,14 +162,18 @@ func StopApplication(ctx context.Context, root string, expectedRole ha.RuntimeRo
 	// The crash-only design intentionally has no maintenance lease. If the role
 	// changes after this final proof, normal update recovery restarts Fleet.
 	composeCtx := ctx
-	args := fleetApplicationComposeArgsAt(root, "stop")
+	var flags []string
 	if expectedRole == ha.RoleActive {
+		flags = []string{"--timeout", "1"}
 		// Bound only the serving node's interruption. A passive stop is not on the
 		// availability path and can use Compose's normal shutdown behavior.
 		stopCtx, cancel := context.WithTimeout(ctx, ha.UpdateActiveStopTimeout)
 		defer cancel()
 		composeCtx = stopCtx
-		args = fleetApplicationComposeArgsAt(root, "stop", "--timeout", "1")
+	}
+	args, err := fleetApplicationDownArgsAt(root, installedFleetEnvironment, haGrafanaVolumeOwnershipMarker, flags...)
+	if err != nil {
+		return fmt.Errorf("load HA application profile: %w", err)
 	}
 	if err := RunCompose(composeCtx, args); err != nil {
 		return fmt.Errorf("stop HA application: %w", err)
@@ -206,8 +214,7 @@ func StartApplication(ctx context.Context, root, targetVersion string, requirePa
 	if statusErr != nil && !errors.Is(statusErr, syscall.ECONNREFUSED) {
 		return fmt.Errorf("verify local HA application is stopped: %w", statusErr)
 	}
-	args := fleetApplicationComposeArgsAt(root, "up", "-d", "--no-deps", "--no-build", "--pull", "never", "--wait", "--wait-timeout", "60")
-	if err := RunCompose(ctx, args); err != nil {
+	if err := startFleetApplication(ctx, root, "-d", "--no-deps", "--no-build", "--pull", "never", "--wait", "--wait-timeout", "60"); err != nil {
 		return fmt.Errorf("start HA application: %w", err)
 	}
 	for {

--- a/server/internal/ha/deployment/update_test.go
+++ b/server/internal/ha/deployment/update_test.go
@@ -79,7 +79,6 @@ func TestPrepareApplicationUpdateStopsBeforeImageLoadWhenComposeValidationFails(
 	// Arrange
 	root := testInstallRelease(t)
 	composeErr := errors.New("invalid target Compose model")
-	var composeArgs []string
 	var commands []string
 	deps := installDependencies{
 		readFile: os.ReadFile,
@@ -90,23 +89,12 @@ func TestPrepareApplicationUpdateStopsBeforeImageLoadWhenComposeValidationFails(
 	}
 
 	// Act
-	err := prepareApplicationUpdate(context.Background(), root, deps, func(_ context.Context, args []string) error {
-		composeArgs = append([]string(nil), args...)
+	err := prepareApplicationUpdate(context.Background(), root, fleetApplicationProfile{"ENABLE_BETA_ALERTS": "true"}, deps, func(_ context.Context, _ []string) error {
 		return composeErr
 	})
 
 	// Assert
 	require.ErrorIs(t, err, composeErr)
-	require.Equal(t, []string{
-		"--project-name", "deployment",
-		"--env-file", filepath.Join(configRoot, "base.env"),
-		"--env-file", filepath.Join(configRoot, fleetEnvironmentFile),
-		"--env-file", filepath.Join(configRoot, "node.env"),
-		"--file", filepath.Join(root, "docker-compose.yaml"),
-		"--file", filepath.Join(root, "docker-compose.alerts.yaml"),
-		"--file", filepath.Join(root, "ha", "fleet-compose.yaml"),
-		"config", "--quiet", "fleet-api", "fleet-client", "grafana",
-	}, composeArgs)
 	require.Empty(t, commands)
 }
 
@@ -123,7 +111,7 @@ func TestPrepareApplicationUpdateRecordsActiveInstallForExistingHADeployment(t *
 	}
 
 	// Act
-	err := prepareApplicationUpdate(t.Context(), root, deps, func(context.Context, []string) error { return nil })
+	err := prepareApplicationUpdate(t.Context(), root, fleetApplicationProfile{"ENABLE_BETA_ALERTS": "true"}, deps, func(context.Context, []string) error { return nil })
 
 	// Assert
 	require.NoError(t, err)
@@ -138,7 +126,7 @@ func TestUpdateCompatibilityRejectsPreGrafanaProfile(t *testing.T) {
 			"DB_DSN=postgresql://fleet:test@db/fleet\n",
 	), 0o600))
 
-	err := requireUpdateCompatibleProfile(path)
+	_, err := loadUpdateCompatibleProfile(path)
 
 	require.ErrorContains(t, err, "reinstall both database hosts")
 }


### PR DESCRIPTION
Reviewable diff: +633/-208 across 14 files (excludes generated, test, and story files).

## Summary

High-availability installs and updates now preserve the operator's feature configuration instead of always starting the alerting stack and ignoring tracing and system-monitoring flags. The HA installer validates and stores the selected profile on both database hosts, while updates reload that profile so enabled sidecars remain enabled and disabled sidecars are removed cleanly. Existing HA installations retain beta alerts by default during migration.

## How it works

The guided installer captures the supported `ENABLE_*` and Datadog settings before executing privileged or remote setup. It validates flag dependencies and tracing credentials, writes a root-protected `fleet.env` only to HA database nodes, and includes the profile in prepared peer bundles. Install, start, preflight, and update commands then build the Fleet Compose project from the base files plus only the alerting, system-monitoring, and tracing overlays selected by that profile.

Updates reload the installed profile before staging images or validating Compose. They stop the current application, start the selected services, and use Compose orphan removal so sidecars disappear when a feature is disabled. Core HA readiness remains required; optional tracing health is reported separately so telemetry failures are visible without taking the Fleet application out of service.

## Diagrams

```mermaid
flowchart LR
  O["Operator ENABLE_* inputs"] --> I["HA guided installer"]
  I --> P["Protected fleet.env on ha-a and ha-b"]
  P --> C["Profile-aware Compose builder"]
  C --> A["Alerts and Grafana overlay"]
  C --> S["System-monitoring overlay"]
  C --> T["Tracing and OTel overlay"]
  U["Host updater"] --> P
```

```mermaid
sequenceDiagram
  participant O as Operator
  participant I as HA installer
  participant H as HA hosts
  participant U as Updater
  O->>I: Select ENABLE_* features
  I->>H: Install protected profile and role bundle
  H->>H: Start selected Compose overlays
  U->>H: Reload persisted profile
  U->>H: Preflight, stage, remove orphans, restart
  H-->>U: HA readiness and sidecar health
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `deployment-files/ha/` | Split alerts, system monitoring, and tracing into selectable HA Compose overlays; documented the persisted profile | Defines the runtime topology for each feature combination |
| `deployment-files/install.sh` | Captures and migrates HA feature settings while isolating `DD_API_KEY` from setup and download subprocesses | Controls compatibility and secret exposure during install and upgrade |
| `deployment-files/server/otel-collector-config.datadog.yaml` | Makes invalid Datadog credentials fail collector health and adds HA hostname handling | Keeps tracing best-effort but visibly degraded when misconfigured |
| `server/internal/ha/deployment/application_profile.go` | Parses, validates, renders, and persists the supported HA application environment | Central validation and migration boundary for feature flags |
| `server/internal/ha/deployment/{compose,install,preflight,start,update,guided_install}.go` | Threads the installed profile through every application lifecycle operation | Ensures install and update use the same selected services |
| HA deployment and shell tests | Adds coverage for profile combinations, migration, secret isolation, Compose selection, and lifecycle behavior | Guards upgrades and feature disablement paths |

## Key technical decisions & trade-offs

- Persist the feature profile on each database host instead of relying on the invoking shell's transient environment, so unattended updates reproduce the installed topology.
- Default beta alerts to enabled for existing HA installations, preserving the established Grafana-backed readiness contract; system monitoring and tracing remain opt-in.
- Require beta alerts when system monitoring is enabled because its metrics writer and provisioned rules share the alerting stack.
- Treat tracing as best-effort for Fleet availability while exposing collector health warnings and failing fast on invalid credentials.
- Pin optional sidecar images by digest, pass only required environment values, and remove Compose orphans so disabling a feature removes its old containers.

## Testing & validation

- Local Codex correctness, security, and simplification reviews completed; correctness and security were clean.
- Full non-E2E PR workflow coverage passed locally: deployment shell suites, client lint/typecheck/unit/build, server lint/build/database tests, proto lint, plugin builds/tests/contract tests, Rust and Python SDK/generator suites, PowerShell checks, and .NET restore/format/build/publish.
- Generation and diff checks passed with no generated-code drift.
- Windows-only `ps2exe` packaging is covered by Windows PR CI; its PowerShell parsing, guard checks, analyzers, and underlying .NET installer publish passed locally in containers.
- E2E suites were not run, per request. Visual snapshot baselines were not changed.
