### PR TITLE
fix(fleetmanagement): refresh Fleet Node-owned miners

### DIFF
--- a/server/generated/sqlc/db.go
+++ b/server/generated/sqlc/db.go
@@ -999,9 +999,6 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.isBatchFinishedStmt, err = db.PrepareContext(ctx, isBatchFinished); err != nil {
 		return nil, fmt.Errorf("error preparing query IsBatchFinished: %w", err)
 	}
-	if q.isDeviceOwnedByFleetNodeStmt, err = db.PrepareContext(ctx, isDeviceOwnedByFleetNode); err != nil {
-		return nil, fmt.Errorf("error preparing query IsDeviceOwnedByFleetNode: %w", err)
-	}
 	if q.listActiveAlertMaintenanceWindowsStmt, err = db.PrepareContext(ctx, listActiveAlertMaintenanceWindows); err != nil {
 		return nil, fmt.Errorf("error preparing query ListActiveAlertMaintenanceWindows: %w", err)
 	}
@@ -3511,11 +3508,6 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing isBatchFinishedStmt: %w", cerr)
 		}
 	}
-	if q.isDeviceOwnedByFleetNodeStmt != nil {
-		if cerr := q.isDeviceOwnedByFleetNodeStmt.Close(); cerr != nil {
-			err = fmt.Errorf("error closing isDeviceOwnedByFleetNodeStmt: %w", cerr)
-		}
-	}
 	if q.listActiveAlertMaintenanceWindowsStmt != nil {
 		if cerr := q.listActiveAlertMaintenanceWindowsStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing listActiveAlertMaintenanceWindowsStmt: %w", cerr)
@@ -5345,7 +5337,6 @@ type Queries struct {
 	insertRepairTicketPartStmt                                   *sql.Stmt
 	inventoryPartExistsBySiteAndNameStmt                         *sql.Stmt
 	isBatchFinishedStmt                                          *sql.Stmt
-	isDeviceOwnedByFleetNodeStmt                                 *sql.Stmt
 	listActiveAlertMaintenanceWindowsStmt                        *sql.Stmt
 	listActiveCurtailedDevicesByOrgStmt                          *sql.Stmt
 	listActiveCurtailmentEventsStmt                              *sql.Stmt
@@ -5970,7 +5961,6 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		insertRepairTicketPartStmt:                                   q.insertRepairTicketPartStmt,
 		inventoryPartExistsBySiteAndNameStmt:                         q.inventoryPartExistsBySiteAndNameStmt,
 		isBatchFinishedStmt:                                          q.isBatchFinishedStmt,
-		isDeviceOwnedByFleetNodeStmt:                                 q.isDeviceOwnedByFleetNodeStmt,
 		listActiveAlertMaintenanceWindowsStmt:                        q.listActiveAlertMaintenanceWindowsStmt,
 		listActiveCurtailedDevicesByOrgStmt:                          q.listActiveCurtailedDevicesByOrgStmt,
 		listActiveCurtailmentEventsStmt:                              q.listActiveCurtailmentEventsStmt,

--- a/server/generated/sqlc/device.sql.go
+++ b/server/generated/sqlc/device.sql.go
@@ -1978,31 +1978,6 @@ func (q *Queries) InsertDevice(ctx context.Context, arg InsertDeviceParams) (int
 	return id, err
 }
 
-const isDeviceOwnedByFleetNode = `-- name: IsDeviceOwnedByFleetNode :one
-SELECT EXISTS (
-    SELECT 1
-    FROM device d
-    JOIN fleet_node_device fnd
-      ON fnd.device_id = d.id
-     AND fnd.org_id = d.org_id
-    WHERE d.device_identifier = $1
-      AND d.org_id = $2
-      AND d.deleted_at IS NULL
-)
-`
-
-type IsDeviceOwnedByFleetNodeParams struct {
-	DeviceIdentifier string
-	OrgID            int64
-}
-
-func (q *Queries) IsDeviceOwnedByFleetNode(ctx context.Context, arg IsDeviceOwnedByFleetNodeParams) (bool, error) {
-	row := q.queryRow(ctx, q.isDeviceOwnedByFleetNodeStmt, isDeviceOwnedByFleetNode, arg.DeviceIdentifier, arg.OrgID)
-	var exists bool
-	err := row.Scan(&exists)
-	return exists, err
-}
-
 const listMinerStateSnapshots = `-- name: ListMinerStateSnapshots :many
 SELECT
     dd.device_identifier,

--- a/server/generated/sqlc/querier.go
+++ b/server/generated/sqlc/querier.go
@@ -858,7 +858,6 @@ type Querier interface {
 	InsertRepairTicketPart(ctx context.Context, arg InsertRepairTicketPartParams) error
 	InventoryPartExistsBySiteAndName(ctx context.Context, arg InventoryPartExistsBySiteAndNameParams) (bool, error)
 	IsBatchFinished(ctx context.Context, commandBatchLogUuid string) (bool, error)
-	IsDeviceOwnedByFleetNode(ctx context.Context, arg IsDeviceOwnedByFleetNodeParams) (bool, error)
 	// The delivery-path read: only windows covering sqlc.arg('now'), so the expired tail never loads.
 	ListActiveAlertMaintenanceWindows(ctx context.Context, arg ListActiveAlertMaintenanceWindowsParams) ([]AlertMaintenanceWindow, error)
 	// Devices locked in a non-terminal event; excluded from candidates to

--- a/server/generated/sqlc/retrying_querier.gen.go
+++ b/server/generated/sqlc/retrying_querier.gen.go
@@ -3738,18 +3738,6 @@ func (q *retryingQuerier) IsBatchFinished(ctx context.Context, commandBatchLogUu
 	return result, err
 }
 
-func (q *retryingQuerier) IsDeviceOwnedByFleetNode(ctx context.Context, arg IsDeviceOwnedByFleetNodeParams) (bool, error) {
-	var result bool
-	err := q.retrier.RetryQuery(ctx, "IsDeviceOwnedByFleetNode", func() error {
-		callResult, callErr := q.next.IsDeviceOwnedByFleetNode(ctx, arg)
-		if callErr == nil {
-			result = callResult
-		}
-		return callErr
-	})
-	return result, err
-}
-
 func (q *retryingQuerier) ListActiveAlertMaintenanceWindows(ctx context.Context, arg ListActiveAlertMaintenanceWindowsParams) ([]AlertMaintenanceWindow, error) {
 	var result []AlertMaintenanceWindow
 	err := q.retrier.RetryQuery(ctx, "ListActiveAlertMaintenanceWindows", func() error {

--- a/server/internal/domain/fleetmanagement/service.go
+++ b/server/internal/domain/fleetmanagement/service.go
@@ -336,16 +336,6 @@ func (s *Service) RefreshMiners(ctx context.Context, req *pb.RefreshMinersReques
 				return
 			}
 
-			ownedByFleetNode, err := s.deviceStore.IsDeviceOwnedByFleetNode(refreshCtx, deviceID, info.OrganizationID)
-			if err != nil {
-				results <- refreshResult{id: deviceID, errMsg: sanitizeRefreshMinerError(err)}
-				return
-			}
-			if ownedByFleetNode {
-				results <- refreshResult{id: deviceID, errMsg: "fleet-node-owned miners are not supported by row refresh yet"}
-				return
-			}
-
 			if err := s.telemetry.RefreshDevice(refreshCtx, telemetryModels.Device{
 				ID: telemetryModels.DeviceIdentifier(device.DeviceIdentifier),
 			}); err != nil {

--- a/server/internal/domain/fleetmanagement/service_test.go
+++ b/server/internal/domain/fleetmanagement/service_test.go
@@ -526,45 +526,41 @@ func TestService_LookupMinerByIdentifier_ShouldReturnHydratedSnapshot(t *testing
 	assert.Equal(t, pb.DeviceOfflineReason_DEVICE_OFFLINE_REASON_FLEET_NODE_UNAVAILABLE, resp.Snapshot.OfflineReason)
 }
 
-func TestService_RefreshMiners_ShouldReturnUnsupportedForFleetNodeOwnedMiner(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	deviceStore := storemocks.NewMockDeviceStore(ctrl)
+func TestService_RefreshMiners_ShouldRefreshFleetNodeOwnedMiner(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping test in short mode")
+	}
+
+	testContext := testutil.InitializeDBServiceInfrastructure(t)
+	testUser := testContext.DatabaseService.CreateSuperAdminUser()
+	deviceIDs := testContext.DatabaseService.CreateTestMiners(testUser.OrganizationID, 1, "https://172.17.0.1:80")
+	require.Len(t, deviceIDs, 1)
+	pairMinerToFleetNode(t, testContext.ServiceProvider.DB, testUser.OrganizationID, deviceIDs[0])
+
 	collector := &recordingRefreshTelemetryCollector{}
-
-	const (
-		deviceID = "node-owned-device"
-		orgID    = int64(123)
-	)
-
-	deviceStore.EXPECT().
-		GetDeviceByDeviceIdentifier(gomock.Any(), deviceID, orgID).
-		Return(&pairingpb.Device{DeviceIdentifier: deviceID}, nil)
-	deviceStore.EXPECT().
-		IsDeviceOwnedByFleetNode(gomock.Any(), deviceID, orgID).
-		Return(true, nil)
-
+	transactor := sqlstores.NewSQLTransactor(testContext.ServiceProvider.DB)
 	service := fleetmanagement.NewService(
-		deviceStore,
-		nil,
+		sqlstores.NewSQLDeviceStore(testContext.ServiceProvider.DB),
+		sqlstores.NewSQLDiscoveredDeviceStore(testContext.ServiceProvider.DB),
 		collector,
-		nil,
-		nil,
-		nil,
-		nil,
-		nil,
-		nil,
-		nil,
-		nil,
+		testContext.ServiceProvider.MinerService,
+		testContext.ServiceProvider.PluginService,
+		sqlstores.NewSQLPoolStore(testContext.ServiceProvider.DB, testContext.ServiceProvider.EncryptService),
+		sqlstores.NewSQLErrorStore(testContext.ServiceProvider.DB, transactor),
+		sqlstores.NewSQLCollectionStore(testContext.ServiceProvider.DB),
+		sqlstores.NewSQLBuildingStore(testContext.ServiceProvider.DB),
+		testContext.ServiceProvider.CommandService,
+		activity.NewService(sqlstores.NewSQLActivityStore(testContext.ServiceProvider.DB)),
 	)
 
-	ctx := testutil.MockAuthContextForTesting(t.Context(), 1, orgID)
-	resp, err := service.RefreshMiners(ctx, &pb.RefreshMinersRequest{DeviceIds: []string{deviceID}})
+	ctx := testutil.MockAuthContextForTesting(t.Context(), testUser.DatabaseID, testUser.OrganizationID)
+	resp, err := service.RefreshMiners(ctx, &pb.RefreshMinersRequest{DeviceIds: deviceIDs})
 
 	require.NoError(t, err)
-	assert.Empty(t, resp.Snapshots)
-	require.Contains(t, resp.Errors, deviceID)
-	assert.Contains(t, resp.Errors[deviceID], "fleet-node-owned miners are not supported")
-	assert.Empty(t, collector.Refreshed())
+	require.Len(t, resp.Snapshots, 1)
+	assert.Equal(t, deviceIDs[0], resp.Snapshots[0].DeviceIdentifier)
+	assert.Empty(t, resp.Errors)
+	assert.Equal(t, deviceIDs, collector.Refreshed())
 }
 
 func TestService_RefreshMiners_ShouldReturnSanitizedRefreshFailure(t *testing.T) {
@@ -581,10 +577,6 @@ func TestService_RefreshMiners_ShouldReturnSanitizedRefreshFailure(t *testing.T)
 	deviceStore.EXPECT().
 		GetDeviceByDeviceIdentifier(gomock.Any(), deviceID, orgID).
 		Return(&pairingpb.Device{DeviceIdentifier: deviceID}, nil)
-	deviceStore.EXPECT().
-		IsDeviceOwnedByFleetNode(gomock.Any(), deviceID, orgID).
-		Return(false, nil)
-
 	service := fleetmanagement.NewService(
 		deviceStore,
 		nil,

--- a/server/internal/domain/stores/interfaces/device.go
+++ b/server/internal/domain/stores/interfaces/device.go
@@ -188,7 +188,6 @@ type DeviceStore interface {
 	// Excludes soft-deleted devices, so DeleteMiners must call it before
 	// the soft-delete.
 	GetDistinctDeviceSiteIDs(ctx context.Context, orgID int64, identifiers []string) ([]*int64, error)
-	IsDeviceOwnedByFleetNode(ctx context.Context, identifier string, orgID int64) (bool, error)
 	UpdateDeviceInfo(ctx context.Context, device *pb.Device, orgID int64) error
 	GetDeviceWithIPAssignment(ctx context.Context, deviceIdentifier string, orgID int64) (*discoverymodels.DiscoveredDevice, error)
 	GetTotalPairedDevices(ctx context.Context, orgID int64, filter *MinerFilter) (int64, error)

--- a/server/internal/domain/stores/interfaces/mocks/mock_device_store.go
+++ b/server/internal/domain/stores/interfaces/mocks/mock_device_store.go
@@ -454,21 +454,6 @@ func (mr *MockDeviceStoreMockRecorder) InsertDevice(ctx, device, orgID, discover
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertDevice", reflect.TypeOf((*MockDeviceStore)(nil).InsertDevice), ctx, device, orgID, discoveredDeviceIdentifier)
 }
 
-// IsDeviceOwnedByFleetNode mocks base method.
-func (m *MockDeviceStore) IsDeviceOwnedByFleetNode(ctx context.Context, identifier string, orgID int64) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsDeviceOwnedByFleetNode", ctx, identifier, orgID)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// IsDeviceOwnedByFleetNode indicates an expected call of IsDeviceOwnedByFleetNode.
-func (mr *MockDeviceStoreMockRecorder) IsDeviceOwnedByFleetNode(ctx, identifier, orgID any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsDeviceOwnedByFleetNode", reflect.TypeOf((*MockDeviceStore)(nil).IsDeviceOwnedByFleetNode), ctx, identifier, orgID)
-}
-
 // ListMinerStateSnapshots mocks base method.
 func (m *MockDeviceStore) ListMinerStateSnapshots(ctx context.Context, orgID int64, cursor string, pageSize int32, filter *interfaces.MinerFilter, sortConfig *interfaces.SortConfig) ([]sqlc.ListMinerStateSnapshotsRow, string, int64, error) {
 	m.ctrl.T.Helper()

--- a/server/internal/domain/stores/sqlstores/device.go
+++ b/server/internal/domain/stores/sqlstores/device.go
@@ -166,20 +166,6 @@ func (s *SQLDeviceStore) GetDistinctDeviceSiteIDs(ctx context.Context, orgID int
 	return nullInt64sToPtrs(rows), nil
 }
 
-func (s *SQLDeviceStore) IsDeviceOwnedByFleetNode(ctx context.Context, identifier string, orgID int64) (bool, error) {
-	isOwned, err := s.getQueries(ctx).IsDeviceOwnedByFleetNode(ctx, sqlc.IsDeviceOwnedByFleetNodeParams{
-		DeviceIdentifier: identifier,
-		OrgID:            orgID,
-	})
-	if err != nil {
-		return false, handleQueryError(err,
-			fmt.Sprintf("device not found with identifier=%s org_id=%d", identifier, orgID),
-			fmt.Sprintf("failed to query fleet node ownership for device identifier=%s org_id=%d", identifier, orgID))
-	}
-
-	return isOwned, nil
-}
-
 func (s *SQLDeviceStore) UpdateDeviceInfo(ctx context.Context, device *pb.Device, orgID int64) error {
 	err := s.getQueries(ctx).UpdateDeviceInfo(ctx, sqlc.UpdateDeviceInfoParams{
 		MacAddress:       networking.NormalizeMAC(device.MacAddress),

--- a/server/sqlc/queries/device.sql
+++ b/server/sqlc/queries/device.sql
@@ -194,18 +194,6 @@ WHERE device_identifier = $1
   AND deleted_at IS NULL
     LIMIT 1;
 
--- name: IsDeviceOwnedByFleetNode :one
-SELECT EXISTS (
-    SELECT 1
-    FROM device d
-    JOIN fleet_node_device fnd
-      ON fnd.device_id = d.id
-     AND fnd.org_id = d.org_id
-    WHERE d.device_identifier = $1
-      AND d.org_id = $2
-      AND d.deleted_at IS NULL
-);
-
 -- name: UpdateDeviceInfo :exec
 UPDATE device
 SET


### PR DESCRIPTION
Reviewable diff: +0/-37 across 4 files (excludes generated, test, and story files).

## Summary

Fleet operators can now refresh a Fleet Node-owned miner from its table row and receive the updated snapshot instead of an unsupported-operation error. The request reuses the existing Fleet Node telemetry command path, so authorization, concurrency limits, timeouts, error sanitization, and mixed-result behavior remain unchanged.

Fixes #465.

## How it works

1. A row refresh submits the existing `RefreshMiners` request with one or more device identifiers.
2. The service keeps the existing authorization and per-device concurrency controls, then passes each confirmed device to the telemetry collector without a separate ownership rejection.
3. For a Fleet Node binding, miner resolution selects `RemoteFleetNodeMiner`. It sends the existing telemetry command over the node control stream and waits for the acknowledged result.
4. The telemetry service writes and flushes the returned status and metrics through its existing pipeline.
5. `RefreshMiners` reloads the persisted snapshot and returns either that snapshot or the existing sanitized per-device error.

```mermaid
flowchart LR
    UI["Miner row refresh"] --> FM["RefreshMiners"]
    FM --> TC["TelemetryService.RefreshDevice"]
    TC --> MR["MinerService resolution"]
    MR --> RN["RemoteFleetNodeMiner"]
    RN --> CS["Fleet Node control stream"]
    CS --> WR["Status and metrics writers"]
    WR --> DB["Stored miner snapshot"]
    DB --> FM
    FM --> UI
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/internal/domain/fleetmanagement/` | Removed the Fleet Node ownership rejection and replaced its unsupported-operation test with a confirmed-binding refresh regression. | This is the behavior change and the main review surface. |
| `server/sqlc/queries/device.sql` and `server/internal/domain/stores/` | Removed the private ownership query and `DeviceStore` method that no longer have a caller. | Confirms the change deletes the obsolete mechanism instead of retaining dead compatibility code. |
| `server/generated/sqlc/` and `stores/interfaces/mocks/` | Regenerated bindings after deleting the query and interface method. | Generated - skip; verify only that removals match the source changes. |

## Key technical decisions & trade-offs

- Reuse the existing telemetry and `RemoteFleetNodeMiner` path instead of adding a Fleet Node-specific refresh RPC or control command.
- Remove the ownership query instead of keeping an unused compatibility layer; the interface is internal and has no remaining callers.
- Keep refresh response semantics unchanged: each device still returns either a reloaded snapshot or a sanitized error, and mixed batches continue processing independently.
- Add no public API, wire-format, client, or migration change.

## Testing & validation

- Added a database-backed regression that creates a confirmed Fleet Node binding, records the `RefreshDevice` call, and verifies the returned snapshot and empty error map. CI must run this test because it is intentionally skipped in short mode.
- Passed `./bin/go test -short ./server/internal/domain/fleetmanagement`.
- Passed focused `TelemetryService.RefreshDevice` and `RemoteFleetNodeMiner` tests.
- Passed compile checks for miner, sqlstores, and generated sqlc packages.
- Passed targeted Go lint with zero issues and `git diff --check`.
- Targeted sqlc and mock generation completed. Full `just gen` stopped during the client `npm clean-install` step because the local npm cache returned `EINTEGRITY`; it produced no unrelated tracked changes.
