### PR TITLE
feat(rollout): release channels tab under Settings > Firmware

### DIFF
--- a/client/src/protoFleet/api/clients.ts
+++ b/client/src/protoFleet/api/clients.ts
@@ -24,6 +24,7 @@ import { NetworkInfoService } from "@/protoFleet/api/generated/networkinfo/v1/ne
 import { OnboardingService } from "@/protoFleet/api/generated/onboarding/v1/onboarding_pb";
 import { PairingService } from "@/protoFleet/api/generated/pairing/v1/pairing_pb";
 import { PoolsService } from "@/protoFleet/api/generated/pools/v1/pools_pb";
+import { RolloutService } from "@/protoFleet/api/generated/rollout/v1/rollout_pb";
 import { ScheduleService } from "@/protoFleet/api/generated/schedule/v1/schedule_pb";
 import { ServerLogService } from "@/protoFleet/api/generated/serverlog/v1/serverlog_pb";
 import { SiteMapService } from "@/protoFleet/api/generated/sitemap/v1/sitemap_pb";
@@ -57,6 +58,7 @@ const alertRuleClient = createClient(AlertRuleService, transport);
 const alertMaintenanceWindowClient = createClient(AlertMaintenanceWindowService, transport);
 const alertHistoryClient = createClient(AlertHistoryService, transport);
 const instanceUpdateClient = createClient(InstanceUpdateService, transport);
+const rolloutClient = createClient(RolloutService, transport);
 
 export {
   alertChannelClient,
@@ -85,5 +87,6 @@ export {
   sitesClient,
   telemetryClient,
   instanceUpdateClient,
+  rolloutClient,
   foremanImportClient,
 };

--- a/client/src/protoFleet/api/useReleaseChannels.test.tsx
+++ b/client/src/protoFleet/api/useReleaseChannels.test.tsx
@@ -1,0 +1,147 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { create } from "@bufbuild/protobuf";
+
+import {
+  ListReleaseChannelsResponseSchema,
+  ListRolloutsResponseSchema,
+  ReleaseChannelSchema,
+  RolloutMethod,
+  RolloutSchema,
+  RolloutStatus,
+} from "@/protoFleet/api/generated/rollout/v1/rollout_pb";
+import { useReleaseChannels } from "@/protoFleet/api/useReleaseChannels";
+
+const {
+  mockListReleaseChannels,
+  mockListRollouts,
+  mockListMinerStateSnapshots,
+  mockCreateReleaseChannel,
+  mockUpdateReleaseChannel,
+  mockDeleteReleaseChannel,
+  mockPreviewReleaseChannelScope,
+  mockApplyReleaseChannelFirmware,
+  mockCancelRollout,
+  mockRetryFailedRolloutDevices,
+} = vi.hoisted(() => ({
+  mockListReleaseChannels: vi.fn(),
+  mockListRollouts: vi.fn(),
+  mockListMinerStateSnapshots: vi.fn(),
+  mockCreateReleaseChannel: vi.fn(),
+  mockUpdateReleaseChannel: vi.fn(),
+  mockDeleteReleaseChannel: vi.fn(),
+  mockPreviewReleaseChannelScope: vi.fn(),
+  mockApplyReleaseChannelFirmware: vi.fn(),
+  mockCancelRollout: vi.fn(),
+  mockRetryFailedRolloutDevices: vi.fn(),
+}));
+
+vi.mock("@/protoFleet/api/clients", () => ({
+  rolloutClient: {
+    listReleaseChannels: mockListReleaseChannels,
+    listRollouts: mockListRollouts,
+    createReleaseChannel: mockCreateReleaseChannel,
+    updateReleaseChannel: mockUpdateReleaseChannel,
+    deleteReleaseChannel: mockDeleteReleaseChannel,
+    previewReleaseChannelScope: mockPreviewReleaseChannelScope,
+    applyReleaseChannelFirmware: mockApplyReleaseChannelFirmware,
+    cancelRollout: mockCancelRollout,
+    retryFailedRolloutDevices: mockRetryFailedRolloutDevices,
+  },
+  fleetManagementClient: {
+    listMinerStateSnapshots: mockListMinerStateSnapshots,
+  },
+}));
+
+const canary = create(ReleaseChannelSchema, { id: 1n, name: "Canary", minerCount: 3 });
+const rollout = create(RolloutSchema, { id: 9n, channelId: 1n, model: "Rig", status: RolloutStatus.ACTIVE });
+
+describe("useReleaseChannels", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListReleaseChannels.mockResolvedValue(create(ListReleaseChannelsResponseSchema, { channels: [canary] }));
+    mockListRollouts.mockResolvedValue(create(ListRolloutsResponseSchema, { rollouts: [rollout] }));
+    mockListMinerStateSnapshots.mockResolvedValue({
+      miners: [{ deviceIdentifier: "rig-001", name: "Rig A01" }],
+    });
+  });
+
+  it("loads channels, rollouts and miner names together", async () => {
+    const { result } = renderHook(() => useReleaseChannels());
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.channels).toEqual([canary]);
+    expect(result.current.rollouts).toEqual([rollout]);
+    expect(result.current.minerNames).toEqual({ "rig-001": "Rig A01" });
+    expect(mockListMinerStateSnapshots).toHaveBeenCalledWith({ pageSize: 500 });
+  });
+
+  it("creates a channel from a draft and refreshes", async () => {
+    mockCreateReleaseChannel.mockResolvedValue({ channel: canary });
+    const { result } = renderHook(() => useReleaseChannels());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    const draft = {
+      name: "Canary",
+      description: "First wave",
+      scope: { rackIds: [40n] },
+      behavior: { method: RolloutMethod.PILOT_THEN_CONTINUE, pilotSize: 2 },
+    };
+    let created;
+    await act(async () => {
+      created = await result.current.createChannel(draft as never);
+    });
+    expect(created).toEqual(canary);
+    expect(mockCreateReleaseChannel).toHaveBeenCalledWith(draft);
+    expect(mockListReleaseChannels).toHaveBeenCalledTimes(2);
+  });
+
+  it("updates and deletes by channel id", async () => {
+    mockUpdateReleaseChannel.mockResolvedValue({ channel: canary });
+    mockDeleteReleaseChannel.mockResolvedValue({});
+    const { result } = renderHook(() => useReleaseChannels());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.updateChannel(1n, { name: "Canary 2", description: "", scope: {}, behavior: {} } as never);
+      await result.current.deleteChannel(1n);
+    });
+    expect(mockUpdateReleaseChannel).toHaveBeenCalledWith(expect.objectContaining({ channelId: 1n, name: "Canary 2" }));
+    expect(mockDeleteReleaseChannel).toHaveBeenCalledWith({ channelId: 1n });
+  });
+
+  it("previews a scope without touching the polled state", async () => {
+    mockPreviewReleaseChannelScope.mockResolvedValue({ minerCount: 4, models: [], conflicts: [] });
+    const { result } = renderHook(() => useReleaseChannels());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    const listCalls = mockListReleaseChannels.mock.calls.length;
+
+    const preview = await result.current.previewScope({ siteIds: [1n] } as never, 7n);
+    expect(preview.minerCount).toBe(4);
+    expect(mockPreviewReleaseChannelScope).toHaveBeenCalledWith({ scope: { siteIds: [1n] }, channelId: 7n });
+    expect(mockListReleaseChannels).toHaveBeenCalledTimes(listCalls);
+  });
+
+  it("applies firmware, cancels and retries by id", async () => {
+    mockApplyReleaseChannelFirmware.mockResolvedValue({ startedRollouts: [rollout] });
+    mockCancelRollout.mockResolvedValue({ rollout });
+    mockRetryFailedRolloutDevices.mockResolvedValue({ rollout });
+    const { result } = renderHook(() => useReleaseChannels());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      const started = await result.current.applyFirmware(1n, [{ model: "Rig", firmwareFileId: "fw-2" }]);
+      expect(started).toEqual([rollout]);
+      await result.current.cancelRollout(9n);
+      const retried = await result.current.retryFailedDevices(9n);
+      expect(retried).toEqual(rollout);
+    });
+    expect(mockApplyReleaseChannelFirmware).toHaveBeenCalledWith({
+      channelId: 1n,
+      assignments: [{ model: "Rig", firmwareFileId: "fw-2" }],
+    });
+    expect(mockCancelRollout).toHaveBeenCalledWith({ rolloutId: 9n });
+    expect(mockRetryFailedRolloutDevices).toHaveBeenCalledWith({ rolloutId: 9n });
+  });
+});

--- a/client/src/protoFleet/api/useReleaseChannels.ts
+++ b/client/src/protoFleet/api/useReleaseChannels.ts
@@ -1,0 +1,195 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { fleetManagementClient, rolloutClient } from "@/protoFleet/api/clients";
+import type {
+  FirmwareAssignment,
+  PreviewReleaseChannelScopeResponse,
+  ReleaseChannel,
+  ReleaseChannelScope,
+  Rollout,
+  RolloutBehavior,
+} from "@/protoFleet/api/generated/rollout/v1/rollout_pb";
+
+const POLL_INTERVAL_MS = 5000;
+
+// What an operator sets on a channel; the server resolves the scope and
+// validates the behavior.
+export interface ReleaseChannelDraft {
+  name: string;
+  description: string;
+  scope: ReleaseChannelScope;
+  behavior: RolloutBehavior;
+}
+
+export interface ReleaseChannelsApi {
+  channels: ReleaseChannel[];
+  rollouts: Rollout[];
+  // deviceIdentifier -> display name, from fleet snapshots.
+  minerNames: Record<string, string>;
+  isLoading: boolean;
+  refresh: () => Promise<void>;
+  createChannel: (draft: ReleaseChannelDraft) => Promise<ReleaseChannel | undefined>;
+  updateChannel: (channelId: bigint, draft: ReleaseChannelDraft) => Promise<ReleaseChannel | undefined>;
+  deleteChannel: (channelId: bigint) => Promise<void>;
+  // Read-only: does not touch the polled state.
+  previewScope: (scope: ReleaseChannelScope, channelId?: bigint) => Promise<PreviewReleaseChannelScopeResponse>;
+  applyFirmware: (
+    channelId: bigint,
+    assignments: Pick<FirmwareAssignment, "model" | "firmwareFileId">[],
+  ) => Promise<Rollout[]>;
+  rollbackFirmware: (rolloutId: bigint) => Promise<Rollout[]>;
+  continueRollout: (rolloutId: bigint) => Promise<void>;
+  pauseRollout: (rolloutId: bigint) => Promise<void>;
+  resumeRollout: (rolloutId: bigint) => Promise<void>;
+  cancelRollout: (rolloutId: bigint) => Promise<void>;
+  retryFailedDevices: (rolloutId: bigint) => Promise<Rollout | undefined>;
+}
+
+// Fetches release channels and rollouts, polling while mounted so firmware
+// versions and update progress stay live.
+export function useReleaseChannels(): ReleaseChannelsApi {
+  const [channels, setChannels] = useState<ReleaseChannel[]>([]);
+  const [rollouts, setRollouts] = useState<Rollout[]>([]);
+  const [minerNames, setMinerNames] = useState<Record<string, string>>({});
+  const [isLoading, setIsLoading] = useState(true);
+  const inFlightRef = useRef(false);
+
+  const refresh = useCallback(async () => {
+    if (inFlightRef.current) return;
+    inFlightRef.current = true;
+    try {
+      const [channelsResp, rolloutsResp, minersResp] = await Promise.all([
+        rolloutClient.listReleaseChannels({}),
+        rolloutClient.listRollouts({}),
+        fleetManagementClient.listMinerStateSnapshots({ pageSize: 500 }),
+      ]);
+      setChannels(channelsResp.channels);
+      setRollouts(rolloutsResp.rollouts);
+      setMinerNames(Object.fromEntries(minersResp.miners.map((miner) => [miner.deviceIdentifier, miner.name])));
+    } finally {
+      inFlightRef.current = false;
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh().catch((error) => console.error("Failed to load release channels", error));
+    const timer = setInterval(() => {
+      refresh().catch((error) => console.error("Failed to refresh release channels", error));
+    }, POLL_INTERVAL_MS);
+    return () => clearInterval(timer);
+  }, [refresh]);
+
+  const createChannel = useCallback(
+    async (draft: ReleaseChannelDraft) => {
+      const resp = await rolloutClient.createReleaseChannel(draft);
+      await refresh();
+      return resp.channel;
+    },
+    [refresh],
+  );
+
+  const updateChannel = useCallback(
+    async (channelId: bigint, draft: ReleaseChannelDraft) => {
+      const resp = await rolloutClient.updateReleaseChannel({ channelId, ...draft });
+      await refresh();
+      return resp.channel;
+    },
+    [refresh],
+  );
+
+  const deleteChannel = useCallback(
+    async (channelId: bigint) => {
+      await rolloutClient.deleteReleaseChannel({ channelId });
+      await refresh();
+    },
+    [refresh],
+  );
+
+  const previewScope = useCallback(
+    (scope: ReleaseChannelScope, channelId?: bigint) =>
+      rolloutClient.previewReleaseChannelScope({ scope, channelId: channelId ?? 0n }),
+    [],
+  );
+
+  const applyFirmware = useCallback(
+    async (channelId: bigint, assignments: Pick<FirmwareAssignment, "model" | "firmwareFileId">[]) => {
+      const resp = await rolloutClient.applyReleaseChannelFirmware({
+        channelId,
+        assignments: assignments.map((a) => ({ model: a.model, firmwareFileId: a.firmwareFileId })),
+      });
+      await refresh();
+      return resp.startedRollouts;
+    },
+    [refresh],
+  );
+
+  const rollbackFirmware = useCallback(
+    async (rolloutId: bigint) => {
+      const resp = await rolloutClient.rollbackReleaseChannelFirmware({ rolloutId });
+      await refresh();
+      return resp.startedRollouts;
+    },
+    [refresh],
+  );
+
+  const continueRollout = useCallback(
+    async (rolloutId: bigint) => {
+      await rolloutClient.continueRollout({ rolloutId });
+      await refresh();
+    },
+    [refresh],
+  );
+
+  const pauseRollout = useCallback(
+    async (rolloutId: bigint) => {
+      await rolloutClient.pauseRollout({ rolloutId });
+      await refresh();
+    },
+    [refresh],
+  );
+
+  const resumeRollout = useCallback(
+    async (rolloutId: bigint) => {
+      await rolloutClient.resumeRollout({ rolloutId });
+      await refresh();
+    },
+    [refresh],
+  );
+
+  const cancelRollout = useCallback(
+    async (rolloutId: bigint) => {
+      await rolloutClient.cancelRollout({ rolloutId });
+      await refresh();
+    },
+    [refresh],
+  );
+
+  const retryFailedDevices = useCallback(
+    async (rolloutId: bigint) => {
+      const resp = await rolloutClient.retryFailedRolloutDevices({ rolloutId });
+      await refresh();
+      return resp.rollout;
+    },
+    [refresh],
+  );
+
+  return {
+    channels,
+    rollouts,
+    minerNames,
+    isLoading,
+    refresh,
+    createChannel,
+    updateChannel,
+    deleteChannel,
+    previewScope,
+    applyFirmware,
+    rollbackFirmware,
+    continueRollout,
+    pauseRollout,
+    resumeRollout,
+    cancelRollout,
+    retryFailedDevices,
+  };
+}

--- a/client/src/protoFleet/components/TargetSelectionModal/MinerSelectionModal.tsx
+++ b/client/src/protoFleet/components/TargetSelectionModal/MinerSelectionModal.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 
 import type { MinerListFilter } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
 import MinerSelectionList, {
@@ -46,6 +46,30 @@ const MinerSelectionModal = ({
     totalMiners: undefined,
   });
 
+  // MinerSelectionList notifies from an effect keyed on this callback, so it
+  // must keep its identity across renders or every notification re-renders
+  // the modal, hands the list a new callback, and re-fires the effect.
+  const handleSelectionChange = useCallback(
+    ({
+      selectedItems,
+      allSelected,
+      totalMiners,
+    }: {
+      selectedItems: string[];
+      allSelected: boolean;
+      totalMiners?: number;
+    }) =>
+      setDraftSelection((prev) =>
+        prev.allSelected === allSelected &&
+        prev.totalMiners === totalMiners &&
+        prev.selectedMinerIds.length === selectedItems.length &&
+        prev.selectedMinerIds.every((id, i) => id === selectedItems[i])
+          ? prev
+          : { selectedMinerIds: selectedItems, allSelected, totalMiners },
+      ),
+    [],
+  );
+
   if (!open) {
     return null;
   }
@@ -92,9 +116,7 @@ const MinerSelectionModal = ({
           disableFilteredSelectAll
           scope={scope}
           filterConfig={filterConfig}
-          onSelectionChange={({ selectedItems, allSelected, totalMiners }) =>
-            setDraftSelection({ selectedMinerIds: selectedItems, allSelected, totalMiners })
-          }
+          onSelectionChange={handleSelectionChange}
         />
       </div>
     </Modal>

--- a/client/src/protoFleet/features/settings/components/Firmware.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Firmware.test.tsx
@@ -1,4 +1,6 @@
-import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { MemoryRouter } from "react-router-dom";
+import { act, fireEvent, render as renderBare, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import Firmware from "./Firmware";
 
@@ -32,6 +34,33 @@ vi.mock("@/protoFleet/features/settings/components/EditFirmwareMetadataDialog", 
 }));
 
 vi.mock("@/shared/features/toaster");
+
+// The release channels tab polls the rollout API; the Files tests only need
+// the hook to be quiet.
+vi.mock("@/protoFleet/api/useReleaseChannels", () => ({
+  useReleaseChannels: () => ({
+    channels: [],
+    rollouts: [],
+    minerNames: {},
+    isLoading: false,
+    refresh: vi.fn(),
+    createChannel: vi.fn(),
+    updateChannel: vi.fn(),
+    deleteChannel: vi.fn(),
+    previewScope: vi.fn(),
+    applyFirmware: vi.fn(),
+    rollbackFirmware: vi.fn(),
+    continueRollout: vi.fn(),
+    pauseRollout: vi.fn(),
+    resumeRollout: vi.fn(),
+    cancelRollout: vi.fn(),
+    retryFailedDevices: vi.fn(),
+  }),
+}));
+
+// The active tab lives in the URL, so the page needs a router.
+const render = (ui: ReactElement, initialEntry = "/settings/firmware") =>
+  renderBare(<MemoryRouter initialEntries={[initialEntry]}>{ui}</MemoryRouter>);
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -332,5 +361,20 @@ describe("Firmware", () => {
         }),
       );
     });
