### PR TITLE
fix(client): stop MinerSelectionModal re-rendering in a loop

### DIFF
--- a/client/src/protoFleet/components/TargetSelectionModal/MinerSelectionModal.tsx
+++ b/client/src/protoFleet/components/TargetSelectionModal/MinerSelectionModal.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 
 import type { MinerListFilter } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
 import MinerSelectionList, {
@@ -46,6 +46,30 @@ const MinerSelectionModal = ({
     totalMiners: undefined,
   });
 
+  // MinerSelectionList notifies from an effect keyed on this callback, so it
+  // must keep its identity across renders or every notification re-renders
+  // the modal, hands the list a new callback, and re-fires the effect.
+  const handleSelectionChange = useCallback(
+    ({
+      selectedItems,
+      allSelected,
+      totalMiners,
+    }: {
+      selectedItems: string[];
+      allSelected: boolean;
+      totalMiners?: number;
+    }) =>
+      setDraftSelection((prev) =>
+        prev.allSelected === allSelected &&
+        prev.totalMiners === totalMiners &&
+        prev.selectedMinerIds.length === selectedItems.length &&
+        prev.selectedMinerIds.every((id, i) => id === selectedItems[i])
+          ? prev
+          : { selectedMinerIds: selectedItems, allSelected, totalMiners },
+      ),
+    [],
+  );
+
   if (!open) {
     return null;
   }
@@ -92,9 +116,7 @@ const MinerSelectionModal = ({
           disableFilteredSelectAll
           scope={scope}
           filterConfig={filterConfig}
-          onSelectionChange={({ selectedItems, allSelected, totalMiners }) =>
-            setDraftSelection({ selectedMinerIds: selectedItems, allSelected, totalMiners })
-          }
+          onSelectionChange={handleSelectionChange}
         />
       </div>
     </Modal>

--- a/client/src/protoFleet/features/settings/components/Schedules/MinerSelectionModal.test.tsx
+++ b/client/src/protoFleet/features/settings/components/Schedules/MinerSelectionModal.test.tsx
@@ -1,18 +1,46 @@
-import type { ReactNode } from "react";
-import { render } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { type ReactNode, useEffect } from "react";
+import { act, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { create } from "@bufbuild/protobuf";
 
 import MinerSelectionModal from "./MinerSelectionModal";
 import { MinerListFilterSchema } from "@/protoFleet/api/generated/fleetmanagement/v1/fleetmanagement_pb";
+import type { MinerSelectionListProps } from "@/protoFleet/components/MinerSelectionList";
 
 const mockMinerSelectionList = vi.fn();
+const notifyCount = { current: 0 };
+// Bounds the notify loop so a regression fails the assertion instead of
+// hanging the run until React gives up.
+const NOTIFY_CAP = 100;
+
+// Mirrors the real list's contract: it reports its selection from an effect
+// keyed on the callback identity, which is what looped the modal when it
+// passed a fresh arrow on every render.
+const MinerSelectionListStub = ({
+  onSelectionChange,
+  initialSelectedItems,
+  initialAllSelected,
+}: MinerSelectionListProps) => {
+  useEffect(() => {
+    if (notifyCount.current >= NOTIFY_CAP) {
+      return;
+    }
+    notifyCount.current += 1;
+    onSelectionChange?.({
+      selectedItems: initialSelectedItems ?? [],
+      allSelected: initialAllSelected ?? false,
+      totalMiners: 2,
+    });
+  }, [onSelectionChange, initialSelectedItems, initialAllSelected]);
+
+  return <div>Miner selection list</div>;
+};
 
 vi.mock("@/protoFleet/components/MinerSelectionList", () => ({
   __esModule: true,
-  default: (props: unknown) => {
+  default: (props: MinerSelectionListProps) => {
     mockMinerSelectionList(props);
-    return <div>Miner selection list</div>;
+    return <MinerSelectionListStub {...props} />;
   },
 }));
 
@@ -21,9 +49,19 @@ vi.mock("@/shared/components/Modal", () => ({
   default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
 }));
 
+const lastListProps = () => {
+  const { calls } = mockMinerSelectionList.mock;
+  return calls[calls.length - 1]?.[0] as MinerSelectionListProps;
+};
+
 describe("MinerSelectionModal", () => {
   beforeEach(() => {
     mockMinerSelectionList.mockReset();
+    notifyCount.current = 0;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("disables filtered select-all for schedule targeting", () => {
@@ -58,5 +96,59 @@ describe("MinerSelectionModal", () => {
     );
 
     expect(mockMinerSelectionList).toHaveBeenCalledWith(expect.objectContaining({ initialFilter }));
+  });
+
+  it("keeps onSelectionChange identity stable across re-renders", () => {
+    const selectedMinerIds = ["miner-1"];
+    const { rerender } = render(
+      <MinerSelectionModal open selectedMinerIds={selectedMinerIds} onDismiss={vi.fn()} onSave={vi.fn()} />,
+    );
+    const initialCallback = lastListProps().onSelectionChange;
+
+    rerender(
+      <MinerSelectionModal
+        open
+        selectedMinerIds={selectedMinerIds}
+        scope={{ siteIds: [7n], includeUnassigned: false }}
+        onDismiss={vi.fn()}
+        onSave={vi.fn()}
+      />,
+    );
+
+    expect(lastListProps().onSelectionChange).toBe(initialCallback);
+  });
+
+  it("does not loop when the list notifies from an effect keyed on the callback", () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    render(<MinerSelectionModal open selectedMinerIds={["miner-1"]} onDismiss={vi.fn()} onSave={vi.fn()} />);
+
+    const loopErrors = consoleError.mock.calls.filter(([message]) =>
+      String(message).includes("Maximum update depth exceeded"),
+    );
+    expect(loopErrors).toEqual([]);
+    // The first notification changes the draft (totalMiners becomes known), so
+    // the modal re-renders exactly once; the stable callback keeps the list's
+    // effect from firing again.
+    expect(notifyCount.current).toBe(1);
+    expect(mockMinerSelectionList).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips draft updates that do not change the selection", () => {
+    render(<MinerSelectionModal open selectedMinerIds={["miner-1"]} onDismiss={vi.fn()} onSave={vi.fn()} />);
+    const onSelectionChange = lastListProps().onSelectionChange;
+    const rendersAfterMount = mockMinerSelectionList.mock.calls.length;
+
+    // Same content as the stub's mount notification, but a fresh array: the
+    // updater compares by value and returns the previous state.
+    act(() => {
+      onSelectionChange?.({ selectedItems: ["miner-1"], allSelected: false, totalMiners: 2 });
+    });
+    expect(mockMinerSelectionList).toHaveBeenCalledTimes(rendersAfterMount);
+
+    act(() => {
+      onSelectionChange?.({ selectedItems: ["miner-1"], allSelected: true, totalMiners: 2 });
+    });
+    expect(mockMinerSelectionList).toHaveBeenCalledTimes(rendersAfterMount + 1);
   });
 });


### PR DESCRIPTION
Reviewable diff: +26/-4 across 1 file (excludes generated, test, and story files).

## Summary

Opening the shared miner picker (`MinerSelectionModal`, used by the curtailment, schedule and alert-rule flows) no longer re-renders in a loop until React stops it with `Maximum update depth exceeded` in the dev console. The modal now hands `MinerSelectionList` a callback that keeps its identity across renders and ignores selection reports that would not change the draft, so the list's notify effect fires once per real change instead of once per render. A regression test drives a stub list the way the real list behaves and fails against the pre-fix component.

**Stack.** First PR in the firmware release channels series. Based on `main`, so the diff is the full change. Stacked on top: #1014 (RolloutService API) -> #1015 (schema, queries, store) -> #1016 (domain service) -> #1017 (rollout engine) -> #1018 (API wiring) -> #1019 (client data hook) -> #1020 (Release Channels tab) -> #1021 (active updates UI) -> #1022 (header pill and activity log) -> #1023 (E2E). Nothing upstream is needed to judge this change. The release-channels E2E in #1023 opens this modal and would otherwise inherit the console-error storm, which is why the fix leads the stack. Out of scope: the same inline-callback pattern in `SearchMinersModal` (loop-safe today because it stores a boolean), and whether the modal's `draftSelection` mirror is still needed at all. Both are left for a follow-up.

## How it works

`MinerSelectionList` owns the selection and reports it to its parent from a `useEffect` whose dependency list includes the `onSelectionChange` prop. The modal keeps a `draftSelection` copy of that report as the fallback for the Done button when the list's imperative handle is unavailable.

Before: the modal passed a new arrow function on every render and always stored a new state object. Each report re-rendered the modal, which created a new callback, which re-fired the list's effect, which reported again, until React's nested-update limit.

After:

1. `handleSelectionChange` is created once with `useCallback(..., [])`. It only calls the state setter, so it has no dependencies. A modal re-render no longer changes the list's effect dependencies, so the effect does not re-fire.
2. The state updater compares the incoming report with the previous draft (`allSelected`, `totalMiners`, and `selectedMinerIds` element by element) and returns the previous object when nothing changed. React bails out of the update, so an unchanged report causes no re-render even if something else re-fires the effect.

Either change alone breaks the loop; together they also prevent redundant renders from repeated equal reports. The Done path is unchanged: it still reads the list's imperative handle first and falls back to `draftSelection`.

## Diagrams

```mermaid
flowchart LR
    Consumers["CurtailmentStartModal / ScheduleModal / AddRuleModal"] --> Modal["MinerSelectionModal"]
    Modal -- "onSelectionChange (stable via useCallback)" --> List["MinerSelectionList"]
    List -- "notify effect, deps include onSelectionChange" --> Handler["handleSelectionChange"]
    Handler -- "unchanged: return prev, no render" --> Draft["draftSelection state"]
    Handler -- "changed: new object, one render" --> Draft
    Draft -. "fallback only" .-> Done["Done button: onSave(getSelectionValue())"]
    List -. "imperative handle (primary)" .-> Done
```

```mermaid
sequenceDiagram
    participant M as MinerSelectionModal
    participant L as MinerSelectionList
    Note over M,L: Before: fresh arrow on every render
    L->>M: onSelectionChange(report)
    M->>M: setDraftSelection(new object), re-render
    M->>L: new onSelectionChange prop
    L->>M: effect re-fires, onSelectionChange(report)
    Note over M,L: repeats until Maximum update depth exceeded
    Note over M,L: After: memoized callback plus value bail-out
    L->>M: onSelectionChange(report)
    M->>M: changed, new object, one re-render
    M->>L: same onSelectionChange prop
    Note over L: deps unchanged, effect does not re-fire
```

## Areas of the code involved

| Area / file | What changed | Why it matters for review |
| --- | --- | --- |
| `client/src/protoFleet/components/TargetSelectionModal/MinerSelectionModal.tsx` | `onSelectionChange` is a `useCallback` with a value-comparing functional state update instead of an inline arrow that always stored a new object | The whole fix. Check the equality check covers every field of `draftSelection` and that the hook stays above the `if (!open) return null` early return |
| `client/src/protoFleet/features/settings/components/Schedules/MinerSelectionModal.test.tsx` | Stub list now notifies from an effect keyed on the callback (capped at 100 notifications); three new cases for callback identity, no loop on mount, and equal-value bail-out | Test only. Confirms the stub reproduces the real child contract rather than a static div |

## Key technical decisions & trade-offs

- **Fix at the consumer, not in `MinerSelectionList`.** Dropping `onSelectionChange` from the list's effect deps would change behaviour for its other caller and fight the hooks lint rule; keeping the list untouched follows the scoped-fix convention. The list's effect can still loop for a future consumer that passes an inline callback and stores an object.
- **Belt and braces: stable identity plus value bail-out.** The memoized callback alone closes the loop. The bail-out additionally suppresses redundant renders from repeated equal reports, at the cost of an ordered element-wise compare of `selectedMinerIds` (a reordered-but-equal selection still renders once; it does not loop).
- **Keep `draftSelection`.** Its only reader is the Done fallback for when the list's imperative handle is null. Removing the state and the notify edge would delete the loop class structurally but changes the Done contract, so it is left as a follow-up rather than folded into a bug fix.
- **Hand-written callback parameter type.** Matches the list's `onSelectionChange` shape today (`totalMiners?: number` against the prop's `number | undefined`, compatible because `exactOptionalPropertyTypes` is off). Deriving it from `MinerSelectionListProps` would remove the drift risk.
- **Regression test lives in the Schedules test file.** `Schedules/MinerSelectionModal.tsx` is a one-line re-export of the fixed component and already stubs the list and `Modal`, so extending it avoided a second harness. The stub caps notifications at 100 so a regression fails an assertion instead of hanging the run.

## Testing & validation

- `vitest`: `Schedules/MinerSelectionModal.test.tsx` 6/6 pass at head. With the component reverted to `main`, the three new cases fail as intended (callback identity differs, notify count hits the cap, React logs `Maximum update depth exceeded`, equal-value update still re-renders) and the three pre-existing prop-forwarding cases still pass.
- Neighbouring suites (`Schedules/*`, `MinerSelectionList.test.tsx`): 12 files, 94 tests pass.
- `tsc --noEmit`, `eslint --max-warnings 0`, `prettier --check` clean.
- Manual: opening the modal in the dev app with Playwright produced 33 console errors before the fix and 0 after.
- Not covered: no E2E asserts on console errors, so the alerts and schedules specs pass at both base and head; nothing pins the `MinerSelectionList` side of the contract (its own tests never pass `onSelectionChange`).
