### PR TITLE
ci: add extended Codex timeout benchmark

### DIFF
--- a/.github/scripts/codex_sharding_test.py
+++ b/.github/scripts/codex_sharding_test.py
@@ -1096,6 +1096,7 @@ class WorkflowInvariantTest(unittest.TestCase):
             "--corpus-file .codex-trusted/.github/codex-benchmark-corpus.json", called
         )
         self.assertIn("codex-security-review-terra-benchmark", parent)
+        self.assertIn("codex-security-review-extended-timeout-benchmark", parent)
         self.assertIn("&& 'unified-40' || 'all'", parent)
 
     def test_shard_prompt_comes_from_trusted_checkout(self):

--- a/.github/scripts/evaluate_review_policy_test.py
+++ b/.github/scripts/evaluate_review_policy_test.py
@@ -232,9 +232,6 @@ const github = {
         "REVIEW_AGENT_RESULT": scenario.get("agent_result", "success"),
         "REVIEW_AGENT_JOB_NAME": "Run bounded Codex reviewer",
         "CODEX_TIMEOUT_MINUTES": scenario.get("timeout_minutes", "9"),
-        "CODEX_JOB_TIMEOUT_MINUTES": scenario.get(
-            "job_timeout_minutes", scenario.get("timeout_minutes", "9")
-        ),
         "CODEX_CANCELLATION_CLEANUP_SECONDS": scenario.get("cleanup_seconds", "300"),
         "AGENT_JOB_NAME": scenario.get("agent_job_name", "Run bounded Codex reviewer"),
         "SHARD_JOB_ID": str(scenario.get("shard_job_id", 456)),
@@ -679,37 +676,6 @@ class ReviewPolicyTest(unittest.TestCase):
         self.assertNotIn("issues: write", workflow_text)
         self.assertNotIn("pull-requests: write", workflow_text)
 
-    def test_extended_timeout_reserves_trusted_setup_allowance(self):
-        workflow = load_workflow("codex-security-review-benchmark.yml")
-        setup = find_step(workflow, "benchmark-review", "validate_setup")
-        job_start = find_step(workflow, "benchmark-review", "job_start")
-        extended_event = (
-            "${{ github.event.action == "
-            "'codex-security-review-extended-timeout-benchmark' }}"
-        )
-        self.assertEqual(job_start["if"], extended_event)
-        self.assertEqual(setup["if"], extended_event)
-        script = setup["run"]
-
-        for name, max_setup_seconds, elapsed_seconds, expected_code in (
-            ("existing-profile-no-limit", "0", 300, 0),
-            ("extended-within-allowance", "45", 44, 0),
-            ("extended-over-allowance", "45", 46, 1),
-        ):
-            with self.subTest(name=name):
-                result = subprocess.run(
-                    ["bash", "-c", script],
-                    env={
-                        **os.environ,
-                        "CODEX_MAX_SETUP_SECONDS": max_setup_seconds,
-                        "JOB_STARTED_AT": str(int(time.time()) - elapsed_seconds),
-                    },
-                    check=False,
-                    capture_output=True,
-                    text=True,
-                )
-                self.assertEqual(result.returncode, expected_code, result.stderr)
-
     def test_codex_benchmark_matrix_comes_from_needs_not_the_matrix_context(self):
         workflow = load_workflow("codex-security-review-benchmark.yml")
         job = workflow["jobs"]["benchmark-review"]
@@ -734,8 +700,6 @@ class ReviewPolicyTest(unittest.TestCase):
                 "verbosity": "${{ steps.select.outputs.verbosity }}",
                 "codex_args": "${{ steps.select.outputs.codex_args }}",
                 "timeout_minutes": "${{ steps.select.outputs.timeout_minutes }}",
-                "job_timeout_minutes": "${{ steps.select.outputs.job_timeout_minutes }}",
-                "max_setup_seconds": "${{ steps.select.outputs.max_setup_seconds }}",
                 "prompt_profile": "${{ steps.select.outputs.prompt_profile }}",
                 "repeat": "${{ steps.select.outputs.repeat }}",
             },
@@ -798,8 +762,6 @@ class ReviewPolicyTest(unittest.TestCase):
             ["-c", "model_reasoning_effort=xhigh"],
         )
         self.assertEqual(outputs["timeout_minutes"], "12")
-        self.assertEqual(outputs["job_timeout_minutes"], "12")
-        self.assertEqual(outputs["max_setup_seconds"], "0")
         self.assertEqual(outputs["prompt_profile"], "baseline")
         self.assertEqual(outputs["repeat"], "initial")
         self.assertEqual(len(include), len(adjudicated) * len(corpus["variants"]))
@@ -851,8 +813,6 @@ class ReviewPolicyTest(unittest.TestCase):
         self.assertEqual(outputs["service_tier"], "default")
         self.assertEqual(outputs["verbosity"], "low")
         self.assertEqual(outputs["timeout_minutes"], "12")
-        self.assertEqual(outputs["job_timeout_minutes"], "12")
-        self.assertEqual(outputs["max_setup_seconds"], "0")
         self.assertEqual(
             json.loads(outputs["codex_args"]),
             [
@@ -897,8 +857,6 @@ class ReviewPolicyTest(unittest.TestCase):
         self.assertEqual(outputs["service_tier"], "unspecified")
         self.assertEqual(outputs["verbosity"], "unspecified")
         self.assertEqual(outputs["timeout_minutes"], "14")
-        self.assertEqual(outputs["job_timeout_minutes"], "15")
-        self.assertEqual(outputs["max_setup_seconds"], "45")
         self.assertEqual(
             json.loads(outputs["codex_args"]),
             ["-c", "model_reasoning_effort=xhigh"],
@@ -1000,22 +958,11 @@ class ReviewPolicyTest(unittest.TestCase):
             int(production_job["env"]["CODEX_TIMEOUT_MINUTES"]),
         )
         selected_timeout = "${{ needs.select-cases.outputs.timeout_minutes }}"
-        selected_job_timeout = "${{ needs.select-cases.outputs.job_timeout_minutes }}"
         dynamic_timeout = "${{ fromJSON(needs.select-cases.outputs.timeout_minutes) }}"
-        dynamic_job_timeout = (
-            "${{ fromJSON(needs.select-cases.outputs.job_timeout_minutes) }}"
-        )
         self.assertEqual(benchmark_codex["timeout-minutes"], dynamic_timeout)
-        self.assertEqual(benchmark_job["timeout-minutes"], dynamic_job_timeout)
+        self.assertEqual(benchmark_job["timeout-minutes"], dynamic_timeout)
         self.assertEqual(
             benchmark_job["env"]["CODEX_TIMEOUT_MINUTES"], selected_timeout
-        )
-        self.assertEqual(
-            benchmark_job["env"]["CODEX_JOB_TIMEOUT_MINUTES"], selected_job_timeout
-        )
-        self.assertEqual(
-            benchmark_job["env"]["CODEX_MAX_SETUP_SECONDS"],
-            "${{ needs.select-cases.outputs.max_setup_seconds }}",
         )
         self.assertEqual(
             production_finalizer["env"]["CODEX_TIMEOUT_MINUTES"],
@@ -1033,15 +980,14 @@ class ReviewPolicyTest(unittest.TestCase):
             benchmark_finalizer["env"]["CODEX_TIMEOUT_MINUTES"], selected_timeout
         )
         self.assertEqual(
-            benchmark_finalizer["env"]["CODEX_JOB_TIMEOUT_MINUTES"],
-            selected_job_timeout,
-        )
-        self.assertEqual(
             benchmark_finalizer["env"]["CODEX_CANCELLATION_CLEANUP_SECONDS"],
             "300",
         )
         self.assertLessEqual(
             production_codex["timeout-minutes"], production_job["timeout-minutes"]
+        )
+        self.assertEqual(
+            benchmark_codex["timeout-minutes"], benchmark_job["timeout-minutes"]
         )
 
     def test_codex_benchmark_records_timeouts_distinctly_from_failures(self):
@@ -1157,7 +1103,7 @@ class ReviewPolicyTest(unittest.TestCase):
 
         self.assertEqual(
             review_job["timeout-minutes"],
-            "${{ fromJSON(needs.select-cases.outputs.job_timeout_minutes) }}",
+            "${{ fromJSON(needs.select-cases.outputs.timeout_minutes) }}",
         )
         self.assertEqual(finalizer["needs"], ["select-cases", "benchmark-review"])
         self.assertIn("always()", finalizer["if"])
@@ -1178,11 +1124,6 @@ class ReviewPolicyTest(unittest.TestCase):
                 "Require benchmark API key",
             )
         ]
-        extended_successful_steps = [
-            {"name": "Record trusted benchmark job start", "conclusion": "success"},
-            *successful_steps,
-            {"name": "Validate benchmark setup allowance", "conclusion": "success"},
-        ]
         timeout_job = {
             "name": "pr-957 / unified-40 / initial",
             "conclusion": "cancelled",
@@ -1198,19 +1139,11 @@ class ReviewPolicyTest(unittest.TestCase):
                 },
             ],
         }
-        extended_timeout_job = {
-            **timeout_job,
-            "steps": [
-                *extended_successful_steps,
-                timeout_job["steps"][-1],
-            ],
-        }
         inspect_cases = [
-            ("budget-timeout", timeout_job, "12", "12", "budget-timeout"),
+            ("budget-timeout", timeout_job, "12", "budget-timeout"),
             (
                 "early-cancellation",
                 {**timeout_job, "completed_at": "2026-08-26T00:05:00Z"},
-                "12",
                 "12",
                 "unexpected-cancellation",
             ),
@@ -1218,55 +1151,28 @@ class ReviewPolicyTest(unittest.TestCase):
                 "cancellation-plus-cleanup",
                 {**timeout_job, "completed_at": "2026-08-26T00:12:00Z"},
                 "12",
-                "12",
                 "unexpected-cancellation",
             ),
             (
                 "setup-cancellation",
                 {**timeout_job, "steps": successful_steps[:1]},
                 "12",
-                "12",
                 "unexpected-cancellation",
             ),
             (
                 "extended-timeout-budget-plus-cleanup",
-                {
-                    **extended_timeout_job,
-                    "completed_at": "2026-08-26T00:20:00Z",
-                },
+                {**timeout_job, "completed_at": "2026-08-26T00:19:00Z"},
                 "14",
-                "15",
                 "budget-timeout",
             ),
             (
                 "extended-timeout-insufficient-evidence",
-                {
-                    **extended_timeout_job,
-                    "completed_at": "2026-08-26T00:19:59Z",
-                },
+                {**timeout_job, "completed_at": "2026-08-26T00:18:59Z"},
                 "14",
-                "15",
-                "unexpected-cancellation",
-            ),
-            (
-                "extended-timeout-missing-setup-evidence",
-                {
-                    **extended_timeout_job,
-                    "steps": timeout_job["steps"],
-                    "completed_at": "2026-08-26T00:20:00Z",
-                },
-                "14",
-                "15",
                 "unexpected-cancellation",
             ),
         ]