+  });
+
+  it("shows the Files tab by default and switches to Release channels", async () => {
+    render(<Firmware />);
+    await waitFor(() => expect(screen.getByText("Loading firmware files...")).toBeInTheDocument());
+
+    fireEvent.mouseDown(screen.getByRole("button", { name: "Release channels" }));
+    await waitFor(() => expect(screen.getByText("No release channels")).toBeInTheDocument());
+    expect(screen.queryByText("Loading firmware files...")).not.toBeInTheDocument();
+  });
+
+  it("deep-links to the Release channels tab from the URL", async () => {
+    render(<Firmware />, "/settings/firmware?tab=release-channels");
+    await waitFor(() => expect(screen.getByText("No release channels")).toBeInTheDocument());
+    expect(screen.queryByText("Loading firmware files...")).not.toBeInTheDocument();
   });
 });

--- a/client/src/protoFleet/features/settings/components/Firmware.tsx
+++ b/client/src/protoFleet/features/settings/components/Firmware.tsx
@@ -1,10 +1,13 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import clsx from "clsx";
 import { type FirmwareFileInfo, type FirmwareMetadataInput, useFirmwareApi } from "@/protoFleet/api/useFirmwareApi";
+import { useReleaseChannels } from "@/protoFleet/api/useReleaseChannels";
 import DeleteAllFirmwareDialog from "@/protoFleet/features/settings/components/DeleteAllFirmwareDialog";
 import DeleteFirmwareDialog from "@/protoFleet/features/settings/components/DeleteFirmwareDialog";
 import EditFirmwareMetadataDialog from "@/protoFleet/features/settings/components/EditFirmwareMetadataDialog";
 import FirmwareUploadDialog from "@/protoFleet/features/settings/components/FirmwareUploadDialog";
+import ReleaseChannelsTab from "@/protoFleet/features/settings/components/ReleaseChannels/ReleaseChannelsTab";
 import SettingsEmptyState from "@/protoFleet/features/settings/components/SettingsEmptyState";
 import SettingsPageHeader from "@/protoFleet/features/settings/components/SettingsPageHeader";
 import { ChevronDown, Edit, Trash } from "@/shared/assets/icons";
@@ -12,6 +15,7 @@ import Button, { sizes, variants } from "@/shared/components/Button";
 import { formatFileSize } from "@/shared/components/FileSizeValue";
 import List from "@/shared/components/List";
 import { ColConfig, ColTitles } from "@/shared/components/List/types";
+import SegmentedControl from "@/shared/components/SegmentedControl";
 import { pushToast, STATUSES } from "@/shared/features/toaster";
 import { formatTimestamp, isoToEpochSeconds } from "@/shared/utils/formatTimestamp";
 
@@ -131,7 +135,7 @@ function toFileData(info: FirmwareFileInfo): FirmwareFileData {
   };
 }
 
-const Firmware = () => {
+const FirmwareFilesSection = () => {
   const { listFirmwareFiles, updateFirmwareMetadata, deleteFirmwareFile, deleteAllFirmwareFiles } = useFirmwareApi();
   const [files, setFiles] = useState<FirmwareFileData[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -347,6 +351,41 @@ const Firmware = () => {
         onDismiss={() => setShowDeleteAllDialog(false)}
         isSubmitting={isDeletingAll}
       />
+    </div>
+  );
+};
+
+const TAB_FILES = "files";
+const TAB_RELEASE_CHANNELS = "releaseChannels";
+export const RELEASE_CHANNELS_TAB_PARAM = "release-channels";
+
+const firmwareTabs = [
+  { key: TAB_FILES, title: "Files" },
+  { key: TAB_RELEASE_CHANNELS, title: "Release channels" },
+];
+
+// The active tab lives in the `tab` search param so other surfaces can
+// deep-link straight to the release channels view. Channels and updates are
+// polled here, above the tabs, so one poll can feed every surface on the page.
+const Firmware = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const activeTab = searchParams.get("tab") === RELEASE_CHANNELS_TAB_PARAM ? TAB_RELEASE_CHANNELS : TAB_FILES;
+  const channelsApi = useReleaseChannels();
+
+  return (
+    <div className="flex flex-col gap-6">
+      <SegmentedControl
+        // SegmentedControl is uncontrolled; remount it when navigation
+        // (rather than a click) changes the URL-derived tab.
+        key={activeTab}
+        className="self-start"
+        segments={firmwareTabs}
+        initialSegmentKey={activeTab}
+        onSelect={(key) => {
+          setSearchParams(key === TAB_RELEASE_CHANNELS ? { tab: RELEASE_CHANNELS_TAB_PARAM } : {}, { replace: true });
+        }}
+      />
+      {activeTab === TAB_RELEASE_CHANNELS ? <ReleaseChannelsTab api={channelsApi} /> : <FirmwareFilesSection />}
     </div>
   );
 };

--- a/client/src/protoFleet/features/settings/components/ReleaseChannels/FirmwarePickerButton.tsx
+++ b/client/src/protoFleet/features/settings/components/ReleaseChannels/FirmwarePickerButton.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useState } from "react";
+import clsx from "clsx";
+
+import { ChevronDown } from "@/shared/assets/icons";
+import Button, { sizes, variants } from "@/shared/components/Button";
+import Popover, { PopoverProvider, usePopover } from "@/shared/components/Popover";
+import Radio from "@/shared/components/Radio";
+import { positions } from "@/shared/constants";
+
+interface FirmwareOption {
+  value: string;
+  label: string;
+  description?: string;
+}
+
+interface FirmwarePickerButtonProps {
+  // Accessible name for the trigger, e.g. "Firmware for Rig".
+  label: string;
+  options: FirmwareOption[];
+  value: string;
+  onChange: (value: string) => void;
+  testId: string;
+}
+
+// Button-styled firmware selector for the model group header: the trigger
+// shows the currently selected version and opens a listbox of the available
+// versions. The form-field Select is too heavy for this spot.
+const FirmwarePickerContent = ({ label, options, value, onChange, testId }: FirmwarePickerButtonProps) => {
+  const [open, setOpen] = useState(false);
+  const { triggerRef, setPopoverRenderMode } = usePopover();
+
+  // Portal to body so the listbox escapes the channel table's overflow.
+  useEffect(() => {
+    setPopoverRenderMode("portal-scrolling");
+  }, [setPopoverRenderMode]);
+
+  const selected = options.find((option) => option.value === value);
+
+  return (
+    <div className="relative">
+      <div ref={triggerRef}>
+        <Button
+          variant={variants.secondary}
+          size={sizes.compact}
+          text={selected?.label ?? "No firmware"}
+          suffixIcon={
+            <ChevronDown width="w-3" className={clsx("shrink-0 transition-transform", open && "rotate-180")} />
+          }
+          ariaLabel={label}
+          ariaHasPopup="listbox"
+          ariaExpanded={open}
+          testId={testId}
+          onClick={() => setOpen((current) => !current)}
+        />
+      </div>
+      {open ? (
+        <Popover
+          position={positions["bottom right"]}
+          className="!w-auto !space-y-0 !rounded-xl border border-border-5 !bg-surface-elevated-base !p-0 !shadow-300 !backdrop-blur-none"
+          closePopover={() => setOpen(false)}
+          closeIgnoreSelectors={[`[data-testid='${testId}']`]}
+        >
+          <div
+            role="listbox"
+            aria-label={`${label} options`}
+            className="max-h-80 min-w-64 overflow-y-auto overscroll-contain p-1.5"
+          >
+            {options.map((option) => (
+              <div
+                key={option.value}
+                role="option"
+                aria-selected={value === option.value ? "true" : "false"}
+                className={clsx(
+                  "flex cursor-pointer items-center gap-3 rounded-xl p-3 text-left select-none",
+                  "text-text-primary transition-[background-color] duration-200 ease-in-out hover:bg-core-primary-5",
+                )}
+                onClick={() => {
+                  onChange(option.value);
+                  setOpen(false);
+                }}
+              >
+                <Radio selected={value === option.value} />
+                <div className="min-w-0 grow">
+                  <div className="truncate text-emphasis-300">{option.label}</div>
+                  {option.description ? (
+                    <div className="text-200 text-text-primary-70">{option.description}</div>
+                  ) : null}
+                </div>
+              </div>
+            ))}
+          </div>
+        </Popover>
+      ) : null}
+    </div>
+  );
+};
+
+const FirmwarePickerButton = (props: FirmwarePickerButtonProps) => (
+  <PopoverProvider>
+    <FirmwarePickerContent {...props} />
+  </PopoverProvider>
+);
+
+export default FirmwarePickerButton;
+export type { FirmwareOption };

