### PR TITLE
Bound curtailment config retry batches

### DIFF
--- a/server/generated/sqlc/curtailment_mqtt.sql.go
+++ b/server/generated/sqlc/curtailment_mqtt.sql.go
@@ -15,12 +15,26 @@ import (
 
 const claimRigConfigReconciliation = `-- name: ClaimRigConfigReconciliation :one
 WITH candidate AS (
-    SELECT organization_id
-    FROM curtailment_rig_config_reconciliation
-    WHERE desired_generation > enqueued_generation
-      AND retry_at <= CURRENT_TIMESTAMP
-      AND (lease_expires_at IS NULL OR lease_expires_at <= CURRENT_TIMESTAMP)
-    ORDER BY retry_at, organization_id
+    SELECT reconciliation.organization_id
+    FROM curtailment_rig_config_reconciliation AS reconciliation
+    WHERE reconciliation.desired_generation > reconciliation.enqueued_generation
+      AND reconciliation.retry_at <= CURRENT_TIMESTAMP
+      AND (reconciliation.lease_expires_at IS NULL OR reconciliation.lease_expires_at <= CURRENT_TIMESTAMP)
+      AND NOT EXISTS (
+          -- A second active row means the current and retry batch slots are full.
+          SELECT 1
+          FROM command_batch_log AS active_batch
+          WHERE active_batch.organization_id = reconciliation.organization_id
+            AND active_batch.type = 'ApplyCurtailmentConfig'
+            AND active_batch.status IN ('PENDING', 'PROCESSING')
+            AND EXISTS (
+                SELECT 1
+                FROM queue_message AS message
+                WHERE message.command_batch_log_uuid = active_batch.uuid
+            )
+          OFFSET 1
+      )
+    ORDER BY reconciliation.retry_at, reconciliation.organization_id
     FOR UPDATE SKIP LOCKED
     LIMIT 1
 )

--- a/server/internal/domain/command/reaper_integration_test.go
+++ b/server/internal/domain/command/reaper_integration_test.go
@@ -284,6 +284,110 @@ func TestReaperIntegration(t *testing.T) {
 	})
 }
 
+func TestRigConfigTerminalFailureRequeueIsDeferredWithoutBeingLost(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping database integration test in short mode")
+	}
+
+	conn, dbService, user := setupReaperTest(t)
+	queries := sqlc.New(conn)
+	ctx := t.Context()
+	device := dbService.CreateDevice(user.OrganizationID, "proto")
+	require.NoError(t, queries.RequestRigConfigReconciliation(ctx, sqlc.RequestRigConfigReconciliationParams{
+		OrganizationID: user.OrganizationID,
+		RequestedBy:    user.DatabaseID,
+	}))
+	require.NoError(t, queries.CompleteRigConfigReconciliation(ctx, sqlc.CompleteRigConfigReconciliationParams{
+		OrganizationID:     user.OrganizationID,
+		EnqueuedGeneration: 1,
+	}))
+
+	commandType := commandtype.ApplyCurtailmentConfig
+	createBatch := func(batchUUID string) {
+		_, err := queries.CreateCommandBatchLog(ctx, sqlc.CreateCommandBatchLogParams{
+			Uuid:           batchUUID,
+			Type:           commandType.String(),
+			CreatedBy:      user.DatabaseID,
+			CreatedAt:      time.Now(),
+			Status:         sqlc.BatchStatusEnumPENDING,
+			DevicesCount:   1,
+			Payload:        pqtype.NullRawMessage{},
+			OrganizationID: sql.NullInt64{Int64: user.OrganizationID, Valid: true},
+		})
+		require.NoError(t, err)
+	}
+	createActiveBatch := func(batchUUID string) {
+		createBatch(batchUUID)
+		require.NoError(t, queries.CreateQueueMessage(ctx, sqlc.CreateQueueMessageParams{
+			CommandBatchLogUuid: batchUUID,
+			CommandType:         commandType.String(),
+			DeviceID:            device.DatabaseID,
+			Status:              sqlc.QueueStatusEnumPENDING,
+			Payload:             pqtype.NullRawMessage{},
+		}))
+	}
+	desiredGeneration := func() int64 {
+		var generation int64
+		err := conn.QueryRowContext(ctx,
+			"SELECT desired_generation FROM curtailment_rig_config_reconciliation WHERE organization_id = $1",
+			user.OrganizationID,
+		).Scan(&generation)
+		require.NoError(t, err)
+		return generation
+	}
+	makeRetryDue := func() {
+		_, err := conn.ExecContext(ctx,
+			"UPDATE curtailment_rig_config_reconciliation SET retry_at = CURRENT_TIMESTAMP WHERE organization_id = $1",
+			user.OrganizationID,
+		)
+		require.NoError(t, err)
+	}
+
+	createActiveBatch("rig-config-current")
+	createActiveBatch("rig-config-retry")
+	require.NoError(t, queries.RequeueRigConfigReconciliationAfterTerminalFailure(ctx, user.OrganizationID))
+	require.Equal(t, int64(2), desiredGeneration(), "terminal failure should persist while both batch slots are occupied")
+	makeRetryDue()
+	_, err := queries.ClaimRigConfigReconciliation(ctx)
+	require.ErrorIs(t, err, sql.ErrNoRows, "reconciliation should wait while two config batches are active")
+
+	_, err = queries.MarkCommandBatchFinished(ctx, "rig-config-current")
+	require.NoError(t, err)
+	claimed, err := queries.ClaimRigConfigReconciliation(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), claimed.DesiredGeneration, "persisted retry should be claimed when a batch slot opens")
+
+	createActiveBatch("rig-config-next-retry")
+	require.NoError(t, queries.RequeueRigConfigReconciliationAfterTerminalFailure(ctx, user.OrganizationID))
+	require.NoError(t, queries.CompleteRigConfigReconciliation(ctx, sqlc.CompleteRigConfigReconciliationParams{
+		OrganizationID:     user.OrganizationID,
+		EnqueuedGeneration: 2,
+	}))
+	require.Equal(t, int64(3), desiredGeneration(), "failure before enqueue completion should remain pending")
+	_, err = queries.ClaimRigConfigReconciliation(ctx)
+	require.ErrorIs(t, err, sql.ErrNoRows, "pending retry should wait while both batch slots are occupied")
+
+	_, err = queries.MarkCommandBatchFinished(ctx, "rig-config-retry")
+	require.NoError(t, err)
+	claimed, err = queries.ClaimRigConfigReconciliation(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int64(3), claimed.DesiredGeneration, "one-shot failure should be claimed after a batch slot opens")
+
+	require.NoError(t, queries.CompleteRigConfigReconciliation(ctx, sqlc.CompleteRigConfigReconciliationParams{
+		OrganizationID:     user.OrganizationID,
+		EnqueuedGeneration: 3,
+	}))
+	createBatch("rig-config-orphan-1")
+	createBatch("rig-config-orphan-2")
+	require.NoError(t, queries.RequestRigConfigReconciliation(ctx, sqlc.RequestRigConfigReconciliationParams{
+		OrganizationID: user.OrganizationID,
+		RequestedBy:    user.DatabaseID,
+	}))
+	claimed, err = queries.ClaimRigConfigReconciliation(ctx)
+	require.NoError(t, err)
+	require.Equal(t, int64(4), claimed.DesiredGeneration, "empty orphaned batches should not consume retry slots")
+}
+
 func TestExecutionServiceStartupPreservesPendingAndFailsProcessing(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping database integration test in short mode")

--- a/server/sqlc/queries/curtailment_mqtt.sql
+++ b/server/sqlc/queries/curtailment_mqtt.sql
@@ -223,12 +223,26 @@ SET requested_by = EXCLUDED.requested_by,
 
 -- name: ClaimRigConfigReconciliation :one
 WITH candidate AS (
-    SELECT organization_id
-    FROM curtailment_rig_config_reconciliation
-    WHERE desired_generation > enqueued_generation
-      AND retry_at <= CURRENT_TIMESTAMP
-      AND (lease_expires_at IS NULL OR lease_expires_at <= CURRENT_TIMESTAMP)
-    ORDER BY retry_at, organization_id
+    SELECT reconciliation.organization_id
+    FROM curtailment_rig_config_reconciliation AS reconciliation
+    WHERE reconciliation.desired_generation > reconciliation.enqueued_generation
+      AND reconciliation.retry_at <= CURRENT_TIMESTAMP
+      AND (reconciliation.lease_expires_at IS NULL OR reconciliation.lease_expires_at <= CURRENT_TIMESTAMP)
+      AND NOT EXISTS (
+          -- A second active row means the current and retry batch slots are full.
+          SELECT 1
+          FROM command_batch_log AS active_batch
+          WHERE active_batch.organization_id = reconciliation.organization_id
+            AND active_batch.type = 'ApplyCurtailmentConfig'
+            AND active_batch.status IN ('PENDING', 'PROCESSING')
+            AND EXISTS (
+                SELECT 1
+                FROM queue_message AS message
+                WHERE message.command_batch_log_uuid = active_batch.uuid
+            )
+          OFFSET 1
+      )
+    ORDER BY reconciliation.retry_at, reconciliation.organization_id
     FOR UPDATE SKIP LOCKED
     LIMIT 1
 )


### PR DESCRIPTION
Reviewable diff: +20/-6 across 1 files (excludes generated, test, and story files).

## Summary

This prevents unreachable Proto rigs from driving fleetd and TimescaleDB load through an unbounded stream of overlapping full-fleet curtailment configuration batches. Terminal failures remain durable, but reconciliation now limits each organization to the current configuration batch plus one retry. Crash-orphaned batch rows with no queue messages do not consume those execution slots.

## How it works

Each terminal `ApplyCurtailmentConfig` failure still advances the organization's desired reconciliation generation. The claim query counts only active configuration batches that contain queue work; when two exist, it leaves the desired generation pending. Once an older batch finishes, the reconciler claims the latest accumulated generation and enqueues one replacement batch, coalescing all failures that arrived while the slots were occupied.

## Diagrams

```mermaid
flowchart LR
    F["Terminal config command fails"] --> P["Persist desired generation"]
    P --> C{"Two real config batches active?"}
    C -- "Yes" --> W["Leave generation pending"]
    C -- "No" --> E["Claim latest generation"]
    E --> Q["Enqueue one full-fleet retry batch"]
    Q --> C
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/sqlc/queries/curtailment_mqtt.sql` | Added the real-batch slot check to reconciliation claiming | This is the load-shedding and durability boundary |
| `server/generated/sqlc/curtailment_mqtt.sql.go` | Regenerated query binding | Generated — skip |
| `server/internal/domain/command/reaper_integration_test.go` | Covers occupied slots, enqueue-completion races, and empty orphaned batches | Demonstrates retries are deferred rather than lost |

## Key technical decisions & trade-offs

- Persist every terminal failure and gate the consumer, rather than dropping producer notifications; generation values may advance more than once, but claims coalesce them into one batch.
- Count batches with queue messages rather than every pending batch row; this preserves crash recovery without adding a migration or cleanup path.
- Allow two active batches rather than serializing to one; this retains the existing current-plus-retry behavior while placing a hard bound on polling work.

## Testing & validation

- `go test ./internal/domain/command -count=1`
- `go test ./internal/domain/curtailment/mqttingest ./generated/sqlc -count=1`
- `just -f server/justfile lint`
- The database regression uses a real TimescaleDB instance and covers both one-shot failure races and zero-message orphaned batch rows.