-        for (
-            name,
-            job,
-            timeout_minutes,
-            job_timeout_minutes,
-            expected_classification,
-        ) in inspect_cases:
+        for name, job, timeout_minutes, expected_classification in inspect_cases:
             with self.subTest(inspect=name), tempfile.TemporaryDirectory() as tmp:
                 completed, output = run_github_script(
                     inspect_script,
@@ -1275,7 +1181,6 @@ class ReviewPolicyTest(unittest.TestCase):
                         "artifacts": [],
                         "agent_job_name": timeout_job["name"],
                         "timeout_minutes": timeout_minutes,
-                        "job_timeout_minutes": job_timeout_minutes,
                     },
                     tmp,
                 )

--- a/.github/scripts/evaluate_review_policy_test.py
+++ b/.github/scripts/evaluate_review_policy_test.py
@@ -232,6 +232,9 @@ const github = {
         "REVIEW_AGENT_RESULT": scenario.get("agent_result", "success"),
         "REVIEW_AGENT_JOB_NAME": "Run bounded Codex reviewer",
         "CODEX_TIMEOUT_MINUTES": scenario.get("timeout_minutes", "9"),
+        "CODEX_JOB_TIMEOUT_MINUTES": scenario.get(
+            "job_timeout_minutes", scenario.get("timeout_minutes", "9")
+        ),
         "CODEX_CANCELLATION_CLEANUP_SECONDS": scenario.get("cleanup_seconds", "300"),
         "AGENT_JOB_NAME": scenario.get("agent_job_name", "Run bounded Codex reviewer"),
         "SHARD_JOB_ID": str(scenario.get("shard_job_id", 456)),
@@ -620,7 +623,10 @@ class ReviewPolicyTest(unittest.TestCase):
             "github.event.action == 'codex-security-review-terra-benchmark' || "
             "github.event.action == 'codex-security-review-extended-timeout-benchmark'"
         )
-        self.assertEqual(job["if"], f"${{{{ {unsharded_events} }}}}")
+        self.assertEqual(
+            job["if"],
+            f"${{{{ needs.select-cases.result == 'success' && ({unsharded_events}) }}}}",
+        )
         self.assertIn(unsharded_events, workflow["jobs"]["benchmark-finalize"]["if"])
         self.assertNotIn("workflow_dispatch:", workflow_text)
         self.assertNotIn("${{ inputs", workflow_text)
@@ -673,6 +679,37 @@ class ReviewPolicyTest(unittest.TestCase):
         self.assertNotIn("issues: write", workflow_text)
         self.assertNotIn("pull-requests: write", workflow_text)
 
+    def test_extended_timeout_reserves_trusted_setup_allowance(self):
+        workflow = load_workflow("codex-security-review-benchmark.yml")
+        setup = find_step(workflow, "benchmark-review", "validate_setup")
+        job_start = find_step(workflow, "benchmark-review", "job_start")
+        extended_event = (
+            "${{ github.event.action == "
+            "'codex-security-review-extended-timeout-benchmark' }}"
+        )
+        self.assertEqual(job_start["if"], extended_event)
+        self.assertEqual(setup["if"], extended_event)
+        script = setup["run"]
+
+        for name, max_setup_seconds, elapsed_seconds, expected_code in (
+            ("existing-profile-no-limit", "0", 300, 0),
+            ("extended-within-allowance", "45", 44, 0),
+            ("extended-over-allowance", "45", 46, 1),
+        ):
+            with self.subTest(name=name):
+                result = subprocess.run(
+                    ["bash", "-c", script],
+                    env={
+                        **os.environ,
+                        "CODEX_MAX_SETUP_SECONDS": max_setup_seconds,
+                        "JOB_STARTED_AT": str(int(time.time()) - elapsed_seconds),
+                    },
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertEqual(result.returncode, expected_code, result.stderr)
+
     def test_codex_benchmark_matrix_comes_from_needs_not_the_matrix_context(self):
         workflow = load_workflow("codex-security-review-benchmark.yml")
         job = workflow["jobs"]["benchmark-review"]
@@ -697,6 +734,8 @@ class ReviewPolicyTest(unittest.TestCase):
                 "verbosity": "${{ steps.select.outputs.verbosity }}",
                 "codex_args": "${{ steps.select.outputs.codex_args }}",
                 "timeout_minutes": "${{ steps.select.outputs.timeout_minutes }}",
+                "job_timeout_minutes": "${{ steps.select.outputs.job_timeout_minutes }}",
+                "max_setup_seconds": "${{ steps.select.outputs.max_setup_seconds }}",
                 "prompt_profile": "${{ steps.select.outputs.prompt_profile }}",
                 "repeat": "${{ steps.select.outputs.repeat }}",
             },
@@ -759,6 +798,8 @@ class ReviewPolicyTest(unittest.TestCase):
             ["-c", "model_reasoning_effort=xhigh"],
         )
         self.assertEqual(outputs["timeout_minutes"], "12")
+        self.assertEqual(outputs["job_timeout_minutes"], "12")
+        self.assertEqual(outputs["max_setup_seconds"], "0")
         self.assertEqual(outputs["prompt_profile"], "baseline")
         self.assertEqual(outputs["repeat"], "initial")
         self.assertEqual(len(include), len(adjudicated) * len(corpus["variants"]))
@@ -810,6 +851,8 @@ class ReviewPolicyTest(unittest.TestCase):
         self.assertEqual(outputs["service_tier"], "default")
         self.assertEqual(outputs["verbosity"], "low")
         self.assertEqual(outputs["timeout_minutes"], "12")
+        self.assertEqual(outputs["job_timeout_minutes"], "12")
+        self.assertEqual(outputs["max_setup_seconds"], "0")
         self.assertEqual(
             json.loads(outputs["codex_args"]),
             [
@@ -854,6 +897,8 @@ class ReviewPolicyTest(unittest.TestCase):
         self.assertEqual(outputs["service_tier"], "unspecified")
         self.assertEqual(outputs["verbosity"], "unspecified")
         self.assertEqual(outputs["timeout_minutes"], "14")
+        self.assertEqual(outputs["job_timeout_minutes"], "15")
+        self.assertEqual(outputs["max_setup_seconds"], "45")
         self.assertEqual(
             json.loads(outputs["codex_args"]),
             ["-c", "model_reasoning_effort=xhigh"],
@@ -955,11 +1000,22 @@ class ReviewPolicyTest(unittest.TestCase):
             int(production_job["env"]["CODEX_TIMEOUT_MINUTES"]),
         )
         selected_timeout = "${{ needs.select-cases.outputs.timeout_minutes }}"
+        selected_job_timeout = "${{ needs.select-cases.outputs.job_timeout_minutes }}"
         dynamic_timeout = "${{ fromJSON(needs.select-cases.outputs.timeout_minutes) }}"
+        dynamic_job_timeout = (
+            "${{ fromJSON(needs.select-cases.outputs.job_timeout_minutes) }}"
+        )
         self.assertEqual(benchmark_codex["timeout-minutes"], dynamic_timeout)
-        self.assertEqual(benchmark_job["timeout-minutes"], dynamic_timeout)
+        self.assertEqual(benchmark_job["timeout-minutes"], dynamic_job_timeout)
         self.assertEqual(
             benchmark_job["env"]["CODEX_TIMEOUT_MINUTES"], selected_timeout
+        )
+        self.assertEqual(
+            benchmark_job["env"]["CODEX_JOB_TIMEOUT_MINUTES"], selected_job_timeout
+        )
+        self.assertEqual(
+            benchmark_job["env"]["CODEX_MAX_SETUP_SECONDS"],
+            "${{ needs.select-cases.outputs.max_setup_seconds }}",
         )
         self.assertEqual(
             production_finalizer["env"]["CODEX_TIMEOUT_MINUTES"],
@@ -977,14 +1033,15 @@ class ReviewPolicyTest(unittest.TestCase):
             benchmark_finalizer["env"]["CODEX_TIMEOUT_MINUTES"], selected_timeout
         )
         self.assertEqual(
+            benchmark_finalizer["env"]["CODEX_JOB_TIMEOUT_MINUTES"],
+            selected_job_timeout,
+        )
+        self.assertEqual(
             benchmark_finalizer["env"]["CODEX_CANCELLATION_CLEANUP_SECONDS"],
             "300",
         )
         self.assertLessEqual(
             production_codex["timeout-minutes"], production_job["timeout-minutes"]
-        )
-        self.assertEqual(
-            benchmark_codex["timeout-minutes"], benchmark_job["timeout-minutes"]
         )
 
     def test_codex_benchmark_records_timeouts_distinctly_from_failures(self):
@@ -1100,7 +1157,7 @@ class ReviewPolicyTest(unittest.TestCase):
 
         self.assertEqual(
             review_job["timeout-minutes"],
-            "${{ fromJSON(needs.select-cases.outputs.timeout_minutes) }}",
+            "${{ fromJSON(needs.select-cases.outputs.job_timeout_minutes) }}",
         )
         self.assertEqual(finalizer["needs"], ["select-cases", "benchmark-review"])
         self.assertIn("always()", finalizer["if"])
@@ -1121,6 +1178,11 @@ class ReviewPolicyTest(unittest.TestCase):
                 "Require benchmark API key",
             )
         ]
+        extended_successful_steps = [
+            {"name": "Record trusted benchmark job start", "conclusion": "success"},
+            *successful_steps,
+            {"name": "Validate benchmark setup allowance", "conclusion": "success"},
+        ]
         timeout_job = {
             "name": "pr-957 / unified-40 / initial",
             "conclusion": "cancelled",
@@ -1136,11 +1198,19 @@ class ReviewPolicyTest(unittest.TestCase):
                 },
             ],
         }
+        extended_timeout_job = {
+            **timeout_job,
+            "steps": [
+                *extended_successful_steps,
+                timeout_job["steps"][-1],
+            ],
+        }
         inspect_cases = [
-            ("budget-timeout", timeout_job, "12", "budget-timeout"),
+            ("budget-timeout", timeout_job, "12", "12", "budget-timeout"),
             (
                 "early-cancellation",
                 {**timeout_job, "completed_at": "2026-08-26T00:05:00Z"},
+                "12",
                 "12",
                 "unexpected-cancellation",
             ),
@@ -1148,28 +1218,55 @@ class ReviewPolicyTest(unittest.TestCase):
                 "cancellation-plus-cleanup",
                 {**timeout_job, "completed_at": "2026-08-26T00:12:00Z"},
                 "12",
+                "12",
                 "unexpected-cancellation",
             ),
             (
                 "setup-cancellation",
                 {**timeout_job, "steps": successful_steps[:1]},
                 "12",
+                "12",
                 "unexpected-cancellation",
             ),
             (
                 "extended-timeout-budget-plus-cleanup",
-                {**timeout_job, "completed_at": "2026-08-26T00:19:00Z"},
+                {
+                    **extended_timeout_job,
+                    "completed_at": "2026-08-26T00:20:00Z",
+                },
                 "14",
+                "15",
                 "budget-timeout",
             ),
             (
                 "extended-timeout-insufficient-evidence",
-                {**timeout_job, "completed_at": "2026-08-26T00:18:59Z"},
+                {
+                    **extended_timeout_job,
+                    "completed_at": "2026-08-26T00:19:59Z",
+                },
                 "14",
+                "15",
+                "unexpected-cancellation",
+            ),
+            (
+                "extended-timeout-missing-setup-evidence",
+                {
+                    **extended_timeout_job,
+                    "steps": timeout_job["steps"],
+                    "completed_at": "2026-08-26T00:20:00Z",
+                },
+                "14",
+                "15",
                 "unexpected-cancellation",
             ),
         ]