--- a/client/src/protoFleet/features/settings/components/ReleaseChannels/ModelMinersModal.tsx
+++ b/client/src/protoFleet/features/settings/components/ReleaseChannels/ModelMinersModal.tsx
@@ -1,0 +1,89 @@
+import { useMemo } from "react";
+
+import { phaseLabels, phaseTone } from "./rolloutStatus";
+import StatusChip from "./StatusChip";
+import {
+  type ReleaseChannelModelGroup,
+  type Rollout,
+  RolloutDevicePhase,
+} from "@/protoFleet/api/generated/rollout/v1/rollout_pb";
+import { variants } from "@/shared/components/Button";
+import Modal, { sizes } from "@/shared/components/Modal";
+
+interface ModelMinersModalProps {
+  channelName: string;
+  group: ReleaseChannelModelGroup;
+  activeRollout: Rollout | undefined;
+  minerNames: Record<string, string>;
+  onClose: () => void;
+}
+
+// Per-model miner table, shown on demand so the manage view stays compact no
+// matter how many miners a model group holds. Data flows from the polled
+// channel, so firmware versions and phases update live while open.
+const ModelMinersModal = ({ channelName, group, activeRollout, minerNames, onClose }: ModelMinersModalProps) => {
+  const phases = useMemo(() => {
+    const byIdentifier: Record<string, RolloutDevicePhase> = {};
+    for (const device of activeRollout?.devices ?? []) {
+      byIdentifier[device.deviceIdentifier] = device.phase;
+    }
+    return byIdentifier;
+  }, [activeRollout]);
+
+  return (
+    <Modal
+      open
+      size={sizes.large}
+      title={`${group.model || "Unknown model"} miners`}
+      description={channelName}
+      onDismiss={onClose}
+      buttons={[{ text: "Done", variant: variants.primary, onClick: onClose }]}
+    >
+      <table className="w-full text-left text-200">
+        <thead>
+          <tr className="text-text-primary-50">
+            <th className="py-1.5 pr-4 font-normal">Miner</th>
+            <th className="py-1.5 pr-4 font-normal">Current firmware</th>
+            <th className="py-1.5 font-normal">Status</th>
+          </tr>
+        </thead>
+        <tbody className="text-text-primary">
+          {group.miners.map((miner) => {
+            const phase = phases[miner.deviceIdentifier];
+            const onTarget = group.firmwareVersion !== "" && miner.firmwareVersion === group.firmwareVersion;
+            return (
+              <tr
+                key={miner.deviceIdentifier}
+                className="border-t border-border-5"
+                data-testid={`channel-miner-${miner.deviceIdentifier}`}
+              >
+                <td className="py-2 pr-4">
+                  {minerNames[miner.deviceIdentifier] || miner.deviceIdentifier}
+                  {miner.conflicted ? (
+                    <span className="ml-2 text-text-primary-50" title="Another channel's scope also covers this miner">
+                      (also in another channel)
+                    </span>
+                  ) : null}
+                </td>
+                <td className="py-2 pr-4">{miner.firmwareVersion || "Unknown"}</td>
+                <td className="py-2">
+                  {phase !== undefined && phase !== RolloutDevicePhase.UNSPECIFIED ? (
+                    <StatusChip label={phaseLabels[phase]} tone={phaseTone(phase)} />
+                  ) : onTarget ? (
+                    <StatusChip label="On assigned version" tone="success" />
+                  ) : group.firmwareVersion !== "" ? (
+                    <StatusChip label="Not on assigned version" tone="neutral" />
+                  ) : (
+                    <span className="text-text-primary-50">—</span>
+                  )}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </Modal>
+  );
+};
+
+export default ModelMinersModal;

--- a/client/src/protoFleet/features/settings/components/ReleaseChannels/ReleaseChannelManageView.stories.tsx
+++ b/client/src/protoFleet/features/settings/components/ReleaseChannels/ReleaseChannelManageView.stories.tsx
@@ -1,0 +1,149 @@
+import type { ReactNode } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import ReleaseChannelManageView from "./ReleaseChannelManageView";
+import {
+  activeRigRollout,
+  batchedRigRollout,
+  canaryChannel,
+  canaryChannelSettled,
+  canaryHistory,
+  canaryPreview,
+  completedRigRollout,
+  conflictingPreview,
+  emptyChannel,
+  firmwareFiles,
+  minerNames,
+  productionChannel,
+} from "./ReleaseChannels.fixtures";
+
+// The per-channel management surface behind "Manage": General, Applies to
+// and Update behavior are saved together; Firmware is assigned per model and
+// starts an update paced by the saved behavior. The same view creates a
+// channel when no channel is passed.
+const meta = {
+  title: "Proto Fleet/Firmware/Release Channels/Manage View",
+  component: ReleaseChannelManageView,
+  parameters: {
+    layout: "fullscreen",
+  },
+} satisfies Meta<typeof ReleaseChannelManageView>;
+
+export default meta;
+
+type Story = StoryObj<typeof ReleaseChannelManageView>;
+
+const resolveTo = (preview: typeof canaryPreview) => () => Promise.resolve(preview);
+const settle = () => Promise.resolve();
+
+const Frame = ({ children }: { children: ReactNode }) => (
+  <div className="min-h-screen bg-surface-base p-6">
+    <div className="max-w-5xl">{children}</div>
+  </div>
+);
+
+export const UpdateInProgress: Story = {
+  name: "Rig update in progress",
+  render: () => (
+    <Frame>
+      <ReleaseChannelManageView
+        channel={canaryChannel}
+        rollouts={canaryHistory}
+        firmwareFiles={firmwareFiles}
+        minerNames={minerNames}
+        previewScope={resolveTo(canaryPreview)}
+        onSave={settle}
+        onDelete={() => {}}
+        onApply={settle}
+      />
+    </Frame>
+  ),
+};
+
+export const BatchReviewWithFailure: Story = {
+  name: "Batch review with a failed miner",
+  render: () => (
+    <Frame>
+      <ReleaseChannelManageView
+        channel={{ ...canaryChannel, behavior: batchedRigRollout.behavior }}
+        rollouts={[batchedRigRollout, completedRigRollout]}
+        firmwareFiles={firmwareFiles}
+        minerNames={minerNames}
+        previewScope={resolveTo(canaryPreview)}
+        onSave={settle}
+        onDelete={() => {}}
+        onApply={settle}
+      />
+    </Frame>
+  ),
+};
+
+export const Settled: Story = {
+  name: "Every model up to date",
+  render: () => (
+    <Frame>
+      <ReleaseChannelManageView
+        channel={canaryChannelSettled}
+        rollouts={[completedRigRollout]}
+        firmwareFiles={firmwareFiles}
+        minerNames={minerNames}
+        previewScope={resolveTo(canaryPreview)}
+        onSave={settle}
+        onDelete={() => {}}
+        onApply={settle}
+      />
+    </Frame>
+  ),
+};
+
+export const ScopeOverlap: Story = {
+  name: "Scope overlaps another channel",
+  render: () => (
+    <Frame>
+      <ReleaseChannelManageView
+        channel={productionChannel}
+        rollouts={[]}
+        firmwareFiles={firmwareFiles}
+        minerNames={minerNames}
+        previewScope={resolveTo(conflictingPreview)}
+        onSave={settle}
+        onDelete={() => {}}
+        onApply={settle}
+      />
+    </Frame>
+  ),
+};
+
+export const EmptyChannel: Story = {
+  name: "Empty channel",
+  render: () => (
+    <Frame>
+      <ReleaseChannelManageView
+        channel={emptyChannel}
+        rollouts={[]}
+        firmwareFiles={firmwareFiles}
+        minerNames={minerNames}
+        previewScope={resolveTo({ ...canaryPreview, minerCount: 0, models: [] })}
+        onSave={settle}
+        onDelete={() => {}}
+        onApply={settle}
+      />
+    </Frame>
+  ),
+};
+
+export const Create: Story = {
+  name: "Create a release channel",
+  render: () => (
+    <Frame>
+      <ReleaseChannelManageView
+        rollouts={[activeRigRollout]}
+        firmwareFiles={firmwareFiles}
+        minerNames={minerNames}
+        previewScope={resolveTo(canaryPreview)}
+        onSave={settle}
+        onApply={settle}
+      />
+    </Frame>
+  ),
+};

--- a/client/src/protoFleet/features/settings/components/ReleaseChannels/ReleaseChannelManageView.tsx
+++ b/client/src/protoFleet/features/settings/components/ReleaseChannels/ReleaseChannelManageView.tsx
@@ -1,0 +1,451 @@
+import { type ReactElement, type ReactNode, useCallback, useMemo, useState } from "react";
+import { create, equals } from "@bufbuild/protobuf";
+
+import { defaultBehavior } from "./behaviorUtils";
+import { ModelStatusCell } from "./channelStatus";
+import FirmwarePickerButton from "./FirmwarePickerButton";
+import ModelMinersModal from "./ModelMinersModal";
+import RolloutControls from "./RolloutControls";
+import {
+  isActive,
+  isPaused,
+  pacingSummary,
+  rolloutDeviceCounts,
+  rolloutProgressColorMap,
+  rolloutProgressSegments,
+  rolloutProgressSummary,
+} from "./rolloutStatus";
+import ScopeEditor from "./ScopeEditor";
+import {
+  type PreviewReleaseChannelScopeResponse,
+  type ReleaseChannel,
+  type ReleaseChannelModelGroup,
+  type ReleaseChannelScope,
+  ReleaseChannelScopeSchema,
+  type Rollout,
+  type RolloutBehavior,
+  RolloutBehaviorSchema,
+  RolloutStatus,
+} from "@/protoFleet/api/generated/rollout/v1/rollout_pb";
+import type { FirmwareFileInfo } from "@/protoFleet/api/useFirmwareApi";
+import type { ReleaseChannelDraft } from "@/protoFleet/api/useReleaseChannels";
+import Button, { sizes, variants } from "@/shared/components/Button";
+import CompositionBar from "@/shared/components/CompositionBar";
+import Dialog from "@/shared/components/Dialog";
+import Input from "@/shared/components/Input";
+import Textarea from "@/shared/components/Textarea";
+import { pushToast, STATUSES } from "@/shared/features/toaster";
+
+// Attention pill with a pulsing dot, shown while an update is ongoing.
+const UpdateActivePill = ({ count, testId }: { count: number; testId?: string }) => (
+  <span
+    data-testid={testId}
+    className="inline-flex items-center gap-1.5 rounded-full bg-intent-warning-10 px-2 py-0.5 text-200 font-normal whitespace-nowrap text-text-primary"
+  >
+    <span className="size-2 shrink-0 animate-pulse rounded-full bg-intent-warning-fill" />
+    {count === 1 ? "Update in progress" : `${count} updates in progress`}
+  </span>
+);
+
+function Section({ title, subtext, children }: { title: string; subtext?: string; children: ReactNode }): ReactElement {
+  return (
+    <section className="grid gap-3">
+      <div className="grid">
+        <div className="text-emphasis-300 text-text-primary">{title}</div>
+        {subtext ? <div className="text-300 text-text-primary-70">{subtext}</div> : null}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+interface FirmwarePickerCellProps {
+  group: ReleaseChannelModelGroup;
+  firmwareFiles: FirmwareFileInfo[];
+  stagedFileId: string;
+  onStageFirmware: (model: string, fileId: string) => void;
+}
+
+const FirmwarePickerCell = ({ group, firmwareFiles, stagedFileId, onStageFirmware }: FirmwarePickerCellProps) => {
+  const options = useMemo(() => {
+    const matching = firmwareFiles.filter((f) => f.target_model.toLowerCase() === group.model.toLowerCase());
+    return [
+      { value: "", label: "No firmware" },
+      ...matching.map((f) => ({
+        value: f.id,
+        label: f.firmware_version || f.filename,
+        description: f.filename,
+      })),
+    ];
+  }, [firmwareFiles, group.model]);
+
+  return (
+    <FirmwarePickerButton
+      label={`Firmware for ${group.model || "unknown model"}`}
+      options={options}
+      value={stagedFileId}
+      onChange={(value) => onStageFirmware(group.model, value)}
+      testId={`channel-firmware-select-${group.model}`}
+    />
+  );
+};
+
+interface ReleaseChannelManageViewProps {
+  // Undefined creates a new channel.
+  channel?: ReleaseChannel;
+  rollouts: Rollout[];
+  firmwareFiles: FirmwareFileInfo[];
+  minerNames: Record<string, string>;
+  previewScope: (scope: ReleaseChannelScope, channelId?: bigint) => Promise<PreviewReleaseChannelScopeResponse>;
+  onSave: (draft: ReleaseChannelDraft) => Promise<void>;
+  onDelete?: (channel: ReleaseChannel) => void;
+  onApply: (channelId: bigint, assignments: { model: string; firmwareFileId: string }[]) => Promise<void>;
+}
+
+// The per-channel management surface behind "Manage" (and the create flow):
+// General, Applies to and Update behavior are saved together; Firmware is
+// applied per model and starts an update paced by the saved behavior.
+const ReleaseChannelManageView = ({
+  channel,
+  rollouts,
+  firmwareFiles,
+  minerNames,
+  previewScope,
+  onSave,
+  onDelete,
+  onApply,
+}: ReleaseChannelManageViewProps) => {
+  // The draft is seeded once from the channel; the parent remounts this
+  // view (keyed by channel id) when a different channel is opened.
+  const [name, setName] = useState(channel?.name ?? "");
+  const [description, setDescription] = useState(channel?.description ?? "");
+  const [scope, setScope] = useState<ReleaseChannelScope>(() => channel?.scope ?? create(ReleaseChannelScopeSchema));
+  const [behavior, setBehavior] = useState<RolloutBehavior>(() => channel?.behavior ?? defaultBehavior());
+  const [preview, setPreview] = useState<PreviewReleaseChannelScopeResponse | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  // Staged (unapplied) firmware choices per model; absent key = server value.
+  const [staged, setStaged] = useState<Record<string, string>>({});
+  const [isApplying, setIsApplying] = useState(false);
+  const [showApplyDialog, setShowApplyDialog] = useState(false);
+  // Model whose miner table is open in the "View miners" modal.
+  const [minersModel, setMinersModel] = useState<string | null>(null);
+
+  const channelId = channel?.id;
+  const previewForChannel = useCallback(
+    (candidate: ReleaseChannelScope) => previewScope(candidate, channelId),
+    [previewScope, channelId],
+  );
+
+  const dirty =
+    channel === undefined ||
+    name.trim() !== channel.name ||
+    description.trim() !== channel.description ||
+    !equals(ReleaseChannelScopeSchema, scope, channel.scope ?? create(ReleaseChannelScopeSchema)) ||
+    !equals(RolloutBehaviorSchema, behavior, channel.behavior ?? create(RolloutBehaviorSchema));
+  const hasConflicts = (preview?.conflicts.length ?? 0) > 0;
+  const canSave = dirty && name.trim() !== "" && !hasConflicts && !isSaving;
+
+  const handleSave = () => {
+    setIsSaving(true);
+    onSave({ name: name.trim(), description: description.trim(), scope, behavior })
+      .then(() => {
+        pushToast({
+          message: channel ? "Release channel saved" : `Created release channel ${name.trim()}`,
+          status: STATUSES.success,
+        });
+      })
+      .catch((error) => {
+        pushToast({ message: error?.message || "Couldn't save the release channel", status: STATUSES.error });
+      })
+      .finally(() => setIsSaving(false));
+  };
+
+  const channelRollouts = channel ? rollouts.filter((r) => r.channelId === channel.id) : [];
+  const activeByModel = new Map(channelRollouts.filter(isActive).map((r) => [r.model, r]));
+  const activeCount = activeByModel.size;
+  const modelGroups = channel?.modelGroups ?? [];
+  // Derived from the polled channel on every render so the open modal tracks
+  // live firmware versions and phases; closes if the group empties.
+  const minersGroup = minersModel !== null ? modelGroups.find((group) => group.model === minersModel) : undefined;
+
+  const stagedValue = (group: ReleaseChannelModelGroup): string =>
+    staged[group.model] !== undefined ? staged[group.model] : group.firmwareFileId;
+
+  const dirtyAssignments = modelGroups
+    .filter((group) => stagedValue(group) !== group.firmwareFileId)
+    .map((group) => ({ model: group.model, firmwareFileId: stagedValue(group) }));
+
+  // Human-readable version for a staged file id, for the dialog summary.
+  const versionLabel = (fileId: string): string => {
+    if (fileId === "") return "no firmware";
+    const file = firmwareFiles.find((f) => f.id === fileId);
+    return file?.firmware_version || file?.filename || "unknown version";
+  };
+
+  const handleApply = () => {
+    if (!channel) return;
+    setIsApplying(true);
+    onApply(channel.id, dirtyAssignments)
+      .then(() => {
+        setStaged({});
+        setShowApplyDialog(false);
+        pushToast({ message: "Firmware changes applied", status: STATUSES.success });
+      })
+      .catch((error) => {
+        pushToast({ message: error?.message || "Couldn't apply firmware changes", status: STATUSES.error });
+      })
+      .finally(() => setIsApplying(false));
+  };
+
+  const inScopeCount = preview?.minerCount ?? channel?.minerCount ?? 0;
+  const lastFinishedByModel = new Map<string, Rollout>();
+  for (const r of channelRollouts) {
+    if (r.status !== RolloutStatus.COMPLETED && r.status !== RolloutStatus.COMPLETED_WITH_FAILURES) continue;
+    if (!lastFinishedByModel.has(r.model)) lastFinishedByModel.set(r.model, r); // rollouts arrive newest first
+  }
+
+  return (
+    <div
+      className="flex flex-col gap-8"
+      data-testid={channel ? `release-channel-${channel.name}` : "release-channel-new"}
+    >
+      <div className="flex items-start justify-between gap-4 phone:flex-col phone:items-stretch">
+        <div className="flex flex-col gap-1">
+          <div className="flex items-center gap-3">
+            <h2 className="text-heading-200 text-text-primary">{channel ? channel.name : "New release channel"}</h2>
+            {activeCount > 0 ? <UpdateActivePill count={activeCount} testId="channel-update-pill" /> : null}
+          </div>
+          {channel ? (
+            <div className="flex items-center gap-2 text-200 text-text-primary-50">
+              <span>{channel.minerCount === 1 ? "1 miner" : `${channel.minerCount.toLocaleString()} miners`}</span>
+              <span>·</span>
+              <span>{modelGroups.length === 1 ? "1 model" : `${modelGroups.length} models`}</span>
+            </div>
+          ) : null}
+        </div>
+        <div className="flex gap-2 phone:flex-col phone:items-stretch">
+          {channel && onDelete ? (
+            <Button
+              variant={variants.danger}
+              size={sizes.compact}
+              text="Delete"
+              onClick={() => onDelete(channel)}
+              testId="delete-channel"
+            />
+          ) : null}
+          <Button
+            variant={variants.primary}
+            size={sizes.compact}
+            text={channel ? "Save changes" : "Create channel"}
+            onClick={handleSave}
+            disabled={!canSave}
+            loading={isSaving}
+            testId="save-channel"
+          />
+        </div>
+      </div>
+
+      <Section title="General">
+        <div className="grid gap-3">
+          <Input
+            id="channel-name"
+            label="Name"
+            initValue={name}
+            onChange={(value) => setName(value)}
+            autoFocus={!channel}
+          />
+          <Textarea
+            id="channel-description"
+            label="Description"
+            initValue={description}
+            onChange={(value) => setDescription(value)}
+          />
+        </div>
+      </Section>
+
+      <Section
+        title="Applies to"
+        subtext="Miners are grouped by hardware model. Firmware is assigned per model below once the channel is saved."
+      >
+        <ScopeEditor scope={scope} onChange={setScope} previewScope={previewForChannel} onPreview={setPreview} />
+      </Section>
+
+      <Section title="Update behavior" subtext="How firmware updates are paced across the selected miners.">
+        <RolloutControls behavior={behavior} onChange={setBehavior} inScopeCount={inScopeCount} />
+      </Section>
+
+      {channel ? (
+        <Section
+          title="Firmware"
+          subtext="Assigned firmware is enforced: miners not on the assigned version are updated."
+        >
+          {modelGroups.length === 0 ? (
+            <span className="text-300 text-text-primary-50">
+              No miners in scope yet. Widen the selection above to group miners by model and assign firmware.
+            </span>
+          ) : (
+            <table className="w-full text-left text-200">
+              <thead>
+                <tr className="text-text-primary-50">
+                  <th className="py-1.5 pr-4 font-normal">Model</th>
+                  <th className="py-1.5 pr-4 font-normal">Miners</th>
+                  <th className="py-1.5 pr-4 font-normal">Firmware</th>
+                  <th className="py-1.5 pr-4 font-normal">Update status</th>
+                  <th className="py-1.5 font-normal">
+                    <span className="sr-only">Actions</span>
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="text-text-primary">
+                {modelGroups.map((group) => {
+                  const activeRollout = activeByModel.get(group.model);
+                  const counts = activeRollout ? rolloutDeviceCounts(activeRollout) : undefined;
+                  return [
+                    <tr
+                      key={group.model}
+                      className="border-t border-border-5"
+                      data-testid={`model-group-${group.model}`}
+                    >
+                      <td className="py-3 pr-4 text-emphasis-300">{group.model || "Unknown model"}</td>
+                      <td className="py-3 pr-4">{group.miners.length.toLocaleString()}</td>
+                      <td className="py-3 pr-4">
+                        <FirmwarePickerCell
+                          group={group}
+                          firmwareFiles={firmwareFiles}
+                          stagedFileId={stagedValue(group)}
+                          onStageFirmware={(model, fileId) => setStaged((prev) => ({ ...prev, [model]: fileId }))}
+                        />
+                      </td>
+                      <td className="py-3 pr-4">
+                        <ModelStatusCell
+                          group={group}
+                          activeRollout={activeRollout}
+                          lastFinished={lastFinishedByModel.get(group.model)}
+                        />
+                      </td>
+                      <td className="py-3 text-right">
+                        {group.miners.length > 0 ? (
+                          <Button
+                            variant={variants.secondary}
+                            size={sizes.compact}
+                            text="View miners"
+                            onClick={() => setMinersModel(group.model)}
+                            testId={`view-miners-${group.model}`}
+                          />
+                        ) : null}
+                      </td>
+                    </tr>,
+                    activeRollout && counts ? (
+                      <tr key={`${group.model}-progress`} data-testid={`model-group-rollout-progress-${group.model}`}>
+                        <td className="pb-3" colSpan={5}>
+                          <div className="flex flex-col gap-1.5">
+                            <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1 text-200 text-text-primary-70">
+                              <span>
+                                {isPaused(activeRollout)
+                                  ? `Updating to ${activeRollout.firmwareVersion} (paused)`
+                                  : `Updating to ${activeRollout.firmwareVersion}`}
+                              </span>
+                              <span>{rolloutProgressSummary(counts)}</span>
+                            </div>
+                            <CompositionBar
+                              segments={rolloutProgressSegments(counts)}
+                              height={6}
+                              colorMap={rolloutProgressColorMap}
+                            />
+                          </div>
+                        </td>
+                      </tr>
+                    ) : null,
+                  ];
+                })}
+              </tbody>
+            </table>
+          )}
+
+          {dirtyAssignments.length > 0 ? (
+            <div className="flex items-center justify-between gap-4 rounded-lg bg-intent-warning-10 px-4 py-3">
+              <span className="text-300 text-text-primary">
+                {dirtyAssignments.length === 1
+                  ? "1 firmware change pending"
+                  : `${dirtyAssignments.length} firmware changes pending`}
+                {" — applying starts an update per model."}
+              </span>
+              <div className="flex shrink-0 gap-2">
+                <Button
+                  variant={variants.secondary}
+                  size={sizes.compact}
+                  text="Discard"
+                  disabled={isApplying}
+                  onClick={() => setStaged({})}
+                />
+                <Button
+                  variant={variants.primary}
+                  size={sizes.compact}
+                  text="Apply changes"
+                  onClick={() => setShowApplyDialog(true)}
+                  testId="apply-firmware-changes"
+                />
+              </div>
+            </div>
+          ) : null}
+        </Section>
+      ) : null}
+
+      {channel && minersGroup ? (
+        <ModelMinersModal
+          channelName={channel.name}
+          group={minersGroup}
+          activeRollout={activeByModel.get(minersGroup.model)}
+          minerNames={minerNames}
+          onClose={() => setMinersModel(null)}
+        />
+      ) : null}
+
+      {channel ? (
+        <Dialog
+          open={showApplyDialog}
+          title="Start firmware update?"
+          subtitle={`One update starts per changed model in ${channel.name}. Pacing: ${pacingSummary(channel.behavior).toLowerCase()}.`}
+          testId="apply-firmware-dialog"
+          onDismiss={() => {
+            if (!isApplying) setShowApplyDialog(false);
+          }}
+          buttons={[
+            {
+              text: "Cancel",
+              variant: variants.secondary,
+              onClick: () => setShowApplyDialog(false),
+              disabled: isApplying,
+            },
+            {
+              text: "Start update",
+              variant: variants.primary,
+              onClick: handleApply,
+              loading: isApplying,
+            },
+          ]}
+        >
+          <div>
+            {dirtyAssignments.map((assignment) => (
+              <div
+                key={assignment.model}
+                className="flex items-baseline justify-between gap-4 border-t border-border-5 py-2.5 text-200"
+              >
+                <span className="text-text-primary">{assignment.model || "Unknown model"}</span>
+                <span className="text-right text-text-primary-70">{versionLabel(assignment.firmwareFileId)}</span>
+              </div>
+            ))}
+          </div>
+          {dirty ? (
+            <p className="mt-3 text-200 text-text-primary-70">
+              Unsaved channel changes are not applied to this update. Save the channel first to use them.
+            </p>
+          ) : null}
+        </Dialog>
+      ) : null}
+    </div>
+  );
+};
+
+export default ReleaseChannelManageView;

--- a/client/src/protoFleet/features/settings/components/ReleaseChannels/ReleaseChannels.fixtures.ts
+++ b/client/src/protoFleet/features/settings/components/ReleaseChannels/ReleaseChannels.fixtures.ts
@@ -1,0 +1,444 @@
+import { create } from "@bufbuild/protobuf";
+import { timestampFromDate } from "@bufbuild/protobuf/wkt";
+
+import {
+  MetricComparisonSchema,
+  type PreviewReleaseChannelScopeResponse,
+  PreviewReleaseChannelScopeResponseSchema,
+  type ReleaseChannel,
+  ReleaseChannelSchema,
+  ReleaseChannelScopeSchema,
+  type Rollout,
+  type RolloutBehavior,
+  RolloutBehaviorSchema,
+  RolloutCancelReason,
+  RolloutDevicePhase,
+  RolloutDeviceSchema,
+  RolloutEvidenceSchema,
+  RolloutMethod,
+  RolloutOrder,
+  RolloutSchema,
+  RolloutStage,
+  RolloutState,
+  RolloutStatus,
+} from "@/protoFleet/api/generated/rollout/v1/rollout_pb";
+import type { FirmwareFileInfo } from "@/protoFleet/api/useFirmwareApi";
+
+// Fixture data for the release channel stories and tests: one mixed-fleet
+// channel ("Canary") mid-update on its Rig group, plus the firmware files and
+// display names the components take as props.
+
+const minutesAgo = (minutes: number) => timestampFromDate(new Date(Date.now() - minutes * 60_000));
+
+export const firmwareFiles: FirmwareFileInfo[] = [
+  {
+    id: "fw-rig-143",
+    filename: "proto-rig-1.4.3.swu",
+    size: 52_428_800,
+    uploaded_at: "2026-08-20T09:00:00Z",
+    target_manufacturer: "Proto",
+    target_model: "Rig",
+    firmware_version: "1.4.3",
+  },
+  {
+    id: "fw-rig-144",
+    filename: "proto-rig-1.4.4.swu",
+    size: 52_690_944,
+    uploaded_at: "2026-08-27T14:00:00Z",
+    target_manufacturer: "Proto",
+    target_model: "Rig",
+    firmware_version: "1.4.4",
+  },
+  {
+    id: "fw-s21-301",
+    filename: "s21-3.0.1.bin",
+    size: 33_554_432,
+    uploaded_at: "2026-08-25T11:30:00Z",
+    target_manufacturer: "Bitmain",
+    target_model: "S21",
+    firmware_version: "3.0.1",
+  },
+];
+
+export const minerNames: Record<string, string> = {
+  "rig-001": "Rig A01",
+  "rig-002": "Rig A02",
+  "rig-003": "Rig A03",
+  "rig-004": "Rig B01",
+  "rig-005": "Rig B02",
+  "rig-006": "Rig B03",
+  "s21-001": "S21 Rack 4-1",
+  "s21-002": "S21 Rack 4-2",
+};
+
+export const singleBatchBehavior: RolloutBehavior = create(RolloutBehaviorSchema, {
+  method: RolloutMethod.ALL_AT_ONCE,
+  order: RolloutOrder.LEAST_EFFICIENT_FIRST,
+});
+
+export const pilotBehavior: RolloutBehavior = create(RolloutBehaviorSchema, {
+  method: RolloutMethod.PILOT_THEN_CONTINUE,
+  order: RolloutOrder.LEAST_EFFICIENT_FIRST,
+  pilotSize: 2,
+  reviewAfterEachBatch: true,
+  maxConcurrentOffline: 10,
+});
+
+export const batchedAutoBehavior: RolloutBehavior = create(RolloutBehaviorSchema, {
+  method: RolloutMethod.BATCHED,
+  order: RolloutOrder.LEAST_EFFICIENT_FIRST,
+  batchSize: 2,
+  reviewAfterEachBatch: true,
+  autoContinueOnHealthyTelemetry: true,
+  stabilizationSeconds: 600,
+  thresholds: { maxHashrateDropPercent: 10, maxTemperatureIncreaseCelsius: 5, maxNewErrors: 0 },
+});
+
+const rigMiner = (n: number, firmwareVersion: string) => ({
+  deviceId: BigInt(100 + n),
+  deviceIdentifier: `rig-00${n}`,
+  model: "Rig",
+  firmwareVersion,
+});
+
+// "Canary" applies to one rack plus two hand-picked S21s. Its Rig group is
+// assigned 1.4.4 and partway through updating; S21 has no assignment yet.
+export const canaryChannel: ReleaseChannel = create(ReleaseChannelSchema, {
+  id: BigInt(1),
+  name: "Canary",
+  description: "First wave: rack 4 plus two S21s.",
+  scope: { rackIds: [BigInt(40)], deviceIdentifiers: ["s21-001", "s21-002"] },
+  behavior: pilotBehavior,
+  minerCount: 8,
+  createdAt: minutesAgo(60 * 24 * 3),
+  updatedAt: minutesAgo(60 * 24),
+  modelGroups: [
+    {
+      model: "Rig",
+      firmwareFileId: "fw-rig-144",
+      firmwareVersion: "1.4.4",
+      activeRolloutId: BigInt(41),
+      miners: [
+        rigMiner(1, "1.4.4"),
+        rigMiner(2, "1.4.4"),
+        rigMiner(3, "1.4.3"),
+        rigMiner(4, "1.4.3"),
+        rigMiner(5, "1.4.3"),
+        rigMiner(6, "1.4.3"),
+      ],
+    },
+    {
+      model: "S21",
+      firmwareFileId: "",
+      firmwareVersion: "",
+      activeRolloutId: BigInt(0),
+      miners: [
+        { deviceId: BigInt(201), deviceIdentifier: "s21-001", model: "S21", firmwareVersion: "3.0.0" },
+        {
+          deviceId: BigInt(202),
+          deviceIdentifier: "s21-002",
+          model: "S21",
+          firmwareVersion: "3.0.0",
+          conflicted: true,
+        },
+      ],
+    },
+  ],
+});
+
+// The same channel with the Rig update finished and every miner compliant.
+export const canaryChannelSettled: ReleaseChannel = create(ReleaseChannelSchema, {
+  ...canaryChannel,
+  modelGroups: canaryChannel.modelGroups.map((group) =>
+    group.model === "Rig"
+      ? {
+          ...group,
+          activeRolloutId: BigInt(0),
+          miners: group.miners.map((miner) => ({ ...miner, firmwareVersion: "1.4.4" })),
+        }
+      : group,
+  ),
+});
+
+export const emptyChannel: ReleaseChannel = create(ReleaseChannelSchema, {
+  id: BigInt(2),
+  name: "Staging",
+  description: "",
+  scope: {},
+  behavior: singleBatchBehavior,
+  minerCount: 0,
+  createdAt: minutesAgo(30),
+  updatedAt: minutesAgo(30),
+  modelGroups: [],
+});
+
+// A settled channel with a distinct id, for stories listing several channels.
+export const productionChannel: ReleaseChannel = create(ReleaseChannelSchema, {
+  ...canaryChannelSettled,
+  id: BigInt(3),
+  name: "Production",
+  description: "Everything else.",
+  scope: create(ReleaseChannelScopeSchema, { siteIds: [BigInt(1)] }),
+  behavior: batchedAutoBehavior,
+  minerCount: 240,
+});
+
+export const canaryPreview: PreviewReleaseChannelScopeResponse = create(PreviewReleaseChannelScopeResponseSchema, {
+  minerCount: 8,
+  models: [
+    { model: "Rig", minerCount: 6 },
+    { model: "S21", minerCount: 2 },
+  ],
+});
+
+export const conflictingPreview: PreviewReleaseChannelScopeResponse = create(PreviewReleaseChannelScopeResponseSchema, {
+  minerCount: 8,
+  models: [
+    { model: "Rig", minerCount: 6 },
+    { model: "S21", minerCount: 2 },
+  ],
+  conflicts: [{ channelId: BigInt(3), channelName: "Production", minerCount: 2 }],
+});
+
+// Health fields for a miner as the server reports them: live status and
+// telemetry alongside the baseline captured when the rollout started.
+const TH = 1e12;
+const metric = (baseline: number | undefined, current: number | undefined) =>
+  create(MetricComparisonSchema, { baseline, current });
+// Power, efficiency and temperature scale with hashrate so a degraded miner
+// reads consistently across the strip.
+const healthy = (hashRateTh: number, baselineTh = hashRateTh, ipSuffix = 11) => ({
+  status: "ACTIVE",
+  online: true,
+  hashing: true,
+  hasBaseline: true,
+  baselineHashing: true,
+  ipAddress: `10.20.4.${ipSuffix}`,
+  hashRateHs: metric(baselineTh * TH, hashRateTh * TH),
+  powerW: metric(baselineTh * 30, hashRateTh * 30 + 40),
+  efficiencyJh: metric(30, hashRateTh > 0 ? 30 + 40 / hashRateTh : undefined),
+  tempC: metric(64, hashRateTh >= baselineTh ? 65 : 71),
+  openErrors: 0,
+  baselineOpenErrors: 0,
+});
+const offline = (baselineTh: number, ipSuffix = 11) => ({
+  ...healthy(0, baselineTh, ipSuffix),
+  status: "OFFLINE",
+  online: false,
+  hashing: false,
+  hashRateHs: metric(baselineTh * TH, undefined),
+  powerW: metric(baselineTh * 30, undefined),
+  efficiencyJh: metric(30, undefined),
+  tempC: metric(64, undefined),
+});
+
+const rigDevice = (n: number, firmwareVersion: string, phase: RolloutDevicePhase, extra: object = {}) =>
+  create(RolloutDeviceSchema, {
+    deviceId: BigInt(100 + n),
+    deviceIdentifier: `rig-00${n}`,
+    firmwareVersion,
+    phase,
+    ...healthy(112, 112, 10 + n),
+    ...extra,
+  });
+
+// Ongoing single-batch update to 1.4.4 on the Rig group: two miners done,
+// one mid-flash, three queued.
+export const activeRigRollout: Rollout = create(RolloutSchema, {
+  id: BigInt(41),
+  channelId: BigInt(1),
+  channelName: "Canary",
+  model: "Rig",
+  firmwareFileId: "fw-rig-144",
+  firmwareVersion: "1.4.4",
+  status: RolloutStatus.ACTIVE,
+  state: RolloutState.IN_PROGRESS,
+  stage: RolloutStage.REST,
+  behavior: singleBatchBehavior,
+  stageChangedAt: minutesAgo(4),
+  createdAt: minutesAgo(4),
+  devices: [
+    rigDevice(1, "1.4.4", RolloutDevicePhase.DONE, { attempts: 1 }),
+    rigDevice(2, "1.4.4", RolloutDevicePhase.DONE, { attempts: 1 }),
+    rigDevice(3, "1.4.3", RolloutDevicePhase.IN_PROGRESS, { attempts: 1, ...offline(112, 13) }),
+    rigDevice(4, "1.4.3", RolloutDevicePhase.QUEUED),
+    rigDevice(5, "1.4.3", RolloutDevicePhase.QUEUED),
+    rigDevice(6, "1.4.3", RolloutDevicePhase.QUEUED),
+  ],
+  evidence: create(RolloutEvidenceSchema, {
+    devicesTotal: 6,
+    verified: 2,
+    online: 5,
+    hashing: 5,
+    baselineHashing: 6,
+    hashRateHs: metric(672 * TH, 560 * TH),
+    hashrateChangePercent: -16.7,
+    powerW: metric(560 * 30, 560 * 30 + 200),
+    efficiencyJh: metric(30, 30.4),
+    tempC: metric(64, 65),
+  }),
+});
+
+// A pilot update parked at the review gate with healthy evidence: both pilot
+// miners are back and hashing slightly above baseline.
+export const gatedRigRollout: Rollout = create(RolloutSchema, {
+  ...activeRigRollout,
+  id: BigInt(45),
+  state: RolloutState.PAUSED_AT_PILOT_GATE,
+  stage: RolloutStage.AWAITING_REVIEW,
+  behavior: pilotBehavior,
+  batchCount: 1,
+  currentBatch: 0,
+  stageChangedAt: minutesAgo(6),
+  createdAt: minutesAgo(22),
+  devices: [
+    rigDevice(1, "1.4.4", RolloutDevicePhase.DONE, { batch: 1, attempts: 1, ...healthy(115, 112, 11) }),
+    rigDevice(2, "1.4.4", RolloutDevicePhase.DONE, { batch: 1, attempts: 1, ...healthy(115, 112, 12) }),
+    rigDevice(3, "1.4.3", RolloutDevicePhase.QUEUED),
+    rigDevice(4, "1.4.3", RolloutDevicePhase.QUEUED),
+    rigDevice(5, "1.4.3", RolloutDevicePhase.QUEUED),
+    rigDevice(6, "1.4.3", RolloutDevicePhase.QUEUED),
+  ],
+  evidence: create(RolloutEvidenceSchema, {
+    devicesTotal: 2,
+    verified: 2,
+    online: 2,
+    hashing: 2,
+    baselineHashing: 2,
+    hashRateHs: metric(224 * TH, 230 * TH),
+    hashrateChangePercent: 2.7,
+    holdReason: "Manual review",
+    powerW: metric(224 * 30, 230 * 30 + 80),
+    efficiencyJh: metric(30, 30.3),
+    tempC: metric(64, 65),
+  }),
+});
+
+// Batches of two with auto-continue, holding at the gate after batch 2 of 3
+// because one miner failed and another opened errors.
+export const batchedRigRollout: Rollout = create(RolloutSchema, {
+  ...activeRigRollout,
+  id: BigInt(46),
+  state: RolloutState.PAUSED_AT_BATCH_REVIEW,
+  stage: RolloutStage.AWAITING_REVIEW,
+  behavior: batchedAutoBehavior,
+  batchCount: 3,
+  currentBatch: 1,
+  stageChangedAt: minutesAgo(14),
+  createdAt: minutesAgo(41),
+  devices: [
+    rigDevice(1, "1.4.4", RolloutDevicePhase.DONE, { batch: 1, attempts: 1 }),
+    rigDevice(2, "1.4.4", RolloutDevicePhase.DONE, { batch: 1, attempts: 1 }),
+    rigDevice(3, "1.4.4", RolloutDevicePhase.DONE, { batch: 2, attempts: 1, openErrors: 2 }),
+    rigDevice(4, "1.4.3", RolloutDevicePhase.FAILED, {
+      batch: 2,
+      attempts: 3,
+      lastError: "Did not report 1.4.4 after 3 update attempts",
+      ...offline(112, 14),
+    }),
+    rigDevice(5, "1.4.3", RolloutDevicePhase.QUEUED, { batch: 3 }),
+    rigDevice(6, "1.4.3", RolloutDevicePhase.QUEUED, { batch: 3 }),
+  ],
+  evidence: create(RolloutEvidenceSchema, {
+    devicesTotal: 2,
+    verified: 1,
+    failed: 1,
+    online: 1,
+    hashing: 1,
+    baselineHashing: 2,
+    hashRateHs: metric(112 * TH, 112 * TH),
+    newErrors: 2,
+    holdReason: "1 miners failed to update",
+    powerW: metric(112 * 30, 112 * 30 + 40),
+    efficiencyJh: metric(30, 30.4),
+    tempC: metric(64, 65),
+  }),
+});
+
+// A single-batch update an operator paused mid-flight.
+export const pausedRigRollout: Rollout = create(RolloutSchema, {
+  ...activeRigRollout,
+  id: BigInt(47),
+  state: RolloutState.PAUSED,
+  pausedAt: minutesAgo(3),
+  createdAt: minutesAgo(11),
+  evidence: create(RolloutEvidenceSchema, {
+    ...(activeRigRollout.evidence ?? create(RolloutEvidenceSchema)),
+    holdReason: "Paused",
+  }),
+});
+
+export const completedRigRollout: Rollout = create(RolloutSchema, {
+  id: BigInt(40),
+  channelId: BigInt(1),
+  channelName: "Canary",
+  model: "Rig",
+  firmwareFileId: "fw-rig-143",
+  firmwareVersion: "1.4.3",
+  status: RolloutStatus.COMPLETED,
+  state: RolloutState.COMPLETED,
+  stage: RolloutStage.REST,
+  behavior: singleBatchBehavior,
+  createdAt: minutesAgo(60 * 26),
+  finishedAt: minutesAgo(60 * 25),
+  devices: [1, 2, 3, 4, 5, 6].map((n) => rigDevice(n, "1.4.3", RolloutDevicePhase.DONE, { attempts: 1 })),
+});
+
+export const completedWithFailuresRigRollout: Rollout = create(RolloutSchema, {
+  ...completedRigRollout,
+  id: BigInt(48),
+  firmwareFileId: "fw-rig-144",
+  firmwareVersion: "1.4.4",
+  status: RolloutStatus.COMPLETED_WITH_FAILURES,
+  state: RolloutState.COMPLETED_WITH_FAILURES,
+  createdAt: minutesAgo(60 * 3),
+  finishedAt: minutesAgo(60 * 2),
+  devices: [
+    ...[1, 2, 3, 4, 5].map((n) => rigDevice(n, "1.4.4", RolloutDevicePhase.DONE, { attempts: 1 })),
+    rigDevice(6, "1.4.3", RolloutDevicePhase.FAILED, {
+      attempts: 3,
+      lastError: "Did not report 1.4.4 after 3 update attempts",
+      ...offline(112, 16),
+    }),
+  ],
+});
+
+export const canceledRigRollout: Rollout = create(RolloutSchema, {
+  id: BigInt(39),
+  channelId: BigInt(1),
+  channelName: "Canary",
+  model: "Rig",
+  firmwareFileId: "fw-rig-142",
+  firmwareVersion: "1.4.2",
+  status: RolloutStatus.CANCELED,
+  state: RolloutState.CANCELED,
+  cancelReason: RolloutCancelReason.SUPERSEDED,
+  behavior: singleBatchBehavior,
+  createdAt: minutesAgo(60 * 27),
+  finishedAt: minutesAgo(60 * 26),
+  devices: [],
+});
+
+// A pilot update an operator canceled at the review gate: the pilot miners
+// keep 1.4.4, the rest were never touched.
+export const canceledRemainingRigRollout: Rollout = create(RolloutSchema, {
+  ...gatedRigRollout,
+  id: BigInt(38),
+  status: RolloutStatus.CANCELED,
+  state: RolloutState.CANCELED,
+  cancelReason: RolloutCancelReason.CANCELED_REMAINING,
+  previousFirmwareFileId: "fw-rig-143",
+  previousFirmwareVersion: "1.4.3",
+  createdAt: minutesAgo(60 * 48),
+  finishedAt: minutesAgo(60 * 47),
+  evidence: undefined,
+});
+
+// Newest first, matching the server's ListRollouts order.
+export const canaryHistory: Rollout[] = [
+  activeRigRollout,
+  completedWithFailuresRigRollout,
+  completedRigRollout,
+  canceledRigRollout,
+  canceledRemainingRigRollout,
+];

--- a/client/src/protoFleet/features/settings/components/ReleaseChannels/ReleaseChannelsTab.tsx
+++ b/client/src/protoFleet/features/settings/components/ReleaseChannels/ReleaseChannelsTab.tsx
@@ -1,0 +1,183 @@
+import { useEffect, useState } from "react";
+
+import ReleaseChannelManageView from "./ReleaseChannelManageView";
+import ReleaseChannelsTable from "./ReleaseChannelsTable";
+import type { ReleaseChannel } from "@/protoFleet/api/generated/rollout/v1/rollout_pb";
+import { type FirmwareFileInfo, useFirmwareApi } from "@/protoFleet/api/useFirmwareApi";
+import type { ReleaseChannelsApi } from "@/protoFleet/api/useReleaseChannels";
+import SettingsEmptyState from "@/protoFleet/features/settings/components/SettingsEmptyState";
+import SettingsPageHeader from "@/protoFleet/features/settings/components/SettingsPageHeader";
+import { Alert } from "@/shared/assets/icons";
+import Button, { sizes, variants } from "@/shared/components/Button";
+import Dialog, { DialogIcon } from "@/shared/components/Dialog";
+import { pushToast, STATUSES } from "@/shared/features/toaster";
+
+const RELEASE_CHANNELS_DESCRIPTION =
+  "Group miners into release channels and assign firmware per model. Assigned firmware is enforced: miners not on the assigned version are updated automatically, paced by the channel's update behavior.";
+
+// Which surface the tab shows: the channels table, a channel's manage
+// view, or the create form.
+type View = { kind: "list" } | { kind: "manage"; channelId: bigint } | { kind: "create" };
+
+interface ReleaseChannelsTabProps {
+  // Shared with the active-updates monitor above the tabs, so one poll
+  // feeds both.
+  api: ReleaseChannelsApi;
+  // Channel to open in the manage view on mount (e.g. from an update's
+  // "Manage" action).
+  initialManagedChannelId?: bigint | null;
+}
+
+const ReleaseChannelsTab = ({ api, initialManagedChannelId = null }: ReleaseChannelsTabProps) => {
+  const {
+    channels,
+    rollouts,
+    minerNames,
+    isLoading,
+    createChannel,
+    updateChannel,
+    deleteChannel,
+    previewScope,
+    applyFirmware,
+  } = api;
+  const { listFirmwareFiles } = useFirmwareApi();
+  const [firmwareFiles, setFirmwareFiles] = useState<FirmwareFileInfo[]>([]);
+  const [view, setView] = useState<View>(() =>
+    initialManagedChannelId !== null ? { kind: "manage", channelId: initialManagedChannelId } : { kind: "list" },
+  );
+  const [channelToDelete, setChannelToDelete] = useState<ReleaseChannel | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  useEffect(() => {
+    listFirmwareFiles()
+      .then(setFirmwareFiles)
+      .catch((error) => {
+        pushToast({ message: error?.message || "Failed to load firmware files", status: STATUSES.error });
+      });
+  }, [listFirmwareFiles]);
+
+  const handleDelete = () => {
+    if (!channelToDelete) return;
+    setIsDeleting(true);
+    deleteChannel(channelToDelete.id)
+      .then(() => {
+        pushToast({ message: `Deleted release channel ${channelToDelete.name}`, status: STATUSES.success });
+        setChannelToDelete(null);
+        setView({ kind: "list" });
+      })
+      .catch((error) => {
+        pushToast({ message: error?.message || "Couldn't delete the release channel", status: STATUSES.error });
+      })
+      .finally(() => setIsDeleting(false));
+  };
+
+  // Resolved fresh on every poll so the manage view tracks live progress;
+  // falls back to the table if the channel goes.
+  const managedChannel = view.kind === "manage" ? channels.find((channel) => channel.id === view.channelId) : undefined;
+  const showBack = view.kind === "create" || managedChannel !== undefined;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <SettingsPageHeader title="Release channels" description={RELEASE_CHANNELS_DESCRIPTION} />
+
+      {showBack ? (
+        <button
+          type="button"
+          data-testid="back-to-channels"
+          className="flex cursor-pointer items-center gap-2 self-start text-200 text-text-primary-70 transition-colors hover:text-text-primary"
+          onClick={() => setView({ kind: "list" })}
+        >
+          ← All release channels
+        </button>
+      ) : null}
+
+      {view.kind === "create" ? (
+        <ReleaseChannelManageView
+          key="create"
+          rollouts={rollouts}
+          firmwareFiles={firmwareFiles}
+          minerNames={minerNames}
+          previewScope={previewScope}
+          onSave={async (draft) => {
+            const created = await createChannel(draft);
+            if (created) setView({ kind: "manage", channelId: created.id });
+          }}
+          onApply={async () => {}}
+        />
+      ) : managedChannel ? (
+        <ReleaseChannelManageView
+          key={managedChannel.id.toString()}
+          channel={managedChannel}
+          rollouts={rollouts}
+          firmwareFiles={firmwareFiles}
+          minerNames={minerNames}
+          previewScope={previewScope}
+          onSave={async (draft) => {
+            await updateChannel(managedChannel.id, draft);
+          }}
+          onDelete={setChannelToDelete}
+          onApply={async (channelId, assignments) => {
+            await applyFirmware(channelId, assignments);
+          }}
+        />
+      ) : isLoading ? (
+        <div className="text-center text-text-primary-50">Loading release channels...</div>
+      ) : channels.length === 0 ? (
+        <div className="flex flex-col gap-6">
+          <div>
+            <Button
+              variant={variants.primary}
+              size={sizes.compact}
+              text="Create release channel"
+              onClick={() => setView({ kind: "create" })}
+              className="phone:w-full"
+              testId="create-release-channel"
+            />
+          </div>
+          <SettingsEmptyState
+            title="No release channels"
+            description="Create a release channel, choose which miners it applies to, and assign firmware per model to roll out updates."
+          />
+        </div>
+      ) : (
+        <ReleaseChannelsTable
+          channels={channels}
+          rollouts={rollouts}
+          onCreate={() => setView({ kind: "create" })}
+          onManage={(channel) => setView({ kind: "manage", channelId: channel.id })}
+        />
+      )}
+
+      <Dialog
+        open={channelToDelete !== null}
+        title="Delete release channel?"
+        subtitle={`Miners in ${channelToDelete?.name ?? "this channel"} keep their current firmware, but it is no longer enforced for them and the channel's update history is removed.`}
+        testId="delete-channel-dialog"
+        onDismiss={() => {
+          if (!isDeleting) setChannelToDelete(null);
+        }}
+        icon={
+          <DialogIcon intent="critical">
+            <Alert />
+          </DialogIcon>
+        }
+        buttons={[
+          {
+            text: "Cancel",
+            variant: variants.secondary,
+            onClick: () => setChannelToDelete(null),
+            disabled: isDeleting,
+          },
+          {
+            text: "Delete channel",
+            variant: variants.danger,
+            onClick: handleDelete,
+            loading: isDeleting,
+          },
+        ]}
+      />
+    </div>
+  );
+};
+
+export default ReleaseChannelsTab;

--- a/client/src/protoFleet/features/settings/components/ReleaseChannels/ReleaseChannelsTable.stories.tsx
+++ b/client/src/protoFleet/features/settings/components/ReleaseChannels/ReleaseChannelsTable.stories.tsx
@@ -1,0 +1,93 @@
+import type { ReactNode } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import {
+  activeRigRollout,
+  batchedRigRollout,
+  canaryChannel,
+  completedRigRollout,
+  completedWithFailuresRigRollout,
+  emptyChannel,
+  gatedRigRollout,
+  productionChannel,
+} from "./ReleaseChannels.fixtures";
+import ReleaseChannelsTable from "./ReleaseChannelsTable";
+
+// The release channels overview on the shared List: disclosure rows per
+// channel with miner counts and a roll-up of active updates ("2 updating, 1
+// needs attention"), per-model rows with firmware transitions ("1.4.3 →
+// 1.4.4") and update state, and a Manage action per channel. Rows expand
+// interactively in the story.
+const meta = {
+  title: "Proto Fleet/Firmware/Release Channels/Channels Table",
+  component: ReleaseChannelsTable,
+  parameters: {
+    layout: "fullscreen",
+  },
+} satisfies Meta<typeof ReleaseChannelsTable>;
+
+export default meta;
+
+type Story = StoryObj<typeof ReleaseChannelsTable>;
+
+const noop = () => {};
+
+const Frame = ({ children }: { children: ReactNode }) => (
+  <div className="min-h-screen bg-surface-base p-6">{children}</div>
+);
+
+export const WithActiveUpdate: Story = {
+  name: "With an update in progress",
+  render: () => (
+    <Frame>
+      <ReleaseChannelsTable
+        channels={[canaryChannel, productionChannel, emptyChannel]}
+        rollouts={[activeRigRollout, completedRigRollout]}
+        onCreate={noop}
+        onManage={noop}
+      />
+    </Frame>
+  ),
+};
+
+export const ReviewNeeded: Story = {
+  name: "With a pilot batch awaiting review",
+  render: () => (
+    <Frame>
+      <ReleaseChannelsTable
+        channels={[canaryChannel, productionChannel]}
+        rollouts={[gatedRigRollout, completedRigRollout]}
+        onCreate={noop}
+        onManage={noop}
+      />
+    </Frame>
+  ),
+};
+
+export const WithFailures: Story = {
+  name: "With failed miners",
+  render: () => (
+    <Frame>
+      <ReleaseChannelsTable
+        channels={[canaryChannel, productionChannel]}
+        rollouts={[batchedRigRollout, completedWithFailuresRigRollout]}
+        onCreate={noop}
+        onManage={noop}
+      />
+    </Frame>
+  ),
+};
+
+export const AllSettled: Story = {
+  name: "Everything up to date",
+  render: () => (
+    <Frame>
+      <ReleaseChannelsTable
+        channels={[productionChannel, emptyChannel]}
+        rollouts={[completedRigRollout]}
+        onCreate={noop}
+        onManage={noop}
+      />
+    </Frame>
+  ),
+};

--- a/client/src/protoFleet/features/settings/components/ReleaseChannels/ReleaseChannelsTable.tsx
+++ b/client/src/protoFleet/features/settings/components/ReleaseChannels/ReleaseChannelsTable.tsx
@@ -1,0 +1,233 @@
+import { useMemo, useState } from "react";
+import clsx from "clsx";
+import { timestampMs } from "@bufbuild/protobuf/wkt";
+
+import { StatusCell } from "./channelStatus";
+import { channelUpdateStatus, isActive, modelFirmwareLabel, modelUpdateStatus } from "./rolloutStatus";
+import type {
+  ReleaseChannel,
+  ReleaseChannelModelGroup,
+  Rollout,
+} from "@/protoFleet/api/generated/rollout/v1/rollout_pb";
+import { RolloutStatus } from "@/protoFleet/api/generated/rollout/v1/rollout_pb";
+import { ChevronDown } from "@/shared/assets/icons";
+import Button, { sizes, variants } from "@/shared/components/Button";
+import List from "@/shared/components/List";
+import type { ColConfig, ColTitles } from "@/shared/components/List/types";
+
+interface ReleaseChannelsTableProps {
+  channels: ReleaseChannel[];
+  rollouts: Rollout[];
+  onCreate: () => void;
+  onManage: (channel: ReleaseChannel) => void;
+}
+
+interface ChannelRow {
+  id: string;
+  kind: "channel";
+  channel: ReleaseChannel;
+}
+
+interface ModelRow {
+  id: string;
+  kind: "model";
+  channel: ReleaseChannel;
+  group: ReleaseChannelModelGroup;
+}
+
+type ChannelTableRow = ChannelRow | ModelRow;
+type ChannelColumn = "name" | "miners" | "firmware" | "status" | "actions";
+
+const channelColumns: ChannelColumn[] = ["name", "miners", "firmware", "status", "actions"];
+
+const channelColTitles: ColTitles<ChannelColumn> = {
+  name: "Release channel",
+  miners: "Miners",
+  firmware: "Firmware",
+  status: "Update status",
+  actions: "",
+};
+
+const channelModelKey = (channelId: bigint, model: string) => `${channelId.toString()}:${model}`;
+
+// Newest finished (completed or completed with failures) rollout per
+// (channel, model), for "Updated <date>" and "N failed" cells.
+function lastFinishedByChannelModel(rollouts: Rollout[]): Map<string, Rollout> {
+  const latest = new Map<string, Rollout>();
+  for (const rollout of rollouts) {
+    const finished =
+      rollout.status === RolloutStatus.COMPLETED || rollout.status === RolloutStatus.COMPLETED_WITH_FAILURES;
+    if (!finished || !rollout.finishedAt) continue;
+    const key = channelModelKey(rollout.channelId, rollout.model);
+    const current = latest.get(key);
+    if (!current?.finishedAt || timestampMs(rollout.finishedAt) > timestampMs(current.finishedAt)) {
+      latest.set(key, rollout);
+    }
+  }
+  return latest;
+}
+
+// The release channels overview on the shared List: one disclosure row per
+// channel with aggregate counts, and per-model rows carrying firmware targets
+// and update state.
+const ReleaseChannelsTable = ({ channels, rollouts, onCreate, onManage }: ReleaseChannelsTableProps) => {
+  const [expandedChannelIds, setExpandedChannelIds] = useState(() => new Set<string>());
+
+  const activeByChannelModel = useMemo(
+    () =>
+      new Map(rollouts.filter(isActive).map((rollout) => [channelModelKey(rollout.channelId, rollout.model), rollout])),
+    [rollouts],
+  );
+  const lastFinished = useMemo(() => lastFinishedByChannelModel(rollouts), [rollouts]);
+
+  const rows = useMemo<ChannelTableRow[]>(
+    () =>
+      channels.flatMap((channel) => {
+        const channelKey = channel.id.toString();
+        return [
+          { id: channelKey, kind: "channel" as const, channel },
+          ...(expandedChannelIds.has(channelKey)
+            ? channel.modelGroups.map((group) => ({
+                id: `${channelKey}:${group.model}`,
+                kind: "model" as const,
+                channel,
+                group,
+              }))
+            : []),
+        ];
+      }),
+    [channels, expandedChannelIds],
+  );
+
+  const toggleChannel = (channelKey: string) => {
+    setExpandedChannelIds((current) => {
+      const next = new Set(current);
+      if (next.has(channelKey)) next.delete(channelKey);
+      else next.add(channelKey);
+      return next;
+    });
+  };
+
+  const channelActiveRollouts = (channel: ReleaseChannel): Rollout[] =>
+    channel.modelGroups
+      .map((group) => activeByChannelModel.get(channelModelKey(channel.id, group.model)))
+      .filter((rollout): rollout is Rollout => rollout !== undefined);
+
+  const colConfig: ColConfig<ChannelTableRow, string, ChannelColumn> = {
+    name: {
+      component: (row) => {
+        if (row.kind === "channel") {
+          const channelKey = row.channel.id.toString();
+          const isExpanded = expandedChannelIds.has(channelKey);
+          return (
+            <button
+              type="button"
+              aria-expanded={isExpanded}
+              aria-label={`${isExpanded ? "Collapse" : "Expand"} ${row.channel.name} models`}
+              data-testid={`channel-toggle-${row.channel.name}`}
+              className="flex min-w-0 cursor-pointer items-center gap-2 text-emphasis-300 text-text-primary"
+              onClick={() => toggleChannel(channelKey)}
+            >
+              <ChevronDown width="w-3" className={clsx("shrink-0 transition-transform", !isExpanded && "-rotate-90")} />
+              <span className="truncate" data-testid={`channel-row-${row.channel.name}`}>
+                {row.channel.name}
+              </span>
+            </button>
+          );
+        }
+        return (
+          <span
+            className="ml-5 block min-w-0 truncate border-l border-border-5 pl-5 text-300 text-text-primary"
+            data-testid={`model-row-${row.channel.name}-${row.group.model}`}
+          >
+            {row.group.model || "Unknown model"}
+          </span>
+        );
+      },
+      width: "w-72",
+    },
+    miners: {
+      component: (row) =>
+        row.kind === "channel" ? (
+          <span data-testid={`channel-miners-${row.channel.name}`}>{row.channel.minerCount.toLocaleString()}</span>
+        ) : (
+          row.group.miners.length.toLocaleString()
+        ),
+      width: "w-32",
+    },
+    firmware: {
+      component: (row) =>
+        row.kind === "channel"
+          ? `${row.channel.modelGroups.length} ${row.channel.modelGroups.length === 1 ? "model" : "models"}`
+          : modelFirmwareLabel(row.group),
+      width: "w-64",
+    },
+    status: {
+      component: (row) =>
+        row.kind === "channel" ? (
+          <StatusCell
+            status={channelUpdateStatus(channelActiveRollouts(row.channel))}
+            emphasized
+            testId={`channel-status-${row.channel.name}`}
+          />
+        ) : (
+          <StatusCell
+            status={modelUpdateStatus(
+              row.group,
+              activeByChannelModel.get(channelModelKey(row.channel.id, row.group.model)),
+              lastFinished.get(channelModelKey(row.channel.id, row.group.model)),
+            )}
+            testId={`model-status-${row.channel.name}-${row.group.model}`}
+          />
+        ),
+      width: "w-64",
+    },
+    actions: {
+      component: (row) =>
+        row.kind === "channel" ? (
+          <div className="flex justify-end">
+            <Button
+              ariaLabel={`Manage ${row.channel.name}`}
+              text="Manage"
+              variant={variants.secondary}
+              size={sizes.compact}
+              onClick={() => onManage(row.channel)}
+              testId={`manage-channel-${row.channel.name}`}
+            />
+          </div>
+        ) : null,
+      width: "w-32",
+    },
+  };
+
+  return (
+    <div className="flex flex-col gap-6" data-testid="channels-table">
+      <div>
+        <Button
+          variant={variants.primary}
+          size={sizes.compact}
+          text="Create release channel"
+          onClick={onCreate}
+          className="phone:w-full"
+          testId="create-release-channel"
+        />
+      </div>
+      <List<ChannelTableRow, string, ChannelColumn>
+        activeCols={channelColumns}
+        colTitles={channelColTitles}
+        colConfig={colConfig}
+        items={rows}
+        itemKey="id"
+        total={channels.length}
+        itemName={{ singular: "release channel", plural: "release channels" }}
+        applyColumnWidthsToCells
+        stickyFirstColumn={false}
+      />
+      <div className="text-300 text-text-primary-70">
+        Expand a release channel to inspect each model's last or current update.
+      </div>
+    </div>
+  );
+};
+
+export default ReleaseChannelsTable;

--- a/client/src/protoFleet/features/settings/components/ReleaseChannels/RolloutControls.stories.tsx
+++ b/client/src/protoFleet/features/settings/components/ReleaseChannels/RolloutControls.stories.tsx
@@ -1,0 +1,44 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { defaultBehavior } from "./behaviorUtils";
+import { batchedAutoBehavior, pilotBehavior } from "./ReleaseChannels.fixtures";
+import RolloutControls from "./RolloutControls";
+import type { RolloutBehavior } from "@/protoFleet/api/generated/rollout/v1/rollout_pb";
+
+// The "Update behavior" controls. Flip the method live to see which fields
+// each method exposes; the plan readout tracks the miners in scope.
+const meta = {
+  title: "Proto Fleet/Firmware/Release Channels/Update Behavior",
+  component: RolloutControls,
+  parameters: {
+    layout: "padded",
+  },
+} satisfies Meta<typeof RolloutControls>;
+
+export default meta;
+
+type Story = StoryObj<typeof RolloutControls>;
+
+const Live = ({ initial, inScopeCount }: { initial: RolloutBehavior; inScopeCount: number }) => {
+  const [behavior, setBehavior] = useState(initial);
+  return (
+    <div className="max-w-2xl">
+      <RolloutControls behavior={behavior} onChange={setBehavior} inScopeCount={inScopeCount} />
+    </div>
+  );
+};
+
+export const SingleBatch: Story = {
+  render: () => <Live initial={defaultBehavior()} inScopeCount={48} />,
+};
+
+export const Pilot: Story = {
+  name: "Pilot batch, then remaining",
+  render: () => <Live initial={pilotBehavior} inScopeCount={48} />,
+};
+
+export const BatchesWithAutoContinue: Story = {
+  name: "Multiple batches, auto-continue",
+  render: () => <Live initial={batchedAutoBehavior} inScopeCount={48} />,
+};

--- a/client/src/protoFleet/features/settings/components/ReleaseChannels/RolloutControls.tsx
+++ b/client/src/protoFleet/features/settings/components/ReleaseChannels/RolloutControls.tsx
@@ -1,0 +1,218 @@
+import type { ReactElement } from "react";
+import { create } from "@bufbuild/protobuf";
+
+import { gatesAfterBatch, isPacedMethod, methodOptions, orderOptions, planReadout } from "./behaviorUtils";
+import { methodHelpText } from "./rolloutStatus";
+import {
+  type RolloutAutomationThresholds,
+  RolloutAutomationThresholdsSchema,
+  type RolloutBehavior,
+  RolloutBehaviorSchema,
+  RolloutMethod,
+  RolloutOrder,
+} from "@/protoFleet/api/generated/rollout/v1/rollout_pb";
+import Input from "@/shared/components/Input";
+import Select from "@/shared/components/Select";
+import Switch from "@/shared/components/Switch";
+
+const parseInt0 = (text: string): number => Math.max(0, Number.parseInt(text, 10) || 0);
+const parseOptionalNumber = (text: string): number | undefined => {
+  const trimmed = text.trim();
+  if (trimmed === "") return undefined;
+  const n = Number.parseFloat(trimmed);
+  return Number.isFinite(n) && n >= 0 ? n : undefined;
+};
+const optionalText = (n: number | undefined): string => (n === undefined ? "" : String(n));
+
+interface RolloutControlsProps {
+  behavior: RolloutBehavior;
+  onChange: (behavior: RolloutBehavior) => void;
+  // Miners the channel currently covers, for the plan readout.
+  inScopeCount?: number;
+  disabled?: boolean;
+}
+
+// The "Update behavior" controls, per the release channels design: Method,
+// Order, batch sizing, review and auto-continue with its thresholds, and
+// the ceiling on miners offline at once. Fields a method cannot use are
+// hidden; the server normalizes them away on save as well.
+const RolloutControls = ({
+  behavior,
+  onChange,
+  inScopeCount = 0,
+  disabled = false,
+}: RolloutControlsProps): ReactElement => {
+  const update = (patch: Partial<RolloutBehavior>) =>
+    onChange(create(RolloutBehaviorSchema, { ...behavior, ...patch }));
+  const updateThresholds = (patch: Partial<RolloutAutomationThresholds>) =>
+    update({ thresholds: create(RolloutAutomationThresholdsSchema, { ...behavior.thresholds, ...patch }) });
+
+  const thresholds = behavior.thresholds ?? create(RolloutAutomationThresholdsSchema);
+  const paced = isPacedMethod(behavior.method);
+  const batched = behavior.method === RolloutMethod.BATCHED;
+  const pilot = behavior.method === RolloutMethod.PILOT_THEN_CONTINUE;
+  const gates = gatesAfterBatch(behavior);
+  const readout = planReadout(behavior, inScopeCount);
+
+  return (
+    <div className="flex flex-col gap-4" data-testid="rollout-controls">
+      <div className="grid grid-cols-2 gap-3 phone:grid-cols-1">
+        <Select
+          id="rollout-method"
+          label="Method"
+          options={methodOptions}
+          value={String(behavior.method === RolloutMethod.UNSPECIFIED ? RolloutMethod.ALL_AT_ONCE : behavior.method)}
+          onChange={(value) => update({ method: Number(value) as RolloutMethod })}
+          disabled={disabled}
+          testId="rollout-method"
+        />
+        {paced ? (
+          <Select
+            id="rollout-order"
+            label="Order"
+            options={orderOptions}
+            value={String(
+              behavior.order === RolloutOrder.UNSPECIFIED ? RolloutOrder.LEAST_EFFICIENT_FIRST : behavior.order,
+            )}
+            onChange={(value) => update({ order: Number(value) as RolloutOrder })}
+            disabled={disabled}
+            testId="rollout-order"
+          />
+        ) : null}
+      </div>
+      <p className="text-200 text-text-primary-70">
+        {methodHelpText[behavior.method] || methodHelpText[RolloutMethod.ALL_AT_ONCE]}
+      </p>
+
+      {paced ? (
+        <div className="grid grid-cols-2 gap-3 phone:grid-cols-1">
+          {pilot ? (
+            <Input
+              id="pilot-size"
+              label="Pilot batch size (miners)"
+              type="number"
+              initValue={behavior.pilotSize}
+              onChange={(value) => update({ pilotSize: parseInt0(value) })}
+              disabled={disabled}
+            />
+          ) : (
+            <Input
+              id="batch-size"
+              label="Batch size (miners)"
+              type="number"
+              initValue={behavior.batchSize}
+              onChange={(value) => update({ batchSize: parseInt0(value) })}
+              disabled={disabled}
+            />
+          )}
+          {batched && !behavior.reviewAfterEachBatch ? (
+            <Input
+              id="wait-between-batches"
+              label="Wait between batches (minutes)"
+              type="number"
+              initValue={Math.round(behavior.waitBetweenBatchesSeconds / 60)}
+              onChange={(value) => update({ waitBetweenBatchesSeconds: parseInt0(value) * 60 })}
+              disabled={disabled}
+            />
+          ) : null}
+        </div>
+      ) : null}
+      {readout ? <p className="text-200 text-text-primary-50">{readout}</p> : null}
+
+      {batched ? (
+        <Switch
+          id="review-after-each-batch"
+          label="Review after each batch"
+          checked={behavior.reviewAfterEachBatch}
+          setChecked={(checked) =>
+            update({
+              reviewAfterEachBatch: typeof checked === "function" ? checked(behavior.reviewAfterEachBatch) : checked,
+            })
+          }
+          disabled={disabled}
+        />
+      ) : null}
+
+      {gates ? (
+        <div className="flex flex-col gap-4 rounded-lg bg-core-primary-5 p-4">
+          <Switch
+            id="auto-continue"
+            label="Auto-continue healthy batches"
+            checked={behavior.autoContinueOnHealthyTelemetry}
+            setChecked={(checked) =>
+              update({
+                autoContinueOnHealthyTelemetry:
+                  typeof checked === "function" ? checked(behavior.autoContinueOnHealthyTelemetry) : checked,
+              })
+            }
+            disabled={disabled}
+          />
+          {behavior.autoContinueOnHealthyTelemetry ? (
+            <>
+              <p className="text-200 text-text-primary-70">
+                A reviewed batch continues on its own once every miner is back and hashing, none failed, the limits
+                below hold, and telemetry has settled. Leave a limit empty to skip that check.
+              </p>
+              <div className="grid grid-cols-2 gap-3 phone:grid-cols-1">
+                <Input
+                  id="max-hashrate-drop"
+                  label="Max hashrate drop (%)"
+                  type="number"
+                  initValue={optionalText(thresholds.maxHashrateDropPercent)}
+                  onChange={(value) => updateThresholds({ maxHashrateDropPercent: parseOptionalNumber(value) })}
+                  disabled={disabled}
+                />
+                <Input
+                  id="max-efficiency-increase"
+                  label="Max efficiency increase (%)"
+                  type="number"
+                  initValue={optionalText(thresholds.maxEfficiencyIncreasePercent)}
+                  onChange={(value) => updateThresholds({ maxEfficiencyIncreasePercent: parseOptionalNumber(value) })}
+                  disabled={disabled}
+                />
+                <Input
+                  id="max-temp-increase"
+                  label="Max temp increase (°C)"
+                  type="number"
+                  initValue={optionalText(thresholds.maxTemperatureIncreaseCelsius)}
+                  onChange={(value) => updateThresholds({ maxTemperatureIncreaseCelsius: parseOptionalNumber(value) })}
+                  disabled={disabled}
+                />
+                <Input
+                  id="max-errors"
+                  label="Max errors"
+                  type="number"
+                  initValue={optionalText(thresholds.maxNewErrors)}
+                  onChange={(value) => {
+                    const n = parseOptionalNumber(value);
+                    updateThresholds({ maxNewErrors: n === undefined ? undefined : Math.round(n) });
+                  }}
+                  disabled={disabled}
+                />
+                <Input
+                  id="stabilization-minutes"
+                  label="Wait for telemetry (minutes)"
+                  type="number"
+                  initValue={Math.round(behavior.stabilizationSeconds / 60)}
+                  onChange={(value) => update({ stabilizationSeconds: parseInt0(value) * 60 })}
+                  disabled={disabled}
+                />
+              </div>
+            </>
+          ) : null}
+        </div>
+      ) : null}
+
+      <Input
+        id="max-concurrent-offline"
+        label="Max miners offline at once (0 for no limit)"
+        type="number"
+        initValue={behavior.maxConcurrentOffline}
+        onChange={(value) => update({ maxConcurrentOffline: parseInt0(value) })}
+        disabled={disabled}
+      />
+    </div>
+  );
+};
+
+export default RolloutControls;

--- a/client/src/protoFleet/features/settings/components/ReleaseChannels/ScopeEditor.tsx
+++ b/client/src/protoFleet/features/settings/components/ReleaseChannels/ScopeEditor.tsx
@@ -1,0 +1,229 @@
+import { type ReactElement, useEffect, useState } from "react";
+import { create } from "@bufbuild/protobuf";
+
+import { isScopeEmpty, scopeSummary } from "./scopeUtils";
+import {
+  type PreviewReleaseChannelScopeResponse,
+  type ReleaseChannelScope,
+  ReleaseChannelScopeSchema,
+} from "@/protoFleet/api/generated/rollout/v1/rollout_pb";
+import TargetSelectButton, { getTargetButtonLabel } from "@/protoFleet/components/TargetSelectButton";
+import {
+  BuildingSelectionModal,
+  GroupSelectionModal,
+  MinerSelectionModal,
+  RackSelectionModal,
+  SiteSelectionModal,
+} from "@/protoFleet/components/TargetSelectionModal";
+
+const PREVIEW_DEBOUNCE_MS = 300;
+
+type SelectionKind = "site" | "building" | "rack" | "group" | "miner";
+
+const toStrings = (ids: bigint[]): string[] => ids.map((id) => id.toString());
+const toBigInts = (ids: string[]): bigint[] => ids.map((id) => BigInt(id));
+
+interface ScopeEditorProps {
+  scope: ReleaseChannelScope;
+  onChange: (scope: ReleaseChannelScope) => void;
+  // Resolves the scope live: miners per model and overlapping channels.
+  previewScope: (scope: ReleaseChannelScope) => Promise<PreviewReleaseChannelScopeResponse>;
+  onPreview?: (preview: PreviewReleaseChannelScopeResponse | null) => void;
+  disabled?: boolean;
+}
+
+// The "Applies to" section: one selector per placement level, opening the
+// shared target selection modals, with a live readout of what the scope
+// resolves to and which channels it would overlap.
+const ScopeEditor = ({
+  scope,
+  onChange,
+  previewScope,
+  onPreview,
+  disabled = false,
+}: ScopeEditorProps): ReactElement => {
+  const [openModal, setOpenModal] = useState<SelectionKind | null>(null);
+  const [preview, setPreview] = useState<PreviewReleaseChannelScopeResponse | null>(null);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+
+  const update = (patch: Partial<ReleaseChannelScope>) =>
+    onChange(create(ReleaseChannelScopeSchema, { ...scope, ...patch }));
+
+  // Debounced so a burst of selections resolves once; the latest request
+  // wins. An empty scope clears the preview on the same schedule.
+  useEffect(() => {
+    let cancelled = false;
+    const timer = setTimeout(() => {
+      if (isScopeEmpty(scope)) {
+        setPreview(null);
+        setPreviewError(null);
+        onPreview?.(null);
+        return;
+      }
+      previewScope(scope)
+        .then((result) => {
+          if (cancelled) return;
+          setPreview(result);
+          setPreviewError(null);
+          onPreview?.(result);
+        })
+        .catch((error: unknown) => {
+          if (cancelled) return;
+          setPreview(null);
+          setPreviewError(error instanceof Error ? error.message : "Couldn't resolve the selection");
+          onPreview?.(null);
+        });
+    }, PREVIEW_DEBOUNCE_MS);
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+    // onPreview is a notification callback; re-resolving when the parent
+    // re-renders with a new function identity would loop.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [scope, previewScope]);
+
+  return (
+    <div className="flex flex-col gap-3" data-testid="scope-editor">
+      <div className="grid">
+        <TargetSelectButton
+          label="Sites"
+          value={getTargetButtonLabel(scope.siteIds.length, "site")}
+          disabled={disabled}
+          onClick={() => setOpenModal("site")}
+        />
+        <TargetSelectButton
+          label="Buildings"
+          value={getTargetButtonLabel(scope.buildingIds.length, "building")}
+          disabled={disabled}
+          onClick={() => setOpenModal("building")}
+        />
+        <TargetSelectButton
+          label="Racks"
+          value={getTargetButtonLabel(scope.rackIds.length, "rack")}
+          disabled={disabled}
+          onClick={() => setOpenModal("rack")}
+        />
+        <TargetSelectButton
+          label="Groups"
+          value={getTargetButtonLabel(scope.groupIds.length, "group")}
+          disabled={disabled}
+          onClick={() => setOpenModal("group")}
+        />
+        <TargetSelectButton
+          label="Miners"
+          value={getTargetButtonLabel(scope.deviceIdentifiers.length, "miner")}
+          disabled={disabled}
+          onClick={() => setOpenModal("miner")}
+        />
+      </div>
+
+      <ScopePreview scope={scope} preview={preview} error={previewError} />
+
+      <SiteSelectionModal
+        open={openModal === "site"}
+        selectedSiteIds={toStrings(scope.siteIds)}
+        onDismiss={() => setOpenModal(null)}
+        onSave={(selection) => {
+          update({ siteIds: toBigInts(selection.siteIds) });
+          setOpenModal(null);
+        }}
+      />
+      <BuildingSelectionModal
+        open={openModal === "building"}
+        selectedBuildingIds={toStrings(scope.buildingIds)}
+        onDismiss={() => setOpenModal(null)}
+        onSave={(buildingIds) => {
+          update({ buildingIds: toBigInts(buildingIds) });
+          setOpenModal(null);
+        }}
+      />
+      <RackSelectionModal
+        open={openModal === "rack"}
+        selectedRackIds={toStrings(scope.rackIds)}
+        onDismiss={() => setOpenModal(null)}
+        onSave={(rackIds) => {
+          update({ rackIds: toBigInts(rackIds) });
+          setOpenModal(null);
+        }}
+      />
+      <GroupSelectionModal
+        open={openModal === "group"}
+        selectedGroupIds={toStrings(scope.groupIds)}
+        onDismiss={() => setOpenModal(null)}
+        onSave={(groupIds) => {
+          update({ groupIds: toBigInts(groupIds) });
+          setOpenModal(null);
+        }}
+      />
+      {openModal === "miner" ? (
+        <MinerSelectionModal
+          open
+          selectedMinerIds={scope.deviceIdentifiers}
+          onDismiss={() => setOpenModal(null)}
+          onSave={(selection) => {
+            update({ deviceIdentifiers: selection.selectedMinerIds });
+            setOpenModal(null);
+          }}
+        />
+      ) : null}
+    </div>
+  );
+};
+
+// What the scope resolves to right now, and any channels it would overlap
+// (which blocks saving).
+const ScopePreview = ({
+  scope,
+  preview,
+  error,
+}: {
+  scope: ReleaseChannelScope;
+  preview: PreviewReleaseChannelScopeResponse | null;
+  error: string | null;
+}): ReactElement => {
+  if (isScopeEmpty(scope)) {
+    return (
+      <p className="text-200 text-text-primary-50" data-testid="scope-preview">
+        Select sites, buildings, racks, groups or individual miners. A miner can belong to one release channel.
+      </p>
+    );
+  }
+  if (error) {
+    return (
+      <p className="text-200 text-text-critical" data-testid="scope-preview">
+        {error}
+      </p>
+    );
+  }
+  if (!preview) {
+    return (
+      <p className="text-200 text-text-primary-50" data-testid="scope-preview">
+        Resolving {scopeSummary(scope)}…
+      </p>
+    );
+  }
+  const models = preview.models.map((m) => `${m.minerCount.toLocaleString()} ${m.model || "unknown model"}`).join(", ");
+  return (
+    <div className="flex flex-col gap-1 text-200" data-testid="scope-preview">
+      <span className="text-text-primary">
+        {scopeSummary(scope)} · covers {preview.minerCount.toLocaleString()}{" "}
+        {preview.minerCount === 1 ? "miner" : "miners"}
+        {models ? ` (${models})` : ""}
+      </span>
+      {preview.conflicts.length > 0 ? (
+        <span className="text-text-critical" data-testid="scope-conflicts">
+          Overlaps{" "}
+          {preview.conflicts
+            .map(
+              (c) => `${c.channelName} (${c.minerCount.toLocaleString()} ${c.minerCount === 1 ? "miner" : "miners"})`,
+            )
+            .join(", ")}
+          . Remove those miners from one of the channels before saving.
+        </span>
+      ) : null}
+    </div>
+  );
+};
+
+export default ScopeEditor;

--- a/client/src/protoFleet/features/settings/components/ReleaseChannels/StatusChip.tsx
+++ b/client/src/protoFleet/features/settings/components/ReleaseChannels/StatusChip.tsx
@@ -1,0 +1,19 @@
+import clsx from "clsx";
+
+import type { StatusTone } from "./rolloutStatus";
+
+const StatusChip = ({ label, tone }: { label: string; tone: StatusTone }) => (
+  <span
+    className={clsx(
+      "inline-flex items-center rounded-full px-2 py-0.5 text-200 whitespace-nowrap",
+      tone === "success" && "bg-intent-success-10 text-text-primary",
+      tone === "progress" && "bg-intent-warning-10 text-text-primary",
+      tone === "critical" && "bg-intent-critical-10 text-text-critical",
+      tone === "neutral" && "bg-core-primary-5 text-text-primary-70",
+    )}
+  >
+    {label}
+  </span>
+);
+
+export default StatusChip;

--- a/client/src/protoFleet/features/settings/components/ReleaseChannels/behaviorUtils.ts
+++ b/client/src/protoFleet/features/settings/components/ReleaseChannels/behaviorUtils.ts
@@ -1,0 +1,58 @@
+import { create } from "@bufbuild/protobuf";
+
+import { methodHelpText, methodLabels, orderLabels } from "./rolloutStatus";
+import {
+  RolloutAutomationThresholdsSchema,
+  type RolloutBehavior,
+  RolloutBehaviorSchema,
+  RolloutMethod,
+  RolloutOrder,
+} from "@/protoFleet/api/generated/rollout/v1/rollout_pb";
+
+// Behavior a new channel starts with: a single batch, least efficient first,
+// no ceiling on miners offline. Batch sizing and thresholds carry sensible
+// starting points for when the operator switches to a paced method.
+export const defaultBehavior = (): RolloutBehavior =>
+  create(RolloutBehaviorSchema, {
+    method: RolloutMethod.ALL_AT_ONCE,
+    order: RolloutOrder.LEAST_EFFICIENT_FIRST,
+    batchSize: 10,
+    pilotSize: 1,
+    stabilizationSeconds: 600,
+    thresholds: create(RolloutAutomationThresholdsSchema, { maxHashrateDropPercent: 10, maxNewErrors: 0 }),
+  });
+
+export const methodOptions = [RolloutMethod.ALL_AT_ONCE, RolloutMethod.BATCHED, RolloutMethod.PILOT_THEN_CONTINUE].map(
+  (method) => ({ value: String(method), label: methodLabels[method], description: methodHelpText[method] }),
+);
+
+export const orderOptions = [RolloutOrder.LEAST_EFFICIENT_FIRST, RolloutOrder.RANDOM].map((order) => ({
+  value: String(order),
+  label: orderLabels[order],
+}));
+
+export const isPacedMethod = (method: RolloutMethod): boolean =>
+  method === RolloutMethod.BATCHED || method === RolloutMethod.PILOT_THEN_CONTINUE;
+
+// Whether a finished batch holds for review (and so whether auto-continue
+// and its thresholds apply).
+export const gatesAfterBatch = (behavior: RolloutBehavior): boolean =>
+  behavior.method === RolloutMethod.PILOT_THEN_CONTINUE || behavior.reviewAfterEachBatch;
+
+// Live plan readout: "~3 batches of 10" for the miners currently in scope.
+export function planReadout(behavior: RolloutBehavior, inScopeCount: number): string | null {
+  if (inScopeCount <= 0) return null;
+  switch (behavior.method) {
+    case RolloutMethod.BATCHED: {
+      if (behavior.batchSize <= 0) return null;
+      const batches = Math.ceil(inScopeCount / behavior.batchSize);
+      return `~${batches.toLocaleString()} ${batches === 1 ? "batch" : "batches"} of ${behavior.batchSize.toLocaleString()} across ${inScopeCount.toLocaleString()} miners`;
+    }
+    case RolloutMethod.PILOT_THEN_CONTINUE: {
+      const pilot = Math.min(behavior.pilotSize, inScopeCount);
+      return `Pilot batch of ${pilot.toLocaleString()}, then ${Math.max(inScopeCount - pilot, 0).toLocaleString()} remaining`;
+    }
+    default:
+      return `${inScopeCount.toLocaleString()} miners in a single batch`;
+  }
+}

--- a/client/src/protoFleet/features/settings/components/ReleaseChannels/channelStatus.tsx
+++ b/client/src/protoFleet/features/settings/components/ReleaseChannels/channelStatus.tsx
@@ -1,0 +1,52 @@
+import clsx from "clsx";
+
+import { modelUpdateStatus, type UpdateStatus, type UpdateTone } from "./rolloutStatus";
+import type { ReleaseChannelModelGroup, Rollout } from "@/protoFleet/api/generated/rollout/v1/rollout_pb";
+
+// Status language shared between the release channels overview table and
+// the per-channel manage view. Tones follow the reference design: attention
+// is critical red, active is primary, completed is success, none is muted.
+
+const updateToneDotClasses: Record<UpdateTone, string> = {
+  attention: "bg-intent-critical-fill",
+  active: "bg-core-primary-fill",
+  completed: "bg-intent-success-fill",
+  none: "bg-core-primary-20",
+};
+
+const StatusDot = ({ className }: { className: string }) => (
+  <span className={clsx("inline-block size-2 shrink-0 rounded-full", className)} />
+);
+
+export const StatusCell = ({
+  status,
+  emphasized = false,
+  testId,
+}: {
+  status: UpdateStatus;
+  // Channel rows read heavier than their model rows.
+  emphasized?: boolean;
+  testId?: string;
+}) => (
+  <span
+    className={clsx(
+      "inline-flex items-center gap-2 whitespace-nowrap text-text-primary",
+      emphasized && "text-emphasis-300",
+    )}
+    data-testid={testId}
+  >
+    <StatusDot className={updateToneDotClasses[status.tone]} />
+    {status.label}
+  </span>
+);
+
+export const ModelStatusCell = ({
+  group,
+  activeRollout,
+  lastFinished,
+}: {
+  group: ReleaseChannelModelGroup;
+  activeRollout?: Rollout;
+  // Most recent finished rollout for this model group, for "Updated <date>".
+  lastFinished?: Rollout;
+}) => <StatusCell status={modelUpdateStatus(group, activeRollout, lastFinished)} />;

--- a/client/src/protoFleet/features/settings/components/ReleaseChannels/rolloutStatus.test.ts
+++ b/client/src/protoFleet/features/settings/components/ReleaseChannels/rolloutStatus.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "vitest";
+import { create } from "@bufbuild/protobuf";
+
+import { gatesAfterBatch, planReadout } from "./behaviorUtils";
+import {
+  activeRigRollout,
+  batchedAutoBehavior,
+  batchedRigRollout,
+  canaryChannel,
+  canceledRemainingRigRollout,
+  completedRigRollout,
+  completedWithFailuresRigRollout,
+  gatedRigRollout,
+  pausedRigRollout,
+  pilotBehavior,
+  singleBatchBehavior,
+} from "./ReleaseChannels.fixtures";
+import {
+  channelUpdateStatus,
+  metricDisplay,
+  modelFirmwareLabel,
+  modelUpdateStatus,
+  pacingSummary,
+  rolloutDeviceCounts,
+  rolloutNeedsAttention,
+  rolloutOutcomeLabel,
+  rolloutProgressSegments,
+  rolloutProgressSummary,
+  rolloutStageLabel,
+  scopeCounts,
+} from "./rolloutStatus";
+import { isScopeEmpty, scopeSummary } from "./scopeUtils";
+import {
+  ReleaseChannelScopeSchema,
+  RolloutSchema,
+  RolloutStage,
+} from "@/protoFleet/api/generated/rollout/v1/rollout_pb";
+
+const rigGroup = canaryChannel.modelGroups[0];
+
+describe("rolloutStageLabel", () => {
+  it("uses the design's stage vocabulary", () => {
+    expect(rolloutStageLabel(activeRigRollout)).toBe("In progress");
+    expect(rolloutStageLabel(gatedRigRollout)).toBe("Pilot batch review");
+    expect(rolloutStageLabel(batchedRigRollout)).toBe("Batch review");
+    expect(rolloutStageLabel(pausedRigRollout)).toBe("Paused");
+    expect(rolloutStageLabel(completedRigRollout)).toBe("Completed");
+    expect(rolloutStageLabel(completedWithFailuresRigRollout)).toBe("Completed with failures");
+    expect(rolloutStageLabel(canceledRemainingRigRollout)).toBe("Canceled");
+  });
+
+  it("names the batch under way", () => {
+    const inBatch = create(RolloutSchema, {
+      ...batchedRigRollout,
+      state: 1, // IN_PROGRESS
+      stage: RolloutStage.BATCH,
+      currentBatch: 1,
+    });
+    expect(rolloutStageLabel(inBatch)).toBe("Batch 2 of 3");
+    const pilotBatch = create(RolloutSchema, { ...gatedRigRollout, state: 1, stage: RolloutStage.BATCH });
+    expect(rolloutStageLabel(pilotBatch)).toBe("Pilot batch");
+  });
+});
+
+describe("outcome and pacing labels", () => {
+  it("distinguishes cancel reasons", () => {
+    expect(rolloutOutcomeLabel(canceledRemainingRigRollout)).toBe("Canceled");
+    expect(rolloutOutcomeLabel(completedWithFailuresRigRollout)).toBe("Completed with failures");
+  });
+
+  it("summarizes pacing from the behavior", () => {
+    expect(pacingSummary(singleBatchBehavior)).toBe("Single batch");
+    expect(pacingSummary(pilotBehavior)).toBe("Pilot batch of 2, then remaining");
+    expect(pacingSummary(batchedAutoBehavior)).toBe("Batches of 2, auto-continue when healthy");
+    expect(pacingSummary({ ...batchedAutoBehavior, autoContinueOnHealthyTelemetry: false })).toBe(
+      "Batches of 2, review after each batch",
+    );
+    expect(pacingSummary({ ...batchedAutoBehavior, reviewAfterEachBatch: false, waitBetweenBatchesSeconds: 900 })).toBe(
+      "Batches of 2, 15m between batches",
+    );
+  });
+
+  it("reads out the plan for the miners in scope", () => {
+    expect(planReadout(batchedAutoBehavior, 48)).toBe("~24 batches of 2 across 48 miners");
+    expect(planReadout(pilotBehavior, 48)).toBe("Pilot batch of 2, then 46 remaining");
+    expect(planReadout(singleBatchBehavior, 48)).toBe("48 miners in a single batch");
+    expect(planReadout(singleBatchBehavior, 0)).toBeNull();
+    expect(gatesAfterBatch(pilotBehavior)).toBe(true);
+    expect(gatesAfterBatch({ ...batchedAutoBehavior, reviewAfterEachBatch: false })).toBe(false);
+  });
+});
+
+describe("device counts and progress", () => {
+  it("buckets phases into Updated / Remaining / Failed", () => {
+    const counts = rolloutDeviceCounts(batchedRigRollout);
+    expect(counts).toMatchObject({ updated: 3, failed: 1, queued: 2, total: 6, percent: 50 });
+    expect(rolloutProgressSegments(counts)).toEqual([
+      { name: "Updated", status: "OK", count: 3 },
+      { name: "Remaining", status: "WARNING", count: 2 },
+      { name: "Failed", status: "CRITICAL", count: 1 },
+    ]);
+    expect(rolloutProgressSummary(counts)).toBe("3 of 6 miners updated (50%), 1 failed");
+  });
+
+  it("scopes counts to the batch under review", () => {
+    expect(scopeCounts(gatedRigRollout)).toMatchObject({ updated: 2, total: 2, percent: 100 });
+    expect(scopeCounts(activeRigRollout)).toMatchObject({ updated: 2, total: 6 });
+  });
+
+  it("flags rollouts that need a human", () => {
+    expect(rolloutNeedsAttention(gatedRigRollout)).toBe(true);
+    expect(rolloutNeedsAttention(batchedRigRollout)).toBe(true);
+    expect(rolloutNeedsAttention(activeRigRollout)).toBe(false);
+    expect(rolloutNeedsAttention(completedWithFailuresRigRollout)).toBe(false);
+  });
+});
+
+describe("channel and model status", () => {
+  it("describes the model's active update", () => {
+    expect(modelUpdateStatus(rigGroup, activeRigRollout, undefined)).toEqual({
+      label: "Updating, 2 of 6",
+      tone: "active",
+    });
+    expect(modelUpdateStatus(rigGroup, gatedRigRollout, undefined)).toEqual({
+      label: "Review needed",
+      tone: "attention",
+    });
+    expect(modelUpdateStatus(rigGroup, batchedRigRollout, undefined)).toEqual({
+      label: "1 failed, 1 of 2 updated",
+      tone: "attention",
+    });
+    expect(modelUpdateStatus(rigGroup, pausedRigRollout, undefined)).toEqual({ label: "Paused, 2 of 6", tone: "none" });
+  });
+
+  it("describes a settled model against its assignment", () => {
+    const settled = { ...rigGroup, miners: rigGroup.miners.map((m) => ({ ...m, firmwareVersion: "1.4.4" })) };
+    expect(modelUpdateStatus(settled, undefined, completedRigRollout).label).toMatch(/^Updated /);
+    expect(modelUpdateStatus(rigGroup, undefined, undefined)).toEqual({ label: "2 of 6 on target", tone: "none" });
+    expect(modelUpdateStatus(rigGroup, undefined, completedWithFailuresRigRollout)).toEqual({
+      label: "4 failed to update",
+      tone: "attention",
+    });
+    expect(modelUpdateStatus(canaryChannel.modelGroups[1], undefined, undefined)).toEqual({
+      label: "No firmware assigned",
+      tone: "none",
+    });
+  });
+
+  it("rolls channel updates up", () => {
+    expect(channelUpdateStatus([])).toEqual({ label: "No active updates", tone: "none" });
+    expect(channelUpdateStatus([activeRigRollout, gatedRigRollout, pausedRigRollout])).toEqual({
+      label: "3 updating, 1 needs attention, 1 paused",
+      tone: "attention",
+    });
+  });
+
+  it("shows firmware transitions", () => {
+    expect(modelFirmwareLabel(rigGroup)).toBe("1.4.3 → 1.4.4");
+    expect(modelFirmwareLabel(canaryChannel.modelGroups[1])).toBe("—");
+  });
+});
+
+describe("scope summary", () => {
+  it("labels populated dimensions", () => {
+    expect(scopeSummary(canaryChannel.scope!)).toBe("1 rack, 2 miners");
+    expect(scopeSummary(create(ReleaseChannelScopeSchema))).toBe("No miners selected");
+    expect(isScopeEmpty(create(ReleaseChannelScopeSchema))).toBe(true);
+    expect(isScopeEmpty(canaryChannel.scope!)).toBe(false);
+  });
+});
+
+describe("metricDisplay", () => {
+  it("colors deltas by outcome, not sign", () => {
+    expect(metricDisplay("hashrate", { baseline: 100e12, current: 110e12 }, "C")).toMatchObject({
+      delta: "+10.0%",
+      deltaIntent: "positive",
+    });
+    expect(metricDisplay("efficiency", { baseline: 30, current: 33 }, "C")).toMatchObject({
+      delta: "+10.0%",
+      deltaIntent: "negative",
+    });
+    expect(metricDisplay("temperature", { baseline: 64, current: 66 }, "C")).toMatchObject({
+      delta: "+2.0 °C",
+      deltaIntent: "negative",
+    });
+    expect(metricDisplay("power", { baseline: 3000, current: undefined }, "C")).toMatchObject({ value: "—" });
+  });
+});

--- a/client/src/protoFleet/features/settings/components/ReleaseChannels/rolloutStatus.ts
+++ b/client/src/protoFleet/features/settings/components/ReleaseChannels/rolloutStatus.ts
@@ -1,0 +1,505 @@
+import { type Timestamp, timestampMs } from "@bufbuild/protobuf/wkt";
+
+import {
+  type MetricComparison,
+  type ReleaseChannelModelGroup,
+  type Rollout,
+  type RolloutBehavior,
+  RolloutCancelReason,
+  type RolloutDevice,
+  RolloutDevicePhase,
+  RolloutMethod,
+  RolloutOrder,
+  RolloutStage,
+  RolloutState,
+  RolloutStatus,
+} from "@/protoFleet/api/generated/rollout/v1/rollout_pb";
+import type { Segment } from "@/shared/components/CompositionBar";
+import type { TemperatureUnit } from "@/shared/features/preferences";
+import { getDisplayValue } from "@/shared/utils/stringUtils";
+import { convertCtoF, formatEfficiency, formatHashrate, formatPowerKwOrDash } from "@/shared/utils/telemetryFormat";
+
+// Operator-facing vocabulary for firmware updates. Labels follow the rollout
+// framework design (PR #881): the engine is a "rollout" in code and a
+// "firmware update" to operators; methods are Single batch / Multiple batches
+// / Pilot batch, then remaining; miners are Updated / Updating / Retrying /
+// Queued / Failed / Excluded.
+
+// ---------------------------------------------------------------------------
+// Method, order, state and phase labels
+// ---------------------------------------------------------------------------
+
+export const methodLabels: Record<RolloutMethod, string> = {
+  [RolloutMethod.UNSPECIFIED]: "Single batch",
+  [RolloutMethod.ALL_AT_ONCE]: "Single batch",
+  [RolloutMethod.BATCHED]: "Multiple batches",
+  [RolloutMethod.PILOT_THEN_CONTINUE]: "Pilot batch, then remaining",
+};
+
+export const methodHelpText: Record<RolloutMethod, string> = {
+  [RolloutMethod.UNSPECIFIED]: "",
+  [RolloutMethod.ALL_AT_ONCE]: "Every miner not on the new version updates at once.",
+  [RolloutMethod.BATCHED]:
+    "Miners update in batches of a fixed size. Review after each batch, or let batches follow one another.",
+  [RolloutMethod.PILOT_THEN_CONTINUE]:
+    "A pilot batch updates first. The remaining miners wait until the pilot is reviewed and the update continued.",
+};
+
+export const orderLabels: Record<RolloutOrder, string> = {
+  [RolloutOrder.UNSPECIFIED]: "Least efficient first",
+  [RolloutOrder.LEAST_EFFICIENT_FIRST]: "Least efficient first",
+  [RolloutOrder.RANDOM]: "Random",
+};
+
+export const phaseLabels: Record<RolloutDevicePhase, string> = {
+  [RolloutDevicePhase.UNSPECIFIED]: "",
+  [RolloutDevicePhase.QUEUED]: "Queued",
+  [RolloutDevicePhase.IN_PROGRESS]: "Updating",
+  [RolloutDevicePhase.RETRYING]: "Retrying",
+  [RolloutDevicePhase.DONE]: "Updated",
+  [RolloutDevicePhase.FAILED]: "Failed",
+  [RolloutDevicePhase.EXCLUDED]: "Excluded",
+};
+
+const cancelReasonLabels: Record<RolloutCancelReason, string> = {
+  [RolloutCancelReason.UNSPECIFIED]: "Canceled",
+  [RolloutCancelReason.SUPERSEDED]: "Superseded",
+  [RolloutCancelReason.CANCELED_REMAINING]: "Canceled",
+  [RolloutCancelReason.ROLLED_BACK]: "Rolled back",
+  [RolloutCancelReason.CLEARED]: "Canceled",
+};
+
+// Outcome label for history rows: distinguishes a cancel from a rollout that
+// was simply replaced by a newer assignment or a rollback.
+export function rolloutOutcomeLabel(rollout: Rollout): string {
+  switch (rollout.status) {
+    case RolloutStatus.COMPLETED:
+      return "Completed";
+    case RolloutStatus.COMPLETED_WITH_FAILURES:
+      return "Completed with failures";
+    case RolloutStatus.CANCELED:
+      return cancelReasonLabels[rollout.cancelReason];
+    default:
+      return "In progress";
+  }
+}
+
+// The process step that leads the detail lockup: "Pilot batch", "Batch 2 of
+// 5", "Pilot batch review", "Batch review", "Waiting for telemetry",
+// "Remaining batch", "Paused", "Completed", "Completed with failures".
+export function rolloutStageLabel(rollout: Rollout): string {
+  switch (rollout.state) {
+    case RolloutState.PAUSED:
+      return "Paused";
+    case RolloutState.STABILIZING_TELEMETRY:
+      return "Waiting for telemetry";
+    case RolloutState.PAUSED_AT_PILOT_GATE:
+      return "Pilot batch review";
+    case RolloutState.PAUSED_AT_BATCH_REVIEW:
+      return "Batch review";
+    case RolloutState.COMPLETED:
+      return "Completed";
+    case RolloutState.COMPLETED_WITH_FAILURES:
+      return "Completed with failures";
+    case RolloutState.CANCELED:
+      return rolloutOutcomeLabel(rollout);
+    default:
+      break;
+  }
+  if (rollout.stage === RolloutStage.BATCH) {
+    return isPilot(rollout) ? "Pilot batch" : `Batch ${rollout.currentBatch + 1} of ${rollout.batchCount}`;
+  }
+  if (rollout.stage === RolloutStage.WAITING) return "Waiting for the next batch";
+  return isStaged(rollout) ? "Remaining batch" : "In progress";
+}
+
+// Short label for the batch under way or under review.
+export function batchLabel(rollout: Rollout): string {
+  if (isPilot(rollout)) return "Pilot batch";
+  return `Batch ${rollout.currentBatch + 1} of ${rollout.batchCount}`;
+}
+
+// One line describing how an update is paced, for stat lockups and confirms.
+export function pacingSummary(b: RolloutBehavior | undefined): string {
+  if (!b || b.method === RolloutMethod.ALL_AT_ONCE || b.method === RolloutMethod.UNSPECIFIED) return "Single batch";
+  if (b.method === RolloutMethod.PILOT_THEN_CONTINUE) {
+    return `Pilot batch of ${b.pilotSize.toLocaleString()}, then remaining`;
+  }
+  const review = b.reviewAfterEachBatch
+    ? b.autoContinueOnHealthyTelemetry
+      ? "auto-continue when healthy"
+      : "review after each batch"
+    : b.waitBetweenBatchesSeconds > 0
+      ? `${formatDurationSeconds(b.waitBetweenBatchesSeconds)} between batches`
+      : "back to back";
+  return `Batches of ${b.batchSize.toLocaleString()}, ${review}`;
+}
+
+// ---------------------------------------------------------------------------
+// Rollout predicates
+// ---------------------------------------------------------------------------
+
+export function isStaged(rollout: Rollout): boolean {
+  const method = rollout.behavior?.method;
+  return method === RolloutMethod.BATCHED || method === RolloutMethod.PILOT_THEN_CONTINUE;
+}
+
+export function isPilot(rollout: Rollout): boolean {
+  return rollout.behavior?.method === RolloutMethod.PILOT_THEN_CONTINUE;
+}
+
+export function isActive(rollout: Rollout): boolean {
+  return rollout.status === RolloutStatus.ACTIVE;
+}
+
+export function isPaused(rollout: Rollout): boolean {
+  return rollout.state === RolloutState.PAUSED;
+}
+
+// True while a staged rollout sits at its review gate (manual or waiting on
+// telemetry): the batch is done and the remaining miners wait.
+export function isAwaitingReview(rollout: Rollout): boolean {
+  return isActive(rollout) && rollout.stage === RolloutStage.AWAITING_REVIEW;
+}
+
+// True at a gate that needs a human: auto-continue is off, or its
+// conditions do not hold.
+export function needsManualReview(rollout: Rollout): boolean {
+  return rollout.state === RolloutState.PAUSED_AT_PILOT_GATE || rollout.state === RolloutState.PAUSED_AT_BATCH_REVIEW;
+}
+
+export function isBatchStage(rollout: Rollout): boolean {
+  return isActive(rollout) && rollout.stage === RolloutStage.BATCH;
+}
+
+export function isTerminal(rollout: Rollout): boolean {
+  return !isActive(rollout);
+}
+
+export function hasFailures(rollout: Rollout): boolean {
+  return rollout.devices.some((device) => device.phase === RolloutDevicePhase.FAILED);
+}
+
+// An active rollout that is waiting on a human: at a manual gate, or with
+// failed miners.
+export function rolloutNeedsAttention(rollout: Rollout): boolean {
+  return isActive(rollout) && (needsManualReview(rollout) || hasFailures(rollout));
+}
+
+// ---------------------------------------------------------------------------
+// Device counts and progress
+// ---------------------------------------------------------------------------
+
+export interface RolloutDeviceCounts {
+  updated: number;
+  updating: number;
+  retrying: number;
+  queued: number;
+  failed: number;
+  excluded: number;
+  // Miners in play: everything except excluded.
+  total: number;
+  percent: number;
+}
+
+function deviceCounts(devices: RolloutDevice[]): RolloutDeviceCounts {
+  const counts: RolloutDeviceCounts = {
+    updated: 0,
+    updating: 0,
+    retrying: 0,
+    queued: 0,
+    failed: 0,
+    excluded: 0,
+    total: 0,
+    percent: 0,
+  };
+  for (const device of devices) {
+    switch (device.phase) {
+      case RolloutDevicePhase.DONE:
+        counts.updated += 1;
+        break;
+      case RolloutDevicePhase.IN_PROGRESS:
+        counts.updating += 1;
+        break;
+      case RolloutDevicePhase.RETRYING:
+        counts.retrying += 1;
+        break;
+      case RolloutDevicePhase.FAILED:
+        counts.failed += 1;
+        break;
+      case RolloutDevicePhase.EXCLUDED:
+        counts.excluded += 1;
+        break;
+      default:
+        counts.queued += 1;
+    }
+  }
+  counts.total = devices.length - counts.excluded;
+  counts.percent = counts.total === 0 ? 0 : Math.round((counts.updated / counts.total) * 100);
+  return counts;
+}
+
+export function rolloutDeviceCounts(rollout: Rollout): RolloutDeviceCounts {
+  return deviceCounts(rollout.devices);
+}
+
+// Devices in the batch currently in flight or under review.
+export function currentBatchDevices(rollout: Rollout): RolloutDevice[] {
+  return rollout.devices.filter((device) => device.batch === rollout.currentBatch + 1);
+}
+
+// Devices whose evidence governs the rollout right now: the current batch
+// while batching, waiting or at the gate; everything otherwise.
+export function scopeDevices(rollout: Rollout): RolloutDevice[] {
+  return isActive(rollout) && rollout.stage !== RolloutStage.REST ? currentBatchDevices(rollout) : rollout.devices;
+}
+
+export function scopeCounts(rollout: Rollout): RolloutDeviceCounts {
+  return deviceCounts(scopeDevices(rollout));
+}
+
+export function failedDevices(rollout: Rollout): RolloutDevice[] {
+  return rollout.devices.filter((device) => device.phase === RolloutDevicePhase.FAILED);
+}
+
+// Progress colors follow the active curtailment card: done is primary,
+// remaining is accent, failed is critical.
+export const rolloutProgressColorMap: Record<Segment["status"], string> = {
+  OK: "bg-core-primary-fill",
+  WARNING: "bg-core-accent-fill",
+  CRITICAL: "bg-intent-critical-fill",
+  NA: "bg-core-primary-10",
+};
+
+// Updated / Remaining / Failed, dropping empty buckets.
+export function rolloutProgressSegments(counts: RolloutDeviceCounts): Segment[] {
+  const remaining = counts.updating + counts.retrying + counts.queued;
+  return [
+    { name: "Updated", status: "OK" as const, count: counts.updated },
+    { name: "Remaining", status: "WARNING" as const, count: remaining },
+    { name: "Failed", status: "CRITICAL" as const, count: counts.failed },
+  ].filter((segment) => segment.count > 0);
+}
+
+export function rolloutProgressSummary(counts: RolloutDeviceCounts): string {
+  const minerNoun = counts.total === 1 ? "miner" : "miners";
+  const failed = counts.failed > 0 ? `, ${counts.failed.toLocaleString()} failed` : "";
+  if (counts.percent >= 100) {
+    return `${counts.updated.toLocaleString()} ${minerNoun} updated (100%)${failed}`;
+  }
+  return `${counts.updated.toLocaleString()} of ${counts.total.toLocaleString()} ${minerNoun} updated (${counts.percent}%)${failed}`;
+}
+
+// ---------------------------------------------------------------------------
+// Channel and model status
+// ---------------------------------------------------------------------------
+
+export type StatusTone = "neutral" | "progress" | "success" | "critical";
+
+export const phaseTone = (phase: RolloutDevicePhase): StatusTone => {
+  switch (phase) {
+    case RolloutDevicePhase.DONE:
+      return "success";
+    case RolloutDevicePhase.IN_PROGRESS:
+    case RolloutDevicePhase.RETRYING:
+      return "progress";
+    case RolloutDevicePhase.FAILED:
+      return "critical";
+    default:
+      return "neutral";
+  }
+};
+
+export const rolloutStatusTone = (rollout: Rollout): StatusTone => {
+  switch (rollout.status) {
+    case RolloutStatus.COMPLETED:
+      return "success";
+    case RolloutStatus.COMPLETED_WITH_FAILURES:
+      return "critical";
+    case RolloutStatus.ACTIVE:
+      return "progress";
+    default:
+      return "neutral";
+  }
+};
+
+// Update-status vocabulary for the release channels table, in the design's
+// tones: attention (critical), active (primary), completed (success), none
+// (muted).
+export type UpdateTone = "attention" | "active" | "completed" | "none";
+
+export interface UpdateStatus {
+  label: string;
+  tone: UpdateTone;
+}
+
+const shortDate = (timestamp?: Timestamp): string =>
+  timestamp
+    ? new Date(timestampMs(timestamp)).toLocaleDateString(undefined, {
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+      })
+    : "";
+
+// Status of one model group: its active rollout when there is one, else how
+// the group stands against its assignment (with the last completed update's
+// date when known).
+export function modelUpdateStatus(
+  group: ReleaseChannelModelGroup,
+  activeRollout: Rollout | undefined,
+  lastFinished: Rollout | undefined,
+): UpdateStatus {
+  if (activeRollout) {
+    const counts = scopeCounts(activeRollout);
+    const progress = `${counts.updated} of ${counts.total}`;
+    if (isPaused(activeRollout)) return { label: `Paused, ${progress}`, tone: "none" };
+    if (counts.failed > 0) {
+      return { label: `${counts.failed} failed, ${progress} updated`, tone: "attention" };
+    }
+    if (needsManualReview(activeRollout)) return { label: "Review needed", tone: "attention" };
+    if (activeRollout.state === RolloutState.STABILIZING_TELEMETRY) {
+      return { label: `Waiting for telemetry, ${progress}`, tone: "active" };
+    }
+    return {
+      label: isBatchStage(activeRollout)
+        ? `${batchLabel(activeRollout)}: updating ${progress}`
+        : `Updating, ${progress}`,
+      tone: "active",
+    };
+  }
+  if (group.firmwareVersion === "") return { label: "No firmware assigned", tone: "none" };
+  if (group.miners.length === 0) return { label: "No miners", tone: "none" };
+  const onTarget = group.miners.filter((miner) => miner.firmwareVersion === group.firmwareVersion).length;
+  if (lastFinished?.status === RolloutStatus.COMPLETED_WITH_FAILURES && onTarget < group.miners.length) {
+    return { label: `${group.miners.length - onTarget} failed to update`, tone: "attention" };
+  }
+  if (onTarget === group.miners.length) {
+    const finished = lastFinished?.finishedAt ? shortDate(lastFinished.finishedAt) : "";
+    return { label: finished ? `Updated ${finished}` : "Up to date", tone: "completed" };
+  }
+  return { label: `${onTarget} of ${group.miners.length} on target`, tone: "none" };
+}
+
+// Roll-up of a channel's active rollouts: "2 updating, 1 needs review".
+export function channelUpdateStatus(activeRollouts: Rollout[]): UpdateStatus {
+  if (activeRollouts.length === 0) return { label: "No active updates", tone: "none" };
+  const attention = activeRollouts.filter(rolloutNeedsAttention).length;
+  const paused = activeRollouts.filter(isPaused).length;
+  const parts = [activeRollouts.length === 1 ? "1 updating" : `${activeRollouts.length} updating`];
+  if (attention > 0) parts.push(attention === 1 ? "1 needs attention" : `${attention} need attention`);
+  if (paused > 0) parts.push(`${paused} paused`);
+  return { label: parts.join(", "), tone: attention > 0 ? "attention" : "active" };
+}
+
+// "current → target" while miners converge on the assignment, or just the
+// assigned version once every miner reports it.
+export const modelFirmwareLabel = (group: ReleaseChannelModelGroup): string => {
+  if (group.firmwareVersion === "") return "—";
+  const behind = [...new Set(group.miners.map((miner) => miner.firmwareVersion))].filter(
+    (version) => version !== group.firmwareVersion,
+  );
+  if (behind.length === 0) return group.firmwareVersion;
+  const current = behind.length === 1 ? behind[0] || "Unknown" : "Mixed";
+  return `${current} → ${group.firmwareVersion}`;
+};
+
+// ---------------------------------------------------------------------------
+// Telemetry against baseline
+// ---------------------------------------------------------------------------
+
+const HS_PER_TH = 1e12;
+
+// Server hashrates are in H/s; the shared formatter takes TH/s.
+export function formatHashRateHs(hashRateHs: number): string {
+  return formatHashrate(hashRateHs / HS_PER_TH) ?? "—";
+}
+
+export function formatPercentChange(percent: number): string {
+  const sign = percent > 0 ? "+" : "";
+  return `${sign}${percent.toFixed(1)}%`;
+}
+
+export type MetricKind = "hashrate" | "power" | "efficiency" | "temperature";
+
+export const metricLabels: Record<MetricKind, string> = {
+  hashrate: "Hashrate",
+  power: "Power",
+  efficiency: "Efficiency",
+  temperature: "Temp",
+};
+
+export type DeltaIntent = "positive" | "negative" | "neutral";
+
+export interface MetricDisplay {
+  label: string;
+  // Current reading, or "—" when there is no recent sample.
+  value: string;
+  // Signed change versus baseline; undefined when either half is missing.
+  delta?: string;
+  deltaIntent: DeltaIntent;
+}
+
+export function formatMetricValue(kind: MetricKind, value: number, temperatureUnit: TemperatureUnit): string {
+  switch (kind) {
+    case "hashrate":
+      return formatHashRateHs(value);
+    case "power":
+      return formatPowerKwOrDash(value / 1000);
+    case "efficiency":
+      return formatEfficiency(value) ?? "—";
+    case "temperature": {
+      const shown = temperatureUnit === "F" ? convertCtoF(value) : value;
+      return `${getDisplayValue(shown)} °${temperatureUnit}`;
+    }
+  }
+}
+
+// Whether a move in this metric is good news for the miner: more hashrate is
+// good; more power, worse efficiency (J/TH) and higher temperature are bad.
+function deltaIntent(kind: MetricKind, change: number): DeltaIntent {
+  if (Math.abs(change) < 0.5) return "neutral";
+  const up = change > 0;
+  return (kind === "hashrate") === up ? "positive" : "negative";
+}
+
+// Structural so both generated MetricComparison messages and plain
+// before/after pairs can be passed.
+export type MetricPair = Pick<MetricComparison, "baseline" | "current">;
+
+export function metricDisplay(
+  kind: MetricKind,
+  metric: MetricPair | undefined,
+  temperatureUnit: TemperatureUnit,
+): MetricDisplay {
+  const label = metricLabels[kind];
+  const current = metric?.current;
+  const baseline = metric?.baseline;
+  if (current === undefined) return { label, value: "—", deltaIntent: "neutral" };
+  const value = formatMetricValue(kind, current, temperatureUnit);
+  if (baseline === undefined) return { label, value, deltaIntent: "neutral" };
+  if (kind === "temperature") {
+    // Degrees, not percent: a 2° swing reads as a 2° swing.
+    const degrees = temperatureUnit === "F" ? convertCtoF(current) - convertCtoF(baseline) : current - baseline;
+    const sign = degrees > 0 ? "+" : "";
+    return {
+      label,
+      value,
+      delta: `${sign}${degrees.toFixed(1)} °${temperatureUnit}`,
+      deltaIntent: deltaIntent(kind, degrees),
+    };
+  }
+  if (baseline === 0) return { label, value, deltaIntent: "neutral" };
+  const percent = ((current - baseline) / baseline) * 100;
+  return { label, value, delta: formatPercentChange(percent), deltaIntent: deltaIntent(kind, percent) };
+}
+
+export function formatDurationSeconds(seconds: number): string {
+  if (seconds <= 0) return "0s";
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const rest = minutes % 60;
+  return rest === 0 ? `${hours}h` : `${hours}h ${rest}m`;
+}

--- a/client/src/protoFleet/features/settings/components/ReleaseChannels/scopeUtils.ts
+++ b/client/src/protoFleet/features/settings/components/ReleaseChannels/scopeUtils.ts
@@ -1,0 +1,22 @@
+import type { ReleaseChannelScope } from "@/protoFleet/api/generated/rollout/v1/rollout_pb";
+import { getTargetButtonLabel } from "@/protoFleet/components/TargetSelectButton";
+
+// One label per populated dimension ("2 racks, 5 miners"); "No miners
+// selected" when the scope is empty.
+export function scopeSummary(scope: ReleaseChannelScope): string {
+  const parts: string[] = [];
+  if (scope.siteIds.length > 0) parts.push(getTargetButtonLabel(scope.siteIds.length, "site"));
+  if (scope.buildingIds.length > 0) parts.push(getTargetButtonLabel(scope.buildingIds.length, "building"));
+  if (scope.rackIds.length > 0) parts.push(getTargetButtonLabel(scope.rackIds.length, "rack"));
+  if (scope.groupIds.length > 0) parts.push(getTargetButtonLabel(scope.groupIds.length, "group"));
+  if (scope.deviceIdentifiers.length > 0) parts.push(getTargetButtonLabel(scope.deviceIdentifiers.length, "miner"));
+  return parts.length > 0 ? parts.join(", ") : "No miners selected";
+}
+
+export const isScopeEmpty = (scope: ReleaseChannelScope): boolean =>
+  scope.siteIds.length +
+    scope.buildingIds.length +
+    scope.rackIds.length +
+    scope.groupIds.length +
+    scope.deviceIdentifiers.length ===
+  0;


### PR DESCRIPTION
## Summary

Second of three stacked PRs porting the firmware rollout prototype to production (design note: `docs/plans/2026-09-03-firmware-release-channels-design.md`; server API in #1008). This one adds the release channel management UI; the active-update monitor, detail modal and header pill follow in PR 3.

- **Release channels tab** beside **Files** under Settings > Firmware (`?tab=release-channels` deep-links to it). Disclosure table per the #881 design: channel rows with miner counts and an update roll-up ("2 updating, 1 needs attention"), per-model rows with firmware transitions ("1.4.3 → 1.4.4") and update status, and a Manage action.
- **Manage view** (also the create flow): **General** (name, description), **Applies to** (Sites / Buildings / Racks / Groups / Miners via the shared `TargetSelectionModal`s, with a debounced live preview of the miners covered per model and any overlapping channel, which blocks saving), **Update behavior** (`RolloutControls`: Method, Order, pilot/batch size, wait between batches, review after each batch, auto-continue with hashrate / efficiency / temperature / error thresholds and a telemetry settle time, max miners offline), and **Firmware** (per-model picker, Apply starts an update paced by the saved behavior, live progress bar, View miners).
- `useReleaseChannels` polls channels + rollouts once for the page; `rolloutStatus.ts` adapts proto enums to the design's vocabulary so copy matches #881 verbatim.
- **Fixes a pre-existing render loop in the shared `MinerSelectionModal`**: it passed `MinerSelectionList` a new `onSelectionChange` every render while the list's notify effect depends on that callback, so opening the modal cascaded `Maximum update depth exceeded` (the same errors seen in the prototype's dev logs). The callback is now stable and skips no-op updates. Reproduced and verified fixed against the dev app with Playwright.

## Test plan

- [x] `vitest`: full client suite (405 files / 4,328 tests) — new unit tests for the status adapter, behavior utils, scope summary, `useReleaseChannels`, and Firmware tab switching / deep-link
- [x] `tsc --noEmit`, eslint (`--max-warnings 0`) on all touched files
- [x] Manual against a rebuilt dev backend: create channel → pick miners (no console errors) → save → manage view shows live scope preview, behavior and per-model firmware table; screenshots reviewed
- [ ] Storybook: `Proto Fleet/Firmware/Release Channels/*` stories (table, manage view incl. overlap and create, update behavior)
- [ ] E2E spec lands in PR 3 with the active-update surfaces