### PR TITLE
fix: use OTLP traces path for bare endpoints

### DIFF
--- a/server/internal/infrastructure/fleet-telemetry/telemetry.go
+++ b/server/internal/infrastructure/fleet-telemetry/telemetry.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/url"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
@@ -13,6 +14,8 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 )
+
+const defaultTracesPath = "/v1/traces"
 
 type Config struct {
 	Enabled             bool    `help:"Enable OpenTelemetry traces" default:"false" env:"ENABLED"`
@@ -29,7 +32,7 @@ func Setup(ctx context.Context, version string, cfg Config) (func(context.Contex
 		return func(context.Context) error { return nil }, nil
 	}
 
-	exporter, err := otlptracehttp.New(ctx, otlptracehttp.WithEndpointURL(cfg.Endpoint))
+	exporter, err := otlptracehttp.New(ctx, otlptracehttp.WithEndpointURL(withDefaultTracesPath(cfg.Endpoint)))
 	if err != nil {
 		return nil, fmt.Errorf("create OTLP HTTP exporter: %w", err)
 	}
@@ -69,4 +72,15 @@ func Setup(ctx context.Context, version string, cfg Config) (func(context.Contex
 	))
 
 	return tp.Shutdown, nil
+}
+
+func withDefaultTracesPath(endpoint string) string {
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return endpoint
+	}
+	if parsed.Path == "" || parsed.Path == "/" {
+		parsed.Path = defaultTracesPath
+	}
+	return parsed.String()
 }

--- a/server/internal/infrastructure/fleet-telemetry/telemetry_test.go
+++ b/server/internal/infrastructure/fleet-telemetry/telemetry_test.go
@@ -2,6 +2,8 @@ package fleet_telemetry_test
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -55,4 +57,49 @@ func TestSetupSampleRateCapsRemoteSampledParents(t *testing.T) {
 
 func TestSetupSampleRateOneKeepsRemoteSampledParents(t *testing.T) {
 	require.True(t, startWithRemoteSampledParent(t, 1.0))
+}
+
+func TestSetupUsesExpectedOTLPTracePath(t *testing.T) {
+	tests := []struct {
+		name         string
+		endpointPath string
+		wantPath     string
+	}{
+		{name: "base endpoint", wantPath: "/v1/traces"},
+		{name: "base endpoint with trailing slash", endpointPath: "/", wantPath: "/v1/traces"},
+		{name: "explicit trace endpoint", endpointPath: "/custom/traces", wantPath: "/custom/traces"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			requestPaths := make(chan string, 1)
+			collector := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requestPaths <- r.URL.Path
+				w.Header().Set("Content-Type", "application/x-protobuf")
+			}))
+			t.Cleanup(collector.Close)
+
+			shutdown, err := fleet_telemetry.Setup(t.Context(), "test", fleet_telemetry.Config{
+				Enabled:     true,
+				Endpoint:    collector.URL + test.endpointPath,
+				ServiceName: "test",
+				SampleRate:  1.0,
+			})
+			require.NoError(t, err)
+			t.Cleanup(func() {
+				otel.SetTracerProvider(noop.NewTracerProvider())
+				otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator())
+			})
+
+			_, span := otel.Tracer("test").Start(t.Context(), "operation")
+			span.End()
+			require.NoError(t, shutdown(t.Context()))
+			select {
+			case requestPath := <-requestPaths:
+				require.Equal(t, test.wantPath, requestPath)
+			default:
+				t.Fatal("collector received no trace request")
+			}
+		})
+	}
 }


### PR DESCRIPTION
Reviewable diff: +15/-1 across 1 files (excludes generated, test, and story files).

## Summary

Fleet tracing now reaches OTLP/HTTP collectors when operators configure a collector base URL, including the HA default. Bare and root-path endpoints are normalized to the standard `/v1/traces` signal path, while explicitly configured paths remain unchanged.

## How it works

When Fleet telemetry starts, it parses the configured exporter URL. If the URL has no path or only `/`, Fleet supplies `/v1/traces` before constructing the OpenTelemetry exporter; otherwise, the operator-provided path is preserved. Integration tests start a real HTTP test collector, flush a span through the exporter, and assert the path received by the collector.

## Diagrams

```mermaid
flowchart LR
    A["Fleet telemetry configuration"] --> B["Normalize empty or root URL path"]
    B --> C["OTLP HTTP trace exporter"]
    C --> D["Collector /v1/traces endpoint"]
```

## Areas of the code involved

| Area / package / file | What changed | Why it matters for review |
| --- | --- | --- |
| `server/internal/infrastructure/fleet-telemetry/telemetry.go` | Adds trace-path normalization before exporter construction | Ensures HA tracing uses the collector's OTLP/HTTP trace endpoint without overriding custom paths |
| `server/internal/infrastructure/fleet-telemetry/telemetry_test.go` | Exercises bare, root, and explicit endpoint paths through a real HTTP exporter | Verifies the actual wire path and shutdown flush behavior |

## Key technical decisions & trade-offs

- Normalize only empty and root paths, preserving explicit operator endpoints instead of unconditionally appending `/v1/traces`.
- Test through the OpenTelemetry exporter and an HTTP server instead of unit-testing only the URL helper, covering the SDK behavior that caused the production 404.

## Testing & validation

- `just setup`
- `just gen` with no unexpected generated diff
- `cd server && ../bin/golangci-lint fmt --diff -c .golangci.yaml`
- `cd server && just lint`
- `cd server && just build`
- `cd server && just db-up && just test`
- `bin/python3 .github/scripts/evaluate_review_policy_test.py`
- `bin/python3 .github/scripts/codex_sharding_test.py`
- Local PR-equivalent Codex security/correctness/reliability review: overall risk `NONE`, no findings
- Live HA validation: the same endpoint override sent trace exports to `/v1/traces` and received HTTP 200 responses
- E2E tests were intentionally skipped per operator request