-        for name, job, timeout_minutes, expected_classification in inspect_cases:
+        for (
+            name,
+            job,
+            timeout_minutes,
+            job_timeout_minutes,
+            expected_classification,
+        ) in inspect_cases:
             with self.subTest(inspect=name), tempfile.TemporaryDirectory() as tmp:
                 completed, output = run_github_script(
                     inspect_script,
@@ -1178,6 +1275,7 @@ class ReviewPolicyTest(unittest.TestCase):
                         "artifacts": [],
                         "agent_job_name": timeout_job["name"],
                         "timeout_minutes": timeout_minutes,
+                        "job_timeout_minutes": job_timeout_minutes,
                     },
                     tmp,
                 )

--- a/.github/scripts/evaluate_review_policy_test.py
+++ b/.github/scripts/evaluate_review_policy_test.py
@@ -593,6 +593,7 @@ class ReviewPolicyTest(unittest.TestCase):
                         "codex-security-review-benchmark",
                         "codex-security-review-sharded-benchmark",
                         "codex-security-review-terra-benchmark",
+                        "codex-security-review-extended-timeout-benchmark",
                     ]
                 }
             },
@@ -600,14 +601,14 @@ class ReviewPolicyTest(unittest.TestCase):
         selector = find_step(workflow, "select-cases", "select")
         self.assertEqual(
             selector["env"]["BENCHMARK_PROFILE"],
-            "${{ github.event.action == 'codex-security-review-terra-benchmark' && 'terra-high-default-low' || 'sol' }}",
+            "${{ github.event.action == 'codex-security-review-terra-benchmark' && 'terra-high-default-low' || github.event.action == 'codex-security-review-extended-timeout-benchmark' && 'sol-extended-timeout' || 'sol' }}",
         )
         self.assertIn(
             "github.event.action == 'codex-security-review-terra-benchmark' && 'high' || 'xhigh'",
             selector["env"]["REASONING_EFFORT"],
         )
         self.assertIn(
-            "github.event.action == 'codex-security-review-terra-benchmark') && 'unified-40' || 'all'",
+            "github.event.action == 'codex-security-review-extended-timeout-benchmark') && 'unified-40' || 'all'",
             selector["env"]["CONTEXT_VARIANT"],
         )
         self.assertEqual(
@@ -616,7 +617,8 @@ class ReviewPolicyTest(unittest.TestCase):
         )
         unsharded_events = (
             "github.event.action == 'codex-security-review-benchmark' || "
-            "github.event.action == 'codex-security-review-terra-benchmark'"
+            "github.event.action == 'codex-security-review-terra-benchmark' || "
+            "github.event.action == 'codex-security-review-extended-timeout-benchmark'"
         )
         self.assertEqual(job["if"], f"${{{{ {unsharded_events} }}}}")
         self.assertIn(unsharded_events, workflow["jobs"]["benchmark-finalize"]["if"])
@@ -627,7 +629,10 @@ class ReviewPolicyTest(unittest.TestCase):
         )
         self.assertFalse(job["strategy"]["fail-fast"])
         self.assertEqual(job["strategy"]["max-parallel"], 2)
-        self.assertEqual(codex["timeout-minutes"], 12)
+        self.assertEqual(
+            codex["timeout-minutes"],
+            "${{ fromJSON(needs.select-cases.outputs.timeout_minutes) }}",
+        )
         self.assertTrue(codex["continue-on-error"])
         self.assertIn("!cancelled()", benchmark_writer["if"])
         self.assertEqual(
@@ -691,6 +696,7 @@ class ReviewPolicyTest(unittest.TestCase):
                 "service_tier": "${{ steps.select.outputs.service_tier }}",
                 "verbosity": "${{ steps.select.outputs.verbosity }}",
                 "codex_args": "${{ steps.select.outputs.codex_args }}",
+                "timeout_minutes": "${{ steps.select.outputs.timeout_minutes }}",
                 "prompt_profile": "${{ steps.select.outputs.prompt_profile }}",
                 "repeat": "${{ steps.select.outputs.repeat }}",
             },
@@ -716,6 +722,7 @@ class ReviewPolicyTest(unittest.TestCase):
             benchmark_profile="sol",
             reasoning_effort="xhigh",
             prompt_profile="baseline",
+            repeat="initial",
         ):
             with tempfile.TemporaryDirectory() as tmp:
                 target = Path(tmp) / ".github" / BENCHMARK_CORPUS_PATH.name
@@ -732,7 +739,7 @@ class ReviewPolicyTest(unittest.TestCase):
                         "CONTEXT_VARIANT": variant_name,
                         "REASONING_EFFORT": reasoning_effort,
                         "PROMPT_PROFILE": prompt_profile,
-                        "REPEAT": "initial",
+                        "REPEAT": repeat,
                         "GITHUB_OUTPUT": str(output),
                     },
                     tmp,
@@ -751,6 +758,7 @@ class ReviewPolicyTest(unittest.TestCase):
             json.loads(outputs["codex_args"]),
             ["-c", "model_reasoning_effort=xhigh"],
         )
+        self.assertEqual(outputs["timeout_minutes"], "12")
         self.assertEqual(outputs["prompt_profile"], "baseline")
         self.assertEqual(outputs["repeat"], "initial")
         self.assertEqual(len(include), len(adjudicated) * len(corpus["variants"]))
@@ -801,6 +809,7 @@ class ReviewPolicyTest(unittest.TestCase):
         self.assertEqual(outputs["reasoning_effort"], "high")
         self.assertEqual(outputs["service_tier"], "default")
         self.assertEqual(outputs["verbosity"], "low")
+        self.assertEqual(outputs["timeout_minutes"], "12")
         self.assertEqual(
             json.loads(outputs["codex_args"]),
             [
@@ -825,6 +834,46 @@ class ReviewPolicyTest(unittest.TestCase):
                     benchmark_profile="terra-high-default-low",
                     reasoning_effort=effort,
                     prompt_profile=prompt,
+                )
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(rejected, result.stderr)
+                self.assertEqual(emitted, "")
+
+        result, emitted = select(
+            "adjudicated",
+            "unified-40",
+            benchmark_profile="sol-extended-timeout",
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        outputs = dict(line.split("=", 1) for line in emitted.splitlines())
+        include = json.loads(outputs["matrix"])["include"]
+        self.assertEqual(len(include), len(adjudicated))
+        self.assertEqual({entry["variant"]["id"] for entry in include}, {"unified-40"})
+        self.assertEqual(outputs["model"], "gpt-5.6-sol")
+        self.assertEqual(outputs["reasoning_effort"], "xhigh")
+        self.assertEqual(outputs["service_tier"], "unspecified")
+        self.assertEqual(outputs["verbosity"], "unspecified")
+        self.assertEqual(outputs["timeout_minutes"], "14")
+        self.assertEqual(
+            json.loads(outputs["codex_args"]),
+            ["-c", "model_reasoning_effort=xhigh"],
+        )
+
+        for corpus, variant, effort, prompt, repeat, rejected in (
+            ("large-pr", "unified-40", "xhigh", "baseline", "initial", "large-pr"),
+            ("adjudicated", "compact", "xhigh", "baseline", "initial", "compact"),
+            ("adjudicated", "unified-40", "high", "baseline", "initial", "high"),
+            ("adjudicated", "unified-40", "xhigh", "bounded", "initial", "bounded"),
+            ("adjudicated", "unified-40", "xhigh", "baseline", "repeat-1", "repeat-1"),
+        ):
+            with self.subTest(extended_timeout_rejected=rejected):
+                result, emitted = select(
+                    corpus,
+                    variant,
+                    benchmark_profile="sol-extended-timeout",
+                    reasoning_effort=effort,
+                    prompt_profile=prompt,
+                    repeat=repeat,
                 )
                 self.assertNotEqual(result.returncode, 0)
                 self.assertIn(rejected, result.stderr)
@@ -905,9 +954,12 @@ class ReviewPolicyTest(unittest.TestCase):
             production_codex["timeout-minutes"],
             int(production_job["env"]["CODEX_TIMEOUT_MINUTES"]),
         )
+        selected_timeout = "${{ needs.select-cases.outputs.timeout_minutes }}"
+        dynamic_timeout = "${{ fromJSON(needs.select-cases.outputs.timeout_minutes) }}"
+        self.assertEqual(benchmark_codex["timeout-minutes"], dynamic_timeout)
+        self.assertEqual(benchmark_job["timeout-minutes"], dynamic_timeout)
         self.assertEqual(
-            benchmark_codex["timeout-minutes"],
-            int(benchmark_job["env"]["CODEX_TIMEOUT_MINUTES"]),
+            benchmark_job["env"]["CODEX_TIMEOUT_MINUTES"], selected_timeout
         )
         self.assertEqual(
             production_finalizer["env"]["CODEX_TIMEOUT_MINUTES"],
@@ -922,8 +974,7 @@ class ReviewPolicyTest(unittest.TestCase):
             "300",
         )
         self.assertEqual(
-            benchmark_finalizer["env"]["CODEX_TIMEOUT_MINUTES"],
-            benchmark_job["env"]["CODEX_TIMEOUT_MINUTES"],
+            benchmark_finalizer["env"]["CODEX_TIMEOUT_MINUTES"], selected_timeout
         )
         self.assertEqual(
             benchmark_finalizer["env"]["CODEX_CANCELLATION_CLEANUP_SECONDS"],
@@ -932,7 +983,7 @@ class ReviewPolicyTest(unittest.TestCase):
         self.assertLessEqual(
             production_codex["timeout-minutes"], production_job["timeout-minutes"]
         )
-        self.assertLessEqual(
+        self.assertEqual(
             benchmark_codex["timeout-minutes"], benchmark_job["timeout-minutes"]
         )
 
@@ -1047,7 +1098,10 @@ class ReviewPolicyTest(unittest.TestCase):
         review_job = workflow["jobs"]["benchmark-review"]
         finalizer = workflow["jobs"]["benchmark-finalize"]
 
-        self.assertEqual(review_job["timeout-minutes"], 12)
+        self.assertEqual(
+            review_job["timeout-minutes"],
+            "${{ fromJSON(needs.select-cases.outputs.timeout_minutes) }}",
+        )
         self.assertEqual(finalizer["needs"], ["select-cases", "benchmark-review"])
         self.assertIn("always()", finalizer["if"])
         self.assertEqual(
@@ -1083,24 +1137,39 @@ class ReviewPolicyTest(unittest.TestCase):
             ],
         }
         inspect_cases = [
-            ("budget-timeout", timeout_job, "budget-timeout"),
+            ("budget-timeout", timeout_job, "12", "budget-timeout"),
             (
                 "early-cancellation",
                 {**timeout_job, "completed_at": "2026-08-26T00:05:00Z"},
+                "12",
                 "unexpected-cancellation",
             ),
             (
                 "cancellation-plus-cleanup",
                 {**timeout_job, "completed_at": "2026-08-26T00:12:00Z"},
+                "12",
                 "unexpected-cancellation",
             ),
             (
                 "setup-cancellation",
                 {**timeout_job, "steps": successful_steps[:1]},
+                "12",
+                "unexpected-cancellation",
+            ),
+            (
+                "extended-timeout-budget-plus-cleanup",
+                {**timeout_job, "completed_at": "2026-08-26T00:19:00Z"},
+                "14",
+                "budget-timeout",
+            ),
+            (
+                "extended-timeout-insufficient-evidence",
+                {**timeout_job, "completed_at": "2026-08-26T00:18:59Z"},
+                "14",
                 "unexpected-cancellation",
             ),
         ]
-        for name, job, expected_classification in inspect_cases:
+        for name, job, timeout_minutes, expected_classification in inspect_cases:
             with self.subTest(inspect=name), tempfile.TemporaryDirectory() as tmp:
                 completed, output = run_github_script(
                     inspect_script,
@@ -1108,7 +1177,7 @@ class ReviewPolicyTest(unittest.TestCase):
                         "jobs": [job],
                         "artifacts": [],
                         "agent_job_name": timeout_job["name"],
-                        "timeout_minutes": "12",
+                        "timeout_minutes": timeout_minutes,
                     },
                     tmp,
                 )
@@ -1234,7 +1303,15 @@ class ReviewPolicyTest(unittest.TestCase):
             group,
         )
         self.assertIn(
-            "github.event.action == 'codex-security-review-sharded-benchmark' && 'xhigh'",
+            "github.event.action == 'codex-security-review-sharded-benchmark' ||",
+            group,
+        )
+        self.assertIn(
+            "github.event.action == 'codex-security-review-extended-timeout-benchmark') && 'xhigh'",
+            group,
+        )
+        self.assertIn(
+            "github.event.action == 'codex-security-review-extended-timeout-benchmark' && 'initial'",
             group,
         )
 

