### PR TITLE
fix(ci): skip review policy for check events on non-head commits

### DIFF
--- a/.github/scripts/evaluate_review_policy_test.py
+++ b/.github/scripts/evaluate_review_policy_test.py
@@ -1650,6 +1650,31 @@ class ReviewPolicyTest(unittest.TestCase):
         )
         self.assertIn("github.event.review.state == 'commented'", cancel_expression)
 
+    def test_workflow_skips_check_events_for_commits_that_are_not_a_pr_head(self):
+        workflow = load_workflow("review-policy.yml")
+        group_expression = workflow["concurrency"]["group"]
+        cancel_expression = workflow["concurrency"]["cancel-in-progress"]
+        evaluate_condition = workflow["jobs"]["evaluate"]["if"]
+
+        # An external app posting one check run per commit must not start one
+        # evaluation per commit; only the pull request head can change the
+        # decision. Forks leave head_branch null, so they are still evaluated.
+        non_head_check_run = (
+            "github.event_name == 'check_run' && "
+            "github.event.check_run.check_suite.head_branch != null && "
+            "github.event.check_run.pull_requests[0] == null"
+        )
+        non_head_check_suite = (
+            "github.event_name == 'check_suite' && "
+            "github.event.check_suite.head_branch != null && "
+            "github.event.check_suite.pull_requests[0] == null"
+        )
+        for expression in (group_expression, cancel_expression):
+            self.assertIn(f"({non_head_check_run})", expression)
+            self.assertIn(f"({non_head_check_suite})", expression)
+        self.assertIn(f"!({non_head_check_run})", evaluate_condition)
+        self.assertIn(f"!({non_head_check_suite})", evaluate_condition)
+
     def test_workflow_publishes_pending_status_for_cancelled_evaluation(self):
         workflow = load_workflow("review-policy.yml")
         publish_job = workflow["jobs"]["publish-status"]

--- a/.github/workflows/review-policy.yml
+++ b/.github/workflows/review-policy.yml
@@ -14,6 +14,12 @@ on: # zizmor: ignore[dangerous-triggers] review policy runs from trusted workflo
     types: [submitted, dismissed]
   status:
 
+# check_run and check_suite fan out: an external app such as the DCO check
+# posts one check run per commit of a pull request, so one push fires an event
+# per commit. Only the pull request head can change the decision, so events for
+# other commits are dropped before a runner is allocated. GitHub fills
+# check_run.pull_requests only for same-repository heads and leaves
+# check_suite.head_branch null for forks, so fork events are still evaluated.
 concurrency:
   group: >-
     review-policy-${{
@@ -22,6 +28,8 @@ concurrency:
         (github.event_name == 'check_run' && github.event.action == 'rerequested') ||
         (github.event_name == 'check_suite' && github.event.check_suite.app.slug == 'github-actions') ||
         (github.event_name == 'check_suite' && github.event.action == 'rerequested') ||
+        (github.event_name == 'check_run' && github.event.check_run.check_suite.head_branch != null && github.event.check_run.pull_requests[0] == null) ||
+        (github.event_name == 'check_suite' && github.event.check_suite.head_branch != null && github.event.check_suite.pull_requests[0] == null) ||
         (github.event_name == 'status' && (github.event.context == 'Review Policy' || github.event.context == 'Review Policy Advisory')) ||
         (github.event_name == 'pull_request_review' && github.event.action == 'submitted' && github.event.review.state == 'commented')
       ) &&
@@ -35,6 +43,8 @@ concurrency:
         (github.event_name == 'check_run' && github.event.action == 'rerequested') ||
         (github.event_name == 'check_suite' && github.event.check_suite.app.slug == 'github-actions') ||
         (github.event_name == 'check_suite' && github.event.action == 'rerequested') ||
+        (github.event_name == 'check_run' && github.event.check_run.check_suite.head_branch != null && github.event.check_run.pull_requests[0] == null) ||
+        (github.event_name == 'check_suite' && github.event.check_suite.head_branch != null && github.event.check_suite.pull_requests[0] == null) ||
         (github.event_name == 'status' && (github.event.context == 'Review Policy' || github.event.context == 'Review Policy Advisory')) ||
         (github.event_name == 'pull_request_review' && github.event.action == 'submitted' && github.event.review.state == 'commented')
       )
@@ -55,6 +65,8 @@ jobs:
       !(github.event_name == 'check_run' && github.event.action == 'rerequested') &&
       !(github.event_name == 'check_suite' && github.event.check_suite.app.slug == 'github-actions') &&
       !(github.event_name == 'check_suite' && github.event.action == 'rerequested') &&
