### PR TITLE
feat(rollout): active firmware updates, history and header pill

### DIFF
--- a/client/e2eTests/protoFleet/pages/settingsFirmware.ts
+++ b/client/e2eTests/protoFleet/pages/settingsFirmware.ts
@@ -1,6 +1,7 @@
-import { expect } from "@playwright/test";
+import { expect, type Locator } from "@playwright/test";
 import { DEFAULT_INTERVAL, DEFAULT_TIMEOUT } from "../config/test.config";
 import { BasePage } from "./base";
+import { ModalMinerSelectionList } from "./components/modalMinerSelectionList";
 
 type FirmwareUploadMetadata = {
   manufacturer: string;
@@ -9,10 +10,504 @@ type FirmwareUploadMetadata = {
 };
 
 export class SettingsFirmwarePage extends BasePage {
+  private readonly modalMinerList = new ModalMinerSelectionList(this.page.getByTestId("modal"));
+
   async validateFirmwarePageOpened() {
     await expect(this.page).toHaveURL(/.*\/settings\/firmware/);
     await this.validateTitle("Firmware");
   }
+
+  // --- Release channels ---
+
+  async openFilesTab() {
+    await this.page.getByRole("button", { name: "Files", exact: true }).click();
+    await expect(this.page.getByRole("button", { name: "Upload firmware" })).toBeVisible();
+  }
+
+  async openReleaseChannelsTab() {
+    await this.page.getByRole("button", { name: "Release channels", exact: true }).click();
+    await this.validateTitle("Release channels");
+    // The channels table renders only after loading finishes; helpers like
+    // deleteChannelIfPresent would otherwise race and see no channels.
+    await expect(this.page.getByText("Loading release channels...", { exact: true })).toBeHidden();
+  }
+
+  // The manage view for a channel, shown after drilling in via "Manage" or
+  // right after creating it.
+  channelView(channelName: string): Locator {
+    return this.page.getByTestId(`release-channel-${channelName}`);
+  }
+
+  // The channel's row in the release channels table (a shared List row,
+  // located through the name cell it contains).
+  channelRow(channelName: string): Locator {
+    return this.page.getByTestId("list-row").filter({ has: this.page.getByTestId(`channel-row-${channelName}`) });
+  }
+
+  // Opens the create form and names the channel; scope and behavior are set
+  // with the helpers below before saveNewChannel.
+  async startCreateChannel(channelName: string) {
+    await this.clickButton("Create release channel");
+    await expect(this.page.getByTestId("release-channel-new")).toBeVisible();
+    await this.page.locator("#channel-name").fill(channelName);
+  }
+
+  async saveNewChannel(channelName: string) {
+    const save = this.page.getByTestId("save-channel");
+    await expect(save).toBeEnabled();
+    await save.click();
+    await this.validateTextInToast(`Created release channel ${channelName}`);
+    await expect(this.channelView(channelName)).toBeVisible();
+  }
+
+  async saveChannelChanges() {
+    const save = this.page.getByTestId("save-channel");
+    await expect(save).toBeEnabled();
+    await save.click();
+    await this.validateTextInToast("Release channel saved");
+  }
+
+  // The save action is blocked because the scope overlaps another channel.
+  async validateScopeConflict(otherChannelName: string) {
+    await expect(this.page.getByTestId("scope-conflicts")).toContainText(otherChannelName);
+    await expect(this.page.getByTestId("save-channel")).toBeDisabled();
+  }
+
+  // Opens the "Miners" selector of the Applies to section.
+  async openScopeMiners() {
+    await this.page
+      .getByTestId("scope-editor")
+      .getByRole("button", { name: /^Miners / })
+      .click();
+    await this.validateTitleInModal("Select miners");
+    await this.modalMinerList.waitForListToLoad();
+  }
+
+  // Ticks the checkbox of `count` currently unchecked miners whose model
+  // column matches. Already-selected members keep their state.
+  async selectScopeMinersByModel(model: string, count: number) {
+    const models = await this.modalMinerList.getVisibleCellTexts("type");
+    const rows = this.page.getByTestId("modal").getByTestId("list-row");
+    const indexes: number[] = [];
+    for (let i = 0; i < models.length && indexes.length < count; i++) {
+      if (models[i] !== model) {
+        continue;
+      }
+      const checkbox = rows.nth(i).getByTestId("checkbox").locator("input").first();
+      if (!(await checkbox.isChecked())) {
+        indexes.push(i);
+      }
+    }
+    expect(indexes, `found ${indexes.length} selectable ${model} miners, needed ${count}`).toHaveLength(count);
+    await this.modalMinerList.selectRowsByIndex(indexes);
+  }
+
+  // Toggles one miner by display name (selects or deselects).
+  async toggleScopeMinerByName(name: string) {
+    await this.modalMinerList.selectRowByCellText("name", name);
+  }
+
+  async confirmScopeMinerSelection() {
+    await this.page.getByTestId("modal").getByRole("button", { name: "Done", exact: true }).click();
+    await expect(this.page.getByTestId("modal")).toBeHidden();
+  }
+
+  // The Applies to preview resolved to this many miners.
+  async validateScopeCovers(count: number) {
+    await expect(this.page.getByTestId("scope-preview")).toContainText(
+      `covers ${count} ${count === 1 ? "miner" : "miners"}`,
+    );
+  }
+
+  // --- Update behavior controls ---
+
+  async setMethod(label: "Single batch" | "Multiple batches" | "Pilot batch, then remaining") {
+    await this.page.getByTestId("rollout-method").click();
+    await this.page.getByRole("option", { name: label }).click();
+  }
+
+  async setPilotSize(size: number) {
+    await this.page.locator("#pilot-size").fill(String(size));
+  }
+
+  async setBatchSize(size: number) {
+    await this.page.locator("#batch-size").fill(String(size));
+  }
+
+  // The Switch's checkbox is visually hidden; its label toggles it.
+  private async turnOnSwitch(inputId: string, label: string) {
+    const input = this.page.locator(`#${inputId}`);
+    if (!(await input.isChecked())) {
+      await this.page.getByText(label, { exact: true }).click();
+    }
+    await expect(input).toBeChecked();
+  }
+
+  async enableReviewAfterEachBatch() {
+    await this.turnOnSwitch("review-after-each-batch", "Review after each batch");
+  }
+
+  async enableAutoContinue({ maxHashrateDropPercent }: { maxHashrateDropPercent: number }) {
+    await this.turnOnSwitch("auto-continue", "Auto-continue healthy batches");
+    await this.page.locator("#max-hashrate-drop").fill(String(maxHashrateDropPercent));
+    await this.page.locator("#max-efficiency-increase").fill("");
+    await this.page.locator("#max-temp-increase").fill("");
+    await this.page.locator("#max-errors").fill("");
+    await this.page.locator("#stabilization-minutes").fill("0");
+  }
+
+  // Drills from the channels table into the channel's manage view.
+  async manageChannel(channelName: string) {
+    await this.channelRow(channelName).getByTestId(`manage-channel-${channelName}`).click();
+    await expect(this.channelView(channelName)).toBeVisible();
+  }
+
+  // Returns from the manage view to the channels table.
+  async backToChannels() {
+    await this.page.getByTestId("back-to-channels").click();
+    await expect(this.page.getByTestId("channels-table")).toBeVisible();
+  }
+
+  // Miner count shown in the channel's table row.
+  async validateChannelMinerCount(channelName: string, count: number) {
+    await expect(this.channelRow(channelName).getByTestId(`channel-miners-${channelName}`)).toHaveText(
+      count.toLocaleString(),
+    );
+  }
+
+  // Miner count in the manage view header.
+  async validateChannelViewMinerCount(channelName: string, count: number) {
+    const label = count === 1 ? "1 miner" : `${count} miners`;
+    await expect(this.channelView(channelName).getByText(label, { exact: true }).first()).toBeVisible();
+  }
+
+  async expandChannel(channelName: string) {
+    await this.page.getByTestId(`channel-toggle-${channelName}`).click();
+  }
+
+  // The expanded per-model row reports an ongoing update.
+  async validateModelRowUpdating(channelName: string, model: string) {
+    await expect(this.page.getByTestId(`model-status-${channelName}-${model}`)).toContainText("Updating");
+  }
+
+  // The channel row's status column reports this many active updates.
+  async validateChannelActiveUpdates(channelName: string, count: number) {
+    await expect(this.channelRow(channelName).getByTestId(`channel-status-${channelName}`)).toContainText(
+      `${count} updating`,
+    );
+  }
+
+  // The channel row's status column flags an update waiting on a human.
+  async validateChannelNeedsAttention(channelName: string) {
+    await expect(this.channelRow(channelName).getByTestId(`channel-status-${channelName}`)).toContainText(
+      /needs? attention/,
+    );
+  }
+
+  activeUpdateRow(channelName: string, model: string): Locator {
+    return this.page.locator('[data-testid^="active-update-"]').filter({
+      hasText: `${channelName}, ${model} firmware update`,
+    });
+  }
+
+  async validateActiveUpdateRow(channelName: string, model: string) {
+    await expect(this.activeUpdateRow(channelName, model)).toBeVisible();
+  }
+
+  // Opens the detail of an active update, whichever action label the banner
+  // currently carries ("View update" or "Review update").
+  async openActiveUpdate(channelName: string, model: string) {
+    await this.activeUpdateRow(channelName, model)
+      .getByRole("button", { name: /^(View|Review) update$/ })
+      .click();
+    await this.validateTitleInModal(`${channelName}, ${model} firmware update`);
+    await expect(this.page.getByTestId("modal").getByText("Update status", { exact: true })).toBeVisible();
+  }
+
+  async closeUpdateDetail() {
+    await this.page.getByTestId("modal").getByRole("button", { name: "Close update details" }).click();
+    await expect(this.page.getByTestId("modal")).toBeHidden();
+  }
+
+  minersModal(): Locator {
+    return this.page.getByTestId("modal");
+  }
+
+  // Opens the model group's miner table via its "View miners" button.
+  async openModelMiners(channelName: string, model: string) {
+    await this.channelView(channelName).getByTestId(`view-miners-${model}`).click();
+    await this.validateTitleInModal(`${model} miners`);
+  }
+
+  async closeModelMiners() {
+    await this.minersModal().getByRole("button", { name: "Done", exact: true }).click();
+    await expect(this.minersModal()).toBeHidden();
+  }
+
+  // Display names of the model group's miners, in render order.
+  async getChannelMinerNames(channelName: string, model: string): Promise<string[]> {
+    await this.openModelMiners(channelName, model);
+    const rows = this.minersModal().locator('[data-testid^="channel-miner-"]');
+    const count = await rows.count();
+    const names: string[] = [];
+    for (let i = 0; i < count; i++) {
+      names.push((await rows.nth(i).locator("td").first().innerText()).trim());
+    }
+    await this.closeModelMiners();
+    return names;
+  }
+
+  // The miners modal lists exactly the model group's miners.
+  async validateModelMinersCount(channelName: string, model: string, count: number) {
+    await this.openModelMiners(channelName, model);
+    await expect(this.minersModal().locator('[data-testid^="channel-miner-"]')).toHaveCount(count);
+    await this.closeModelMiners();
+  }
+
+  // Number of the model group's miners currently reporting this version.
+  async countModelMinersOnVersion(channelName: string, model: string, version: string): Promise<number> {
+    await this.openModelMiners(channelName, model);
+    const rows = this.minersModal().locator('[data-testid^="channel-miner-"]');
+    const count = await rows.count();
+    let matches = 0;
+    for (let i = 0; i < count; i++) {
+      if ((await rows.nth(i).innerText()).includes(version)) {
+        matches += 1;
+      }
+    }
+    await this.closeModelMiners();
+    return matches;
+  }
+
+  async selectChannelFirmware(channelName: string, model: string, optionLabel: string | RegExp) {
+    await this.channelView(channelName).getByTestId(`channel-firmware-select-${model}`).click();
+    await this.page.getByRole("option", { name: optionLabel }).click();
+  }
+
+  // The firmware picker of the model group shows this version.
+  async validateModelAssignedFirmware(channelName: string, model: string, version: string | RegExp) {
+    await expect(this.channelView(channelName).getByTestId(`channel-firmware-select-${model}`)).toContainText(version);
+  }
+
+  private applyDialog(): Locator {
+    return this.page.getByTestId("apply-firmware-dialog");
+  }
+
+  // Applies staged firmware changes through the confirmation dialog; the
+  // update runs with the channel's saved behavior.
+  async applyFirmwareChanges(channelName: string) {
+    await this.channelView(channelName).getByTestId("apply-firmware-changes").click();
+    await expect(this.applyDialog()).toBeVisible();
+    await this.applyDialog().getByRole("button", { name: "Start update", exact: true }).click();
+    await expect(this.applyDialog()).toBeHidden();
+    await this.validateTextInToast("Firmware changes applied");
+  }
+
+  async validateChannelUpdateInProgress(channelName: string, version: string) {
+    await expect(this.channelView(channelName).getByText(`Updating to ${version}`)).toBeVisible({
+      timeout: DEFAULT_TIMEOUT,
+    });
+  }
+
+  async validateChannelUpdatePill(channelName: string) {
+    await expect(this.channelView(channelName).getByTestId("channel-update-pill")).toBeVisible();
+  }
+
+  // The model group sits at a review gate: the batch is on the new version
+  // and the rest wait for the update to be continued.
+  async waitForModelReviewNeeded(channelName: string, timeoutMs: number) {
+    await expect(this.channelView(channelName).getByText("Review needed", { exact: true }).first()).toBeVisible({
+      timeout: timeoutMs,
+    });
+  }
+
+  private detailModal(): Locator {
+    return this.page.getByTestId("modal");
+  }
+
+  async validateDetailHeadline(text: string | RegExp) {
+    await expect(this.detailModal().getByTestId("rollout-status-headline")).toHaveText(text);
+  }
+
+  // The review evidence is on screen: verification lockups in the stats
+  // grid and the telemetry strip with its error count.
+  async validateEvidenceVisible() {
+    const stats = this.detailModal().getByTestId("rollout-detail-stats");
+    await expect(stats.getByTestId("evidence-online")).toContainText(/\d+ of \d+/);
+    await expect(stats.getByTestId("evidence-hashing")).toContainText(/\d+ of \d+/);
+    const evidence = this.detailModal().getByTestId("rollout-evidence");
+    await expect(evidence).toBeVisible();
+    await expect(evidence.getByTestId("evidence-hashrate")).toBeVisible();
+    await expect(evidence.getByTestId("evidence-errors")).toBeVisible();
+  }
+
+  // Opens the miners drill-down from the detail's overflow menu and checks
+  // it lists this many miners, then closes it.
+  async validateDetailMinersCount(count: number) {
+    await this.detailModal().getByTestId("view-rollout-more-actions-trigger").click();
+    await this.page.getByTestId("view-rollout-view-miners-action").click();
+    const miners = this.page.getByTestId("rollout-miners-modal");
+    await expect(miners.getByTestId("list-row")).toHaveCount(count);
+    await miners.getByRole("button", { name: "Done", exact: true }).click();
+    await expect(miners).toBeHidden();
+  }
+
+  // Pause from the detail header and confirm the update reports paused;
+  // then resume and confirm it no longer does.
+  async pauseAndResumeFromDetail() {
+    await this.detailModal().getByRole("button", { name: "Pause", exact: true }).click();
+    await this.validateTextInToast("Paused");
+    await this.validateDetailHeadline("Paused");
+    await expect(this.detailModal().getByTestId("paused-banner")).toBeVisible();
+    await this.detailModal().getByRole("button", { name: "Resume", exact: true }).click();
+    await this.validateTextInToast("Resumed");
+    await expect(this.detailModal().getByTestId("paused-banner")).toBeHidden();
+  }
+
+  // Releases the review gate from the detail header; the detail stays open
+  // showing the next step, so close it explicitly afterwards.
+  async continueFromDetail() {
+    await this.detailModal().getByRole("button", { name: "Continue", exact: true }).click();
+    await this.validateTextInToast("Continuing");
+    await expect(this.detailModal().getByRole("button", { name: "Continue", exact: true })).toBeHidden();
+    await this.closeUpdateDetail();
+  }
+
+  // Cancels the remaining update from the detail's overflow menu through the
+  // confirmation dialog.
+  async cancelRemainingFromDetail() {
+    await this.detailModal().getByTestId("view-rollout-more-actions-trigger").click();
+    await this.page.getByTestId("view-rollout-cancel-action").click();
+    const dialog = this.page.getByTestId("cancel-rollout-dialog");
+    await expect(dialog).toBeVisible();
+    await dialog.getByRole("button", { name: "Cancel remaining", exact: true }).click();
+    await expect(dialog).toBeHidden();
+    await this.validateTextInToast("Canceled");
+    await this.closeUpdateDetail();
+  }
+
+  historyModal(): Locator {
+    return this.page.getByTestId("modal");
+  }
+
+  async openChannelHistory(channelName: string) {
+    await this.channelView(channelName).getByTestId("channel-history").click();
+    await this.validateTitleInModal("Update history");
+  }
+
+  async closeChannelHistory() {
+    await this.historyModal().getByRole("button", { name: "Done", exact: true }).click();
+    await expect(this.historyModal()).toBeHidden();
+  }
+
+  // A history entry for this version carries the given outcome label.
+  async validateHistoryOutcome(channelName: string, version: string, outcome: string) {
+    await this.openChannelHistory(channelName);
+    await expect(
+      this.historyModal().locator("tr").filter({ hasText: version }).filter({ hasText: outcome }).first(),
+    ).toBeVisible({ timeout: DEFAULT_TIMEOUT });
+    await this.closeChannelHistory();
+  }
+
+  // The rollback action of the first history entry carrying this version.
+  private historyRollbackButton(version: string): Locator {
+    return this.historyModal()
+      .locator("tr")
+      .filter({ hasText: version })
+      .getByRole("button", { name: "Roll back", exact: true })
+      .first();
+  }
+
+  // A history entry for this version offers a rollback action.
+  async validateHistoryRollbackAvailable(channelName: string, version: string) {
+    await this.openChannelHistory(channelName);
+    await expect(this.historyRollbackButton(version)).toBeVisible();
+    await this.closeChannelHistory();
+  }
+
+  // Restores a past version from the channel's history via its entry's
+  // rollback action and the confirmation dialog (which the active-updates
+  // monitor above the tabs owns).
+  async rollbackChannelFirmware(channelName: string, version: string) {
+    await this.openChannelHistory(channelName);
+    await this.historyRollbackButton(version).click();
+    await expect(this.historyModal()).toBeHidden();
+    const dialog = this.page.getByTestId("rollback-firmware-dialog");
+    await expect(dialog).toBeVisible();
+    await dialog.getByRole("button", { name: "Roll back", exact: true }).click();
+    await expect(dialog).toBeHidden();
+    await this.validateTextInToast("Rolling");
+    // The rollback opens the new update's detail; close it to keep working
+    // in the manage view.
+    await this.closeUpdateDetail();
+  }
+
+  appRolloutPill(): Locator {
+    return this.page.getByRole("button", { name: "View ongoing firmware updates" });
+  }
+
+  async validateAppRolloutPill() {
+    await expect(this.appRolloutPill()).toBeVisible();
+  }
+
+  // The header pill leads with the attention item instead of plain progress.
+  async validateAppRolloutPillNeedsAttention() {
+    await expect(this.appRolloutPill()).toContainText(/needs? attention/);
+  }
+
+  // Opens the app-header pill popover and follows its link to the release
+  // channels view.
+  async followAppRolloutPillToChannels() {
+    await this.appRolloutPill().click();
+    await this.page.getByRole("link", { name: "View release channels", exact: true }).click();
+    await this.validateTitle("Release channels");
+    await expect(this.page.getByText("Loading release channels...", { exact: true })).toBeHidden();
+  }
+
+  // The update is done when every miner in the model group reports the
+  // target version (checked in the live "View miners" modal), the progress
+  // bar clears, and the update shows up as completed in the channel's history.
+  async waitForChannelUpdateCompleted(channelName: string, model: string, version: string, timeoutMs: number) {
+    const view = this.channelView(channelName);
+    await this.openModelMiners(channelName, model);
+    const minerRows = this.minersModal().locator('[data-testid^="channel-miner-"]');
+    const rowCount = await minerRows.count();
+    for (let i = 0; i < rowCount; i++) {
+      await expect(minerRows.nth(i)).toContainText(version, { timeout: timeoutMs });
+    }
+    await this.closeModelMiners();
+    // Status flips on the next enforcement tick after the miners report in.
+    await expect(view.getByText(`Updating to ${version}`)).toBeHidden({ timeout: timeoutMs });
+    await this.openChannelHistory(channelName);
+    await expect(
+      this.historyModal().locator("tr").filter({ hasText: "Completed" }).filter({ hasText: version }).first(),
+    ).toBeVisible({ timeout: DEFAULT_TIMEOUT });
+    await this.closeChannelHistory();
+  }
+
+  // Deletes the channel from its open manage view. Deleting returns to the
+  // channels table, where the row must be gone.
+  async deleteChannel(channelName: string) {
+    await this.channelView(channelName).getByTestId("delete-channel").click();
+    const dialog = this.page.getByTestId("delete-channel-dialog");
+    await expect(dialog).toBeVisible();
+    await dialog.getByRole("button", { name: "Delete channel", exact: true }).click();
+    await expect(dialog).toBeHidden();
+    await expect(this.channelRow(channelName)).toBeHidden();
+  }
+
+  async deleteChannelIfPresent(channelName: string) {
+    if (
+      await this.channelRow(channelName)
+        .isVisible()
+        .catch(() => false)
+    ) {
+      await this.manageChannel(channelName);
+      await this.deleteChannel(channelName);
+    }
+  }
+
+  // --- Firmware files ---
 
   async clickUploadFirmware() {
     await this.clickButton("Upload firmware");

--- a/client/e2eTests/protoFleet/spec/firmwareRollout.spec.ts
+++ b/client/e2eTests/protoFleet/spec/firmwareRollout.spec.ts
@@ -1,0 +1,438 @@
+import { testConfig } from "../config/test.config";
+import { test } from "../fixtures/pageFixtures";
+import { CommonSteps } from "../helpers/commonSteps";
+import { AuthPage } from "../pages/auth";
+import { MinersPage } from "../pages/miners";
+import { SettingsFirmwarePage } from "../pages/settingsFirmware";
+
+test.describe("Firmware release channels", () => {
+  const runId = Date.now();
+  const channelA = `Channel A ${runId}`;
+  const channelB = `Channel B ${runId}`;
+  const channelC = `Channel C ${runId}`;
+  const channelD = `Channel D ${runId}`;
+  const channelE = `Channel E ${runId}`;
+  const channelF = `Channel F ${runId}`;
+  // Unique per run: the fake rigs keep their firmware across runs, and a
+  // version the miners already report would make the assignment a no-op
+  // (no update is created when every member is already compliant).
+  const firmwareVersion = `3.1.${runId}`;
+  const firmwareFileName = `rollout-${firmwareVersion}.swu`;
+  const rollbackVersionV1 = `3.2.${runId}`;
+  const rollbackFileNameV1 = `rollback-${rollbackVersionV1}.swu`;
+  const rollbackVersionV2 = `3.3.${runId}`;
+  const rollbackFileNameV2 = `rollback-${rollbackVersionV2}.swu`;
+  const pilotVersion = `3.4.${runId}`;
+  const pilotFileName = `pilot-${pilotVersion}.swu`;
+  const batchesVersion = `3.5.${runId}`;
+  const batchesFileName = `batches-${batchesVersion}.swu`;
+  const cancelBaseVersion = `3.6.${runId}`;
+  const cancelBaseFileName = `cancel-base-${cancelBaseVersion}.swu`;
+  const cancelTargetVersion = `3.7.${runId}`;
+  const cancelTargetFileName = `cancel-target-${cancelTargetVersion}.swu`;
+
+  // eslint-disable-next-line playwright/no-skipped-test
+  test.skip(testConfig.target === "real", "Release channel E2E is only supported against the fake proto rig setup.");
+
+  test.beforeEach(async ({ page, commonSteps }) => {
+    await page.goto("/");
+    await commonSteps.loginAsAdmin();
+  });
+
+  test.afterEach("CLEANUP: delete channels and uploaded firmware files", async ({ browser }, testInfo) => {
+    const isMobile = testInfo.project.use?.isMobile ?? false;
+    const context = await browser.newContext({
+      baseURL: testConfig.baseUrl,
+      viewport: testInfo.project.use?.viewport,
+    });
+
+    try {
+      const page = await context.newPage();
+      await page.goto("/");
+
+      const authPage = new AuthPage(page, isMobile);
+      const minersPage = new MinersPage(page, isMobile);
+      const settingsFirmwarePage = new SettingsFirmwarePage(page, isMobile);
+      const commonSteps = new CommonSteps(authPage, minersPage);
+      await commonSteps.loginAsAdmin();
+
+      await settingsFirmwarePage.navigateToFirmwareSettings();
+      await settingsFirmwarePage.validateFirmwarePageOpened();
+      await settingsFirmwarePage.openReleaseChannelsTab();
+      for (const name of [channelA, channelB, channelC, channelD, channelE, channelF]) {
+        await settingsFirmwarePage.deleteChannelIfPresent(name);
+      }
+      await settingsFirmwarePage.openFilesTab();
+      await settingsFirmwarePage.deleteAllFirmwareFilesIfAny();
+    } finally {
+      await context.close();
+    }
+  });
+
+  async function uploadRigFirmware(
+    settingsFirmwarePage: SettingsFirmwarePage,
+    files: { fileName: string; version: string }[],
+  ) {
+    await settingsFirmwarePage.navigateToFirmwareSettings();
+    await settingsFirmwarePage.validateFirmwarePageOpened();
+    await settingsFirmwarePage.deleteAllFirmwareFilesIfAny();
+    for (const { fileName, version } of files) {
+      await settingsFirmwarePage.clickUploadFirmware();
+      await settingsFirmwarePage.uploadFirmwareFile(fileName, `payload ${version} ${runId}`, {
+        manufacturer: "Proto",
+        model: "Rig",
+        firmwareVersion: version,
+      });
+      await settingsFirmwarePage.validateFirmwareFileVisible(fileName);
+    }
+  }
+
+  // Creates a channel over `minerCount` Rig miners with the behavior the
+  // callback configures, and lands in its manage view.
+  async function createRigChannel(
+    settingsFirmwarePage: SettingsFirmwarePage,
+    name: string,
+    minerCount: number,
+    configureBehavior?: () => Promise<void>,
+  ) {
+    await settingsFirmwarePage.openReleaseChannelsTab();
+    await settingsFirmwarePage.startCreateChannel(name);
+    await settingsFirmwarePage.openScopeMiners();
+    await settingsFirmwarePage.selectScopeMinersByModel("Rig", minerCount);
+    await settingsFirmwarePage.confirmScopeMinerSelection();
+    await settingsFirmwarePage.validateScopeCovers(minerCount);
+    await configureBehavior?.();
+    await settingsFirmwarePage.saveNewChannel(name);
+    await settingsFirmwarePage.validateChannelViewMinerCount(name, minerCount);
+  }
+
+  test("Create a channel, enforce firmware per model, and keep miners exclusive to one channel", async ({
+    settingsFirmwarePage,
+  }) => {
+    test.setTimeout(testConfig.testTimeout * 6);
+
+    await test.step("Upload a Proto Rig firmware file", async () => {
+      await uploadRigFirmware(settingsFirmwarePage, [{ fileName: firmwareFileName, version: firmwareVersion }]);
+    });
+
+    await test.step("Create a channel over two Rig miners", async () => {
+      await createRigChannel(settingsFirmwarePage, channelA, 2);
+    });
+
+    await test.step("Assign firmware to the Rig model group and apply", async () => {
+      await settingsFirmwarePage.selectChannelFirmware(channelA, "Rig", new RegExp(firmwareVersion));
+      await settingsFirmwarePage.applyFirmwareChanges(channelA);
+    });
+
+    await test.step("Manage view and app header signal the ongoing update", async () => {
+      await settingsFirmwarePage.validateChannelUpdatePill(channelA);
+      await settingsFirmwarePage.validateAppRolloutPill();
+    });
+
+    await test.step("Header pill deep-links to the release channels view", async () => {
+      await settingsFirmwarePage.openFilesTab();
+      await settingsFirmwarePage.followAppRolloutPillToChannels();
+      await settingsFirmwarePage.validateActiveUpdateRow(channelA, "Rig");
+      await settingsFirmwarePage.validateChannelActiveUpdates(channelA, 1);
+    });
+
+    await test.step("Update detail modal and per-model row report the update", async () => {
+      await settingsFirmwarePage.openActiveUpdate(channelA, "Rig");
+      await settingsFirmwarePage.closeUpdateDetail();
+      await settingsFirmwarePage.expandChannel(channelA);
+      await settingsFirmwarePage.validateModelRowUpdating(channelA, "Rig");
+      await settingsFirmwarePage.manageChannel(channelA);
+      await settingsFirmwarePage.validateChannelUpdatePill(channelA);
+    });
+
+    await test.step("View miners modal lists the model's miners; progress stays in the view", async () => {
+      await settingsFirmwarePage.validateModelMinersCount(channelA, "Rig", 2);
+      await settingsFirmwarePage.validateChannelUpdateInProgress(channelA, firmwareVersion);
+    });
+
+    await test.step("Update completes and both miners report the assigned version", async () => {
+      await settingsFirmwarePage.waitForChannelUpdateCompleted(
+        channelA,
+        "Rig",
+        firmwareVersion,
+        testConfig.testTimeout * 4,
+      );
+    });
+
+    let sharedMiner = "";
+
+    await test.step("A second channel cannot claim a miner already in the first", async () => {
+      [sharedMiner] = await settingsFirmwarePage.getChannelMinerNames(channelA, "Rig");
+      await settingsFirmwarePage.backToChannels();
+      await settingsFirmwarePage.startCreateChannel(channelB);
+      await settingsFirmwarePage.openScopeMiners();
+      await settingsFirmwarePage.toggleScopeMinerByName(sharedMiner);
+      await settingsFirmwarePage.confirmScopeMinerSelection();
+      await settingsFirmwarePage.validateScopeConflict(channelA);
+      await settingsFirmwarePage.backToChannels();
+    });
+
+    await test.step("Removing the miner from the first channel frees it for the second", async () => {
+      await settingsFirmwarePage.manageChannel(channelA);
+      await settingsFirmwarePage.openScopeMiners();
+      await settingsFirmwarePage.toggleScopeMinerByName(sharedMiner);
+      await settingsFirmwarePage.confirmScopeMinerSelection();
+      await settingsFirmwarePage.validateScopeCovers(1);
+      await settingsFirmwarePage.saveChannelChanges();
+      await settingsFirmwarePage.validateChannelViewMinerCount(channelA, 1);
+      await settingsFirmwarePage.backToChannels();
+      await settingsFirmwarePage.startCreateChannel(channelB);
+      await settingsFirmwarePage.openScopeMiners();
+      await settingsFirmwarePage.toggleScopeMinerByName(sharedMiner);
+      await settingsFirmwarePage.confirmScopeMinerSelection();
+      await settingsFirmwarePage.validateScopeCovers(1);
+      await settingsFirmwarePage.saveNewChannel(channelB);
+      await settingsFirmwarePage.backToChannels();
+      await settingsFirmwarePage.validateChannelMinerCount(channelA, 1);
+      await settingsFirmwarePage.validateChannelMinerCount(channelB, 1);
+    });
+
+    await test.step("Delete both channels", async () => {
+      await settingsFirmwarePage.manageChannel(channelB);
+      await settingsFirmwarePage.deleteChannel(channelB);
+      await settingsFirmwarePage.manageChannel(channelA);
+      await settingsFirmwarePage.deleteChannel(channelA);
+    });
+  });
+
+  test("Roll back a model's firmware to the previously assigned version", async ({ settingsFirmwarePage }) => {
+    // Three sequential updates have to complete: v1, v2, and the rollback
+    // to v1 again.
+    test.setTimeout(testConfig.testTimeout * 12);
+
+    await test.step("Upload two Proto Rig firmware versions", async () => {
+      await uploadRigFirmware(settingsFirmwarePage, [
+        { fileName: rollbackFileNameV1, version: rollbackVersionV1 },
+        { fileName: rollbackFileNameV2, version: rollbackVersionV2 },
+      ]);
+    });
+
+    await test.step("Create a channel with one Rig miner", async () => {
+      await createRigChannel(settingsFirmwarePage, channelC, 1);
+    });
+
+    await test.step("Roll out the first version", async () => {
+      await settingsFirmwarePage.selectChannelFirmware(channelC, "Rig", new RegExp(rollbackVersionV1));
+      await settingsFirmwarePage.applyFirmwareChanges(channelC);
+      await settingsFirmwarePage.waitForChannelUpdateCompleted(
+        channelC,
+        "Rig",
+        rollbackVersionV1,
+        testConfig.testTimeout * 4,
+      );
+    });
+
+    await test.step("Roll out the second version; the first's history entry offers rollback", async () => {
+      await settingsFirmwarePage.selectChannelFirmware(channelC, "Rig", new RegExp(rollbackVersionV2));
+      await settingsFirmwarePage.applyFirmwareChanges(channelC);
+      await settingsFirmwarePage.validateHistoryRollbackAvailable(channelC, rollbackVersionV1);
+      await settingsFirmwarePage.waitForChannelUpdateCompleted(
+        channelC,
+        "Rig",
+        rollbackVersionV2,
+        testConfig.testTimeout * 4,
+      );
+    });
+
+    await test.step("Roll back from history and wait for the rollback update to complete", async () => {
+      await settingsFirmwarePage.rollbackChannelFirmware(channelC, rollbackVersionV1);
+      await settingsFirmwarePage.validateChannelUpdateInProgress(channelC, rollbackVersionV1);
+      await settingsFirmwarePage.waitForChannelUpdateCompleted(
+        channelC,
+        "Rig",
+        rollbackVersionV1,
+        testConfig.testTimeout * 4,
+      );
+    });
+
+    await test.step("The replaced version's history entry becomes the rollback target (roll forward)", async () => {
+      // v2 had finished before the rollback, so its entry stays Completed;
+      // it now offers a roll forward instead.
+      await settingsFirmwarePage.validateHistoryOutcome(channelC, rollbackVersionV2, "Completed");
+      await settingsFirmwarePage.validateHistoryRollbackAvailable(channelC, rollbackVersionV2);
+    });
+
+    await test.step("Delete the channel", async () => {
+      await settingsFirmwarePage.deleteChannel(channelC);
+    });
+  });
+
+  test("Pilot update updates one miner, gates the rest, and continues after review", async ({
+    settingsFirmwarePage,
+  }) => {
+    // Two update waves have to complete: the pilot miner and, after the
+    // gate is released, the remaining miner.
+    test.setTimeout(testConfig.testTimeout * 8);
+
+    await test.step("Upload a Proto Rig firmware file", async () => {
+      await uploadRigFirmware(settingsFirmwarePage, [{ fileName: pilotFileName, version: pilotVersion }]);
+    });
+
+    await test.step("Create a pilot-then-remaining channel with two Rig miners", async () => {
+      await createRigChannel(settingsFirmwarePage, channelD, 2, async () => {
+        await settingsFirmwarePage.setMethod("Pilot batch, then remaining");
+        await settingsFirmwarePage.setPilotSize(1);
+      });
+    });
+
+    await test.step("Apply the firmware", async () => {
+      await settingsFirmwarePage.selectChannelFirmware(channelD, "Rig", new RegExp(pilotVersion));
+      await settingsFirmwarePage.applyFirmwareChanges(channelD);
+    });
+
+    await test.step("The pilot completes and parks at the review gate", async () => {
+      await settingsFirmwarePage.waitForModelReviewNeeded(channelD, testConfig.testTimeout * 4);
+    });
+
+    await test.step("Exactly one miner is on the new version while gated", async () => {
+      const updated = await settingsFirmwarePage.countModelMinersOnVersion(channelD, "Rig", pilotVersion);
+      test.expect(updated).toBe(1);
+    });
+
+    await test.step("The channels table, active updates and header pill flag the review", async () => {
+      await settingsFirmwarePage.backToChannels();
+      await settingsFirmwarePage.validateChannelNeedsAttention(channelD);
+      await settingsFirmwarePage.validateActiveUpdateRow(channelD, "Rig");
+      await settingsFirmwarePage.validateAppRolloutPillNeedsAttention();
+    });
+
+    await test.step("The review gate shows evidence and can be paused and resumed", async () => {
+      await settingsFirmwarePage.openActiveUpdate(channelD, "Rig");
+      await settingsFirmwarePage.validateDetailHeadline("Pilot batch review");
+      await settingsFirmwarePage.validateEvidenceVisible();
+      await settingsFirmwarePage.validateDetailMinersCount(2);
+      await settingsFirmwarePage.pauseAndResumeFromDetail();
+    });
+
+    await test.step("Continue the update from the detail modal", async () => {
+      await settingsFirmwarePage.continueFromDetail();
+    });
+
+    await test.step("The remaining miner converges on the new version", async () => {
+      await settingsFirmwarePage.manageChannel(channelD);
+      await settingsFirmwarePage.waitForChannelUpdateCompleted(
+        channelD,
+        "Rig",
+        pilotVersion,
+        testConfig.testTimeout * 4,
+      );
+    });
+
+    await test.step("Delete the channel", async () => {
+      await settingsFirmwarePage.deleteChannel(channelD);
+    });
+  });
+
+  test("Batches with auto-continue complete without a manual review", async ({ settingsFirmwarePage }) => {
+    // Two batches of one miner each, each gate released automatically.
+    test.setTimeout(testConfig.testTimeout * 8);
+
+    await test.step("Upload a Proto Rig firmware file", async () => {
+      await uploadRigFirmware(settingsFirmwarePage, [{ fileName: batchesFileName, version: batchesVersion }]);
+    });
+
+    await test.step("Create a batched channel with automatic gates over two Rig miners", async () => {
+      await createRigChannel(settingsFirmwarePage, channelE, 2, async () => {
+        await settingsFirmwarePage.setMethod("Multiple batches");
+        await settingsFirmwarePage.setBatchSize(1);
+        await settingsFirmwarePage.enableReviewAfterEachBatch();
+        await settingsFirmwarePage.enableAutoContinue({ maxHashrateDropPercent: 50 });
+      });
+    });
+
+    await test.step("Apply the firmware", async () => {
+      await settingsFirmwarePage.selectChannelFirmware(channelE, "Rig", new RegExp(batchesVersion));
+      await settingsFirmwarePage.applyFirmwareChanges(channelE);
+      await settingsFirmwarePage.validateChannelUpdateInProgress(channelE, batchesVersion);
+    });
+
+    await test.step("Both batches complete with nobody clicking Continue", async () => {
+      await settingsFirmwarePage.waitForChannelUpdateCompleted(
+        channelE,
+        "Rig",
+        batchesVersion,
+        testConfig.testTimeout * 6,
+      );
+    });
+
+    await test.step("Delete the channel", async () => {
+      await settingsFirmwarePage.deleteChannel(channelE);
+    });
+  });
+
+  test("Canceling the remaining update keeps updated miners, and rolling back restores the base version", async ({
+    settingsFirmwarePage,
+  }) => {
+    // Three update waves: the base version, the pilot of the new version,
+    // and the rollback to the base version after the cancel.
+    test.setTimeout(testConfig.testTimeout * 12);
+
+    await test.step("Upload two Proto Rig firmware versions", async () => {
+      await uploadRigFirmware(settingsFirmwarePage, [
+        { fileName: cancelBaseFileName, version: cancelBaseVersion },
+        { fileName: cancelTargetFileName, version: cancelTargetVersion },
+      ]);
+    });
+
+    await test.step("Create a pilot channel with two Rig miners on the base version", async () => {
+      await createRigChannel(settingsFirmwarePage, channelF, 2, async () => {
+        await settingsFirmwarePage.setMethod("Pilot batch, then remaining");
+        await settingsFirmwarePage.setPilotSize(1);
+      });
+      await settingsFirmwarePage.selectChannelFirmware(channelF, "Rig", new RegExp(cancelBaseVersion));
+      await settingsFirmwarePage.applyFirmwareChanges(channelF);
+      // The pilot on the base version also gates; continue it.
+      await settingsFirmwarePage.waitForModelReviewNeeded(channelF, testConfig.testTimeout * 4);
+      await settingsFirmwarePage.backToChannels();
+      await settingsFirmwarePage.openActiveUpdate(channelF, "Rig");
+      await settingsFirmwarePage.continueFromDetail();
+      await settingsFirmwarePage.manageChannel(channelF);
+      await settingsFirmwarePage.waitForChannelUpdateCompleted(
+        channelF,
+        "Rig",
+        cancelBaseVersion,
+        testConfig.testTimeout * 4,
+      );
+    });
+
+    await test.step("Pilot the new version until it parks at the review gate", async () => {
+      await settingsFirmwarePage.selectChannelFirmware(channelF, "Rig", new RegExp(cancelTargetVersion));
+      await settingsFirmwarePage.applyFirmwareChanges(channelF);
+      await settingsFirmwarePage.waitForModelReviewNeeded(channelF, testConfig.testTimeout * 4);
+    });
+
+    await test.step("Cancel the remaining update from the review gate", async () => {
+      await settingsFirmwarePage.backToChannels();
+      await settingsFirmwarePage.openActiveUpdate(channelF, "Rig");
+      await settingsFirmwarePage.cancelRemainingFromDetail();
+    });
+
+    await test.step("The pilot miner keeps the new version; the assignment stays; nothing restarts", async () => {
+      await settingsFirmwarePage.manageChannel(channelF);
+      await settingsFirmwarePage.validateModelAssignedFirmware(channelF, "Rig", new RegExp(cancelTargetVersion));
+      await settingsFirmwarePage.validateHistoryOutcome(channelF, cancelTargetVersion, "Canceled");
+      const updated = await settingsFirmwarePage.countModelMinersOnVersion(channelF, "Rig", cancelTargetVersion);
+      test.expect(updated).toBe(1);
+    });
+
+    await test.step("Rolling back restores the base version on the pilot miner", async () => {
+      await settingsFirmwarePage.rollbackChannelFirmware(channelF, cancelBaseVersion);
+      await settingsFirmwarePage.validateModelAssignedFirmware(channelF, "Rig", new RegExp(cancelBaseVersion));
+      await settingsFirmwarePage.waitForChannelUpdateCompleted(
+        channelF,
+        "Rig",
+        cancelBaseVersion,
+        testConfig.testTimeout * 4,
+      );
+    });
+
+    await test.step("Delete the channel", async () => {
+      await settingsFirmwarePage.deleteChannel(channelF);
+    });
+  });
+});

--- a/client/src/protoFleet/components/AppLayout/AppLayout.tsx
+++ b/client/src/protoFleet/components/AppLayout/AppLayout.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/protoFleet/components/PageHeader/headerWidgetLayout";
 import { useActiveAlertsPillData } from "@/protoFleet/components/PageHeader/useActiveAlertsPillData";
 import { useCurtailmentPillData } from "@/protoFleet/components/PageHeader/useCurtailmentPillData";
+import { useRolloutPillData } from "@/protoFleet/components/PageHeader/useRolloutPillData";
 import { useSchedulePillData } from "@/protoFleet/components/PageHeader/useSchedulePillData";
 import { primaryNavItems } from "@/protoFleet/config/navItems";
 import { useUpdateIndicator } from "@/protoFleet/features/updates/useUpdateIndicator";
@@ -41,6 +42,7 @@ const AppLayoutContent = ({ children, hideShellHeader = false }: Props) => {
   const updatePill = useUpdateIndicator({ enabled: !hideShellHeader });
   // Same deal for the active-alert poll: no header, no pill to feed.
   const activeAlertsPillData = useActiveAlertsPillData({ enabled: !hideShellHeader });
+  const rolloutPillData = useRolloutPillData({ enabled: !hideShellHeader });
   const hasDismissedSetup = Boolean(dismissedSetup);
   const canReadCurtailment = useHasPermission("curtailment:read");
   const hasVisibleCurtailmentPill = activeCurtailmentEvent !== null && canReadCurtailment;
@@ -50,6 +52,7 @@ const AppLayoutContent = ({ children, hideShellHeader = false }: Props) => {
     hasVisibleAlertsPill: activeAlertsPillData.hasVisiblePill,
     hasVisibleUpdatePill,
     hasVisibleCurtailmentPill,
+    hasVisibleRolloutPill: rolloutPillData.hasVisiblePill,
     hasVisibleSchedules: schedulePillData.hasVisibleSchedules,
   });
   const inlineFirstPhoneWidget = isPhone && shouldInlineFirstPhoneHeaderWidget(headerWidgetCount);
@@ -104,6 +107,7 @@ const AppLayoutContent = ({ children, hideShellHeader = false }: Props) => {
             activeCurtailmentEvent={activeCurtailmentEvent}
             isMenuOpen={isMenuOpen}
             openMenu={() => setIsMenuOpen(true)}
+            rolloutPillData={rolloutPillData}
             schedulePillData={schedulePillData}
             updatePill={updatePill}
           />

--- a/client/src/protoFleet/components/PageHeader/PageHeader.tsx
+++ b/client/src/protoFleet/components/PageHeader/PageHeader.tsx
@@ -12,9 +12,11 @@ import {
   shouldInlineFirstPhoneHeaderWidget,
   shouldStackPhoneHeaderWidgets,
 } from "./headerWidgetLayout";
+import RolloutPill from "./RolloutPill";
 import SchedulePill from "./SchedulePill";
 import SitePicker from "./SitePicker";
 import type { UseActiveAlertsPillDataResult } from "./useActiveAlertsPillData";
+import type { UseRolloutPillDataResult } from "./useRolloutPillData";
 import type { UseSchedulePillDataResult } from "./useSchedulePillData";
 import { useSitesContext } from "@/protoFleet/api/SitesContext";
 import AlertInstancesModal from "@/protoFleet/features/alerts/components/AlertInstancesModal";
@@ -33,6 +35,7 @@ interface PageHeaderProps {
   activeCurtailmentEvent?: CurtailmentPillEvent | null;
   isMenuOpen?: boolean;
   openMenu?: () => void;
+  rolloutPillData?: UseRolloutPillDataResult;
   schedulePillData: UseSchedulePillDataResult;
   updatePill?: UpdatePillData | null;
 }
@@ -51,6 +54,7 @@ interface HeaderWidgetsProps {
   dismissedSetup: boolean;
   onContinueSetup: () => void;
   onSelectAlertGroup: (group: ActiveAlertGroup) => void;
+  rolloutPillData: UseRolloutPillDataResult;
   schedulePillData: UseSchedulePillDataResult;
   stacked?: boolean;
   testId?: string;
@@ -65,7 +69,11 @@ const noActiveAlerts: UseActiveAlertsPillDataResult = {
   hasMore: false,
   hasVisiblePill: false,
 };
-type HeaderWidgetKind = "alerts" | "curtailment" | "schedule" | "update" | "setup";
+const noActiveRollouts: UseRolloutPillDataResult = {
+  activeRollouts: [],
+  hasVisiblePill: false,
+};
+type HeaderWidgetKind = "alerts" | "curtailment" | "schedule" | "rollout" | "update" | "setup";
 
 function HeaderWidgets({
   activeAlertsPillData,
@@ -76,6 +84,7 @@ function HeaderWidgets({
   dismissedSetup,
   onContinueSetup,
   onSelectAlertGroup,
+  rolloutPillData,
   schedulePillData,
   stacked = false,
   testId,
@@ -125,6 +134,10 @@ function HeaderWidgets({
                 onToggleScheduleStatus={onToggleScheduleStatus}
               />
             ) : null;
+          case "rollout":
+            return rolloutPillData.hasVisiblePill ? (
+              <RolloutPill key={widget} rollouts={rolloutPillData.activeRollouts} />
+            ) : null;
           case "update":
             return updatePill ? (
               <Button
@@ -163,6 +176,7 @@ function PageHeader({
   activeCurtailmentEvent = null,
   isMenuOpen,
   openMenu,
+  rolloutPillData = noActiveRollouts,
   schedulePillData,
   updatePill = null,
 }: PageHeaderProps): ReactElement {
@@ -199,6 +213,7 @@ function PageHeader({
     dismissedSetup: hasDismissedSetup,
     onContinueSetup: handleCompleteSetup,
     onSelectAlertGroup: setDrilledInAlertGroup,
+    rolloutPillData,
     schedulePillData,
     updatePill,
   };
@@ -209,6 +224,7 @@ function PageHeader({
     ...(activeAlertsPillData.hasVisiblePill ? (["alerts"] as const) : []),
     ...(hasVisibleCurtailmentPill ? (["curtailment"] as const) : []),
     ...(schedulePillData.hasVisibleSchedules ? (["schedule"] as const) : []),
+    ...(rolloutPillData.hasVisiblePill ? (["rollout"] as const) : []),
     ...(hasVisibleUpdatePill ? (["update"] as const) : []),
     ...(hasDismissedSetup ? (["setup"] as const) : []),
   ];
@@ -217,6 +233,7 @@ function PageHeader({
     hasVisibleAlertsPill: activeAlertsPillData.hasVisiblePill,
     hasVisibleUpdatePill,
     hasVisibleCurtailmentPill,
+    hasVisibleRolloutPill: rolloutPillData.hasVisiblePill,
     hasVisibleSchedules: schedulePillData.hasVisibleSchedules,
   });
   const inlineFirstPhoneWidget = isPhone && shouldInlineFirstPhoneHeaderWidget(headerWidgetCount);

--- a/client/src/protoFleet/components/PageHeader/RolloutPill.stories.tsx
+++ b/client/src/protoFleet/components/PageHeader/RolloutPill.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import RolloutPill from "./RolloutPill";
+import {
+  activeRigRollout,
+  batchedRigRollout,
+  gatedRigRollout,
+} from "@/protoFleet/features/settings/components/ReleaseChannels/ReleaseChannels.fixtures";
+
+// The app-wide header pill shown while firmware updates are running. Its
+// popover lists each update's channel, model, target version and progress,
+// and deep-links to the release channels view. An update parked at a review
+// gate or carrying failed miners takes over the trigger copy and stops the
+// dot pulsing: it is waiting on the operator, not the fleet.
+const meta = {
+  title: "Proto Fleet/Firmware/Release Channels/Header Pill",
+  component: RolloutPill,
+  parameters: {
+    layout: "centered",
+  },
+} satisfies Meta<typeof RolloutPill>;
+
+export default meta;
+
+type Story = StoryObj<typeof RolloutPill>;
+
+export const SingleUpdate: Story = {
+  name: "One update in progress",
+  render: () => <RolloutPill rollouts={[activeRigRollout]} />,
+};
+
+export const ReviewNeeded: Story = {
+  name: "An update needs review",
+  render: () => <RolloutPill rollouts={[gatedRigRollout, activeRigRollout]} />,
+};
+
+export const WithFailures: Story = {
+  name: "An update has failed miners",
+  render: () => <RolloutPill rollouts={[batchedRigRollout]} />,
+};

--- a/client/src/protoFleet/components/PageHeader/RolloutPill.tsx
+++ b/client/src/protoFleet/components/PageHeader/RolloutPill.tsx
@@ -1,0 +1,95 @@
+import type { ReactElement } from "react";
+import { Link } from "react-router-dom";
+
+import PageHeaderPopoverPill from "./PageHeaderPopoverPill";
+import type { Rollout } from "@/protoFleet/api/generated/rollout/v1/rollout_pb";
+import {
+  activeUpdateSummary,
+  isPaused,
+  needsManualReview,
+  rolloutNeedsAttention,
+  rolloutProgressColorMap,
+  rolloutProgressSegments,
+  rolloutStageLabel,
+  scopeCounts,
+} from "@/protoFleet/features/settings/components/ReleaseChannels/rolloutStatus";
+import CompositionBar from "@/shared/components/CompositionBar";
+
+export const RELEASE_CHANNELS_PATH = "/settings/firmware?tab=release-channels";
+
+interface RolloutPillProps {
+  rollouts: Rollout[];
+}
+
+// Trigger copy leads with what needs a human: an update parked at a review
+// gate or carrying failed miners outranks updates that are merely running.
+function triggerLabel(rollouts: Rollout[], attentionCount: number): string {
+  if (attentionCount === 1) return "Firmware update needs attention";
+  if (attentionCount > 1) return `${attentionCount} firmware updates need attention`;
+  return rollouts.length === 1 ? "Firmware update in progress" : `${rollouts.length} firmware updates in progress`;
+}
+
+function RolloutPill({ rollouts }: RolloutPillProps): ReactElement {
+  const attentionCount = rollouts.filter(rolloutNeedsAttention).length;
+  return (
+    <PageHeaderPopoverPill
+      ariaLabel="View ongoing firmware updates"
+      // Solid while something waits on you, pulsing while the fleet is still
+      // being worked on.
+      dotClassName={attentionCount > 0 ? "bg-intent-warning-fill" : "animate-pulse bg-intent-warning-fill"}
+      triggerClassName="rollout-pill-trigger"
+      triggerLabel={triggerLabel(rollouts, attentionCount)}
+    >
+      {({ closePopover }) => (
+        <div className="flex flex-col gap-3">
+          <div className="flex flex-col gap-3">
+            {rollouts.map((rollout) => {
+              const counts = scopeCounts(rollout);
+              const attention = rolloutNeedsAttention(rollout);
+              return (
+                <div
+                  key={rollout.id.toString()}
+                  className="min-w-0 space-y-1.5"
+                  data-testid={`rollout-pill-entry-${rollout.id.toString()}`}
+                >
+                  <div className="truncate text-heading-100 text-text-primary">{rollout.channelName}</div>
+                  <div className="text-200 leading-snug text-text-primary-70">
+                    {`${rollout.model} → ${rollout.firmwareVersion}`}
+                  </div>
+                  <div
+                    className={
+                      attention
+                        ? "text-200 leading-snug text-intent-warning-text"
+                        : "text-200 leading-snug text-text-primary-70"
+                    }
+                  >
+                    {needsManualReview(rollout) || isPaused(rollout)
+                      ? rolloutStageLabel(rollout)
+                      : activeUpdateSummary(rollout)}
+                  </div>
+                  <CompositionBar
+                    segments={rolloutProgressSegments(counts)}
+                    height={6}
+                    colorMap={rolloutProgressColorMap}
+                  />
+                </div>
+              );
+            })}
+          </div>
+
+          <div className="border-t border-border-5 pt-3">
+            <Link
+              to={RELEASE_CHANNELS_PATH}
+              onClick={closePopover}
+              className="block rounded-xl px-3 py-2.5 text-emphasis-300 text-text-primary transition-[background-color] duration-200 ease-in-out hover:bg-core-primary-5"
+            >
+              View release channels
+            </Link>
+          </div>
+        </div>
+      )}
+    </PageHeaderPopoverPill>
+  );
+}
+
+export default RolloutPill;

--- a/client/src/protoFleet/components/PageHeader/headerWidgetLayout.ts
+++ b/client/src/protoFleet/components/PageHeader/headerWidgetLayout.ts
@@ -3,6 +3,7 @@ interface HeaderWidgetVisibility {
   hasVisibleAlertsPill: boolean;
   hasVisibleUpdatePill?: boolean;
   hasVisibleCurtailmentPill: boolean;
+  hasVisibleRolloutPill?: boolean;
   hasVisibleSchedules: boolean;
 }
 
@@ -21,12 +22,14 @@ export function getVisibleHeaderWidgetCount({
   hasVisibleAlertsPill,
   hasVisibleUpdatePill = false,
   hasVisibleCurtailmentPill,
+  hasVisibleRolloutPill = false,
   hasVisibleSchedules,
 }: HeaderWidgetVisibility): number {
   return (
     Number(hasVisibleAlertsPill) +
     Number(hasVisibleCurtailmentPill) +
     Number(hasVisibleSchedules) +
+    Number(hasVisibleRolloutPill) +
     Number(hasVisibleUpdatePill) +
     Number(hasDismissedSetup)
   );

--- a/client/src/protoFleet/components/PageHeader/useRolloutPillData.ts
+++ b/client/src/protoFleet/components/PageHeader/useRolloutPillData.ts
@@ -1,0 +1,46 @@
+import { useEffect, useMemo, useState } from "react";
+
+import { rolloutClient } from "@/protoFleet/api/clients";
+import { type Rollout, RolloutStatus } from "@/protoFleet/api/generated/rollout/v1/rollout_pb";
+import { useHasPermission } from "@/protoFleet/store";
+
+export interface UseRolloutPillDataResult {
+  activeRollouts: Rollout[];
+  hasVisiblePill: boolean;
+}
+
+const POLL_INTERVAL_MS = 15_000;
+
+// Polls for active firmware updates to feed the app-wide header pill.
+// Gated on miner:firmware_update, the permission the rollout RPCs (and the
+// Settings > Firmware page the pill links to) require.
+export const useRolloutPillData = ({ enabled = true }: { enabled?: boolean } = {}): UseRolloutPillDataResult => {
+  const [activeRollouts, setActiveRollouts] = useState<Rollout[]>([]);
+  const canManageFirmware = useHasPermission("miner:firmware_update");
+  const active = enabled && canManageFirmware;
+
+  useEffect(() => {
+    if (!active) {
+      return;
+    }
+    const refresh = () => {
+      rolloutClient
+        .listRollouts({})
+        .then((resp) => setActiveRollouts(resp.rollouts.filter((r) => r.status === RolloutStatus.ACTIVE)))
+        // Header polling is best-effort; the release channels page surfaces errors.
+        .catch(() => {});
+    };
+
+    refresh();
+    const intervalId = window.setInterval(refresh, POLL_INTERVAL_MS);
+    return () => window.clearInterval(intervalId);
+  }, [active]);
+
+  return useMemo(
+    () => ({
+      activeRollouts: active ? activeRollouts : [],
+      hasVisiblePill: active && activeRollouts.length > 0,
+    }),
+    [active, activeRollouts],
+  );
+};

--- a/client/src/protoFleet/features/activity/utils/formatLabel.ts
+++ b/client/src/protoFleet/features/activity/utils/formatLabel.ts
@@ -32,6 +32,16 @@ const labelMap: Record<string, string> = {
   command_preflight_blocked: "Command couldn't run",
   command_filter_skip: "Command ran with skipped miners",
 
+  rollout_started: "Started firmware update",
+  rollout_review_ready: "Firmware update ready for review",
+  rollout_continued: "Continued firmware update",
+  rollout_paused: "Paused firmware update",
+  rollout_resumed: "Resumed firmware update",
+  rollout_canceled: "Canceled remaining firmware updates",
+  rollout_completed: "Completed firmware update",
+  rollout_completed_with_failures: "Completed firmware update with failures",
+  rollout_retried: "Retried failed firmware updates",
+
   create_collection: "Created collection",
   update_collection: "Updated collection",
   delete_collection: "Deleted collection",
@@ -125,6 +135,16 @@ const filterLabelMap: Record<string, string> = {
   uncurtail: "End curtailment",
   command_preflight_blocked: "Command couldn't run",
   command_filter_skip: "Command ran with skipped miners",
+
+  rollout_started: "Firmware update started",
+  rollout_review_ready: "Firmware update ready for review",
+  rollout_continued: "Firmware update continued",
+  rollout_paused: "Firmware update paused",
+  rollout_resumed: "Firmware update resumed",
+  rollout_canceled: "Firmware update canceled",
+  rollout_completed: "Firmware update completed",
+  rollout_completed_with_failures: "Firmware update completed with failures",
+  rollout_retried: "Firmware update retried",
 
   create_collection: "Create collection",
   update_collection: "Update collection",

--- a/client/src/protoFleet/features/settings/components/Firmware.tsx
+++ b/client/src/protoFleet/features/settings/components/Firmware.tsx
@@ -7,6 +7,9 @@ import DeleteAllFirmwareDialog from "@/protoFleet/features/settings/components/D
 import DeleteFirmwareDialog from "@/protoFleet/features/settings/components/DeleteFirmwareDialog";
 import EditFirmwareMetadataDialog from "@/protoFleet/features/settings/components/EditFirmwareMetadataDialog";
 import FirmwareUploadDialog from "@/protoFleet/features/settings/components/FirmwareUploadDialog";
+import ActiveUpdatesMonitor, {
+  type MonitorRequest,
+} from "@/protoFleet/features/settings/components/ReleaseChannels/ActiveUpdatesMonitor";
 import ReleaseChannelsTab from "@/protoFleet/features/settings/components/ReleaseChannels/ReleaseChannelsTab";
 import SettingsEmptyState from "@/protoFleet/features/settings/components/SettingsEmptyState";
 import SettingsPageHeader from "@/protoFleet/features/settings/components/SettingsPageHeader";
@@ -371,6 +374,13 @@ const Firmware = () => {
   const [searchParams, setSearchParams] = useSearchParams();
   const activeTab = searchParams.get("tab") === RELEASE_CHANNELS_TAB_PARAM ? TAB_RELEASE_CHANNELS : TAB_FILES;
   const channelsApi = useReleaseChannels();
+  // Channel an update's "Manage" action asked to open; remounts the channels
+  // tab so it starts on that channel.
+  const [manageRequest, setManageRequest] = useState<{ channelId: bigint; seq: number } | null>(null);
+  // Update detail / rollback the history modal asked the monitor to open.
+  const [monitorRequest, setMonitorRequest] = useState<MonitorRequest | null>(null);
+
+  const showChannels = () => setSearchParams({ tab: RELEASE_CHANNELS_TAB_PARAM }, { replace: true });
 
   return (
     <div className="flex flex-col gap-6">
@@ -382,10 +392,34 @@ const Firmware = () => {
         segments={firmwareTabs}
         initialSegmentKey={activeTab}
         onSelect={(key) => {
-          setSearchParams(key === TAB_RELEASE_CHANNELS ? { tab: RELEASE_CHANNELS_TAB_PARAM } : {}, { replace: true });
+          if (key === TAB_RELEASE_CHANNELS) {
+            showChannels();
+          } else {
+            setManageRequest(null);
+            setSearchParams({}, { replace: true });
+          }
         }}
       />
-      {activeTab === TAB_RELEASE_CHANNELS ? <ReleaseChannelsTab api={channelsApi} /> : <FirmwareFilesSection />}
+      <ActiveUpdatesMonitor
+        api={channelsApi}
+        request={monitorRequest}
+        onRequestHandled={() => setMonitorRequest(null)}
+        onManageChannel={(channelId) => {
+          setManageRequest((current) => ({ channelId, seq: (current?.seq ?? 0) + 1 }));
+          showChannels();
+        }}
+      />
+      {activeTab === TAB_RELEASE_CHANNELS ? (
+        <ReleaseChannelsTab
+          key={manageRequest ? `manage-${manageRequest.seq}` : "channels"}
+          api={channelsApi}
+          initialManagedChannelId={manageRequest?.channelId ?? null}
+          onViewRollout={(rollout) => setMonitorRequest({ kind: "view", rolloutId: rollout.id })}
+          onRollbackRollout={(rollout) => setMonitorRequest({ kind: "rollback", rolloutId: rollout.id })}
+        />
+      ) : (
+        <FirmwareFilesSection />
+      )}
     </div>
   );
 };

--- a/client/src/protoFleet/features/settings/components/ReleaseChannels/ActiveUpdateBanners.stories.tsx
+++ b/client/src/protoFleet/features/settings/components/ReleaseChannels/ActiveUpdateBanners.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import ActiveUpdateBanners from "./ActiveUpdateBanners";
+import ChannelHistoryModal from "./ChannelHistoryModal";
+import {
+  activeRigRollout,
+  batchedRigRollout,
+  canaryChannel,
+  canaryHistory,
+  gatedRigRollout,
+  pausedRigRollout,
+} from "./ReleaseChannels.fixtures";
+
+// Inline progress banners for ongoing firmware updates, stacked above the
+// firmware page tabs; and the per-channel update history they lead to.
+const meta = {
+  title: "Proto Fleet/Firmware/Release Channels/Active Updates",
+  component: ActiveUpdateBanners,
+  parameters: {
+    layout: "padded",
+  },
+} satisfies Meta<typeof ActiveUpdateBanners>;
+
+export default meta;
+
+type Story = StoryObj<typeof ActiveUpdateBanners>;
+
+const noop = () => {};
+
+export const Stacked: Story = {
+  name: "Running, gated, failing and paused updates",
+  render: () => (
+    <div className="max-w-4xl">
+      <ActiveUpdateBanners
+        rollouts={[activeRigRollout, gatedRigRollout, batchedRigRollout, pausedRigRollout]}
+        onViewUpdate={noop}
+      />
+    </div>
+  ),
+};
+
+export const History: Story = {
+  name: "Channel update history",
+  render: () => (
+    <div className="min-h-screen bg-surface-base">
+      <ChannelHistoryModal
+        channel={canaryChannel}
+        rollouts={canaryHistory}
+        onView={noop}
+        onRollback={noop}
+        onClose={noop}
+      />
+    </div>
+  ),
+};

--- a/client/src/protoFleet/features/settings/components/ReleaseChannels/ActiveUpdateBanners.tsx
+++ b/client/src/protoFleet/features/settings/components/ReleaseChannels/ActiveUpdateBanners.tsx
@@ -1,0 +1,36 @@
+import { activeUpdateSummary, failedDevices, needsManualReview } from "./rolloutStatus";
+import type { Rollout } from "@/protoFleet/api/generated/rollout/v1/rollout_pb";
+import { Download } from "@/shared/assets/icons";
+import Callout, { intents } from "@/shared/components/Callout";
+
+interface ActiveUpdateBannersProps {
+  // Ongoing rollouts, most recently started first.
+  rollouts: Rollout[];
+  onViewUpdate: (rollout: Rollout) => void;
+}
+
+// Inline progress banners for ongoing firmware updates, one per rollout,
+// stacked above the firmware page tabs so they are visible from Files and
+// Release channels alike. Each opens the full update detail.
+const ActiveUpdateBanners = ({ rollouts, onViewUpdate }: ActiveUpdateBannersProps) => {
+  if (rollouts.length === 0) return null;
+  return (
+    <div className="flex flex-col gap-3" data-testid="active-updates-section">
+      {rollouts.map((rollout) => (
+        <div key={rollout.id.toString()} data-testid={`active-update-${rollout.id.toString()}`}>
+          <Callout
+            intent={failedDevices(rollout).length > 0 ? intents.danger : intents.warning}
+            prefixIcon={<Download className="text-text-primary" />}
+            title={`${rollout.channelName}, ${rollout.model} firmware update`}
+            subtitle={activeUpdateSummary(rollout)}
+            buttonText={needsManualReview(rollout) ? "Review update" : "View update"}
+            buttonOnClick={() => onViewUpdate(rollout)}
+            testId={`update-banner-${rollout.id.toString()}`}
+          />
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default ActiveUpdateBanners;

--- a/client/src/protoFleet/features/settings/components/ReleaseChannels/ActiveUpdatesMonitor.tsx
+++ b/client/src/protoFleet/features/settings/components/ReleaseChannels/ActiveUpdatesMonitor.tsx
@@ -1,0 +1,245 @@
+import { useMemo, useState } from "react";
+import { timestampMs } from "@bufbuild/protobuf/wkt";
+
+import ActiveUpdateBanners from "./ActiveUpdateBanners";
+import RolloutDetailModal from "./RolloutDetailModal";
+import { isActive } from "./rolloutStatus";
+import type { Rollout } from "@/protoFleet/api/generated/rollout/v1/rollout_pb";
+import type { ReleaseChannelsApi } from "@/protoFleet/api/useReleaseChannels";
+import { Alert } from "@/shared/assets/icons";
+import { variants } from "@/shared/components/Button";
+import Dialog, { DialogIcon } from "@/shared/components/Dialog";
+import { pushToast, STATUSES } from "@/shared/features/toaster";
+
+// Something another surface asked the monitor to do: open a rollout's
+// detail, or confirm rolling back to one.
+export type MonitorRequest = { kind: "view" | "rollback"; rolloutId: bigint };
+
+interface ActiveUpdatesMonitorProps {
+  api: Pick<
+    ReleaseChannelsApi,
+    | "rollouts"
+    | "minerNames"
+    | "continueRollout"
+    | "pauseRollout"
+    | "resumeRollout"
+    | "cancelRollout"
+    | "rollbackFirmware"
+    | "retryFailedDevices"
+  >;
+  // Drills into the release channel behind a rollout.
+  onManageChannel: (channelId: bigint) => void;
+  // From another surface (e.g. the history modal); cleared via onRequestHandled.
+  request?: MonitorRequest | null;
+  onRequestHandled?: () => void;
+}
+
+// Everything about ongoing firmware updates that lives above the firmware
+// page tabs: the banner stack, the full-screen update detail it opens, and
+// the lifecycle actions (continue, pause, resume, retry failed, cancel
+// remaining and roll back, the last two with confirmation).
+const ActiveUpdatesMonitor = ({
+  api,
+  onManageChannel,
+  request = null,
+  onRequestHandled,
+}: ActiveUpdatesMonitorProps) => {
+  const {
+    rollouts,
+    minerNames,
+    continueRollout,
+    pauseRollout,
+    resumeRollout,
+    cancelRollout,
+    rollbackFirmware,
+    retryFailedDevices,
+  } = api;
+  // Rollout open in the update detail modal, resolved live on each poll.
+  const [viewUpdateId, setViewUpdateId] = useState<bigint | null>(null);
+  const [cancelTarget, setCancelTarget] = useState<Rollout | null>(null);
+  const [localRollbackTarget, setLocalRollbackTarget] = useState<Rollout | null>(null);
+  const [isBusy, setIsBusy] = useState(false);
+
+  // Most recently started first.
+  const activeRollouts = useMemo(
+    () =>
+      rollouts
+        .filter(isActive)
+        .sort((a, b) => (b.createdAt ? timestampMs(b.createdAt) : 0) - (a.createdAt ? timestampMs(a.createdAt) : 0)),
+    [rollouts],
+  );
+  const byId = (id: bigint | null | undefined) =>
+    id != null ? rollouts.find((rollout) => rollout.id === id) : undefined;
+  const viewedRollout = byId(request?.kind === "view" ? request.rolloutId : viewUpdateId);
+  const rollbackTarget = request?.kind === "rollback" ? (byId(request.rolloutId) ?? null) : localRollbackTarget;
+  const setRollbackTarget = (target: Rollout | null) => {
+    setLocalRollbackTarget(target);
+    if (target === null && request?.kind === "rollback") onRequestHandled?.();
+  };
+  const closeDetail = () => {
+    setViewUpdateId(null);
+    if (request?.kind === "view") onRequestHandled?.();
+  };
+
+  const handleContinue = (rollout: Rollout) =>
+    continueRollout(rollout.id)
+      .then(() => {
+        pushToast({
+          message: `Continuing ${rollout.model} update in ${rollout.channelName}`,
+          status: STATUSES.success,
+        });
+      })
+      .catch((error) => {
+        pushToast({ message: error?.message || "Couldn't continue the update", status: STATUSES.error });
+      });
+
+  const togglePause = (rollout: Rollout, pause: boolean) =>
+    (pause ? pauseRollout(rollout.id) : resumeRollout(rollout.id))
+      .then(() => {
+        pushToast({
+          message: `${pause ? "Paused" : "Resumed"} ${rollout.model} update in ${rollout.channelName}`,
+          status: STATUSES.success,
+        });
+      })
+      .catch((error) => {
+        pushToast({
+          message: error?.message || `Couldn't ${pause ? "pause" : "resume"} the update`,
+          status: STATUSES.error,
+        });
+      });
+
+  const handleRetry = (rollout: Rollout) =>
+    retryFailedDevices(rollout.id)
+      .then((next) => {
+        if (next && next.id !== rollout.id) setViewUpdateId(next.id);
+        pushToast({ message: `Retrying failed miners in ${rollout.channelName}`, status: STATUSES.success });
+      })
+      .catch((error) => {
+        pushToast({ message: error?.message || "Couldn't retry the failed miners", status: STATUSES.error });
+      });
+
+  const handleCancel = () => {
+    if (!cancelTarget) return;
+    const rollout = cancelTarget;
+    setIsBusy(true);
+    cancelRollout(rollout.id)
+      .then(() => {
+        setCancelTarget(null);
+        pushToast({
+          message: `Canceled the remaining ${rollout.model} updates in ${rollout.channelName}`,
+          status: STATUSES.success,
+        });
+      })
+      .catch((error) => {
+        pushToast({ message: error?.message || "Couldn't cancel the update", status: STATUSES.error });
+      })
+      .finally(() => setIsBusy(false));
+  };
+
+  const handleRollback = () => {
+    if (!rollbackTarget) return;
+    const rollout = rollbackTarget;
+    setIsBusy(true);
+    rollbackFirmware(rollout.id)
+      .then((started) => {
+        setRollbackTarget(null);
+        closeDetail();
+        if (started[0]) setViewUpdateId(started[0].id);
+        pushToast({
+          message: `Rolling ${rollout.model} in ${rollout.channelName} back to ${rollout.previousFirmwareVersion}`,
+          status: STATUSES.success,
+        });
+      })
+      .catch((error) => {
+        pushToast({ message: error?.message || "Couldn't roll back the firmware", status: STATUSES.error });
+      })
+      .finally(() => setIsBusy(false));
+  };
+
+  return (
+    <>
+      <ActiveUpdateBanners rollouts={activeRollouts} onViewUpdate={(rollout) => setViewUpdateId(rollout.id)} />
+
+      {viewedRollout ? (
+        <RolloutDetailModal
+          rollout={viewedRollout}
+          minerNames={minerNames}
+          onClose={closeDetail}
+          onContinue={handleContinue}
+          onPause={(rollout) => togglePause(rollout, true)}
+          onResume={(rollout) => togglePause(rollout, false)}
+          onCancel={setCancelTarget}
+          onRollback={setRollbackTarget}
+          onRetryFailed={handleRetry}
+          onManage={(rollout) => {
+            closeDetail();
+            onManageChannel(rollout.channelId);
+          }}
+        />
+      ) : null}
+
+      <Dialog
+        open={cancelTarget !== null}
+        title="Cancel the remaining updates?"
+        subtitle={
+          cancelTarget
+            ? `The ${cancelTarget.model} update in ${cancelTarget.channelName} stops now. Miners already on ${cancelTarget.firmwareVersion} keep it; miners not yet updated stay on their current version and are not retried until you retry them or change the assignment.`
+            : ""
+        }
+        testId="cancel-rollout-dialog"
+        onDismiss={() => {
+          if (!isBusy) setCancelTarget(null);
+        }}
+        icon={
+          <DialogIcon intent="critical">
+            <Alert />
+          </DialogIcon>
+        }
+        buttons={[
+          {
+            text: "Keep updating",
+            variant: variants.secondary,
+            onClick: () => setCancelTarget(null),
+            disabled: isBusy,
+          },
+          {
+            text: "Cancel remaining",
+            variant: variants.danger,
+            onClick: handleCancel,
+            loading: isBusy,
+          },
+        ]}
+      />
+
+      <Dialog
+        open={rollbackTarget !== null}
+        title="Roll back firmware?"
+        subtitle={
+          rollbackTarget
+            ? `${rollbackTarget.model} in ${rollbackTarget.channelName} goes back to ${rollbackTarget.previousFirmwareVersion}. Any in-progress update for this model is canceled and a new update restores that version on every miner not running it.`
+            : ""
+        }
+        testId="rollback-firmware-dialog"
+        onDismiss={() => {
+          if (!isBusy) setRollbackTarget(null);
+        }}
+        buttons={[
+          {
+            text: "Cancel",
+            variant: variants.secondary,
+            onClick: () => setRollbackTarget(null),
+            disabled: isBusy,
+          },
+          {
+            text: "Roll back",
+            variant: variants.primary,
+            onClick: handleRollback,
+            loading: isBusy,
+          },
+        ]}
+      />
+    </>
+  );
+};
+
+export default ActiveUpdatesMonitor;

--- a/client/src/protoFleet/features/settings/components/ReleaseChannels/ChannelHistoryModal.tsx
+++ b/client/src/protoFleet/features/settings/components/ReleaseChannels/ChannelHistoryModal.tsx
@@ -1,0 +1,108 @@
+import { type Timestamp, timestampMs } from "@bufbuild/protobuf/wkt";
+
+import { rolloutDeviceCounts, rolloutOutcomeLabel, rolloutStatusTone } from "./rolloutStatus";
+import StatusChip from "./StatusChip";
+import { type ReleaseChannel, type Rollout, RolloutStatus } from "@/protoFleet/api/generated/rollout/v1/rollout_pb";
+import Button, { sizes as buttonSizes, variants } from "@/shared/components/Button";
+import Modal, { sizes } from "@/shared/components/Modal";
+import { formatTimestamp } from "@/shared/utils/formatTimestamp";
+
+interface ChannelHistoryModalProps {
+  channel: ReleaseChannel;
+  // This channel's rollouts, newest first (server order).
+  rollouts: Rollout[];
+  onView: (rollout: Rollout) => void;
+  onRollback: (rollout: Rollout) => void;
+  onClose: () => void;
+}
+
+const formatRolloutTimestamp = (timestamp?: Timestamp): string =>
+  timestamp ? formatTimestamp(Math.floor(timestampMs(timestamp) / 1000)) : "—";
+
+// Every update a channel has run, newest first, with a way back into each
+// one's detail and a Roll back action for versions that are not the current
+// assignment.
+const ChannelHistoryModal = ({ channel, rollouts, onView, onRollback, onClose }: ChannelHistoryModalProps) => {
+  // Current firmware assignment per model; entries already matching it get
+  // no rollback action (restoring them would be a no-op).
+  const assignedFileIds = new Map(channel.modelGroups.map((group) => [group.model, group.firmwareFileId]));
+
+  return (
+    <Modal
+      open
+      size={sizes.large}
+      title="Update history"
+      description={channel.name}
+      onDismiss={onClose}
+      buttons={[{ text: "Done", variant: variants.primary, onClick: onClose }]}
+    >
+      {rollouts.length === 0 ? (
+        <div className="py-6 text-center text-text-primary-50">No updates for this channel yet.</div>
+      ) : (
+        <table className="w-full text-left text-200">
+          <thead>
+            <tr className="text-text-primary-50">
+              <th className="py-1.5 pr-4 font-normal">Status</th>
+              <th className="py-1.5 pr-4 font-normal">Model</th>
+              <th className="py-1.5 pr-4 font-normal">Firmware</th>
+              <th className="py-1.5 pr-4 font-normal">Progress</th>
+              <th className="py-1.5 pr-4 font-normal">Started</th>
+              <th className="py-1.5 pr-4 font-normal">Finished</th>
+              <th className="py-1.5 font-normal">
+                <span className="sr-only">Actions</span>
+              </th>
+            </tr>
+          </thead>
+          <tbody className="text-text-primary">
+            {rollouts.map((rollout) => {
+              const counts = rolloutDeviceCounts(rollout);
+              const progress =
+                rollout.status === RolloutStatus.CANCELED && counts.total === 0
+                  ? "—"
+                  : `${counts.updated} of ${counts.total} updated${counts.failed > 0 ? `, ${counts.failed} failed` : ""}`;
+              const isCurrentAssignment = assignedFileIds.get(rollout.model) === rollout.firmwareFileId;
+              return (
+                <tr
+                  key={rollout.id.toString()}
+                  className="border-t border-border-5"
+                  data-testid={`history-row-${rollout.id.toString()}`}
+                >
+                  <td className="py-2 pr-4">
+                    <StatusChip label={rolloutOutcomeLabel(rollout)} tone={rolloutStatusTone(rollout)} />
+                  </td>
+                  <td className="py-2 pr-4">{rollout.model}</td>
+                  <td className="py-2 pr-4">{rollout.firmwareVersion}</td>
+                  <td className="py-2 pr-4">{progress}</td>
+                  <td className="py-2 pr-4">{formatRolloutTimestamp(rollout.createdAt)}</td>
+                  <td className="py-2 pr-4">{formatRolloutTimestamp(rollout.finishedAt)}</td>
+                  <td className="py-2 text-right">
+                    <div className="flex justify-end gap-2">
+                      <Button
+                        variant={variants.secondary}
+                        size={buttonSizes.compact}
+                        text="View"
+                        onClick={() => onView(rollout)}
+                        testId={`history-view-${rollout.id.toString()}`}
+                      />
+                      {isCurrentAssignment ? null : (
+                        <Button
+                          variant={variants.secondary}
+                          size={buttonSizes.compact}
+                          text="Roll back"
+                          onClick={() => onRollback(rollout)}
+                          testId={`history-rollback-${rollout.id.toString()}`}
+                        />
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      )}
+    </Modal>
+  );
+};
+
+export default ChannelHistoryModal;

--- a/client/src/protoFleet/features/settings/components/ReleaseChannels/ReleaseChannelManageView.tsx
+++ b/client/src/protoFleet/features/settings/components/ReleaseChannels/ReleaseChannelManageView.tsx
@@ -99,6 +99,7 @@ interface ReleaseChannelManageViewProps {
   previewScope: (scope: ReleaseChannelScope, channelId?: bigint) => Promise<PreviewReleaseChannelScopeResponse>;
   onSave: (draft: ReleaseChannelDraft) => Promise<void>;
   onDelete?: (channel: ReleaseChannel) => void;
+  onShowHistory?: (channel: ReleaseChannel) => void;
   onApply: (channelId: bigint, assignments: { model: string; firmwareFileId: string }[]) => Promise<void>;
 }
 
@@ -113,6 +114,7 @@ const ReleaseChannelManageView = ({
   previewScope,
   onSave,
   onDelete,
+  onShowHistory,
   onApply,
 }: ReleaseChannelManageViewProps) => {
   // The draft is seeded once from the channel; the parent remounts this
@@ -225,6 +227,15 @@ const ReleaseChannelManageView = ({
           ) : null}
         </div>
         <div className="flex gap-2 phone:flex-col phone:items-stretch">
+          {channel && onShowHistory ? (
+            <Button
+              variant={variants.secondary}
+              size={sizes.compact}
+              text="History"
+              onClick={() => onShowHistory(channel)}
+              testId="channel-history"
+            />
+          ) : null}
           {channel && onDelete ? (
             <Button
               variant={variants.danger}

--- a/client/src/protoFleet/features/settings/components/ReleaseChannels/ReleaseChannelsTab.tsx
+++ b/client/src/protoFleet/features/settings/components/ReleaseChannels/ReleaseChannelsTab.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from "react";
 
+import ChannelHistoryModal from "./ChannelHistoryModal";
 import ReleaseChannelManageView from "./ReleaseChannelManageView";
 import ReleaseChannelsTable from "./ReleaseChannelsTable";
-import type { ReleaseChannel } from "@/protoFleet/api/generated/rollout/v1/rollout_pb";
+import type { ReleaseChannel, Rollout } from "@/protoFleet/api/generated/rollout/v1/rollout_pb";
 import { type FirmwareFileInfo, useFirmwareApi } from "@/protoFleet/api/useFirmwareApi";
 import type { ReleaseChannelsApi } from "@/protoFleet/api/useReleaseChannels";
 import SettingsEmptyState from "@/protoFleet/features/settings/components/SettingsEmptyState";
@@ -26,9 +27,18 @@ interface ReleaseChannelsTabProps {
   // Channel to open in the manage view on mount (e.g. from an update's
   // "Manage" action).
   initialManagedChannelId?: bigint | null;
+  // History actions are handled by the active-updates monitor above the
+  // tabs, which owns the update detail and the rollback confirmation.
+  onViewRollout: (rollout: Rollout) => void;
+  onRollbackRollout: (rollout: Rollout) => void;
 }
 
-const ReleaseChannelsTab = ({ api, initialManagedChannelId = null }: ReleaseChannelsTabProps) => {
+const ReleaseChannelsTab = ({
+  api,
+  initialManagedChannelId = null,
+  onViewRollout,
+  onRollbackRollout,
+}: ReleaseChannelsTabProps) => {
   const {
     channels,
     rollouts,
@@ -47,6 +57,7 @@ const ReleaseChannelsTab = ({ api, initialManagedChannelId = null }: ReleaseChan
   );
   const [channelToDelete, setChannelToDelete] = useState<ReleaseChannel | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [historyChannelId, setHistoryChannelId] = useState<bigint | null>(null);
 
   useEffect(() => {
     listFirmwareFiles()
@@ -75,6 +86,8 @@ const ReleaseChannelsTab = ({ api, initialManagedChannelId = null }: ReleaseChan
   // falls back to the table if the channel goes.
   const managedChannel = view.kind === "manage" ? channels.find((channel) => channel.id === view.channelId) : undefined;
   const showBack = view.kind === "create" || managedChannel !== undefined;
+  // Resolved fresh on every poll so rollback eligibility tracks assignments.
+  const historyChannel = historyChannelId !== null ? channels.find((c) => c.id === historyChannelId) : undefined;
 
   return (
     <div className="flex flex-col gap-6">
@@ -116,6 +129,7 @@ const ReleaseChannelsTab = ({ api, initialManagedChannelId = null }: ReleaseChan
             await updateChannel(managedChannel.id, draft);
           }}
           onDelete={setChannelToDelete}
+          onShowHistory={(channel) => setHistoryChannelId(channel.id)}
           onApply={async (channelId, assignments) => {
             await applyFirmware(channelId, assignments);
           }}
@@ -147,6 +161,22 @@ const ReleaseChannelsTab = ({ api, initialManagedChannelId = null }: ReleaseChan
           onManage={(channel) => setView({ kind: "manage", channelId: channel.id })}
         />
       )}
+
+      {historyChannel ? (
+        <ChannelHistoryModal
+          channel={historyChannel}
+          rollouts={rollouts.filter((rollout) => rollout.channelId === historyChannel.id)}
+          onView={(rollout) => {
+            setHistoryChannelId(null);
+            onViewRollout(rollout);
+          }}
+          onRollback={(rollout) => {
+            setHistoryChannelId(null);
+            onRollbackRollout(rollout);
+          }}
+          onClose={() => setHistoryChannelId(null)}
+        />
+      ) : null}
 
       <Dialog
         open={channelToDelete !== null}

--- a/client/src/protoFleet/features/settings/components/ReleaseChannels/RolloutDetailModal.stories.tsx
+++ b/client/src/protoFleet/features/settings/components/ReleaseChannels/RolloutDetailModal.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import {
+  activeRigRollout,
+  batchedRigRollout,
+  canceledRemainingRigRollout,
+  completedRigRollout,
+  completedWithFailuresRigRollout,
+  gatedRigRollout,
+  minerNames,
+  pausedRigRollout,
+} from "./ReleaseChannels.fixtures";
+import RolloutDetailModal from "./RolloutDetailModal";
+import type { Rollout } from "@/protoFleet/api/generated/rollout/v1/rollout_pb";
+
+// The full-screen update detail: lifecycle actions in the sticky header,
+// failures first, the status lockup, plan stats, progress against plan and
+// the telemetry evidence strip.
+const meta = {
+  title: "Proto Fleet/Firmware/Release Channels/Update Detail",
+  component: RolloutDetailModal,
+  parameters: {
+    layout: "fullscreen",
+  },
+} satisfies Meta<typeof RolloutDetailModal>;
+
+export default meta;
+
+type Story = StoryObj<typeof RolloutDetailModal>;
+
+const settle = () => Promise.resolve();
+const noop = () => {};
+
+const detail = (rollout: Rollout): Story => ({
+  render: () => (
+    <div className="min-h-screen bg-surface-base">
+      <RolloutDetailModal
+        rollout={rollout}
+        minerNames={minerNames}
+        onClose={noop}
+        onContinue={settle}
+        onPause={settle}
+        onResume={settle}
+        onCancel={noop}
+        onRollback={noop}
+        onRetryFailed={settle}
+        onManage={noop}
+      />
+    </div>
+  ),
+});
+
+export const InProgress: Story = { name: "Single batch in progress", ...detail(activeRigRollout) };
+export const PilotReview: Story = { name: "Pilot batch review", ...detail(gatedRigRollout) };
+export const BatchReviewWithFailure: Story = { name: "Batch review with a failed miner", ...detail(batchedRigRollout) };
+export const Paused: Story = { ...detail(pausedRigRollout) };
+export const Completed: Story = { ...detail(completedRigRollout) };
+export const CompletedWithFailures: Story = {
+  name: "Completed with failures",
+  ...detail(completedWithFailuresRigRollout),
+};
+export const CanceledRemaining: Story = { name: "Canceled remaining", ...detail(canceledRemainingRigRollout) };

--- a/client/src/protoFleet/features/settings/components/ReleaseChannels/RolloutDetailModal.tsx
+++ b/client/src/protoFleet/features/settings/components/ReleaseChannels/RolloutDetailModal.tsx
@@ -1,0 +1,480 @@
+import { type ReactElement, type ReactNode, useEffect, useState } from "react";
+import clsx from "clsx";
+import { type Timestamp, timestampMs } from "@bufbuild/protobuf/wkt";
+
+import RolloutMinersModal, { type RolloutMinerFilter } from "./RolloutMinersModal";
+import {
+  type DeltaIntent,
+  failedDevices,
+  formatDurationSeconds,
+  isActive as isActiveRollout,
+  isAwaitingReview,
+  isBatchStage,
+  isPaused,
+  isStaged,
+  metricDisplay,
+  type MetricKind,
+  pacingSummary,
+  rolloutDeviceCounts,
+  rolloutProgressColorMap,
+  rolloutProgressSegments,
+  rolloutStageLabel,
+  scopeCounts,
+} from "./rolloutStatus";
+import {
+  type Rollout,
+  type RolloutEvidence,
+  RolloutState,
+  RolloutStatus,
+} from "@/protoFleet/api/generated/rollout/v1/rollout_pb";
+import { formatCurtailmentElapsedDuration as formatElapsed } from "@/protoFleet/features/energy/curtailmentDisplayUtils";
+import RowActionsMenu, { type RowAction } from "@/protoFleet/features/fleetManagement/components/RowActionsMenu";
+import { useTemperatureUnit } from "@/protoFleet/store";
+import { Alert, Dismiss, Info, Success } from "@/shared/assets/icons";
+import { variants } from "@/shared/components/Button";
+import type { ButtonProps } from "@/shared/components/ButtonGroup";
+import Callout, { intents } from "@/shared/components/Callout";
+import CompositionBar from "@/shared/components/CompositionBar";
+import Header from "@/shared/components/Header";
+import Modal, { sizes as modalSizes } from "@/shared/components/Modal";
+import ProgressCircular from "@/shared/components/ProgressCircular";
+import { formatTimestamp } from "@/shared/utils/formatTimestamp";
+
+const millisecondsPerSecond = 1000;
+
+const formatRolloutTimestamp = (timestamp?: Timestamp): string =>
+  timestamp ? formatTimestamp(Math.floor(timestampMs(timestamp) / 1000)) : "—";
+
+const minersNoun = (count: number): string => (count === 1 ? "1 miner" : `${count.toLocaleString()} miners`);
+
+// Ticks once per second so the elapsed readout moves between polling
+// snapshots (same pattern as the curtailment card).
+function ElapsedValue({ sinceMs }: { sinceMs: number }): ReactElement {
+  const [nowMs, setNowMs] = useState(() => Date.now());
+  useEffect(() => {
+    const intervalId = setInterval(() => setNowMs(Date.now()), millisecondsPerSecond);
+    return () => clearInterval(intervalId);
+  }, []);
+  return <span>{`${formatElapsed(Math.max((nowMs - sinceMs) / millisecondsPerSecond, 0))} elapsed`}</span>;
+}
+
+// Same lockup as the curtailment detail's StatBlock.
+function StatBlock({
+  label,
+  value,
+  detail,
+  testId,
+}: {
+  label: string;
+  value: string;
+  detail?: string;
+  testId?: string;
+}) {
+  return (
+    <div className="min-w-0" data-testid={testId}>
+      <div className="text-200 text-text-primary-50">{label}</div>
+      <div className="mt-1 text-emphasis-300 break-words text-text-primary" title={value}>
+        {value}
+      </div>
+      {detail ? <div className="mt-1 text-200 break-words text-text-primary-70">{detail}</div> : null}
+    </div>
+  );
+}
+
+const deltaTextColor: Record<DeltaIntent, string> = {
+  positive: "text-intent-success-fill",
+  negative: "text-intent-critical-fill",
+  neutral: "text-text-primary-50",
+};
+
+// Baseline-vs-current telemetry for the miners in scope, plus the error
+// count: the evidence an operator weighs at a review gate.
+function PerformanceStrip({ evidence }: { evidence: RolloutEvidence }): ReactElement {
+  const temperatureUnit = useTemperatureUnit();
+  const metrics: { kind: MetricKind; comparison: RolloutEvidence["hashRateHs"] }[] = [
+    { kind: "hashrate", comparison: evidence.hashRateHs },
+    { kind: "power", comparison: evidence.powerW },
+    { kind: "efficiency", comparison: evidence.efficiencyJh },
+    { kind: "temperature", comparison: evidence.tempC },
+  ];
+  return (
+    <div data-testid="rollout-performance">
+      <div className="grid gap-x-8 gap-y-5 text-text-primary tablet:grid-cols-2 laptop:grid-cols-5">
+        {metrics.map(({ kind, comparison }) => {
+          const display = metricDisplay(kind, comparison, temperatureUnit);
+          return (
+            <div key={kind} className="min-w-0" data-testid={`evidence-${kind}`}>
+              <div className="text-200 text-text-primary-50">{display.label}</div>
+              <div className="mt-1 flex flex-wrap items-baseline gap-x-2 gap-y-1 text-emphasis-300 text-text-primary">
+                <span className="min-w-0 whitespace-nowrap">{display.value}</span>
+                {display.delta ? <span className={deltaTextColor[display.deltaIntent]}>{display.delta}</span> : null}
+              </div>
+            </div>
+          );
+        })}
+        <div className="min-w-0" data-testid="evidence-errors">
+          <div className="text-200 text-text-primary-50">New errors</div>
+          <div
+            className={clsx(
+              "mt-1 text-emphasis-300",
+              evidence.newErrors > 0 ? "text-text-critical" : "text-text-primary",
+            )}
+          >
+            {evidence.newErrors.toLocaleString()}
+          </div>
+        </div>
+      </div>
+      <div className="mt-3 text-200 text-text-primary-50">
+        Compares the baseline before the update with telemetry after miners come back.
+      </div>
+    </div>
+  );
+}
+
+function statusIcon(rollout: Rollout): ReactNode {
+  switch (rollout.state) {
+    case RolloutState.COMPLETED:
+      return <Success className="text-intent-success-fill" />;
+    case RolloutState.COMPLETED_WITH_FAILURES:
+      return <Alert className="text-intent-critical-fill" />;
+    case RolloutState.CANCELED:
+      return <Info className="text-text-primary-50" />;
+    case RolloutState.PAUSED_AT_PILOT_GATE:
+    case RolloutState.PAUSED_AT_BATCH_REVIEW:
+      return <Info className="text-text-primary" />;
+    case RolloutState.PAUSED:
+      return <Alert className="text-core-accent-fill" />;
+    default:
+      return <ProgressCircular indeterminate className="text-core-primary-fill" />;
+  }
+}
+
+// Human summary of the auto-continue thresholds a rollout was started with.
+function thresholdSummary(rollout: Rollout): string {
+  const b = rollout.behavior;
+  if (!b?.autoContinueOnHealthyTelemetry) return "Manual";
+  const t = b.thresholds;
+  const parts: string[] = [];
+  if (t?.maxHashrateDropPercent !== undefined) parts.push(`hashrate drop ≤ ${t.maxHashrateDropPercent}%`);
+  if (t?.maxEfficiencyIncreasePercent !== undefined) parts.push(`efficiency +≤ ${t.maxEfficiencyIncreasePercent}%`);
+  if (t?.maxTemperatureIncreaseCelsius !== undefined) parts.push(`temp +≤ ${t.maxTemperatureIncreaseCelsius}°C`);
+  if (t?.maxNewErrors !== undefined) parts.push(`≤ ${t.maxNewErrors} new errors`);
+  if (b.stabilizationSeconds > 0) parts.push(`${formatDurationSeconds(b.stabilizationSeconds)} to settle`);
+  return parts.length > 0 ? `Automatic (${parts.join(", ")})` : "Automatic";
+}
+
+export interface RolloutDetailActions {
+  // Releases the review gate.
+  onContinue: (rollout: Rollout) => Promise<void>;
+  onPause: (rollout: Rollout) => Promise<void>;
+  onResume: (rollout: Rollout) => Promise<void>;
+  // Open confirmations (the caller owns the dialogs).
+  onCancel: (rollout: Rollout) => void;
+  onRollback: (rollout: Rollout) => void;
+  onRetryFailed: (rollout: Rollout) => Promise<void>;
+  // Drills into the rollout's release channel.
+  onManage?: (rollout: Rollout) => void;
+}
+
+interface RolloutDetailModalProps extends RolloutDetailActions {
+  // Live rollout from the poll, so progress and status track the server.
+  rollout: Rollout;
+  minerNames: Record<string, string>;
+  onClose: () => void;
+}
+
+// Full-screen update detail: a sticky header carrying the lifecycle actions,
+// then (failures first) the status lockup, plan stat lockups, progress
+// against plan, and the telemetry evidence strip. Miner drill-downs open as
+// a standalone list modal.
+const RolloutDetailModal = ({
+  rollout,
+  minerNames,
+  onClose,
+  onContinue,
+  onPause,
+  onResume,
+  onCancel,
+  onRollback,
+  onRetryFailed,
+  onManage,
+}: RolloutDetailModalProps) => {
+  const [isContinuing, setIsContinuing] = useState(false);
+  const [isTogglingPause, setIsTogglingPause] = useState(false);
+  const [isRetrying, setIsRetrying] = useState(false);
+  const [minersFilter, setMinersFilter] = useState<RolloutMinerFilter | null>(null);
+
+  const active = isActiveRollout(rollout);
+  const awaitingReview = isAwaitingReview(rollout);
+  const paused = isPaused(rollout);
+  const staged = isStaged(rollout);
+  const counts = scopeCounts(rollout);
+  const totals = rolloutDeviceCounts(rollout);
+  const failed = failedDevices(rollout).length;
+  const segments = rolloutProgressSegments(counts);
+  const evidence = rollout.evidence;
+  const startedAtMs = rollout.createdAt ? timestampMs(rollout.createdAt) : undefined;
+  const finishedAtMs = rollout.finishedAt ? timestampMs(rollout.finishedAt) : undefined;
+  const title = `${rollout.channelName}, ${rollout.model} firmware update`;
+  const canRollBack =
+    rollout.previousFirmwareFileId !== "" && rollout.previousFirmwareFileId !== rollout.firmwareFileId;
+
+  const handleContinue = () => {
+    setIsContinuing(true);
+    onContinue(rollout).finally(() => setIsContinuing(false));
+  };
+  const handleTogglePause = () => {
+    setIsTogglingPause(true);
+    (paused ? onResume(rollout) : onPause(rollout)).finally(() => setIsTogglingPause(false));
+  };
+  const handleRetry = () => {
+    setIsRetrying(true);
+    onRetryFailed(rollout).finally(() => setIsRetrying(false));
+  };
+  const busy = isContinuing || isTogglingPause || isRetrying;
+
+  // Header action bar: Manage / Continue / Resume / Pause / Retry failed
+  // inline, the rest in an overflow menu, mirroring the design's
+  // ViewRolloutModal.
+  const headerButtons: ButtonProps[] = [];
+  if (onManage) {
+    headerButtons.push({
+      text: "Manage",
+      variant: variants.secondary,
+      onClick: () => onManage(rollout),
+      disabled: busy,
+      testId: "view-rollout-manage-action",
+    });
+  }
+  if (awaitingReview) {
+    headerButtons.push({
+      text: "Continue",
+      variant: variants.primary,
+      onClick: handleContinue,
+      loading: isContinuing,
+      disabled: isTogglingPause || isRetrying,
+      testId: "view-rollout-continue-action",
+    });
+  }
+  if (active) {
+    headerButtons.push({
+      text: paused ? "Resume" : "Pause",
+      variant: paused ? variants.primary : variants.secondary,
+      onClick: handleTogglePause,
+      loading: isTogglingPause,
+      disabled: isContinuing || isRetrying,
+      testId: paused ? "view-rollout-resume-action" : "view-rollout-pause-action",
+    });
+  }
+  if (failed > 0 && rollout.status !== RolloutStatus.CANCELED) {
+    headerButtons.push({
+      text: "Retry failed",
+      variant: variants.secondary,
+      onClick: handleRetry,
+      loading: isRetrying,
+      disabled: isContinuing || isTogglingPause,
+      testId: "view-rollout-retry-action",
+    });
+  }
+  const overflowActions: RowAction[] = [
+    { label: "View miners", onClick: () => setMinersFilter("all"), testId: "view-rollout-view-miners-action" },
+  ];
+  if (canRollBack) {
+    overflowActions.push({
+      label: `Roll back to ${rollout.previousFirmwareVersion}`,
+      onClick: () => onRollback(rollout),
+      testId: "view-rollout-rollback-action",
+    });
+  }
+  if (active) {
+    overflowActions.push({
+      label: "Cancel remaining",
+      onClick: () => onCancel(rollout),
+      showGroupDivider: false,
+      testId: "view-rollout-cancel-action",
+    });
+  }
+
+  return (
+    <>
+      <Modal
+        open
+        onDismiss={onClose}
+        size={modalSizes.fullscreen}
+        showHeader={false}
+        className="!p-0"
+        bodyClassName="flex h-full min-h-0 w-full flex-col overflow-auto bg-surface-base pb-6"
+      >
+        <div className="sticky top-0 z-10 bg-surface-base px-6 pt-6 pb-4" data-testid="rollout-detail-header">
+          <Header
+            title={title}
+            titleSize="text-heading-200"
+            icon={<Dismiss />}
+            iconAriaLabel="Close update details"
+            iconOnClick={onClose}
+            inline
+            centerButton
+            stackButtonsOnPhone={false}
+            buttons={headerButtons}
+          >
+            <RowActionsMenu
+              actions={overflowActions}
+              ariaLabel={`More actions for ${title}`}
+              popoverTestId="view-rollout-more-actions-menu"
+              testIdPrefix="view-rollout-more-actions"
+              triggerClassName="!h-10 !w-10 !px-0 !py-0"
+              triggerVariant={variants.secondary}
+            />
+          </Header>
+        </div>
+
+        <div className="mx-auto w-full max-w-[800px] px-6 pb-6" data-testid={`rollout-detail-${rollout.id.toString()}`}>
+          <div className="pt-6">
+            {failed > 0 ? (
+              <Callout
+                intent={intents.danger}
+                prefixIcon={<Alert />}
+                testId="rollout-failed-banner"
+                title={`${minersNoun(failed)} failed to update`}
+                subtitle="They did not report the new version after three update attempts and are left alone until retried. Review them, then retry or continue without them."
+                buttonText="Review miners"
+                buttonOnClick={() => setMinersFilter("failed")}
+              />
+            ) : null}
+
+            <div className={clsx("grid gap-3", failed > 0 && "mt-10")}>
+              <div className="flex size-10 items-center justify-center rounded-lg bg-core-primary-5">
+                {statusIcon(rollout)}
+              </div>
+              <div>
+                <div className="text-heading-50 text-text-primary-70">Update status</div>
+                <div className="text-heading-300 text-text-primary" data-testid="rollout-status-headline">
+                  {rolloutStageLabel(rollout)}
+                </div>
+              </div>
+            </div>
+
+            {awaitingReview ? (
+              <Callout
+                className="mt-10"
+                intent={intents.information}
+                prefixIcon={<Info />}
+                testId="review-banner"
+                title={`${counts.updated === counts.total ? "Every miner" : `${counts.updated} of ${counts.total} miners`} in this batch ${counts.updated === 1 && counts.total === 1 ? "is" : "are"} on ${rollout.firmwareVersion}.`}
+                subtitle={
+                  evidence && rollout.behavior?.autoContinueOnHealthyTelemetry
+                    ? evidence.readyToAdvance
+                      ? "Conditions met — continuing automatically."
+                      : rollout.state === RolloutState.STABILIZING_TELEMETRY
+                        ? `Continues automatically in ${formatDurationSeconds(evidence.stabilizationRemainingSeconds)} if telemetry holds.`
+                        : `Holding for review: ${evidence.holdReason}.`
+                    : rollout.currentBatch + 1 < rollout.batchCount
+                      ? "Check the evidence below, then continue to start the next batch."
+                      : "Check the evidence below, then continue to update the remaining miners."
+                }
+              />
+            ) : null}
+
+            {paused ? (
+              <Callout
+                className="mt-10"
+                intent={intents.information}
+                prefixIcon={<Info />}
+                testId="paused-banner"
+                title="Update paused"
+                subtitle="No new update commands are sent and the update does not advance until resumed. Miners already updating finish on their own."
+              />
+            ) : null}
+
+            <div className="mt-10" data-testid="rollout-detail-stats">
+              <div className="grid gap-x-12 gap-y-5 text-text-primary tablet:grid-cols-4">
+                <StatBlock label="Scope" value={`${rollout.channelName} channel, ${minersNoun(totals.total)}`} />
+                <StatBlock label="Method" value={pacingSummary(rollout.behavior)} />
+                {staged ? <StatBlock label="Review gates" value={thresholdSummary(rollout)} /> : null}
+                <StatBlock
+                  label="Target version"
+                  value={rollout.firmwareVersion}
+                  detail={rollout.previousFirmwareVersion ? `from ${rollout.previousFirmwareVersion}` : undefined}
+                />
+                {evidence ? (
+                  <>
+                    <StatBlock
+                      label="Back online"
+                      value={`${evidence.online} of ${evidence.devicesTotal}`}
+                      testId="evidence-online"
+                    />
+                    <StatBlock
+                      label="Hashing"
+                      value={`${evidence.hashing} of ${evidence.devicesTotal}`}
+                      detail={`was ${evidence.baselineHashing} before the update`}
+                      testId="evidence-hashing"
+                    />
+                  </>
+                ) : null}
+                <StatBlock label="Started" value={formatRolloutTimestamp(rollout.createdAt)} />
+                {rollout.finishedAt ? (
+                  <StatBlock label="Finished" value={formatRolloutTimestamp(rollout.finishedAt)} />
+                ) : null}
+              </div>
+            </div>
+
+            <div className="mt-10 grid gap-3" data-testid="rollout-detail-progress">
+              <div className="flex flex-wrap items-start justify-between gap-x-4 gap-y-1">
+                <div className="text-200 text-text-primary-50">
+                  {`${isBatchStage(rollout) || awaitingReview ? `${rolloutStageLabel(rollout)}: ` : ""}${counts.updated.toLocaleString()} of ${counts.total.toLocaleString()} miners updated (${counts.percent}%)`}
+                </div>
+                <div className="text-right text-200 text-text-primary">
+                  {active && startedAtMs !== undefined ? (
+                    <ElapsedValue sinceMs={startedAtMs} />
+                  ) : startedAtMs !== undefined && finishedAtMs !== undefined ? (
+                    `${formatElapsed((finishedAtMs - startedAtMs) / millisecondsPerSecond)} elapsed`
+                  ) : null}
+                </div>
+              </div>
+              <CompositionBar segments={segments} height={12} colorMap={rolloutProgressColorMap} />
+              <div className="flex flex-wrap items-start gap-x-5 gap-y-1 text-200 text-text-primary-70">
+                {segments.map((segment) => (
+                  <span key={segment.name} className="flex items-start gap-2">
+                    <span
+                      className={clsx(
+                        "mt-1.5 inline-block h-2 w-2 shrink-0 rounded-full",
+                        rolloutProgressColorMap[segment.status],
+                      )}
+                    />
+                    {`${segment.name} (${(segment.count ?? 0).toLocaleString()})`}
+                  </span>
+                ))}
+                {staged && counts.total !== totals.total ? (
+                  <span className="ml-auto text-right text-text-primary-50">
+                    {`${(totals.total - counts.total).toLocaleString()} outside this batch`}
+                  </span>
+                ) : null}
+                {totals.excluded > 0 ? (
+                  <span className="text-right text-text-primary-50">{`${totals.excluded.toLocaleString()} excluded`}</span>
+                ) : null}
+              </div>
+            </div>
+
+            {active && evidence ? (
+              <div className="mt-10" data-testid="rollout-evidence">
+                <PerformanceStrip evidence={evidence} />
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </Modal>
+
+      {minersFilter !== null ? (
+        <RolloutMinersModal
+          key={minersFilter}
+          rollout={rollout}
+          minerNames={minerNames}
+          initialFilter={minersFilter}
+          onClose={() => setMinersFilter(null)}
+        />
+      ) : null}
+    </>
+  );
+};
+
+export default RolloutDetailModal;

--- a/client/src/protoFleet/features/settings/components/ReleaseChannels/RolloutMinersModal.tsx
+++ b/client/src/protoFleet/features/settings/components/ReleaseChannels/RolloutMinersModal.tsx
@@ -1,0 +1,258 @@
+import { type ReactElement, useMemo, useState } from "react";
+import clsx from "clsx";
+
+import { type DeltaIntent, failedDevices, metricDisplay, type MetricKind, scopeDevices } from "./rolloutStatus";
+import { type Rollout, type RolloutDevice, RolloutDevicePhase } from "@/protoFleet/api/generated/rollout/v1/rollout_pb";
+import { useTemperatureUnit } from "@/protoFleet/store";
+import List from "@/shared/components/List";
+import type { ColConfig, ColTitles } from "@/shared/components/List/types";
+import Modal from "@/shared/components/Modal";
+import ProgressCircular from "@/shared/components/ProgressCircular";
+import SegmentedControl from "@/shared/components/SegmentedControl";
+import StatusCircle, { statuses } from "@/shared/components/StatusCircle";
+
+export type RolloutMinerFilter = "all" | "failed";
+
+type MinerColumn = "miner" | "firmware" | "hashrate" | "power" | "efficiency" | "temperature";
+
+const minerColumns: MinerColumn[] = ["miner", "firmware", "hashrate", "power", "efficiency", "temperature"];
+
+const minerColTitles: ColTitles<MinerColumn> = {
+  miner: "Miner",
+  firmware: "Update status",
+  hashrate: "Hashrate",
+  power: "Power",
+  efficiency: "Efficiency",
+  temperature: "Temp",
+};
+
+const deltaTextColor: Record<DeltaIntent, string> = {
+  positive: "text-intent-success-fill",
+  negative: "text-intent-critical-fill",
+  neutral: "text-text-primary-50",
+};
+
+interface MinerRow {
+  id: string;
+  device: RolloutDevice;
+  name: string;
+}
+
+function MinerCell({ row, model }: { row: MinerRow; model: string }): ReactElement {
+  const detail = [model, row.device.ipAddress].filter(Boolean).join(" · ");
+  return (
+    <span className="flex min-w-0 flex-col gap-1">
+      <span className="text-emphasis-300 break-words text-text-primary" title={row.name}>
+        {row.name}
+      </span>
+      {detail ? (
+        <span className="text-200 break-words text-text-primary-50" title={detail}>
+          {detail}
+        </span>
+      ) : null}
+    </span>
+  );
+}
+
+// Per-miner phase for the status column: the shared StatusCircle dot, an
+// inline spinner while in flight, and the design's phase wording.
+function PhaseCell({ device, targetVersion }: { device: RolloutDevice; targetVersion: string }): ReactElement {
+  const dot = (status: keyof typeof statuses) => (
+    <StatusCircle status={status} variant="simple" width="w-[6px]" testId="rollout-column-status" />
+  );
+  let state: ReactElement;
+  switch (device.phase) {
+    case RolloutDevicePhase.DONE:
+      state = (
+        <span className="flex items-center gap-2 text-text-primary">
+          {dot(statuses.normal)}
+          {`Updated to ${targetVersion}`}
+        </span>
+      );
+      break;
+    case RolloutDevicePhase.FAILED:
+      state = (
+        <span className="flex items-center gap-2 text-text-primary">
+          {dot(statuses.error)}
+          Failed
+        </span>
+      );
+      break;
+    case RolloutDevicePhase.RETRYING:
+      state = (
+        <span className="flex items-center gap-2 text-text-primary">
+          {dot(statuses.warning)}
+          <ProgressCircular size={14} indeterminate />
+          {`Retrying (attempt ${device.attempts})`}
+        </span>
+      );
+      break;
+    case RolloutDevicePhase.IN_PROGRESS:
+      state = (
+        <span className="flex items-center gap-2 text-text-primary">
+          {dot(statuses.warning)}
+          <ProgressCircular size={14} indeterminate />
+          {device.firmwareVersion === targetVersion ? "Verifying" : "Updating firmware"}
+        </span>
+      );
+      break;
+    case RolloutDevicePhase.EXCLUDED:
+      state = (
+        <span className="flex items-center gap-2 text-text-primary-70">
+          {dot(statuses.inactive)}
+          Excluded (left the channel)
+        </span>
+      );
+      break;
+    default:
+      state = (
+        <span className="flex items-center gap-2 text-text-primary-70">
+          {dot(statuses.inactive)}
+          {device.firmwareVersion ? `Queued (${device.firmwareVersion})` : "Queued"}
+        </span>
+      );
+  }
+
+  const reasons: string[] = [];
+  if (device.phase === RolloutDevicePhase.FAILED && device.lastError) reasons.push(device.lastError);
+  if (device.openErrors > device.baselineOpenErrors) {
+    const added = device.openErrors - device.baselineOpenErrors;
+    reasons.push(added === 1 ? "1 new error" : `${added} new errors`);
+  }
+  if (device.phase !== RolloutDevicePhase.DONE && device.phase !== RolloutDevicePhase.QUEUED && !device.online) {
+    reasons.push(device.status ? `Device ${device.status.toLowerCase()}` : "Offline");
+  }
+
+  return (
+    <span className="flex min-w-0 flex-col gap-1">
+      {state}
+      {reasons.length > 0 ? (
+        <span className="text-200 break-words text-intent-critical-fill">{reasons.join("; ")}</span>
+      ) : null}
+    </span>
+  );
+}
+
+function MetricCell({ device, kind }: { device: RolloutDevice; kind: MetricKind }): ReactElement {
+  const temperatureUnit = useTemperatureUnit();
+  const metric =
+    kind === "hashrate"
+      ? device.hashRateHs
+      : kind === "power"
+        ? device.powerW
+        : kind === "efficiency"
+          ? device.efficiencyJh
+          : device.tempC;
+  const display = metricDisplay(kind, metric, temperatureUnit);
+  return (
+    <span className="flex min-w-0 flex-col gap-1 text-text-primary" title={`${display.value} ${display.delta ?? ""}`}>
+      <span className="break-words">{display.value}</span>
+      {display.delta ? (
+        <span className={clsx("text-200 break-words", deltaTextColor[display.deltaIntent])}>{display.delta}</span>
+      ) : null}
+    </span>
+  );
+}
+
+interface RolloutMinersModalProps {
+  rollout: Rollout;
+  // deviceIdentifier -> display name.
+  minerNames: Record<string, string>;
+  initialFilter?: RolloutMinerFilter;
+  onClose: () => void;
+}
+
+// Miner drill-down for an update: every targeted miner (or just the failed
+// ones) with its phase and telemetry against baseline.
+const RolloutMinersModal = ({ rollout, minerNames, initialFilter = "all", onClose }: RolloutMinersModalProps) => {
+  const [filter, setFilter] = useState<RolloutMinerFilter>(initialFilter);
+
+  const rows = useMemo<MinerRow[]>(
+    () =>
+      rollout.devices.map((device) => ({
+        id: device.deviceIdentifier,
+        device,
+        name: minerNames[device.deviceIdentifier] ?? device.deviceIdentifier,
+      })),
+    [rollout, minerNames],
+  );
+  const visibleRows = filter === "failed" ? rows.filter((row) => row.device.phase === RolloutDevicePhase.FAILED) : rows;
+  const failedCount = failedDevices(rollout).length;
+  const summary =
+    filter === "failed"
+      ? `${failedCount.toLocaleString()} ${failedCount === 1 ? "miner" : "miners"} failed to update`
+      : `${rows.length.toLocaleString()} miners in this update, ${scopeDevices(rollout).length.toLocaleString()} in the current batch`;
+
+  const colConfig: ColConfig<MinerRow, string, MinerColumn> = {
+    miner: { component: (row) => <MinerCell row={row} model={rollout.model} />, width: "w-[220px]", allowWrap: true },
+    firmware: {
+      component: (row) => <PhaseCell device={row.device} targetVersion={rollout.firmwareVersion} />,
+      width: "w-[240px]",
+      allowWrap: true,
+    },
+    hashrate: {
+      component: (row) => <MetricCell device={row.device} kind="hashrate" />,
+      width: "w-[128px]",
+      allowWrap: true,
+    },
+    power: { component: (row) => <MetricCell device={row.device} kind="power" />, width: "w-[112px]", allowWrap: true },
+    efficiency: {
+      component: (row) => <MetricCell device={row.device} kind="efficiency" />,
+      width: "w-[128px]",
+      allowWrap: true,
+    },
+    temperature: {
+      component: (row) => <MetricCell device={row.device} kind="temperature" />,
+      width: "w-[112px]",
+      allowWrap: true,
+    },
+  };
+
+  return (
+    <Modal
+      open
+      onDismiss={onClose}
+      title="Miners in firmware update"
+      size="large"
+      className="flex !h-[calc(100dvh-(--spacing(32)))] max-h-[calc(100dvh-(--spacing(32)))] flex-col !overflow-hidden"
+      bodyClassName="flex flex-1 min-h-0 flex-col"
+      divider={false}
+      testId="rollout-miners-modal"
+      buttons={[{ text: "Done", variant: "primary", onClick: onClose, dismissModalOnClick: false }]}
+    >
+      <div className="flex min-h-0 flex-1 flex-col gap-4">
+        <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
+          <SegmentedControl
+            segments={[
+              { key: "all", title: "All miners" },
+              { key: "failed", title: "Failed" },
+            ]}
+            initialSegmentKey={initialFilter}
+            onSelect={(key) => setFilter(key as RolloutMinerFilter)}
+          />
+          <div className="text-200 text-text-primary-70">{summary}</div>
+        </div>
+        <List<MinerRow, string, MinerColumn>
+          activeCols={minerColumns}
+          colTitles={minerColTitles}
+          colConfig={colConfig}
+          items={visibleRows}
+          itemKey="id"
+          total={visibleRows.length}
+          itemName={{ singular: "miner", plural: "miners" }}
+          containerClassName="min-h-0"
+          tableClassName="mb-0 w-full !table-fixed"
+          applyColumnWidthsToCells
+          stickyFirstColumn={false}
+          emptyStateRow={
+            <div className="py-10 text-center text-300 text-text-primary-70">
+              {filter === "failed" ? "No miners failed." : "No miners to show."}
+            </div>
+          }
+        />
+      </div>
+    </Modal>
+  );
+};
+
+export default RolloutMinersModal;

--- a/client/src/protoFleet/features/settings/components/ReleaseChannels/rolloutStatus.test.ts
+++ b/client/src/protoFleet/features/settings/components/ReleaseChannels/rolloutStatus.test.ts
@@ -16,6 +16,7 @@ import {
   singleBatchBehavior,
 } from "./ReleaseChannels.fixtures";
 import {
+  activeUpdateSummary,
   channelUpdateStatus,
   metricDisplay,
   modelFirmwareLabel,
@@ -105,6 +106,13 @@ describe("device counts and progress", () => {
   it("scopes counts to the batch under review", () => {
     expect(scopeCounts(gatedRigRollout)).toMatchObject({ updated: 2, total: 2, percent: 100 });
     expect(scopeCounts(activeRigRollout)).toMatchObject({ updated: 2, total: 6 });
+  });
+
+  it("summarizes an active update for banners and the header pill", () => {
+    expect(activeUpdateSummary(activeRigRollout)).toBe("2 of 6 miners updated");
+    expect(activeUpdateSummary(gatedRigRollout)).toBe("2 of 6 miners updated, Pilot batch review");
+    expect(activeUpdateSummary(batchedRigRollout)).toBe("3 of 6 miners updated, 1 failed, Batch review");
+    expect(activeUpdateSummary(pausedRigRollout)).toBe("2 of 6 miners updated, Paused");
   });
 
   it("flags rollouts that need a human", () => {

--- a/client/src/protoFleet/features/settings/components/ReleaseChannels/rolloutStatus.ts
+++ b/client/src/protoFleet/features/settings/components/ReleaseChannels/rolloutStatus.ts
@@ -290,6 +290,17 @@ export function rolloutProgressSummary(counts: RolloutDeviceCounts): string {
   return `${counts.updated.toLocaleString()} of ${counts.total.toLocaleString()} ${minerNoun} updated (${counts.percent}%)${failed}`;
 }
 
+// "74 of 87 miners updated, 2 failed, Batch 5 of 6": the one-line summary for
+// banners and the header pill.
+export function activeUpdateSummary(rollout: Rollout): string {
+  const counts = rolloutDeviceCounts(rollout);
+  const failed = failedDevices(rollout).length;
+  const parts = [`${counts.updated.toLocaleString()} of ${counts.total.toLocaleString()} miners updated`];
+  if (failed > 0) parts.push(failed === 1 ? "1 failed" : `${failed.toLocaleString()} failed`);
+  if (isPaused(rollout) || isAwaitingReview(rollout) || isBatchStage(rollout)) parts.push(rolloutStageLabel(rollout));
+  return parts.join(", ");
+}
+
 // ---------------------------------------------------------------------------
 // Channel and model status
 // ---------------------------------------------------------------------------

--- a/server/migrations/000147_rollout_activity_labels.down.sql
+++ b/server/migrations/000147_rollout_activity_labels.down.sql
@@ -1,0 +1,4 @@
+DROP FUNCTION IF EXISTS activity_display_label(TEXT, TEXT, TEXT, JSONB, TEXT);
+
+ALTER FUNCTION activity_display_label_v142(TEXT, TEXT, TEXT, JSONB, TEXT)
+    RENAME TO activity_display_label;

--- a/server/migrations/000147_rollout_activity_labels.up.sql
+++ b/server/migrations/000147_rollout_activity_labels.up.sql
@@ -1,0 +1,46 @@
+-- Display labels for firmware update (rollout) activity events. Keep in sync
+-- with the client label maps (client/src/protoFleet/features/activity/utils).
+-- Preserves the 000142 implementation as a helper so the down migration can
+-- restore it byte-for-byte.
+ALTER FUNCTION activity_display_label(TEXT, TEXT, TEXT, JSONB, TEXT)
+    RENAME TO activity_display_label_v142;
+
+CREATE OR REPLACE FUNCTION activity_display_label(
+    event_type TEXT,
+    scope_type TEXT,
+    scope_label TEXT,
+    metadata JSONB,
+    description TEXT
+) RETURNS TEXT
+LANGUAGE SQL
+IMMUTABLE
+PARALLEL SAFE
+AS $$
+SELECT CASE
+    WHEN event_type LIKE 'rollout_%'
+        THEN CONCAT(
+            CASE event_type
+                WHEN 'rollout_started'                 THEN 'Started firmware update'
+                WHEN 'rollout_review_ready'            THEN 'Firmware update ready for review'
+                WHEN 'rollout_continued'               THEN 'Continued firmware update'
+                WHEN 'rollout_paused'                  THEN 'Paused firmware update'
+                WHEN 'rollout_resumed'                 THEN 'Resumed firmware update'
+                WHEN 'rollout_canceled'                THEN 'Canceled remaining firmware updates'
+                WHEN 'rollout_completed'               THEN 'Completed firmware update'
+                WHEN 'rollout_completed_with_failures' THEN 'Completed firmware update with failures'
+                WHEN 'rollout_retried'                 THEN 'Retried failed firmware updates'
+                ELSE 'Firmware update'
+            END,
+            COALESCE(
+                ': ' || NULLIF(CONCAT_WS(' ',
+                    metadata->>'channel_name',
+                    metadata->>'model',
+                    CASE WHEN metadata->>'firmware_version' IS NOT NULL
+                         THEN '→ ' || (metadata->>'firmware_version') END
+                ), ''),
+                ''
+            )
+        )
+    ELSE activity_display_label_v142(event_type, scope_type, scope_label, metadata, description)
+END
+$$;

--- a/server/migrations/rollout_activity_labels_test.go
+++ b/server/migrations/rollout_activity_labels_test.go
@@ -1,0 +1,47 @@
+package migrations_test
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/block/proto-fleet/server/internal/testutil"
+	"github.com/block/proto-fleet/server/migrations"
+)
+
+func TestRolloutActivityLabelsMigrationDownAndUp(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test in short mode")
+	}
+	db := testutil.GetTestDB(t)
+	ctx := t.Context()
+	downSQL, err := migrations.Migrations.ReadFile("000147_rollout_activity_labels.down.sql")
+	require.NoError(t, err)
+	upSQL, err := migrations.Migrations.ReadFile("000147_rollout_activity_labels.up.sql")
+	require.NoError(t, err)
+
+	const query = `SELECT activity_display_label('rollout_completed_with_failures', CAST(NULL AS TEXT), NULL,
+		'{"channel_name":"Canary","model":"Rig","firmware_version":"2.0.0"}'::jsonb, '')`
+
+	var label string
+	require.NoError(t, db.QueryRowContext(ctx, query).Scan(&label))
+	require.Equal(t, "Completed firmware update with failures: Canary Rig → 2.0.0", label)
+
+	_, err = db.ExecContext(ctx, string(downSQL))
+	require.NoError(t, err)
+	var priorLabel sql.NullString
+	require.NoError(t, db.QueryRowContext(ctx, query).Scan(&priorLabel))
+	require.False(t, priorLabel.Valid, "before 000147 the function has no rollout labels")
+
+	_, err = db.ExecContext(ctx, string(upSQL))
+	require.NoError(t, err)
+	require.NoError(t, db.QueryRowContext(ctx, query).Scan(&label))
+	require.Equal(t, "Completed firmware update with failures: Canary Rig → 2.0.0", label)
+
+	// Earlier labels still resolve through the preserved helper.
+	require.NoError(t, db.QueryRowContext(ctx,
+		`SELECT activity_display_label('cli_reset_password', CAST(NULL AS TEXT), NULL, '{"target_username":"owner"}'::jsonb, '')`,
+	).Scan(&label))
+	require.Equal(t, "Break-glass password reset for owner", label)
+}


### PR DESCRIPTION
## Summary

Third of three stacked PRs porting the firmware rollout prototype to production (server API in #1008, channels UI in #1010; design note `docs/plans/2026-09-03-firmware-release-channels-design.md`). This one lands the surfaces for updates in flight and their history.

- **Active updates monitor** above the Settings > Firmware tabs: a banner per ongoing update (Callout, danger tone when miners have failed), opening the **update detail** — sticky header with Manage / Continue / Pause / Resume / Retry failed and an overflow with View miners / Roll back / Cancel remaining (both confirmed); failures-first callout; status lockup in the #881 vocabulary (Pilot batch review, Batch review, Waiting for telemetry, Paused, Completed, Completed with failures, Canceled); plan stats (scope, pacing, review gates incl. thresholds, target version, back online / hashing); progress against plan with Updated / Remaining / Failed segments; and the telemetry evidence strip (hashrate, power, efficiency, temperature vs baseline, new errors).
- **Miners drill-down** with per-miner phase (Updated / Updating / Verifying / Retrying (attempt n) / Failed / Queued / Excluded), last error, and telemetry deltas; a Failed filter.
- **Update history** per channel (View and Roll back per entry; rollback offered only for versions that are not the current assignment) and a **header pill** that leads with whatever needs attention and deep-links to the release channels tab.
- **Activity labels** for every rollout event, client-side and via migration `000147` (layers over the `000142` function; down restores it byte-for-byte; round-trip test included).
- **E2E** (`firmwareRollout.spec.ts`): create channel with a miner scope; enforce per model; exclusive membership (overlap rejected, then freed by editing the first channel); header pill deep-link; pilot gate with evidence, pause/resume, continue; batches with auto-continue and no manual review; cancel remaining keeps updated miners and is not restarted; roll back from history (incl. roll-forward offer).

## Test plan

- [x] `vitest`: full client suite (405 files / 4,329 tests) incl. new banner-summary and status tests
- [x] `go test ./migrations/` — `000147` down/up round-trip; `dbtest` template applies through 147
- [x] `tsc --noEmit`, eslint (`--max-warnings 0`) on all touched files
- [x] E2E: all 5 `firmwareRollout.spec.ts` scenarios pass against the fake proto rigs (desktop project, ~14 min)
- [ ] Storybook: `Proto Fleet/Firmware/Release Channels/{Update Detail, Active Updates, Header Pill}`
- [ ] Deploy the stack to a dev fleet for a real pilot update end to end

## Follow-ups (deferred by design)

Scheduled start; pacing on the Fleet bulk "Update firmware" modal; caching the `ListRollouts` read path at fleet scale.