--- a/.github/workflows/codex-security-review-benchmark.yml
+++ b/.github/workflows/codex-security-review-benchmark.yml
@@ -9,6 +9,7 @@ on:
       - codex-security-review-benchmark
       - codex-security-review-sharded-benchmark
       - codex-security-review-terra-benchmark
+      - codex-security-review-extended-timeout-benchmark
 
 permissions:
   actions: read
@@ -21,21 +22,23 @@ concurrency:
     codex-security-review-benchmark-${{
       github.event.action
     }}-${{
+      github.event.action == 'codex-security-review-extended-timeout-benchmark' && 'adjudicated' ||
       github.event.client_payload.corpus == 'large-pr' && 'large-pr' || 'adjudicated'
     }}-${{
-      (github.event.action == 'codex-security-review-sharded-benchmark' || github.event.action == 'codex-security-review-terra-benchmark') && 'unified-40' ||
+      (github.event.action == 'codex-security-review-sharded-benchmark' || github.event.action == 'codex-security-review-terra-benchmark' || github.event.action == 'codex-security-review-extended-timeout-benchmark') && 'unified-40' ||
       github.event.client_payload['context-variant'] == 'unified-40' && 'unified-40' ||
       github.event.client_payload['context-variant'] == 'unified-10' && 'unified-10' ||
       github.event.client_payload['context-variant'] == 'compact' && 'compact' || 'all'
     }}-${{
       github.event.action == 'codex-security-review-terra-benchmark' && 'high' ||
-      github.event.action == 'codex-security-review-sharded-benchmark' && 'xhigh' ||
+      (github.event.action == 'codex-security-review-sharded-benchmark' || github.event.action == 'codex-security-review-extended-timeout-benchmark') && 'xhigh' ||
       github.event.client_payload['reasoning-effort'] == 'high' && 'high' ||
       github.event.client_payload['reasoning-effort'] == 'medium' && 'medium' || 'xhigh'
     }}-${{
-      (github.event.action == 'codex-security-review-sharded-benchmark' || github.event.action == 'codex-security-review-terra-benchmark') && 'baseline' ||
+      (github.event.action == 'codex-security-review-sharded-benchmark' || github.event.action == 'codex-security-review-terra-benchmark' || github.event.action == 'codex-security-review-extended-timeout-benchmark') && 'baseline' ||
       github.event.client_payload['prompt-profile'] == 'bounded' && 'bounded' || 'baseline'
     }}-${{
+      github.event.action == 'codex-security-review-extended-timeout-benchmark' && 'initial' ||
       github.event.client_payload.repeat == 'repeat-1' && 'repeat-1' ||
       github.event.client_payload.repeat == 'repeat-2' && 'repeat-2' || 'initial'
     }}
@@ -53,6 +56,7 @@ jobs:
       service_tier: ${{ steps.select.outputs.service_tier }}
       verbosity: ${{ steps.select.outputs.verbosity }}
       codex_args: ${{ steps.select.outputs.codex_args }}
+      timeout_minutes: ${{ steps.select.outputs.timeout_minutes }}
       prompt_profile: ${{ steps.select.outputs.prompt_profile }}
       repeat: ${{ steps.select.outputs.repeat }}
     steps:
@@ -68,9 +72,9 @@ jobs:
         id: select
         env:
           REVIEW_MODE: ${{ github.event.action == 'codex-security-review-sharded-benchmark' && 'sharded' || 'unsharded' }}
-          BENCHMARK_PROFILE: ${{ github.event.action == 'codex-security-review-terra-benchmark' && 'terra-high-default-low' || 'sol' }}
+          BENCHMARK_PROFILE: ${{ github.event.action == 'codex-security-review-terra-benchmark' && 'terra-high-default-low' || github.event.action == 'codex-security-review-extended-timeout-benchmark' && 'sol-extended-timeout' || 'sol' }}
           CORPUS: ${{ github.event.client_payload.corpus || 'adjudicated' }}
-          CONTEXT_VARIANT: ${{ github.event.client_payload['context-variant'] || ((github.event.action == 'codex-security-review-sharded-benchmark' || github.event.action == 'codex-security-review-terra-benchmark') && 'unified-40' || 'all') }}
+          CONTEXT_VARIANT: ${{ github.event.client_payload['context-variant'] || ((github.event.action == 'codex-security-review-sharded-benchmark' || github.event.action == 'codex-security-review-terra-benchmark' || github.event.action == 'codex-security-review-extended-timeout-benchmark') && 'unified-40' || 'all') }}
           REASONING_EFFORT: ${{ github.event.client_payload['reasoning-effort'] || (github.event.action == 'codex-security-review-terra-benchmark' && 'high' || 'xhigh') }}
           PROMPT_PROFILE: ${{ github.event.client_payload['prompt-profile'] || 'baseline' }}
           REPEAT: ${{ github.event.client_payload.repeat || 'initial' }}
@@ -87,6 +91,7 @@ jobs:
           reasoning_effort = os.environ["REASONING_EFFORT"]
           prompt_profile = os.environ["PROMPT_PROFILE"]
           repeat = os.environ["REPEAT"]