+      !(github.event_name == 'check_run' && github.event.check_run.check_suite.head_branch != null && github.event.check_run.pull_requests[0] == null) &&
+      !(github.event_name == 'check_suite' && github.event.check_suite.head_branch != null && github.event.check_suite.pull_requests[0] == null) &&
       !(github.event_name == 'status' && contains(fromJSON('["Review Policy","Review Policy Advisory"]'), github.event.context)) &&
       !(github.event_name == 'pull_request_review' && github.event.action == 'submitted' && github.event.review.state == 'commented')
     runs-on: ubuntu-latest


### PR DESCRIPTION
Reviewable diff: +12/-0 across 1 file (excludes generated, test, and story files).

## Summary

`Review Policy` currently starts one evaluation for every `check_run` / `check_suite` completion in the repository. External check apps post one check run **per commit** of a pull request (the DCO check does), so a single push or body edit on a 56-commit PR started 56 Review Policy runs, 55 of which allocated a runner only to log `No pull request was associated with this event` and exit. The workflow's run counter is at ~100,900 against ~6,700 for `PR Gate`, almost all from this fan-out. This change drops check events for commits that are not an open pull request head before a runner is allocated. Fork PRs keep today's behaviour.

## How it works

GitHub fills `check_run.pull_requests` (and `check_suite.pull_requests`) only when the check's commit is the head of an open pull request in the same repository, and leaves `check_suite.head_branch` null when the commit came from a fork ([Checks API](https://docs.github.com/en/rest/checks/runs), [webhook payloads](https://docs.github.com/en/webhooks/webhook-events-and-payloads#check_run)). The workflow already classifies some events as ignorable in three places: the concurrency `group` (so ignored events never cancel a real evaluation), `cancel-in-progress`, and the `evaluate` job's `if:`. The same new condition is added to all three:

```
github.event_name == 'check_run'
  && github.event.check_run.check_suite.head_branch != null   # same-repo commit
  && github.event.check_run.pull_requests[0] == null          # not an open PR head
```

and its `check_suite` twin. A matching event still creates a workflow run entry (GitHub creates one for every subscribed event), but the job is skipped in the scheduler with no runner time. The head-commit event still has `pull_requests` populated, so the policy re-evaluates exactly once when an external check lands, as before. Fork events have `head_branch == null`, fail the first clause, and go through the existing API-based resolution.

## Diagrams

```mermaid
flowchart LR
    A["Push / PR edit"] --> B["DCO app posts one check run per commit"]
    B --> C["check_run: completed x N"]
    C --> D{"head_branch set and pull_requests empty?"}
    D -- "yes: not a PR head (N-1 events)" --> E["concurrency group ignored-run_id; evaluate job skipped, no runner"]
    D -- "no: PR head, or fork" --> F["Resolve pull request via API"]
    F --> G["Evaluate Review Policy"]
```

## Areas of the code involved

| Area / file | What changed | Why it matters for review |
| --- | --- | --- |
| `.github/workflows/review-policy.yml` | Two conditions added to the ignore list in the concurrency `group`, `cancel-in-progress`, and the `evaluate` job `if:`; a comment above `concurrency:` explains the fan-out and the fork caveat | The three copies must stay identical; the fork guard (`head_branch != null`) is what keeps this from silently skipping external contributors' PRs |
| `.github/scripts/evaluate_review_policy_test.py` | `test_workflow_skips_check_events_for_commits_that_are_not_a_pr_head` asserts the condition, including the fork guard, is present in all three expressions | Test — pins the fix against later edits to the ignore lists |

## Key technical decisions & trade-offs

- **Filter in `if:` and concurrency, not in the resolve script.** The script already returns "no pull request" for these events, but only after a runner has been allocated; the expression-level filter is the only place GitHub lets a workflow decline work for free. Alternative: leave as is and accept ~10 s of runner time per commit per push.
- **Fail open for forks.** When `head_branch` is null the event is evaluated as today rather than skipped, at the cost of keeping the fan-out for fork PRs. Alternative: skip whenever `pull_requests` is empty, which would stop the policy from re-evaluating when the DCO check completes on a fork PR.
- **Keep the `check_run` trigger.** The policy requires `DCO Check` from `block-dco-check` (`.github/review-policy.json`), so the event is load-bearing for the head commit; dropping the trigger was not an option.

## Testing & validation

- `python3 .github/scripts/evaluate_review_policy_test.py`: 73 tests pass, including the new one (the loader parses the workflow with Ruby's YAML, so the expressions are checked as written).
- Pre-commit hooks pass (`python-ruff`).
- Not covered: the expressions run only in GitHub's evaluator. Evidence for the behaviour they rely on comes from the DCO runs on #1014 at `2026-09-08T01:33:32Z`: 56 `DCO Check` check runs (one per PR commit) followed by 56 Review Policy runs, 55 resolving to no pull request. After merge, the next push to a multi-commit PR should show those 55 as skipped runs with zero duration.