+          timeout_minutes = 12
           if review_mode == "sharded":
               allowed = {
                   "corpus": ({"adjudicated", "large-pr"}, corpus_name),
@@ -109,6 +114,18 @@ jobs:
               model = "gpt-5.6-terra"
               service_tier = "default"
               verbosity = "low"
+          elif benchmark_profile == "sol-extended-timeout":
+              allowed = {
+                  "corpus": ({"adjudicated"}, corpus_name),
+                  "context-variant": ({"unified-40"}, variant_name),
+                  "reasoning-effort": ({"xhigh"}, reasoning_effort),
+                  "prompt-profile": ({"baseline"}, prompt_profile),
+                  "repeat": ({"initial"}, repeat),
+              }
+              model = "gpt-5.6-sol"
+              service_tier = "unspecified"
+              verbosity = "unspecified"
+              timeout_minutes = 14
           elif benchmark_profile == "sol":
               allowed = {
                   "corpus": ({"adjudicated", "large-pr"}, corpus_name),
@@ -159,6 +176,7 @@ jobs:
               handle.write(f"service_tier={service_tier}\n")
               handle.write(f"verbosity={verbosity}\n")
               handle.write(f"codex_args={json.dumps(codex_args, separators=(',', ':'))}\n")
+              handle.write(f"timeout_minutes={timeout_minutes}\n")
               handle.write(f"prompt_profile={prompt_profile}\n")
               handle.write(f"repeat={repeat}\n")
           for entry in matrix["include"]:
@@ -187,12 +205,12 @@ jobs:
   benchmark-review:
     name: ${{ matrix.case.id }} / ${{ matrix.variant.id }} / ${{ needs.select-cases.outputs.repeat }}
     needs: select-cases
-    if: ${{ github.event.action == 'codex-security-review-benchmark' || github.event.action == 'codex-security-review-terra-benchmark' }}
+    if: ${{ github.event.action == 'codex-security-review-benchmark' || github.event.action == 'codex-security-review-terra-benchmark' || github.event.action == 'codex-security-review-extended-timeout-benchmark' }}
     runs-on: ubuntu-latest
     # The composite action ignored its caller step timeout in production, so the
     # matrix job itself is the enforceable model budget. A separate matrix finalizer
     # creates timeout artifacts after GitHub finishes cancelled-job cleanup.
-    timeout-minutes: 12
+    timeout-minutes: ${{ fromJSON(needs.select-cases.outputs.timeout_minutes) }}
     strategy:
       fail-fast: false
       max-parallel: 2
@@ -200,7 +218,7 @@ jobs:
     env:
       OPENAI_API_KEY_PRESENT: ${{ secrets.OPENAI_API_KEY != '' }}
       CODEX_MODEL: ${{ needs.select-cases.outputs.model }}
-      CODEX_TIMEOUT_MINUTES: "12"
+      CODEX_TIMEOUT_MINUTES: ${{ needs.select-cases.outputs.timeout_minutes }}
       CODEX_REASONING_EFFORT: ${{ needs.select-cases.outputs.reasoning_effort }}
       CODEX_SERVICE_TIER: ${{ needs.select-cases.outputs.service_tier }}
       CODEX_VERBOSITY: ${{ needs.select-cases.outputs.verbosity }}
@@ -266,7 +284,7 @@ jobs:
 
       - name: Run bounded benchmark review
         id: run_codex
-        timeout-minutes: 12
+        timeout-minutes: ${{ fromJSON(needs.select-cases.outputs.timeout_minutes) }}
         continue-on-error: true
         uses: openai/codex-action@86365089eb2b84e0a8fb0717b304f8bdcb13b20e # v1.12
         with:
@@ -595,7 +613,7 @@ jobs:
   benchmark-finalize:
     name: Finalize ${{ matrix.case.id }} / ${{ matrix.variant.id }} / ${{ needs.select-cases.outputs.repeat }}
     needs: [select-cases, benchmark-review]
-    if: ${{ always() && (github.event.action == 'codex-security-review-benchmark' || github.event.action == 'codex-security-review-terra-benchmark') && needs.select-cases.result == 'success' }}
+    if: ${{ always() && (github.event.action == 'codex-security-review-benchmark' || github.event.action == 'codex-security-review-terra-benchmark' || github.event.action == 'codex-security-review-extended-timeout-benchmark') && needs.select-cases.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:
@@ -612,7 +630,7 @@ jobs:
       CODEX_REASONING_EFFORT: ${{ needs.select-cases.outputs.reasoning_effort }}
       CODEX_SERVICE_TIER: ${{ needs.select-cases.outputs.service_tier }}
       CODEX_VERBOSITY: ${{ needs.select-cases.outputs.verbosity }}
-      CODEX_TIMEOUT_MINUTES: "12"
+      CODEX_TIMEOUT_MINUTES: ${{ needs.select-cases.outputs.timeout_minutes }}
       CODEX_CANCELLATION_CLEANUP_SECONDS: "300"
       REVIEW_BASE_SHA: ${{ matrix.case.base }}
       REVIEW_HEAD_SHA: ${{ matrix.case.head }}

--- a/.github/workflows/codex-security-review-benchmark.yml
+++ b/.github/workflows/codex-security-review-benchmark.yml
@@ -57,6 +57,8 @@ jobs:
       verbosity: ${{ steps.select.outputs.verbosity }}
       codex_args: ${{ steps.select.outputs.codex_args }}
       timeout_minutes: ${{ steps.select.outputs.timeout_minutes }}
+      job_timeout_minutes: ${{ steps.select.outputs.job_timeout_minutes }}
+      max_setup_seconds: ${{ steps.select.outputs.max_setup_seconds }}
       prompt_profile: ${{ steps.select.outputs.prompt_profile }}
       repeat: ${{ steps.select.outputs.repeat }}
     steps:
@@ -92,6 +94,8 @@ jobs:
           prompt_profile = os.environ["PROMPT_PROFILE"]
           repeat = os.environ["REPEAT"]
           timeout_minutes = 12
+          job_timeout_minutes = 12
+          max_setup_seconds = 0
           if review_mode == "sharded":
               allowed = {
                   "corpus": ({"adjudicated", "large-pr"}, corpus_name),
@@ -126,6 +130,8 @@ jobs:
               service_tier = "unspecified"
               verbosity = "unspecified"
               timeout_minutes = 14
+              job_timeout_minutes = 15
+              max_setup_seconds = 45
           elif benchmark_profile == "sol":
               allowed = {
                   "corpus": ({"adjudicated", "large-pr"}, corpus_name),
@@ -177,6 +183,8 @@ jobs:
               handle.write(f"verbosity={verbosity}\n")
               handle.write(f"codex_args={json.dumps(codex_args, separators=(',', ':'))}\n")
               handle.write(f"timeout_minutes={timeout_minutes}\n")
+              handle.write(f"job_timeout_minutes={job_timeout_minutes}\n")
+              handle.write(f"max_setup_seconds={max_setup_seconds}\n")
               handle.write(f"prompt_profile={prompt_profile}\n")
               handle.write(f"repeat={repeat}\n")
           for entry in matrix["include"]:
@@ -205,12 +213,13 @@ jobs:
   benchmark-review:
     name: ${{ matrix.case.id }} / ${{ matrix.variant.id }} / ${{ needs.select-cases.outputs.repeat }}
     needs: select-cases
-    if: ${{ github.event.action == 'codex-security-review-benchmark' || github.event.action == 'codex-security-review-terra-benchmark' || github.event.action == 'codex-security-review-extended-timeout-benchmark' }}
+    if: ${{ needs.select-cases.result == 'success' && (github.event.action == 'codex-security-review-benchmark' || github.event.action == 'codex-security-review-terra-benchmark' || github.event.action == 'codex-security-review-extended-timeout-benchmark') }}
     runs-on: ubuntu-latest
     # The composite action ignored its caller step timeout in production, so the
-    # matrix job itself is the enforceable model budget. A separate matrix finalizer
-    # creates timeout artifacts after GitHub finishes cancelled-job cleanup.
-    timeout-minutes: ${{ fromJSON(needs.select-cases.outputs.timeout_minutes) }}
+    # matrix job is the enforceable deadline. The extended profile reserves one job
+    # minute for bounded setup before its 14-minute model step. A separate matrix
+    # finalizer creates timeout artifacts after cancelled-job cleanup.
+    timeout-minutes: ${{ fromJSON(needs.select-cases.outputs.job_timeout_minutes) }}
     strategy:
       fail-fast: false
       max-parallel: 2
@@ -219,6 +228,8 @@ jobs:
       OPENAI_API_KEY_PRESENT: ${{ secrets.OPENAI_API_KEY != '' }}
       CODEX_MODEL: ${{ needs.select-cases.outputs.model }}
       CODEX_TIMEOUT_MINUTES: ${{ needs.select-cases.outputs.timeout_minutes }}
+      CODEX_JOB_TIMEOUT_MINUTES: ${{ needs.select-cases.outputs.job_timeout_minutes }}
+      CODEX_MAX_SETUP_SECONDS: ${{ needs.select-cases.outputs.max_setup_seconds }}
       CODEX_REASONING_EFFORT: ${{ needs.select-cases.outputs.reasoning_effort }}
       CODEX_SERVICE_TIER: ${{ needs.select-cases.outputs.service_tier }}
       CODEX_VERBOSITY: ${{ needs.select-cases.outputs.verbosity }}
@@ -228,6 +239,11 @@ jobs:
       REVIEW_BLOB_BASE_URL: ${{ format('https://github.com/{0}/blob/{1}', github.repository, matrix.case.head) }}
       REVIEW_DIFF_FILE: .git/codex-review.diff
     steps:
+      - name: Record trusted benchmark job start
+        if: ${{ github.event.action == 'codex-security-review-extended-timeout-benchmark' }}
+        id: job_start
+        run: echo "started_at=$(date +%s)" >> "$GITHUB_OUTPUT"
+
       - name: Checkout fixed historical head
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -279,6 +295,22 @@ jobs:
         run: |
           if [ "$OPENAI_API_KEY_PRESENT" != "true" ]; then
             echo "OPENAI_API_KEY is required for Codex Security Review Benchmark." >&2
+            exit 1
+          fi
+
+      - name: Validate benchmark setup allowance
+        if: ${{ github.event.action == 'codex-security-review-extended-timeout-benchmark' }}
+        id: validate_setup
+        env:
+          JOB_STARTED_AT: ${{ steps.job_start.outputs.started_at }}
+        run: |
+          set -euo pipefail
+          if [ "$CODEX_MAX_SETUP_SECONDS" -eq 0 ]; then
+            exit 0
+          fi
+          setup_seconds=$(( $(date +%s) - JOB_STARTED_AT ))
+          if [ "$setup_seconds" -gt "$CODEX_MAX_SETUP_SECONDS" ]; then
+            echo "Benchmark setup took ${setup_seconds}s; the trusted limit is ${CODEX_MAX_SETUP_SECONDS}s." >&2
             exit 1
           fi
 
@@ -631,6 +663,7 @@ jobs:
       CODEX_SERVICE_TIER: ${{ needs.select-cases.outputs.service_tier }}
       CODEX_VERBOSITY: ${{ needs.select-cases.outputs.verbosity }}
       CODEX_TIMEOUT_MINUTES: ${{ needs.select-cases.outputs.timeout_minutes }}
+      CODEX_JOB_TIMEOUT_MINUTES: ${{ needs.select-cases.outputs.job_timeout_minutes }}
       CODEX_CANCELLATION_CLEANUP_SECONDS: "300"
       REVIEW_BASE_SHA: ${{ matrix.case.base }}
       REVIEW_HEAD_SHA: ${{ matrix.case.head }}
@@ -661,12 +694,20 @@ jobs:
             let cancellationClassification = conclusion === 'success' ? 'completed' : 'automation-failure';
             let cancellationDetail = '';
             if (conclusion === 'cancelled') {
+              const modelBudgetSeconds = Number(process.env.CODEX_TIMEOUT_MINUTES) * 60;
+              const jobBudgetSeconds = Number(process.env.CODEX_JOB_TIMEOUT_MINUTES) * 60;
               const requiredSteps = [
                 'Checkout fixed historical head',
                 'Fetch and validate fixed historical range',
                 'Write review packet and scope metrics',
                 'Require benchmark API key',
               ];
+              if (jobBudgetSeconds > modelBudgetSeconds) {
+                requiredSteps.push(
+                  'Record trusted benchmark job start',
+                  'Validate benchmark setup allowance',
+                );
+              }
               const prerequisitesSucceeded = requiredSteps.every(name =>
                 job.steps?.some(step => step.name === name && step.conclusion === 'success')
               );
@@ -683,13 +724,12 @@ jobs:
                   codexStep?.conclusion === 'cancelled' ||
                   (codexStep?.status === 'in_progress' && codexStep?.conclusion == null)
                 );
-              const budgetSeconds = Number(process.env.CODEX_TIMEOUT_MINUTES) * 60;
               const cleanupSeconds = Number(process.env.CODEX_CANCELLATION_CLEANUP_SECONDS);
               const budgetEvidence =
                 prerequisitesSucceeded &&
                 codexReachedReviewPhase &&
                 elapsedSeconds !== null &&
-                elapsedSeconds >= budgetSeconds + cleanupSeconds;
+                elapsedSeconds >= jobBudgetSeconds + cleanupSeconds;
               cancellationClassification = budgetEvidence ? 'budget-timeout' : 'unexpected-cancellation';
               cancellationDetail = JSON.stringify({
                 prerequisites_succeeded: prerequisitesSucceeded,
@@ -697,7 +737,8 @@ jobs:
                 codex_status: codexStep?.status || null,
                 codex_conclusion: codexStep?.conclusion || null,
                 observed_job_seconds: elapsedSeconds,
-                budget_seconds: budgetSeconds,
+                model_budget_seconds: modelBudgetSeconds,
+                job_budget_seconds: jobBudgetSeconds,
                 expected_cleanup_seconds: cleanupSeconds,
               });
             }

--- a/.github/workflows/codex-security-review-benchmark.yml
+++ b/.github/workflows/codex-security-review-benchmark.yml
@@ -57,8 +57,6 @@ jobs:
       verbosity: ${{ steps.select.outputs.verbosity }}
       codex_args: ${{ steps.select.outputs.codex_args }}
       timeout_minutes: ${{ steps.select.outputs.timeout_minutes }}
-      job_timeout_minutes: ${{ steps.select.outputs.job_timeout_minutes }}
-      max_setup_seconds: ${{ steps.select.outputs.max_setup_seconds }}
       prompt_profile: ${{ steps.select.outputs.prompt_profile }}
       repeat: ${{ steps.select.outputs.repeat }}
     steps:
@@ -94,8 +92,6 @@ jobs:
           prompt_profile = os.environ["PROMPT_PROFILE"]
           repeat = os.environ["REPEAT"]
           timeout_minutes = 12
-          job_timeout_minutes = 12
-          max_setup_seconds = 0
           if review_mode == "sharded":
               allowed = {
                   "corpus": ({"adjudicated", "large-pr"}, corpus_name),
@@ -130,8 +126,6 @@ jobs:
               service_tier = "unspecified"
               verbosity = "unspecified"
               timeout_minutes = 14
-              job_timeout_minutes = 15
-              max_setup_seconds = 45
           elif benchmark_profile == "sol":
               allowed = {
                   "corpus": ({"adjudicated", "large-pr"}, corpus_name),
@@ -183,8 +177,6 @@ jobs:
               handle.write(f"verbosity={verbosity}\n")
               handle.write(f"codex_args={json.dumps(codex_args, separators=(',', ':'))}\n")
               handle.write(f"timeout_minutes={timeout_minutes}\n")
-              handle.write(f"job_timeout_minutes={job_timeout_minutes}\n")
-              handle.write(f"max_setup_seconds={max_setup_seconds}\n")
               handle.write(f"prompt_profile={prompt_profile}\n")
               handle.write(f"repeat={repeat}\n")
           for entry in matrix["include"]:
@@ -216,10 +208,9 @@ jobs:
     if: ${{ needs.select-cases.result == 'success' && (github.event.action == 'codex-security-review-benchmark' || github.event.action == 'codex-security-review-terra-benchmark' || github.event.action == 'codex-security-review-extended-timeout-benchmark') }}
     runs-on: ubuntu-latest
     # The composite action ignored its caller step timeout in production, so the
-    # matrix job is the enforceable deadline. The extended profile reserves one job
-    # minute for bounded setup before its 14-minute model step. A separate matrix
-    # finalizer creates timeout artifacts after cancelled-job cleanup.
-    timeout-minutes: ${{ fromJSON(needs.select-cases.outputs.job_timeout_minutes) }}
+    # matrix job itself is the enforceable reviewer budget, including setup. A
+    # separate matrix finalizer creates timeout artifacts after cleanup.
+    timeout-minutes: ${{ fromJSON(needs.select-cases.outputs.timeout_minutes) }}
     strategy:
       fail-fast: false
       max-parallel: 2
@@ -228,8 +219,6 @@ jobs:
       OPENAI_API_KEY_PRESENT: ${{ secrets.OPENAI_API_KEY != '' }}
       CODEX_MODEL: ${{ needs.select-cases.outputs.model }}
       CODEX_TIMEOUT_MINUTES: ${{ needs.select-cases.outputs.timeout_minutes }}
-      CODEX_JOB_TIMEOUT_MINUTES: ${{ needs.select-cases.outputs.job_timeout_minutes }}
-      CODEX_MAX_SETUP_SECONDS: ${{ needs.select-cases.outputs.max_setup_seconds }}
       CODEX_REASONING_EFFORT: ${{ needs.select-cases.outputs.reasoning_effort }}
       CODEX_SERVICE_TIER: ${{ needs.select-cases.outputs.service_tier }}
       CODEX_VERBOSITY: ${{ needs.select-cases.outputs.verbosity }}
@@ -239,11 +228,6 @@ jobs:
       REVIEW_BLOB_BASE_URL: ${{ format('https://github.com/{0}/blob/{1}', github.repository, matrix.case.head) }}
       REVIEW_DIFF_FILE: .git/codex-review.diff
     steps:
-      - name: Record trusted benchmark job start
-        if: ${{ github.event.action == 'codex-security-review-extended-timeout-benchmark' }}
-        id: job_start
-        run: echo "started_at=$(date +%s)" >> "$GITHUB_OUTPUT"
-
       - name: Checkout fixed historical head
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -295,22 +279,6 @@ jobs:
         run: |
           if [ "$OPENAI_API_KEY_PRESENT" != "true" ]; then
             echo "OPENAI_API_KEY is required for Codex Security Review Benchmark." >&2
-            exit 1
-          fi
-
-      - name: Validate benchmark setup allowance
-        if: ${{ github.event.action == 'codex-security-review-extended-timeout-benchmark' }}
-        id: validate_setup
-        env:
-          JOB_STARTED_AT: ${{ steps.job_start.outputs.started_at }}
-        run: |
-          set -euo pipefail
-          if [ "$CODEX_MAX_SETUP_SECONDS" -eq 0 ]; then
-            exit 0
-          fi
-          setup_seconds=$(( $(date +%s) - JOB_STARTED_AT ))
-          if [ "$setup_seconds" -gt "$CODEX_MAX_SETUP_SECONDS" ]; then
-            echo "Benchmark setup took ${setup_seconds}s; the trusted limit is ${CODEX_MAX_SETUP_SECONDS}s." >&2
             exit 1
           fi
 
@@ -663,7 +631,6 @@ jobs:
       CODEX_SERVICE_TIER: ${{ needs.select-cases.outputs.service_tier }}
       CODEX_VERBOSITY: ${{ needs.select-cases.outputs.verbosity }}
       CODEX_TIMEOUT_MINUTES: ${{ needs.select-cases.outputs.timeout_minutes }}
-      CODEX_JOB_TIMEOUT_MINUTES: ${{ needs.select-cases.outputs.job_timeout_minutes }}
       CODEX_CANCELLATION_CLEANUP_SECONDS: "300"
       REVIEW_BASE_SHA: ${{ matrix.case.base }}
       REVIEW_HEAD_SHA: ${{ matrix.case.head }}
@@ -694,20 +661,12 @@ jobs:
             let cancellationClassification = conclusion === 'success' ? 'completed' : 'automation-failure';
             let cancellationDetail = '';
             if (conclusion === 'cancelled') {
-              const modelBudgetSeconds = Number(process.env.CODEX_TIMEOUT_MINUTES) * 60;
-              const jobBudgetSeconds = Number(process.env.CODEX_JOB_TIMEOUT_MINUTES) * 60;
               const requiredSteps = [
                 'Checkout fixed historical head',
                 'Fetch and validate fixed historical range',
                 'Write review packet and scope metrics',
                 'Require benchmark API key',
               ];
-              if (jobBudgetSeconds > modelBudgetSeconds) {
-                requiredSteps.push(
-                  'Record trusted benchmark job start',
-                  'Validate benchmark setup allowance',
-                );
-              }
               const prerequisitesSucceeded = requiredSteps.every(name =>
                 job.steps?.some(step => step.name === name && step.conclusion === 'success')
               );
@@ -724,12 +683,13 @@ jobs:
                   codexStep?.conclusion === 'cancelled' ||
                   (codexStep?.status === 'in_progress' && codexStep?.conclusion == null)
                 );
+              const budgetSeconds = Number(process.env.CODEX_TIMEOUT_MINUTES) * 60;
               const cleanupSeconds = Number(process.env.CODEX_CANCELLATION_CLEANUP_SECONDS);
               const budgetEvidence =
                 prerequisitesSucceeded &&
                 codexReachedReviewPhase &&
                 elapsedSeconds !== null &&
-                elapsedSeconds >= jobBudgetSeconds + cleanupSeconds;
+                elapsedSeconds >= budgetSeconds + cleanupSeconds;
               cancellationClassification = budgetEvidence ? 'budget-timeout' : 'unexpected-cancellation';
               cancellationDetail = JSON.stringify({
                 prerequisites_succeeded: prerequisitesSucceeded,
@@ -737,8 +697,7 @@ jobs:
                 codex_status: codexStep?.status || null,
                 codex_conclusion: codexStep?.conclusion || null,
                 observed_job_seconds: elapsedSeconds,
-                model_budget_seconds: modelBudgetSeconds,
-                job_budget_seconds: jobBudgetSeconds,
+                budget_seconds: budgetSeconds,
                 expected_cleanup_seconds: cleanupSeconds,
               });
             }

--- a/docs/plans/2026-09-03-extended-codex-security-review-timeout-plan.md
+++ b/docs/plans/2026-09-03-extended-codex-security-review-timeout-plan.md
@@ -25,7 +25,7 @@ adjudicated experiment shows that extra model time converts timeouts into valid
 reviews.
 
 The [bounded-review benchmark report](../codex-security-review-benchmark-report.md)
-records the retained nine-minute production model budget, followed by
+records the retained nine-minute production outer-job budget, followed by
 approximately five minutes of GitHub cancellation cleanup and trusted
 finalization. The original plan's closure is tracked separately in
 [PR #1006](https://github.com/block/proto-fleet/pull/1006).
@@ -67,16 +67,21 @@ It selects exactly this profile:
 | Service tier | Unspecified, matching production |
 | Verbosity | Unspecified, matching production |
 | Prompt | Baseline |
-| Model-job budget | 14 minutes |
+| Codex execution budget | 14 minutes |
+| Outer job budget | 15 minutes |
+| Maximum setup allowance | 45 seconds |
 | Cancellation cleanup evidence | 5 minutes |
-| Expected fail-closed ceiling | Approximately 20 minutes |
+| Fail-closed delivery target | Within 21 minutes |
 | Repeat | Initial only |
 
 The event type selects a trusted profile; caller-controlled values cannot choose
 another model, context, effort, prompt, corpus, repeat, or timeout. The selector
-emits the allowlisted timeout for the model job, model step, result metadata,
-and trusted finalizer. Existing Sol, Terra, and sharded benchmark behavior
-remains at its current budget.
+emits separate allowlisted Codex and outer-job timeouts. The extended profile
+records its job start before checkout, rejects setup over 45 seconds, and
+reserves one outer-job minute so Codex receives the intended 14-minute execution
+window. Result metadata records 14 minutes, while the finalizer verifies the
+15-minute outer deadline plus cleanup. Existing Sol, Terra, and sharded
+benchmark behavior remains at its current budget.
 
 `repository_dispatch` continues to load workflow code from `main`, so the API
 key cannot be exposed to feature-branch workflow changes. Concurrency keys map
@@ -92,8 +97,8 @@ extended-timeout dispatches.
 4. Adjudicate completion, expected-finding recall, new-finding validity, wall
    time, token use, tool calls, repeated reads, and compactions.
 5. Record evidence in the benchmark report and this plan in a separate PR.
-6. Only if every gate passes, propose a production change from nine to 14 model
-   minutes with an approximately 20-minute fail-closed ceiling.
+6. Only if every gate passes, propose a production change to a 14-minute Codex
+   window, 15-minute outer job, and 21-minute fail-closed delivery target.
 7. If production changes, observe a fixed 30-run window and revert to nine
    minutes if the longer budget does not materially improve completion.
 
@@ -110,8 +115,9 @@ extended-timeout dispatches.
 4. Every case must produce one trusted completed-result or verified-timeout
    artifact with the exact fixed SHA range and a 14-minute timeout budget.
 5. Timeout finalizers must require successful setup, evidence that Codex reached
-   the review phase, and at least 14 model minutes plus five cleanup minutes.
-   Ambiguous or early cancellation remains an automation failure.
+   the review phase, and at least the 15-minute outer job budget plus five cleanup
+   minutes. Setup over 45 seconds and ambiguous or early cancellation remain
+   automation failures.
 6. Existing 12-minute Sol and Terra events and six-minute sharded jobs must
    retain their current behavior.
 7. No production workflow setting changes in the benchmark-support PR.
@@ -120,8 +126,9 @@ extended-timeout dispatches.
 
 Passing the six-case benchmark permits a separate production proposal; it does
 not silently change production. That proposal must preserve the current
-fail-closed finalizer and update the model job, timeout metadata, tests, and
-operator-facing target together.
+fail-closed finalizer and update the Codex step to 14 minutes, the outer job to
+15 minutes, the setup guard, timeout metadata, tests, and operator-facing target
+together.
 
 The first 30 chronological runs after rollout form the production observation
 window. Report all runs, but calculate model completion among runs with trusted
@@ -129,7 +136,7 @@ completed or verified-timeout outcomes. The longer budget is retained only if:
 
 - at least 50% of trusted model outcomes complete, compared with 3/16 (18.75%)
   in the original observation;
-- every verified timeout posts an exact-SHA `HIGH` fallback within 20 minutes;
+- every verified timeout posts an exact-SHA `HIGH` fallback within 21 minutes;
 - every superseded, ambiguous, setup, API, artifact, or posting failure remains
   fail closed;
 - no reviewer reaches GitHub's 30-minute ceiling; and
@@ -145,10 +152,11 @@ not compared to the PR #977-heavy baseline without qualification.
 - Reject extended-timeout requests for another corpus, context, effort, prompt,
   or repeat.
 - Assert the typed event routes only to the unsharded reviewer and finalizer.
-- Assert the selected timeout controls the outer model job, Codex step metadata,
-  and trusted timeout classifier.
-- Exercise the classifier at 14 minutes plus five minutes of cleanup and reject
-  shorter cancellation evidence.
+- Assert the trusted selector reserves a 15-minute outer job for the 14-minute
+  Codex window and rejects setup over 45 seconds.
+- Assert the selected timeouts control Codex metadata and the trusted classifier.
+- Exercise the classifier at 15 outer-job minutes plus five cleanup minutes and
+  reject shorter cancellation evidence.
 - Keep production/benchmark prompt, packet, schema, sandbox, and safety parity
   tests passing.
 - Run the review-policy and sharding suites, Ruff, Actionlint, corpus validation,

--- a/docs/plans/2026-09-03-extended-codex-security-review-timeout-plan.md
+++ b/docs/plans/2026-09-03-extended-codex-security-review-timeout-plan.md
@@ -1,8 +1,9 @@
 ---
 title: "Extended Codex security review timeout benchmark"
 date: 2026-09-03
-status: proposed
+status: implementing
 type: plan
+tracker: https://github.com/block/proto-fleet/pull/1007
 ---
 
 # Extended Codex security review timeout benchmark

--- a/docs/plans/2026-09-03-extended-codex-security-review-timeout-plan.md
+++ b/docs/plans/2026-09-03-extended-codex-security-review-timeout-plan.md
@@ -25,20 +25,20 @@ adjudicated experiment shows that extra model time converts timeouts into valid
 reviews.
 
 The [bounded-review benchmark report](../codex-security-review-benchmark-report.md)
-records the retained nine-minute production outer-job budget, followed by
+records the retained nine-minute production outer reviewer budget, followed by
 approximately five minutes of GitHub cancellation cleanup and trusted
 finalization. The original plan's closure is tracked separately in
 [PR #1006](https://github.com/block/proto-fleet/pull/1006).
 
 ## Goals
 
-- Test whether a 14-minute model budget materially improves Sol completion on
-  the fixed six-PR adjudicated corpus.
+- Test whether a 14-minute outer reviewer budget materially improves Sol
+  completion on the fixed six-PR adjudicated corpus.
 - Hold model, context, reasoning, prompt, output contract, sandbox, and trusted
   finalization constant with production.
 - Preserve fail-closed timeout and automation-failure classifications.
 - Bound the initial experiment to six cases, at most two concurrent model jobs,
-  and at most 84 model-minutes.
+  and at most 84 reviewer-job minutes.
 - Produce uniquely named result or verified-timeout artifacts for manual
   adjudication.
 
@@ -67,21 +67,20 @@ It selects exactly this profile:
 | Service tier | Unspecified, matching production |
 | Verbosity | Unspecified, matching production |
 | Prompt | Baseline |
-| Codex execution budget | 14 minutes |
-| Outer job budget | 15 minutes |
-| Maximum setup allowance | 45 seconds |
+| Outer reviewer-job budget, including setup | 14 minutes |
 | Cancellation cleanup evidence | 5 minutes |
-| Fail-closed delivery target | Within 21 minutes |
+| Expected fail-closed ceiling | Approximately 20 minutes |
 | Repeat | Initial only |
 
 The event type selects a trusted profile; caller-controlled values cannot choose
 another model, context, effort, prompt, corpus, repeat, or timeout. The selector
-emits separate allowlisted Codex and outer-job timeouts. The extended profile
-records its job start before checkout, rejects setup over 45 seconds, and
-reserves one outer-job minute so Codex receives the intended 14-minute execution
-window. Result metadata records 14 minutes, while the finalizer verifies the
-15-minute outer deadline plus cleanup. Existing Sol, Terra, and sharded
-benchmark behavior remains at its current budget.
+emits the allowlisted timeout for the outer reviewer job, Codex step metadata,
+result artifact, and trusted finalizer. Because the pinned composite action
+ignores caller-step cancellation, the enforceable 14-minute clock begins with
+the job and includes checkout, packet generation, and setup; this experiment
+does not claim 14 minutes of model processing. It compares the same boundary as
+the current nine-minute production and 12-minute benchmark controls. Existing
+Sol, Terra, and sharded benchmark behavior remains at its current budget.
 
 `repository_dispatch` continues to load workflow code from `main`, so the API
 key cannot be exposed to feature-branch workflow changes. Concurrency keys map
@@ -97,8 +96,9 @@ extended-timeout dispatches.
 4. Adjudicate completion, expected-finding recall, new-finding validity, wall
    time, token use, tool calls, repeated reads, and compactions.
 5. Record evidence in the benchmark report and this plan in a separate PR.
-6. Only if every gate passes, propose a production change to a 14-minute Codex
-   window, 15-minute outer job, and 21-minute fail-closed delivery target.
+6. Only if every gate passes, propose a production change from a nine- to
+   14-minute outer reviewer budget with an approximately 20-minute fail-closed
+   ceiling.
 7. If production changes, observe a fixed 30-run window and revert to nine
    minutes if the longer budget does not materially improve completion.
 
@@ -113,11 +113,10 @@ extended-timeout dispatches.
 3. Every new `MEDIUM`, `HIGH`, or `CRITICAL` finding must be valid. Both clean
    controls must complete without an invalid material finding.
 4. Every case must produce one trusted completed-result or verified-timeout
-   artifact with the exact fixed SHA range and a 14-minute timeout budget.
+   artifact with the exact fixed SHA range and a 14-minute outer timeout budget.
 5. Timeout finalizers must require successful setup, evidence that Codex reached
-   the review phase, and at least the 15-minute outer job budget plus five cleanup
-   minutes. Setup over 45 seconds and ambiguous or early cancellation remain
-   automation failures.
+   the review phase, and at least 14 reviewer-job minutes plus five cleanup
+   minutes. Ambiguous or early cancellation remains an automation failure.
 6. Existing 12-minute Sol and Terra events and six-minute sharded jobs must
    retain their current behavior.
 7. No production workflow setting changes in the benchmark-support PR.
@@ -126,9 +125,8 @@ extended-timeout dispatches.
 
 Passing the six-case benchmark permits a separate production proposal; it does
 not silently change production. That proposal must preserve the current
-fail-closed finalizer and update the Codex step to 14 minutes, the outer job to
-15 minutes, the setup guard, timeout metadata, tests, and operator-facing target
-together.
+fail-closed finalizer and update the outer reviewer job, timeout metadata,
+tests, and operator-facing target together.
 
 The first 30 chronological runs after rollout form the production observation
 window. Report all runs, but calculate model completion among runs with trusted
@@ -136,7 +134,7 @@ completed or verified-timeout outcomes. The longer budget is retained only if:
 
 - at least 50% of trusted model outcomes complete, compared with 3/16 (18.75%)
   in the original observation;
-- every verified timeout posts an exact-SHA `HIGH` fallback within 21 minutes;
+- every verified timeout posts an exact-SHA `HIGH` fallback within 20 minutes;
 - every superseded, ambiguous, setup, API, artifact, or posting failure remains
   fail closed;
 - no reviewer reaches GitHub's 30-minute ceiling; and
@@ -148,15 +146,14 @@ not compared to the PR #977-heavy baseline without qualification.
 ## Test plan
 
 - Execute the trusted selector and assert the exact Sol/xhigh/unified-40/baseline
-  profile and 14-minute budget.
+  profile and 14-minute outer reviewer budget.
 - Reject extended-timeout requests for another corpus, context, effort, prompt,
   or repeat.
 - Assert the typed event routes only to the unsharded reviewer and finalizer.
-- Assert the trusted selector reserves a 15-minute outer job for the 14-minute
-  Codex window and rejects setup over 45 seconds.
-- Assert the selected timeouts control Codex metadata and the trusted classifier.
-- Exercise the classifier at 15 outer-job minutes plus five cleanup minutes and
-  reject shorter cancellation evidence.
+- Assert the selected timeout controls the outer reviewer job, Codex step
+  metadata, and trusted timeout classifier.
+- Exercise the classifier at 14 reviewer-job minutes plus five minutes of cleanup
+  and reject shorter cancellation evidence.
 - Keep production/benchmark prompt, packet, schema, sandbox, and safety parity
   tests passing.
 - Run the review-policy and sharding suites, Ruff, Actionlint, corpus validation,
@@ -165,7 +162,8 @@ not compared to the PR #977-heavy baseline without qualification.
 ## Cost and authorization
 
 The developer approved one six-case billable benchmark on 2026-09-03 after the
-trusted support lands on `main`. With two-way concurrency and a 14-minute budget,
-the run is capped at 84 model-minutes. Any repeat, large-PR run, or production
-rollout requires a separate decision; secret-backed execution must never run
-from this feature branch.
+trusted support lands on `main`. With two-way concurrency and a 14-minute
+budget, the run is capped at 84 reviewer-job minutes and no more than 84
+model-minutes. Any repeat, large-PR run, or production rollout requires a
+separate decision; secret-backed execution must never run from this feature
+branch.

--- a/docs/plans/2026-09-03-extended-codex-security-review-timeout-plan.md
+++ b/docs/plans/2026-09-03-extended-codex-security-review-timeout-plan.md
@@ -1,0 +1,162 @@
+---
+title: "Extended Codex security review timeout benchmark"
+date: 2026-09-03
+status: proposed
+type: plan
+---
+
+# Extended Codex security review timeout benchmark
+
+## Context
+
+The first 30 production runs of the bounded Codex reviewer produced three
+completed reviews and 13 verified model-timeout fallbacks. Eight other runs were
+verified superseded and six ambiguous cancellations failed hard. Completed
+reviews finished quickly: the production maximum was 140 seconds, and all 22
+completed Sol tuning cases finished within 172 seconds. By contrast, the
+12-minute Sol control completed only four of 18 benchmark cases.
+
+That distribution is bimodal rather than a demonstrated long tail: observed
+reviews either completed within roughly three minutes or exhausted their model
+budget. A longer timeout may still be worthwhile because an automated review is
+valuable, but production should not absorb more latency until a fixed,
+adjudicated experiment shows that extra model time converts timeouts into valid
+reviews.
+
+The [bounded-review benchmark report](../codex-security-review-benchmark-report.md)
+records the retained nine-minute production model budget, followed by
+approximately five minutes of GitHub cancellation cleanup and trusted
+finalization. The original plan's closure is tracked separately in
+[PR #1006](https://github.com/block/proto-fleet/pull/1006).
+
+## Goals
+
+- Test whether a 14-minute model budget materially improves Sol completion on
+  the fixed six-PR adjudicated corpus.
+- Hold model, context, reasoning, prompt, output contract, sandbox, and trusted
+  finalization constant with production.
+- Preserve fail-closed timeout and automation-failure classifications.
+- Bound the initial experiment to six cases, at most two concurrent model jobs,
+  and at most 84 model-minutes.
+- Produce uniquely named result or verified-timeout artifacts for manual
+  adjudication.
+
+## Non-goals
+
+- Changing production before the candidate passes every gate.
+- Changing `gpt-5.6-sol`, `unified=40`, `xhigh`, or the baseline prompt.
+- Repeating the rejected context, effort, prompt, sharding, or Terra candidates.
+- Running repeats or the large-PR corpus without another explicit billable-run
+  approval.
+- Weakening timeout evidence, fallback severity, or the approval-free review
+  policy.
+
+## Fixed candidate
+
+Add a typed `codex-security-review-extended-timeout-benchmark`
+`repository_dispatch` event to the trusted default-branch benchmark workflow.
+It selects exactly this profile:
+
+| Setting | Value |
+| --- | --- |
+| Corpus | Six adjudicated PRs |
+| Model | `gpt-5.6-sol` |
+| Context | `unified=40` |
+| Reasoning effort | `xhigh` |
+| Service tier | Unspecified, matching production |
+| Verbosity | Unspecified, matching production |
+| Prompt | Baseline |
+| Model-job budget | 14 minutes |
+| Cancellation cleanup evidence | 5 minutes |
+| Expected fail-closed ceiling | Approximately 20 minutes |
+| Repeat | Initial only |
+
+The event type selects a trusted profile; caller-controlled values cannot choose
+another model, context, effort, prompt, corpus, repeat, or timeout. The selector
+emits the allowlisted timeout for the model job, model step, result metadata,
+and trusted finalizer. Existing Sol, Terra, and sharded benchmark behavior
+remains at its current budget.
+
+`repository_dispatch` continues to load workflow code from `main`, so the API
+key cannot be exposed to feature-branch workflow changes. Concurrency keys map
+all inputs to allowlisted values before selection and serialize duplicate
+extended-timeout dispatches.
+
+## Sequence
+
+1. Land the typed event, trusted selector, dynamic allowlisted timeout wiring,
+   tests, and this plan on `main`.
+2. Dispatch one initial adjudicated run with the fixed extended-timeout event.
+3. Download all six trusted artifacts and action logs.
+4. Adjudicate completion, expected-finding recall, new-finding validity, wall
+   time, token use, tool calls, repeated reads, and compactions.
+5. Record evidence in the benchmark report and this plan in a separate PR.
+6. Only if every gate passes, propose a production change from nine to 14 model
+   minutes with an approximately 20-minute fail-closed ceiling.
+7. If production changes, observe a fixed 30-run window and revert to nine
+   minutes if the longer budget does not materially improve completion.
+
+## Acceptance gates
+
+1. The initial adjudicated benchmark must complete all six cases. A verified
+   timeout or automation failure rejects the candidate; repeats cannot erase the
+   failure.
+2. Completed reviews must recall both adjudicated `HIGH` findings without
+   downgrade and at least 90% of the five adjudicated `MEDIUM` findings. With
+   five findings, this requires 5/5.
+3. Every new `MEDIUM`, `HIGH`, or `CRITICAL` finding must be valid. Both clean
+   controls must complete without an invalid material finding.
+4. Every case must produce one trusted completed-result or verified-timeout
+   artifact with the exact fixed SHA range and a 14-minute timeout budget.
+5. Timeout finalizers must require successful setup, evidence that Codex reached
+   the review phase, and at least 14 model minutes plus five cleanup minutes.
+   Ambiguous or early cancellation remains an automation failure.
+6. Existing 12-minute Sol and Terra events and six-minute sharded jobs must
+   retain their current behavior.
+7. No production workflow setting changes in the benchmark-support PR.
+
+## Production rollout gate
+
+Passing the six-case benchmark permits a separate production proposal; it does
+not silently change production. That proposal must preserve the current
+fail-closed finalizer and update the model job, timeout metadata, tests, and
+operator-facing target together.
+
+The first 30 chronological runs after rollout form the production observation
+window. Report all runs, but calculate model completion among runs with trusted
+completed or verified-timeout outcomes. The longer budget is retained only if:
+
+- at least 50% of trusted model outcomes complete, compared with 3/16 (18.75%)
+  in the original observation;
+- every verified timeout posts an exact-SHA `HIGH` fallback within 20 minutes;
+- every superseded, ambiguous, setup, API, artifact, or posting failure remains
+  fail closed;
+- no reviewer reaches GitHub's 30-minute ceiling; and
+- human adjudication finds no quality regression or invalid approval-free path.
+
+Packet size and rapid-push concentration must be reported so the new window is
+not compared to the PR #977-heavy baseline without qualification.
+
+## Test plan
+
+- Execute the trusted selector and assert the exact Sol/xhigh/unified-40/baseline
+  profile and 14-minute budget.
+- Reject extended-timeout requests for another corpus, context, effort, prompt,
+  or repeat.
+- Assert the typed event routes only to the unsharded reviewer and finalizer.
+- Assert the selected timeout controls the outer model job, Codex step metadata,
+  and trusted timeout classifier.
+- Exercise the classifier at 14 minutes plus five minutes of cleanup and reject
+  shorter cancellation evidence.
+- Keep production/benchmark prompt, packet, schema, sandbox, and safety parity
+  tests passing.
+- Run the review-policy and sharding suites, Ruff, Actionlint, corpus validation,
+  and `git diff --check`.
+
+## Cost and authorization
+
+The developer approved one six-case billable benchmark on 2026-09-03 after the
+trusted support lands on `main`. With two-way concurrency and a 14-minute budget,
+the run is capped at 84 model-minutes. Any repeat, large-PR run, or production
+rollout requires a separate decision; secret-backed execution must never run
+from this feature branch.


### PR DESCRIPTION
Reviewable diff: +200/-13 across 2 files (excludes generated, test, and story files).

## Summary

Adds a trusted benchmark-only path to test whether a 14-minute outer reviewer budget improves security-review completion without changing production. The six-case experiment holds Sol/xhigh/unified-40/baseline constant, caps execution at 84 reviewer-job minutes and no more than 84 model-minutes, and rejects any caller attempt to change the corpus, configuration, repeat, or timeout. Production remains at nine minutes unless the candidate completes 6/6 and passes all recall and validity gates.

## How it works

A typed `repository_dispatch` event loads the workflow from trusted `main`. The selector maps that event to one fixed profile and emits a trusted 14-minute outer reviewer budget. Because the pinned composite action ignores caller-step cancellation, this enforceable clock includes checkout, packet generation, and setup; it intentionally does not claim 14 minutes of model processing. Cancelled cases qualify as timeouts only after setup succeeded, Codex started, and the job observed the 14-minute reviewer budget plus five minutes of cleanup.

Once this support is merged, one approved six-case dispatch will run against fixed historical SHAs. Results remain benchmark artifacts for manual adjudication and cannot affect pull-request review policy or production settings.

## Diagrams

```mermaid
flowchart LR
  A["Typed repository_dispatch"] --> B["Trusted selector on main"]
  B --> C["Fixed Sol / xhigh / unified-40 / baseline profile"]
  B --> D["14-minute outer reviewer budget"]
  C --> E["Six fixed historical PR cases"]
  D --> E
  E --> F["Completed result artifact"]
  E --> G["Verified timeout artifact"]
  F --> H["Manual recall and validity adjudication"]
  G --> H
  H --> I["Separate production proposal only if every gate passes"]
```

```mermaid
sequenceDiagram
  participant Caller
  participant Main as Trusted main workflow
  participant Codex
  participant Finalizer
  Caller->>Main: Fixed extended-timeout event
  Main->>Main: Reject non-allowlisted payload values
  Main->>Codex: Six cases, max two concurrent
  alt Review completes
    Codex-->>Main: Structured review
    Main-->>Finalizer: Completed artifact
  else Outer reviewer job exhausts 14 minutes
    Codex-->>Finalizer: Cancelled job evidence
    Finalizer->>Finalizer: Verify setup, review phase, and cleanup duration
    Finalizer-->>Finalizer: Fail-closed timeout artifact
  end
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `.github/workflows/codex-security-review-benchmark.yml` | Added the typed event, fixed profile, trusted timeout output, dynamic bounded job wiring, and finalizer routing | Verify no caller-controlled timeout or profile reaches secret-backed execution and existing benchmark profiles remain at 12 minutes |
| `.github/scripts/*_test.py` | Added selector, routing, concurrency, and 14-minute cancellation-classifier coverage | Tests — verify trusted boundaries and fail-closed behavior |
| `docs/plans/2026-09-03-extended-codex-security-review-timeout-plan.md` | Defined sequence, cost cap, benchmark gates, and conditional production observation | Verify the experiment cannot silently roll into production or expand its billable scope |

## Key technical decisions & trade-offs

- Use a fixed 14-minute outer reviewer budget including setup rather than claim an unenforceable model-only window; this compares the same boundary as the current nine-minute production and 12-minute benchmark controls.
- Test approximately 20 minutes end-to-end rather than making a small increase; prior completions all finished within three minutes while 12-minute controls still timed out.
- Require initial 6/6 completion, 2/2 `HIGH` recall, and 5/5 `MEDIUM` recall before proposing production; extra time alone is not treated as a quality improvement.
- Permit only the adjudicated corpus and initial repeat; repeats and large-PR runs require another explicit billable-run decision.
- Keep production unchanged in this PR; rollout and its 30-run observation are separate reviewed changes.

## Testing & validation

- `python3 .github/scripts/evaluate_review_policy_test.py` — 72 passed.
- `python3 .github/scripts/codex_sharding_test.py` — 52 passed.
- Ruff check and format passed for both changed Python test files.
- `git diff --check` passed.
- Targeted Actionlint passed for `.github/workflows/codex-security-review-benchmark.yml`; the repository-wide invocation reports the pre-existing custom `fleet-testing` runner label.
- No secret-backed benchmark has run from this branch; dispatch waits for merge to trusted `main`.
